### PR TITLE
doc(sample): Add javascript sandbox integration (jsFiddle)

### DIFF
--- a/docs/src/templates/doc_widgets.css
+++ b/docs/src/templates/doc_widgets.css
@@ -25,6 +25,30 @@ ul.doc-example > li.doc-example-heading {
   margin-bottom: -10px;
 }
 
+li.doc-example-source form {
+ 	height:14px;
+}
+
+li.doc-example-source form button {
+	cursor: pointer;
+    float: right;
+    height: 24px;
+    width: 120px;
+    padding-bottom: 4px;
+    margin-right:10px;
+	margin-top: 10px;
+    background-color: #FFF;
+    font-weight: bold;
+    color: #7989D6;
+    border-color: #7989D6;
+    -moz-border-radius: 8px;
+    -webkit-border-radius:8px;
+    border-radius: 8px;
+}
+
+li.doc-example-source form textarea {
+	display: none;
+}
 li.doc-example-live {
   padding: 10px;
   font-size: 1.2em;

--- a/docs/src/templates/doc_widgets.css
+++ b/docs/src/templates/doc_widgets.css
@@ -25,30 +25,38 @@ ul.doc-example > li.doc-example-heading {
   margin-bottom: -10px;
 }
 
-li.doc-example-source form {
- 	height:14px;
+span.nojsfiddle {
+  float: right;
+  font-size: .9em;
+  margin-right:10px;
+  margin-top: 10px;
 }
 
-li.doc-example-source form button {
-	cursor: pointer;
-    float: right;
-    height: 24px;
-    width: 120px;
-    padding-bottom: 4px;
-    margin-right:10px;
-	margin-top: 10px;
-    background-color: #FFF;
-    font-weight: bold;
-    color: #7989D6;
-    border-color: #7989D6;
-    -moz-border-radius: 8px;
-    -webkit-border-radius:8px;
-    border-radius: 8px;
+form.jsfiddle {
+  height:14px;
 }
 
-li.doc-example-source form textarea {
-	display: none;
+form.jsfiddle button {
+  cursor: pointer;
+  float: right;
+  height: 24px;
+  width: 120px;
+  padding-bottom: 4px;
+  margin-right:10px;
+  margin-top: 10px;
+  background-color: #FFF;
+  font-weight: bold;
+  color: #7989D6;
+  border-color: #7989D6;
+  -moz-border-radius: 8px;
+  -webkit-border-radius:8px;
+  border-radius: 8px;
 }
+
+form.jsfiddle textarea, form.jsfiddle input {
+  display: none;
+}
+
 li.doc-example-live {
   padding: 10px;
   font-size: 1.2em;

--- a/docs/src/templates/doc_widgets.js
+++ b/docs/src/templates/doc_widgets.js
@@ -29,14 +29,37 @@
     //jqlite instead. jqlite's find() method currently supports onlt getElementsByTagName!
     var example = element.find('pre').eq(0),  //doc-source
         exampleSrc = example.text(),
-        scenario = element.find('pre').eq(1); //doc-scenario
+        sandbox = exampleSrc.match(/<doc:sandbox>(.*)<\/doc:sandbox>|<doc:sandbox\/>/),
+        scenario = element.find('pre').eq(1), //doc-scenario
+        sandboxLaunchCode = ''; 
 
+    // jsFiddle is default sandbox, if sandbox tag found use whatever is in there
+    if(sandbox.length > 0) {
+    	// ngdoc with this tag will not render form/button
+    	sandboxLaunchCode = sandbox[1] || ''; 
+    	exampleSrc = exampleSrc.replace(sandbox[0], '').trim(); // remove doc:sandbox from code sample
+    } else {
+    	var fiddleUrl = 'http://jsfiddle.net/api/post/jquery/1.5.2/';
+	    // nested textareas 
+        var fiddleSrc =  exampleSrc.replace(/<textarea>/gi,'&lt;textarea&gt;');
+        fiddleSrc = fiddleSrc.replace(/<\/textarea>/gi,'&lt;/textarea&gt;'); 
+        
+	    sandboxLaunchCode = '<form method="post" action="' + fiddleUrl + '" target="check">' +
+		    '<textarea name="html">' + 
+		    ' <script src="' + angularJsUrl + '" ng:autobind></script>' +
+		    fiddleSrc +  
+		    '</textarea>' +
+		    '<button name="jsFiddle" title="Fiddle with the sample.\nNOTE: a new browser tab/window will open" class="fiddle">' + 
+		    'edit at jsFiddle</button></form>';
+  	}
+    
     var code = indent(exampleSrc);
-    var tabHtml =
+    var tabHtml = 
       '<ul class="doc-example">' +
         '<li class="doc-example-heading"><h3>Source</h3></li>' +
         '<li class="doc-example-source" ng:non-bindable>' +
-          '<pre class="brush: js; html-script: true; highlight: [' +
+        sandboxLaunchCode + // may or may not have value
+        '<pre class="brush: js; html-script: true; highlight: [' +
           code.hilite + ']; toolbar: false;"></pre></li>' +
         '<li class="doc-example-heading"><h3>Live Preview</h3></li>' +
         '<li class="doc-example-live">' + exampleSrc +'</li>';

--- a/docs/src/templates/doc_widgets.js
+++ b/docs/src/templates/doc_widgets.js
@@ -29,24 +29,30 @@
     //jqlite instead. jqlite's find() method currently supports onlt getElementsByTagName!
     var example = element.find('pre').eq(0),  //doc-source
         exampleSrc = example.text(),
-        sandbox = exampleSrc.match(/<doc:sandbox>(.*)<\/doc:sandbox>|<doc:sandbox\/>/),
+        nojsfiddle = exampleSrc.match(/<doc:nojsfiddle>(.*)<\/doc:nojsfiddle>|<doc:nojsfiddle\/>/),
         scenario = element.find('pre').eq(1), //doc-scenario
-        sandboxLaunchCode = ''; 
+        jsfiddleLaunchCode = ''; 
 
-    // jsFiddle is default sandbox, if sandbox tag found use whatever is in there
-    if(sandbox.length > 0) {
+    // jsFiddle is there by default, doc:nojsfiddle is to opt out or use something else
+    if(nojsfiddle && nojsfiddle.length > 0) {
     	// ngdoc with this tag will not render form/button
-    	sandboxLaunchCode = sandbox[1] || ''; 
-    	exampleSrc = exampleSrc.replace(sandbox[0], '').trim(); // remove doc:sandbox from code sample
+    	jsfiddleLaunchCode = nojsfiddle[1] || ''; 
+    	exampleSrc = exampleSrc.replace(nojsfiddle[0], '').trim(); // remove doc:nojsfiddle from code sample
     } else {
-    	var fiddleUrl = 'http://jsfiddle.net/api/post/jquery/1.5.2/';
+    	var fiddleUrl = 'http://jsfiddle.net/api/post/library/pure/';
 	    // nested textareas 
         var fiddleSrc =  exampleSrc.replace(/<textarea>/gi,'&lt;textarea&gt;');
         fiddleSrc = fiddleSrc.replace(/<\/textarea>/gi,'&lt;/textarea&gt;'); 
-        
-	    sandboxLaunchCode = '<form method="post" action="' + fiddleUrl + '" target="check">' +
+	    jsfiddleLaunchCode = '<form class="jsfiddle" method="post" action="' + fiddleUrl + '" target="_blank">' +
+	    	'<textarea name="css">' +
+	    	'body { font-family: Arial,Helvetica,sans-serif; }\n' +
+	    	'body, td, th { font-size: 14px; margin: 0; }\n' + 
+	    	'table { border-collapse: separate; border-spacing: 2px; display: table; margin-bottom: 0; margin-top: 0; -moz-box-sizing: border-box; text-indent: 0; }\n' +
+	    	'a:link, a:visited, a:hover { color: #5D6DB6; text-decoration: none; }\n' +
+	    	'</textarea>' + 
+	    	'<input type="text" name="title" value="AngularJS Live Example"/>' + 
 		    '<textarea name="html">' + 
-		    ' <script src="' + angularJsUrl + '" ng:autobind></script>' +
+		    '<script src="' + angularJsUrl + '" ng:autobind></script>\n' +
 		    fiddleSrc +  
 		    '</textarea>' +
 		    '<button name="jsFiddle" title="Fiddle with the sample.\nNOTE: a new browser tab/window will open" class="fiddle">' + 
@@ -58,7 +64,7 @@
       '<ul class="doc-example">' +
         '<li class="doc-example-heading"><h3>Source</h3></li>' +
         '<li class="doc-example-source" ng:non-bindable>' +
-        sandboxLaunchCode + // may or may not have value
+        jsfiddleLaunchCode + // may or may not have value
         '<pre class="brush: js; html-script: true; highlight: [' +
           code.hilite + ']; toolbar: false;"></pre></li>' +
         '<li class="doc-example-heading"><h3>Live Preview</h3></li>' +


### PR DESCRIPTION
Change doc-widget.js to:
- By default, render "edit in jsFiddle" button which posts live sample code to jsFiddle.
- Handle new (and optional), doc:sandbox/ tag in ngdocs which overrides default jsFiddle behvaior.
  If new xml tag has content, then extract and render new content.
  Do not render the xml tag(s).
- Update stylesheet to make new "edit in jsFiddle" button consistent with angular documentation.
