### PR TITLE
Rake build needs YAML package

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -180,6 +180,7 @@ end
 
 desc 'Create angular distribution'
 task :package => [:clean, :compile, :docs] do
+  require 'yaml'
   v = YAML::load( File.open( 'version.yaml' ) )['version']
   match = v.match(/^([^-]*)(-snapshot)?$/)
   version = match[1] + (match[2] ? ('-' + %x(git rev-parse HEAD)[0..7]) : '')


### PR DESCRIPTION
Before this, trying to `rake package`, I get (among a bunch of other stuff):

```
rake aborted!
uninitialized constant YAML
/usr/local/google/home/alieuall/src/angular.js/Rakefile:183
(See full trace by running task with --trace)
```

After this, it builds as expected.  I don't know any ruby or rake.  This is just trial-and-error assembling knowledge from internet searches.  The suggested `--trace` doesn't give a lot more info.
