### PR TITLE
fix(ngResource): Add suport for nested params

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -224,6 +224,8 @@ angular.module('ngResource', ['ng']).
         extend = angular.extend,
         copy = angular.copy,
         isFunction = angular.isFunction,
+        isArray = angular.isArray,
+        isObject = angular.isObject,
         getter = function(obj, path) {
           return $parse(path)(obj);
         };
@@ -267,6 +269,19 @@ angular.module('ngResource', ['ng']).
         replace((pctEncodeSpaces ? null : /%20/g), '+');
     }
 
+    function buildQuery(value, prefix) {
+      var out = [];
+      if (isArray(value) || isObject(value)) {
+        forEach(value, function(v, k) {
+          var newPrefix = prefix ? prefix + '[' + k + ']' : k;
+          out = out.concat(buildQuery(v, newPrefix));
+        });
+      } else {
+        out.push(encodeUriQuery(prefix) + '=' + encodeUriQuery(value));
+      }
+      return out;
+    }
+
     function Route(template, defaults) {
       this.template = template = template + '#';
       this.defaults = defaults || {};
@@ -296,15 +311,17 @@ angular.module('ngResource', ['ng']).
             url = url.replace(new RegExp("/?:" + urlParam + "(\\W)", "g"), '$1');
           }
         });
-        url = url.replace(/\/?#$/, '');
-        var query = [];
+
+        var serializeableParams = {};
         forEach(params, function(value, key){
           if (!self.urlParams[key]) {
-            query.push(encodeUriQuery(key) + '=' + encodeUriQuery(value));
+            serializeableParams[key] = value;
           }
         });
+
+        var query = buildQuery(serializeableParams);
         query.sort();
-        url = url.replace(/\/*$/, '');
+        url = url.replace(/\/?#$/, '').replace(/\/*$/, '');
         return url + (query.length ? '?' + query.join('&') : '');
       }
     };

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -87,9 +87,11 @@ describe("resource", function() {
 
     $httpBackend.expect('GET', '/Path/foo%231').respond('{}');
     $httpBackend.expect('GET', '/Path/doh!@foo?bar=baz%231').respond('{}');
+    $httpBackend.expect('GET', '/Path/doh?bar%5B0%5D=e&bar%5B1%5D%5Bbaz%5D=z&foo%5Bc%5D=d').respond('{}');
 
     R.get({a: 'foo#1'});
     R.get({a: 'doh!@foo', bar: 'baz#1'});
+    R.get({a: 'doh', foo: {c: 'd'}, bar: ['e', {baz: 'z'}]});
   });
 
 


### PR DESCRIPTION
Allow ngResource to properly construct a query string for params which
have objects or arrays as values.
