### PR TITLE
fix($injector): properly infer dependencies from fn with no args

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -38,7 +38,7 @@
  * Implicit module which gets automatically added to each {@link angular.module.AUTO.$injector $injector}.
  */
 
-var FN_ARGS = /^function\s*[^\(]*\(([^\)]*)\)/m;
+var FN_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
 var FN_ARG_SPLIT = /,/;
 var FN_ARG = /^\s*(_?)(.+?)\1\s*$/;
 var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -160,6 +160,13 @@ describe('injector', function() {
     });
 
 
+    it('should handle no arg functions with spaces in the arguments list', function() {
+      function fn( ) {}
+      expect(inferInjectionArgs(fn)).toEqual([]);
+      expect(fn.$inject).toEqual([]);
+    });
+
+
     it('should handle args with both $ and _', function() {
       function $f_n0($a_) {}
       expect(inferInjectionArgs($f_n0)).toEqual(['$a_']);


### PR DESCRIPTION
Previously if there was a white-space in fn: fn( ) {} we failed to infer no args.

This was originally reported by recht, but I decided to use a different fix.

Closes #829
