### PR TITLE
feat($cacheFactory): Make Cache.put return the value

### DIFF
--- a/src/ng/cacheFactory.js
+++ b/src/ng/cacheFactory.js
@@ -14,7 +14,7 @@
  * @returns {object} Newly created cache object with the following set of methods:
  *
  * - `{object}` `info()` — Returns id, size, and options of cache.
- * - `{void}` `put({string} key, {*} value)` — Puts a new key-value pair into the cache.
+ * - `{{*}}` `put({string} key, {*} value)` — Puts a new key-value pair into the cache.
  * - `{{*}}` `get({string} key)` — Returns cached value for `key` or undefined for cache miss.
  * - `{void}` `remove({string} key)` — Removes a key-value pair from the cache.
  * - `{void}` `removeAll()` — Removes all cached values.
@@ -46,13 +46,15 @@ function $CacheFactoryProvider() {
 
           refresh(lruEntry);
 
-          if (isUndefined(value)) return;
+          if (isUndefined(value)) return value;
           if (!(key in data)) size++;
           data[key] = value;
 
           if (size > capacity) {
             this.remove(staleEnd.key);
           }
+
+          return value;
         },
 
 

--- a/test/ng/cacheFactorySpec.js
+++ b/test/ng/cacheFactorySpec.js
@@ -99,6 +99,12 @@ describe('$cacheFactory', function() {
         cache.remove(123);
         expect(cache.info().size).toBe(0);
       }));
+
+      it("should return value from put", inject(function($cacheFactory) {
+        function DummyClass() {}
+        var obj = new DummyClass();
+        expect(cache.put('k1', obj)).toBe(obj);
+      }));
     });
 
 


### PR DESCRIPTION
Using cache.put is slightly awkward because you can't just wrap an expression with it like you can a standard object.

Coffeescript with plain object:
cache = {}
(key) -> cache[key] ?= genValue(key)

Coffeescript with $cacheFactory cache:

cache = $cacheFactory.get('cache')
(key) -> cache.get(key) ? (r = genValue(key); cache.put(key, r); r)

With this change:

cache = $cacheFactory.get('cache')
(key) -> cache.get(key) ? cache.put(key, genValue(key))
