### PR TITLE
Scenario runner binding throw

### DIFF
--- a/src/scenario/dsl.js
+++ b/src/scenario/dsl.js
@@ -87,20 +87,20 @@ angular.scenario.dsl('using', function() {
  */
 angular.scenario.dsl('binding', function() {
   function contains(text, value) {
-    return text && text.indexOf(value) >=0;
+    return text && text.indexOf(value) >= 0;
   }
   return function(name) {
     return this.addFutureAction("select binding '" + name + "'", function($window, $document, done) {
       var elements = $document.elements('.ng-binding');
       for ( var i = 0; i < elements.length; i++) {
         var element = new elements.init(elements[i]);
-        if (contains(element.attr('ng:bind'), name) >= 0 ||
-            contains(element.attr('ng:bind-template'), name) >= 0) {
+        if (contains(element.attr('ng:bind'), name) ||
+            contains(element.attr('ng:bind-template'), name)) {
           done(null, element.text());
           return;
         }
       }
-      throw "Could not find binding: " + name;
+      done('Binding selector ' + name + ' did not match.');
     });
   };
 });

--- a/test/scenario/dslSpec.js
+++ b/test/scenario/dslSpec.js
@@ -271,7 +271,19 @@ describe("angular.scenario.dsl", function() {
         expect($root.futureResult).toEqual('foo some baz');
       });
 
-      it('should return error if no binding exists', function() {
+      it('should match bindings by substring match', function() {
+        doc.append('<pre class="ng-binding" ng:bind="foo.bar() && test.baz() | filter">binding value</pre>');
+        $root.dsl.binding('test.baz');
+        expect($root.futureResult).toEqual('binding value');
+      });
+
+      it('should return error if no bindings in document', function() {
+        $root.dsl.binding('foo.bar');
+        expect($root.futureError).toMatch(/did not match/);
+      });
+
+      it('should return error if no binding matches', function() {
+        doc.append('<span class="ng-binding" ng:bind="foo">some value</span>');
         $root.dsl.binding('foo.bar');
         expect($root.futureError).toMatch(/did not match/);
       });


### PR DESCRIPTION
I was wrong about throw being the same as done(error) in a DSL statement. Throw is an "error" and done(error) is a "failure".

Also, there was a test for the binding not matching before, but it tested in a condition where there were no bindings at all in the document in which case elements() in your new binding() would still throw.

I added a new test that checks for bindings existing but none of them matching.

I also fixed an issue where you were using contains() and checking if the return value was >= 0 but the function returns a boolean and false >= 0 is true. I'll code review more carefully next time.
