### PR TITLE
gen_docs.sh should look for globally installed jasmine-node as well

### DIFF
--- a/gen_docs.sh
+++ b/gen_docs.sh
@@ -15,5 +15,6 @@ if ! type -p "$JASMINE_NODE" >/dev/null 2>&1;then
 fi
 
 if [[ ! -e gen_docs.disable ]]; then
+  echo 'Testing, then building documentation...'
   "$JASMINE_NODE" docs/spec --noColor && node docs/src/gen-docs.js
 fi

--- a/gen_docs.sh
+++ b/gen_docs.sh
@@ -1,4 +1,19 @@
-#!/bin/bash
-if [ ! -e gen_docs.disable ]; then
-  ./node_modules/.bin/jasmine-node docs/spec --noColor && node docs/src/gen-docs.js
+#!/usr/bin/env bash
+
+JASMINE_NODE='jasmine-node'
+if ! type -p "$JASMINE_NODE" >/dev/null 2>&1;then
+  # Locally (npm)-installed jasmine-node
+  local_jasmine='./node_modules/.bin/jasmine-node'
+
+  if [[ -x "$local_jasmine" ]];then
+    JASMINE_NODE="$local_jasmine"
+  else
+    echo 'Could not find a locally or globally installed executable of' \
+         'jasmine-node. Try: `npm install jasmine-node`.' >&2
+    exit 1
+  fi
+fi
+
+if [[ ! -e gen_docs.disable ]]; then
+  "$JASMINE_NODE" docs/spec --noColor && node docs/src/gen-docs.js
 fi


### PR DESCRIPTION
Making sure gen_docs.sh looks for a globally installed copy of jasmine-node as well as local.

Finally re-based and cleaned this up to a single commit (previous pull requests, 54fcda45283686c1b30f4ef15fcabe14d925593f 14593762ba8598c99562ccbad61867a214a2f607, were sloppy).
