### PR TITLE
fix($location): url rewriting if element was removed

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -550,8 +550,8 @@ function $LocationProvider(){
 
       // traverse the DOM up to find first A tag
       while (lowercase(elm[0].nodeName) !== 'a') {
-        if (elm[0] === $rootElement[0]) return;
-        elm = elm.parent();
+        // ignore rewriting if no A tag (reached root element, or no parent - removed from document)
+        if (elm[0] === $rootElement[0] || !(elm = elm.parent())[0]) return;
       }
 
       var absHref = elm.prop('href'),

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1087,6 +1087,21 @@ describe('$location', function() {
         expect(event.preventDefault).not.toHaveBeenCalled();
       });
     });
+
+
+    // regression https://github.com/angular/angular.js/issues/1058
+    it('should not throw if element was removed', inject(function($document, $rootElement, $location) {
+      // we need to do this otherwise we can't simulate events
+      $document.find('body').append($rootElement);
+
+      $rootElement.html('<button></button>');
+      var button = $rootElement.find('button');
+
+      button.bind('click', function() {
+        button.remove();
+      });
+      browserTrigger(button, 'click');
+    }));
   });
 
 


### PR DESCRIPTION
When user clicks a link, $location needs to intercept this event.  The <a> doesn't have to be target element of the DOM event, so it needs to traverse the DOM, to find first <a> parent.

If the target element was removed from DOM, during the same event, it would throw an exception. This fixes the issue.

Closes #1058
