### PR TITLE
fix(docs): indicate support for passing a string as the `controller` pro...

### DIFF
--- a/src/ng/route.js
+++ b/src/ng/route.js
@@ -27,8 +27,9 @@ function $RouteProvider(){
    *
    *    Object properties:
    *
-   *    - `controller` – `{function()=}` – Controller fn that should be associated with newly
-   *      created scope.
+   *    - `controller` – `{(string|function()=}` – Controller fn that should be associated with newly
+   *      created scope or the name of a {@link angular.Module#controller registered controller} 
+   *      if passed as a string.
    *    - `template` – `{string=}` –  html template as a string that should be used by
    *      {@link ng.directive:ngView ngView} or
    *      {@link ng.directive:ngInclude ngInclude} directives.


### PR DESCRIPTION
fix(docs): indicate support for passing a string as the `controller` property on $routeProvider's route object
