### PR TITLE
fix(injector) Fixes #1452: Provider can't be configured with an array

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -441,9 +441,9 @@ function createInjector(modulesToLoad) {
   }
 
   function provider(name, provider_) {
-    if (isFunction(provider_)) {
+    if (isArray(provider_) || isFunction(provider_)) {
       provider_ = providerInjector.instantiate(provider_);
-    }
+    }    
     if (!provider_.$get) {
       throw Error('Provider ' + name + ' must define $get factory method.');
     }

--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -441,6 +441,9 @@ function createInjector(modulesToLoad) {
   }
 
   function provider(name, provider_) {
+    if (isArray(provider_)) {
+      provider_ = providerInjector.instantiate(provider_);
+    }
     if (isFunction(provider_)) {
       provider_ = providerInjector.instantiate(provider_);
     }

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -394,6 +394,17 @@ describe('injector', function() {
         });
 
 
+        it('should configure $provide using an array', function() {
+          function Type() {};
+          Type.prototype.$get = function() {
+            return 'abc';
+          };
+          expect(createInjector([function($provide) {
+            $provide.provider('value', [Type]);
+          }]).get('value')).toEqual('abc');
+        });
+
+
         it('should configure a set of providers', function() {
           expect(createInjector([function($provide) {
             $provide.provider({value: valueFn({$get:Array})});


### PR DESCRIPTION
The `provider` constructor now checks to see if the arguments are an
array, which it then instantiates via the `providerInjector`.
