### PR TITLE
fix($injector): provider can now be defined in the array format

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -441,7 +441,7 @@ function createInjector(modulesToLoad) {
   }
 
   function provider(name, provider_) {
-    if (isFunction(provider_)) {
+    if (isFunction(provider_) || isArray(provider_)) {
       provider_ = providerInjector.instantiate(provider_);
     }
     if (!provider_.$get) {

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -394,6 +394,20 @@ describe('injector', function() {
         });
 
 
+        it('should configure $provide using an array', function() {
+          function Type(PREFIX) {
+            this.prefix = PREFIX;
+          };
+          Type.prototype.$get = function() {
+            return this.prefix + 'def';
+          };
+          expect(createInjector([function($provide) {
+            $provide.constant('PREFIX', 'abc');
+            $provide.provider('value', ['PREFIX', Type]);
+          }]).get('value')).toEqual('abcdef');
+        });
+
+
         it('should configure a set of providers', function() {
           expect(createInjector([function($provide) {
             $provide.provider({value: valueFn({$get:Array})});


### PR DESCRIPTION
`injector.instantiate` is now called for arrays too, instead of only for functions.

Closes #1452
