### PR TITLE
Fix failing unit tests in IE7 (Binder, select widget)

### DIFF
--- a/test/CompilerSpec.js
+++ b/test/CompilerSpec.js
@@ -40,7 +40,7 @@ describe('compiler', function(){
       compiler.compile('<div>A</div><span></span>');
     }).toThrow("Cannot compile multiple element roots: " + ie("<div>A</div><span></span>"));
     function ie(text) {
-      return msie && msie < 9 ? uppercase(text) : text;
+      return msie < 9 ? uppercase(text) : text;
     }
   });
 

--- a/test/testabilityPatch.js
+++ b/test/testabilityPatch.js
@@ -223,7 +223,12 @@ function sortedHtml(element, showNgClass) {
             attr.name !='style' &&
             attr.name.substr(0, 6) != 'jQuery') {
           // in IE we need to check for all of these.
-          if (!/ng-\d+/.exec(attr.name) && attr.name != 'getElementById')
+          if (!/ng-\d+/.exec(attr.name) &&
+              attr.name != 'getElementById' &&
+              // IE7 has `selected` in attributes
+              attr.name !='selected' &&
+              // IE7 adds `value` attribute to all LI tags
+              (node.nodeName != 'LI' || attr.name != 'value'))
             attrs.push(' ' + attr.name + '="' + attr.value + '"');
         }
       }


### PR DESCRIPTION
The fix does not change any production code, we only need to ignore couple of attributes that IE7 should not display:
- value attribute for LI
- selected attribut for SELECT

Simplified condition in compiler test, this should have been part of f9f0905f4ad7b1d0bb9b606a6d25fb1f88354a78
