### PR TITLE
Naive implementation for better error messages from $interpolate

### DIFF
--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -98,19 +98,24 @@ function $InterpolateProvider() {
           exp,
           concat = [];
 
-      while(index < length) {
-        if ( ((startIndex = text.indexOf(startSymbol, index)) != -1) &&
-             ((endIndex = text.indexOf(endSymbol, startIndex + startSymbolLength)) != -1) ) {
-          (index != startIndex) && parts.push(text.substring(index, startIndex));
-          parts.push(fn = $parse(exp = text.substring(startIndex + startSymbolLength, endIndex)));
-          fn.exp = exp;
-          index = endIndex + endSymbolLength;
-          hasInterpolation = true;
-        } else {
-          // we did not find anything, so we have to add the remainder to the parts array
-          (index != length) && parts.push(text.substring(index));
-          index = length;
+      try {
+        while(index < length) {
+          if ( ((startIndex = text.indexOf(startSymbol, index)) != -1) &&
+               ((endIndex = text.indexOf(endSymbol, startIndex + startSymbolLength)) != -1) ) {
+            (index != startIndex) && parts.push(text.substring(index, startIndex));
+            parts.push(fn = $parse(exp = text.substring(startIndex + startSymbolLength, endIndex)));
+            fn.exp = exp;
+            index = endIndex + endSymbolLength;
+            hasInterpolation = true;
+          } else {
+            // we did not find anything, so we have to add the remainder to the parts array
+            (index != length) && parts.push(text.substring(index));
+            index = length;
+          }
         }
+      }
+      catch (err) {
+        throw new Error('Error within interpolation: ' + text + ';' + err.toString());
       }
 
       if (!(length = parts.length)) {

--- a/test/BinderSpec.js
+++ b/test/BinderSpec.js
@@ -175,7 +175,7 @@ describe('Binder', function() {
       $rootScope.error['throw'] = function() {throw 'MyError';};
       errorLogs.length = 0;
       $rootScope.$apply();
-      expect(errorLogs.shift()).toBe('MyError');
+      expect(errorLogs.shift().message).toBe('Error while interpolating: {{error.throw()}}\nMyError');
 
       $rootScope.error['throw'] = function() {return 'ok';};
       $rootScope.$apply();

--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -25,6 +25,29 @@ describe('$interpolate', function() {
     expect($interpolate('{{ false }}')()).toEqual('false');
   }));
 
+  it('should rethrow exceptions', inject(function($interpolate, $rootScope) {
+    $rootScope.err = function () {
+      throw new Error('oops');
+    };
+    expect(function () {
+      $interpolate('{{err()}}')($rootScope);
+    }).toThrow('Error while interpolating: {{err()}}\nError: oops');
+  }));
+
+  iit('should stop interpolation when encountering an exception', inject(function($interpolate, $compile, $rootScope) {
+    $rootScope.err = function () {
+      throw new Error('oops');
+    };
+    var dom = jqLite('<div>{{1 + 1}}</div><div>{{err()}}</div><div>{{1 + 2}}</div>');
+    $compile(dom)($rootScope);
+    expect(function () {
+      $rootScope.$apply();
+    }).toThrow('Error while interpolating: {{err()}}\nError: oops');
+    expect(dom[0].innerHTML).toEqual('2');
+    expect(dom[1].innerHTML).toEqual('{{err()}}');
+    expect(dom[2].innerHTML).toEqual('{{1 + 2}}');
+  }));
+
 
   it('should return interpolation function', inject(function($interpolate, $rootScope) {
     $rootScope.name = 'Misko';


### PR DESCRIPTION
This is not yet complete, but I'm recording this so I don't lose my train of thought and get some feedback. It would be nice to know specifically what part of the interpolation failed. For instance, have the massage distinguish between `foo()` and `bar` throwing exceptions with input like: `{{foo()}} and {{bar()}}`. I also still need to add a test for this.

Addresses issue #832.
