### PR TITLE
refactor(fromJson): Remove error() and just throw

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -83,9 +83,6 @@ var $boolean          = 'boolean',
     slice             = [].slice,
     push              = [].push,
     toString          = Object.prototype.toString,
-    error             = window[$console]
-                           ? bind(window[$console], window[$console]['error'] || noop)
-                           : noop,
 
     /** @name angular */
     angular           = window.angular || (window.angular = {}),

--- a/src/JSON.js
+++ b/src/JSON.js
@@ -37,17 +37,12 @@ function fromJson(json, useNative) {
 
   var obj;
 
-  try {
-    if (useNative && window.JSON && window.JSON.parse) {
-      obj = JSON.parse(json);
-    } else {
-      obj = parseJson(json, true)();
-    }
-    return transformDates(obj);
-  } catch (e) {
-    error("fromJson error: ", json, e);
-    throw e;
+  if (useNative && window.JSON && window.JSON.parse) {
+    obj = JSON.parse(json);
+  } else {
+    obj = parseJson(json, true)();
   }
+  return transformDates(obj);
 
   // TODO make forEach optionally recursive and remove this function
   // TODO(misko): remove this once the $http service is checked in.


### PR DESCRIPTION
It's more likely you are using angular.fromJson() inside Angular world, which means you get proper
exception handling by $exceptionHandler.

There is no point to explicitly push it to console and it causes memory leaks on most browsers 
(tried Chrome stable/canary, Safari, FF).
