### PR TITLE
Update extensionMap()

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -281,11 +281,18 @@ function inherit(parent, extra) {
 function noop() {}
 function identity($) {return $;}
 function valueFn(value) {return function(){ return value; };}
+
 function extensionMap(angular, name, transform) {
   var extPoint;
   return angular[name] || (extPoint = angular[name] = function (name, fn, prop){
     name = (transform || identity)(name);
     if (isDefined(fn)) {
+      if (isDefined(extPoint[name])) {
+        foreach(extPoint[name], function(property, key) {
+          if (key.charAt(0) == '$' && isUndefined(fn[key]))
+            fn[key] = property;
+        });
+      }
       extPoint[name] = extend(fn, prop || {});
     }
     return extPoint[name];

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -26,8 +26,8 @@ describe("copy", function(){
   it("should return same object", function (){
     var obj = {};
     var arr = [];
-    assertSame(obj, copy({}, obj));
-    assertSame(arr, copy([], arr));
+    expect(copy({}, obj)).toBe(obj);
+    expect(copy([], arr)).toBe(arr);
   });
 
   it("should copy Date", function(){
@@ -40,26 +40,26 @@ describe("copy", function(){
   it("should copy array", function(){
     var src = [1, {name:"value"}];
     var dst = [{key:"v"}];
-    assertSame(dst, copy(src, dst));
-    assertEquals([1, {name:"value"}], dst);
-    assertEquals({name:"value"}, dst[1]);
-    assertNotSame(src[1], dst[1]);
+    expect(copy(src, dst)).toBe(dst);
+    expect(dst).toEqual([1, {name:"value"}]);
+    expect(dst[1]).toEqual({name:"value"});
+    expect(dst[1]).not.toBe(src[1]);
   });
 
   it('should copy empty array', function() {
     var src = [];
     var dst = [{key: "v"}];
-    assertEquals([], copy(src, dst));
-    assertEquals([], dst);
+    expect(copy(src, dst)).toEqual([]);
+    expect(dst).toEqual([]);
   });
 
   it("should copy object", function(){
     var src = {a:{name:"value"}};
     var dst = {b:{key:"v"}};
-    assertSame(dst, copy(src, dst));
-    assertEquals({a:{name:"value"}}, dst);
-    assertEquals(src.a, dst.a);
-    assertNotSame(src.a, dst.a);
+    expect(copy(src, dst)).toBe(dst);
+    expect(dst).toEqual({a:{name:"value"}});
+    expect(dst.a).toEqual(src.a);
+    expect(dst.a).not.toBe(src.a);
   });
 
   it("should copy primitives", function(){

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -300,3 +300,31 @@ describe('extensionMap', function() {
     expect(result.two).not.toBeDefined();
   });
 });
+
+describe('angular service', function() {
+  it('should override services', function() {
+    var scope = createScope();
+    angular.service('fake', function() { return 'old'; });
+    angular.service('fake', function() { return 'new'; });
+    
+    expect(scope.$inject('fake')).toEqual('new');
+  });
+  
+  it('should preserve $ properties on override', function() {
+    angular.service('fake', {$one: true}, {$two: true});
+    var result = angular.service('fake', {$third: true});
+    
+    expect(result.$one).toBeTruthy();
+    expect(result.$two).toBeTruthy();
+    expect(result.$third).toBeTruthy();
+  });
+  
+  it('should not preserve non-angular properties on override', function() {
+    angular.service('fake', {one: true}, {two: true});
+    var result = angular.service('fake', {third: true});
+    
+    expect(result.one).not.toBeDefined();
+    expect(result.two).not.toBeDefined();
+    expect(result.third).toBeTruthy();
+  });
+});

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -280,3 +280,23 @@ describe('angularJsConfig', function() {
                                           ie_compat_id: 'ng-ie-compat'});
   });
 });
+
+describe('extensionMap', function() {
+  it('should preserve $ properties on override', function() {
+    var extension = extensionMap({}, 'fake');
+    extension('first', {$one: true, $two: true});
+    var result = extension('first', {$one: false, $three: true});
+
+    expect(result.$one).toBeFalsy();
+    expect(result.$two).toBeTruthy();
+    expect(result.$three).toBeTruthy();
+  });
+  
+  it('should not preserve non-angular properties', function() {
+    var extension = extensionMap({}, 'fake');
+    extension('first', {two: true});
+    var result = extension('first', {$one: false, $three: true});
+
+    expect(result.two).not.toBeDefined();
+  });
+});


### PR DESCRIPTION
See issue #51

If user override existing extension, angular properties ($) will be preserved.

This piece of logic could be refactored into separate method:
Something like we have extend(), addMissingProperties() - I can't find a name
for this method...
