### PR TITLE
Fix some awkward wording.

### DIFF
--- a/docs/content/tutorial/step_05.ngdoc
+++ b/docs/content/tutorial/step_05.ngdoc
@@ -180,7 +180,7 @@ native APIs and the global state associated with them — both of which make tes
 HTTP request and tell it what to respond with. Note that the responses are not returned until we call
 the `$httpBackend.flush` method.
 
-Now, we will make assertions to verify that the `phones` model doesn't exist on the scope, before
+Now, we will make assertions to verify that the `phones` model doesn't exist on `scope` before
 the response is received:
 
 <pre>


### PR DESCRIPTION
Typically you exist _in_ a scope, not on it. But since the sentence is about the `scope` object, it makes sense to use "on", but only if you make it clear you are talking about the object and not the concept.

Also removed an unneeded comma.
