### PR TITLE
Support to use XDomainRequest in $http requests

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -381,6 +381,7 @@ function $HttpProvider() {
      *    - **withCredentials** - `{boolean}` - whether to to set the `withCredentials` flag on the
      *      XHR object. See {@link https://developer.mozilla.org/en/http_access_control#section_5
      *      requests with credentials} for more information.
+     *    - **useXDomain** 0 `{boolean}` - use XDomainRequest in IE requests 
      *
      * @returns {HttpPromise} Returns a {@link ng.$q promise} object with the
      *   standard `then` method and two http specific methods: `success` and `error`. The `then`
@@ -697,7 +698,7 @@ function $HttpProvider() {
       // if we won't have the response in cache, send the request to the backend
       if (!cachedResp) {
         $httpBackend(config.method, url, reqData, done, reqHeaders, config.timeout,
-            config.withCredentials);
+            config.withCredentials, config.useXDomain);
       }
 
       return promise;

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -1,7 +1,7 @@
 describe('$httpBackend', function() {
 
   var $backend, $browser, callbacks,
-      xhr, fakeDocument, callback;
+      xhr, xdr, fakeDocument, callback;
 
   // TODO(vojta): should be replaced by $defer mock
   function fakeTimeout(fn, delay) {
@@ -38,7 +38,7 @@ describe('$httpBackend', function() {
         })
       }
     };
-    $backend = createHttpBackend($browser, MockXhr, fakeTimeout, callbacks, fakeDocument);
+    $backend = createHttpBackend($browser, MockXhr, MockXhr, fakeTimeout, callbacks, fakeDocument);
     callback = jasmine.createSpy('done');
   }));
 
@@ -234,7 +234,7 @@ describe('$httpBackend', function() {
 
 
     it('should convert 0 to 200 if content', function() {
-      $backend = createHttpBackend($browser, MockXhr, null, null, null, 'http');
+      $backend = createHttpBackend($browser, MockXhr, null, null, null, null, 'http');
 
       $backend('GET', 'file:///whatever/index.html', null, callback);
       respond(0, 'SOME CONTENT');
@@ -245,7 +245,7 @@ describe('$httpBackend', function() {
 
 
     it('should convert 0 to 200 if content - relative url', function() {
-      $backend = createHttpBackend($browser, MockXhr, null, null, null, 'file');
+      $backend = createHttpBackend($browser, MockXhr, null, null, null, null, 'file');
 
       $backend('GET', '/whatever/index.html', null, callback);
       respond(0, 'SOME CONTENT');
@@ -256,7 +256,7 @@ describe('$httpBackend', function() {
 
 
     it('should convert 0 to 404 if no content', function() {
-      $backend = createHttpBackend($browser, MockXhr, null, null, null, 'http');
+      $backend = createHttpBackend($browser, MockXhr, null, null, null, null, 'http');
 
       $backend('GET', 'file:///whatever/index.html', null, callback);
       respond(0, '');
@@ -267,7 +267,7 @@ describe('$httpBackend', function() {
 
 
     it('should convert 0 to 200 if content - relative url', function() {
-      $backend = createHttpBackend($browser, MockXhr, null, null, null, 'file');
+      $backend = createHttpBackend($browser, MockXhr, null, null, null, null, 'file');
 
       $backend('GET', '/whatever/index.html', null, callback);
       respond(0, '');
@@ -277,4 +277,3 @@ describe('$httpBackend', function() {
     });
   });
 });
-


### PR DESCRIPTION
A new config param that makes IE use XDomainRequest instead of XMLHttpRequest. Useful to use CORS
