### PR TITLE
fix($resource): properly call error callback when resource is called with

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -76,9 +76,16 @@ ResourceFactory.prototype = {
         case 4:
           error = a4;
           success = a3;
+          //fallthrough
         case 3:
         case 2:
           if (isFunction(a2)) {
+            if (isFunction(a1)) {
+              success = a1;
+              error = a2;
+              break;
+            }
+
             success = a2;
             error = a3;
             //fallthrough

--- a/test/ResourceSpec.js
+++ b/test/ResourceSpec.js
@@ -244,22 +244,35 @@ describe("resource", function() {
 
   describe('failure mode', function() {
     var ERROR_CODE = 500,
-        ERROR_RESPONSE = 'Server Error';
+        ERROR_RESPONSE = 'Server Error',
+        errorCB;
 
     beforeEach(function() {
-      xhr.expectGET('/CreditCard/123').respond(ERROR_CODE, ERROR_RESPONSE);
+      errorCB = jasmine.createSpy();
     });
 
     it('should report error when non 2xx if error callback is not provided', function() {
+      xhr.expectGET('/CreditCard/123').respond(ERROR_CODE, ERROR_RESPONSE);
       CreditCard.get({id:123});
       xhr.flush();
       expect($xhrErr).toHaveBeenCalled();
     });
 
     it('should call the error callback if provided on non 2xx response', function() {
-      CreditCard.get({id:123}, noop, callback);
+      xhr.expectGET('/CreditCard/123').respond(ERROR_CODE, ERROR_RESPONSE);
+      CreditCard.get({id:123}, callback, errorCB);
       xhr.flush();
-      expect(callback).toHaveBeenCalledWith(500, ERROR_RESPONSE);
+      expect(errorCB).toHaveBeenCalledWith(500, ERROR_RESPONSE);
+      expect(callback).not.toHaveBeenCalled();
+      expect($xhrErr).not.toHaveBeenCalled();
+    });
+
+    it('should call the error callback if provided on non 2xx response', function() {
+      xhr.expectGET('/CreditCard').respond(ERROR_CODE, ERROR_RESPONSE);
+      CreditCard.get(callback, errorCB);
+      xhr.flush();
+      expect(errorCB).toHaveBeenCalledWith(500, ERROR_RESPONSE);
+      expect(callback).not.toHaveBeenCalled();
       expect($xhrErr).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
fix($resource): properly call error callback when resource is called with two arguments
