### PR TITLE
Update docs/content/guide/module.ngdoc

### DIFF
--- a/docs/content/guide/module.ngdoc
+++ b/docs/content/guide/module.ngdoc
@@ -35,7 +35,7 @@ Important things to notice:
 
       // configure the module.
       // in this example we will create a greeting filter
-      simpleAppModule.filter('greet', function() {
+      myAppModule.filter('greet', function() {
        return function(name) {
           return 'Hello, ' + name + '!';
         };


### PR DESCRIPTION
fixed example app, `simpleAppModule` should have been `myAppModule`.
