### PR TITLE
Scenario runner navigate 404

### DIFF
--- a/lib/nodeserver/server.js
+++ b/lib/nodeserver/server.js
@@ -8,10 +8,8 @@ var DEFAULT_PORT = 8000;
 
 function main(argv) {
   new HttpServer({
-    'GET': (function() { 
-      var servlet = new StaticServlet();
-      return servlet.handleRequest.bind(servlet)
-    })()
+    'GET': createServlet(StaticServlet),
+    'HEAD': createServlet(StaticServlet)
   }).start(Number(argv[2]) || DEFAULT_PORT);
 }
 
@@ -20,6 +18,11 @@ function escapeHtml(value) {
     replace('<', '&lt;').
     replace('>', '&gt').
     replace('"', '&quot;');
+}
+
+function createServlet(Class) {
+  var servlet = new Class();
+  return servlet.handleRequest.bind(servlet);
 }
 
 /**
@@ -61,11 +64,10 @@ HttpServer.prototype.handleRequest_ = function(req, res) {
   }
 };
 
-
 /**
  * Handles static content.
  */
-function  StaticServlet() {}
+function StaticServlet() {}
 
 StaticServlet.MimeMap = {
   'txt': 'text/plain',
@@ -164,13 +166,17 @@ StaticServlet.prototype.sendFile_ = function(req, res, path) {
     'Content-Type': StaticServlet.
       MimeMap[path.split('.').pop()] || 'text/plain'
   });
