### PR TITLE
feat($parse+Scope): smarter handling of constant expressions

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -840,9 +840,10 @@ function getterFn(path, csp) {
  * @param {string} expression String expression to compile.
  * @returns {function(context, locals)} a function which represents the compiled expression:
  *
- *    * `context`: an object against which any expressions embedded in the strings are evaluated
- *      against (Topically a scope object).
- *    * `locals`: local variables context object, useful for overriding values in `context`.
+ *    * `context` – `{object}` – an object against which any expressions embedded in the strings
+ *      are evaluated against (tipically a scope object).
+ *    * `locals` – `{object=}` – local variables context object, useful for overriding values in
+ *      `context`.
  *
  *    The return function also has an `assign` property, if the expression is assignable, which
  *    allows one to set values to expressions.

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -295,6 +295,8 @@ function parser(text, json, $filter, csp){
   if (tokens.length !== 0) {
     throwError("is an unexpected token", tokens[0]);
   }
+  value.literal = !!value.literal;
+  value.constant = !!value.constant;
   return value;
 
   ///////////////////////////////////
@@ -342,15 +344,19 @@ function parser(text, json, $filter, csp){
   }
 
   function unaryFn(fn, right) {
-    return function(self, locals) {
+    return extend(function(self, locals) {
       return fn(self, locals, right);
-    };
+    }, {
+      constant:right.constant
+    });
   }
 
   function binaryFn(left, fn, right) {
-    return function(self, locals) {
+    return extend(function(self, locals) {
       return fn(self, locals, left, right);
-    };
+    }, {
+      constant:left.constant && right.constant
+    });
   }
 
   function statements() {
@@ -518,6 +524,9 @@ function parser(text, json, $filter, csp){
       if (!primary) {
         throwError("not a primary expression", token);
       }
+      if (token.json) {
+        primary.constant = primary.literal = true;
+      }
     }
 
     var next, context;
@@ -606,23 +615,32 @@ function parser(text, json, $filter, csp){
   // This is used with json array declaration
   function arrayDeclaration () {
     var elementFns = [];
+    var allConstant = true;
     if (peekToken().text != ']') {
       do {
-        elementFns.push(expression());
+        var elementFn = expression();
+        elementFns.push(elementFn);
+        if (!elementFn.constant) {
+          allConstant = false;
+        }
       } while (expect(','));
     }
     consume(']');
-    return function(self, locals){
+    return extend(function(self, locals){
       var array = [];
       for ( var i = 0; i < elementFns.length; i++) {
         array.push(elementFns[i](self, locals));
       }
       return array;
-    };
+    }, {
+      literal:true,
+      constant:allConstant
+    });
   }
 
   function object () {
     var keyValues = [];
+    var allConstant = true;
     if (peekToken().text != '}') {
       do {
         var token = expect(),
@@ -630,10 +648,13 @@ function parser(text, json, $filter, csp){
         consume(":");
         var value = expression();
         keyValues.push({key:key, value:value});
+        if (!value.constant) {
+          allConstant = false;
+        }
       } while (expect(','));
     }
     consume('}');
-    return function(self, locals){
+    return extend(function(self, locals){
       var object = {};
       for ( var i = 0; i < keyValues.length; i++) {
         var keyValue = keyValues[i];
@@ -641,7 +662,10 @@ function parser(text, json, $filter, csp){
         object[keyValue.key] = value;
       }
       return object;
-    };
+    }, {
+      literal:true,
+      constant:allConstant
+    });
   }
 }
 
@@ -845,8 +869,13 @@ function getterFn(path, csp) {
  *    * `locals` – `{object=}` – local variables context object, useful for overriding values in
  *      `context`.
  *
- *    The return function also has an `assign` property, if the expression is assignable, which
- *    allows one to set values to expressions.
+ *    The returned function also has the following properties:
+ *      * `literal` – `{boolean}` – whether the expression's top-level node is a JavaScript
+ *        literal.
+ *      * `constant` – `{boolean}` – whether the expression is made entirely of JavaScript
+ *        constant literals.
+ *      * `assign` – `{?function(context, value)}` – if the expression is assignable, this will be
+ *        set to a function to change its value on the given context.
  *
  */
 function $ParseProvider() {

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -298,6 +298,14 @@ function $RootScopeProvider(){
           watcher.fn = function(newVal, oldVal, scope) {listenFn(scope);};
         }
 
+        if (typeof watchExp == 'string' && get.constant) {
+          var originalFn = watcher.fn;
+          watcher.fn = function(newVal, oldVal, scope) {
+            originalFn.call(this, newVal, oldVal, scope);
+            arrayRemove(array, watcher);
+          };
+        }
+
         if (!array) {
           array = scope.$$watchers = [];
         }

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -783,7 +783,7 @@ function $RootScopeProvider(){
 
     /**
      * function used as an initial value for watchers.
-     * because it's uniqueue we can easily tell it apart from other values
+     * because it's unique we can easily tell it apart from other values
      */
     function initWatchVal() {}
   }];

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -661,6 +661,74 @@ describe('parser', function() {
           expect($parse('a.b')({a: {b: 0}}, {a: null})).toEqual(undefined);
         }));
       });
+
+      describe('literal', function() {
+        it('should mark scalar value expressions as literal', inject(function($parse) {
+          expect($parse('0').literal).toBe(true);
+          expect($parse('"hello"').literal).toBe(true);
+          expect($parse('true').literal).toBe(true);
+          expect($parse('false').literal).toBe(true);
+          expect($parse('null').literal).toBe(true);
+          expect($parse('undefined').literal).toBe(true);
+        }));
+
+        it('should mark array expressions as literal', inject(function($parse) {
+          expect($parse('[]').literal).toBe(true);
+          expect($parse('[1, 2, 3]').literal).toBe(true);
+          expect($parse('[1, identifier]').literal).toBe(true);
+        }));
+
+        it('should mark object expressions as literal', inject(function($parse) {
+          expect($parse('{}').literal).toBe(true);
+          expect($parse('{x: 1}').literal).toBe(true);
+          expect($parse('{foo: bar}').literal).toBe(true);
+        }));
+
+        it('should not mark function calls or operator expressions as literal', inject(function($parse) {
+          expect($parse('1 + 1').literal).toBe(false);
+          expect($parse('call()').literal).toBe(false);
+          expect($parse('[].length').literal).toBe(false);
+        }));
+      });
+
+      describe('constant', function() {
+        it('should mark scalar value expressions as constant', inject(function($parse) {
+          expect($parse('12.3').constant).toBe(true);
+          expect($parse('"string"').constant).toBe(true);
+          expect($parse('true').constant).toBe(true);
+          expect($parse('false').constant).toBe(true);
+          expect($parse('null').constant).toBe(true);
+          expect($parse('undefined').constant).toBe(true);
+        }));
+
+        it('should mark arrays as constant if they only contain constant elements', inject(function($parse) {
+          expect($parse('[]').constant).toBe(true);
+          expect($parse('[1, 2, 3]').constant).toBe(true);
+          expect($parse('["string", null]').constant).toBe(true);
+          expect($parse('[[]]').constant).toBe(true);
+          expect($parse('[1, [2, 3], {4: 5}]').constant).toBe(true);
+        }));
+
+        it('should not mark arrays as constant if they contain any non-constant elements', inject(function($parse) {
+          expect($parse('[foo]').constant).toBe(false);
+          expect($parse('[x + 1]').constant).toBe(false);
+          expect($parse('[bar[0]]').constant).toBe(false);
+        }));
+
+        it('should mark complex expressions involving constant values as constant', inject(function($parse) {
+          expect($parse('!true').constant).toBe(true);
+          expect($parse('1 - 1').constant).toBe(true);
+          expect($parse('"foo" + "bar"').constant).toBe(true);
+          expect($parse('5 != null').constant).toBe(true);
+          expect($parse('{standard: 4/3, wide: 16/9}').constant).toBe(true);
+        }));
+
+        it('should not mark any expression involving variables or function calls as constant', inject(function($parse) {
+          expect($parse('true.toString()').constant).toBe(false);
+          expect($parse('foo(1, 2, 3)').constant).toBe(false);
+          expect($parse('"name" + id').constant).toBe(false);
+        }));
+      });
     });
   });
 });

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -216,7 +216,7 @@ describe('Scope', function() {
     });
 
 
