### PR TITLE
fix(parser): string concatination with undefined model

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -5,7 +5,13 @@ var OPERATORS = {
     'true':function(){return true;},
     'false':function(){return false;},
     undefined:noop,
-    '+':function(self, locals, a,b){a=a(self, locals); b=b(self, locals); return (isDefined(a)?a:0)+(isDefined(b)?b:0);},
+    '+':function(self, locals, a,b){
+      a=a(self, locals); b=b(self, locals);
+      if (isDefined(a)) {
+        if (isDefined(b)) return a+b;
+        return a;
+      }
+      return isDefined(b)?b:undefined;},
     '-':function(self, locals, a,b){a=a(self, locals); b=b(self, locals); return (isDefined(a)?a:0)-(isDefined(b)?b:0);},
     '*':function(self, locals, a,b){return a(self, locals)*b(self, locals);},
     '/':function(self, locals, a,b){return a(self, locals)/b(self, locals);},

--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -15,6 +15,7 @@ describe('$interpolate', function() {
 
   it('should suppress falsy objects', inject(function($interpolate) {
     expect($interpolate('{{undefined}}')()).toEqual('');
+    expect($interpolate('{{undefined+undefined}}')()).toEqual('');
     expect($interpolate('{{null}}')()).toEqual('');
     expect($interpolate('{{a.b}}')()).toEqual('');
   }));
@@ -30,6 +31,18 @@ describe('$interpolate', function() {
     $rootScope.name = 'Misko';
     expect($interpolate('Hello {{name}}!')($rootScope)).toEqual('Hello Misko!');
   }));
+
+
+  it('should ignore undefined model', inject(function($interpolate) {
+    expect($interpolate("Hello {{'World' + foo}}")()).toEqual('Hello World');
+  }));
+
+
+  it('should ignore undefined return value', inject(function($interpolate, $rootScope) {
+    $rootScope.foo = function() {return undefined};
+    expect($interpolate("Hello {{'World' + foo()}}")($rootScope)).toEqual('Hello World');
+  }));
+
 
   describe('provider', function() {
     beforeEach(module(function($interpolateProvider) {


### PR DESCRIPTION
Related to issue #988
- {{'string' + undefinedModel}} results in 'string'
- {{undefined+undefined}} results in empty string
