### PR TITLE
fix(docs): use window.eval instead of window.execScript on IE

### DIFF
--- a/docs/src/templates/doc_widgets.js
+++ b/docs/src/templates/doc_widgets.js
@@ -56,8 +56,13 @@
     element.append(tabs);
 
     var script = (exampleSrc.match(/<script[^\>]*>([\s\S]*)<\/script>/) || [])[1] || '';
+
     try {
-      window.eval(script);
+      if (window.execScript) { // IE
+        window.execScript(script || '"stupid IE!"'); // IE complains when evaling empty string
+      } else {
+        window.eval(script);
+      }
     } catch (e) {
       alert(e);
     }


### PR DESCRIPTION
IE doesn't have window.eval which our docs use. Instead there is
execScript, which however throws an exception when an empty string is
passed in, so I created a workaround with a workaround.
