### PR TITLE
Trim arguments

### DIFF
--- a/src/Injector.js
+++ b/src/Injector.js
@@ -48,7 +48,7 @@ function inferInjectionArgs(fn) {
     var args = fn.$inject = [];
     var fnText = fn.toString().replace(STRIP_COMMENTS, '');
     var argDecl = fnText.match(FN_ARGS);
-    forEach(argDecl[1].split(FN_ARG_SPLIT), function(arg){
+    forEach(trim(argDecl[1]).split(FN_ARG_SPLIT), function(arg){
       arg.replace(FN_ARG, function(all, name){
         args.push(name);
       });


### PR DESCRIPTION
It turns out that if you have a function like this: function ( ) { }, Chrome will return the space in the empty parameter list while Firefox will not. This means that the injection lookup will get a string like this: " ", which is not handled in inferInjectionArgs.
