### PR TITLE
fix($compile): correctly merge class attr for replace directives

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -844,6 +844,7 @@ function $CompileProvider($provide) {
       var srcAttr = src.$attr,
           dstAttr = dst.$attr,
           $element = dst.$$element;
+
       // reapply the old attributes to the new element
       forEach(dst, function(value, key) {
         if (key.charAt(0) != '$') {
@@ -853,10 +854,12 @@ function $CompileProvider($provide) {
           dst.$set(key, value, true, srcAttr[key]);
         }
       });
+
       // copy the new attributes on the old attrs object
       forEach(src, function(value, key) {
         if (key == 'class') {
           safeAddClass($element, value);
+          dst.class = (dst.class ? dst.class + ' ' : '') + value;
         } else if (key == 'style') {
           $element.attr('style', $element.attr('style') + ';' + value);
         } else if (key.charAt(0) != '$' && !dst.hasOwnProperty(key)) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -378,6 +378,14 @@ describe('$compile', function() {
               expect(element).toBe(attr.$$element);
             }
           }));
+          $compileProvider.directive('replaceWithInterpolatedClass', valueFn({
+            replace: true,
+            template: '<div class="class_{{1+1}}">Replace with interpolated class!</div>',
+            compile: function(element, attr) {
+              attr.$set('compiled', 'COMPILED');
+              expect(element).toBe(attr.$$element);
+	    }
+          }));
         }));
 
 
@@ -453,6 +461,14 @@ describe('$compile', function() {
             '</div>')($rootScope);
           $rootScope.$digest();
           expect(element.text()).toEqual('Append!Append!');
+        }));
+
+
+        it('should handle interpolated css from replacing directive', inject(
+            function($compile, $rootScope) {
+          element = $compile('<div replace-with-interpolated-class></div>')($rootScope);
+          $rootScope.$digest();
+          expect(element).toHaveClass('class_2');
         }));
 
 


### PR DESCRIPTION
Merging of interpolated class attribute from directive template with replace:true works

Closes #1006
