### PR TITLE
Length-based validation + "password" is correct input field type

### DIFF
--- a/src/widget/input.js
+++ b/src/widget/input.js
@@ -667,7 +667,7 @@ angularWidget('input', function(inputElement){
          patternMatch = valueFn(true);
        } else {
          if (pattern.match(/^\/(.*)\/$/)) {
-           pattern = new RegExp(pattern.substring(1, pattern.length - 2));
+           pattern = new RegExp(pattern.substring(1, pattern.length - 1));
            patternMatch = function(value) {
              return pattern.test(value);
            }

--- a/src/widget/input.js
+++ b/src/widget/input.js
@@ -79,6 +79,8 @@ var INTEGER_REGEXP = /^\s*(\-|\+)?\d+\s*$/;
  * @param {string} ng:model Assignable angular expression to data-bind to.
  * @param {string=} name Property name of the form under which the widgets is published.
  * @param {string=} required Sets `REQUIRED` validation error key if the value is not entered.
+ * @param {number=} minlength Sets `MINLENGTH` validation error key if the value is shorter than minlength.
+ * @param {number=} maxlength Sets `MAXLENGTH` validation error key if the value is longer than maxlength.
  * @param {string=} ng:pattern Sets `PATTERN` validation error key if the value does not match the
  *    RegExp pattern expression. Expected value is `/regexp/` for inline patterns or `regexp` for
  *    patterns defined as scope expressions.
@@ -656,6 +658,8 @@ angularWidget('input', function(inputElement){
           modelScope = this,
           patternMatch, widget,
           pattern = trim(inputElement.attr('ng:pattern')),
+          minlength = parseInt(inputElement.attr('minlength'), 10),
+          maxlength = parseInt(inputElement.attr('maxlength'), 10),
           loadFromScope = type.match(/^\s*\@\s*(.*)/);
 
 
@@ -713,12 +717,20 @@ angularWidget('input', function(inputElement){
       widget.$on('$validate', function(event) {
         var $viewValue = trim(widget.$viewValue);
         var inValid = widget.$required && !$viewValue;
+        var tooLong = maxlength && $viewValue && $viewValue.length > maxlength,
+            tooShort = minlength && $viewValue && $viewValue.length < minlength;
         var missMatch = $viewValue && !patternMatch($viewValue);
         if (widget.$error.REQUIRED != inValid){
           widget.$emit(inValid ? '$invalid' : '$valid', 'REQUIRED');
         }
         if (widget.$error.PATTERN != missMatch){
           widget.$emit(missMatch ? '$invalid' : '$valid', 'PATTERN');
+        }
+        if (widget.$error.MINLENGTH != tooShort){
+          widget.$emit(tooShort ? '$invalid' : '$valid', 'MINLENGTH');
+        }
+        if (widget.$error.MAXLENGTH != tooLong){
+          widget.$emit(tooLong ? '$invalid' : '$valid', 'MAXLENGTH');
         }
       });
 

--- a/src/widget/input.js
+++ b/src/widget/input.js
@@ -79,8 +79,8 @@ var INTEGER_REGEXP = /^\s*(\-|\+)?\d+\s*$/;
  * @param {string} ng:model Assignable angular expression to data-bind to.
  * @param {string=} name Property name of the form under which the widgets is published.
  * @param {string=} required Sets `REQUIRED` validation error key if the value is not entered.
- * @param {number=} minlength Sets `MINLENGTH` validation error key if the value is shorter than minlength.
- * @param {number=} maxlength Sets `MAXLENGTH` validation error key if the value is longer than maxlength.
+ * @param {number=} ng:minlength Sets `MINLENGTH` validation error key if the value is shorter than minlength.
+ * @param {number=} ng:maxlength Sets `MAXLENGTH` validation error key if the value is longer than maxlength.
  * @param {string=} ng:pattern Sets `PATTERN` validation error key if the value does not match the
  *    RegExp pattern expression. Expected value is `/regexp/` for inline patterns or `regexp` for
  *    patterns defined as scope expressions.
@@ -658,8 +658,8 @@ angularWidget('input', function(inputElement){
           modelScope = this,
           patternMatch, widget,
           pattern = trim(inputElement.attr('ng:pattern')),
-          minlength = parseInt(inputElement.attr('minlength'), 10),
-          maxlength = parseInt(inputElement.attr('maxlength'), 10),
+          minlength = parseInt(inputElement.attr('ng:minlength'), 10),
+          maxlength = parseInt(inputElement.attr('ng:maxlength'), 10),
           loadFromScope = type.match(/^\s*\@\s*(.*)/);
 
 

--- a/test/widget/inputSpec.js
+++ b/test/widget/inputSpec.js
@@ -556,6 +556,10 @@ describe('widget: input', function() {
           scope.regexp = /^\d\d\d-\d\d-\d\d\d\d$/;
         });
 
+    itShouldVerify('text with length limits',
+        ['aaa', 'aaaaa', 'aaaaaaaaa'],
+        ['', 'a', 'aa', 'aaaaaaaaaa'],
+        {'ng:minlength': 3, 'ng:maxlength': 9});
 
     it('should throw an error when scope pattern can\'t be found', function() {
       var el = jqLite('<input ng:model="foo" ng:pattern="fooRegexp">'),

--- a/test/widget/inputSpec.js
+++ b/test/widget/inputSpec.js
@@ -412,6 +412,13 @@ describe('widget: input', function() {
       });
     });
 
+    describe('password', function () {
+      it('should not change password type to text', function () {
+        doc = angular.element('<form name="form"><input type="password" ng:model="name" /></form>');
+        scope = angular.compile(doc)();
+        expect(doc.find('input')[0].getAttribute('type')).toEqual('password');
+      });
+    });
 
     it('should ignore text widget which have no name', function() {
       compile('<input type="text"/>');


### PR DESCRIPTION
First I added missing validation method based on field length. I use "minlength" and "maxlength" <input/>'s attributes to set min and max value length, and set input.$error.MINLENGTH and input.$error.MAXLENGTH in case field's value is too short/long.

The second commit a fix: &lt;input type="password" /> kept converted to &lt;input type="text" /> by angular.js, which made it effectively useless for forms handling. I added "password" type to the list of correct HTML5 input types
