### PR TITLE
process ISO 8601 formatted date/time strings with date filter

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -194,6 +194,8 @@ angularFilter.date = function(date, format) {
 
   if (isNumber(date)) {
     date = new Date(date);
+  } else if (isString(date) && Date.parse(date)) {
+    date = new Date(date);
   } else if (!(date instanceof Date)) {
     return date;
   }

--- a/src/filters.js
+++ b/src/filters.js
@@ -192,9 +192,10 @@ angularFilter.date = function(date, format) {
     date = parseInt(date, 10);
   }
 
-  if (date && (isNumber(date) || Date.parse(date.toString()))) {
+  if (date instanceof Date) {
+  } else if (date && (isNumber(date) || Date.parse(date.toString()))) {
     date = new Date(date);
-  } else if (!(date instanceof Date)) {
+  } else {
     return date;
   }
 

--- a/src/filters.js
+++ b/src/filters.js
@@ -192,7 +192,7 @@ angularFilter.date = function(date, format) {
     date = parseInt(date, 10);
   }
 
-  if (isNumber(date) || Date.parse(date.toString())) {
+  if (date && (isNumber(date) || Date.parse(date.toString()))) {
     date = new Date(date);
   } else if (!(date instanceof Date)) {
     return date;

--- a/src/filters.js
+++ b/src/filters.js
@@ -192,9 +192,7 @@ angularFilter.date = function(date, format) {
     date = parseInt(date, 10);
   }
 
-  if (isNumber(date)) {
-    date = new Date(date);
-  } else if (isString(date) && Date.parse(date)) {
+  if (isNumber(date) || Date.parse(date.toString())) {
     date = new Date(date);
   } else if (!(date instanceof Date)) {
     return date;

--- a/test/FiltersSpec.js
+++ b/test/FiltersSpec.js
@@ -115,6 +115,10 @@ describe('filter', function(){
       expect(filter.date(noon.getTime() + "")).toEqual(noon.toLocaleDateString());
     });
 
+    it('should be able to parse ISO 8601 dates/times using', function() {
+      expect(filter.date(noon.toISOString())).toEqual(noon.toLocaleDateString());
+    });
+
     it('should accept format', function() {
       expect(filter.date(morning, "yy-MM-dd HH:mm:ss")).
                            toEqual('10-09-03 07:05:08');

--- a/test/angular-mocks.js
+++ b/test/angular-mocks.js
@@ -243,6 +243,10 @@ function TzDate(offset, timestamp) {
     return offset * 60;
   };
 
+  this.toISOString = function() {
+    return this.date.toISOString();
+  };
+
   //hide all methods not implemented in this mock that the Date prototype exposes
   var unimplementedMethods = ['getDay', 'getMilliseconds', 'getTime', 'getUTCDate', 'getUTCDay',
       'getUTCFullYear', 'getUTCHours', 'getUTCMilliseconds', 'getUTCMinutes', 'getUTCMonth',


### PR DESCRIPTION
This actually just uses the parsing that the Date builtin provides.  If it fails to parse the date, behavior does not change.

Tested in FF 3.6 and Chrome 7.0.
