### PR TITLE
fix($compile): reference local in isolate scope

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -747,7 +747,7 @@ function $CompileProvider($provide) {
                       lastValue = scope[scopeName] = parentValue;
                     } else {
                       // if the parent can be assigned then do so
-                      parentSet(parentScope, lastValue = scope[scopeName]);
+                      parentSet(parentScope, parentValue = lastValue = scope[scopeName]);
                     }
                   }
                   return parentValue;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1709,6 +1709,7 @@ describe('$compile', function() {
             attrAlias: '@attr',
             ref: '=',
             refAlias: '= ref',
+            reference: '=',
             expr: '&',
             exprAlias: '&expr'
           },
@@ -1829,6 +1830,24 @@ describe('$compile', function() {
         $rootScope.name = 'misko';
         $rootScope.$apply();
         expect(componentScope.ref).toBe('hello misko');
+      }));
+
+      // regression
+      it('should stabilize model', inject(function() {
+        compile('<div><span my-component reference="name">');
+
+        var lastRefValueInParent;
+        $rootScope.$watch('name', function(ref) {
+          lastRefValueInParent = ref;
+        });
+
+        $rootScope.name = 'aaa';
+        $rootScope.$apply();
+
+        componentScope.reference = 'new';
+        $rootScope.$apply();
+
+        expect(lastRefValueInParent).toBe('new');
       }));
     });
 


### PR DESCRIPTION
This was really corner case:
Watcher needs to return changed value, to notify that model might have changed and one more $digest cycle needs to be performed.

The watcher, that takes care of reference binding into an isolate scope ("="), did not return changed value, if the change was from the isolate scope to the parent.

If any other watcher returned change, it worked fine, as this change caused re-digest.

Closes #1272
