### PR TITLE
action.verifyCache is not an error handler.

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -124,7 +124,7 @@ ResourceFactory.prototype = {
             }
             (success||noop)(value);
           },
-          error || action.verifyCache,
+          error,
           action.verifyCache);
         return value;
       };


### PR DESCRIPTION
I have just spent a couple hours figuring out why my implementation of $xhr.error service was not called by the $resource service on errors.

There's clearly a typo in the changed line, since there's no reason to pass action.verifyCache as error function.
