### PR TITLE
Tutorial - Step 3 - Filtering repeaters: fixed typo

### DIFF
--- a/docs/content/tutorial/step_03.ngdoc
+++ b/docs/content/tutorial/step_03.ngdoc
@@ -56,7 +56,7 @@ __`app/index.html`:__
 
 We added a standard HTML `<input>` tag and used angular's
 {@link api/ng.filter:filter $filter} function to process the input for the
-`ngRepeate` directive.
+`ngRepeat` directive.
 
 This lets a user enter search criteria and immediately see the effects of their search on the phone
 list. This new code demonstrates the following:


### PR DESCRIPTION
Changed `ngRepeate` to `ngRepeat`.
