### PR TITLE
Fix unit test in IE7

### DIFF
--- a/src/angular-mocks.js
+++ b/src/angular-mocks.js
@@ -203,7 +203,9 @@ MockBrowser.prototype = {
       }
       return this.cookieHash;
     }
-  }
+  },
+
+  addJs: function(){}
 };
 
 angular.service('$browser', function(){

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -454,9 +454,8 @@ describe('angular', function(){
         return this.childNodes[1];
       };
 
-      angularInit({autobind: 'child'}, dom);
 
-      delete dom.getElementById; //make IE and sortedHtml happy
+      angularInit({autobind: 'child'}, dom);
 
       expect(sortedHtml(dom)).toEqual('<div foo="{{1+2}}">{{2+3}}' +
                                         '<div bar="7" id="child" ng:bind-attr="{"bar":"{{3+4}}"}">'+

--- a/test/testabilityPatch.js
+++ b/test/testabilityPatch.js
@@ -215,7 +215,7 @@ function sortedHtml(element, showNgClass) {
             attr.name !='style' &&
             attr.name.substr(0, 6) != 'jQuery') {
           // in IE we need to check for all of these.
-          if (!/ng-\d+/.exec(attr.name))
+          if (!/ng-\d+/.exec(attr.name) && attr.name != 'getElementById')
             attrs.push(' ' + attr.name + '="' + attr.value + '"');
         }
       }


### PR DESCRIPTION
This commit fixes 2 tests in IE7, so now all tests pass in IE7, IE8 on my machine.

Unfortunately there is still one test, that is even not executed in IE - there are 810 tests executed in Chrome / FF / Opera, but only 809 tests in IE7 / IE8.
That's problem of JSTD, it silently ignore tests with syntax errors:
http://code.google.com/p/js-test-driver/issues/detail?id=21
