### PR TITLE
fix($parse): Allow property names that collide with native object proper...

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -83,9 +83,6 @@ var $boolean          = 'boolean',
     slice             = [].slice,
     push              = [].push,
     toString          = Object.prototype.toString,
-    error             = window[$console]
-                           ? bind(window[$console], window[$console]['error'] || noop)
-                           : noop,
 
     /** @name angular */
     angular           = window.angular || (window.angular = {}),

--- a/src/JSON.js
+++ b/src/JSON.js
@@ -37,17 +37,12 @@ function fromJson(json, useNative) {
 
   var obj;
 
-  try {
-    if (useNative && window.JSON && window.JSON.parse) {
-      obj = JSON.parse(json);
-    } else {
-      obj = parseJson(json, true)();
-    }
-    return transformDates(obj);
-  } catch (e) {
-    error("fromJson error: ", json, e);
-    throw e;
+  if (useNative && window.JSON && window.JSON.parse) {
+    obj = JSON.parse(json);
+  } else {
+    obj = parseJson(json, true)();
   }
+  return transformDates(obj);
 
   // TODO make forEach optionally recursive and remove this function
   // TODO(misko): remove this once the $http service is checked in.

--- a/test/service/parseSpec.js
+++ b/test/service/parseSpec.js
@@ -227,6 +227,17 @@ describe('parser', function() {
     expect(scope.$eval("x.y.z", scope)).not.toBeDefined();
   });
 
+  it('should support property names that colide with native object properties', function() {
+    // regression
+    scope.watch = 1;
+    scope.constructor = 2;
+    scope.toString = 3;
+
+    expect(scope.$eval('watch', scope)).toBe(1);
+    expect(scope.$eval('constructor', scope)).toBe(2);
+    expect(scope.$eval('toString', scope)).toBe(3);
+  });
+
   it('should evaluate grouped expressions', function() {
     expect(scope.$eval("(1+2)*3")).toEqual((1+2)*3);
   });


### PR DESCRIPTION
...ties

I.e. constructor, toString, or watch on FF
(https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/watch)
- optimize parser a bit to not create getter function for operators
