### PR TITLE
Resource class is shared across $resources

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -58,7 +58,7 @@ ResourceFactory.prototype = {
       return ids;
     }
 
-    function Resource(value){
+    var Resource = function Resource(value){
       copy(value || {}, this);
     }
 


### PR DESCRIPTION
Each time a $resource is defined, the shared Resource class is redefined.  If custom actions were defined on an earlier resource, those actions disappear.  Limiting the scope where Resource is defined prevents this from happening.
