### PR TITLE
fix(booleanAttrs): convert to boolean

### DIFF
--- a/src/ng/directive/booleanAttrDirs.js
+++ b/src/ng/directive/booleanAttrDirs.js
@@ -288,7 +288,7 @@ forEach(BOOLEAN_ATTR, function(propName, attrName) {
         return function(scope, element, attr) {
           attr.$$observers[attrName] = [];
           scope.$watch(attr[normalized], function(value) {
-            attr.$set(attrName, value);
+            attr.$set(attrName, !!value);
           });
         };
       }

--- a/test/ng/directive/booleanAttrDirSpecs.js
+++ b/test/ng/directive/booleanAttrDirSpecs.js
@@ -23,6 +23,18 @@ describe('boolean attr directives', function() {
   }));
 
 
+  it('should properly evaluate 0 as false', inject(function($rootScope, $compile) {
+    // jQuery does not treat 0 as false, when setting attr()
+    element = $compile('<button ng-disabled="isDisabled">Button</button>')($rootScope)
+    $rootScope.isDisabled = 0;
+    $rootScope.$digest();
+    expect(element.attr('disabled')).toBeFalsy();
+    $rootScope.isDisabled = 1;
+    $rootScope.$digest();
+    expect(element.attr('disabled')).toBeTruthy();
+  }));
+
+
   it('should bind disabled', inject(function($rootScope, $compile) {
     element = $compile('<button ng-disabled="isDisabled">Button</button>')($rootScope)
     $rootScope.isDisabled = false;


### PR DESCRIPTION
jQuery's attr() does not handle 0 as false, when it comes to boolean attrs.

Another solution might be to not set attr() for boolean attrs at all...
