### PR TITLE
Updating JSDoc to return Promise instead of * in $timeout service.

### DIFF
--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -29,7 +29,7 @@ function $TimeoutProvider() {
       * @param {number=} [delay=0] Delay in milliseconds.
       * @param {boolean=} [invokeApply=true] If set to false skips model dirty checking, otherwise
       *   will invoke `fn` within the {@link ng.$rootScope.Scope#$apply $apply} block.
-      * @returns {*} Promise that will be resolved when the timeout is reached. The value this
+      * @returns {Promise} Promise that will be resolved when the timeout is reached. The value this
       *   promise will be resolved with is the return value of the `fn` function.
       */
     function timeout(fn, delay, invokeApply) {


### PR DESCRIPTION
The cancel function accepts a Promise, but the timeout function fails to specify returning a Promise.

My guess is this could be because of the Promise object being augmented with the timeout ID from the $browser, but I'm not so sure.
