### PR TITLE
Appends slashes to urls

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -295,7 +295,7 @@ angular.module('ngResource', ['ng']).
         });
         query.sort();
         url = url.replace(/\/*$/, '');
-        return url + (query.length ? '?' + query.join('&') : '');
+        return url + (query.length ? '?' + query.join('&') : '') + '/'; // append slashes to urls
       }
     };
 


### PR DESCRIPTION
Angular intenionally removes slashes from urls defined in ngResource and this causes bugs and problems in frameworks like django. It simply _adds_ slashes to urls for it work.
