### PR TITLE
feat($timeout-mock): verify no pending tasks

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1329,17 +1329,39 @@ function MockXhr() {
  * @description
  *
  * This service is just a simple decorator for {@link ng.$timeout $timeout} service
- * that adds a "flush" method.
- */
+ * that adds a "flush" and "verifyNoPendingTasks" methods.
+ */ 
 
-/**
- * @ngdoc method
- * @name ngMock.$timeout#flush
- * @methodOf ngMock.$timeout
- * @description
- *
- * Flushes the queue of pending tasks.
- */
+angular.mock.$TimeoutDecorator = function($delegate, $browser) {
+
+  /**
+   * @ngdoc method
+   * @name ngMock.$timeout#flush
+   * @methodOf ngMock.$timeout
+   * @description
+   *
+   * Flushes the queue of pending tasks.
+   */
+  $delegate.flush = function() {
+    $browser.defer.flush();
+  };
+
+  /**
+   * @ngdoc method
+   * @name ngMock.$timeout#verifyNoPendingTasks
+   * @methodOf ngMock.$timeout
+   * @description
+   *
+   * Verifies that there are no pending tasks that need to be flushed.
+   */
+  $delegate.verifyNoPendingTasks = function() {
+    if ($browser.deferredFns.length) {
+      throw Error('Deferred tasks have not been flushed');
+    }
+  };
+
+  return $delegate;
+};
 
 /**
  *
@@ -1365,14 +1387,8 @@ angular.module('ngMock', ['ng']).provider({
   $httpBackend: angular.mock.$HttpBackendProvider,
   $rootElement: angular.mock.$RootElementProvider
 }).config(function($provide) {
-  $provide.decorator('$timeout', function($delegate, $browser) {
-    $delegate.flush = function() {
-      $browser.defer.flush();
-    };
-    return $delegate;
-  });
+  $provide.decorator('$timeout', angular.mock.$TimeoutDecorator);
 });
-
 
 /**
  * @ngdoc overview

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1363,7 +1363,7 @@ angular.mock.$TimeoutDecorator = function($delegate, $browser) {
 
   function formatPendingTasksAsString(tasks) {
     var result = [];
-    forEach(tasks, function(task) {
+    angular.forEach(tasks, function(task) {
       result.push('{id: ' + task.id + ', ' + 'time: ' + task.time + '}');
     });
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1356,9 +1356,19 @@ angular.mock.$TimeoutDecorator = function($delegate, $browser) {
    */
   $delegate.verifyNoPendingTasks = function() {
     if ($browser.deferredFns.length) {
-      throw Error('Deferred tasks have not been flushed');
+      throw Error('Deferred tasks to flush (' + $browser.deferredFns.length + '): ' +
+          formatPendingTasksAsString($browser.deferredFns));
     }
   };
+
+  function formatPendingTasksAsString(tasks) {
+    var result = [];
+    forEach(tasks, function(task) {
+      result.push('{id: ' + task.id + ', ' + 'time: ' + task.time + '}');
+    });
+
+    return result.join(', ');
+  }
 
   return $delegate;
 };

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -327,6 +327,21 @@ describe('ngMock', function() {
       $timeout.flush();
       expect(logger).toEqual(['t1', 't3', 't2']);
     }));
+
+
+    it('should throw an exception when not flushed', inject(function($timeout){
+      $timeout(angular.noop);
+
+      expect(function() {$timeout.verifyNoPendingTasks();}).toThrow('Deferred tasks have not been flushed');
+    }));
+
+
+    it('should do nothing when all tasks have been flushed', inject(function($timeout) {
+      $timeout(angular.noop);     
+
+      $timeout.flush();
+      expect(function() {$timeout.verifyNoPendingTasks();}).not.toThrow();
+    }));
   });
 
 

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -330,14 +330,15 @@ describe('ngMock', function() {
 
 
     it('should throw an exception when not flushed', inject(function($timeout){
-      $timeout(angular.noop);
+      $timeout(noop);
 
-      expect(function() {$timeout.verifyNoPendingTasks();}).toThrow('Deferred tasks have not been flushed');
+      var expectedError = 'Deferred tasks to flush (1): {id: 0, time: 0}';
+      expect(function() {$timeout.verifyNoPendingTasks();}).toThrow(expectedError);
     }));
 
 
     it('should do nothing when all tasks have been flushed', inject(function($timeout) {
-      $timeout(angular.noop);     
+      $timeout(noop);
 
       $timeout.flush();
       expect(function() {$timeout.verifyNoPendingTasks();}).not.toThrow();


### PR DESCRIPTION
Added verifyNoPendingTasks method, which throws error if not all
deferred tasks have been flushed

Related to the issue #1245