-  file.on('data', res.write.bind(res));
-  file.on('close', function() {
+  if (req.method === 'HEAD') {
     res.end();
-  });
-  file.on('error', function(error) {
-    self.sendError_(req, res, error);
-  });
+  } else {
+    file.on('data', res.write.bind(res));
+    file.on('close', function() {
+      res.end();
+    });
+    file.on('error', function(error) {
+      self.sendError_(req, res, error);
+    });
+  }
 };
 
 StaticServlet.prototype.sendDirectory_ = function(req, res, path) {
@@ -207,6 +213,10 @@ StaticServlet.prototype.writeDirectoryIndex_ = function(req, res, path, files) {
   res.writeHead(200, {
     'Content-Type': 'text/html'
   });
+  if (req.method === 'HEAD') {
+    res.end();
+    return;
+  }
   res.write('<!doctype html>\n');
   res.write('<title>' + escapeHtml(path) + '</title>\n');
   res.write('<style>\n');

--- a/src/scenario/Scenario.js
+++ b/src/scenario/Scenario.js
@@ -1,3 +1,4 @@
+
 /**
  * Setup file for the Scenario.
  * Must be first in the compilation/bootstrap list.

--- a/src/scenario/dsl.js
+++ b/src/scenario/dsl.js
@@ -62,7 +62,7 @@ angular.scenario.dsl('navigateTo', function() {
       }
       application.navigateTo(url, function() {
         done(null, url);
-      });
+      }, done);
     });
   };
 });
@@ -271,7 +271,7 @@ angular.scenario.dsl('element', function() {
       if (href && elements[0].nodeName.toUpperCase() === 'A') {
         this.application.navigateTo(href, function() {
           done();
-        });
+        }, done);
       } else {
         done();
       }

--- a/test/scenario/ApplicationSpec.js
+++ b/test/scenario/ApplicationSpec.js
@@ -1,15 +1,24 @@
 describe('angular.scenario.Application', function() {
   var app, frames;
 
+  function callLoadHandlers(app) {
+    var handlers = app.getFrame_().data('events').load;
+    expect(handlers).toBeDefined();
+    expect(handlers.length).toEqual(1);
+    handlers[0].handler();
+  }
+
   beforeEach(function() {
     frames = _jQuery("<div></div>");
     app = new angular.scenario.Application(frames);
+    app.checkUrlStatus_ = function(url, callback) {
+      callback.call(this);
+    };
   });
 
   it('should return new $window and $document after navigate', function() {
     var called;
     var testWindow, testDocument, counter = 0;
-    app.navigateTo = noop;
     app.getWindow_ = function() {
       return {x:counter++, document:{x:counter++}};
     };
@@ -50,6 +59,31 @@ describe('angular.scenario.Application', function() {
     expect(app.getFrame_().attr('test')).toBeFalsy();
   });
 
+  it('should call error handler if document not accessible', function() {
+    app.getWindow_ = function() {
+      return {};
+    };
+    app.navigateTo('about:blank', angular.noop, function(error) {
+      expect(error).toMatch(/Sandbox Error/);
+    });
+    callLoadHandlers(app);
+  });
+
+  it('should call error handler if using file:// URL', function() {
+    app.navigateTo('file://foo/bar.txt', angular.noop, function(error) {
+      expect(error).toMatch(/Sandbox Error/);
+    });
+  });
+
+  it('should call error handler if status check fails', function() {
+    app.checkUrlStatus_ = function(url, callback) {
+      callback.call(this, 'Example Error');
+    };
+    app.navigateTo('about:blank', angular.noop, function(error) {
+      expect(error).toEqual('Example Error');
+    });
+  });
+
   it('should hide old iframes and navigate to about:blank', function() {
     app.navigateTo('about:blank#foo');
     app.navigateTo('about:blank#bar');
@@ -70,15 +104,12 @@ describe('angular.scenario.Application', function() {
   it('should call onload handler when frame loads', function() {
     var called;
     app.getWindow_ = function() {
-      return {};
+      return {document: {}};
     };
     app.navigateTo('about:blank', function($window, $document) {
       called = true;
     });
-    var handlers = app.getFrame_().data('events').load;
-    expect(handlers).toBeDefined();
-    expect(handlers.length).toEqual(1);
-    handlers[0].handler();
+    callLoadHandlers(app);
     expect(called).toBeTruthy();
   });
 
@@ -112,5 +143,68 @@ describe('angular.scenario.Application', function() {
     expect(polled).toBeTruthy();
     expect(handlers.length).toEqual(1);
     handlers[0]();
+  });
+
+  describe('jQuery ajax', function() {
+    var options;
+    var response;
+    var jQueryAjax;
+
+    beforeEach(function() {
+      response = {
+        status: 200,
+        statusText: 'OK'
+      };
+      jQueryAjax = _jQuery.ajax;
+      _jQuery.ajax = function(opts) {
+        options = opts;
+        opts.complete.call(this, response);
+      };
+      app.checkUrlStatus_ = angular.scenario.Application.
+        prototype.checkUrlStatus_;
+    });
+
+    afterEach(function() {
+      _jQuery.ajax = jQueryAjax;
+    });
+
+    it('should perform a HEAD request to verify file existence', function() {
+      app.navigateTo('http://www.google.com/', angular.noop, angular.noop);
+      expect(options.type).toEqual('HEAD');
+      expect(options.url).toEqual('http://www.google.com/');
+    });
+    
+    it('should call error handler if status code is less than 200', function() {
+      var finished;
+      response.status = 199;
+      response.statusText = 'Error Message';
+      app.navigateTo('about:blank', angular.noop, function(error) {
+        expect(error).toEqual('199 Error Message');
+        finished = true;
+      });
+      expect(finished).toBeTruthy();
+    });
+    
+    it('should call error handler if status code is greater than 299', function() {
+      var finished;
+      response.status = 300;
+      response.statusText = 'Error';
+      app.navigateTo('about:blank', angular.noop, function(error) {
+        expect(error).toEqual('300 Error');
+        finished = true;
+      });
+      expect(finished).toBeTruthy();
+    });
+    
+    it('should call error handler if status code is 0 for sandbox error', function() {
+      var finished;
+      response.status = 0;
+      response.statusText = '';
+      app.navigateTo('about:blank', angular.noop, function(error) {
+        expect(error).toEqual('Sandbox Error: Cannot access about:blank');
+        finished = true;
+      });
+      expect(finished).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
Check if the URL in navigateTo() is going to return a 2xx (success) status code. Now navigateTo() fails tests if navigating to a 404 or a 500. Also display better error messages about sandbox exceptions (cross domain or file://). Better test cases for Application sandbox error handling as well.

Also implements the http HEAD method in the nodeserver for testing.

Note: This new code will behave badly if your server side code modifies state on a http HEAD request. For example, if your app used onetime URL tokens so that a URL could only be visited once the navigateTo() would fail since it would visit the URL twice. The same is true if you naviateTo('delete_something.html') and performed the actual delete on a HEAD request. No well behaved application should do this since it's entirely against the definition of the HEAD http method.
