### PR TITLE
docs(typos): fix dev guide typos and grammatical errors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,6 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
-# Custom for Visual Studio
-*.cs     diff=csharp
-*.sln    merge=union
-*.csproj merge=union
-*.vbproj merge=union
-*.fsproj merge=union
-*.dbproj merge=union
-
 # Standard to msysgit
 *.doc	 diff=astextplain
 *.DOC	 diff=astextplain

--- a/docs/content/guide/bootstrap.ngdoc
+++ b/docs/content/guide/bootstrap.ngdoc
@@ -25,7 +25,7 @@ initialization.
 </pre>
 
   * Place the `script` tag at the buttom of the page. Placing script tags at the end of the page
-    improves app load time becouse the HTML loading is not blocked by loading of the `angular.js`
+    improves app load time because the HTML loading is not blocked by loading of the `angular.js`
     script. You can get the latest bits from {@link http://code.angularjs.org}. Please don't link
     your production code to this URL, as it will expose a security hole on your site. For
     experimental development linking to our site is fine.

--- a/docs/content/guide/bootstrap.ngdoc
+++ b/docs/content/guide/bootstrap.ngdoc
@@ -25,7 +25,7 @@ initialization.
 </pre>
 
   * Place the `script` tag at the buttom of the page. Placing script tags at the end of the page
-    improves app load time because the HTML loading is not blocked by loading of the `angular.js`
+    improves app load time becouse the HTML loading is not blocked by loading of the `angular.js`
     script. You can get the latest bits from {@link http://code.angularjs.org}. Please don't link
     your production code to this URL, as it will expose a security hole on your site. For
     experimental development linking to our site is fine.

--- a/docs/content/guide/dev_guide.mvc.understanding_controller.ngdoc
+++ b/docs/content/guide/dev_guide.mvc.understanding_controller.ngdoc
@@ -253,7 +253,7 @@ describe('state', function() {
         var mainCtrl = $controller(MainCtrl, {$scope: mainScope});
         childScope = mainScope.$new();
         var childCtrl = $controller(ChildCtrl, {$scope: childScope});
-        babyScope = $rootScope.$new();
+        babyScope = childCtrl.$new();
         var babyCtrl = $controller(BabyCtrl, {$scope: babyScope});
     }));
 

--- a/docs/content/guide/dev_guide.mvc.understanding_controller.ngdoc
+++ b/docs/content/guide/dev_guide.mvc.understanding_controller.ngdoc
@@ -253,7 +253,7 @@ describe('state', function() {
         var mainCtrl = $controller(MainCtrl, {$scope: mainScope});
         childScope = mainScope.$new();
         var childCtrl = $controller(ChildCtrl, {$scope: childScope});
-        babyScope = childCtrl.$new();
+        babyScope = $rootScope.$new();
         var babyCtrl = $controller(BabyCtrl, {$scope: babyScope});
     }));
 

--- a/docs/content/guide/dev_guide.services.creating_services.ngdoc
+++ b/docs/content/guide/dev_guide.services.creating_services.ngdoc
@@ -2,12 +2,12 @@
 @name Developer Guide: Angular Services: Creating Services
 @description
 
