### PR TITLE
fix($location): rewrite links with nested elements

### DIFF
--- a/src/service/location.js
+++ b/src/service/location.js
@@ -442,12 +442,16 @@ angularServiceInject('$location', function($browser, $sniffer, $locationConfig, 
       // TODO(vojta): rewrite link when opening in new tab/window (in legacy browser)
       // currently we open nice url link and redirect then
 
-      if (uppercase(event.target.nodeName) != 'A' || event.ctrlKey || event.metaKey ||
-          event.which == 2) return;
+      if (event.ctrlKey || event.metaKey || event.which == 2) return;
 
-      var elm = jqLite(event.target),
-          href = elm.attr('href');
+      var elm = jqLite(event.target);
 
+      // traverse the DOM up to find first A tag
+      while (elm.length && lowercase(elm[0].nodeName) !== 'a') {
+        elm = elm.parent();
+      }
+
+      var href = elm.attr('href');
       if (!href || isDefined(elm.attr('ng:ext-link')) || elm.attr('target')) return;
 
       // remove same domain from full url links (IE7 always returns full hrefs)

--- a/test/service/locationSpec.js
+++ b/test/service/locationSpec.js
@@ -556,10 +556,11 @@ describe('$location', function() {
 
     var root, link, extLink, $browser, originalBrowser, lastEventPreventDefault;
 
-    function init(linkHref, html5Mode, supportHist, attrs) {
+    function init(linkHref, html5Mode, supportHist, attrs, content) {
       var jqRoot = jqLite('<div></div>');
       attrs = attrs ? ' ' + attrs + ' ' : '';
-      link = jqLite('<a href="' + linkHref + '"' + attrs + '>link</a>')[0];
+      content = content || 'link';
+      link = jqLite('<a href="' + linkHref + '"' + attrs + '>' + content + '</a>')[0];
       root = jqRoot.append(link)[0];
 
       jqLite(document.body).append(jqRoot);
@@ -667,6 +668,15 @@ describe('$location', function() {
       init('http://host.com/base/new', true);
       browserTrigger(link, 'click');
       expectRewriteTo('http://host.com/base/index.html#!/new');
+    });
+
+
+    it('should rewrite when clicked span inside link', function() {
+      init('some/link', true, true, '', '<span>link</span>');
+      var span = jqLite(link).find('span');
+
+      browserTrigger(span, 'click');
+      expectRewriteTo('http://host.com/base/some/link');
     });
 
 


### PR DESCRIPTION
So docs is fixed now, inner links do not reload the page:
http://ci.angularjs.org/job/angular.js-vojta/41/artifact/build/pkg/0.10.4-849c5365/docs-0.10.4-849c5365/index.html

For example:

``` html
<a href="some/link">inner <span>text</span></a>
```

If you click on "text", then the span element is event.target, so we need to traverse the DOM.
