### PR TITLE
fix(select): Select option with a label of 0 is not shown. Closes #1401.

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -386,7 +386,8 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
               selected,
               selectedSet = false, // nothing is selected yet
               lastElement,
-              element;
+              element,
+              label;
 
           if (multiple) {
             selectedSet = new HashMap(modelValue);
@@ -410,9 +411,11 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
               selected = modelValue === valueFn(scope, locals);
               selectedSet = selectedSet || selected; // see if at least one item is selected
             }
+            label = displayFn(scope, locals); // what will be seen by the user
+            label = label === undefined ? '' : label; // doing displayFn(scope, locals) || '' overwrites zero values
             optionGroup.push({
               id: keyName ? keys[index] : index,   // either the index into array or key from object
-              label: displayFn(scope, locals) || '', // what will be seen by the user
+              label: label, 
               selected: selected                   // determine if we should be selected
             });
           }

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -493,6 +493,21 @@ describe('select', function() {
       expect(sortedHtml(options[2])).toEqual('<option value="2">C</option>');
     });
 
+    it('should render zero as a valid display value', function() {
+      createSingleSelect();
+
+      scope.$apply(function() {
+        scope.values = [{name: 0}, {name: 1}, {name: 2}];
+        scope.selected = scope.values[0];
+      });
+
+      var options = element.find('option');
+      expect(options.length).toEqual(3);
+      expect(sortedHtml(options[0])).toEqual('<option value="0">0</option>');
+      expect(sortedHtml(options[1])).toEqual('<option value="1">1</option>');
+      expect(sortedHtml(options[2])).toEqual('<option value="2">2</option>');
+    });
+
 
     it('should render an object', function() {
       createSelect({


### PR DESCRIPTION
Bug caused by the use of the `||` operator to replace all non-truthy values with an empty string. Changed to replace only `undefined` values.

Closes #1401.
