### PR TITLE
PUT and DELETE requests should have  Content-Type header

### DIFF
--- a/src/Browser.js
+++ b/src/Browser.js
@@ -14,8 +14,9 @@ var XHR_HEADERS = {
     "Accept": "application/json, text/plain, */*",
     "X-Requested-With": "XMLHttpRequest"
   },
-  POST: {'Content-Type': 'application/x-www-form-urlencoded'}
+  NON_GET: {'Content-Type': 'application/x-www-form-urlencoded'}
 };
+XHR_HEADERS.POST = XHR_HEADERS.PUT = XHR_HEADERS.DELETE = XHR_HEADERS.NON_GET
 
 /**
  * @private

--- a/test/BrowserSpecs.js
+++ b/test/BrowserSpecs.js
@@ -144,11 +144,23 @@ describe('browser', function(){
       expect(xhr.headers['Content-Type']).not.toBeDefined();
     });
 
-    it('should set Content-type header for POST requests', function() {
-      browser.xhr('POST', 'URL', 'POST-DATA', function(c, r) {});
+    describe('non GET requests', function(){
+      afterEach(function() {
+        expect(xhr.headers['Content-Type']).toBeDefined();
+        expect(xhr.headers['Content-Type']).toEqual('application/x-www-form-urlencoded');
+      });
 
-      expect(xhr.headers['Content-Type']).toBeDefined();
-      expect(xhr.headers['Content-Type']).toEqual('application/x-www-form-urlencoded');
+      it('should set Content-type header for POST requests', function() {
+        browser.xhr('POST', 'URL', 'POST-DATA', function(c, r) {});
+      });
+
+      it('should set Content-type header for PUT requests', function() {
+        browser.xhr('PUT', 'URL', 'POST-DATA', function(c, r) {});
+      });
+
+      it('should set Content-type header for DELETE requests', function() {
+        browser.xhr('PUT', 'URL', 'POST-DATA', function(c, r) {});
+      });
     });
 
     it('should set default headers for custom methods', function() {


### PR DESCRIPTION
In commit https://github.com/angular/angular.js/commit/9f56af9c15e1096033c91c2619f7f7f0115d0032 you kept "Content-Type": "application/x-www-form-urlencoded" only for POST request. I believe that the idea was to skip it from GET requests, and it should be kept for PUT and DELETE. Otherwise some browsers sent application/xml request what it not correct.
