### PR TITLE
Fixing this strange bug with innerHTML and <tr> tags

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -591,9 +591,7 @@ function $CompileProvider($provide) {
           directiveValue = denormalizeTemplate(directiveValue);
 
           if (directive.replace) {
-            $template = jqLite('<div>' +
-                                 trim(directiveValue) +
-                               '</div>').contents();
+            $template = jqLite('<div></div>').html(trim(directiveValue)).contents();
             compileNode = $template[0];
 
             if ($template.length != 1 || compileNode.nodeType !== 1) {
@@ -911,7 +909,7 @@ function $CompileProvider($provide) {
           content = denormalizeTemplate(content);
 
           if (replace) {
-            $template = jqLite('<div>' + trim(content) + '</div>').contents();
+            $template = jqLite('<div></div>').html(trim(content)).contents();
             compileNode = $template[0];
 
             if ($template.length != 1 || compileNode.nodeType !== 1) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -533,6 +533,12 @@ describe('$compile', function() {
                 template: '  <div></div> \n'
               }
             });
+            directive('trRootElem', function() {
+              return {
+                replace: true,
+                template: '<tr><td></td></tr>'
+              }
+            });
           });
 
           inject(function($compile) {
@@ -547,6 +553,10 @@ describe('$compile', function() {
             // ws is ok
             expect(function() {
               $compile('<p single-root-with-white-space></p>');
+            }).not.toThrow();
+            
+            expect(function() {
+              $compile('<table><tr tr-root-elem></tr></table>');
             }).not.toThrow();
           });
         });


### PR DESCRIPTION
There's this bug (at least in Chrome) where the original $('<div>' + stuff + '</div>') wouldn't do the right thing when stuff was a string that started with, say, a <tr>. This change fixes that bug, but hasn't been rigorously tested in any way. I'm just curious if this is the right approach for the fix.

You can see what I think of as a bug here http://jsfiddle.net/A2FPR/2/
