### PR TITLE
Date filter millis

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -75,14 +75,8 @@ var DATE_FORMATS = {
 var DATE_FORMATS_SPLIT = /([^yMdHhmsaZ]*)(y+|M+|d+|H+|h+|m+|s+|a|Z)(.*)/;
 
 angularFilter.date = function(date, format) {
-  var text, fn;
-  if (!date) return date;
-  if (!(date instanceof Date)) {
-    text = parseInt(date, 10);
-    date = new Date();
-    date.setTime(text);
-  }
-  text = date.toLocaleDateString();
+  if (!(date instanceof Date)) return date;
+  var text = date.toLocaleDateString(), fn;
   if (format && isString(format)) {
     text = '';
     var parts = [];

--- a/src/filters.js
+++ b/src/filters.js
@@ -73,9 +73,19 @@ var DATE_FORMATS = {
         }
 };
 var DATE_FORMATS_SPLIT = /([^yMdHhmsaZ]*)(y+|M+|d+|H+|h+|m+|s+|a|Z)(.*)/;
+var NUMBER_STRING = /^\d+$/;
 
 angularFilter.date = function(date, format) {
-  if (!(date instanceof Date)) return date;
+  if (isString(date) && NUMBER_STRING.test(date)) {
+    date = parseInt(date, 10);
+  }
+
+  if (isNumber(date)) {
+    date = new Date(date);
+  } else if (!(date instanceof Date)) {
+    return date;
+  }
+
   var text = date.toLocaleDateString(), fn;
   if (format && isString(format)) {
     text = '';

--- a/test/FiltersSpec.js
+++ b/test/FiltersSpec.js
@@ -98,17 +98,21 @@ describe('filter', function(){
     morning.getTimezoneOffset =
       noon.getTimezoneOffset =
         midnight.getTimezoneOffset =
-          function() { return 7 * 60; };
+          function() {return 7 * 60;};
 
     it('should ignore falsy inputs', function() {
       expect(filter.date(null)).toEqual(null);
       expect(filter.date('')).toEqual('');
-      expect(filter.date(123)).toEqual(123);
     });
 
     it('should do basic filter', function() {
       expect(filter.date(noon)).toEqual(noon.toLocaleDateString());
       expect(filter.date(noon, '')).toEqual(noon.toLocaleDateString());
+    });
+
+    it('should accept number or number string representing milliseconds as input', function() {
+      expect(filter.date(noon.getTime())).toEqual(noon.toLocaleDateString());
+      expect(filter.date(noon.getTime() + "")).toEqual(noon.toLocaleDateString());
     });
 
     it('should accept format', function() {
@@ -122,8 +126,6 @@ describe('filter', function(){
                        toEqual('2010-09-03 12=12:05:08pm0700');
 
     });
-
-
   });
 });
 

--- a/test/FiltersSpec.js
+++ b/test/FiltersSpec.js
@@ -103,6 +103,7 @@ describe('filter', function(){
     it('should ignore falsy inputs', function() {
       expect(filter.date(null)).toEqual(null);
       expect(filter.date('')).toEqual('');
+      expect(filter.date(123)).toEqual(123);
     });
 
     it('should do basic filter', function() {
@@ -122,9 +123,6 @@ describe('filter', function(){
 
     });
 
-    it('should accept miliseconds as date', function(){
-      expect(filter.date("123", "yyyy")).toEqual('1969');
-    });
 
   });
 });


### PR DESCRIPTION
- reverts previous commit (don't try to parse string (that's a rat hole))
- support numbers as input and consider them to be milliseconds
- implementations is simpler
- better tests
