### PR TITLE
Typo on ng.$routeProvider docs

### DIFF
--- a/src/ng/route.js
+++ b/src/ng/route.js
@@ -38,7 +38,7 @@ function $RouteProvider(){
    *    - `resolve` - `{Object.<string, function>=}` - An optional map of dependencies which should
    *      be injected into the controller. If any of these dependencies are promises, they will be
    *      resolved and converted to a value before the controller is instantiated and the
-   *      `$aftreRouteChange` event is fired. The map object is:
+   *      `$afterRouteChange` event is fired. The map object is:
    *
    *      - `key` – `{string}`: a name of a dependency to be injected into the controller.
    *      - `factory` - `{string|function}`: If `string` then it is an alias for a service.


### PR DESCRIPTION
Just a minor typo: it says "`$aftreRouteChange`" where it meant `$afterRouteChange`.
