### PR TITLE
fix(markup): Make special attrs such as ng:href work even without binding

### DIFF
--- a/src/markups.js
+++ b/src/markups.js
@@ -418,7 +418,7 @@ angularAttrMarkup('{{}}', function(value, name, element){
     value = decodeURI(value);
   var bindings = parseBindings(value),
       bindAttr;
-  if (hasBindings(bindings)) {
+  if (hasBindings(bindings) || SPECIAL_ATTRS[name]) {
     element.removeAttr(name);
     bindAttr = fromJson(element.attr(NG_BIND_ATTR) || "{}");
     bindAttr[SPECIAL_ATTRS[name] || name] = value;

--- a/test/markupSpec.js
+++ b/test/markupSpec.js
@@ -154,6 +154,14 @@ describe("markups", function(){
     expect(sortedHtml(element)).toEqual('<a ng:bind-attr="{"href":"{{url}}","rel":"{{rel}}"}"></a>');
   });
 
+  it('should bind Text with no Bindings', function() {
+    forEach('src,href,checked,disabled,multiple,readonly,selected'.split(','), function(name) {
+      compile('<div ng:' + name +'="some"></div>');
+      expect(sortedHtml(element)).toEqual('<div ng:bind-attr="{"' + name +'":"some"}"></div>');
+      dealoc(element);
+    });
+  })
+
   it('should Parse Text With No Bindings', function(){
     var parts = parseBindings("a");
     assertEquals(parts.length, 1);


### PR DESCRIPTION
fix(markup): Make special attrs such as ng:href work even without binding
- special attrs such as ng:href, ng:check did not work as intended when
  their values do not contain bindings. And this commit is to fix that

Closes #534
