### PR TITLE
fix(option): support option elements in datalist

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -521,7 +521,6 @@ var optionDirective = ['$interpolate', function($interpolate) {
   return {
     restrict: 'E',
     priority: 100,
-    require: '^select',
     compile: function(element, attr) {
       if (isUndefined(attr.value)) {
         var interpolateFn = $interpolate(element.text(), true);
@@ -530,8 +529,13 @@ var optionDirective = ['$interpolate', function($interpolate) {
         }
       }
 
-      return function (scope, element, attr, selectCtrl) {
-        if (selectCtrl.databound) {
+      return function (scope, element, attr) {
+        var selectCtrlName = '$selectController',
+            parent = element.parent(),
+            selectCtrl = parent.data(selectCtrlName) ||
+              parent.parent().data(selectCtrlName); // in case we are in optgroup
+
+        if (selectCtrl && selectCtrl.databound) {
           // For some reason Opera defaults to true and if not overridden this messes up the repeater.
           // We don't want the view to drive the initialization of the model anyway.
           element.prop('selected', false);

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1108,7 +1108,7 @@ describe('select', function() {
   });
 
 
-  describe('OPTION value', function() {
+  describe('option', function() {
 
     it('should populate value attribute on OPTION', function() {
       compile('<select ng-model="x"><option selected>abc</option></select>');
@@ -1125,5 +1125,18 @@ describe('select', function() {
       compile('<select ng-model="x"><option>hello</select>');
       expect(element).toEqualSelect(['hello']);
     });
+
+    it('should not blow up when option directive is found inside of a datalist',
+        inject(function($compile, $rootScope) {
+      var element = $compile('<div>' +
+                               '<datalist><option>some val</option></datalist>' +
+                               '<span>{{foo}}</span>' +
+                             '</div>')($rootScope);
+
+      $rootScope.foo = 'success';
+      $rootScope.$digest();
+      expect(element.find('span').text()).toBe('success');
+      dealoc(element);
+    }));
   });
 });


### PR DESCRIPTION
previously we expected to find option elements only within select element and if
that was not the case we throw an error. This made it impossible to include datalist
element with nested option elements in the template.

Closes #1165
