### PR TITLE
Declaration missed for fix on PR #1222

### DIFF
--- a/docs/content/guide/module.ngdoc
+++ b/docs/content/guide/module.ngdoc
@@ -31,7 +31,7 @@ Important things to notice:
   <doc:source>
     <script>
       // declare a module
-      var simpleAppModule = angular.module('myApp', []);
+      var myAppModule = angular.module('myApp', []);
 
       // configure the module.
       // in this example we will create a greeting filter


### PR DESCRIPTION
The var declaration was missed for the update to the module documentation.  Changes it from var simpleAppModule to var myAppModule.
