### PR TITLE
Bugfix: Date-filter should support high-precision date-times

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -320,7 +320,7 @@ dateFilter.$inject = ['$locale'];
 function dateFilter($locale) {
 
 
-  var R_ISO8601_STR = /^(\d{4})-?(\d\d)-?(\d\d)(?:T(\d\d)(?::?(\d\d)(?::?(\d\d)(?:\.(\d{3}))?)?)?(Z|([+-])(\d\d):?(\d\d)))?$/;
+  var R_ISO8601_STR = /^(\d{4})-?(\d\d)-?(\d\d)(?:T(\d\d)(?::?(\d\d)(?::?(\d\d)(?:\.(\d+))?)?)?(Z|([+-])(\d\d):?(\d\d)))?$/;
   function jsonStringToDate(string){
     var match;
     if (match = string.match(R_ISO8601_STR)) {

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -270,5 +270,18 @@ describe('filters', function() {
       //no time
       expect(date('2003-09-10', format)).toEqual('2003-09 00');
     });
+    
+    it('should support different degrees of subsecond precision', function () {
+      var format = 'yyyy-MM-dd';
+      
+      expect(date('2003-09-10T13:02:03.12345678Z', format)).toEqual('2003-09-10');
+      expect(date('2003-09-10T13:02:03.1234567Z', format)).toEqual('2003-09-10');
+      expect(date('2003-09-10T13:02:03.123456Z', format)).toEqual('2003-09-10');
+      expect(date('2003-09-10T13:02:03.12345Z', format)).toEqual('2003-09-10');
+      expect(date('2003-09-10T13:02:03.1234Z', format)).toEqual('2003-09-10');
+      expect(date('2003-09-10T13:02:03.123Z', format)).toEqual('2003-09-10');
+      expect(date('2003-09-10T13:02:03.12Z', format)).toEqual('2003-09-10');
+      expect(date('2003-09-10T13:02:03.1Z', format)).toEqual('2003-09-10');
+    });
   });
 });


### PR DESCRIPTION
Hi,

We're using angular.js in a .net project, leveraging json.net as our server-side json serializer. This library outputs datetimes with more than three digits of precision in the millisecond part, and these strings are not recognized by the date filter. The enclosed fix (with test) updates the regular expression for ISO format dates to recognize 1-\* rather than exactly 3 digits for milliseconds (according to wikipedia, "There is no limit on the number of decimal places for the decimal fraction"; I won't cash out $105 to check with the standard myself ;-)).

As always, let us know if we can improve this patch and resubmit.

All the best,

Stein Jakob Nordbø
