### PR TITLE
Fix "API Docs" link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ it makes development fun!
 
 * Web site: http://angularjs.org
 * Tutorial: http://docs.angularjs.org/tutorial
-* API Docs: http://docs.angularjs.org
+* API Docs: http://docs.angularjs.org/api
 * Developer Guide: http://docs.angularjs.org/guide
 * Contribution guidelines: http://docs.angularjs.org/misc/contribute
 


### PR DESCRIPTION
The "API Docs" link points to docs.angularjs.org which pulls up the old version of the angular api.
It should link to docs.angularjs.org/api.
