### PR TITLE
refactor($sniffer): make $sniffer service private

### DIFF
--- a/src/service/sniffer.js
+++ b/src/service/sniffer.js
@@ -1,7 +1,8 @@
 'use strict';
 
 /**
- * @ngdoc object
+ * !!! This is an undocumented "private" service !!!
+ *
  * @name angular.module.ng.$sniffer
  * @requires $window
  *
@@ -13,8 +14,6 @@
  */
 function $SnifferProvider(){
   this.$get = ['$window', function($window){
-    if ($window.Modernizr) return $window.Modernizr;
-
     return {
       history: !!($window.history && $window.history.pushState),
       hashchange: 'onhashchange' in $window &&

--- a/test/service/snifferSpec.js
+++ b/test/service/snifferSpec.js
@@ -30,9 +30,4 @@ describe('$sniffer', function() {
       expect(sniffer({onhashchange: true, document: {documentMode: 7}}).hashchange).toBe(false);
     });
   });
-
-  it('should use Modernizr if defined', function() {
-    var Modernizr = {};
-    expect(sniffer({Modernizr: Modernizr})).toBe(Modernizr);
-  });
 });


### PR DESCRIPTION
This service has been accidentaly documented in the past, it should not be considered
to be public api.

I'm also removing fallback to Modernizr since we don't need it.

Breaks any app that depends on this service and its fallback to Modernizr, please
migrate to custom "Modernizr" service:

```
module.value('Modernizr', function() { return Modernizr; });
```
