### PR TITLE
prevent resulting src="" in html

### DIFF
--- a/src/ng/directive/booleanAttrs.js
+++ b/src/ng/directive/booleanAttrs.js
@@ -302,6 +302,9 @@ forEach(['src', 'href'], function(attrName) {
       priority: 99, // it needs to run after the attributes are interpolated
       link: function(scope, element, attr) {
         attr.$observe(normalized, function(value) {
+          if (!value)
+             return;
+
           attr.$set(attrName, value);
 
           // on IE, if "ng:src" directive declaration is used and "src" attribute doesn't exist

--- a/test/ng/directive/ngSrcSpec.js
+++ b/test/ng/directive/ngSrcSpec.js
@@ -1,0 +1,17 @@
+'use strict';
+
+describe('ngSrc', function() {
+  var element;
+
+  afterEach(function() {
+    dealoc(element);
+  });
+
+  it('should not result empty string in img src', inject(function($rootScope, $compile) {
+    $rootScope.image = {};
+    element = $compile('<img ng-src="{{image.url}}">')($rootScope);
+    $rootScope.$digest();
+    expect(element.attr('src')).not.toBe('');
+    expect(element.attr('src')).toBe(undefined);
+  }));
+});


### PR DESCRIPTION
Hello,

Current implementation of ngSrc may lead to empty src attribute when page is loading.

For example:

```
<img ng-src="{{image.url}}">
```

can be temporarily rendered as

```
<img src="">
```

before the `image` resource is loaded.

Some browser emits a request to _the current page_ when seeing `<img src="">` (Firefox13 and IE8 will, Chromium20 won't), which leads to performance problems.

This commit addressed this issue.