-    it('should prevent infinite recursion and print print watcher function name or body',
+    it('should prevent infinite recursion and print watcher function name or body',
         inject(function($rootScope) {
       $rootScope.$watch(function watcherA() {return $rootScope.a;}, function() {$rootScope.b++;});
       $rootScope.$watch(function() {return $rootScope.b;}, function() {$rootScope.a++;});
@@ -328,7 +328,7 @@ describe('Scope', function() {
     }));
 
 
-    it('should always call the watchr with newVal and oldVal equal on the first run',
+    it('should always call the watcher with newVal and oldVal equal on the first run',
         inject(function($rootScope) {
       var log = [];
       function logger(scope, newVal, oldVal) {

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -99,6 +99,13 @@ describe('Scope', function() {
       expect(spy).wasCalled();
     }));
 
+    it('should not keep constant expressions on watch queue', inject(function($rootScope) {
+      $rootScope.$watch('1 + 1', function() {});
+      $rootScope.$digest();
+
+      expect($rootScope.$$watchers.length).toEqual(0);
+    }));
+
 
     it('should delegate exceptions', function() {
       module(function($exceptionHandlerProvider) {
@@ -119,10 +126,14 @@ describe('Scope', function() {
       var log = '';
       $rootScope.$watch('a', function() { log += 'a'; });
       $rootScope.$watch('b', function() { log += 'b'; });
+      // constant expressions have slightly different handling,
+      // let's ensure they are kept in the same list as others
+      $rootScope.$watch('1', function() { log += '1'; });
       $rootScope.$watch('c', function() { log += 'c'; });
+      $rootScope.$watch('2', function() { log += '2'; });
       $rootScope.a = $rootScope.b = $rootScope.c = 1;
       $rootScope.$digest();
-      expect(log).toEqual('abc');
+      expect(log).toEqual('ab1c2');
     }));
 
 


### PR DESCRIPTION
This patch adds two properties to functions returned by `$parse`: literal and constant.
- `literal` is set to true if the expression's top-level is a JavaScript
    literal (number, string, boolean, null/undefined, array, object), even
    if it contains non-literals inside.
- `constant` is set to true if the expression is known to be made
    entirely of constant values, i.e., evaluating it will always yield the
    same result.

A consequence is that a JSON expression is guaranteed to be both literal and constant.

Then, `Scope.prototype.$watch()` checks for `constant`, and won't keep it in the watchers list, meaning this expression is evaluated only once rather than needlessly evaluating it on every `$digest` cycle. For this reason, this also solves issue #1376.
