### PR TITLE
fix($http): lowercase keys of headers when headers is an object.

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -42,7 +42,14 @@ function parseHeaders(headers) {
  *   - if called with no arguments returns an object containing all headers.
  */
 function headersGetter(headers) {
-  var headersObj = isObject(headers) ? headers : undefined;
+  var headersObj;
+
+  if (isObject(headers)) {
+    headersObj = {};
+    forEach(headers, function (value, key) {
+      this[lowercase(key)] = value;
+    }, headersObj);
+  }
 
   return function(name) {
     if (!headersObj) headersObj =  parseHeaders(headers);

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -626,6 +626,18 @@ describe('$http', function() {
           expect(callback).toHaveBeenCalledOnce();
         });
 
+        it('should have access to request headers uppercase', function() {
+          $httpBackend.expect('POST', '/url', 'header1').respond(200);
+          $http.post('/url', 'req', {
+            headers: {H1: 'header1'},
+            transformRequest: function(data, headers) {
+              return headers('H1');
+            }
+          }).success(callback);
+          $httpBackend.flush();
+
+          expect(callback).toHaveBeenCalledOnce();
+        });
 
         it('should pipeline more functions', function() {
           function first(d, h) {return d + '-first' + ':' + h('h1')}


### PR DESCRIPTION
Can't get header value because the keys are not lowercased. I guess this is a bug.
