### PR TITLE
fix($browser/$location): single quote in url causes infinite digest in F...

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -165,7 +165,8 @@ function Browser(window, document, $log, $sniffer) {
       return self;
     // getter
     } else {
-      return location.href;
+      // the replacement is a workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=407172
+      return location.href.replace(/%27/g,"'");
     }
   };
 

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -462,6 +462,12 @@ describe('browser', function() {
     it('should return $browser to allow chaining', function() {
       expect(browser.url('http://any.com')).toBe(browser);
     });
+
+
+    it('should decode single quotes to work around FF bug 407273', function() {
+      fakeWindow.location.href = "http://ff-bug/?single%27quote";
+      expect(browser.url()).toBe("http://ff-bug/?single'quote");
+    });
   });
 
   describe('urlChange', function() {


### PR DESCRIPTION
...F

The real issue is in FF, see https://bugzilla.mozilla.org/show_bug.cgi?id=407172.

FF overly encodes stuff which breaks our expectations and then we fail .url() != currentUrl.absUrl()
comparison unexpectidly, which leads to infinite digest.

The workaround is to correct for this inconsistency in $browser and decode any single quotes in urls.

Closes #920
