### PR TITLE
fix issue #1212. don't ignore url param when === 0

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -283,7 +283,14 @@ angular.module('ngResource', ['ng']).
 
         params = params || {};
         forEach(this.urlParams, function(_, urlParam){
-          encodedVal = encodeUriSegment(params[urlParam] || self.defaults[urlParam] || "");
+          var value = params[urlParam];
+          if (typeof value == 'undefined' || value === null) {
+            value = self.defaults[urlParam];
+          }
+          if (typeof value == 'undefined' || value === null) {
+            value = "";
+          }
+          encodedVal = encodeUriSegment(value);
           url = url.replace(new RegExp(":" + urlParam + "(\\W)"), encodedVal + "$1");
         });
         url = url.replace(/\/?#$/, '');


### PR DESCRIPTION
when a param value was 0 (or false) it was ignored and removed from url.
after this fix that only happens if the value is undefined or null.
