### PR TITLE
fix(removePatch): fire $destroy event when full jQuery is used

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -129,12 +129,7 @@ function JQLitePatchJQueryRemove(name, dispatchThis) {
       for(setIndex = 0, setLength = set.length; setIndex < setLength; setIndex++) {
         element = jqLite(set[setIndex]);
         if (fireEvent) {
-          events = element.data('events');
-          if ( (fns = events && events.$destroy) ) {
-            forEach(fns, function(fn){
-              fn.handler();
-            });
-          }
+          element.trigger('$destroy');
         } else {
           fireEvent = !fireEvent;
         }

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -129,7 +129,7 @@ function JQLitePatchJQueryRemove(name, dispatchThis) {
       for(setIndex = 0, setLength = set.length; setIndex < setLength; setIndex++) {
         element = jqLite(set[setIndex]);
         if (fireEvent) {
-          element.trigger('$destroy');
+          element.triggerHandler('$destroy');
         } else {
           fireEvent = !fireEvent;
         }


### PR DESCRIPTION
We found an issue where jQuery 1.8.2 is used where form controls created by ngRepeat are never removed from the parent form because the $destroy custom event is not fired.  As a result, if a control was invalid (due to the model binding) and then destroyed the form's validity state became out-of-sync with the model and impossible to restore.  This patch corrects the issue.

The previous code relied upon internal jQuery structures which are not
present in v.1.8.2 (current).  This code uses the public API to fire the
$destroy custom event, and so should work with any post-1.4 jQuery
version.
