### PR TITLE
feat(scenario):  add mouseover method to the ngScenario dsl

### DIFF
--- a/src/ngScenario/dsl.js
+++ b/src/ngScenario/dsl.js
@@ -325,6 +325,7 @@ angular.scenario.dsl('select', function() {
  * Usage:
  *    element(selector, label).count() get the number of elements that match selector
  *    element(selector, label).click() clicks an element
+ *    element(selector, label).mouseover() mouseover an element
  *    element(selector, label).query(fn) executes fn(selectedElements, done)
  *    element(selector, label).{method}() gets the value (as defined by jQuery, ex. val)
  *    element(selector, label).{method}(value) sets the value (as defined by jQuery, ex. val)
@@ -378,6 +379,14 @@ angular.scenario.dsl('element', function() {
       } else {
         done();
       }
+    });
+  };
+
+  chain.mouseover = function() {
+    return this.addFutureAction("element '" + this.label + "' mouseover", function($window, $document, done) {
+      var elements = $document.elements();
+      elements.trigger('mouseover')
+      done()
     });
   };
 

--- a/src/ngScenario/dsl.js
+++ b/src/ngScenario/dsl.js
@@ -385,8 +385,8 @@ angular.scenario.dsl('element', function() {
   chain.mouseover = function() {
     return this.addFutureAction("element '" + this.label + "' mouseover", function($window, $document, done) {
       var elements = $document.elements();
-      elements.trigger('mouseover')
-      done()
+      elements.trigger('mouseover');
+      done();
     });
   };
 

--- a/test/ngScenario/dslSpec.js
+++ b/test/ngScenario/dslSpec.js
@@ -312,6 +312,26 @@ describe("angular.scenario.dsl", function() {
         dealoc(elm);
       });
 
+      it('should execute mouseover', function() {
+        var mousedOver;
+        doc.append('<div></div>');
+        doc.find('div').mouseover(function() {
+          mousedOver = true;
+        });
+        $root.dsl.element('div').mouseover();
+        expect(mousedOver).toBe(true);
+      });
+
+      it('should bubble up the mouseover event', function() {
+        var mousedOver;
+        doc.append('<div id="outer"><div id="inner"></div></div>');
+        doc.find('#outer').mouseover(function() {
+          mousedOver = true;
+        });
+        $root.dsl.element('#inner').mouseover();
+        expect(mousedOver).toBe(true);
+      });
+
       it('should count matching elements', function() {
         doc.append('<span></span><span></span>');
         $root.dsl.element('span').count();


### PR DESCRIPTION
so e2e tests are more readable.
- it adds a mouseover() method to element that trigger the mouseover
  event on that element.

Motivation: I wanted to write a test that checks that the method in
the ng-mouseover directive was correct.

``` coffeescript
it "should display the user friends when mouseover the avatar ", ->
  element(".user-avatar").mouseover()
  # ...
```
