### PR TITLE
fix(removePatch): fire $destroy event when full jQuery is used

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -129,12 +129,7 @@ function JQLitePatchJQueryRemove(name, dispatchThis) {
       for(setIndex = 0, setLength = set.length; setIndex < setLength; setIndex++) {
         element = jqLite(set[setIndex]);
         if (fireEvent) {
-          events = element.data('events');
-          if ( (fns = events && events.$destroy) ) {
-            forEach(fns, function(fn){
-              fn.handler();
-            });
-          }
+          element.trigger('$destroy');
         } else {
           fireEvent = !fireEvent;
         }


### PR DESCRIPTION
This patch corrects a problem observed when using ngRepeat to create required inputs inside a form.  If the user removed the text from an input (making it invalid) and then carried out an action to delete the appropriate part of the model then the input element was never removed from the form, causing the form to stay $invalid although in fact all current elements were $valid.  Because the form then had an invalid validation token retained for a destroyed control it was not possible to recover the correct state for the form without destroying it.

The previous code relied upon internal jQuery structures which are not present in v.1.8.2 (current).  This code uses the public API to fire the $destroy custom event, and so should work with any post-1.4 jQuery version.
