### PR TITLE
Making testacular a dependency to avoid having to install it globally

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -329,7 +329,7 @@ end
 
 
 def start_testacular(config, singleRun, browsers, misc_options)
-  sh "testacular start " +
+  sh "./node_modules/testacular/bin/testacular start " +
                 "#{config} " +
                 "#{'--single-run=true' if singleRun} " +
                 "#{'--browsers=' + browsers.gsub('+', ',') if browsers} " +

--- a/docs/content/misc/contribute.ngdoc
+++ b/docs/content/misc/contribute.ngdoc
@@ -99,11 +99,7 @@ pre-packaged bundle.
   * `npm install`
 
 
-* Lastly, you'll also need Testacular our spectacular test runner that we use for running unit and end-to-end tests.
-
-  * `sudo npm install -g testacular`
-
-
+* Lastly, you'll also need Testacular our spectacular test runner that we use for running unit and end-to-end tests. This will install automatically when you do `npm install`
 
 ## Creating a Github Account and Forking Angular
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "AngularJS",
   "version": "0.0.0",
   "dependencies" : {
+    "testacular" : "*",
     "jasmine-node" :  "*",
     "q-fs" : "*",
     "qq" : "*"


### PR DESCRIPTION
Doing a global install of `testacular` causes npm issues on some machines. This commit makes it a local dependency and modifies the `Rakefile` accordingly. 
