### PR TITLE
Fix $browser.xhr (JSONP)

### DIFF
--- a/src/Browser.js
+++ b/src/Browser.js
@@ -37,6 +37,7 @@ var XHR_HEADERS = {
  */
 function Browser(window, document, body, XHR, $log) {
   var self = this,
+      rawDocument = document[0],
       location = window.location,
       setTimeout = window.setTimeout;
 
@@ -96,7 +97,7 @@ function Browser(window, document, body, XHR, $log) {
     outstandingRequestCount ++;
     if (lowercase(method) == 'json') {
       var callbackId = ("angular_" + Math.random() + '_' + (idCounter++)).replace(/\d\./, '');
-      var script = jqLite('<script>')
+      var script = jqLite(rawDocument.createElement('script'))
           .attr({type: 'text/javascript', src: url.replace('JSON_CALLBACK', callbackId)});
       window[callbackId] = function(data){
         window[callbackId] = undefined;
@@ -272,7 +273,6 @@ function Browser(window, document, body, XHR, $log) {
   //////////////////////////////////////////////////////////////
   // Cookies API
   //////////////////////////////////////////////////////////////
-  var rawDocument = document[0];
   var lastCookies = {};
   var lastCookieString = '';
 


### PR DESCRIPTION
Creating &lt;script&gt; tags would require a lot of extra work if we want all browsers
to load and execute these scripts. We decided to not implement that in jqLite.

See #369 for more information.

Closes #369
