### PR TITLE
Mention how attribute names map to directive names.

### DIFF
--- a/docs/content/tutorial/step_00.ngdoc
+++ b/docs/content/tutorial/step_00.ngdoc
@@ -173,10 +173,11 @@ __`app/index.html`:__
 
           <html ng-app>
 
-  The `ng-app` attribute is represents an Angular directive used to flag an element which Angular
-  should consider to be the root element of our application. This gives application developers the
-  freedom to tell Angular if the entire html page or only a portion of it should be treated as the
-  Angular application.
+  The `ng-app` attribute is represents an Angular directive (named `ngApp`; Angular uses
+  `name-with-dashes` for attribute names and `camelCase` for the corresponding directive name)
+  used to flag an element which Angular should consider to be the root element of our application.
+  This gives application developers the freedom to tell Angular if the entire html page or only a
+  portion of it should be treated as the Angular application.
 
 * AngularJS script tag:
 


### PR DESCRIPTION
In the tutorial, the ngApp directive suddenly pops up without directly connecting it to the ng-app attribute. Explaining that explicitly and how attribute names map to directive names help make sure that one doesn't think they missed something or there is a typo in the directive name compared to the attribute (and vice-versa).
