### PR TITLE
refactor($rootScope): allow partial $digest within $apply

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -592,7 +592,7 @@ function $RootScopeProvider(){
         } finally {
           clearPhase();
           try {
-            $rootScope.$digest();
+            this.$root.$digest();
           } catch (e) {
             $exceptionHandler(e);
             throw e;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1821,7 +1821,7 @@ describe('$compile', function() {
         expect(componentScope.ref).toBe('hello world');
 
         componentScope.ref = 'ignore me';
-        expect($rootScope.$apply).
+        expect(function() {$rootScope.$apply()}).
             toThrow("Non-assignable model expression: 'hello ' + name (directive: myComponent)");
         expect(componentScope.ref).toBe('hello world');
         // reset since the exception was rethrown which prevented phase clearing


### PR DESCRIPTION
$apply() was calling $digest() on $rootScope using closure variable, which makes it hard to override. Now it calls it on this.$root, which means people can override the $root property on  a scope in order to make $apply $digest only part of the app.

This is useful for stuff like dialogs, where you can set the dialogs scope to be $root and therefore any subsequent $apply() will $digest only the dialog, without the rest of the universe.