-While angular offers several useful services, for any nontrivial application you'll find it useful
+While Angular offers several useful services, for any nontrivial application you'll find it useful
 to write your own custom services. To do this you begin by registering a service factory function
 with a module either via the {@link api/angular.module Module#factory api} or directly
 via the {@link api/AUTO.$provide $provide} api inside of module config function.
 
-All angular services participate in {@link di dependency injection (DI)} by registering
+All Angular services participate in {@link di dependency injection (DI)} by registering
 themselves with Angular's DI system (injector) under a `name` (id) as well as by declaring
 dependencies which need to be provided for the factory function of the registered service. The
 ability to swap dependencies for mocks/stubs/dummies in tests allows for services to be highly
@@ -76,17 +76,17 @@ angular.module('myModule', [], function($provide) {
 
 # Instantiating Angular Services
 
-All services in Angular are instantiates services lazily, this means that a service will be created
+All services in Angular are instantiated lazily. This means that a service will be created
 only when it is needed for instantiation of a service or an application component that depends on it.
-In other words, angular won't instantiate lazy services unless they are requested directly or
+In other words, Angular won't instantiate lazy services unless they are requested directly or
 indirectly by the application.
 
 
 # Services as singletons
 
-Lastly, it is important to realize that all angular services are application singletons. This means
-that there is only one instance of a given service per injector. Since angular is lethally allergic
-to the global state, it is possible to create multiple injectors, each with its own instance of a
+Lastly, it is important to realize that all Angular services are application singletons. This means
+that there is only one instance of a given service per injector. Since Angular is lethally allergic
+to global state, it is possible to create multiple injectors, each with its own instance of a
 given service, but that is rarely needed, except in tests where this property is crucially
 important.
 

--- a/docs/content/guide/dev_guide.services.creating_services.ngdoc
+++ b/docs/content/guide/dev_guide.services.creating_services.ngdoc
@@ -2,12 +2,12 @@
 @name Developer Guide: Angular Services: Creating Services
 @description
 
-While Angular offers several useful services, for any nontrivial application you'll find it useful
+While angular offers several useful services, for any nontrivial application you'll find it useful
 to write your own custom services. To do this you begin by registering a service factory function
 with a module either via the {@link api/angular.module Module#factory api} or directly
 via the {@link api/AUTO.$provide $provide} api inside of module config function.
 
-All Angular services participate in {@link di dependency injection (DI)} by registering
+All angular services participate in {@link di dependency injection (DI)} by registering
 themselves with Angular's DI system (injector) under a `name` (id) as well as by declaring
 dependencies which need to be provided for the factory function of the registered service. The
 ability to swap dependencies for mocks/stubs/dummies in tests allows for services to be highly
@@ -76,17 +76,17 @@ angular.module('myModule', [], function($provide) {
 
 # Instantiating Angular Services
 
-All services in Angular are instantiated lazily. This means that a service will be created
+All services in Angular are instantiates services lazily, this means that a service will be created
 only when it is needed for instantiation of a service or an application component that depends on it.
-In other words, Angular won't instantiate lazy services unless they are requested directly or
+In other words, angular won't instantiate lazy services unless they are requested directly or
 indirectly by the application.
 
 
 # Services as singletons
 
-Lastly, it is important to realize that all Angular services are application singletons. This means
-that there is only one instance of a given service per injector. Since Angular is lethally allergic
-to global state, it is possible to create multiple injectors, each with its own instance of a
+Lastly, it is important to realize that all angular services are application singletons. This means
+that there is only one instance of a given service per injector. Since angular is lethally allergic
+to the global state, it is possible to create multiple injectors, each with its own instance of a
 given service, but that is rarely needed, except in tests where this property is crucially
 important.
 

--- a/docs/content/guide/dev_guide.services.testing_services.ngdoc
+++ b/docs/content/guide/dev_guide.services.testing_services.ngdoc
@@ -2,7 +2,7 @@
 @name Developer Guide: Angular Services: Testing Angular Services
 @description
 
-Following is a unit test for the service in the example in {@link
+The following is a unit test for the 'notify' service in the 'Dependencies' example in {@link
 dev_guide.services.creating_services Creating Angular Services}. The unit test example uses Jasmine
 spy (mock) instead of a real browser alert.
 

--- a/docs/content/guide/dev_guide.services.testing_services.ngdoc
+++ b/docs/content/guide/dev_guide.services.testing_services.ngdoc
@@ -2,7 +2,7 @@
 @name Developer Guide: Angular Services: Testing Angular Services
 @description
 
-The following is a unit test for the 'notify' service in the 'Dependencies' example in {@link
+Following is a unit test for the service in the example in {@link
 dev_guide.services.creating_services Creating Angular Services}. The unit test example uses Jasmine
 spy (mock) instead of a real browser alert.
 

--- a/docs/content/guide/dev_guide.templates.css-styling.ngdoc
+++ b/docs/content/guide/dev_guide.templates.css-styling.ngdoc
@@ -9,7 +9,7 @@ Angular sets these CSS classes. It is up to your application to provide useful s
 
 * `ng-invalid`, `ng-valid`
   - **Usage:** angular applies this class to an input widget element if that element's input does
-    notpass validation. (see {@link api/ng.directive:input input} directive).
+    not pass validation. (see {@link api/ng.directive:input input} directive).
 
 * `ng-pristine`, `ng-dirty`
   - **Usage:** angular {@link api/ng.directive:input input} directive applies `ng-pristine` class

--- a/docs/content/guide/dev_guide.templates.css-styling.ngdoc
+++ b/docs/content/guide/dev_guide.templates.css-styling.ngdoc
@@ -9,7 +9,7 @@ Angular sets these CSS classes. It is up to your application to provide useful s
 
 * `ng-invalid`, `ng-valid`
   - **Usage:** angular applies this class to an input widget element if that element's input does
-    not pass validation. (see {@link api/ng.directive:input input} directive).
+    notpass validation. (see {@link api/ng.directive:input input} directive).
 
 * `ng-pristine`, `ng-dirty`
   - **Usage:** angular {@link api/ng.directive:input input} directive applies `ng-pristine` class

--- a/docs/content/guide/dev_guide.templates.filters.ngdoc
+++ b/docs/content/guide/dev_guide.templates.filters.ngdoc
@@ -14,9 +14,6 @@ displaying it to the user. You can pass expressions through a chain of filters l
 The expression evaluator simply passes the value of name to
 {@link api/ng.filter:uppercase uppercase filter}.
 
-In addition to formatting data, filters can also modify the DOM. This allows filters to handle
-tasks such as conditionally applying CSS styles to filtered output.
-
 
 ## Related Topics
 

--- a/docs/content/guide/dev_guide.templates.filters.ngdoc
+++ b/docs/content/guide/dev_guide.templates.filters.ngdoc
@@ -14,6 +14,9 @@ displaying it to the user. You can pass expressions through a chain of filters l
 The expression evaluator simply passes the value of name to
 {@link api/ng.filter:uppercase uppercase filter}.
 
+In addition to formatting data, filters can also modify the DOM. This allows filters to handle
+tasks such as conditionally applying CSS styles to filtered output.
+
 
 ## Related Topics
 

--- a/docs/content/guide/di.ngdoc
+++ b/docs/content/guide/di.ngdoc
@@ -165,7 +165,7 @@ For example:
   });
 </pre>
 
-Results in code bloat do to the need of temporary variable:
+Results in code bloat due to the need of temporary variable:
 <pre>
   var greeterFactory = function(renamed$window) {
     ...;

--- a/docs/content/guide/di.ngdoc
+++ b/docs/content/guide/di.ngdoc
@@ -165,7 +165,7 @@ For example:
   });
 </pre>
 
-Results in code bloat due to the need of temporary variable:
+Results in code bloat do to the need of temporary variable:
 <pre>
   var greeterFactory = function(renamed$window) {
     ...;

--- a/docs/content/guide/forms.ngdoc
+++ b/docs/content/guide/forms.ngdoc
@@ -300,7 +300,7 @@ The following example shows how to add two-way data-binding to contentEditable e
         });
 
         // model -> view
-        ctrl.render = function(value) {
+        ctrl.$render = function(value) {
           elm.html(value);
         };
 

--- a/docs/content/guide/forms.ngdoc
+++ b/docs/content/guide/forms.ngdoc
@@ -300,7 +300,7 @@ The following example shows how to add two-way data-binding to contentEditable e
         });
 
         // model -> view
-        ctrl.$render = function(value) {
+        ctrl.render = function(value) {
           elm.html(value);
         };
 

--- a/docs/content/guide/overview.ngdoc
+++ b/docs/content/guide/overview.ngdoc
@@ -202,7 +202,6 @@ Angular frees you from the following pain:
 
 # Watch a Presentation About Angular
 
-Here is an early presentation on angular, but note that substantial development has occurred since
-the talk was given in July of 2010.
+This presentation was recorded in May 2012.
 
 <iframe width="560" height="315" src="http://www.youtube.com/embed/bfrn5VNpwsg" frameborder="0" allowfullscreen></iframe>

--- a/docs/content/guide/overview.ngdoc
+++ b/docs/content/guide/overview.ngdoc
@@ -202,7 +202,6 @@ Angular frees you from the following pain:
 
 # Watch a Presentation About Angular
 
-Here is an early presentation on angular, but note that substantial development has occurred since
-the talk was given in July of 2010.
+Watch this presentation (recorded in May 2012) to get a great introduction to Angular.
 
 <iframe width="560" height="315" src="http://www.youtube.com/embed/bfrn5VNpwsg" frameborder="0" allowfullscreen></iframe>

--- a/docs/content/guide/overview.ngdoc
+++ b/docs/content/guide/overview.ngdoc
@@ -202,6 +202,7 @@ Angular frees you from the following pain:
 
 # Watch a Presentation About Angular
 
-Watch this presentation (recorded in May 2012) to get a great introduction to Angular.
+Here is an early presentation on angular, but note that substantial development has occurred since
+the talk was given in July of 2010.
 
 <iframe width="560" height="315" src="http://www.youtube.com/embed/bfrn5VNpwsg" frameborder="0" allowfullscreen></iframe>

--- a/docs/content/guide/overview.ngdoc
+++ b/docs/content/guide/overview.ngdoc
@@ -202,6 +202,7 @@ Angular frees you from the following pain:
 
 # Watch a Presentation About Angular
 
-This presentation was recorded in May 2012.
+Here is an early presentation on angular, but note that substantial development has occurred since
+the talk was given in July of 2010.
 
 <iframe width="560" height="315" src="http://www.youtube.com/embed/bfrn5VNpwsg" frameborder="0" allowfullscreen></iframe>

--- a/docs/content/guide/scope.ngdoc
+++ b/docs/content/guide/scope.ngdoc
@@ -222,7 +222,7 @@ The normal flow of browser receiving an event is that it executes a correspondin
 callback. Once the callback completes the browser re-renders the DOM and returns to waiting for
 more events.
 
-When the browser calls into JavaScript the code executes outside they Angular execution context,
+When the browser calls into JavaScript the code executes outside the Angular execution context,
 which means that Angular is unaware of model modifications. To properly process model
 modifications the execution has to enter the Angular execution context using the {@link
 api/ng.$rootScope.Scope#$apply `$apply`} method. Only model modifications which
@@ -256,7 +256,7 @@ the `$digest` phase. This delay is desirable, since it coalesces multiple model 
   3. **Model mutation**
 
      For mutations to be properly observed, you should make them only within the {@link
-     api/ng.$rootScope.Scope#$apply scope.$apply()}. (Angular apis do this
+     api/ng.$rootScope.Scope#$apply scope.$apply()}. (Angular APIs do this
      implicitly, so no extra `$apply` call is needed when doing synchronous work in controllers,
      or asynchronous work with {@link api/ng.$http $http} or {@link
      api/ng.$timeout $timeout} services.

--- a/docs/content/guide/scope.ngdoc
+++ b/docs/content/guide/scope.ngdoc
@@ -222,7 +222,7 @@ The normal flow of browser receiving an event is that it executes a correspondin
 callback. Once the callback completes the browser re-renders the DOM and returns to waiting for
 more events.
 
-When the browser calls into JavaScript the code executes outside the Angular execution context,
+When the browser calls into JavaScript the code executes outside they Angular execution context,
 which means that Angular is unaware of model modifications. To properly process model
 modifications the execution has to enter the Angular execution context using the {@link
 api/ng.$rootScope.Scope#$apply `$apply`} method. Only model modifications which
@@ -256,7 +256,7 @@ the `$digest` phase. This delay is desirable, since it coalesces multiple model 
   3. **Model mutation**
 
      For mutations to be properly observed, you should make them only within the {@link
-     api/ng.$rootScope.Scope#$apply scope.$apply()}. (Angular APIs do this
+     api/ng.$rootScope.Scope#$apply scope.$apply()}. (Angular apis do this
      implicitly, so no extra `$apply` call is needed when doing synchronous work in controllers,
      or asynchronous work with {@link api/ng.$http $http} or {@link
      api/ng.$timeout $timeout} services.


### PR DESCRIPTION
Fix various typos as pointed out by comments below the documentation.

I apologise for the sheer number of commits (most of which were reverted). I had some teething problems setting up my Windows machine for GitHub, more specifically - configuring git to properly handle line endings.
