### PR TITLE
fix(Scope): ensure that a scope is destroyed only once

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -134,6 +134,7 @@ function $RootScopeProvider(){
                      this.$$nextSibling = this.$$prevSibling =
                      this.$$childHead = this.$$childTail = null;
       this['this'] = this.$root =  this;
+      this.$$destroyed = false;
       this.$$asyncQueue = [];
       this.$$listeners = {};
     }
@@ -467,10 +468,12 @@ function $RootScopeProvider(){
        * perform any necessary cleanup.
        */
       $destroy: function() {
-        if ($rootScope == this) return; // we can't remove the root node;
+        // we can't destroy the root scope or a scope that has been already destroyed
+        if ($rootScope == this || this.$$destroyed) return;
         var parent = this.$parent;
 
         this.$broadcast('$destroy');
+        this.$$destroyed = true;
 
         if (parent.$$childHead == this) parent.$$childHead = this.$$nextSibling;
         if (parent.$$childTail == this) parent.$$childTail = this.$$prevSibling;

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -407,6 +407,22 @@ describe('Scope', function() {
       first.$destroy();
       expect(log).toEqual('first; first-child');
     }));
+
+
+    it('should $destroy a scope only once and ignore any further destroy calls',
+        inject(function($rootScope) {
+      $rootScope.$digest();
+      expect(log).toBe('123');
+
+      first.$destroy();
+      first.$apply();
+      expect(log).toBe('12323');
+
+      first.$destroy();
+      first.$destroy();
+      first.$apply();
+      expect(log).toBe('1232323');
+    }));
   });
 
 


### PR DESCRIPTION
Due to bd524fc4 calling $destroy() on a scope mupltiple times cases NPE.

Closes #1627
