### PR TITLE
event.preventDefault() for links in Opera

### DIFF
--- a/src/ng/directive/a.js
+++ b/src/ng/directive/a.js
@@ -22,6 +22,7 @@ var htmlAnchorDirective = valueFn({
         // if we have no href url, then don't navigate anywhere.
         if (!element.attr('href')) {
           event.preventDefault();
+          return false;
         }
       });
     }


### PR DESCRIPTION
I began to test my angular application in recent Opera (12.00, OS X) and found that clicking the links without href attribute does not always prevented, so it messes up navigation. Adding the "return false" fixes the issue to me.
