### PR TITLE
In-line Documentation fix

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -81,7 +81,7 @@
  *   parameters:
  *
  *   - HTTP GET "class" actions: `Resource.action([parameters], [success], [error])`
- *   - non-GET "class" actions: `Resource.action(postData, [parameters], [success], [error])`
+ *   - non-GET "class" actions: `Resource.action([parameters], postData, [success], [error])`
  *   - non-GET instance actions:  `instance.$action([parameters], [success], [error])`
  *
  *


### PR DESCRIPTION
Reverse order of [parameters] and postData in documentation for non-GET "class" actions.
