### PR TITLE
Extended customizability of $resource

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -359,12 +359,18 @@ angular.module('ngResource', ['ng']).
           }
 
           var value = this instanceof Resource ? this : (action.isArray ? [] : new Resource(data));
-          $http({
+          var config = angular.extend({
             method: action.method,
             url: route.url(extend({}, extractParams(data), action.params || {}, params)),
             data: data
-          }).then(function(response) {
-              var data = response.data;
+          }, (action.httpConfig || {}));
+          $http(config).then(function(response) {
+              var data;
+              if (action.parseResponse) {
+                data = action.parseResponse(response);
+              } else {
+                data = response.data;
+              }
 
               if (data) {
                 if (action.isArray) {

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -115,6 +115,23 @@ describe("resource", function() {
     expect(item).toEqualData({id: 'abc'});
   });
 
+  it("should let custom action httpConfig and parseResponse override defaults", function() {
+    $httpBackend.expect('GET', '/Book/234').respond({result: {author: 'Dickens'}});
+    var Book = $resource(
+      '/Book/:id',
+      {id:'@bookId'},
+      {get: {
+        method: 'POST', 
+        parseResponse: function(response) { return response.data.result }, 
+        httpConfig: { method: 'GET' } //custom httpConfig overrides default 
+      }}
+    );
+    var book = Book.get({bookId: 234});
+
+    $httpBackend.flush();
+    expect(book).toEqualData({author: 'Dickens'});
+  });
+
 
   it("should create resource", function() {
     $httpBackend.expect('POST', '/CreditCard', '{"name":"misko"}').respond({id: 123, name: 'misko'});


### PR DESCRIPTION
Added an option to $resource's `action` parameters.  The user can define a custom httpConfig and a custom parseResponse function.  These allow the user to work with a lot more systems (sending custom headers through action.httpConfig and parsing weird responses with parseResponse).

Example use case.  these additions let me use www.parse.com and $resource together easily.

``` javascript
var myHttpConfig = { headers: myHeaders }; //Our pre-defined custom headers to use parse.com
var ParseResource = $resource('https://api.parse.com/1/classes/:class/:id', {
  class: '@class',
  id: '@id',
}, {
  get: { method: 'GET', httpConfig: myHttpConfig },
  create: { method: 'POST', httpConfig: myHttpConfig },
  save: { method: 'PUT', httpConfig: myHttpConfig },
  query: { 
    httpConfig: myHttpConfig,
    isArray: true,
    // Parse.com's response from a query is stored in response.data.result,
    // a parseResponse function allows us to use this
    parseResponse: function(response) {
      return response.data.result;
    }
  }, 
  remove: { method: 'DELETE', httpConfig: myHttpConfig }
});
```

I don't know if action.httpConfig and action.parseResponse are the best names, but I think the idea of adding these two simple things adds a lot more flexibility to $resource.
