### PR TITLE
fix(SpecRunner.js): data-ng and x-ng based attributes are now found

### DIFF
--- a/src/ngScenario/SpecRunner.js
+++ b/src/ngScenario/SpecRunner.js
@@ -119,7 +119,9 @@ angular.scenario.SpecRunner.prototype.addFutureAction = function(name, behavior,
         });
         var result = $document.find(selector);
         if (selector.match(NG)) {
-          result = result.add(selector.replace(NG, '[ng-'), $document);
+             _jQuery.each(['[ng-','[data-ng-','[x-ng-'], function(index, value){
+		result = result.add(selector.replace(NG, value), $document);
+	     }) 
         }
         if (!result.length) {
           throw {

--- a/test/ngScenario/dslSpec.js
+++ b/test/ngScenario/dslSpec.js
@@ -216,6 +216,30 @@ describe("angular.scenario.dsl", function() {
         $root.dsl.select('test').option('A');
         expect(doc.find('[ng-model="test"]').val()).toEqual('A');
       });
+      
+      it('should select single option using data-ng', function() {
+        doc.append(
+          '<select data-ng-model="test">' +
+          '  <option value=A>one</option>' +
+          '  <option value=B selected>two</option>' +
+          '</select>'
+        );
+        $root.dsl.select('test').option('A');
+        expect(doc.find('[data-ng-model="test"]').val()).toEqual('A');
+      });
+      it('should select single option using x-ng', function() {
+        doc.append(
+          '<select x-ng-model="test">' +
+          '  <option value=A>one</option>' +
+          '  <option value=B selected>two</option>' +
+          '</select>'
+        );
+        $root.dsl.select('test').option('A');
+        expect(doc.find('[x-ng-model="test"]').val()).toEqual('A');
+      });
+
+
+
 
       it('should select option by name', function() {
         doc.append(
@@ -574,6 +598,20 @@ describe("angular.scenario.dsl", function() {
         chain.enter('foo');
         expect(_jQuery('input[ng-model="test.input"]').val()).toEqual('foo');
       });
+      it('should change value in text input in data-ng form', function() {
+        doc.append('<input data-ng-model="test.input" value="something">');
+        var chain = $root.dsl.input('test.input');
+        chain.enter('foo');
+        expect(_jQuery('input[data-ng-model="test.input"]').val()).toEqual('foo');
+      });
+      it('should change value in text input in x-ng form', function() {
+        doc.append('<input x-ng-model="test.input" value="something">');
+        var chain = $root.dsl.input('test.input');
+        chain.enter('foo');
+        expect(_jQuery('input[x-ng-model="test.input"]').val()).toEqual('foo');
+      });
+
+
 
       it('should return error if no input exists', function() {
         var chain = $root.dsl.input('test.input');
@@ -650,5 +688,6 @@ describe("angular.scenario.dsl", function() {
         expect($root.futureError).toMatch(/did not match/);
       });
     });
+    
   });
 });


### PR DESCRIPTION
Prefixed attributes like data-ng-model and x-ng-model were not being
found by the Selector. It was only looking at ng: and ng- prefixed
attributes.
Added a few tests as well to ensure the aforementioned prefixed
attributes are being matched properly.

Closes #1020
