### PR TITLE
fix($http): Do not serialize File object

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -417,6 +417,11 @@ function isScope(obj) {
 }
 
 
+function isFile(obj) {
+  return toString.apply(obj) === '[object File]';
+}
+
+
 function isBoolean(value) {return typeof value == $boolean;}
 function isTextNode(node) {return nodeName_(node) == '#text';}
 

--- a/src/service/http.js
+++ b/src/service/http.js
@@ -102,7 +102,7 @@ function $HttpProvider() {
 
     // transform outgoing request data
     transformRequest: function(d) {
-      return isObject(d) ? toJson(d) : d;
+      return isObject(d) && !isFile(d) ? toJson(d) : d;
     },
 
     // default headers

--- a/test/service/httpSpec.js
+++ b/test/service/httpSpec.js
@@ -564,6 +564,25 @@ describe('$http', function() {
             $httpBackend.expect('POST', '/url', 'string-data').respond('');
             $http({method: 'POST', url: '/url', data: 'string-data'});
           });
+
+
+          it('should ignore File objects', function() {
+            var file = {
+              some: true,
+              // $httpBackend compares toJson values by default,
+              // we need to be sure it's not serialized into json string
+              test: function(actualValue) {
+                return this === actualValue;
+              }
+            };
+
+            // I'm really sorry for doing this :-D
+            // Unfortunatelly I don't know how to trick toString.apply(obj) comparison
+            spyOn(window, 'isFile').andReturn(true);
+
+            $httpBackend.expect('POST', '/some', file).respond('');
+            $http({method: 'POST', url: '/some', data: file});
+          });
         });
 
 


### PR DESCRIPTION
We might auto set X-File headers, when you pass a File object, but I can't find any spec on that...
(ie X-File-Size, content-type, etc...)
