### PR TITLE
feat:$xhr: provide access to $xhr header defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - New [ng:disabled], [ng:selected], [ng:checked], [ng:multiple] and [ng:readonly] directives.
 - Added support for string representation of month and day in [date] filter.
 - Added support for `prepend()` to [jqLite].
+- Added support for configurable HTTP header defaults for the [$xhr] service.
 
 
 ### Bug Fixes

--- a/docs/src/templates/docs.js
+++ b/docs/src/templates/docs.js
@@ -15,7 +15,18 @@ function DocsController($location, $browser, $window) {
       self.sectionId = parts[1];
       self.partialId = parts[2] || 'index';
       self.pages = angular.Array.filter(NG_PAGES, {section:self.sectionId});
-      self.partialTitle = (angular.Array.filter(self.pages, function(doc){return doc.id == self.partialId;})[0]||{}).name || 'Error: Page Not Found!';
+
+      var i = self.pages.length;
+      while (i--) {
+        if (self.pages[i].id == self.partialId) {
+          self.partialTitle = self.pages[i].name
+          break;
+        }
+      }
+      if (i<0) {
+        self.partialTitle = 'Error: Page Not Found!';
+        delete self.partialId;
+      }
     }
   });
 
@@ -24,7 +35,7 @@ function DocsController($location, $browser, $window) {
   };
 
   this.getCurrentPartial = function(){
-    return './' + this.sectionId + '/' + this.partialId + '.html';
+    return this.partialId ? ('./' + this.sectionId + '/' + this.partialId + '.html') : '';
   };
 
   this.getClass = function(page) {
@@ -84,26 +95,3 @@ function TutorialInstructionsCtrl($cookieStore) {
     $cookieStore.put('selEnv', id);
   };
 }
-
-/**
- * Display 404 page and suggest new link if possible
- */
-angular.service('$xhr.error', function($location) {
-  function suggestLink(wrongLink) {
-    var link = wrongLink.replace(/^!\/?/, '');
-
-    if (link.match(/^angular/)) return 'api/' + link;
-    else if (link.match(/^cookbook/)) return link.replace('cookbook.', 'cookbook/');
-  }
-
-  return function(request, response) {
-    var suggestion = suggestLink($location.hashPath),
-        HTML_404 = '<h1>Error: Page Not Found</h1>' +
-                   '<p>Sorry this page has not been found.</p>';
-
-    if (suggestion)
-      HTML_404 += '<p>Looks like you are using an old link. Please update your bookmark to: <a href="#!/' + suggestion + '">' + suggestion + '</a></p>';
-
-    request.callback(200, HTML_404);
-  };
-});

--- a/docs/src/templates/offline.html
+++ b/docs/src/templates/offline.html
@@ -1,4 +1,4 @@
 <h2>OFFLINE</h2>
 
-<p>This page if unavailable because your are offline.</p>
+<p>This page is currently unavailable because your are offline.</p>
 <p>Please connect to the Internet and reload the page.</p>

--- a/src/Browser.js
+++ b/src/Browser.js
@@ -8,14 +8,6 @@ var XHR = window.XMLHttpRequest || function () {
   throw new Error("This browser does not support XMLHttpRequest.");
 };
 
