### PR TITLE
fix (directive): Preserve display type in ngShow and ngHide

### DIFF
--- a/src/ng/directive/ngShowHide.js
+++ b/src/ng/directive/ngShowHide.js
@@ -34,8 +34,10 @@
  */
 //TODO(misko): refactor to remove element from the DOM
 var ngShowDirective = ngDirective(function(scope, element, attr){
+  var elDisplay = element.css('display');
+  elDisplay = elDisplay === 'none' ? '' : elDisplay;
   scope.$watch(attr.ngShow, function ngShowWatchAction(value){
-    element.css('display', toBoolean(value) ? '' : 'none');
+    element.css('display', toBoolean(value) ? elDisplay : 'none');
   });
 });
 
@@ -74,7 +76,9 @@ var ngShowDirective = ngDirective(function(scope, element, attr){
  */
 //TODO(misko): refactor to remove element from the DOM
 var ngHideDirective = ngDirective(function(scope, element, attr){
+  var elDisplay = element.css('display');
+  elDisplay = elDisplay === 'none' ? '' : elDisplay;
   scope.$watch(attr.ngHide, function ngHideWatchAction(value){
-    element.css('display', toBoolean(value) ? 'none' : '');
+    element.css('display', toBoolean(value) ? 'none' : elDisplay);
   });
 });

--- a/test/ng/directive/ngShowHideSpec.js
+++ b/test/ng/directive/ngShowHideSpec.js
@@ -28,6 +28,16 @@ describe('ngShow / ngHide', function() {
       $rootScope.$digest();
       expect(isCssVisible(element)).toBe(true);
     }));
+
+    it('should preserve the display type', inject(function($rootScope, $compile) {
+      element = jqLite('<div style="display: table;" ng-show="exp"></div>');
+      element = $compile(element)($rootScope);
+      $rootScope.$digest();
+      expect(element.css('display')).toEqual('none');
+      $rootScope.exp = true;
+      $rootScope.$digest();
+      expect(element.css('display')).toEqual('table');
+    }));
   });
 
   describe('ngHide', function() {
@@ -38,6 +48,16 @@ describe('ngShow / ngHide', function() {
       $rootScope.exp = true;
       $rootScope.$digest();
       expect(isCssVisible(element)).toBe(false);
+    }));
+
+    it('should preserve the display type', inject(function($rootScope, $compile) {
+      element = jqLite('<div style="display: table;" ng-hide="exp"></div>');
+      element = $compile(element)($rootScope);
+      $rootScope.$digest();
+      expect(element.css('display')).toEqual('table');
+      $rootScope.exp = true;
+      $rootScope.$digest();
+      expect(element.css('display')).toEqual('none');
     }));
   });
 });


### PR DESCRIPTION
From #1540, this preserves the display type when showing and hiding an element. This will only apply on the initial display state of the element. If the element's display type is modified to another value after creation, this will only set it back to its initial state, not the state it was before ngShow or ngHide have been performed.
