### PR TITLE
docs(angular.module): fixed a typo in run function

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -215,7 +215,7 @@ function setupModuleLoader(window) {
            * @param {Function} initializationFn Execute this function after injector creation.
            *    Useful for application initialization.
            * @description
-           * Use this method to register work which needs to be performed when the injector with
+           * Use this method to register work which needs to be performed when the injector
            * with the current module is finished loading.
            */
           run: function(block) {


### PR DESCRIPTION
The word **with** was doubled across rows in the ngDoc documentation for `angular.Module#run` method.
