### PR TITLE
fix:bootstrap: Fix bootstrap on IE<8

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -959,7 +959,7 @@ function angularJsConfig(document, config) {
     match = (scripts[j].src || "").match(rngScript);
     if (match) {
       config.base_url = match[1];
-      config.ie_compat = match[1] + 'angular-ie-compat' + (match[2] || '') + '.js';
+      config.ie_compat = 'angular-ie-compat' + (match[2] || '') + '.js';
       extend(config, parseKeyValue(match[6]));
       eachAttribute(jqLite(scripts[j]), function(value, name){
         if (/^ng:/.exec(name)) {

--- a/src/angular-bootstrap.js
+++ b/src/angular-bootstrap.js
@@ -150,10 +150,12 @@
     // empty the cache to prevent mem leaks
     globalVars = {};
 
-    //angular-ie-compat.js needs to be pregenerated for development with IE<8
-    if (msie<8) addScript('../angular-ie-compat.js');
+    var config = angularJsConfig(document);
 
-    angularInit(angularJsConfig(document), document);
+    // angular-ie-compat.js needs to be pregenerated for development with IE<8
+    config.ie_compat = '../build/angular-ie-compat.js';
+
+    angularInit(config, document);
   }
 
   if (window.addEventListener){


### PR DESCRIPTION
No reason for including ie-compat in bootstrap, it's included during angularInit.

Fix including ie-compat even for production.
