### PR TITLE
Dynamic default params for $resource

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -308,6 +308,7 @@ angular.module('ngResource', ['ng']).
       function extractParams(data){
         var ids = {};
         forEach(paramDefaults || {}, function(value, key){
+          if (isFunction(value)) { value = value(); }
           ids[key] = value.charAt && value.charAt(0) == '@' ? getter(data, value.substr(1)) : value;
         });
         return ids;

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -298,6 +298,17 @@ describe("resource", function() {
   });
 
 
+  it('should bind default dynamic parameters', function() {
+    $httpBackend.expect('GET', '/CreditCard/123.visa?minimum=0.05').respond({id: 123});
+    var minimum = 5;
+    var Visa = CreditCard.bind({verb:'.visa', minimum: function() { return minimum; }});
+    minimum = 0.05;
+    var visa = Visa.get({id:123});
+    $httpBackend.flush();
+    expect(visa).toEqualData({id:123});
+  });
+
+
   it('should exercise full stack', function() {
     var Person = $resource('/Person/:id');
 


### PR DESCRIPTION
As discussed in an email thread, here is a pull request to get dynamic default parameters for $resource so it's possible to do:

var User = $resource('/user', {'group': function() { return $location.search().group; }});

....
//modify group in $location
....

// the group is fetched only when I request for the user
user = User.get({'userId': myId}, function() { .... });
