### PR TITLE
ngOptions with ngMultiple

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -189,7 +189,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
 
       var selectCtrl = ctrls[0],
           ngModelCtrl = ctrls[1],
-          multiple = attr.multiple,
+          multiple = attr.ngMultiple,
           optionsExp = attr.ngOptions,
           nullOption = false, // if false, user will not be able to select it (used by ngOptions)
           emptyOption,


### PR DESCRIPTION
Before this fix, you had to declare twice (old+new way):
<select data-ng-model="..." data-ng-options="..."
    data-multiple="true" 
    data-ng-multiple="true">
</select>
