### PR TITLE
Scope event changes

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -616,9 +616,8 @@ function $RootScopeProvider(){
        *   - `targetScope` - {Scope}: the scope on which the event was `$emit`-ed or `$broadcast`-ed.
        *   - `currentScope` - {Scope}: the current scope which is handling the event.
        *   - `name` - {string}: Name of the event.
-       *   - `cancel` - {function=}: calling `cancel` function will cancel further event propagation
+       *   - `stopPropagation` - {function=}: calling `stopPropagation` function will cancel further event propagation
        *     (available only for events that were `$emit`-ed).
-       *   - `cancelled` - {boolean}: Whether the event was cancelled.
        */
       $on: function(name, listener) {
         var namedListeners = this.$$listeners[name];
@@ -659,11 +658,11 @@ function $RootScopeProvider(){
         var empty = [],
             namedListeners,
             scope = this,
+            stopPropagation = false,
             event = {
               name: name,
               targetScope: scope,
-              cancel: function() {event.cancelled = true;},
-              cancelled: false
+              stopPropagation: function() {stopPropagation = true;}
             },
             listenerArgs = concat([event], arguments, 1),
             i, length;
@@ -674,7 +673,7 @@ function $RootScopeProvider(){
           for (i=0, length=namedListeners.length; i<length; i++) {
             try {
               namedListeners[i].apply(null, listenerArgs);
-              if (event.cancelled) return event;
+              if (stopPropagation) return event;
             } catch (e) {
               $exceptionHandler(e);
             }

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -618,6 +618,8 @@ function $RootScopeProvider(){
        *   - `name` - {string}: Name of the event.
        *   - `stopPropagation` - {function=}: calling `stopPropagation` function will cancel further event propagation
        *     (available only for events that were `$emit`-ed).
+       *   - `preventDefault` - {function}: calling `preventDefault` sets `defaultPrevented` flag to true.
+       *   - `defaultPrevented` - {boolean}: true if `preventDefault` was called.
        */
       $on: function(name, listener) {
         var namedListeners = this.$$listeners[name];
@@ -662,7 +664,11 @@ function $RootScopeProvider(){
             event = {
               name: name,
               targetScope: scope,
-              stopPropagation: function() {stopPropagation = true;}
+              stopPropagation: function() {stopPropagation = true;},
+              preventDefault: function() {
+                event.defaultPrevented = true;
+              },
+              defaultPrevented: false
             },
             listenerArgs = concat([event], arguments, 1),
             i, length;
@@ -712,8 +718,14 @@ function $RootScopeProvider(){
         var target = this,
             current = target,
             next = target,
-            event = { name: name,
-                      targetScope: target },
+            event = {
+              name: name,
+              targetScope: target,
+              preventDefault: function() {
+                event.defaultPrevented = true;
+              },
+              defaultPrevented: false
+            },
             listenerArgs = concat([event], arguments, 1);
 
         //down while you can, then up and next sibling or up and next sibling until back at root

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -697,6 +697,18 @@ describe('Scope', function() {
           grandChild.$emit('myEvent');
           expect(event).toBeDefined();
         });
+
+
+        it('should have preventDefault method and defaultPrevented property', function() {
+          var event = grandChild.$emit('myEvent');
+          expect(event.defaultPrevented).toBe(false);
+
+          child.$on('myEvent', function(event) {
+            event.preventDefault();
+          });
+          event = grandChild.$emit('myEvent');
+          expect(event.defaultPrevented).toBe(true);
+        });
       });
     });
 

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -668,8 +668,8 @@ describe('Scope', function() {
       }));
 
 
-      it('should allow cancelation of event propagation', function() {
-        child.$on('myEvent', function(event) { event.cancel(); });
+      it('should allow stopping event propagation', function() {
+        child.$on('myEvent', function(event) { event.stopPropagation(); });
         grandChild.$emit('myEvent');
         expect(log).toEqual('2>1>');
       });
@@ -682,17 +682,6 @@ describe('Scope', function() {
           expect(arg2).toBe('arg2');
         });
         child.$emit('abc', 'arg1', 'arg2');
-      });
-
-
-      it('should return event object with cancelled property', function() {
-        child.$on('some', function(event) {
-          event.cancel();
-        });
-
-        var result = grandChild.$emit('some');
-        expect(result).toBeDefined();
-        expect(result.cancelled).toBe(true);
       });
 
 


### PR DESCRIPTION
Things to consider:
- e.stopPropagation() during $broadcast stops propagation _only for given branch_ (it does depth-first traverse).
- e.stopPropagation() if not allowed throws exception ( noop ?)
- do we really want options object rather than just third boolean attribute (allowToStopPropagation)
- by default stopPropagation is allowed
