### PR TITLE
Do a one-off interpolation of @ locals

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -725,9 +725,13 @@ function $CompileProvider($provide) {
                   scope[scopeName] = value;
                 });
                 attrs.$$observers[attrName].$$scope = parentScope;
+                if( attrs[attrName] ) {
+                  // If the attribute has been provided then we trigger an interpolation to ensure the value is there for use in the link fn
+                  scope[scopeName] = $interpolate(attrs[attrName])(parentScope);
+                }
                 break;
               }
-
+              
               case '=': {
                 parentGet = $parse(attrs[attrName]);
                 parentSet = parentGet.assign || function() {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1728,27 +1728,21 @@ describe('$compile', function() {
     describe('attribute', function() {
       it('should copy simple attribute', inject(function() {
         compile('<div><span my-component attr="some text">');
-        expect(componentScope.attr).toEqual(undefined);
-        expect(componentScope.attrAlias).toEqual(undefined);
-
-        $rootScope.$apply();
 
         expect(componentScope.attr).toEqual('some text');
         expect(componentScope.attrAlias).toEqual('some text');
         expect(componentScope.attrAlias).toEqual(componentScope.attr);
       }));
 
+      it('should set up the interpolation before it reaches the link function', inject(function() {
+        $rootScope.name = 'misko';
+        compile('<div><span my-component attr="hello {{name}}">');
+        expect(componentScope.attr).toEqual('hello misko');
+        expect(componentScope.attrAlias).toEqual('hello misko');
+      }));
 
       it('should update when interpolated attribute updates', inject(function() {
         compile('<div><span my-component attr="hello {{name}}">');
-        expect(componentScope.attr).toEqual(undefined);
-        expect(componentScope.attrAlias).toEqual(undefined);
-
-        $rootScope.name = 'misko';
-        $rootScope.$apply();
-
-        expect(componentScope.attr).toEqual('hello misko');
-        expect(componentScope.attrAlias).toEqual('hello misko');
 
         $rootScope.name = 'igor';
         $rootScope.$apply();


### PR DESCRIPTION
Ensures that the link fn receives attributes that are already interpolated.

This will make the @ locals consistent with = locals, in that they can be used straight up in the link function.

Currently this confuses many directive developers.
It also requires that they use attrs.$observe to access the interpolated value in the link function even though it could be readily available there.

Obviously, if they want to be able to do work when the interpolated value changes they will still need to create a $observe function but this is currently true of '=' locals, where the initial value is available in the link function but they have to use $watch to deal with changes to the value.

[ Disclaimer: I am running on Windows, and I couldn't get the e2e tests to run but all the unit tests seem to pass.]
