### PR TITLE
Making rc10's $timeout.cancel() accept a undefined param like rc9's $defer.cancel() used to.

### DIFF
--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -70,7 +70,7 @@ function $TimeoutProvider() {
       * Cancels a task associated with the `promise`. As a result of this the promise will be
       * resolved with a rejection.
       *
-      * @param {Promise} promise Promise returned by the `$timeout` function.
+      * @param {Promise=} promise Promise returned by the `$timeout` function.
       * @returns {boolean} Returns `true` if the task hasn't executed yet and was successfully
       *   canceled.
       */

--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -75,7 +75,7 @@ function $TimeoutProvider() {
       *   canceled.
       */
     timeout.cancel = function(promise) {
-      if (promise.$$timeoutId in deferreds) {
+      if (promise && promise.$$timeoutId in deferreds) {
         deferreds[promise.$$timeoutId].reject('canceled');
         return $browser.defer.cancel(promise.$$timeoutId);
       }

--- a/test/ng/timeoutSpec.js
+++ b/test/ng/timeoutSpec.js
@@ -142,5 +142,14 @@ describe('$timeout', function() {
       expect($timeout.cancel(promise1)).toBe(false);
       expect($timeout.cancel(promise2)).toBe(true);
     }));
+
+
+    it('should not throw a runtime exception when given an undefined promise', inject(function($timeout) {
+      try {
+        expect($timeout.cancel()).toBe(false);
+      } catch(e) {
+        fail(e);
+      }
+    }));
   });
 });


### PR DESCRIPTION
With rc9 you could call $defer.cancel() with an undefined value. With rc10, $defer's replacement $timeout throws an RTE when calling $timeout.cancel() with undefined.

This diff updates rc10 to behave like rc9 by verifying that the promise sent to $timeout.cancel() exists before attempting to work with it. 
