### PR TITLE
Disable trim an option for form fields using ng-model

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -373,9 +373,9 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
     var value = trim(element.val());
 
     // Trim is great but sometimes we need that extra white space.
-    // To prevent using the trim add the attribute ng-trim with the value of "0" or "off"
+    // To prevent using the trim add the attribute ng-trim with the value of "0" or "off" or "false"
     // e.g. <input ng-model="foo" ng-trim="off">
-    if (attr.ngTrim === 'off' || attr.ngTrim == 0) {
+    if (attr.ngTrim === 'off' || attr.ngTrim === "0" || attr.ngTrim==="false") {
       value = element.val();
     }
     

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -372,6 +372,14 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   var listener = function() {
     var value = trim(element.val());
 
+    // Trim is great but sometimes we need that extra white space.
+    // To prevent using the trim add the attribute ng-trim with the value of "0" or "off"
+    // e.g. <input ng-model="foo" ng-trim="off">
+    if (attr.ngTrim === 'off' || attr.ngTrim == 0) {
+      value = element.val();
+    }
+    
+
     if (ctrl.$viewValue !== value) {
       scope.$apply(function() {
         ctrl.$setViewValue(value);

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -25,6 +25,8 @@ var inputType = {
    *    patterns defined as scope expressions.
    * @param {string=} ngChange Angular expression to be executed when input changes due to user
    *    interaction with the input element.
+   * @param {boolean=} ngNoTrim Prevents Angular from automatically trimming the value to contain no 
+   *    extra white space
    *
    * @example
       <doc:example>
@@ -37,7 +39,7 @@ var inputType = {
          </script>
          <form name="myForm" ng-controller="Ctrl">
            Single word: <input type="text" name="input" ng-model="text"
-                               ng-pattern="word" required>
+                               ng-pattern="word" required ng-no-trim>
            <span class="error" ng-show="myForm.input.$error.required">
              Required!</span>
            <span class="error" ng-show="myForm.input.$error.pattern">
@@ -65,6 +67,12 @@ var inputType = {
           it('should be invalid if multi word', function() {
             input('text').enter('hello world');
             expect(binding('myForm.input.$valid')).toEqual('false');
+          });
+
+          it('should not be trimmed', function() {
+            input('text').enter('untrimmed ');
+            expect(binding('text')).toEqual('untrimmed ');
+            expect(binding('myForm.input.$valid')).toEqual('true');
           });
         </doc:scenario>
       </doc:example>
@@ -370,13 +378,13 @@ function isEmpty(value) {
 function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 
   var listener = function() {
-    var value = trim(element.val());
+    var value = element.val();
 
-    // Trim is great but sometimes we need that extra white space.
-    // To prevent using the trim add the attribute ng-trim with the value of "0" or "off" or "false"
-    // e.g. <input ng-model="foo" ng-trim="off">
-    if (attr.ngTrim === 'off' || attr.ngTrim === "0" || attr.ngTrim==="false") {
-      value = element.val();
+    // By default we will trim the value
+    // If the attribute ng-no-trim exists we will avoid trimming
+    // e.g. <input ng-model="foo" ng-no-trim>
+    if (isUndefined(attr.ngNoTrim)) {
+      var value = trim(value);
     }
     
 


### PR DESCRIPTION
Using AngularJS today I found myself needing that extra whitespace at the end of the value of an input field.

I added a couple lines for optionally disabling the trim that occurs by default with ng-model.

<input ng-model="foo" ng-trim="false">

Now {{foo}} will include a space at the end when you enter "bar ".

Without that attribute, "ng-trim", the value will be trimmed same as normal.
