### PR TITLE
Tweak formatting and wording of a list.

### DIFF
--- a/docs/content/tutorial/step_03.ngdoc
+++ b/docs/content/tutorial/step_03.ngdoc
@@ -61,7 +61,7 @@ We added a standard HTML `<input>` tag and used angular's
 This lets a user enter search criteria and immediately see the effects of their search on the phone
 list. This new code demonstrates the following:
 
-* Data-binding. This is one of the core features in Angular. When the page loads, Angular binds the
+* Data-binding: This is one of the core features in Angular. When the page loads, Angular binds the
 name of the input box to a variable of the same name in the data model and keeps the two in sync.
 
   In this code, the data that a user types into the input box (named __`query`__) is immediately
@@ -71,7 +71,7 @@ the DOM to reflect the current state of the model.
 
       <img  class="diagram" src="img/tutorial/tutorial_03.png">
 
-* Use of `filter` filter. The {@link api/ng.filter:filter filter} function uses the
+* Use of the `filter` filter: The {@link api/ng.filter:filter filter} function uses the
 `query` value to create a new array that contains only those records that match the `query`.
 
   `ngRepeat` automatically updates the view in response to the changing number of phones returned


### PR DESCRIPTION
Having a single word sentence and another one not containing a grammatically correct sentence seemed. Maybe use colons to denote that they are acting as topics for the rest of the li (as this patch does)?
