### PR TITLE
Allow html in title attributes in tab-pane directive

### DIFF
--- a/src/bootstrap/bootstrap.js
+++ b/src/bootstrap/bootstrap.js
@@ -102,7 +102,7 @@ directive.tabbable = function() {
         tabs.push(tab);
 
         attr.$observe('value', update)();
-        attr.$observe('title', function(){ update(); a.text(tab.title); })();
+        attr.$observe('title', function(){ update(); a.html(tab.title); })();
 
         function update() {
           tab.title = attr.title;


### PR DESCRIPTION
Usefull to add html decoration in the title like icons.
For example with Glyphicons:

<div class="tab-pane" title="<i class='icon-user'></i> User settings" value="userSettings">
...
</div>
