### PR TITLE
fix(compile): Interpolate @ locals before the link function runs

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -726,9 +726,13 @@ function $CompileProvider($provide) {
                   scope[scopeName] = value;
                 });
                 attrs.$$observers[attrName].$$scope = parentScope;
+                if( attrs[attrName] ) {
+                  // If the attribute has been provided then we trigger an interpolation to ensure the value is there for use in the link fn
+                  scope[scopeName] = $interpolate(attrs[attrName])(parentScope);
+                }
                 break;
               }
-
+              
               case '=': {
                 parentGet = $parse(attrs[attrName]);
                 parentSet = parentGet.assign || function() {

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1028,7 +1028,7 @@ function $CompileProvider($provide) {
             interpolateFn = $interpolate(attr[name], true);
           }
 
-          attr[name] = undefined;
+          attr[name] = interpolateFn(scope);
           ($$observers[name] || ($$observers[name] = [])).$$inter = true;
           (attr.$$observers && attr.$$observers[name].$$scope || scope).
             $watch(interpolateFn, function interpolateFnWatchAction(value) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1761,27 +1761,21 @@ describe('$compile', function() {
     describe('attribute', function() {
       it('should copy simple attribute', inject(function() {
         compile('<div><span my-component attr="some text">');
-        expect(componentScope.attr).toEqual(undefined);
-        expect(componentScope.attrAlias).toEqual(undefined);
-
-        $rootScope.$apply();
 
         expect(componentScope.attr).toEqual('some text');
         expect(componentScope.attrAlias).toEqual('some text');
         expect(componentScope.attrAlias).toEqual(componentScope.attr);
       }));
 
+      it('should set up the interpolation before it reaches the link function', inject(function() {
+        $rootScope.name = 'misko';
+        compile('<div><span my-component attr="hello {{name}}">');
+        expect(componentScope.attr).toEqual('hello misko');
+        expect(componentScope.attrAlias).toEqual('hello misko');
+      }));
 
       it('should update when interpolated attribute updates', inject(function() {
         compile('<div><span my-component attr="hello {{name}}">');
-        expect(componentScope.attr).toEqual(undefined);
-        expect(componentScope.attrAlias).toEqual(undefined);
-
-        $rootScope.name = 'misko';
-        $rootScope.$apply();
-
-        expect(componentScope.attr).toEqual('hello misko');
-        expect(componentScope.attrAlias).toEqual('hello misko');
 
         $rootScope.name = 'igor';
         $rootScope.$apply();

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1349,9 +1349,10 @@ describe('$compile', function() {
     }));
 
 
-    it('should set interpolated attrs to undefined', inject(function($rootScope, $compile) {
+    it('should set interpolated attrs to initial interpolation value', inject(function($rootScope, $compile) {
+      $rootScope.whatever = 'test value';
       $compile('<div some-attr="{{whatever}}" observer></div>')($rootScope);
-      expect(directiveAttrs.someAttr).toBeUndefined();
+      expect(directiveAttrs.someAttr).toBe($rootScope.whatever);
     }));
 
 


### PR DESCRIPTION
Do a one-off interpolation of @ locals to ensure that the link fn receives attributes that are already interpolated.

(Rebased and reworded the commit message to make it easier to merge!)
