### PR TITLE
fix(compiler): revert 8611ebe6 - calling  after linking

### DIFF
--- a/docs/content/guide/dev_guide.bootstrap.manual_bootstrap.ngdoc
+++ b/docs/content/guide/dev_guide.bootstrap.manual_bootstrap.ngdoc
@@ -17,7 +17,7 @@ explicitly.
   <script src="http://code.angularjs.org/angular.js"></script>
   <script>
      angular.element(document).ready(function() {
-       angular.compile(document)();
+       angular.compile(document)().$apply();
      });
   </script>
 </head>

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -119,6 +119,15 @@ Template.prototype = {
  * the same scope as the one passed into the template function, or if none were provided it's the
  * newly create scope.
  *
+ * It is important to understand that the returned scope is "linked" to the view DOM, but no linking
+ * (instance) functions registered by {@link angular.directive directives} or
+ * {@link angular.widget widgets} found in the template have been executed yet. This means that the
+ * view is likely empty and doesn't contain any values that result from evaluation on the scope. To
+ * bring the view to life, the scope needs to run through a $digest phase which typically is done by
+ * Angular automatically, except for the case when an application is being
+ * {@link guide/dev_guide.bootstrap.manual_bootstrap} manually bootstrapped, in which case the
+ * $digest phase must be invoked by calling {@link angular.scope.$apply}.
+ *
  * If you need access to the bound view, there are two ways to do it:
  *
  * - If you are not asking the linking function to clone the template, create the DOM element(s)
@@ -209,7 +218,6 @@ Compiler.prototype = {
       scope.$element = element;
       (cloneConnectFn||noop)(element, scope);
       template.link(element, scope);
-      if (!scope.$$phase) scope.$digest();
       return scope;
     };
   },

--- a/test/CompilerSpec.js
+++ b/test/CompilerSpec.js
@@ -110,7 +110,6 @@ describe('compiler', function() {
     expect(sortedHtml(scope.$element)).
       toEqual('<div>' +
                 'before<#comment></#comment>' +
-                '<span>x</span>' +
                 'after' +
               '</div>');
     scope.value = 1;
@@ -118,7 +117,6 @@ describe('compiler', function() {
     expect(sortedHtml(scope.$element)).
       toEqual('<div>' +
           'before<#comment></#comment>' +
-          '<span>x</span>' +
           '<span>x</span>' +
           'after' +
         '</div>');
@@ -129,7 +127,6 @@ describe('compiler', function() {
           'before<#comment></#comment>' +
           '<span>x</span>' +
           '<span>x</span>' +
-          '<span>x</span>' +
           'after' +
         '</div>');
     scope.value = 3;
@@ -137,7 +134,6 @@ describe('compiler', function() {
     expect(sortedHtml(scope.$element)).
       toEqual('<div>' +
           'before<#comment></#comment>' +
-          '<span>x</span>' +
           '<span>x</span>' +
           '<span>x</span>' +
           '<span>x</span>' +

--- a/test/markupSpec.js
+++ b/test/markupSpec.js
@@ -167,20 +167,12 @@ describe("markups", function() {
   });
 
   it('should bind Text with no Bindings', function() {
-    forEach(['checked', 'disabled', 'multiple', 'readonly', 'selected'], function(name) {
+    forEach(['checked', 'disabled', 'multiple', 'readonly', 'selected', 'src', 'href'],
+        function(name) {
       compile('<div ng:' + name +'="some"></div>');
-      expect(element.attr('ng:bind-attr')).toBe('{"' + name +'":"some"}');
-      expect(element.attr(name)).toBe(name);
+      expect(sortedHtml(element)).toEqual('<div ng:bind-attr="{"' + name +'":"some"}"></div>');
       dealoc(element);
     });
-
-    compile('<div ng:src="some"></div>');
-    expect(sortedHtml(element)).toEqual('<div ng:bind-attr="{"src":"some"}" src="some"></div>');
-    dealoc(element);
-
-    compile('<div ng:href="some"></div>');
-    expect(sortedHtml(element)).toEqual('<div href="some" ng:bind-attr="{"href":"some"}"></div>');
-    dealoc(element);
   });
 
   it('should Parse Text With No Bindings', function() {


### PR DESCRIPTION
Change introduced by me in 8611ebe6 results in considerable inefficiencies when the compiler
and linker is used from within a widget, in which case, we call $digest unnecessary since it
will be called by the $apply which called the directive/widget in the first place.

There are only two places when the extra $digest call can be useful - when manually bootstrapping
the app or in tests. However even in tests this behavior can result in unwanted results (especially
when ng:controller is involved). So it is better to leave it for the developer to call $digest
when it is really needed.
