### PR TITLE
Fix JQLiteClone in IE7/8

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -82,7 +82,8 @@ var jqCache = JQLite.cache = {},
       : function(element, type, fn) {element.attachEvent('on' + type, fn);}),
     removeEventListenerFn = (window.document.removeEventListener
       ? function(element, type, fn) {element.removeEventListener(type, fn, false); }
-      : function(element, type, fn) {element.detachEvent('on' + type, fn); });
+      : function(element, type, fn) {element.detachEvent('on' + type, fn); }),
+    html5Clone = window.document.createElement('nav').cloneNode(true).outerHTML !== '<:nav></:nav>';
 
 function jqNextId() { return ++jqId; }
 
@@ -175,7 +176,15 @@ function JQLite(element) {
 }
 
 function JQLiteClone(element) {
-  return element.cloneNode(true);
+  var clone;
+  if (html5Clone) {
+    clone = element.cloneNode(true);
+  } else {
+    var div = document.createElement('div');
+    div.innerHTML = element.outerHTML;
+    clone = div.firstChild;
+  }
+  return clone;
 }
 
 function JQLiteDealoc(element){

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1081,6 +1081,31 @@ describe('jqLite', function() {
   });
 
 
+  describe('clone', function() {
+    function test(outerHTML) {
+      function normalize(str) {
+        return str.toLowerCase().replace(/^\s+|\s+$/g, '');
+      }
+      outerHTML = normalize(outerHTML);
+      var element = jqLite(outerHTML);
+      var clone = element.clone();
+      expect(normalize(clone[0].outerHTML)).toBe(outerHTML);
+      expect(normalize(clone[0].outerHTML)).toBe(normalize(element[0].outerHTML));
+    }
+
+
+    it('should return a clone with the same outerHTML', function() {
+      test('<div><span>text</span></div>');
+    });
+
+
+    it('should support unrecognized HTML elements', function() {
+      document.createElement('article');
+      test('<article><span>text</span></article>');
+    });
+  });
+
+
   describe('eq', function() {
     it('should select the nth element ', function() {
       var element = jqLite('<div><span>aa</span></div><div><span>bb</span></div>');


### PR DESCRIPTION
Addresses Issue #1381, wherein non-native HTML elements receive an
empty namespace when used within directives on IE7/8.  For example,
`<nav></nav>` renders as `<:nav></:nav>`, which prevents the tag
from being styled.

The root cause is the use of `cloneNode` within `JQLiteClone`.  Even
with an HTML5 polyfill, early versions of IE are unable to clone
non-native elements without adding this 'empty' namespace.

The solution, as seen in the corresponding `clone` function in full
jQuery, is to use innerHTML upon another established element to create
the clone.
