### PR TITLE
chore(testing): Testacular config files + rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -170,24 +170,60 @@ task :package => [:clean, :minify, :version, :docs] do
 end
 
 
-namespace :server do
+desc 'Run all AngularJS tests'
+task :test, :browsers, :misc_options do |t, args|
 
-  desc 'Run JsTestDriver Server'
-  task :start do
-    sh %x(java -jar lib/jstestdriver/JsTestDriver.jar --browser open --port 9876)
+  puts args
+
+  [ 'test:jqlite',
+    'test:jquery',
+    'test:modules',
+    'test:e2e'
+  ].each do |task|
+    Rake::Task[task].invoke(args[:browsers], args[:misc_options])
   end
-
-  desc 'Run JavaScript tests against the server'
-  task :test do
-    sh %(java -jar lib/jstestdriver/JsTestDriver.jar --tests all)
-  end
-
 end
 
 
-desc 'Run JavaScript tests'
-task :test do
-  sh %(java -jar lib/jstestdriver/JsTestDriver.jar --tests all --browser open --port 9876)
+namespace :test do
+
+  desc 'Run jqLite-based unit test suite (single run)'
+  task :jqlite, :browsers, :misc_options do |t, args|
+    start_testacular('testacular-jqlite.conf.js', true, args[:browsers], args[:misc_options])
+  end
+
+
+  desc 'Run jQuery-based unit test suite (single run)'
+  task :jquery, :browsers do |t, args|
+    start_testacular('testacular-jquery.conf.js', true, args[:browsers], args[:misc_options])
+  end
+
+
+  desc 'Run bundled modules unit test suite (single run)'
+  task :modules, :browsers, :misc_options do |t, args|
+    start_testacular('testacular-modules.conf.js', true, args[:browsers], args[:misc_options])
+  end
+
+
+  desc 'Run e2e test suite (single run)'
+  task :e2e, :browsers, :misc_options do |t, args|
+    start_testacular('testacular-e2e.conf.js', true, args[:browsers], args[:misc_options])
+  end
+end
+
+
+namespace :autotest do
+
+  desc 'Run jqLite-based unit test suite (autowatch)'
+  task :jqlite, :browsers, :misc_options do |t, args|
+    start_testacular('testacular-jqlite.conf.js', false, args[:browsers], args[:misc_options])
+  end
+
+
+  desc 'Run jQuery-based unit test suite (autowatch)'
+  task :jquery, :browsers, :misc_options do |t, args|
+    start_testacular('testacular-jquery.conf.js', false, args[:browsers], args[:misc_options])
+  end
 end
 
 
@@ -301,4 +337,13 @@ def rewrite_file(filename)
     f.rewind
     f.write content
   end
+end
+
+
+def start_testacular(config, singleRun, browsers, misc_options)
+  sh "testacular start " +
+                "#{config} " +
+                "#{'--single-run=true' if singleRun} " +
+                "#{'--browsers=' + browsers.gsub('+', ',') if browsers} " +
+                "#{misc_options}"
 end

--- a/angularFiles.js
+++ b/angularFiles.js
@@ -196,36 +196,30 @@ angularFiles = {
   ]
 };
 
