### PR TITLE
Add dblclick method to the ngSecenario dsl

### DIFF
--- a/src/ngScenario/dsl.js
+++ b/src/ngScenario/dsl.js
@@ -365,6 +365,22 @@ angular.scenario.dsl('element', function() {
     });
   };
 
+  chain.dblclick = function() {
+    return this.addFutureAction("element '" + this.label + "' dblclick", function($window, $document, done) {
+      var elements = $document.elements();
+      var href = elements.attr('href');
+      var eventProcessDefault = elements.trigger('dblclick')[0];
+
+      if (href && elements[0].nodeName.toUpperCase() === 'A' && eventProcessDefault) {
+        this.application.navigateTo(href, function() {
+          done();
+        }, done);
+      } else {
+        done();
+      }
+    });
+  };
+
   chain.query = function(fn) {
     return this.addFutureAction('element ' + this.label + ' custom query', function($window, $document, done) {
       fn.call(this, $document.elements(), done);

--- a/test/ngScenario/dslSpec.js
+++ b/test/ngScenario/dslSpec.js
@@ -280,6 +280,38 @@ describe("angular.scenario.dsl", function() {
         dealoc(elm);
       });
 
+      it('should execute dblclick', function() {
+        var clicked;
+        // Hash is important, otherwise we actually
+        // go to a different page and break the runner
+        doc.append('<a href="#"></a>');
+        doc.find('a').dblclick(function() {
+          clicked = true;
+        });
+        $root.dsl.element('a').dblclick();
+      });
+
+      it('should navigate page if dblclick on anchor', function() {
+        expect($window.location).not.toEqual('#foo');
+        doc.append('<a href="#foo"></a>');
+        $root.dsl.element('a').dblclick();
+        expect($window.location).toMatch(/#foo$/);
+      });
+
+      it('should not navigate if dblclick event was cancelled', function() {
+        var initLocation = $window.location,
+            elm = jqLite('<a href="#foo"></a>');
+
+        doc.append(elm);
+        elm.bind('dblclick', function(event) {
+          event.preventDefault();
+        });
+
+        $root.dsl.element('a').dblclick();
+        expect($window.location).toBe(initLocation);
+        dealoc(elm);
+      });
+
       it('should count matching elements', function() {
         doc.append('<span></span><span></span>');
         $root.dsl.element('span').count();


### PR DESCRIPTION
I wanted to write a test to check that an action happens when a user double click on a element. It looks like the angular-scenario dsl does not provide any method for that.  

With the new dblclick method I can write the test as: 

``` coffeescript
  describe "Edit property", ->
    it "should display the input field after double clicking on a property value", ->
      expect(element("[name='Account'] li").attr("class")).toBe "ng-scope"
      element("[name='Account'] div").dblclick()
      expect(element("[name='Account'] li").attr("class")).toBe "ng-scope editing"
```
