### PR TITLE
fix($cacheFactory) return undefined when removing non-existent cache ent...

### DIFF
--- a/src/ng/cacheFactory.js
+++ b/src/ng/cacheFactory.js
@@ -70,6 +70,8 @@ function $CacheFactoryProvider() {
         remove: function(key) {
           var lruEntry = lruHash[key];
 
+          if (!lruEntry) return;
+
           if (lruEntry == freshEnd) freshEnd = lruEntry.p;
           if (lruEntry == staleEnd) staleEnd = lruEntry.n;
           link(lruEntry.n,lruEntry.p);

--- a/test/ng/cacheFactorySpec.js
+++ b/test/ng/cacheFactorySpec.js
@@ -88,6 +88,10 @@ describe('$cacheFactory', function() {
         expect(cache.get('k2')).toBeUndefined();
       }));
 
+      it('should return undefined when entry does not exist', inject(function($cacheFactory) {
+        expect(cache.remove('non-existent')).toBeUndefined();
+      }));
+
 
       it('should stringify keys', inject(function($cacheFactory) {
         cache.put('123', 'foo');


### PR DESCRIPTION
...ry

Making remove behave like get() when an entry does not exist by returning undefined. 

From #1497
