### PR TITLE
handle spaces between () and argument names in functions when autowiring...

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -53,7 +53,7 @@ function annotate(fn) {
       $inject = [];
       fnText = fn.toString().replace(STRIP_COMMENTS, '');
       argDecl = fnText.match(FN_ARGS);
-      forEach(argDecl[1].split(FN_ARG_SPLIT), function(arg){
+      forEach(trim(argDecl[1]).split(FN_ARG_SPLIT), function(arg){
         arg.replace(FN_ARG, function(all, underscore, name){
           $inject.push(name);
         });


### PR DESCRIPTION
... in Chrome

Turns out that you'll get weird errors in Chrome if you define a function like this (without providing explicit injections):
function ( $httpBackend ) {

}
