### PR TITLE
Add support to Catch-All routes

### DIFF
--- a/src/ng/route.js
+++ b/src/ng/route.js
@@ -326,6 +326,12 @@ function $RouteProvider(){
           if (regex.match(paramRegExp)) {
             regex = regex.replace(paramRegExp, "([^\\/]*)$1");
             params.push(param);
+          } else {
+            var specialParamRegExp = new RegExp("\\*" + param + "([\\W])");
+            if (regex.match(specialParamRegExp)) {
+              regex = regex.replace(specialParamRegExp, "(.*)$1");
+              params.push(param);         
+            }
           }
         }
       });


### PR DESCRIPTION
It allows to accept routes like `edit/color/:color/largecode/*largecode` to match with something like this 
`http://appdomain.com/edit/color/brown/largecode/code/with/slashs`.

**I really need it because my app ids contains slashs.**
