### PR TITLE
Rhino/YUI Compressor fails on reserved keyword

### DIFF
--- a/src/service/locale.js
+++ b/src/service/locale.js
@@ -52,7 +52,7 @@ function $LocaleProvider(){
         SHORTDAY: 'Sun,Mon,Tue,Wed,Thu,Fri,Sat'.split(','),
         AMPMS: ['AM','PM'],
         medium: 'MMM d, y h:mm:ss a',
-        short: 'M/d/yy h:mm a',
+        'short': 'M/d/yy h:mm a',
         fullDate: 'EEEE, MMMM d, y',
         longDate: 'MMMM d, y',
         mediumDate: 'MMM d, y',


### PR DESCRIPTION
The DATETIME localization uses "short" as property key, which makes the YUI javascript compressor fail. Converted key to string.
