### PR TITLE
fix($resource): Prevent default params to be shared between actions

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -314,8 +314,8 @@ angular.module('ngResource', ['ng']).
 
       function extractParams(data, actionParams){
         var ids = {};
-        paramDefaults = extend(paramDefaults, actionParams);
-        forEach(paramDefaults || {}, function(value, key){
+        actionParams = extend({}, paramDefaults, actionParams);
+        forEach(actionParams, function(value, key){
           ids[key] = value.charAt && value.charAt(0) == '@' ? getter(data, value.substr(1)) : value;
         });
         return ids;

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -122,6 +122,17 @@ describe("resource", function() {
   });
 
 
+  it('should not pass default params between actions', function() {
+    var R = $resource('/Path', {}, {get: {method: 'GET', params: {objId: '1'}}, perform: {method: 'GET'}});
+
+    $httpBackend.expect('GET', '/Path?objId=1').respond('{}');
+    $httpBackend.expect('GET', '/Path').respond('{}');
+
+    R.get({});
+    R.perform({});
+  });
+
+
   it("should build resource with action default param overriding default param", function() {
     $httpBackend.expect('GET', '/Customer/123').respond({id: 'abc'});
     var TypeItem = $resource('/:type/:typeId', {type: 'Order'},


### PR DESCRIPTION
Having a $resource defined as:

var R = $resource('/Path', {}, {
  get: {method: 'GET', params: {objId: '1'}},
  perform: {method: 'GET'}
});

was causing both actions to call the same URI (if called in this order):

R.get({}); // => /Path?objId=1
R.perform({}); // => /Path?objId=1
