### PR TITLE
feat(jqLite): make injector() and scope() work with the document object

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -117,8 +117,11 @@ function forEach(obj, iterator, context) {
       for (key = 0; key < obj.length; key++)
         iterator.call(context, obj[key], key);
     } else {
-      for (key in obj)
-        iterator.call(context, obj[key], key);
+      for (key in obj) {
+        if (obj.hasOwnProperty(key)) {
+          iterator.call(context, obj[key], key);
+        }
+      }
     }
   }
   return obj;

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -279,6 +279,13 @@ function JQLiteController(element, name) {
 
 function JQLiteInheritedData(element, name, value) {
   element = jqLite(element);
+
+  // if element is the document object work with the html element instead
+  // this makes $(document).scope() possible
+  if(element[0].nodeType == 9) {
+    element = element.find('html');
+  }
+
   while (element.length) {
     if (value = element.data(name)) return value;
     element = element.parent();

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -234,6 +234,25 @@ describe('angular', function() {
     });
   });
 
+
+  describe('forEach', function() {
+    it('should iterate over *own* object properties', function() {
+      function MyObj() {
+        this.bar = 'barVal';
+        this.baz = 'bazVal';
+      };
+      MyObj.prototype.foo = 'fooVal';
+
+      var obj = new MyObj(),
+          log = [];
+
+      forEach(obj, function(value, key) { log.push(key + ':' + value)});
+
+      expect(log).toEqual(['bar:barVal', 'baz:bazVal']);
+    });
+  });
+
+
   describe('sortedKeys', function() {
     it('should collect keys from object', function() {
       expect(sortedKeys({c:0, b:0, a:0})).toEqual(['a', 'b', 'c']);

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -107,6 +107,20 @@ describe('jqLite', function() {
       expect(deepChild.inheritedData('myData')).toBeFalsy();
       dealoc(element);
     });
+
+
+    it('should work with the child html element instead if the current element is the document obj',
+      function() {
+        var item = {},
+            doc = jqLite(document),
+            html = doc.find('html');
+
+        html.data('item', item);
+        expect(doc.inheritedData('item')).toBe(item);
+        expect(html.inheritedData('item')).toBe(item);
+        dealoc(doc);
+      }
+    );
   });
 
 
@@ -118,6 +132,18 @@ describe('jqLite', function() {
       dealoc(element);
     });
 
+    it('should retrieve scope attached to the html element if its requested on the document',
+        function() {
+      var doc = jqLite(document),
+          html = doc.find('html'),
+          scope = {};
+
+      html.data('$scope', scope);
+
+      expect(doc.scope()).toBe(scope);
+      expect(html.scope()).toBe(scope);
+      dealoc(doc);
+    });
 
     it('should walk up the dom to find scope', function() {
       var element = jqLite('<ul><li><p><b>deep deep</b><p></li></ul>');
@@ -145,6 +171,27 @@ describe('jqLite', function() {
 
 
       expect(span.injector()).toBe(injector);
+      dealoc(template);
+    });
+
+
+    it('should retrieve injector attached to the html element if its requested on document',
+        function() {
+      var doc = jqLite(document),
+          html = doc.find('html'),
+          injector = {};
+
+      html.data('$injector', injector);
+
+      expect(doc.injector()).toBe(injector);
+      expect(html.injector()).toBe(injector);
+      dealoc(doc);
+    });
+
+
+    it('should do nothing with a noncompiled template', function() {
+      var template = jqLite('<div><span></span></div>');
+      expect(template.injector()).toBeUndefined();
       dealoc(template);
     });
   });


### PR DESCRIPTION
For typical app that has ng-app directive on the html element, we now can do:

angular.element(document).injector() or .injector()
angular.element(document).scope() or .scope()

instead of:

angular.element(document.getElementsByTagName('html')[0]).injector()
...
