### PR TITLE
fix($rootScope): allow removing a listener during event

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -633,7 +633,7 @@ function $RootScopeProvider(){
         namedListeners.push(listener);
 
         return function() {
-          arrayRemove(namedListeners, listener);
+          namedListeners[indexOf(namedListeners, listener)] = null;
         };
       },
 
@@ -681,6 +681,7 @@ function $RootScopeProvider(){
           namedListeners = scope.$$listeners[name] || empty;
           event.currentScope = scope;
           for (i=0, length=namedListeners.length; i<length; i++) {
+            if (!namedListeners[i]) continue;
             try {
               namedListeners[i].apply(null, listenerArgs);
               if (stopPropagation) return event;
@@ -737,6 +738,7 @@ function $RootScopeProvider(){
           current = next;
           event.currentScope = current;
           forEach(current.$$listeners[name], function(listener) {
+            if (!listener) return;
             try {
               listener.apply(null, listenerArgs);
             } catch(e) {

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -708,6 +708,47 @@ describe('Scope', function() {
       });
 
 
+      // regression
+      it('should survive removing listener inside listener', function() {
+        var spy1 = jasmine.createSpy('1st listener');
+        var spy2 = jasmine.createSpy('2nd listener');
+        var spy3 = jasmine.createSpy('3rd listener');
+
+        var remove1 = child.$on('evt', spy1);
+        var remove2 = child.$on('evt', spy2);
+        var remove3 = child.$on('evt', spy3);
+
+        spy1.andCallFake(remove1);
+
+        // should call all listeners and remove 1st
+        child.$emit('evt');
+        expect(spy1).toHaveBeenCalledOnce();
+        expect(spy2).toHaveBeenCalledOnce();
+        expect(spy3).toHaveBeenCalledOnce();
+
+        spy1.reset();
+        spy2.reset();
+        spy3.reset();
+
+        // should only 2nd, because 2nd remove 3rd
+        spy2.andCallFake(remove3);
+        child.$emit('evt');
+        expect(spy1).not.toHaveBeenCalled();
+        expect(spy2).toHaveBeenCalledOnce();
+        expect(spy3).not.toHaveBeenCalled();
+
+        spy1.reset();
+        spy2.reset();
+        spy3.reset();
+
+        // test $broadcast as well
+        child.$broadcast('evt');
+        expect(spy1).not.toHaveBeenCalled();
+        expect(spy2).toHaveBeenCalledOnce();
+        expect(spy3).not.toHaveBeenCalled();
+      });
+
+
       describe('event object', function() {
         it('should have methods/properties', function() {
           var event;


### PR DESCRIPTION
There is a bug, if an event listener is removed during the event. The next listener can be skipped, or null pointer exception can happen.

Not sure, what is the best solution for this problem.

I assume, that removing listeners does not happen so often. Otherwise we might iterate through the array and remove empty items after every event / or just sometimes :-D
