### PR TITLE
Added missing </div> tag to sourceEdit directive template

### DIFF
--- a/docs/src/templates/js/docs.js
+++ b/docs/src/templates/js/docs.js
@@ -37,7 +37,8 @@ docsApp.directive.sourceEdit = function(getEmbeddedTemplate) {
         '<ul class="dropdown-menu">' +
         '  <li><a ng-click="plunkr($event)" href="">In Plunkr</a></li>' +
         '  <li><a ng-click="fiddle($event)" href="">In JsFiddle</a></li>' +
-        '</ul>',
+        '</ul>' +
+        '</div>',
     scope: true,
     controller: function($scope, $attrs, openJsFiddle, openPlunkr) {
       var sources = {


### PR DESCRIPTION
I was browsing the code and noticed something odd in the sourceEdit directive template. it seemed to miss an end div tag.... so I added one. 
