### PR TITLE
fix(bootstrap): fix bootstrap on IE<8 and including ie-compat.js

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -944,7 +944,7 @@ function angularInit(config, document){
     if (config.css)
       $browser.addCss(config.base_url + config.css);
     else if(msie<8)
-      $browser.addJs(config.base_url + config.ie_compat, config.ie_compat_id);
+      $browser.addJs(config.ie_compat, config.ie_compat_id);
   }
 }
 

--- a/src/angular-bootstrap.js
+++ b/src/angular-bootstrap.js
@@ -150,10 +150,12 @@
     // empty the cache to prevent mem leaks
     globalVars = {};
 
-    //angular-ie-compat.js needs to be pregenerated for development with IE<8
-    if (msie<8) addScript('../angular-ie-compat.js');
+    var config = angularJsConfig(document);
 
-    angularInit(angularJsConfig(document), document);
+    // angular-ie-compat.js needs to be pregenerated for development with IE<8
+    config.ie_compat = serverPath + '../build/angular-ie-compat.js';
+
+    angularInit(config, document);
   }
 
   if (window.addEventListener){


### PR DESCRIPTION
No reason for including ie-compat in bootstrap, it's included during angularInit.

Fix including ie-compat even for production.
