### PR TITLE
Fix scenario runner on IE7, IE8

### DIFF
--- a/docs/content/cookbook/advancedform.ngdoc
+++ b/docs/content/cookbook/advancedform.ngdoc
@@ -71,8 +71,8 @@ ng:validate="regexp:zip"/><br/><br/>
        <input type="text" name="contact.value" ng:required/>
         [ <a href="" ng:click="form.contacts.$remove(contact)">X</a> ]
      </div>
-   <button ng:click="cancel()" disabled="{{master.$equals(form)}}">Cancel</button>
-   <button ng:click="save()" disabled="{{$invalidWidgets.visible() ||
+   <button ng:click="cancel()" ng:disabled="{{master.$equals(form)}}">Cancel</button>
+   <button ng:click="save()" ng:disabled="{{$invalidWidgets.visible() ||
 master.$equals(form)}}">Save</button>
 
 

--- a/src/markups.js
+++ b/src/markups.js
@@ -236,7 +236,11 @@ angularTextMarkup('option', function(text, textNode, parentElement){
  */
 
 var NG_BIND_ATTR = 'ng:bind-attr';
-var SPECIAL_ATTRS = {'ng:src': 'src', 'ng:href': 'href'};
+var SPECIAL_ATTRS = {};
+forEach('src,href,checked,disabled,multiple,readonly,selected'.split(','), function(name) {
+  SPECIAL_ATTRS['ng:' + name] = name;
+});
+
 angularAttrMarkup('{{}}', function(value, name, element){
   // don't process existing attribute markup
   if (angularDirective(name) || angularDirective("@" + name)) return;

--- a/src/scenario/Application.js
+++ b/src/scenario/Application.js
@@ -58,6 +58,7 @@ angular.scenario.Application.prototype.navigateTo = function(url, loadFn, errorF
     this.executeAction(loadFn);
   } else {
     frame.css('display', 'none').attr('src', 'about:blank');
+    frame.remove();
     this.context.find('#test-frames').append('<iframe>');
     frame = this.getFrame_();
     frame.load(function() {

--- a/src/scenario/dsl.js
+++ b/src/scenario/dsl.js
@@ -180,7 +180,7 @@ angular.scenario.dsl('input', function() {
     return this.addFutureAction("input '" + this.name + "' enter '" + value + "'", function($window, $document, done) {
       var input = $document.elements(':input[name="$1"]', this.name);
       input.val(value);
-      input.trigger('change');
+      input.trigger('keydown');
       done();
     });
   };


### PR DESCRIPTION
I did only remove config attribute from docs-scenario.html (`ng:scenario-output="json"`) as I don't think we want this change. We could use just `html` output, as that's actually the only output being used, but using `json` output wouldn't display any result and scenario runner wouldn't work with JSTD.

Couple of failing tests on both IE7, IE8 had been fixed with that commit.
The issue with input.enter() is fixed.
- add ng:disabled, ng:checked, ng:multiple, ng:readonly, ng:selected
- fetch fixed cookbook/advancedform (use ng:disabled)
- fire keydown instead of change on input
- remove frame when test finishes
