### PR TITLE
Update: Fix for Issue #912 ($position in repeat directive can't be both first and last at the same time) 

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -12,10 +12,9 @@
  * Special properties are exposed on the local scope of each template instance, including:
  *
  *   * `$index` – `{number}` – iterator offset of the repeated element (0..length-1)
- *   * `$position` – `{string}` – position of the repeated element in the iterator. One of:
- *        * `'first'`,
- *        * `'middle'`
- *        * `'last'`
+ *   * `$first` – `{boolean}` – true if the repeated element is first in the iterator. 
+ *   * `$middle` – `{boolean}` – true if the repeated element is between the first and last in the iterator.
+ *   * `$last` – `{boolean}` – true if the repeated element is last in the iterator. 
  *
  *
  * @element ANY

--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -145,10 +145,11 @@ var ngRepeatDirective = ngDirective({
           childScope[valueIdent] = value;
           if (keyIdent) childScope[keyIdent] = key;
           childScope.$index = index;
-          childScope.$position = index === 0 ?
-              'first' :
-              (index == collectionLength - 1 ? 'last' : 'middle');
-
+          
+          childScope.$first = index === 0;
+          childScope.$middle = index > 0 && index < collectionLength-1;
+          childScope.$last = index == collectionLength - 1;
+          
           if (!last) {
             linker(childScope, function(clone){
               cursor.after(clone);

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -108,7 +108,7 @@ describe('ngRepeat', function() {
       inject(function($rootScope, $compile) {
     element = $compile(
       '<ul>' +
-        '<li ng-repeat="item in items" ng-bind="item + \':\' + $first+'-'+$middle+'-'+$last + \'|\'"></li>' +
+        '<li ng-repeat="item in items" ng-bind="item + \':\' + $first+\'-\'+$middle+\'-\'+$last + \'|\'"></li>' +
       '</ul>')($rootScope);
     $rootScope.items = ['misko', 'shyam', 'doug'];
     $rootScope.$digest();
@@ -133,7 +133,7 @@ describe('ngRepeat', function() {
       inject(function($rootScope, $compile) {
     element = $compile(
       '<ul>' +
-        '<li ng-repeat="(key, val) in items" ng-bind="key + \':\' + val + \':\' + $first+'-'+$middle+'-'+$last + \'|\'">' +
+        '<li ng-repeat="(key, val) in items" ng-bind="key + \':\' + val + \':\' + $first+\'-\'+$middle+\'-\'+$last + \'|\'">' +
         '</li>' +
       '</ul>')($rootScope);
     $rootScope.items = {'misko':'m', 'shyam':'s', 'doug':'d', 'frodo':'f'};

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -104,42 +104,50 @@ describe('ngRepeat', function() {
   }));
 
 
-  it('should expose iterator position as $position when iterating over arrays',
+  it('should expose iterator position as $first, $middle and $last when iterating over arrays',
       inject(function($rootScope, $compile) {
     element = $compile(
       '<ul>' +
-        '<li ng-repeat="item in items" ng-bind="item + \':\' + $position + \'|\'"></li>' +
+        '<li ng-repeat="item in items" ng-bind="item + \':\' + $first+'-'+$middle+'-'+$last + \'|\'"></li>' +
       '</ul>')($rootScope);
     $rootScope.items = ['misko', 'shyam', 'doug'];
     $rootScope.$digest();
-    expect(element.text()).toEqual('misko:first|shyam:middle|doug:last|');
+    expect(element.text()).toEqual('misko:true-false-false|shyam:false-true-false|doug:false-false-true|');
 
     $rootScope.items.push('frodo');
     $rootScope.$digest();
-    expect(element.text()).toEqual('misko:first|shyam:middle|doug:middle|frodo:last|');
+    expect(element.text()).toEqual('misko:true-false-false|shyam:false-true-false|doug:false-true-false|frodo:false-false-true|');
 
     $rootScope.items.pop();
     $rootScope.items.pop();
     $rootScope.$digest();
-    expect(element.text()).toEqual('misko:first|shyam:last|');
+    expect(element.text()).toEqual('misko:true-false-false|shyam:false-false-true|');
+    
+    $rootScope.items.pop();
+    $rootScope.$digest();
+    expect(element.text()).toEqual('misko:true-false-true|');
   }));
 
 
-  it('should expose iterator position as $position when iterating over objects',
+  it('should expose iterator position as $first, $middle and $last when iterating over objects',
       inject(function($rootScope, $compile) {
     element = $compile(
       '<ul>' +
-        '<li ng-repeat="(key, val) in items" ng-bind="key + \':\' + val + \':\' + $position + \'|\'">' +
+        '<li ng-repeat="(key, val) in items" ng-bind="key + \':\' + val + \':\' + $first+'-'+$middle+'-'+$last + \'|\'">' +
         '</li>' +
       '</ul>')($rootScope);
     $rootScope.items = {'misko':'m', 'shyam':'s', 'doug':'d', 'frodo':'f'};
     $rootScope.$digest();
-    expect(element.text()).toEqual('doug:d:first|frodo:f:middle|misko:m:middle|shyam:s:last|');
+    expect(element.text()).toEqual('doug:d:true-false-false|frodo:f:false-true-false|misko:m:false-true-false|shyam:s:false-false-true|');
 
     delete $rootScope.items.doug;
     delete $rootScope.items.frodo;
     $rootScope.$digest();
-    expect(element.text()).toEqual('misko:m:first|shyam:s:last|');
+    expect(element.text()).toEqual('misko:m:true-false-false|shyam:s:false-false-true|');
+    
+    delete $rootScope.items.shyam;
+    $rootScope.$digest();
+    expect(element.text()).toEqual('misko:m:true-false-true|');
   }));
 
 


### PR DESCRIPTION
Same pull request as #928 but it's from a separate branch, so future commits that I do to my master won't affect it. See #928 for more info.

Sorry for the mess.

> Fix for issue #912 (https://github.com/angular/angular.js/issues/912)
> 
> Implementation of my suggested fix where three boolean values $first, $middle and $last replaces the $position variable. I also added a test case for single item lists.
