### PR TITLE
Fixing #571

### DIFF
--- a/src/apis.js
+++ b/src/apis.js
@@ -714,7 +714,7 @@ var angularArray = {
            expect(binding('numbers.$limitTo(limit) | json')).toEqual('[1,2,3]');
          });
 
-          it('should update the output when -3 is entered', function() {
+         it('should update the output when -3 is entered', function() {
            input('limit').enter(-3);
            expect(binding('numbers.$limitTo(limit) | json')).toEqual('[7,8,9]');
          });
@@ -723,8 +723,6 @@ var angularArray = {
            input('limit').enter(100);
            expect(binding('numbers.$limitTo(limit) | json')).toEqual('[1,2,3,4,5,6,7,8,9]');
          });
-
-         
        </doc:scenario>
      </doc:example>
    */

--- a/src/apis.js
+++ b/src/apis.js
@@ -697,8 +697,8 @@ var angularArray = {
    * @param {string|Number} limit The length of the returned array. If the `limit` number is
    *     positive, `limit` number of items from the beginning of the source array are copied.
    *     If the number is negative, `limit` number  of items from the end of the source array are
-   *     copied.
-   * @returns {Array} A new sub-array of length `limit`.
+   *     copied. The `limit` will be trimmed if it exceeds `array.length`
+   * @returns {Array} A new sub-array of length `limit` or less if input array had less than `limit` elements.
    *
    * @example
      <doc:example>
@@ -714,10 +714,17 @@ var angularArray = {
            expect(binding('numbers.$limitTo(limit) | json')).toEqual('[1,2,3]');
          });
 
-         it('should update the output when -3 is entered', function() {
+          it('should update the output when -3 is entered', function() {
            input('limit').enter(-3);
            expect(binding('numbers.$limitTo(limit) | json')).toEqual('[7,8,9]');
          });
+
+         it('should not exceed the maximum size of input array', function() {
+           input('limit').enter(100);
+           expect(binding('numbers.$limitTo(limit) | json')).toEqual('[1,2,3,4,5,6,7,8,9]');
+         });
+
+         
        </doc:scenario>
      </doc:example>
    */
@@ -725,6 +732,16 @@ var angularArray = {
     limit = parseInt(limit, 10);
     var out = [],
         i, n;
+
+    // check that array is iterable
+    if (!array || !(array instanceof Array))
+      return out;
+
+    // if abs(limit) exceeds maximum length, trim it
+    if (limit > array.length)
+      limit = array.length;
+    else if (limit < -array.length)
+      limit = -array.length;
 
     if (limit > 0) {
       i = 0;

--- a/test/ApiSpecs.js
+++ b/test/ApiSpecs.js
@@ -175,6 +175,25 @@ describe('api', function(){
         expect(angular.Array.limitTo(items, null)).toEqual([]);
         expect(angular.Array.limitTo(items, undefined)).toEqual([]);
       });
+
+
+      it('should return an empty array when input is not Array type', function() {
+        expect(angular.Array.limitTo('bogus', 1)).toEqual([]);
+        expect(angular.Array.limitTo(null, 1)).toEqual([]);
+        expect(angular.Array.limitTo(undefined, 1)).toEqual([]);
+        expect(angular.Array.limitTo(null, 1)).toEqual([]);
+        expect(angular.Array.limitTo(undefined, 1)).toEqual([]);
+        expect(angular.Array.limitTo({}, 1)).toEqual([]);
+      });
+
+      it('should return a copy of input array if X is exceeds array length', function () {
+        expect(angular.Array.limitTo(items, 19)).toEqual(items);
+        expect(angular.Array.limitTo(items, '9')).toEqual(items);
+        expect(angular.Array.limitTo(items, -9)).toEqual(items);
+        expect(angular.Array.limitTo(items, '-9')).toEqual(items);
+
+        expect(angular.Array.limitTo(items, 9)).not.toBe(items);
+      });
     });
 
 

--- a/test/ApiSpecs.js
+++ b/test/ApiSpecs.js
@@ -186,6 +186,7 @@ describe('api', function(){
         expect(angular.Array.limitTo({}, 1)).toEqual([]);
       });
 
+
       it('should return a copy of input array if X is exceeds array length', function () {
         expect(angular.Array.limitTo(items, 19)).toEqual(items);
         expect(angular.Array.limitTo(items, '9')).toEqual(items);


### PR DESCRIPTION
`angular.Array.limitTo`'s  result cannot exceed original input array size

Tests and a little doc update provided.

Also added a little guard in case supplied input array is not Array type.
