### PR TITLE
changed simpleApp to myApp in the Module page guide for consistency

### DIFF
--- a/docs/content/guide/module.ngdoc
+++ b/docs/content/guide/module.ngdoc
@@ -27,15 +27,15 @@ Important things to notice:
   * Notice the reference to the `myApp` module in the `<html ng:app="myApp">`, it is what
     bootstraps the app using your module.
 
-<doc:example module='simpleApp'>
+<doc:example module='myApp'>
   <doc:source>
     <script>
       // declare a module
-      var simpleAppModule = angular.module('simpleApp', []);
+      var simpleAppModule = angular.module('myApp', []);
 
       // configure the module.
       // in this example we will create a greeting filter
-      simpleAppModule.filter('greet', function() {
+      myAppModule.filter('greet', function() {
        return function(name) {
           return 'Hello, ' + name + '!';
         };


### PR DESCRIPTION
Paragraph says:
Notice the reference to the myApp module in the <html ng-app="myApp">, it is what bootstraps the app using your module.

But the code has:

<!-- index.html -->

```
<!doctype html>
<html ng-app="simpleApp">
<head>
<script src="http://code.angularjs.org/angular-1.0.1.min.js"></script>
<script src="script.js"></script>
</head>
<body>
<div>
{{ 'World' | greet }}
</div>
</body>
</html>
```

<!-- script.js -->

```
// declare a module
var simpleAppModule = angular.module('simpleApp', []);

// configure the module.
// in this example we will create a greeting filter
simpleAppModule.filter('greet', function() {
return function(name) {
return 'Hello, ' + name + '!';
};
});
```
