### PR TITLE
fix($q): $q.reject should forward callbacks if missing

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -274,7 +274,7 @@ function qFactory(nextTick, exceptionHandler) {
       then: function(callback, errback) {
         var result = defer();
         nextTick(function() {
-          result.resolve(errback(reason));
+          result.resolve((errback || defaultErrback)(reason));
         });
         return result.promise;
       }

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -480,6 +480,14 @@ describe('q', function() {
       syncResolve(deferred, rejectedPromise);
       expect(log).toEqual(['error(Error: not gonna happen)']);
     });
+
+
+    it('should return a promise that forwards callbacks if the callbacks are missing', function() {
+      var rejectedPromise = q.reject('rejected');
+      promise.then(success(), error());
+      syncResolve(deferred, rejectedPromise.then());
+      expect(log).toEqual(['error(rejected)']);
+    });
   });
 
 


### PR DESCRIPTION
Closes #845
