### PR TITLE
Change listed library to 10.6

### DIFF
--- a/docs/content/guide/dev_guide.overview.ngdoc
+++ b/docs/content/guide/dev_guide.overview.ngdoc
@@ -88,7 +88,7 @@ dev_guide.bootstrap auto initialize} your application.
 
 We load the angular using the  `<script>` tag:
 
-    `<script src="http://code.angularjs.org/0.9.15/angular-0.9.15.min.js"></script>`
+    `<script src="http://docs-next.angularjs.org/angular-0.10.6.min.js"></script>`
 
 From the `ng:model` attribute of the `<input>` tags, angular automatically sets up two-way data
 binding, and we also demonstrate some easy input validation:


### PR DESCRIPTION
Going through docs-next, on overview page saw reference to 9.15.  A quick grep doesn't show anywhere else 9.15 or 10.15 appears, though, so other than that is good.
