### PR TITLE
docs: load angular from can only on production

### DIFF
--- a/docs/src/templates/index.html
+++ b/docs/src/templates/index.html
@@ -22,7 +22,7 @@
           baseUrl = location.href.replace(rUrl, indexFile),
           jQuery = /index-jq[^\.]*\.html$/.test(baseUrl),
           debug = /index[^\.]*-debug\.html$/.test(baseUrl),
-          gae = (baseUrl.split('/').length == 4),
+          production = location.hostname === 'docs.angularjs.org',
           headEl = document.getElementsByTagName('head')[0],
           sync = true,
           angularVersion = {
@@ -45,7 +45,7 @@
       addTag('script', {src: 'docs-keywords.js'}, sync);
 
       function path(name) {
-        if (gae) {
+        if (production) {
           if (name.match(/^angular(-\w+)?\.js/) && !name.match(/bootstrap/)) {
             name =  '//ajax.googleapis.com/ajax/libs/angularjs/' +
                 angularVersion.stable +

--- a/testacular-e2e.conf.js
+++ b/testacular-e2e.conf.js
@@ -6,8 +6,10 @@ autoWatch = false;
 singleRun = true;
 logLevel = LOG_INFO;
 logColors = true;
-browsers = ['Chrome']
+browsers = ['Chrome'];
 
 proxies = {
+  // angular.js, angular-resource.js, etc
+  '/angular': 'http://localhost:8000/build/angular',
   '/': 'http://localhost:8000/build/docs/'
 };


### PR DESCRIPTION
So that when running the docs locally, eg. during e2e testing, we use the latest build version of angular, rather than the stable one from CDN.
