### PR TITLE
Added URL Suffixes to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,18 @@
 AngularJS
 =========
 
-AngularJS lets you write client-side web applications as if you had a smarter browser.  It lets use
-good old HTML (or HAML, Jade and friends!) as your template language and lets you extend HTML’s
-syntax to express your application’s components clearly and succinctly.  It automatically
-synchronizes data from your UI (view) with your JavaScript objects (model) through 2-way data
-binding. To help you structure your application better and make it easy to test AngularJS teaches
-the browser how to do dependency injection and inversion of control. Oh yeah and it also helps with
-server-side communication, taming async callbacks with promises and deferreds; and make client-side
-navigation and deeplinking with hashbang urls or HTML5 pushState a piece of cake. The best of all:
-it makes development fun!
+This repo is a fork of AngularJS which adds support for parameter suffixes for resources.
 
-* Web site: http://angularjs.org
-* Tutorial: http://docs.angularjs.org/tutorial
-* API Docs: http://docs.angularjs.org
-* Developer Guide: http://docs.angularjs.org/guide
+This way you can create resources which have a URL which relates to /resources/:id.json
 
-Compiling
----------
-    rake compile
+## Usage
+```
+angular.module('App',['ngResource']).factory('Model',['$resource',function($resource) {
 
-Running Tests
--------------
-    ./server.sh                          # start the server
-    open http://localhost:9876/capture   # capture browser
-    ./test.sh                            # run all unit tests
-
-
+  return $resource('/path/to/resource',{
+      _suffx : '.json'
+    },{
+      //actions
+    }
+  );
+}]);

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -279,9 +279,15 @@ angular.module('ngResource', ['ng']).
       url: function(params) {
         var self = this,
             url = this.template,
+            suffix,
             encodedVal;
 
         params = params || {};
+        if(params['_suffix']) {
+          suffix = params['_suffix'];
+          delete params['_suffix'];
+        }
+
         forEach(this.urlParams, function(_, urlParam){
           encodedVal = encodeUriSegment(params[urlParam] || self.defaults[urlParam] || "");
           url = url.replace(new RegExp(":" + urlParam + "(\\W)"), encodedVal + "$1");
@@ -295,6 +301,9 @@ angular.module('ngResource', ['ng']).
         });
         query.sort();
         url = url.replace(/\/*$/, '');
+        if(suffix) {
+          url += suffix;
+        }
         return url + (query.length ? '?' + query.join('&') : '');
       }
     };


### PR DESCRIPTION
When using AngularJS with a server-side framework that requires a URL suffix like .json then angular will keep the suffix for all resource variants. So when you have a POST or index request then you end up having URLs that look like "/resource/.json".

Here's the issue in detail:
http://stackoverflow.com/questions/11622665/format-all-model-service-urls-to-include-json-in-angular-js

I've added the code into the repo to fix this. By setting a _suffix variable in the params{} hash when creating a resource then the suffix can be added properly.
