### PR TITLE
ngRepeater isn't a thing, ngRepeat is

### DIFF
--- a/docs/content/tutorial/step_03.ngdoc
+++ b/docs/content/tutorial/step_03.ngdoc
@@ -150,7 +150,7 @@ and title elements:
 
   Be sure to *remove* the `ng-controller` declaration from the body element.
 
-  While using double curlies works fine in within the title element, you might have noticed that
+  While using double curlies works fine within the title element, you might have noticed that
 for a split second they are actually displayed to the user while the page is loading. A better
 solution would be to use the {@link api/ng.directive:ngBind
 ngBind} or {@link api/ng.directive:ngBindTemplate

--- a/docs/content/tutorial/step_08.ngdoc
+++ b/docs/content/tutorial/step_08.ngdoc
@@ -77,7 +77,7 @@ route by the `$route` service.
 ## Template
 
 The TBD placeholder line has been replaced with lists and bindings that comprise the phone details.
-Note where we use the angular `{{expression}}` markup and `ngRepeater`s to project phone data from
+Note where we use the angular `{{expression}}` markup and `ngRepeat` to project phone data from
 our model into the view.
 
 


### PR DESCRIPTION
And there is no need to make it plural as it is implicit from the word "use", e.g. "look at where we use red in this painting".
