### PR TITLE
fix(docs): fix qfs.read() encoding issue

### DIFF
--- a/docs/src/reader.js
+++ b/docs/src/reader.js
@@ -24,7 +24,7 @@ function collect() {
       var work;
       if(/\.js$/.test(file)) {
         console.log("reading " + file + ".......");
-        work = Q.when(qfs.read(file), function(content) {
+        work = Q.when(qfs.read(file, 'b'), function(content) {
           processJsFile(content, file).forEach (function(doc) {
             allDocs.push(doc);
           });
@@ -45,7 +45,7 @@ function collect() {
        var work2;
        if (file.match(/\.ngdoc$/)) {
          console.log("reading " + file + ".......");
-         work2 = Q.when(qfs.read(file), function(content){
+         work2 = Q.when(qfs.read(file, 'b'), function(content){
             var section = '@section ' + file.split('/')[2] + '\n';
             allDocs.push(new ngdoc.Doc(section + content.toString(),file, 1).parse());
           });

--- a/docs/src/writer.js
+++ b/docs/src/writer.js
@@ -83,7 +83,7 @@ function merge(srcs, to) {
   srcs.forEach(function (src) {
     done = Q.when(done, function(content) {
       if(content) contents.push(content);
-      return qfs.read(src);
+      return qfs.read(src, 'b');
     });
   });
 


### PR DESCRIPTION
- must use binary reading when using read function in q-fs module
  otherwise some unicode character may be garbled.
