### PR TITLE
docs(contribute): fix task name for continuous testing

### DIFF
--- a/docs/content/misc/contribute.ngdoc
+++ b/docs/content/misc/contribute.ngdoc
@@ -186,7 +186,7 @@ change. To execute tests in this mode run:
 
 1. To start the Testacular server, capture Chrome browser and run unit tests, run:
 
-        rake test:jqlite
+        rake autotest:jqlite
 
 2. To capture more browsers, open this url in the desired browser (url might be different if you have multiple instance
    of Testacular running, read Testacular's console output for the correct url):


### PR DESCRIPTION
Just something that confused me until I checked `rake -T`. The docs were advocating the `test:*` namespace for both single-run test and continuous watching.
