### PR TITLE
Nested forms not propagating dirty/pristine state

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -117,6 +117,7 @@ function FormController(element, attrs) {
     element.removeClass(PRISTINE_CLASS).addClass(DIRTY_CLASS);
     form.$dirty = true;
     form.$pristine = false;
+    parentForm.$setDirty();
   };
 
 }

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -184,6 +184,9 @@ describe('form', function() {
       inputB.$setValidity('MyError', true);
       expect(parent.$error.MyError).toBe(false);
       expect(child.$error.MyError).toBe(false);
+
+      child.$setDirty();
+      expect(parent.$dirty).toBeTruthy();
     });
 
 


### PR DESCRIPTION
In a nested form like below, the outer form has the class ng-pristine while the inner form is ng-dirty.  Valid/invalid state does propagate.

``` html
<form>
  <div ng-form>
    <input ng-model="foo">
  </div>
</form>
```

See http://jsfiddle.net/L4gdj/
