### PR TITLE
feat(noConflict): restore previous namespace

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -58,11 +58,29 @@ var Error             = window.Error,
     push              = [].push,
     toString          = Object.prototype.toString,
 
+
+    _angular          = window.angular, 
     /** @name angular */
     angular           = window.angular || (window.angular = {}),
     angularModule,
     nodeName_,
     uid               = ['0', '0', '0'];
+
+/**
+ * @ngdoc function
+ * @name angular.noConflict
+ * @function
+ *
+ * @description
+ * Restores the previous global value of angular and returns the current instance. Other libraries may already use the angular namespace. Or a previous version of angular is already loaded on the page. In these cases you may want to restore the previous namespace and keep a reference to angular. 
+ *
+ * @returns {Object} the current angular namespace
+ */
+function noConflict() {
+  var a = window.angular;
+  window.angular = _angular;
+  return a;
+}
 
 /**
  * @ngdoc function

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -58,11 +58,29 @@ var Error             = window.Error,
     push              = [].push,
     toString          = Object.prototype.toString,
 
+
+    _angular          = window.angular, 
     /** @name angular */
     angular           = window.angular || (window.angular = {}),
     angularModule,
     nodeName_,
     uid               = ['0', '0', '0'];
+
+/**
+ * @ngdoc function
+ * @name angular.noConflict
+ * @function
+ *
+ * @description
+ * Restores the previous global value of angular and returns the current instance. Other libraries may already use the angular namespace. Or a previous version of angular is already loaded on the page. In these cases you may want to restore the previous namespace and keep a reference to angular. 
+ *
+ * @returns the current angular namespace
+ */
+function noConflict() {
+  var a = window.angular;
+  window.angular = _angular;
+  return a;
+}
 
 /**
  * @ngdoc function

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -48,7 +48,8 @@ function publishExternalAPI(angular){
     'isDate': isDate,
     'lowercase': lowercase,
     'uppercase': uppercase,
-    'callbacks': {counter: 0}
+    'callbacks': {counter: 0},
+    'noConflict': noConflict
   });
 
   angularModule = setupModuleLoader(window);

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -632,4 +632,27 @@ describe('angular', function() {
       expect(toJson({key: $rootScope})).toEqual('{"key":"$SCOPE"}');
     }));
   });
+
+  describe('noConflict', function() {
+    var globalAngular;
+    beforeEach(function() {
+      globalAngular = angular;  
+    });
+
+    afterEach(function() {
+      angular = globalAngular;  
+    });
+
+    it('should return angular', function() {
+      var a = angular.noConflict();
+      expect(a).toBe(globalAngular);
+    });
+
+    it('should restore original angular', function() {
+      var a = angular.noConflict();
+      expect(angular).toBeUndefined();
+    });
+      
+  });
+
 });


### PR DESCRIPTION
Angular needs to provide a way to restore the previously defined `angular` global namespace to prevent conflict with existing scripts. This is especially important if there are multiple versions of angular loaded onto the same page. If angular is used in a thirdparty javascript environment it should provide a way to clean up the global after loading. 

This feature is similiar to the jQuery [noConflict](http://api.jquery.com/jQuery.noConflict/) function. 
