### PR TITLE
fix(route): $destroy scope after update and reload

### DIFF
--- a/src/service/route.js
+++ b/src/service/route.js
@@ -258,6 +258,7 @@ function $RouteProvider(){
 
       if (next && last && next.$route === last.$route
           && equals(next.pathParams, last.pathParams) && !next.reloadOnSearch && !forceReload) {
+        next.scope = last.scope;
         $route.current = next;
         copy(next.params, $routeParams);
         last.scope && last.scope.$emit('$routeUpdate');


### PR DESCRIPTION
When we update route (changing only search param, no route reload) and then reload (change to different
route), it did not $destroy last scope.
