### PR TITLE
Leave trailing slashes in $resource routes in some situations

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -20,16 +20,18 @@ Route.prototype = {
     params = params || {};
     forEach(this.urlParams, function(_, urlParam){
       encodedVal = encodeUriSegment(params[urlParam] || self.defaults[urlParam] || "");
-      url = url.replace(new RegExp(":" + urlParam + "(\\W)"), encodedVal + "$1");
+      if (encodedVal)
+        url = url.replace(new RegExp(":" + urlParam + "(\\W)"), encodedVal + "$1");
+      else
+        url = url.replace(new RegExp("/?:" + urlParam + "(\\W)"), "$1");
     });
-    url = url.replace(/\/?#$/, '');
+    url = url.replace(/#$/, '');
     var query = [];
     forEachSorted(params, function(value, key){
       if (!self.urlParams[key]) {
         query.push(encodeUriQuery(key) + '=' + encodeUriQuery(value));
       }
     });
-    url = url.replace(/\/*$/, '');
     return url + (query.length ? '?' + query.join('&') : '');
   }
 };


### PR DESCRIPTION
This changes how $resource routes are generated by removing the / before an empty URL parameter instead of removing trailing slashes always.
