### PR TITLE
Exposing response headers for the current xhr codebase.

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -104,7 +104,7 @@ ResourceFactory.prototype = {
           action.method,
           route.url(extend({}, action.params || {}, extractParams(data), params)),
           data,
-          function(status, response) {
+          function(status, response, responseHeaders) {
             if (response) {
               if (action.isArray) {
                 value.length = 0;
@@ -115,7 +115,7 @@ ResourceFactory.prototype = {
                 copy(response, value);
               }
             }
-            (success||noop)(value);
+            (success||noop)(value, responseHeaders);
           },
           error || action.verifyCache,
           action.verifyCache);

--- a/src/angular-mocks.js
+++ b/src/angular-mocks.js
@@ -152,7 +152,13 @@ function MockBrowser() {
           throw new Error("Missing HTTP request header: " + key + ": " + value);
         }
       });
-      callback(expectation.code, expectation.response);
+      callback(expectation.code, expectation.response, function(header) {
+        if (header) {
+          return expectation.responseHeaders && expectation.responseHeaders[header] || null;
+        } else {
+          return expectation.responseHeaders || {};
+        }
+      });
     });
   };
   self.xhr.expectations = expectations;
@@ -162,12 +168,18 @@ function MockBrowser() {
     if (data && angular.isString(data)) url += "|" + data;
     var expect = expectations[method] || (expectations[method] = {});
     return {
-      respond: function(code, response) {
+      respond: function(code, response, responseHeaders) {
         if (!angular.isNumber(code)) {
+          headers = response;
           response = code;
           code = 200;
         }
-        expect[url] = {code:code, response:response, headers: headers || {}};
+        expect[url] = {
+          code: code,
+          response: response,
+          headers: headers || {},
+          responseHeaders: responseHeaders || {}
+        };
       }
     };
   };

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -147,8 +147,10 @@
  *
    <pre>
      var User = $resource('/user/:userId', {userId:'@id'});
-     User.get({userId:123}, function(u){
+     User.get({userId:123}, function(u, responseHeaders){
        u.abc = true;
+       u.encoding = responseHeaders('Content-Encoding');
+       u.allHeaders = responseHeaders();
        u.$save();
      });
    </pre>

--- a/src/service/xhr.bulk.js
+++ b/src/service/xhr.bulk.js
@@ -48,13 +48,14 @@ angularServiceInject('$xhr.bulk', function($xhr, $error, $log){
         queue.requests = [];
         queue.callbacks = [];
         $xhr('POST', url, {requests: currentRequests},
-          function(code, response) {
+          function(code, response, responseHeaders) {
             forEach(response, function(response, i) {
               try {
                 if (response.status == 200) {
-                  (currentRequests[i].success || noop)(response.status, response.response);
+                  (currentRequests[i].success || noop)
+                      (response.status, response.response, responseHeaders);
                 } else if (isFunction(currentRequests[i].error)) {
-                    currentRequests[i].error(response.status, response.response);
+                    currentRequests[i].error(response.status, response.response, responseHeaders);
                 } else {
                   $error(currentRequests[i], response);
                 }
@@ -64,11 +65,11 @@ angularServiceInject('$xhr.bulk', function($xhr, $error, $log){
             });
             (success || noop)();
           },
-          function(code, response) {
+          function(code, response, responseHeaders) {
             forEach(currentRequests, function(request, i) {
               try {
                 if (isFunction(request.error)) {
-                  request.error(code, response);
+                  request.error(code, response, responseHeaders);
                 } else {
                   $error(request, response);
                 }

--- a/src/service/xhr.js
+++ b/src/service/xhr.js
@@ -96,7 +96,7 @@
  *   angular generated callback function.
  * @param {(string|Object)=} post Request content as either a string or an object to be stringified
  *   as JSON before sent to the server.
- * @param {function(number, (string|Object))} success A function to be called when the response is
+ * @param {function(number, (string|Object), Function)} success A function to be called when the response is
  *   received. The success function will be called with:
  *
  *   - {number} code [HTTP status code](http://en.wikipedia.org/wiki/List_of_HTTP_status_codes) of
@@ -104,6 +104,9 @@
  *     {@link angular.service.$xhr.error} service (or custom error callback).
  *   - {string|Object} response Response object as string or an Object if the response was in JSON
  *     format.
+ *   - {function(string=)} responseHeaders A function that when called with a {string} header name,
+ *     returns the value of that header or null if it does not exist; when called without
+ *     arguments, returns an object containing every response header
  * @param {function(number, (string|Object))} error A function to be called if the response code is
  *   not 2xx.. Accepts the same arguments as success, above.
  *
@@ -170,7 +173,7 @@ angularServiceInject('$xhr', function($browser, $error, $log, $updateView){
       post = toJson(post);
     }
 
-    $browser.xhr(method, url, post, function(code, response){
+    $browser.xhr(method, url, post, function(code, response, responseHeaders){
       try {
         if (isString(response)) {
           if (response.match(/^\)\]\}',\n/)) response=response.substr(6);
@@ -179,9 +182,9 @@ angularServiceInject('$xhr', function($browser, $error, $log, $updateView){
           }
         }
         if (200 <= code && code < 300) {
-          success(code, response);
+          success(code, response, responseHeaders);
         } else if (isFunction(error)) {
-          error(code, response);
+          error(code, response, responseHeaders);
         } else {
           $error(
             {method: method, url: url, data: post, success: success},

--- a/test/BrowserSpecs.js
+++ b/test/BrowserSpecs.js
@@ -49,6 +49,13 @@ describe('browser', function(){
       this.send = function(post){
         xhr.post = post;
       };
+      this.getResponseHeader = function(header) {
+        return header;
+      };
+      this.getAllResponseHeaders = function() {
+        return 'Content-Type: application/json\n\rContent-Encoding: gzip';
+      }
+      
     };
 
     logs = {log:[], warn:[], info:[], error:[]};
@@ -143,6 +150,33 @@ describe('browser', function(){
 
       expect(code).toEqual(202);
       expect(response).toEqual('RESPONSE');
+    });
+
+    describe('response headers', function() {
+      it('should return a single response header', function() {
+        browser.xhr('GET', 'URL', null, function(code, resp, headers) {
+          expect(headers('A-Header')).toEqual('A-Header');
+        });
+        
+        xhr.status = 200;
+        xhr.responseText = 'RESPONSE';
+        xhr.readyState = 4;
+        xhr.onreadystatechange();
+      });
+
+      it('should return an object containing all response headers', function() {
+        browser.xhr('GET', 'URL', null, function(code, resp, headers) {
+          expect(headers()).toEqual({
+            'Content-Type': 'application/json',
+            'Content-Encoding': 'gzip'
+          });
+        });
+
+        xhr.status = 200;
+        xhr.responseText = 'RESPONSE';
+        xhr.readyState = 4;
+        xhr.onreadystatechange();
+      });
     });
   });
 

--- a/test/ResourceSpec.js
+++ b/test/ResourceSpec.js
@@ -83,7 +83,8 @@ describe("resource", function() {
     expect(callback).not.toHaveBeenCalled();
     xhr.flush();
     nakedExpect(cc).toEqual({id:123, name:'misko'});
-    expect(callback).toHaveBeenCalledWith(cc);
+    expect(callback.mostRecentCall.args[0]).toEqual(cc);
+    expect(callback.mostRecentCall.args[1]()).toEqual({});
   });
 
   it("should read resource", function(){
@@ -94,7 +95,8 @@ describe("resource", function() {
     expect(callback).not.toHaveBeenCalled();
     xhr.flush();
     nakedExpect(cc).toEqual({id:123, number:'9876'});
-    expect(callback).toHaveBeenCalledWith(cc);
+    expect(callback.mostRecentCall.args[0]).toEqual(cc);
+    expect(callback.mostRecentCall.args[1]()).toEqual({});
   });
 
   it("should read partial resource", function(){
@@ -108,7 +110,8 @@ describe("resource", function() {
     expect(cc.number).not.toBeDefined();
     cc.$get(callback);
     xhr.flush();
-    expect(callback).toHaveBeenCalledWith(cc);
+    expect(callback.mostRecentCall.args[0]).toEqual(cc);
+    expect(callback.mostRecentCall.args[1]()).toEqual({});
     expect(cc.number).toEqual('9876');
   });
 
@@ -129,7 +132,8 @@ describe("resource", function() {
     expect(callback).not.toHaveBeenCalled();
     xhr.flush();
     nakedExpect(ccs).toEqual([{id:1}, {id:2}]);
-    expect(callback).toHaveBeenCalledWith(ccs);
+    expect(callback.mostRecentCall.args[0]).toEqual(ccs);
+    expect(callback.mostRecentCall.args[1]()).toEqual({});
   });
 
   it("should have all arguments optional", function(){
@@ -147,14 +151,16 @@ describe("resource", function() {
     CreditCard.remove({id:123}, callback);
     expect(callback).not.toHaveBeenCalled();
     xhr.flush();
-    nakedExpect(callback.mostRecentCall.args).toEqual([{}]);
+    nakedExpect(callback.mostRecentCall.args[0]).toEqual({});
+    nakedExpect(callback.mostRecentCall.args[1]()).toEqual({});
 
     callback.reset();
     xhr.expectDELETE("/CreditCard/333").respond(204, null);
     CreditCard.remove({id:333}, callback);
     expect(callback).not.toHaveBeenCalled();
     xhr.flush();
-    nakedExpect(callback.mostRecentCall.args).toEqual([{}]);
+    nakedExpect(callback.mostRecentCall.args[0]).toEqual({});
+    nakedExpect(callback.mostRecentCall.args[1]()).toEqual({});
   });
 
   it('should post charge verb', function(){
@@ -183,7 +189,8 @@ describe("resource", function() {
     nakedExpect(cc).toEqual({name:'misko'});
     xhr.flush();
     nakedExpect(cc).toEqual({id:123});
-    expect(callback).toHaveBeenCalledWith(cc);
+    expect(callback.mostRecentCall.args[0]).toEqual(cc);
+    expect(callback.mostRecentCall.args[1]()).toEqual({});
   });
 
   it('should not mutate the resource object if response contains no body', function(){
@@ -259,7 +266,9 @@ describe("resource", function() {
     it('should call the error callback if provided on non 2xx response', function() {
       CreditCard.get({id:123}, noop, callback);
       xhr.flush();
-      expect(callback).toHaveBeenCalledWith(500, ERROR_RESPONSE);
+      expect(callback.mostRecentCall.args[0]).toEqual(500);
+      expect(callback.mostRecentCall.args[1]).toEqual(ERROR_RESPONSE);
+      expect(callback.mostRecentCall.args[2]()).toEqual({});
       expect($xhrErr).not.toHaveBeenCalled();
     });
   });

--- a/test/service/xhr.bulkSpec.js
+++ b/test/service/xhr.bulkSpec.js
@@ -18,8 +18,9 @@ describe('$xhr.bulk', function() {
   });
 
 
-  function callback(code, response) {
+  function callback(code, response, responseHeaders) {
     expect(code).toEqual(200);
+    expect(responseHeaders()).toEqual({});
     log = log + toJson(response) + ';';
   }
 
@@ -81,6 +82,8 @@ describe('$xhr.bulk', function() {
     $browserXhr.flush();
 
     expect($xhrError).not.toHaveBeenCalled();
-    expect(callback).toHaveBeenCalledWith(404, 'NotFound');
+    expect(callback.mostRecentCall.args[0]).toEqual(404);
+    expect(callback.mostRecentCall.args[1]).toEqual('NotFound');
+    expect(callback.mostRecentCall.args[2]()).toEqual({});
   });
 });

--- a/test/service/xhr.cacheSpec.js
+++ b/test/service/xhr.cacheSpec.js
@@ -17,8 +17,9 @@ describe('$xhr.cache', function() {
   });
 
 
-  function callback(code, response) {
+  function callback(code, response, responseHeaders) {
     expect(code).toEqual(200);
+    expect(responseHeaders()).toEqual({});
     log = log + toJson(response) + ';';
   }
 
@@ -55,7 +56,12 @@ describe('$xhr.cache', function() {
 
 
   it('should serve requests from cache', function(){
-    cache.data.url = {value:'123'};
+    cache.data.url = {
+      value: '123',
+      headers: function() {
+        return {};
+      }
+    };
     cache('GET', 'url', null, callback);
     $browser.defer.flush();
     expect(log).toEqual('"123";');
@@ -152,13 +158,17 @@ describe('$xhr.cache', function() {
 
     cache('GET', '/url', null, successSpy, errorSpy, false, true);
     $browserXhr.flush();
-    expect(errorSpy).toHaveBeenCalledWith(500, 'error');
+    expect(errorSpy.mostRecentCall.args[0]).toEqual(500);
+    expect(errorSpy.mostRecentCall.args[1]).toEqual('error');
+    expect(errorSpy.mostRecentCall.args[2]()).toEqual({});
     expect(successSpy).not.toHaveBeenCalled();
 
     errorSpy.reset();
     cache('GET', '/url', successSpy, errorSpy, false, true);
     $browserXhr.flush();
-    expect(errorSpy).toHaveBeenCalledWith(500, 'error');
+    expect(errorSpy.mostRecentCall.args[0]).toEqual(500);
+    expect(errorSpy.mostRecentCall.args[1]).toEqual('error');
+    expect(errorSpy.mostRecentCall.args[2]()).toEqual({});
     expect(successSpy).not.toHaveBeenCalled();
   });
 

--- a/test/service/xhrSpec.js
+++ b/test/service/xhrSpec.js
@@ -18,8 +18,9 @@ describe('$xhr', function() {
   });
 
 
-  function callback(code, response) {
-    log = log + '{code=' + code + '; response=' + toJson(response) + '}';
+  function callback(code, response, responseHeader) {
+    log = log + '{code=' + code + '; response=' + toJson(response) + '; responseHeaders=' +
+        toJson(responseHeader()) + '}';
   }
 
 
@@ -35,9 +36,9 @@ describe('$xhr', function() {
     $browserXhr.flush();
 
     expect(log).toEqual(
-        '{code=200; response="third"}' +
-        '{code=200; response=["second"]}' +
-        '{code=200; response="first"}');
+        '{code=200; response="third"; responseHeaders={}}' +
+        '{code=200; response=["second"]; responseHeaders={}}' +
+        '{code=200; response="first"; responseHeaders={}}');
   });
 
   it('should allow all 2xx requests', function(){
@@ -50,8 +51,8 @@ describe('$xhr', function() {
     $browserXhr.flush();
 
     expect(log).toEqual(
-        '{code=200; response="1"}' +
-        '{code=299; response="2"}');
+        '{code=200; response="1"; responseHeaders={}}' +
+        '{code=299; response="2"; responseHeaders={}}');
   });
 
 
@@ -124,14 +125,18 @@ describe('$xhr', function() {
     $xhr('GET', '/url', null, successSpy, errorSpy);
     $browserXhr.flush();
 
-    expect(errorSpy).toHaveBeenCalledWith(500, 'error');
+    expect(errorSpy.mostRecentCall.args[0]).toEqual(500);
+    expect(errorSpy.mostRecentCall.args[1]).toEqual('error');
+    expect(errorSpy.mostRecentCall.args[2]()).toEqual({});
     expect(successSpy).not.toHaveBeenCalled();
 
     errorSpy.reset();
     $xhr('GET', '/url', successSpy, errorSpy);
     $browserXhr.flush();
 
-    expect(errorSpy).toHaveBeenCalledWith(500, 'error');
+    expect(errorSpy.mostRecentCall.args[0]).toEqual(500);
+    expect(errorSpy.mostRecentCall.args[1]).toEqual('error');
+    expect(errorSpy.mostRecentCall.args[2]()).toEqual({});
     expect(successSpy).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
feat($resource,$xhr): make HTTP headers available to $xhr and $resource callbacks
- $browser.xhr exposes headers function for retrieving one or all headers
- $xhr service exposes the headers function to both success and error callbacks
- $resource service exposes the headers function in all of its callbacks
