### PR TITLE
docs(jqlite): add missing methods

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -38,21 +38,28 @@
  * - [css()](http://api.jquery.com/css/)
  * - [data()](http://api.jquery.com/data/)
  * - [eq()](http://api.jquery.com/eq/)
+ * - [find()](http://api.jquery.com/find/)
  * - [hasClass()](http://api.jquery.com/hasClass/)
+ * - [html()](http://api.jquery.com/html/)
+ * - [next()](http://api.jquery.com/next/)
  * - [parent()](http://api.jquery.com/parent/)
+ * - [prepend()](http://api.jquery.com/prepend/)
  * - [prop()](http://api.jquery.com/prop/)
+ * - [ready()](http://api.jquery.com/ready/)
  * - [remove()](http://api.jquery.com/remove/)
  * - [removeAttr()](http://api.jquery.com/removeAttr/)
  * - [removeClass()](http://api.jquery.com/removeClass/)
  * - [removeData()](http://api.jquery.com/removeData/)
  * - [replaceWith()](http://api.jquery.com/replaceWith/)
  * - [text()](http://api.jquery.com/text/)
- * - [trigger()](http://api.jquery.com/trigger/)
+ * - [toggleClass()](http://api.jquery.com/toggleClass/)
  * - [unbind()](http://api.jquery.com/unbind/)
+ * - [val()](http://api.jquery.com/val/)
  *
  * ## In addtion to the above, Angular privides an additional method to both jQuery and jQuery lite:
  *
  * - `scope()` - retrieves the current Angular scope of the element.
+ * - `inheritedData()` - same as `data()`, but traverse up, until finds a value
  *
  * @param {string|DOMElement} element HTML string or DOMElement to be wrapped into jQuery.
  * @returns {Object} jQuery object.


### PR DESCRIPTION
no real change, just docs...

I think, we should mention, that even these methods that jqLite implements are not the same as the jQuery ones. For example `find()` is very simplistic...
But I don't know, how to say that - need a help by some native speakers from Slovakia :-D
