### PR TITLE
fix:SiteMap(docs) in SiteMap.js: SiteMap.xml was wrongly generated

### DIFF
--- a/docs/src/SiteMap.js
+++ b/docs/src/SiteMap.js
@@ -14,7 +14,7 @@ function SiteMap(docs){
     docs.forEach(function(doc){
       map.push(' <url><loc>http://docs.angularjs.org/#!/' +
                             encode(doc.section) + '/' +
-                            encode(doc.name) +
+                            encode(doc.id) +
                      '</loc><changefreq>weekly</changefreq></url>');
     });
     map.push('</urlset>');


### PR DESCRIPTION
doc.id should be used instead of doc.name, otherwise links are wrongly
generated
