### PR TITLE
Allow ng-model bindings to arbitrary functions

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -995,7 +995,16 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
 
   // model -> value
   var ctrl = this;
-  $scope.$watch(ngModelGet, function(value) {
+  var returnValue = ngModelGet(this, $scope);
+  var watcher = isFunction(returnValue)?
+                  (function(self, locals){
+                    return returnValue.call(self);
+                  }):ngModelGet;
+  $scope.$watch(watcher, function(value) {
+
+    if (isFunction(value)) {
+      value = value();
+    }
 
     // ignore change from view
     if (ctrl.$modelValue === value) return;

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -646,13 +646,22 @@ function setter(obj, path, setValue) {
   for (var i = 0; element.length > 1; i++) {
     var key = element.shift();
     var propertyObj = obj[key];
+    if (isFunction(propertyObj)) {
+      propertyObj = propertyObj();
+    }
     if (!propertyObj) {
       propertyObj = {};
       obj[key] = propertyObj;
     }
     obj = propertyObj;
   }
-  obj[element.shift()] = setValue;
+  var key = element.shift();
+  if (isFunction(obj[key])) {
+    obj[key](setValue);
+  }
+  else {
+    obj[key] = setValue;
+  }
   return setValue;
 }
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -196,6 +196,14 @@ describe('NgModelController', function() {
       expect(ctrl.$modelValue).toBe(10);
     });
 
+    it('should set the value to $modelValue when value is a function', function() {
+      scope.$apply(function() {
+        scope.value = function() {
+          return 10;
+        };
+      });
+      expect(ctrl.$modelValue).toBe(10);
+    });
 
     it('should pipeline all registered formatters in reversed order and set result to $viewValue',
         function() {
@@ -217,7 +225,6 @@ describe('NgModelController', function() {
       expect(log).toEqual([3, 5]);
       expect(ctrl.$viewValue).toBe('5');
     });
-
 
     it('should $render only if value changed', function() {
       spyOn(ctrl, '$render');


### PR DESCRIPTION
This allows for very flexible 2-way binding to inputs through getters/setters.
For example:

``` html
<div ng-controller="MyCtrl">
  <input ng-model="fun"/>
</div>

<script>
  var myApp = angular.module('myApp',[]);

  myApp.controller('MyCtrl', function($scope) {
    var _test = 'Hello World!';
    $scope.fun = function(value) {
      if (value !== undefined){
        _test = value;
      }
      return _test;
    }
  });
</script>
```

The value of `INPUT[ng-model="fun"]` will be `Hello World!`. As the value changes from user input the function will be called with the new value as the argument, enabling the function to handle how the value gets set.

You can see a working example with this [jsfiddle](http://jsfiddle.net/CamShaft/kLgTL/10/).
