### PR TITLE
Remove a sudden listing of an attribute name next to its directive name.

### DIFF
--- a/docs/content/tutorial/step_03.ngdoc
+++ b/docs/content/tutorial/step_03.ngdoc
@@ -150,7 +150,7 @@ and title elements:
 
   Be sure to *remove* the `ng-controller` declaration from the body element.
 
-  While using double curlies works fine in within the title element, you might have noticed that
+  While using double curlies works fine within the title element, you might have noticed that
 for a split second they are actually displayed to the user while the page is loading. A better
 solution would be to use the {@link api/ng.directive:ngBind
 ngBind} or {@link api/ng.directive:ngBindTemplate

--- a/docs/content/tutorial/step_06.ngdoc
+++ b/docs/content/tutorial/step_06.ngdoc
@@ -65,7 +65,7 @@ api/ng.directive:ngSrc ngSrc} directive. That directive prevents the
 browser from treating the angular `{{ expression }}` markup literally, and initiating a request to
 invalid url `http://localhost:8000/app/{{phone.imageUrl}}`, which it would have done if we had only
 specified an attribute binding in a regular `src` attribute (`<img  class="diagram" src="{{phone.imageUrl}}">`).
-Using `ngSrc` (`ng-src`) prevents the browser from making an http request to an invalid location.
+Using the `ngSrc` directive prevents the browser from making an http request to an invalid location.
 
 
 ## Test


### PR DESCRIPTION
In the entire tutorial up to this point, it has been left up to the reader to map directive names to attribute names (except for the introduction of the concept in step 0). This patch keeps this consistency by removing the single instance thus far of bothering to list the directive name and attribute name directly next to each other.
