### PR TITLE
Issue #159: fix date filter

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -217,10 +217,16 @@ angularFilter.date = function(date, format) {
   var text = date.toLocaleDateString(), fn;
   if (format && isString(format)) {
     text = '';
-    var parts = [];
+    var parts = [], match;
     while(format) {
-      parts = concat(parts, DATE_FORMATS_SPLIT.exec(format), 1);
-      format = parts.pop();
+      match = DATE_FORMATS_SPLIT.exec(format);
+      if (match) {
+        parts = concat(parts, match, 1);
+        format = parts.pop();
+      } else {
+        parts.push(format);
+        format = null;
+      }
     }
     foreach(parts, function(value){
       fn = DATE_FORMATS[value];

--- a/test/FiltersSpec.js
+++ b/test/FiltersSpec.js
@@ -142,5 +142,9 @@ describe('filter', function() {
       expect(filter.date(isoString)).
           toEqual(angular.String.toDate(isoString).toLocaleDateString());
     });
+
+    it('should parse format ending with non-replaced string', function() {
+      expect(filter.date(morning, 'yy/xxx')).toEqual('10/xxx');
+    });
   });
 });


### PR DESCRIPTION
date.filter was not able to parse format ending with non-replaced strings, like `'dd/mm/non-replaced'`

So now:
    {{1280526317792 | date: 'MM/dd/YY'}}
      -->> 07/30/YY

```
{{1280526317792 | date: 'MM/dd/yy'}}
  -->> 07/30/10
```
