### PR TITLE
feat(e2e dsl) fail when trying to select an option that does not exist

### DIFF
--- a/src/ngScenario/dsl.js
+++ b/src/ngScenario/dsl.js
@@ -298,6 +298,8 @@ angular.scenario.dsl('select', function() {
         option = select.find('option:contains("' + value + '")');
         if (option.length) {
           select.val(option.val());
+        } else {
+            return done("option '" + value + "' not found");
         }
       }
       select.trigger('change');

--- a/test/ngScenario/dslSpec.js
+++ b/test/ngScenario/dslSpec.js
@@ -269,6 +269,17 @@ describe("angular.scenario.dsl", function() {
         $root.dsl.select('test').options('A', 'B');
         expect($root.futureError).toMatch(/did not match/);
       });
+      
+      it('should fail to select an option that does not exist', function(){
+          doc.append(
+              '<select ng-model="test">' +
+              '  <option value=A>one</option>' +
+              '  <option value=B selected>two</option>' +
+              '</select>'
+            );
+            $root.dsl.select('test').option('three');
+            expect($root.futureError).toMatch(/not found/);
+      });
     });
 
     describe('Element', function() {


### PR DESCRIPTION
I am using e2e testing to test-drive my views.

Without this change, it is fails silently when I try to select an option that doesn't exist. then my test fails at a later stage when the app is not in the expected state. 

This change is useful for me because it shortens the feedback cycle when I test-drive my stuff.