-// Execute only in slim-jim
-if (typeof JASMINE_ADAPTER !== 'undefined') {
-  // Testacular config
-  var mergedFiles = [];
-  angularFiles.jstd.forEach(function(file) {
-    // replace @ref
-    var match = file.match(/^\@(.*)/);
-    if (match) {
-      var deps = angularFiles[match[1]];
-      if (!deps) {
-        console.log('No dependency:' + file)
+if (exports) {
+  exports.files = angularFiles
+  exports.mergeFiles = function mergeFiles() {
+    var files = [];
+
+    [].splice.call(arguments, 0).forEach(function(file) {
+      if (file.match(/testacular/)) {
+        files.push(file);
+      } else {
+        angularFiles[file].forEach(function(f) {
+          // replace @ref
+          var match = f.match(/^\@(.*)/);
+          if (match) {
+            var deps = angularFiles[match[1]];
+            files = files.concat(deps);
+          } else {
+            if (!/jstd|jasmine/.test(f)) { //TODO(i): remove once we don't have jstd/jasmine in repo
+              files.push(f);
+            }
+          }
+        });
       }
-      mergedFiles = mergedFiles.concat(deps);
-    } else {
-      mergedFiles.push(file);
-    }
-  });
+    });
 
-  files = [JASMINE, JASMINE_ADAPTER];
-
-  mergedFiles.forEach(function(file){
-    if (/jstd|jasmine/.test(file)) return;
-    files.push(file);
-  });
-
-
-  exclude = angularFiles.jstdExclude;
-
-  autoWatch = true;
-  autoWatchInterval = 1;
-  logLevel = LOG_INFO;
-  logColors = true;
+    return files;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,5 +5,6 @@
     "jasmine-node" :  "*",
     "q-fs" : "*",
     "qq" : "*"
+    "testacular": "*"
   }
 }

--- a/testacular-e2e.conf.js
+++ b/testacular-e2e.conf.js
@@ -1,0 +1,13 @@
+var angularFiles = require(__dirname + '/angularFiles.js');
+
+files = [ANGULAR_SCENARIO, ANGULAR_SCENARIO_ADAPTER, 'build/docs/docs-scenario.js'];
+
+autoWatch = false;
+singleRun = true;
+logLevel = LOG_INFO;
+logColors = true;
+browsers = ['Chrome']
+
+proxies = {
+  '/': 'http://localhost:8000/build/docs/'
+};

--- a/testacular-jqlite.conf.js
+++ b/testacular-jqlite.conf.js
@@ -1,0 +1,9 @@
+var angularFiles = require(__dirname + '/angularFiles.js');
+
+files = angularFiles.mergeFiles(JASMINE, JASMINE_ADAPTER, 'jstd');
+exclude = ['**/*jasmine*/**', '**/*jstd*/**'].concat(angularFiles.files.jstdExclude);
+
+autoWatch = true;
+logLevel = LOG_INFO;
+logColors = true;
+browsers = ['Chrome']

--- a/testacular-jquery.conf.js
+++ b/testacular-jquery.conf.js
@@ -1,0 +1,9 @@
+var angularFiles = require(__dirname + '/angularFiles.js');
+
+files = angularFiles.mergeFiles(JASMINE, JASMINE_ADAPTER, 'jstdJquery');
+exclude = ['**/*jasmine*/**', '**/*jstd*/**'].concat(angularFiles.files.jstdJqueryExclude);
+
+autoWatch = true;
+logLevel = LOG_INFO;
+logColors = true;
+browsers = ['Chrome']

--- a/testacular-modules.conf.js
+++ b/testacular-modules.conf.js
@@ -1,0 +1,9 @@
+var angularFiles = require(__dirname + '/angularFiles.js');
+
+files = angularFiles.mergeFiles(JASMINE, JASMINE_ADAPTER, 'jstdModules', 'angularSrcModules');
+exclude = ['**/*jasmine*/**', '**/*jstd*/**'];
+
+autoWatch = true;
+logLevel = LOG_INFO;
+logColors = true;
+browsers = ['Chrome']


### PR DESCRIPTION
- adds testacular config files for jqlite, jquery, modules and e2e tests
- replaces obsolete JsTD Rake tasks with Testacular onces
- rake tasks are parameterazied so that they can be used locally as well as on CI server

usage:

rake test  # run all tests on Chrome
rake test[Safari]  # run all tests on Safari
rake test:jqlite # run unit tests using jqlite on Chrome
rake test:jqlite[Safari,"--reporter=dots"]  # run jqlite-based unit tests on Safari with dots reporter
rake autotest:jquery  # start testacular with jquery-based config and watch fs for changes
rake test:e2e # run end to end tests
