### PR TITLE
documentation fixes

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -72,7 +72,7 @@ Compilation of HTML happens in three phases:
 
   1. First the HTML is parsed into DOM using the standard browser API. This is important to
   realize because the templates must be parsable HTML. This is in contrast to most templating
-  systems that operate on strings, rather then on DOM elements.
+  systems that operate on strings, rather than on DOM elements.
 
   2. The compilation of the DOM is performed by the call to {@link api/ng.$compile
   $compile()} method. The method traverses the DOM and matches the directives. If a match is found
@@ -146,7 +146,7 @@ instance of an `li` is performed.
 {@link api/ng.directive:ngRepeat ngRepeat} works by preventing the
 compilation process form descending into `li` element. Instead the {@link
 api/ng.directive:ngRepeat ngRepeat} directive compiles `li`
-seperatly. The result of of the `li` element compilation is a linking function which contains all
+separately. The result of of the `li` element compilation is a linking function which contains all
 of the directives contained in the `li` element ready to be attached to a specific clone of `li`
 element. At runtime the {@link api/ng.directive:ngRepeat ngRepeat}
 watches the expression and as items are added to the array it clones the `li` element, creates a

--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -174,6 +174,7 @@ In this example we will build a directive which displays the current time.
    <script>
      function Ctrl2($scope) {
        $scope.format = 'M/d/yy h:mm:ss a';
+       $scope.stop = function() { $scope.$broadcast( 'stopTimer' ); };
      }
 
      angular.module('time', [])
@@ -209,6 +210,11 @@ In this example we will build a directive which displays the current time.
            // to prevent updating time ofter the DOM element was removed.
            element.bind('$destroy', function() {
              $timeout.cancel(timeoutId);
+           });
+
+           scope.$on('stopTimer', function() {
+           console.log( "Inside stop timer event" );
+             $timeout.cancel(timeoutId); 
            });
 
            updateLater(); // kick of the UI update process.

--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -178,12 +178,12 @@ In this example we will build a directive which displays the current time.
 
      angular.module('time', [])
        // Register the 'myCurrentTime' directive factory method.
-       // We inject $defer and dateFilter service since the factory method is DI.
-       .directive('myCurrentTime', function($defer, dateFilter) {
+       // We inject $timeout and dateFilter service since the factory method is DI.
+       .directive('myCurrentTime', function($timeout, dateFilter) {
          // return the directive link function. (compile function not needed)
          return function(scope, element, attrs) {
            var format,  // date format
-               deferId; // deferId, so that we can cancel the time updates
+               timeoutId; // timeoutId, so that we can cancel the time updates
 
            // used to update the UI
            function updateTime() {
@@ -198,8 +198,8 @@ In this example we will build a directive which displays the current time.
 
            // schedule update in one second
            function updateLater() {
-             // save the deferId for canceling
-             deferId = $defer(function() {
+             // save the timeoutId for canceling
+             timeoutId = $timeout(function() {
                updateTime(); // update DOM
                updateLater(); // schedule another update
              }, 1000);
@@ -208,7 +208,7 @@ In this example we will build a directive which displays the current time.
            // listen on DOM destroy (removal) event, and cancel the next UI update
            // to prevent updating time ofter the DOM element was removed.
            element.bind('$destroy', function() {
-             $defer.cancel(deferId);
+             $timeout.cancel(timeoutId);
            });
 
            updateLater(); // kick of the UI update process.
@@ -217,7 +217,9 @@ In this example we will build a directive which displays the current time.
    </script>
    <div ng-controller="Ctrl2">
      Date format: <input ng-model='format'> <hr/>
-     Current time is: <span my-current-time="format"></span
+     Current time is: <span my-current-time="format"></span>
+     <br/>
+     <button ng-click="stop()">Stop Timer</button>
    </div>
   </doc:source>
   <doc:scenario>


### PR DESCRIPTION
There were a few spelling errors, and some broken code based on the change from defer to timeout.

I thought it would be useful to add a "stop" button to the timer code (to show how you could programmatically use the timeoutId via your controller), but this does not work inside the generated documentation.  

However, this same code works within JSFiddle:

http://jsfiddle.net/xhrud/ETMg7/

I won't be hurt if you decide to ignore the code with the stop button.  (Unfortunately, the second commit has the button inside of it, and should be modified.)

Chris
