### PR TITLE
Issue #856: add ability to reset a form to its pristine state

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -129,8 +129,8 @@ function FormController(element, attrs) {
    * Sets the form to its pristine state.
    *
    * This method can be called to remove the 'ng-dirty' class and set the form to its pristine
-   * state (ng-pristine class). Calling this method will also affect all the controls contained in
-   * this form.
+   * state (ng-pristine class). This method will also propagate to all the controls contained
+   * in this form.
    *
    * Setting a form back to a pristine state is often useful when we want to 'reuse' a form after
    * saving or resetting it.

--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -5,7 +5,8 @@ var nullFormCtrl = {
   $addControl: noop,
   $removeControl: noop,
   $setValidity: noop,
-  $setDirty: noop
+  $setDirty: noop,
+  $setPristine: noop
 };
 
 /**
@@ -119,6 +120,31 @@ function FormController(element, attrs) {
     form.$pristine = false;
   };
 
+  /**
+   * @ngdoc function
+   * @name ng.directive:form.FormController#$setPristine
+   * @methodOf ng.directive:form.FormController
+   *
+   * @description
+   * Sets the form to its pristine state.
+   *
+   * This method can be called to remove the 'ng-dirty' class and set the form to its pristine
+   * state (ng-pristine class). Calling this method will also affect all the controls contained in
+   * this form.
+   *
+   * Setting a form back to a pristine state is often useful when we want to 'reuse' a form after
+   * saving or resetting it.
+   */
+  form.$setPristine = function () {
+    element.removeClass(DIRTY_CLASS).addClass(PRISTINE_CLASS);
+    form.$dirty = false;
+    form.$pristine = true;
+    angular.forEach(form, function(value, key) {
+      if (value.$name && value.$setPristine) {
+        value.$setPristine();
+      }
+    });
+  };
 }
 
 

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -947,6 +947,22 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
     parentForm.$setValidity(validationErrorKey, isValid, this);
   };
 
+  /**
+   * @ngdoc function
+   * @name ng.directive:ngModel.NgModelController#$setPristine
+   * @methodOf ng.directive:ngModel.NgModelController
+   *
+   * @description
+   * Sets the control to its pristine state.
+   *
+   * This method can be called to remove the 'ng-dirty' class and set the control to its pristine
+   * state (ng-pristine class).
+   */
+  this.$setPristine = function () {
+    this.$dirty = false;
+    this.$pristine = true;
+    $element.removeClass(DIRTY_CLASS).addClass(PRISTINE_CLASS);
+  }
 
   /**
    * @ngdoc function

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -341,7 +341,7 @@ describe('form', function() {
 
     it('should set form and controls to the pristine state', function() {
 
-      var form = scope.form, input = doc.find('input').eq(0)
+      var form = scope.form, input = doc.find('input').eq(0);
 
       control.$setViewValue('');
       scope.$apply();

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -327,4 +327,30 @@ describe('form', function() {
       expect(doc).toBeDirty();
     });
   });
+
+  describe('set pristine state', function() {
+
+    beforeEach(function() {
+      doc = $compile(
+        '<form name="form">' +
+          '<input ng-model="name" name="name" store-model-ctrl/>' +
+          '</form>')(scope);
+
+      scope.$digest();
+    });
+
+    it('should set form and controls to the pristine state', function() {
+
+      var form = scope.form, input = doc.find('input').eq(0)
+
+      control.$setViewValue('');
+      scope.$apply();
+      expect(doc).toBeDirty();
+
+      form.$setPristine();
+      expect(doc).toBePristine();
+      expect(input).toBePristine();
+      expect(control.$pristine).toBeTruthy();
+    });
+  });
 });

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -117,6 +117,18 @@ describe('NgModelController', function() {
     });
   });
 
+  describe('setPristine', function() {
+
+    it('should set control to its pristine state', function() {
+      ctrl.$setViewValue('edit');
+      expect(ctrl.$dirty).toBe(true);
+      expect(ctrl.$pristine).toBe(false);
+
+      ctrl.$setPristine();
+      expect(ctrl.$dirty).toBe(false);
+      expect(ctrl.$pristine).toBe(true);
+    });
+  });
 
   describe('view -> model', function() {
 


### PR DESCRIPTION
This is a fix for the (quite up-voted now) issue #856. The whole commit boils down to adding the $setPristine() method to both ng.directive:form.FormController and ng.directive:ngModel.NgModelController; tests are added as well.

Here is a jsFiddle that shows an issue: http://jsfiddle.net/pkozlowski_opensource/qT9pu/2/ (just type sth in a field and then delete it).

Here is another jsFillde with the issue fixed: http://jsfiddle.net/pkozlowski_opensource/2x8HD/4/ (just type sth in a field and then delete it and click on 'Revert edits').
