### PR TITLE
fix(docs): remove more unecessary use of hide() and show() method

### DIFF
--- a/docs/src/templates/doc_widgets.js
+++ b/docs/src/templates/doc_widgets.js
@@ -181,7 +181,6 @@
     '</div>';
 
   angular.widget('doc:tutorial-instructions', function(element) {
-    element.hide();
     this.descend(true);
 
     var tabs = angular.element(HTML_TPL.replace('{show}', element.attr('show') || 'false')),
@@ -207,7 +206,6 @@
 
     element.html('');
     element.append(tabs);
-    element.show();
   });
 
 


### PR DESCRIPTION
- tutorial section of docs fails to render properly as
  doc:tutorial-instructions widget uses deprecated show and hide methods
  of jQlite.
