### PR TITLE
JSONP requests with the same callback name

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -37,12 +37,12 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
     url = url || $browser.url();
 
     if (lowercase(method) == 'jsonp') {
-      var callbackId = '_' + (callbacks.counter++).toString(36);
+      var callbackId = url.indexOf('JSON_SINGLE_CALLBACK') === -1 ? '_' + (callbacks.counter++).toString(36) : 'single';
       callbacks[callbackId] = function(data) {
         callbacks[callbackId].data = data;
       };
 
-      jsonpReq(url.replace('JSON_CALLBACK', 'angular.callbacks.' + callbackId),
+      jsonpReq(url.replace('JSON_CALLBACK', 'angular.callbacks.' + callbackId).replace('JSON_SINGLE_CALLBACK', 'angular.callbacks.single'),
           function() {
         if (callbacks[callbackId].data) {
           completeRequest(callback, 200, callbacks[callbackId].data);

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -235,6 +235,31 @@ describe('$httpBackend', function() {
       expect(fakeDocument.$$scripts[0].src).toBe($browser.url());
     });
 
+    it('should always call callback with the same name when use JSON_SINGLE_CALLBACK', function() {
+      callback.andCallFake(function(status, response) {
+        expect(status).toBe(200);
+        expect(response).toBe('some-data');
+      });
+
+      $backend('JSONP', 'http://example.org/path?cb=JSON_SINGLE_CALLBACK', null, callback);
+      expect(fakeDocument.$$scripts.length).toBe(1);
+
+      var script = fakeDocument.$$scripts.shift(),
+          url = script.src.match(/([^\?]*)\?cb=angular\.callbacks\.single/);
+
+      expect(url[1]).toBe('http://example.org/path');
+      callbacks['single']('some-data');
+
+      if (script.onreadystatechange) {
+        script.readyState = 'complete';
+        script.onreadystatechange();
+      } else {
+        script.onload()
+      }
+
+      expect(callback).toHaveBeenCalledOnce();
+    });
+
 
     // TODO(vojta): test whether it fires "async-start"
     // TODO(vojta): test whether it fires "async-end" on both success and error


### PR DESCRIPTION
Instead of use JSON_CALLBACK to jsonp requests (and angular.callbacks_X callbacks), using JSON_SINGLE_CALLBACK to use always the same callback name (useful to caching)
