### PR TITLE
Small fixes

### DIFF
--- a/src/angular-mocks.js
+++ b/src/angular-mocks.js
@@ -237,12 +237,14 @@ angular.service('$exceptionHandler', function(e) {
  *
  * See {@link angular.mock} for more info on angular mocks.
  */
-angular.service('$log', function() {
+angular.service('$log', MockLogFactory);
+
+function MockLogFactory() {
   var $log = {
-    log: function(){ $log.logs.push(arguments); },
-    warn: function(){ $log.logs.push(arguments); },
-    info: function(){ $log.logs.push(arguments); },
-    error: function(){ $log.logs.push(arguments); }
+    log: function(){ $log.log.logs.push(arguments); },
+    warn: function(){ $log.warn.logs.push(arguments); },
+    info: function(){ $log.info.logs.push(arguments); },
+    error: function(){ $log.error.logs.push(arguments); }
   };
 
   $log.log.logs = [];
@@ -251,7 +253,7 @@ angular.service('$log', function() {
   $log.error.logs = [];
 
   return $log;
-});
+}
 
 
 /**

--- a/test/angular-mocksSpec.js
+++ b/test/angular-mocksSpec.js
@@ -119,3 +119,46 @@ describe('TzDate', function() {
     expect(date2.getUTCSeconds()).toBe(0);
   });
 });
+
+describe('$log', function() {
+  var $log;
+  beforeEach(function() {
+    $log = MockLogFactory();
+  });
+
+  it('should provide log method', function() {
+    expect(function() { $log.log(''); }).not.toThrow();
+  });
+
+  it('should provide info method', function() {
+    expect(function() { $log.info(''); }).not.toThrow();
+  });
+
+  it('should provide warn method', function() {
+    expect(function() { $log.warn(''); }).not.toThrow();
+  });
+
+  it('should provide error method', function() {
+    expect(function() { $log.error(''); }).not.toThrow();
+  });
+
+  it('should store log messages', function() {
+    $log.log('fake log');
+    expect($log.log.logs).toContain(['fake log']);
+  });
+
+  it('should store info messages', function() {
+    $log.info('fake log');
+    expect($log.info.logs).toContain(['fake log']);
+  });
+
+  it('should store warn messages', function() {
+    $log.warn('fake log');
+    expect($log.warn.logs).toContain(['fake log']);
+  });
+
+  it('should store error messages', function() {
+    $log.error('fake log');
+    expect($log.error.logs).toContain(['fake log']);
+  });
+});

--- a/test/testabilityPatch.js
+++ b/test/testabilityPatch.js
@@ -70,7 +70,7 @@ beforeEach(function(){
           expected = toJson(this.actual);
         }
         return "Expected " + expected + " to be an Error with message " + toJson(message);
-      }
+      };
       return this.actual.name == 'Error' && this.actual.message == message;
     },
 
@@ -83,7 +83,7 @@ beforeEach(function(){
           expected = toJson(this.actual);
         }
         return "Expected " + expected + " to match an Error with message " + toJson(messageRegexp);
-      }
+      };
       return this.actual.name == 'Error' && messageRegexp.test(this.actual.message);
     }
   });


### PR DESCRIPTION
- added two missing semi-colons
- mock $log: fixed bug and added some tests

After that, I realised that MockBrowser uses slightly different structure - instead of factory function it defines classic constructor function which is called with new...
Let me know, if you prefer this way, I can rewrite MockLogFactory using the same approach to keep it consistent...
