### PR TITLE
doc($http): fix link typo in $http doc

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -172,7 +172,7 @@ function $HttpProvider() {
     /**
      * @ngdoc function
      * @name ng.$http
-     * @requires $httpBacked
+     * @requires $httpBackend
      * @requires $browser
      * @requires $cacheFactory
      * @requires $rootScope


### PR DESCRIPTION
Should be $httpBackend instead of $httpBacked

Closes #1516