-// default xhr headers
-var XHR_HEADERS = {
-  DEFAULT: {
-    "Accept": "application/json, text/plain, */*",
-    "X-Requested-With": "XMLHttpRequest"
-  },
-  POST: {'Content-Type': 'application/x-www-form-urlencoded'}
-};
 
 /**
  * @private
@@ -108,8 +100,7 @@ function Browser(window, document, body, XHR, $log) {
     } else {
       var xhr = new XHR();
       xhr.open(method, url, true);
-      forEach(extend({}, XHR_HEADERS.DEFAULT, XHR_HEADERS[uppercase(method)] || {}, headers || {}),
-        function(value, key) {
+      forEach(headers, function(value, key) {
           if (value) xhr.setRequestHeader(key, value);
       });
       xhr.onreadystatechange = function() {

--- a/src/apis.js
+++ b/src/apis.js
@@ -581,14 +581,14 @@ var angularArray = {
                                   {name:'Adam', phone:'555-5678', age:35},
                                   {name:'Julie', phone:'555-8765', age:29}]"></div>
 
-         <pre>Sorting predicate = {{predicate}} reverse = {{reverse}}</pre>
+         <pre>Sorting predicate = {{predicate}}; reverse = {{reverse}}</pre>
          <hr/>
          [ <a href="" ng:click="predicate=''">unsorted</a> ]
          <table ng:init="predicate='-age'">
            <tr>
              <th><a href="" ng:click="predicate = 'name'; reverse=false">Name</a>
                  (<a href ng:click="predicate = '-name'; reverse=false">^</a>)</th>
-             <th><a href="" ng:click="predicate = 'phone'; reverse=!reverse">Phone</a></th>
+             <th><a href="" ng:click="predicate = 'phone'; reverse=!reverse">Phone Number</a></th>
              <th><a href="" ng:click="predicate = 'age'; reverse=!reverse">Age</a></th>
            <tr>
            <tr ng:repeat="friend in friends.$orderBy(predicate, reverse)">
@@ -600,7 +600,7 @@ var angularArray = {
        </doc:source>
        <doc:scenario>
          it('should be reverse ordered by aged', function() {
-           expect(binding('predicate')).toBe('Sorting predicate = -age');
+           expect(binding('predicate')).toBe('Sorting predicate = -age; reverse = ');
            expect(repeater('.doc-example-live table', 'friend in friends').column('friend.age')).
              toEqual(['35', '29', '21', '19', '10']);
            expect(repeater('.doc-example-live table', 'friend in friends').column('friend.name')).

--- a/test/BrowserSpecs.js
+++ b/test/BrowserSpecs.js
@@ -100,31 +100,6 @@ describe('browser', function(){
       });
     });
 
-    it('should set headers for all requests', function(){
-      var code, response, headers = {};
-      browser.xhr('GET', 'URL', 'POST', function(c,r){
-        code = c;
-        response = r;
-      }, {'X-header': 'value'});
-
-      expect(xhr.method).toEqual('GET');
-      expect(xhr.url).toEqual('URL');
-      expect(xhr.post).toEqual('POST');
-      expect(xhr.headers).toEqual({
-        "Accept": "application/json, text/plain, */*",
-        "X-Requested-With": "XMLHttpRequest",
-        "X-header":"value"
-      });
-
-      xhr.status = 202;
-      xhr.responseText = 'RESPONSE';
-      xhr.readyState = 4;
-      xhr.onreadystatechange();
-
-      expect(code).toEqual(202);
-      expect(response).toEqual('RESPONSE');
-    });
-
     it('should normalize IE\'s 1223 status code into 204', function() {
       var callback = jasmine.createSpy('XHR');
 
@@ -138,24 +113,28 @@ describe('browser', function(){
       expect(callback.argsForCall[0][0]).toEqual(204);
     });
 
-    it('should not set Content-type header for GET requests', function() {
-      browser.xhr('GET', 'URL', 'POST-DATA', function(c, r) {});
+    it('should set only the requested headers', function() {
+      var code, response, headers = {};
+      browser.xhr('POST', 'URL', null, function(c,r){
+        code = c;
+        response = r;
+      }, {'X-header1': 'value1', 'X-header2': 'value2'});
 
-      expect(xhr.headers['Content-Type']).not.toBeDefined();
-    });
+      expect(xhr.method).toEqual('POST');
+      expect(xhr.url).toEqual('URL');
+      expect(xhr.post).toEqual('');
+      expect(xhr.headers).toEqual({
+        "X-header1":"value1",
+        "X-header2":"value2"
+      });
 
-    it('should set Content-type header for POST requests', function() {
-      browser.xhr('POST', 'URL', 'POST-DATA', function(c, r) {});
+      xhr.status = 202;
+      xhr.responseText = 'RESPONSE';
+      xhr.readyState = 4;
+      xhr.onreadystatechange();
 
-      expect(xhr.headers['Content-Type']).toBeDefined();
-      expect(xhr.headers['Content-Type']).toEqual('application/x-www-form-urlencoded');
-    });
-
-    it('should set default headers for custom methods', function() {
-      browser.xhr('CUSTOM', 'URL', 'POST-DATA', function(c, r) {});
-
-      expect(xhr.headers['Accept']).toEqual('application/json, text/plain, */*');
-      expect(xhr.headers['X-Requested-With']).toEqual('XMLHttpRequest');
+      expect(code).toEqual(202);
+      expect(response).toEqual('RESPONSE');
     });
   });
 

--- a/test/service/xhrSpec.js
+++ b/test/service/xhrSpec.js
@@ -102,6 +102,131 @@ describe('$xhr', function() {
     expect(response).toEqual([1, 'abc', {foo:'bar'}]);
   });
 
+
+  describe('http headers', function() {
+
+    describe('default headers', function() {
+
+      it('should set default headers for GET request', function(){
+        var callback = jasmine.createSpy('callback');
+
+        $browserXhr.expectGET('URL', '', {'Accept': 'application/json, text/plain, */*',
+                                          'X-Requested-With': 'XMLHttpRequest'}).
+                    respond(234, 'OK');
+
+        $xhr('GET', 'URL', callback);
+        $browserXhr.flush();
+        expect(callback).toHaveBeenCalled();
+      });
+
+
+      it('should set default headers for POST request', function(){
+        var callback = jasmine.createSpy('callback');
+
+        $browserXhr.expectPOST('URL', 'xx', {'Accept': 'application/json, text/plain, */*',
+                                             'X-Requested-With': 'XMLHttpRequest',
+                                             'Content-Type': 'application/x-www-form-urlencoded'}).
+                    respond(200, 'OK');
+
+        $xhr('POST', 'URL', 'xx', callback);
+        $browserXhr.flush();
+        expect(callback).toHaveBeenCalled();
+      });
+
+
+      it('should set default headers for custom HTTP method', function(){
+        var callback = jasmine.createSpy('callback');
+
+        $browserXhr.expect('FOO', 'URL', '', {'Accept': 'application/json, text/plain, */*',
+                                              'X-Requested-With': 'XMLHttpRequest'}).
+                    respond(200, 'OK');
+
+        $xhr('FOO', 'URL', callback);
+        $browserXhr.flush();
+        expect(callback).toHaveBeenCalled();
+      });
+
+
+      describe('custom headers', function() {
+
+        it('should allow appending a new header to the common defaults', function() {
+          var callback = jasmine.createSpy('callback');
+
+          $browserXhr.expectGET('URL', '', {'Accept': 'application/json, text/plain, */*',
+                                            'X-Requested-With': 'XMLHttpRequest',
+                                            'Custom-Header': 'value'}).
+                      respond(200, 'OK');
+
+          $xhr.defaults.headers.common['Custom-Header'] = 'value';
+          $xhr('GET', 'URL', callback);
+          $browserXhr.flush();
+          expect(callback).toHaveBeenCalled();
+          callback.reset();
+
+          $browserXhr.expectPOST('URL', 'xx', {'Accept': 'application/json, text/plain, */*',
+                                               'X-Requested-With': 'XMLHttpRequest',
+                                               'Content-Type': 'application/x-www-form-urlencoded',
+                                               'Custom-Header': 'value'}).
+                      respond(200, 'OK');
+
+         $xhr('POST', 'URL', 'xx', callback);
+         $browserXhr.flush();
+         expect(callback).toHaveBeenCalled();
+        });
+
+
+        it('should allow appending a new header to a method specific defaults', function() {
+          var callback = jasmine.createSpy('callback');
+
+          $browserXhr.expectGET('URL', '', {'Accept': 'application/json, text/plain, */*',
+                                            'X-Requested-With': 'XMLHttpRequest',
+                                            'Content-Type': 'application/json'}).
+                      respond(200, 'OK');
+
+          $xhr.defaults.headers.get['Content-Type'] = 'application/json';
+          $xhr('GET', 'URL', callback);
+          $browserXhr.flush();
+          expect(callback).toHaveBeenCalled();
+          callback.reset();
+
+          $browserXhr.expectPOST('URL', 'x', {'Accept': 'application/json, text/plain, */*',
+                                              'X-Requested-With': 'XMLHttpRequest',
+                                              'Content-Type': 'application/x-www-form-urlencoded'}).
+                      respond(200, 'OK');
+
+         $xhr('POST', 'URL', 'x', callback);
+         $browserXhr.flush();
+         expect(callback).toHaveBeenCalled();
+        });
+
+
+        it('should support overwriting and deleting default headers', function() {
+          var callback = jasmine.createSpy('callback');
+
+          $browserXhr.expectGET('URL', '', {'Accept': 'application/json, text/plain, */*'}).
+                      respond(200, 'OK');
+
+          //delete a default header
+          delete $xhr.defaults.headers.common['X-Requested-With'];
+          $xhr('GET', 'URL', callback);
+          $browserXhr.flush();
+          expect(callback).toHaveBeenCalled();
+          callback.reset();
+
+          $browserXhr.expectPOST('URL', 'xx', {'Accept': 'application/json, text/plain, */*',
+                                               'Content-Type': 'application/json'}).
+                      respond(200, 'OK');
+
+         //overwrite a default header
+         $xhr.defaults.headers.post['Content-Type'] = 'application/json';
+         $xhr('POST', 'URL', 'xx', callback);
+         $browserXhr.flush();
+         expect(callback).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
   describe('xsrf', function(){
     it('should copy the XSRF cookie into a XSRF Header', function(){
       var code, response;


### PR DESCRIPTION
$xhr header defaults are now exposed as $xhr.defaults.headers.common and
$xhr.default.headers.<httpmethod>. This allows applications to configure
their defaults as needed.

This commit doesn't allow headers to be set per request, only per
application. Per request change would require api change, which I tried
to avoid _for now_.
