### PR TITLE
refactor(angular): removed unnecessary parameter for slice function

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -793,11 +793,11 @@ function elementError(element, type, error) {
 }
 
 function concat(array1, array2, index) {
-  return array1.concat(slice.call(array2, index, array2.length));
+  return array1.concat(slice.call(array2, index));
 }
 
 function sliceArgs(args, startIndex) {
-  return slice.call(args, startIndex || 0, args.length);
+  return slice.call(args, startIndex || 0);
 }
 
 
@@ -823,7 +823,7 @@ function bind(self, fn) {
     return curryArgs.length
       ? function() {
           return arguments.length
-            ? fn.apply(self, curryArgs.concat(slice.call(arguments, 0, arguments.length)))
+            ? fn.apply(self, curryArgs.concat(slice.call(arguments, 0)))
             : fn.apply(self, curryArgs);
         }
       : function() {

--- a/src/parser.js
+++ b/src/parser.js
@@ -744,7 +744,7 @@ function getterFn(path) {
               ' t = angular.Global.typeOf(l);\n' +
               ' fn = (angular[t.charAt(0).toUpperCase() + t.substring(1)]||{})["' + name + '"];\n' +
               ' if (fn) s = function(){ return fn.apply(l, ' +
-                   '[l].concat(Array.prototype.slice.call(arguments, 0, arguments.length))); };\n' +
+                   '[l].concat(Array.prototype.slice.call(arguments, 0))); };\n' +
               '}\n';
     }
   });


### PR DESCRIPTION
- the end index for slice, if not specified, is default to the
  end of the array it operates on.
