### PR TITLE
Fix the regexp serialization issue for scenario runner

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -693,6 +693,8 @@ function toJsonReplacer(key, value) {
     val = '$DOCUMENT';
   } else if (isScope(value)) {
     val = '$SCOPE';
+  } else if (value instanceof RegExp) {
+    val = value.toString();
   }
 
   return val;


### PR DESCRIPTION
This is simliar to Issue 119. 

Problem: If given a RegExp in toMatch and fails, {} is printed in the output. (This happens in angular-phonecat Step 03)

Fix: Use string value of the RegExp in `toJsonReplacer`.

Question: This may affect the correctness of `angular.fromJson` since `angular.fromJson(angular.toJson(/test/))` should be an `Object`. Jasmine uses their own pp method that handles RegExp in a similar way. Would it be better to fix this by introducing a simple pp method in ngScenario?

Thanks,
Gary
