### PR TITLE
fixed opera date.toISOString issue

### DIFF
--- a/src/apis.js
+++ b/src/apis.js
@@ -764,11 +764,13 @@ var angularString = {
 
 var angularDate = {
     'toString':function(date){
-      return !date ?
-                date :
-                date.toISOString ?
-                  date.toISOString() :
-                  padNumber(date.getUTCFullYear(), 4) + '-' +
+       if (!date) return date;
+
+       var isoString = date.toISOString ? date.toISOString() : '';
+
+       return (isoString.length==24) ?
+                isoString :
+                padNumber(date.getUTCFullYear(), 4) + '-' +
                   padNumber(date.getUTCMonth() + 1, 2) + '-' +
                   padNumber(date.getUTCDate(), 2) + 'T' +
                   padNumber(date.getUTCHours(), 2) + ':' +


### PR DESCRIPTION
opera did not implement date.toISOString correctly according to Javascript guideline. 
So we have to change the toString method of angularDate at line 766 of src/apis.js. 
