### PR TITLE
doc(tutorial): fix navigation widget to work without jQuery

### DIFF
--- a/docs/src/templates/doc_widgets.js
+++ b/docs/src/templates/doc_widgets.js
@@ -146,8 +146,9 @@
     this.descend(true);
 
     var tabs = angular.element(HTML_TPL.replace('{show}', element.attr('show') || 'false')),
-        nav = tabs.find('.tabs-nav ul'),
-        content = tabs.find('.tabs-content-inner'),
+        nav = tabs.find('ul'),
+        // jqLite finds only by tag name
+        content = tabs.find('div').find('div'),
         children = element.children();
 
     if (children.length) {


### PR DESCRIPTION
jqLite doesn't support class selectors, can find only by tag name...
