### PR TITLE
fix(script): Incorrectly reading script text on ie (follow-up)

### DIFF
--- a/src/ng/directive/script.js
+++ b/src/ng/directive/script.js
@@ -35,11 +35,8 @@ var scriptDirective = ['$templateCache', function($templateCache) {
     terminal: true,
     compile: function(element, attr) {
       if (attr.type == 'text/ng-template') {
-        var templateUrl = attr.id,
-            // IE is not consistent, in scripts we have to read .text but in other nodes we have to read .textContent
-            text = element[0].text;
-
-        $templateCache.put(templateUrl, text);
+        var templateUrl = attr.id;
+        $templateCache.put(templateUrl, element.html());
       }
     }
   };


### PR DESCRIPTION
The solution proposed by Misko (#0ec13428d7ba1cff67cde43bc90277481cab82ba) break the code for Chrome. The JQuery docs says: "To get the value of a script element, use the .html() method." (http://api.jquery.com/text/)
