### PR TITLE
Add support for no top-level json array

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -115,7 +115,21 @@ ResourceFactory.prototype = {
             if (response) {
               if (action.isArray) {
                 value.length = 0;
-                forEach(response, function(item) {
+                var actualArray;
+                if (isArray(response)) {
+                  // the response is a top-level json array
+                  actualArray = response;
+                } else {
+                  // the response may be a top-level json object
+                  // which contains an array
+                  for (var key in response) {
+                    if(isArray(response[key])) {
+                      actualArray = response[key];
+                      break;
+                    }
+                  }
+                }
+                forEach(actualArray, function(item) {
                   value.push(new Resource(item));
                 });
               } else {


### PR DESCRIPTION
The $resource service relies on the fact that JSON arrays are top-level arrays. However, JSON shouldn't contains top-level array for security reasons (see http://flask.pocoo.org/docs/security/#json-security). 

This patch allows the usage of isArray:true in the $resource services. The expected JSON is a top-level object which contains an array:
{
  foo: [bar, baz]
}
