### PR TITLE
fix(date filter): default to fullDate format

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -318,7 +318,7 @@ var GET_TIME_ZONE = /[A-Z]{3}(?![+\-])/,
  * @param {(Date|number|string)} date Date to format either as Date object, milliseconds (string or
  *    number) or ISO 8601 extended datetime string (yyyy-MM-ddTHH:mm:ss.SSSZ).
  * @param {string=} format Formatting rules (see Description). If not specified,
- *    `fullDate` is used.
+ *    `mediumDate` is used.
  * @returns {string} Formatted string or the input if input is not recognized as date/millis.
  *
  * @example
@@ -349,7 +349,7 @@ angularFilter.date = function(date, format) {
       parts = [],
       fn, match;
 
-  format = format || 'fullDate'
+  format = format || 'mediumDate'
   format = $locale.DATETIME_FORMATS[format] || format;
   if (isString(date)) {
     if (NUMBER_STRING.test(date)) {

--- a/src/filters.js
+++ b/src/filters.js
@@ -318,7 +318,7 @@ var GET_TIME_ZONE = /[A-Z]{3}(?![+\-])/,
  * @param {(Date|number|string)} date Date to format either as Date object, milliseconds (string or
  *    number) or ISO 8601 extended datetime string (yyyy-MM-ddTHH:mm:ss.SSSZ).
  * @param {string=} format Formatting rules (see Description). If not specified,
- *    Date#toLocaleDateString is used.
+ *    `fullDate` is used.
  * @returns {string} Formatted string or the input if input is not recognized as date/millis.
  *
  * @example
@@ -344,7 +344,12 @@ var GET_TIME_ZONE = /[A-Z]{3}(?![+\-])/,
    </doc:example>
  */
 angularFilter.date = function(date, format) {
-  var $locale = this.$service('$locale');
+  var $locale = this.$service('$locale'),
+      text = '',
+      parts = [],
+      fn, match;
+
+  format = format || 'fullDate'
   format = $locale.DATETIME_FORMATS[format] || format;
   if (isString(date)) {
     if (NUMBER_STRING.test(date)) {
@@ -362,26 +367,23 @@ angularFilter.date = function(date, format) {
     return date;
   }
 
-  var text = date.toLocaleDateString(), fn;
-  if (format && isString(format)) {
-    text = '';
-    var parts = [], match;
-    while(format) {
-      match = DATE_FORMATS_SPLIT.exec(format);
-      if (match) {
-        parts = concat(parts, match, 1);
-        format = parts.pop();
-      } else {
-        parts.push(format);
-        format = null;
-      }
+  while(format) {
+    match = DATE_FORMATS_SPLIT.exec(format);
+    if (match) {
+      parts = concat(parts, match, 1);
+      format = parts.pop();
+    } else {
+      parts.push(format);
+      format = null;
     }
-    forEach(parts, function(value){
-      fn = DATE_FORMATS[value];
-      text += fn ? fn(date, $locale.DATETIME_FORMATS)
-                 : value.replace(/(^'|'$)/g, '').replace(/''/g, "'");
-    });
   }
+
+  forEach(parts, function(value){
+    fn = DATE_FORMATS[value];
+    text += fn ? fn(date, $locale.DATETIME_FORMATS)
+               : value.replace(/(^'|'$)/g, '').replace(/''/g, "'");
+  });
+
   return text;
 };
 

--- a/test/FiltersSpec.js
+++ b/test/FiltersSpec.js
@@ -225,13 +225,13 @@ describe('filter', function() {
     });
 
     it('should do basic filter', function() {
-      expect(date(noon)).toEqual(noon.toLocaleDateString());
-      expect(date(noon, '')).toEqual(noon.toLocaleDateString());
+      expect(date(noon)).toEqual(date(noon, 'fullDate'));
+      expect(date(noon, '')).toEqual(date(noon, 'fullDate'));
     });
 
     it('should accept number or number string representing milliseconds as input', function() {
-      expect(date(noon.getTime())).toEqual(noon.toLocaleDateString());
-      expect(date(noon.getTime() + "")).toEqual(noon.toLocaleDateString());
+      expect(date(noon.getTime())).toEqual(date(noon.getTime(), 'fullDate'));
+      expect(date(noon.getTime() + "")).toEqual(date(noon.getTime() + "", 'fullDate'));
     });
 
     it('should accept various format strings', function() {
@@ -297,7 +297,7 @@ describe('filter', function() {
     it('should be able to parse ISO 8601 dates/times using', function() {
       var isoString = '2010-09-03T05:05:08.872Z';
       expect(date(isoString)).
-          toEqual(angular.String.toDate(isoString).toLocaleDateString());
+          toEqual(date(isoString, 'fullDate'));
     });
 
     it('should parse format ending with non-replaced string', function() {

--- a/test/FiltersSpec.js
+++ b/test/FiltersSpec.js
@@ -225,13 +225,13 @@ describe('filter', function() {
     });
 
     it('should do basic filter', function() {
-      expect(date(noon)).toEqual(date(noon, 'fullDate'));
-      expect(date(noon, '')).toEqual(date(noon, 'fullDate'));
+      expect(date(noon)).toEqual(date(noon, 'mediumDate'));
+      expect(date(noon, '')).toEqual(date(noon, 'mediumDate'));
     });
 
     it('should accept number or number string representing milliseconds as input', function() {
-      expect(date(noon.getTime())).toEqual(date(noon.getTime(), 'fullDate'));
-      expect(date(noon.getTime() + "")).toEqual(date(noon.getTime() + "", 'fullDate'));
+      expect(date(noon.getTime())).toEqual(date(noon.getTime(), 'mediumDate'));
+      expect(date(noon.getTime() + "")).toEqual(date(noon.getTime() + "", 'mediumDate'));
     });
 
     it('should accept various format strings', function() {
@@ -297,7 +297,7 @@ describe('filter', function() {
     it('should be able to parse ISO 8601 dates/times using', function() {
       var isoString = '2010-09-03T05:05:08.872Z';
       expect(date(isoString)).
-          toEqual(date(isoString, 'fullDate'));
+          toEqual(date(isoString, 'mediumDate'));
     });
 
     it('should parse format ending with non-replaced string', function() {


### PR DESCRIPTION
The browser's behave inconsistently, so we should just stick to one format
when the format is not specified by the developer

Closes #605
