### PR TITLE
 $http config.param expands array values properly.

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -758,10 +758,15 @@ function $HttpProvider() {
           var parts = [];
           forEachSorted(params, function(value, key) {
             if (value == null || value == undefined) return;
-            if (isObject(value)) {
-              value = toJson(value);
-            }
-            parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+            if (!isArray(value)) value = [value];
+
+            forEach(value, function(v) {
+              if (isObject(v)) {
+                v = toJson(v);
+              }
+              parts.push(encodeURIComponent(key) + '=' +
+                         encodeURIComponent(v));
+            });
           });
           return url + ((url.indexOf('?') == -1) ? '?' : '&') + parts.join('&');
         }

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -147,6 +147,12 @@ describe('$http', function() {
         $httpBackend.expect('GET', '/url?a=1&b=%7B%22c%22%3A3%7D').respond('');
         $http({url: '/url', params: {a:1, b:{c:3}}, method: 'GET'});
       }));
+
+
+      it('should expand arrays in params map', inject(function($httpBackend, $http) {
+          $httpBackend.expect('GET', '/url?a=1&a=2&a=3').respond('');
+          $http({url: '/url', params: {a: [1,2,3]}, method: 'GET'});
+      }));
     });
 
 


### PR DESCRIPTION
Today, calling e.g. $http(url, { params: { a: [1,2,3] } }) results in a query
string like "?a=%5B1%2C2%2C3%5D" which is undesirable. This commit enhances
buildURL to createa query string like "?a=1&a=2&a=3".

Fixes #1363.
