### PR TITLE
doc:$route: Fix $route example and couple of typos in docs

### DIFF
--- a/docs/examples/book.html
+++ b/docs/examples/book.html
@@ -1,0 +1,2 @@
+controller: {{name}}<br />
+Book Id: {{params.bookId}}<br />

--- a/docs/examples/chapter.html
+++ b/docs/examples/chapter.html
@@ -1,0 +1,3 @@
+controller: {{name}}<br />
+Book Id: {{prams.bookId}}<br />
+Chapter Id: {{params.chapterId}}

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -13,8 +13,8 @@
  * * {@link angular.formatter.index index} - Manages indexing into an HTML select widget
  * * {@link angular.formatter.json json} - Formats user input in JSON format
  * * {@link angular.formatter.list list} - Formats user input string as an array
- * * {@link angular.formatter.number} - Formats user input strings as a number
- * * {@link angular.formatter.trim} - Trims extras spaces from end of user input
+ * * {@link angular.formatter.number number} - Formats user input strings as a number
+ * * {@link angular.formatter.trim trim} - Trims extras spaces from end of user input
  *
  * For more information about how angular formatters work, and how to create your own formatters,
  * see {@link guide/dev_guide.templates.formatters Understanding Angular Formatters} in the angular

--- a/src/service/route.js
+++ b/src/service/route.js
@@ -22,13 +22,16 @@
     <doc:example>
       <doc:source>
         <script>
-          angular.service('myApp', function($route) {
-            $route.when('/Book/:bookId', {template:'rsrc/book.html', controller:BookCntl});
-            $route.when('/Book/:bookId/ch/:chapterId', {template:'rsrc/chapter.html', controller:ChapterCntl});
+          function MainCntl($route, $location) {
+            this.$route = $route;
+            this.$location = $location;
+
+            $route.when('/Book/:bookId', {template: 'examples/book.html', controller: BookCntl});
+            $route.when('/Book/:bookId/ch/:chapterId', {template: 'examples/chapter.html', controller: ChapterCntl});
             $route.onChange(function() {
               $route.current.scope.params = $route.current.params;
             });
-          }, {$inject: ['$route']});
+          }
 
           function BookCntl() {
             this.name = "BookCntl";
@@ -39,18 +42,19 @@
           }
         </script>
 
-        Chose:
-        <a href="#/Book/Moby">Moby</a> |
-        <a href="#/Book/Moby/ch/1">Moby: Ch1</a> |
-        <a href="#/Book/Gatsby">Gatsby</a> |
-        <a href="#/Book/Gatsby/ch/4?key=value">Gatsby: Ch4</a><br/>
-        <input type="text" name="$location.hashPath" size="80" />
-        <pre>$location={{$location}}</pre>
-        <pre>$route.current.template={{$route.current.template}}</pre>
-        <pre>$route.current.params={{$route.current.params}}</pre>
-        <pre>$route.current.scope.name={{$route.current.scope.name}}</pre>
-        <hr/>
-        <ng:include src="$route.current.template" scope="$route.current.scope"/>
+        <div ng:controller="MainCntl">
+          Choose:
+          <a href="#/Book/Moby">Moby</a> |
+          <a href="#/Book/Moby/ch/1">Moby: Ch1</a> |
+          <a href="#/Book/Gatsby">Gatsby</a> |
+          <a href="#/Book/Gatsby/ch/4?key=value">Gatsby: Ch4</a><br/>
+          $location.hashPath: <input type="text" name="$location.hashPath" size="80" />
+          <pre>$route.current.template = {{$route.current.template}}</pre>
+          <pre>$route.current.params = {{$route.current.params}}</pre>
+          <pre>$route.current.scope.name = {{$route.current.scope.name}}</pre>
+          <hr />
+          <ng:view></ng:view>
+        </div>
       </doc:source>
       <doc:scenario>
       </doc:scenario>

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -597,9 +597,9 @@ angularWidget('button', inputWidgetSelector);
  * @param {comprehension_expression} comprehension _expresion_ `for` _item_ `in` _array_.
  *
  *   * _array_: an expression which evaluates to an array of objects to bind.
- *   * _item_: local variable which will reffer to the item in the _array_ during the itteration
- *   * _expression_: The result of this expression will is `option` label. The
- *        `expression` most likely reffers to the _item_ varibale.
+ *   * _item_: local variable which will refer to the item in the _array_ during the iteration
+ *   * _expression_: The result of this expression will be `option` label. The
+ *        `expression` most likely refers to the _item_ variable.
  *
  * @example
     <doc:example>


### PR DESCRIPTION
Rewrite $route example a bit, as it required $location and $route services
to be eager published in the root scope.

Add missing partials (move them to docs/examples directory)

Fix small typos in formatter and ng:options docs.
