### PR TITLE
Don't clobber paramDefaults in ngResource actions

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -313,9 +313,9 @@ angular.module('ngResource', ['ng']).
       actions = extend({}, DEFAULT_ACTIONS, actions);
 
       function extractParams(data, actionParams){
-        var ids = {};
-        paramDefaults = extend(paramDefaults, actionParams);
-        forEach(paramDefaults || {}, function(value, key){
+        var ids = {},
+            actualParams = extend({}, paramDefaults, actionParams);
+        forEach(actualParams, function(value, key){
           ids[key] = value.charAt && value.charAt(0) == '@' ? getter(data, value.substr(1)) : value;
         });
         return ids;


### PR DESCRIPTION
The 'paramDefaults' parameter is global to a resource created by $resource.  The
'extractParams' function was merging 'actionParams' into it every time when it
really should be creating a new object that is a merge of paramDefaults and
actionParams. paramDefaults itself should remain unchanged.

The following code proves the issue (it's a negative test I didn't add a spec for it).

  it('should not clobber paramDefaults', function() {

```
var R = $resource('/Customer/:id/:otherActionParam',
  {id: '@id'}, {otherAction: {method: 'POST', params: {otherActionParam: 'other-action-says-hi'}}});

var thing = new R({id:123});

$httpBackend.expect('POST', '/Customer/123/other-action-says-hi').respond();
thing.$otherAction();
$httpBackend.flush();

// This expectation fails because other-action-says-hi is still here.
$httpBackend.expect('POST', '/Customer/123').respond();
thing.$save();
$httpBackend.flush();
```

  });
