### PR TITLE
$location: links to different base paths should not be rewritten but fully reloaded by the browser

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -503,6 +503,9 @@ function $LocationProvider(){
         var href = elm.attr('href');
         if (!href || isDefined(elm.attr('ng-ext-link')) || elm.attr('target')) return;
 
+        // link to different base path
+        if (basePath != '/' && href[0] === '/' && href.indexOf(basePath) !== 0) { return; }
+
         // remove same domain from full url links (IE7 always returns full hrefs)
         href = href.replace(absUrlPrefix, '');
 

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -687,7 +687,7 @@ describe('$location', function() {
     function initBrowser() {
       return function($browser){
         $browser.url('http://host.com/base');
-        $browser.$$baseHref = '/base/index.html';
+        $browser.$$baseHref = '/base/';
       };
     }
 
@@ -752,7 +752,7 @@ describe('$location', function() {
         initLocation(),
         function($browser) {
           browserTrigger(link, 'click');
-          expectRewriteTo($browser, 'http://host.com/base/index.html#!/link?a#b');
+          expectRewriteTo($browser, 'http://host.com/base/#!/link?a#b');
         }
       );
     });
@@ -765,7 +765,7 @@ describe('$location', function() {
         initLocation(),
         function($browser) {
           browserTrigger(link, 'click');
-          expectRewriteTo($browser, 'http://host.com/base/index.html#!/link?a#b');
+          expectRewriteTo($browser, 'http://host.com/base/#!/link?a#b');
         }
       );
     });
@@ -798,7 +798,7 @@ describe('$location', function() {
 
 
     it('should not rewrite full url links do different domain', function() {
-      configureService('http://www.dot.abc/a?b=c', true);
+      configureService('http://www.dot.abc/base/a?b=c', true);
       inject(
         initBrowser(),
         initLocation(),
@@ -843,7 +843,7 @@ describe('$location', function() {
         initLocation(),
         function($browser) {
           browserTrigger(link, 'click');
-          expectRewriteTo($browser, 'http://host.com/base/index.html#!/new');
+          expectRewriteTo($browser, 'http://host.com/base/#!/new');
         }
       );
     });
@@ -863,6 +863,82 @@ describe('$location', function() {
       );
     });
 
+
+    it('should not rewrite when link to different base path when history enabled on new browser', function() {
+      configureService('/other_base/link', true, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser) {
+          browserTrigger(link, 'click');
+          expectNoRewrite($browser);
+        }
+      );
+    });
+
+
+	it('should not rewrite when link to different base path when history enabled on old browser', function() {
+      configureService('/other_base/link', true, false);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser) {
+          browserTrigger(link, 'click');
+          expectNoRewrite($browser);
+        }
+      );
+    });
+
+
+	it('should not rewrite when link to different base path when history disabled', function() {
+      configureService('/other_base/link', false);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser) {
+          browserTrigger(link, 'click');
+          expectNoRewrite($browser);
+        }
+      );
+    });
+
+
+	it('should not rewrite when full link to different base path when history enabled on new browser', function() {
+      configureService('http://host.com/other_base/link', true, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser) {
+          browserTrigger(link, 'click');
+          expectNoRewrite($browser);
+        }
+      );
+    });
+
+
+	it('should not rewrite when full link to different base path when history enabled on old browser', function() {
+      configureService('http://host.com/other_base/link', true, false);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser) {
+          browserTrigger(link, 'click');
+          expectNoRewrite($browser);
+        }
+      );
+    });
+
+	it('should not rewrite when full link to different base path when history disabled', function() {
+      configureService('http://host.com/other_base/link', false);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser) {
+          browserTrigger(link, 'click');
+          expectNoRewrite($browser);
+        }
+      );
+    });
 
     // don't run next tests on IE<9, as browserTrigger does not simulate pressed keys
     if (!(msie < 9)) {


### PR DESCRIPTION
Let's consider an angular app that is deployed at dom.tld/app1 and which use the html5 mode of the $location service. In such a configuration, the header section of the index file should contain a <base href="..." /> tag, and thus the base path of the app1 is known.

For now, links that go to the same domain (dom.tld) are rewritten by the $location service, unless if the link contains the directive 'ng-ext-link' or the attribute 'target'. 

This pull request prevents links that go to the same domain but to other bases to be rewritten by the $location service. Thus, links such as dom.tld/app2/... will not be rewritten and will cause a full browser reload. 

(I've also noticed that the 'ng-ext-link' directive doesn't compile with the new $compiler system since the 1.0.0 and it hard-coded. For instance, it is not possible to use the several directive syntaxes with this directive.)
