### PR TITLE
I discovered that IE7 and IE8 throw a javascript error on delete window[...

### DIFF
--- a/src/Browser.js
+++ b/src/Browser.js
@@ -110,7 +110,7 @@ function Browser(window, document, body, XHR, $log, $sniffer) {
         } else {
           completeOutstandingRequest(callback);
         }
-        delete window[callbackId];
+        window[callbackId] = null;//IE7 IE8 don't like delete window[callbackId];
         body[0].removeChild(script);
       });
     } else {


### PR DESCRIPTION
I discovered that IE7 and IE8 throw a javascript error on 

delete window[callbackId];

The specific IE7/8 error reported is:
Message: Object doesn't support this action

Doesn't seem to be a problem in IE9, Chrome, or Firefox
thanks guys, you rock!
