### PR TITLE
fix(jqLite): JQLiteHasClass should work even when minified

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -219,9 +219,7 @@ function JQLiteData(element, key, value) {
   }
 }
 
-function JQLiteHasClass(element, selector, _) {
-  // the argument '_' is important, since it makes the function have 3 arguments, which
-  // is needed for delegate function to realize the this is a getter.
+function JQLiteHasClass(element, selector) {
   return ((" " + element.className + " ").replace(/[\n\t]/g, " ").
       indexOf( " " + selector + " " ) > -1);
 }
@@ -427,7 +425,9 @@ forEach({
   JQLite.prototype[name] = function(arg1, arg2) {
     var i, key;
 
-    if ((fn.length == 2 ? arg1 : arg2) === undefined) {
+    // JQLiteHasClass has only two arguments, but is a getter-only fn, so we need to special case it
+    // in a way that is minification-proof.
+    if (((fn.length == 2 && fn !== JQLiteHasClass) ? arg1 : arg2) === undefined) {
       if (isObject(arg1)) {
         // we are a write, but the object properties are the key/values
         for(i=0; i < this.length; i++) {


### PR DESCRIPTION
closure compiler is smarter than we expected and drops the unused fn
argument - this breaks the meta-programing logic of jqLite.

The fix special cases JQLiteHasClass since its the only fn that needs
this treatment in a way that is minification-proof.
