### PR TITLE
verifyCache is not an error handler.

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -36,8 +36,9 @@ Route.prototype = {
   }
 };
 
-function ResourceFactory(xhr) {
+function ResourceFactory(xhr, xhrError) {
   this.xhr = xhr;
+  this.xhrError = xhrError;
 }
 
 ResourceFactory.DEFAULT_ACTIONS = {
@@ -124,7 +125,7 @@ ResourceFactory.prototype = {
             }
             (success||noop)(value);
           },
-          error || action.verifyCache,
+          error || self.xhrError,
           action.verifyCache);
         return value;
       };

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -200,7 +200,7 @@
       </doc:scenario>
     </doc:example>
  */
-angularServiceInject('$resource', function($xhr){
-  var resource = new ResourceFactory($xhr);
+angularServiceInject('$resource', function($xhr, xhrError){
+  var resource = new ResourceFactory($xhr, xhrError);
   return bind(resource, resource.route);
-}, ['$xhr.cache']);
+}, ['$xhr.cache', '$xhr.error']);


### PR DESCRIPTION
The $resource service incorrectly uses action.verifyCache as default error handler. This patch changes it to use $xhr.error as with $xhr service.

All tests pass.
