### PR TITLE
Added contribution guidelines file for GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+## Submitting issues
+
+If you have questions about how to use AngularJS, please direct these to the
+[Google Group][groups] discussion list or [StackOverflow][stackoverflow]. We are
+also available on [IRC][irc].
+
+### Guidelines
+
+* Search the archive first, it's likely that your question was already answered.
+* A live example demonstrating your problem or question, will get an answer faster.
+* Create one using this [template][template]
+* If you get help, help others. Good karma rulez!
+
+If your issue appears to be a bug, and hasn't been reported, open a new issue.
+Help us to maximize the effort we can spend fixing issues and adding new
+features, by not reporting duplicate issues.
+
+[stackoverflow]: http://stackoverflow.com/questions/tagged/angularjs
+[groups]: https://groups.google.com/forum/?fromgroups#!forum/angular
+[irc]: http://webchat.freenode.net/?channels=angularjs&uio=d4
+[template]: http://plnkr.co/edit/gist:3510140
+
+## Contributing to Source Code
+
+We'd love for you to contribute to our source code and to make AngularJS even
+better than it is today! Here are the guidelines we'd like you to follow:
+
+* Major changes that you intend to contribute to the project should be discussed
+first on our [mailing list][list] so that we can better coordinate our efforts,
+prevent duplication of work, and help you to craft the change so that it is
+successfully accepted upstream.
+
+* Small changes and bug fixes can be crafted and submitted to Github as a
+pull request.
+
+* Please see [commit message][test] for the details on appropriate tests to run
+
+* Contributing requires a signed CLA.
+    * For [individuals][cla-ind]
+    * For [corporations][cla-corp]
+
+[list]: https://groups.google.com/forum/?fromgroups#!forum/angular
+[test]: https://github.com/angular/angular.js/commit/9d168f058f9c6d7eeae0daa7cb72ea4e02a0003a
+[cla-ind]: http://code.google.com/legal/individual-cla-v1.0.html
+[cla-corp]: http://code.google.com/legal/corporate-cla-v1.0.html


### PR DESCRIPTION
Added file to help curb dupe issue reports.

Info take from AngularJS docs page, groups header, etc

See  https://github.com/blog/1184-contributing-guidelines
