### PR TITLE
docs(misc): update download page to recommend Google CDN

### DIFF
--- a/docs/content/misc/downloading.ngdoc
+++ b/docs/content/misc/downloading.ngdoc
@@ -2,10 +2,9 @@
 @name Downloading
 @description
 
-# Including angular scripts from the angular server
-The quickest way to get started is to point your html `<script>` tag to a
-<http://code.angularjs.org/> URL.  This way, you don't have to download anything or maintain a
-local copy.
+# Including angular scripts from the Google CDN
+The quickest way to get started is to point your html `<script>` tag to a Google CDN URL.
+This way, you don't have to download anything or maintain a local copy.
 
 There are two types of angular script URLs you can point to, one for development and one for
 production:
@@ -15,21 +14,25 @@ development.
 * __angular-<version>.min.js__ — This is the minified version, which we strongly suggest you use in
 production.
 
-To point your code to an angular script on the angular server, use the following template.  This
-example points to (non-minified) version 0.10.6:
+To point your code to an angular script on the Google CDN server, use the following template.  This
+example points to the minified version 1.0.2:
 
 <pre>
   <!doctype html>
   <html ng-app>
     <head>
       <title>My Angular App</title>
-      <script src="http://code.angularjs.org/angular-0.10.6.js"></script>
+      <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.0.2/angular.min.js"></script>
     </head>
     <body>
     </body>
   </html>
 </pre>
 
+Note that only versions 1.0.1 and above are available on the CDN, if you need an earlier version
+you can use the <http://code.angularjs.org/> URL which was the previous recommended location for
+hosted code source. If you're still using the angular server you should switch to the CDN version
+for even faster loading times.
 
 # Downloading and hosting angular files locally
 This option is for those who want to work with angular offline, or those who want to host the


### PR DESCRIPTION
Documentation should point people to the CDN for hosted code.

Also the example link should use the minified code as that's what people will copy and paste :)
