### PR TITLE
Rename foreach() to forEach()

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -115,7 +115,7 @@ var _undefined        = undefined,
 /**
  * @workInProgress
  * @ngdoc function
- * @name angular.foreach
+ * @name angular.forEach
  * @function
  *
  * @description
@@ -127,7 +127,7 @@ var _undefined        = undefined,
    <pre>
      var values = {name: 'misko', gender: 'male'};
      var log = [];
-     angular.foreach(values, function(value, key){
+     angular.forEach(values, function(value, key){
        this.push(key + ': ' + value);
      }, log);
      expect(log).toEqual(['name: misko', 'gender:male']);
@@ -138,7 +138,7 @@ var _undefined        = undefined,
  * @param {Object} context Object to become context (`this`) for the iterator function.
  * @returns {Objet|Array} Reference to `obj`.
  */
-function foreach(obj, iterator, context) {
+function forEach(obj, iterator, context) {
   var key;
   if (obj) {
     if (isFunction(obj)){
@@ -160,7 +160,7 @@ function foreach(obj, iterator, context) {
   return obj;
 }
 
-function foreachSorted(obj, iterator, context) {
+function forEachSorted(obj, iterator, context) {
   var keys = [];
   for (var key in obj) keys.push(key);
   keys.sort();
@@ -197,9 +197,9 @@ function formatError(arg) {
  * @param {...Object} src The source object(s).
  */
 function extend(dst) {
-  foreach(arguments, function(obj){
+  forEach(arguments, function(obj){
     if (obj !== dst) {
-      foreach(obj, function(value, key){
+      forEach(obj, function(value, key){
         dst[key] = value;
       });
     }
@@ -448,7 +448,7 @@ function isVisible(element) {
 
 function map(obj, iterator, context) {
   var results = [];
-  foreach(obj, function(value, index, list) {
+  forEach(obj, function(value, index, list) {
     results.push(iterator.call(context, value, index, list));
   });
   return results;
@@ -569,7 +569,7 @@ function copy(source, destination){
         destination.push(copy(source[i]));
       }
     } else {
-      foreach(destination, function(value, key){
+      forEach(destination, function(value, key){
         delete destination[key];
       });
       for ( var key in source) {
@@ -767,7 +767,7 @@ function compile(element, parentScope) {
  */
 function parseKeyValue(/**string*/keyValue) {
   var obj = {}, key_value, key;
-  foreach((keyValue || "").split('&'), function(keyValue){
+  forEach((keyValue || "").split('&'), function(keyValue){
     if (keyValue) {
       key_value = keyValue.split('=');
       key = unescape(key_value[0]);
@@ -779,7 +779,7 @@ function parseKeyValue(/**string*/keyValue) {
 
 function toKeyValue(obj) {
   var parts = [];
-  foreach(obj, function(value, key) {
+  forEach(obj, function(value, key) {
     parts.push(escape(key) + (value === true ? '' : '=' + escape(value)));
   });
   return parts.length ? parts.join('&') : '';

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -30,7 +30,6 @@ extend(angular, {
   'copy': copy,
   'extend': extend,
   'equals': equals,
-  'foreach': foreach,
   'injector': createInjector,
   'noop':noop,
   'bind':bind,
@@ -45,4 +44,6 @@ extend(angular, {
   'isNumber': isNumber,
   'isArray': isArray
 });
+
+angular.forEach = forEach;
 

--- a/src/Browser.js
+++ b/src/Browser.js
@@ -136,7 +136,7 @@ function Browser(window, document, body, XHR, $log) {
    * @methodOf angular.service.$browser
    */
   self.poll = function() {
-    foreach(pollFns, function(pollFn){ pollFn(); });
+    forEach(pollFns, function(pollFn){ pollFn(); });
   };
 
   /**

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -16,8 +16,8 @@ Template.prototype = {
   init: function(element, scope) {
     var inits = {};
     this.collectInits(element, inits, scope);
-    foreachSorted(inits, function(queue){
-      foreach(queue, function(fn) {fn();});
+    forEachSorted(inits, function(queue){
+      forEach(queue, function(fn) {fn();});
     });
   },
 
@@ -32,7 +32,7 @@ Template.prototype = {
       scope.$onEval(childScope.$eval);
       element.data($$scope, childScope);
     }
-    foreach(this.inits, function(fn) {
+    forEach(this.inits, function(fn) {
       queue.push(function() {
         childScope.$tryEval(function(){
           return childScope.$service(fn, childScope, element);
@@ -232,7 +232,7 @@ Compiler.prototype = {
       for(var i=0, child=element[0].childNodes;
           i<child.length; i++) {
         if (isTextNode(child[i])) {
-          foreach(self.markup, function(markup){
+          forEach(self.markup, function(markup){
             if (i<child.length) {
               var textNode = jqLite(child[i]);
               markup.call(selfApi, textNode.text(), textNode, element);
@@ -245,7 +245,7 @@ Compiler.prototype = {
     if (directives) {
       // Process attributes/directives
       eachAttribute(element, function(value, name){
-        foreach(self.attrMarkup, function(markup){
+        forEach(self.attrMarkup, function(markup){
           markup.call(selfApi, value, name, element);
         });
       });
@@ -287,6 +287,6 @@ function eachAttribute(element, fn){
     }
     attrValue[name] = value;
   }
-  foreachSorted(attrValue, fn);
+  forEachSorted(attrValue, fn);
 }
 

--- a/src/Injector.js
+++ b/src/Injector.js
@@ -47,14 +47,14 @@ function createInjector(providerScope, providers, cache) {
       returnValue = cache[value];
     } else if (isArray(value)) {
       returnValue = [];
-      foreach(value, function(name) {
+      forEach(value, function(name) {
         returnValue.push(inject(name));
       });
     } else if (isFunction(value)) {
       returnValue = inject(value.$inject || []);
       returnValue = value.apply(scope, concat(returnValue, arguments, 2));
     } else if (isObject(value)) {
-      foreach(providers, function(provider, name){
+      forEach(providers, function(provider, name){
         if (provider.$eager)
           inject(name);
 

--- a/src/JSON.js
+++ b/src/JSON.js
@@ -53,12 +53,12 @@ function fromJson(json, useNative) {
     throw e;
   }
 
-  // TODO make foreach optionally recursive and remove this function
+  // TODO make forEach optionally recursive and remove this function
   function transformDates(obj) {
     if (isString(obj) && obj.length === DATE_ISOSTRING_LN) {
       return angularString.toDate(obj);
     } else if (isArray(obj) || isObject(obj)) {
-      foreach(obj, function(val, name) {
+      forEach(obj, function(val, name) {
         obj[name] = transformDates(val);
       });
     }

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -4,7 +4,7 @@ function Route(template, defaults) {
   this.template = template = template + '#';
   this.defaults = defaults || {};
   var urlParams = this.urlParams = {};
-  foreach(template.split(/\W/), function(param){
+  forEach(template.split(/\W/), function(param){
     if (param && template.match(new RegExp(":" + param + "\\W"))) {
       urlParams[param] = true;
     }
@@ -17,13 +17,13 @@ Route.prototype = {
     var self = this;
     var url = this.template;
     params = params || {};
-    foreach(this.urlParams, function(_, urlParam){
+    forEach(this.urlParams, function(_, urlParam){
       var value = params[urlParam] || self.defaults[urlParam] || "";
       url = url.replace(new RegExp(":" + urlParam + "(\\W)"), value + "$1");
     });
     url = url.replace(/\/?#$/, '');
     var query = [];
-    foreachSorted(params, function(value, key){
+    forEachSorted(params, function(value, key){
       if (!self.urlParams[key]) {
         query.push(encodeURI(key) + '=' + encodeURI(value));
       }
@@ -52,7 +52,7 @@ ResourceFactory.prototype = {
     actions = extend({}, ResourceFactory.DEFAULT_ACTIONS, actions);
     function extractParams(data){
       var ids = {};
-      foreach(paramDefaults || {}, function(value, key){
+      forEach(paramDefaults || {}, function(value, key){
         ids[key] = value.charAt && value.charAt(0) == '@' ? getter(data, value.substr(1)) : value;
       });
       return ids;
@@ -62,7 +62,7 @@ ResourceFactory.prototype = {
       copy(value || {}, this);
     }
 
-    foreach(actions, function(action, name){
+    forEach(actions, function(action, name){
       var isPostOrPut = action.method == 'POST' || action.method == 'PUT';
       Resource[name] = function (a1, a2, a3) {
         var params = {};
@@ -97,7 +97,7 @@ ResourceFactory.prototype = {
             if (status == 200) {
               if (action.isArray) {
                 value.length = 0;
-                foreach(response, function(item){
+                forEach(response, function(item){
                   value.push(new Resource(item));
                 });
               } else {

--- a/src/Scope.js
+++ b/src/Scope.js
@@ -48,7 +48,7 @@ var scopeId = 0,
     getterFnCache = {},
     compileCache = {},
     JS_KEYWORDS = {};
-foreach(
+forEach(
     ("abstract,boolean,break,byte,case,catch,char,class,const,continue,debugger,default," +
     "delete,do,double,else,enum,export,extends,false,final,finally,float,for,function,goto," +
     "if,implements,import,ininstanceof,intinterface,long,native,new,null,package,private," +
@@ -61,7 +61,7 @@ function getterFn(path){
   if (fn) return fn;
 
   var code = 'var l, fn, t;\n';
-  foreach(path.split('.'), function(key) {
+  forEach(path.split('.'), function(key) {
     key = (JS_KEYWORDS[key]) ? '["' + key + '"]' : '.' + key;
     code += 'if(!s) return s;\n' +
             'l=s;\n' +
@@ -575,7 +575,7 @@ function createScope(parent, providers, instanceCache) {
     $become: function(Class) {
       if (isFunction(Class)) {
         instance.constructor = Class;
-        foreach(Class.prototype, function(fn, name){
+        forEach(Class.prototype, function(fn, name){
           instance[name] = bind(instance, fn);
         });
         instance.$service.apply(instance, concat([Class, instance], arguments, 1));

--- a/src/apis.js
+++ b/src/apis.js
@@ -499,7 +499,7 @@ var angularArray = {
   'count':function(array, condition) {
     if (!condition) return array.length;
     var fn = angular['Function']['compile'](condition), count = 0;
-    foreach(array, function(value){
+    forEach(array, function(value){
       if (fn(value)) {
         count ++;
       }
@@ -747,7 +747,7 @@ var angularFunction = {
 
 function defineApi(dst, chain){
   angular[dst] = angular[dst] || {};
-  foreach(chain, function(parent){
+  forEach(chain, function(parent){
     extend(angular[dst], parent);
   });
 }

--- a/src/directives.js
+++ b/src/directives.js
@@ -222,7 +222,7 @@ function compileBindTemplate(template){
   var fn = bindTemplateCache[template];
   if (!fn) {
     var bindings = [];
-    foreach(parseBindings(template), function(text){
+    forEach(parseBindings(template), function(text){
       var exp = binding(text);
       bindings.push(exp ? function(element){
         var error, value = this.$tryEval(exp, function(e){

--- a/src/filters.js
+++ b/src/filters.js
@@ -222,7 +222,7 @@ angularFilter.date = function(date, format) {
       parts = concat(parts, DATE_FORMATS_SPLIT.exec(format), 1);
       format = parts.pop();
     }
-    foreach(parts, function(value){
+    forEach(parts, function(value){
       fn = DATE_FORMATS[value];
       text += fn ? fn(date) : value;
     });

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -117,7 +117,7 @@ angularFormatter.list = formatter(
   function(obj) { return obj ? obj.join(", ") : obj; },
   function(value) {
     var list = [];
-    foreach((value || '').split(','), function(item){
+    forEach((value || '').split(','), function(item){
       item = trim(item);
       if (item) list.push(item);
     });

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -18,7 +18,7 @@ function jqClearData(element) {
   var cacheId = element[jqName],
       cache = jqCache[cacheId];
   if (cache) {
-    foreach(cache.bind || {}, function(fn, type){
+    forEach(cache.bind || {}, function(fn, type){
       removeEventListenerFn(element, type, fn);
     });
     delete jqCache[cacheId];
@@ -93,7 +93,7 @@ JQLite.prototype = {
         bind = self.data('bind'),
         eventHandler;
     if (!bind) this.data('bind', bind = {});
-    foreach(type.split(' '), function(type){
+    forEach(type.split(' '), function(type){
       eventHandler = bind[type];
       if (!eventHandler) {
         bind[type] = eventHandler = function(event) {
@@ -107,7 +107,7 @@ JQLite.prototype = {
               event.cancelBubble = true; //ie
             };
           }
-          foreach(eventHandler.fns, function(fn){
+          forEach(eventHandler.fns, function(fn){
             fn.call(self, event);
           });
         };
@@ -129,7 +129,7 @@ JQLite.prototype = {
   append: function(node) {
     var self = this[0];
     node = jqLite(node);
-    foreach(node, function(child){
+    forEach(node, function(child){
       self.appendChild(child);
     });
   },
@@ -187,7 +187,7 @@ JQLite.prototype = {
   attr: function(name, value){
     var e = this[0];
     if (isObject(name)) {
-      foreach(name, function(value, name){
+      forEach(name, function(value, name){
         e.setAttribute(name, value);
       });
     } else if (isDefined(value)) {

--- a/src/markups.js
+++ b/src/markups.js
@@ -35,7 +35,7 @@ angularTextMarkup('{{}}', function(text, textNode, parentElement) {
       parentElement.attr('ng:bind-template', text);
     } else {
       var cursor = textNode, newElement;
-      foreach(parseBindings(text), function(text){
+      forEach(parseBindings(text), function(text){
         var exp = binding(text);
         if (exp) {
           newElement = self.element('span');

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -252,7 +252,7 @@ function htmlSanitizeWriter(buf){
       if (!ignore && validElements[tag] == true) {
         out('<');
         out(tag);
-        foreach(attrs, function(value, key){
+        forEach(attrs, function(value, key){
           var lkey=lowercase(key);
           if (validAttrs[lkey]==true && (uriAttrs[lkey]!==true || value.match(URI_REGEXP))) {
             out(' ');

--- a/src/scenario/Describe.js
+++ b/src/scenario/Describe.js
@@ -21,7 +21,7 @@ angular.scenario.Describe = function(descName, parent) {
   var beforeEachFns = this.beforeEachFns;
   this.setupBefore = function() {
     if (parent) parent.setupBefore.call(this);
-    angular.foreach(beforeEachFns, function(fn) { fn.call(this); }, this);
+    angular.forEach(beforeEachFns, function(fn) { fn.call(this); }, this);
   };
 
   /**
@@ -29,7 +29,7 @@ angular.scenario.Describe = function(descName, parent) {
    */
   var afterEachFns = this.afterEachFns;
   this.setupAfter  = function() {
-    angular.foreach(afterEachFns, function(fn) { fn.call(this); }, this);
+    angular.forEach(afterEachFns, function(fn) { fn.call(this); }, this);
     if (parent) parent.setupAfter.call(this);
   };
 };
@@ -133,14 +133,14 @@ angular.scenario.Describe.prototype.xit = angular.noop;
  */
 angular.scenario.Describe.prototype.getSpecs = function() {
   var specs = arguments[0] || [];
-  angular.foreach(this.children, function(child) {
+  angular.forEach(this.children, function(child) {
     child.getSpecs(specs);
   });
-  angular.foreach(this.its, function(it) {
+  angular.forEach(this.its, function(it) {
     specs.push(it);
   });
   var only = [];
-  angular.foreach(specs, function(it) {
+  angular.forEach(specs, function(it) {
     if (it.only) {
       only.push(it);
     }

--- a/src/scenario/ObjectModel.js
+++ b/src/scenario/ObjectModel.js
@@ -19,7 +19,7 @@ angular.scenario.ObjectModel = function(runner) {
 
   runner.on('SpecBegin', function(spec) {
     var block = self.value;
-    angular.foreach(self.getDefinitionPath(spec), function(def) {
+    angular.forEach(self.getDefinitionPath(spec), function(def) {
       if (!block.children[def.name]) {
         block.children[def.name] = {
           id: def.id,

--- a/src/scenario/Runner.js
+++ b/src/scenario/Runner.js
@@ -16,7 +16,7 @@ angular.scenario.Runner = function($window) {
     beforeEach: this.beforeEach,
     afterEach: this.afterEach
   };
-  angular.foreach(this.api, angular.bind(this, function(fn, key) {
+  angular.forEach(this.api, angular.bind(this, function(fn, key) {
     this.$window[key] = angular.bind(this, fn);
   }));
 };
@@ -33,7 +33,7 @@ angular.scenario.Runner.prototype.emit = function(eventName) {
   eventName = eventName.toLowerCase();
   if (!this.listeners[eventName])
     return;
-  angular.foreach(this.listeners[eventName], function(listener) {
+  angular.forEach(this.listeners[eventName], function(listener) {
     listener.apply(self, args);
   });
 };
@@ -164,17 +164,17 @@ angular.scenario.Runner.prototype.run = function(application) {
   asyncForEach(this.rootDescribe.getSpecs(), function(spec, specDone) {
     var dslCache = {};
     var runner = self.createSpecRunner_($root);
-    angular.foreach(angular.scenario.dsl, function(fn, key) {
+    angular.forEach(angular.scenario.dsl, function(fn, key) {
       dslCache[key] = fn.call($root);
     });
-    angular.foreach(angular.scenario.dsl, function(fn, key) {
+    angular.forEach(angular.scenario.dsl, function(fn, key) {
       self.$window[key] = function() {
         var line = callerFile(3);
         var scope = angular.scope(runner);
 
         // Make the dsl accessible on the current chain
         scope.dsl = {};
-        angular.foreach(dslCache, function(fn, key) {
+        angular.forEach(dslCache, function(fn, key) {
           scope.dsl[key] = function() {
             return dslCache[key].apply(scope, arguments);
           };

--- a/src/scenario/Scenario.js
+++ b/src/scenario/Scenario.js
@@ -38,7 +38,7 @@ angular.scenario.dsl = angular.scenario.dsl || function(name, fn) {
         return result;
       var self = this;
       var chain = angular.extend({}, result);
-      angular.foreach(chain, function(value, name) {
+      angular.forEach(chain, function(value, name) {
         if (angular.isFunction(value)) {
           chain[name] = function() {
             return executeStatement.call(self, value, arguments);
@@ -101,7 +101,7 @@ function angularScenarioInit($scenario, config) {
     output = config.scenario_output.split(',');
   }
 
-  angular.foreach(angular.scenario.output, function(fn, name) {
+  angular.forEach(angular.scenario.output, function(fn, name) {
     if (!output.length || indexOf(output,name) != -1) {
       var context = body.append('<div></div>').find('div:last');
       context.attr('id', name);

--- a/src/scenario/SpecRunner.js
+++ b/src/scenario/SpecRunner.js
@@ -112,7 +112,7 @@ angular.scenario.SpecRunner.prototype.addFutureAction = function(name, behavior,
         var args = Array.prototype.slice.call(arguments, 1);
         selector = (self.selector || '') + ' ' + (selector || '');
         selector = _jQuery.trim(selector) || '*';
-        angular.foreach(args, function(value, index) {
+        angular.forEach(args, function(value, index) {
           selector = selector.replace('$' + (index + 1), value);
         });
         var result = $document.find(selector);

--- a/src/scenario/dsl.js
+++ b/src/scenario/dsl.js
@@ -331,7 +331,7 @@ angular.scenario.dsl('element', function() {
     });
   };
 
-  angular.foreach(KEY_VALUE_METHODS, function(methodName) {
+  angular.forEach(KEY_VALUE_METHODS, function(methodName) {
     chain[methodName] = function(name, value) {
       var futureName = "element '" + this.label + "' get " + methodName + " '" + name + "'";
       if (angular.isDefined(value)) {
@@ -344,7 +344,7 @@ angular.scenario.dsl('element', function() {
     };
   });
 
-  angular.foreach(VALUE_METHODS, function(methodName) {
+  angular.forEach(VALUE_METHODS, function(methodName) {
     chain[methodName] = function(value) {
       var futureName = "element '" + this.label + "' " + methodName;
       if (angular.isDefined(value)) {

--- a/src/scenario/output/Html.js
+++ b/src/scenario/output/Html.js
@@ -121,7 +121,7 @@ angular.scenario.output('html', function(context, runner) {
    */
   function findContext(spec) {
     var currentContext = context.find('#specs');
-    angular.foreach(model.getDefinitionPath(spec), function(defn) {
+    angular.forEach(model.getDefinitionPath(spec), function(defn) {
       var id = 'describe-' + defn.id;
       if (!context.find('#' + id).length) {
         currentContext.find('> .test-children').append(

--- a/src/scenario/output/Xml.js
+++ b/src/scenario/output/Xml.js
@@ -17,7 +17,7 @@ angular.scenario.output('xml', function(context, runner) {
    * @param {Object} tree node to serialize
    */
   function serializeXml(context, tree) {
-     angular.foreach(tree.children, function(child) {
+     angular.forEach(tree.children, function(child) {
        var describeContext = $('<describe></describe>');
        describeContext.attr('id', child.id);
        describeContext.attr('name', child.name);
@@ -26,14 +26,14 @@ angular.scenario.output('xml', function(context, runner) {
      });
      var its = $('<its></its>');
      context.append(its);
-     angular.foreach(tree.specs, function(spec) {
+     angular.forEach(tree.specs, function(spec) {
        var it = $('<it></it>');
        it.attr('id', spec.id);
        it.attr('name', spec.name);
        it.attr('duration', spec.duration);
        it.attr('status', spec.status);
        its.append(it);
-       angular.foreach(spec.steps, function(step) {
+       angular.forEach(spec.steps, function(step) {
          var stepContext = $('<step></step>');
          stepContext.attr('name', step.name);
          stepContext.attr('duration', step.duration);

--- a/src/services.js
+++ b/src/services.js
@@ -369,7 +369,7 @@ angularServiceInject("$log", function($window){
     if (logFn.apply) {
       return function(){
         var args = [];
-        foreach(arguments, function(arg){
+        forEach(arguments, function(arg){
           args.push(formatError(arg));
         });
         return logFn.apply(console, args);
@@ -552,7 +552,7 @@ angularServiceInject("$invalidWidgets", function(){
   /** Return count of all invalid widgets that are currently visible */
   invalidWidgets.visible = function() {
     var count = 0;
-    foreach(invalidWidgets, function(widget){
+    forEach(invalidWidgets, function(widget){
       count = count + (isVisible(widget) ? 1 : 0);
     });
     return count;
@@ -592,7 +592,7 @@ function switchRouteMatcher(on, when, dstName) {
   var regex = '^' + when.replace(/[\.\\\(\)\^\$]/g, "\$1") + '$',
       params = [],
       dst = {};
-  foreach(when.split(/\W/), function(param){
+  forEach(when.split(/\W/), function(param){
     if (param) {
       var paramRegExp = new RegExp(":" + param + "([\\W])");
       if (regex.match(paramRegExp)) {
@@ -603,7 +603,7 @@ function switchRouteMatcher(on, when, dstName) {
   });
   var match = on.match(new RegExp(regex));
   if (match) {
-    foreach(params, function(name, index){
+    forEach(params, function(name, index){
       dst[name] = match[index + 1];
     });
     if (dstName) this.$set(dstName, dst);
@@ -712,7 +712,7 @@ angularServiceInject('$route', function(location) {
   function updateRoute(){
     var childScope;
     $route.current = _null;
-    angular.foreach(routes, function(routeParams, route) {
+    angular.forEach(routes, function(routeParams, route) {
       if (!childScope) {
         var pathParams = matcher(location.hashPath, route);
         if (pathParams) {
@@ -724,7 +724,7 @@ angularServiceInject('$route', function(location) {
         }
       }
     });
-    angular.foreach(onChange, parentScope.$tryEval);
+    angular.forEach(onChange, parentScope.$tryEval);
     if (childScope) {
       childScope.$become($route.current.controller);
     }
@@ -813,7 +813,7 @@ angularServiceInject('$xhr.bulk', function($xhr, $error, $log){
       post = _null;
     }
     var currentQueue;
-    foreach(bulkXHR.urls, function(queue){
+    forEach(bulkXHR.urls, function(queue){
       if (isFunction(queue.match) ? queue.match(url) : queue.match.exec(url)) {
         currentQueue = queue;
       }
@@ -827,13 +827,13 @@ angularServiceInject('$xhr.bulk', function($xhr, $error, $log){
   }
   bulkXHR.urls = {};
   bulkXHR.flush = function(callback){
-    foreach(bulkXHR.urls, function(queue, url){
+    forEach(bulkXHR.urls, function(queue, url){
       var currentRequests = queue.requests;
       if (currentRequests && currentRequests.length) {
         queue.requests = [];
         queue.callbacks = [];
         $xhr('POST', url, {requests:currentRequests}, function(code, response){
-          foreach(response, function(response, i){
+          forEach(response, function(response, i){
             try {
               if (response.status == 200) {
                 (currentRequests[i].callback || noop)(response.status, response.response);
@@ -922,7 +922,7 @@ angularServiceInject('$xhr.cache', function($xhr, $defer){
             cache.data[url] = { value: response };
           var callbacks = inflight[url].callbacks;
           delete inflight[url];
-          foreach(callbacks, function(callback){
+          forEach(callbacks, function(callback){
             try {
               (callback||noop)(status, copy(response));
             } catch(e) {

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -359,15 +359,15 @@ function optionsAccessor(scope, element) {
   return {
     get: function(){
       var values = [];
-      foreach(options, function(option){
+      forEach(options, function(option){
         if (option.selected) values.push(option.value);
       });
       return values;
     },
     set: function(values){
       var keys = {};
-      foreach(values, function(value){ keys[value] = true; });
-      foreach(options, function(option){
+      forEach(values, function(value){ keys[value] = true; });
+      forEach(options, function(option){
         option.selected = keys[option.value];
       });
     }
@@ -698,7 +698,7 @@ var ngSwitch = angularWidget('ng:switch', function (element){
     if (isString(when)) {
       switchCase.when = function(scope, value){
         var args = [value, when];
-        foreach(usingExprParams, function(arg){
+        forEach(usingExprParams, function(arg){
           args.push(arg);
         });
         return usingFn.apply(scope, args);
@@ -711,7 +711,7 @@ var ngSwitch = angularWidget('ng:switch', function (element){
   });
 
   // this needs to be here for IE
-  foreach(cases, function(_case){
+  forEach(cases, function(_case){
     _case.element.remove();
   });
 
@@ -722,7 +722,7 @@ var ngSwitch = angularWidget('ng:switch', function (element){
       var found = false;
       element.html('');
       childScope = createScope(scope);
-      foreach(cases, function(switchCase){
+      forEach(cases, function(switchCase){
         if (!found && switchCase.when(childScope, value)) {
           found = true;
           var caseElement = quickClone(switchCase.element);

--- a/test/BrowserSpecs.js
+++ b/test/BrowserSpecs.js
@@ -7,7 +7,7 @@ describe('browser', function(){
   }
 
   fakeSetTimeout.flush = function() {
-    foreach(setTimeoutQueue, function(fn) {
+    forEach(setTimeoutQueue, function(fn) {
       fn();
     });
   };

--- a/test/angular-mocks.js
+++ b/test/angular-mocks.js
@@ -141,7 +141,7 @@ function MockBrowser() {
 MockBrowser.prototype = {
 
   poll: function poll(){
-    angular.foreach(this.pollFns, function(pollFn){
+    angular.forEach(this.pollFns, function(pollFn){
       pollFn();
     });
   },
@@ -304,7 +304,7 @@ function TzDate(offset, timestamp) {
       'setYear', 'toDateString', 'toJSON', 'toGMTString', 'toLocaleFormat', 'toLocaleString',
       'toLocaleTimeString', 'toSource', 'toString', 'toTimeString', 'toUTCString', 'valueOf'];
 
-  angular.foreach(unimplementedMethods, function(methodName) {
+  angular.forEach(unimplementedMethods, function(methodName) {
     this[methodName] = function() {
       throw {
         name: "MethodNotImplemented",

--- a/test/scenario/RunnerSpec.js
+++ b/test/scenario/RunnerSpec.js
@@ -54,7 +54,7 @@ describe('angular.scenario.Runner', function() {
   });
 
   it('should publish the functions in the public API', function() {
-    angular.foreach(runner.api, function(fn, name) {
+    angular.forEach(runner.api, function(fn, name) {
       var func;
       if (name in $window) {
         func = $window[name];

--- a/test/scenario/dslSpec.js
+++ b/test/scenario/dslSpec.js
@@ -28,7 +28,7 @@ describe("angular.scenario.dsl", function() {
       });
     };
     $root.dsl = {};
-    angular.foreach(angular.scenario.dsl, function(fn, name) {
+    angular.forEach(angular.scenario.dsl, function(fn, name) {
       $root.dsl[name] = function() {
         return fn.call($root).apply($root, arguments);
       };
@@ -281,7 +281,7 @@ describe("angular.scenario.dsl", function() {
       it('should add all jQuery key/value methods', function() {
         var METHODS = ['css', 'attr'];
         var chain = $root.dsl.element('input');
-        angular.foreach(METHODS, function(name) {
+        angular.forEach(METHODS, function(name) {
           expect(angular.isFunction(chain[name])).toBeTruthy();
         });
       });
@@ -316,7 +316,7 @@ describe("angular.scenario.dsl", function() {
           'innerWidth', 'outerWidth', 'position', 'scrollLeft', 'scrollTop', 'offset'
         ];
         var chain = $root.dsl.element('input');
-        angular.foreach(METHODS, function(name) {
+        angular.forEach(METHODS, function(name) {
           expect(angular.isFunction(chain[name])).toBeTruthy();
         });
       });

--- a/test/scenario/mocks.js
+++ b/test/scenario/mocks.js
@@ -35,7 +35,7 @@ angular.scenario.testing.MockRunner.prototype.on = function(eventName, fn) {
   
 angular.scenario.testing.MockRunner.prototype.emit = function(eventName) {
   var args = Array.prototype.slice.call(arguments, 1);
-  angular.foreach(this.listeners[eventName] || [], function(fn) {
+  angular.forEach(this.listeners[eventName] || [], function(fn) {
     fn.apply(this, args);
   });
 };

--- a/test/testabilityPatch.js
+++ b/test/testabilityPatch.js
@@ -56,10 +56,10 @@ afterEach(clearJqCache);
 
 function clearJqCache(){
   var count = 0;
-  foreachSorted(jqCache, function(value, key){
+  forEachSorted(jqCache, function(value, key){
     count ++;
     delete jqCache[key];
-    foreach(value, function(value, key){
+    forEach(value, function(value, key){
       if (value.$element) 
         dump(key, sortedHtml(value.$element));
       else 
@@ -91,7 +91,6 @@ extend(angular, {
   'copy': copy,
   'extend': extend,
   'equals': equals,
-  'foreach': foreach,
   'noop':noop,
   'bind':bind,
   'toJson': toJson,
@@ -106,10 +105,11 @@ extend(angular, {
   'isArray': isArray
 });
 
+angular.forEach = forEach;
 
 function sortedHtml(element, showNgClass) {
   var html = "";
-  foreach(jqLite(element), function toString(node) {
+  forEach(jqLite(element), function toString(node) {
     if (node.nodeName == "#text") {
       html += node.nodeValue.
         replace(/&(\w+[&;\W])?/g, function(match, entity){return entity?match:'&amp;';}).
@@ -155,7 +155,7 @@ function sortedHtml(element, showNgClass) {
       if (node.style) {
         var style = [];
         if (node.style.cssText) {
-          foreach(node.style.cssText.split(';'), function(value){
+          forEach(node.style.cssText.split(';'), function(value){
             value = trim(value);
             if (value) {
               style.push(lowercase(value));
@@ -174,7 +174,7 @@ function sortedHtml(element, showNgClass) {
         style.sort();
         var tmp = style;
         style = [];
-        foreach(tmp, function(value){
+        forEach(tmp, function(value){
           if (!value.match(/^max[^\-]/))
             style.push(value);
         });


### PR DESCRIPTION
Issue #85

There was a problem with extending angular (see: src/AngularPublic.js:38, test/testabilityPatch.js:82), because extend method uses forEach() internally...
If iterated object has method forEach (like Array does), it uses this method, so we can't extend angular with 'forEach' property. This was not causing problems, as JS is case sensitive, so foreach != forEach. I solved this by setting forEach property separately without using extend.
Another solution could be to change extend method to not use forEach, as I hope that for (var k in obj) should be enough...
