### PR TITLE
ng-repeat : Fix issues when iterating over primitives

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -29,6 +29,7 @@ angularFiles = {
     'src/ng/httpBackend.js',
     'src/ng/locale.js',
     'src/ng/timeout.js',
+    'src/ng/whatChanged.js',
 
     'src/ng/filter.js',
     'src/ng/filter/filter.js',

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -125,6 +125,7 @@ function publishExternalAPI(angular){
         $sniffer: $SnifferProvider,
         $templateCache: $TemplateCacheProvider,
         $timeout: $TimeoutProvider,
+        $whatChanged: $WhatChangedProvider,
         $window: $WindowProvider
       });
     }

--- a/src/apis.js
+++ b/src/apis.js
@@ -109,3 +109,186 @@ HashQueueMap.prototype = {
     }
   }
 };
+
+/**
+ * A generic collection that wraps an array
+ * @returns an object that wraps an array as a generic collection
+ */
+var WrappedArray = function(array) {
+  this.collection = array;
+}
+WrappedArray.prototype = {
+  get: function(index) {
+    return this.collection[index];
+  },
+  key: function(index) {
+    return index;
+  },
+  length: function() {
+    return this.collection.length;
+  },
+  copy: function() {
+    return new WrappedArray(this.collection.slice(0));
+  }
+};
+
+/**
+ * A generic collection that wraps an object so that you can access its keyed values in order
+ * @returns an object that wraps an object as a generic collection
+ */
+var WrappedObject = function(object) {
+  this.collection = object;
+  this.keys = [];
+  for(var key in this.collection) {
+    if (this.collection.hasOwnProperty(key) && key.charAt(0) != '$') {
+      this.keys.push(key);
+    }
+  }
+  this.keys.sort();
+}
+WrappedObject.prototype = {
+  get: function(index) {
+    return this.collection[this.keys[index]];
+  },
+  key: function(index) {
+    return this.keys[index];
+  },
+  length: function() {
+    return this.keys.length;
+  },
+  copy: function() {
+    var dst = {};
+    for(var key in this.collection) {
+      if (this.collection.hasOwnProperty(key) && key.charAt(0) != '$') {
+        dst[key] = this.collection[key];
+      }
+    }
+    return new WrappedObject(dst);
+  }
+};
+
+  /**
+   * Track changes to objects (rather than primitives) in between two collections
+   * @param original {object} collection that has a get method
+   * @param changed {object} collection that has a get method
+   */
+  function ObjectTracker(original, changed) {
+    this.original = original;
+    this.changed = changed;
+    this.entries = [];
+  }
+  ObjectTracker.prototype = {
+    getEntry: function (obj) {
+      var key = hashKey(obj);
+      var entry = this.entries[key];
+      if ( !angular.isDefined(entry) ) {
+        entry = ({ newIndexes: [], oldIndexes: [], obj: obj });
+      }
+      this.entries[key] = entry;
+      return entry;
+    },
+    // An object is now at this index where it wasn't before
+    addNewEntry: function(index) {
+      this.getEntry(this.changed.get(index)).newIndexes.push(index);
+    },
+    // An object is no longer at this index
+    addOldEntry: function(index) {
+      this.getEntry(this.original.get(index)).oldIndexes.push(index);
+    }
+  };
+
+  /*
+   * Track all the changes found between the original and changed collections
+   * @param original {object} collection that has a get method
+   * @param changed {object} collection that has a get method
+   */
+  function ChangeTracker(original, changed) {
+    this.original = original;
+    this.changed = changed;
+    // All additions in the form {index, value}
+    this.additions = [];
+    // All deletions in the form {index, oldValue}
+    this.deletions = [];
+    // All primitive value modifications in the form { index, }
+    this.modifications = [];
+    // All moved objects in the form {index, oldIndex, value}
+    this.moves = [];
+  }
+  ChangeTracker.prototype = {
+    // An addition was found at the given index
+    pushAddition: function(index) {
+      this.additions.push({ index: index, value: this.changed.get(index)});
+    },
+    // A deletion was found at the given index
+    pushDeletion: function(index) {
+      this.deletions.push({ index: index, oldValue: this.original.get(index)});
+    },
+    // A modification to a primitive value was found at the given index
+    pushModification: function(index) {
+      this.modifications.push( { index: index, oldValue: this.original.get(index), newValue: this.changed.get(index)});
+    },
+    // An object has moved from oldIndex to newIndex
+    pushMove: function(oldIndex, newIndex) {
+      this.moves.push( { oldIndex: oldIndex, index: newIndex, value: this.original.get(oldIndex)});
+    }
+  };
+
+  /**
+   * A flat list of changes ordered by collection key
+   */
+  function FlattenedChanges(changes) {
+    this.changes = [];
+    var index, item;
+    // Flatten all the changes into a array ordered by index
+    for(index = 0; index < changes.modifications.length; index++) {
+      item = changes.modifications[index];
+      this.modified(item);
+    }
+    for(index = 0; index < changes.deletions.length; index++) {
+      item = changes.deletions[index];
+      this.deleted(item);
+    }
+    for(index = 0; index < changes.additions.length; index++) {
+      item = changes.additions[index];
+      this.added(item);
+    }
+    for(index = 0; index < changes.moves.length; index++) {
+      item = changes.moves[index];
+      this.moved(item);
+    }
+  }
+  FlattenedChanges.prototype = {
+    modified: function(item) {
+      item.modified = true;
+      this.changes[item.index] = item;
+    },
+    moved: function(change) {
+      var item = this.changes[change.index];
+      if ( angular.isDefined(item) ) {
+        item.value = change.value;
+        item.oldIndex = change.oldIndex;
+      } else {
+        item = change;
+      }
+      item.moved = true;
+      this.changes[change.index] = item;
+    },
+    added: function(change){
+      var item = this.changes[change.index];
+      if ( angular.isDefined(item) ) {
+        item.value = change.value;
+      } else {
+        item = change;
+      }
+      item.added = true;
+      this.changes[change.index] = item;
+    },
+    deleted: function(change) {
+      var item = this.changes[change.index];
+      if ( !angular.isDefined(item) ) {
+        item = change;
+      }
+      item.deleted = true;
+      this.changes[change.index] = item;
+    }
+  };

--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -61,129 +61,128 @@ var ngRepeatDirective = ngDirective({
   transclude: 'element',
   priority: 1000,
   terminal: true,
-  compile: function(element, attr, linker) {
-    return function(scope, iterStartElement, attr){
-      var expression = attr.ngRepeat;
-      var match = expression.match(/^\s*(.+)\s+in\s+(.*)\s*$/),
-        lhs, rhs, valueIdent, keyIdent;
-      if (! match) {
-        throw Error("Expected ngRepeat in form of '_item_ in _collection_' but got '" +
-          expression + "'.");
-      }
-      lhs = match[1];
-      rhs = match[2];
-      match = lhs.match(/^(?:([\$\w]+)|\(([\$\w]+)\s*,\s*([\$\w]+)\))$/);
-      if (!match) {
-        throw Error("'item' in 'item in collection' should be identifier or (key, value) but got '" +
-            lhs + "'.");
-      }
-      valueIdent = match[3] || match[1];
-      keyIdent = match[2];
+  compile: function(element, attr, clone) {
+    var expression = attr.ngRepeat;
+    var match = expression.match(/^\s*(.+)\s+in\s+(.*)\s*$/);
+    if (!match) {
+      throw Error("Expected ngRepeat in form of '_item_ in _collection_' but got '" + expression + "'.");
+    }
+    var identifiers = match[1];
+    var sourceExpression = match[2];
 
-      // Store a list of elements from previous run. This is a hash where key is the item from the
-      // iterator, and the value is an array of objects with following properties.
-      //   - scope: bound scope
-      //   - element: previous element.
-      //   - index: position
-      // We need an array of these objects since the same object can be returned from the iterator.
-      // We expect this to be a rare case.
-      var lastOrder = new HashQueueMap();
+    match = identifiers.match(/^(?:([\$\w]+)|\(([\$\w]+)\s*,\s*([\$\w]+)\))$/);
+    if (!match) {
+      throw Error("'item' in 'item in collection' should be identifier or (key, value) but got '" +
+          identifiers + "'.");
+    }
+    var valueIdentifier = match[3] || match[1];
+    var keyIdentifier = match[2];
+
+    var updateScope = function(scope, value, key) {
+      scope[valueIdentifier] = value;
+      if (keyIdentifier) {
+        scope[keyIdentifier] = key;
+      }
+    };
+
+    // Return the linking function for this directive
+    return function(scope, startElement, attr){
+      var originalCollection = new WrappedArray([]);
+      var originalChildItems = [];
+      var containerElement = startElement.parent();
 
       scope.$watch(function ngRepeatWatch(scope){
-        var index, length,
-            collection = scope.$eval(rhs),
-            cursor = iterStartElement,     // current position of the node
-            // Same as lastOrder but it has the current state. It will become the
-            // lastOrder on the next iteration.
-            nextOrder = new HashQueueMap(),
-            arrayLength,
-            childScope,
-            key, value, // key/value of iteration
-            array,
-            last;       // last object information {scope, element, index}
+        var item, key;
+        var source = scope.$eval(sourceExpression);
+        var newCollection = isArray(source) ? new WrappedArray(source) : new WrappedObject(source);
+        var newChildItems = [];
+        var temp = whatChanged(originalCollection, newCollection);
+        var changes = new FlattenedChanges(temp).changes;
 
-
-
-        if (!isArray(collection)) {
-          // if object, extract keys, sort them and use to determine order of iteration over obj props
-          array = [];
-          for(key in collection) {
-            if (collection.hasOwnProperty(key) && key.charAt(0) != '$') {
-              array.push(key);
+        // Iterate over the flattened changes array - updating the childscopes and elements accordingly
+        var lastChildScope, newChildScope, newChildItem;
+        var currentElement = startElement;
+        var itemIndex = 0, changeIndex = 0;
+        while(changeIndex < changes.length) {
+          item = changes[changeIndex];
+          if ( !angular.isDefined(item) ) {
+            // No change for this item just copy it over
+            newChildItem = originalChildItems[itemIndex];
+            newChildItems.push(newChildItem);
+            currentElement = newChildItem.element;
+            itemIndex++;
+            changeIndex++;
+            continue;
+          }
+          if ( item.deleted ) {
+            // An item has been deleted here - destroy the old scope and remove the old element
+            var originalChildItem = originalChildItems[itemIndex];
+            originalChildItem.scope.$destroy();
+            originalChildItem.element.remove();
+            // If an item is added or moved here as well then the index will incremented in the added or moved if statement below
+            if ( !item.added && !item.moved ) {
+              itemIndex++;
             }
           }
-          array.sort();
-        } else {
-          array = collection || [];
-        }
-
-        arrayLength = array.length;
-
-        // we are not using forEach for perf reasons (trying to avoid #call)
-        for (index = 0, length = array.length; index < length; index++) {
-          key = (collection === array) ? index : array[index];
-          value = collection[key];
-
-          last = lastOrder.shift(value);
-
-          if (last) {
-            // if we have already seen this object, then we need to reuse the
-            // associated scope/element
-            childScope = last.scope;
-            nextOrder.push(value, last);
-
-            if (index === last.index) {
-              // do nothing
-              cursor = last.element;
-            } else {
-              // existing item which got moved
-              last.index = index;
-              // This may be a noop, if the element is next, but I don't know of a good way to
-              // figure this out,  since it would require extra DOM access, so let's just hope that
-              // the browsers realizes that it is noop, and treats it as such.
-              cursor.after(last.element);
-              cursor = last.element;
-            }
-          } else {
-            // new item which we don't know about
-            childScope = scope.$new();
-          }
-
-          childScope[valueIdent] = value;
-          if (keyIdent) childScope[keyIdent] = key;
-          childScope.$index = index;
-
-          childScope.$first = (index === 0);
-          childScope.$last = (index === (arrayLength - 1));
-          childScope.$middle = !(childScope.$first || childScope.$last);
-
-          if (!last) {
-            linker(childScope, function(clone){
-              cursor.after(clone);
-              last = {
-                  scope: childScope,
-                  element: (cursor = clone),
-                  index: index
-                };
-              nextOrder.push(value, last);
+          if ( item.added ) {
+            // An item has been added here - create a new scope and clone a new element
+            newChildItem = { scope: scope.$new() };
+            updateScope(newChildItem.scope, item.value, newCollection.key(item.index));
+            clone(newChildItem.scope, function(newChildElement){
+              currentElement.after(newChildElement);
+              currentElement = newChildItem.element = newChildElement;
             });
+            newChildItems.push(newChildItem);
+            itemIndex++;
           }
+          if ( item.modified ) {
+            // This item is a primitive that has been modified - update the scope
+            newChildItem = originalChildItems[itemIndex];
+            updateScope(newChildItem.scope, item.newValue, newCollection.key(item.index));
+            newChildItems.push(newChildItem);
+            currentElement = newChildItem.element;
+            itemIndex++;
+          }
+          if ( item.moved ) {
+            // An object has moved here from somewhere else - move the element accordingly
+            newChildItem = originalChildItems[item.oldIndex];
+            newChildItems.push(newChildItem);
+            currentElement.after(newChildItem.element);
+            currentElement = newChildItem.element;
+            itemIndex++;
+          }
+          changeIndex++;
+        }
+        while( itemIndex < originalChildItems.length ) {
+          // No change for this item just copy it over
+          newChildItem = originalChildItems[itemIndex];
+          newChildItems.push(newChildItem);
+          currentElement = newChildItem.element;
+          itemIndex++;
         }
 
-        //shrink children
-        for (key in lastOrder) {
-          if (lastOrder.hasOwnProperty(key)) {
-            array = lastOrder[key];
-            while(array.length) {
-              value = array.pop();
-              value.element.remove();
-              value.scope.$destroy();
-            }
+        // Update $index, $first, $middle & $last
+        for(var index=0; index<newChildItems.length; index++) {
+          if (angular.isDefined(newChildItems[index]) ) {
+            newChildScope = newChildItems[index].scope;
+            newChildScope.$index = index;
+            newChildScope.$first = (index === 0);
+            newChildScope.$middle = (index !== 0);
+            newChildScope.$last = false;
+            lastChildScope = newChildScope;
           }
         }
+        // Fix up last item
+        if ( angular.isDefined(lastChildScope) ) {
+          lastChildScope.$last = true;
+          lastChildScope.$middle = false;
+        }
 
-        lastOrder = nextOrder;
+        // Store originals for next time
+        originalCollection = newCollection.copy();
+        originalChildItems = newChildItems.slice(0);
       });
+
     };
   }
 });

--- a/src/ng/whatChanged.js
+++ b/src/ng/whatChanged.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/**
+ * Work out what changed between two generic colletions
+ * @param original {object} collection that has a get method
+ * @param changed {object} collection that has a get method
+ */
+function whatChanged(original, changed) {
+  var objTracker = new ObjectTracker(original, changed);
+  var changes = new ChangeTracker(original, changed);
+
+  var index = 0, changedItem, originalItem;
+  while(index < original.length() && index < changed.length()) {
+    changedItem = changed.get(index);
+    originalItem = original.get(index);
+    if ( originalItem !== changedItem ) {
+      // Something has changed...
+      if ( !angular.isObject(originalItem) ) {
+        // Original item is not an object
+        if ( !angular.isObject(changedItem) ) {
+          // Neither is Changed item - so we add a modifications at this index
+          changes.pushModification(index);
+        } else {
+          // Changed item is an object - so add a deletion for the original primitive...
+          changes.pushDeletion(index);
+          // ...and store the new object index for later
+          objTracker.addNewEntry(index);
+        }
+      } else {
+        // Original item is an object
+        if ( !angular.isObject(changedItem) ) {
+          // Changed item is not an object - so add an addition for the new primitive...
+          changes.pushAddition(index);
+          // ...and store the old object index for later
+          objTracker.addOldEntry(index);
+        } else {
+          // Both Original and Changed items are objects - so store both items for later
+          objTracker.addOldEntry(index);
+          objTracker.addNewEntry(index);
+        }
+      }
+    }
+    index++;
+  }
+
+  while ( index < changed.length() ) {
+    if ( !angular.isObject(changed.get(index)) ) {
+      changes.pushAddition(index);
+    } else {
+      objTracker.addNewEntry(index);
+    }
+    index++;
+  }
+  while ( index < original.length() ) {
+    if ( !angular.isObject(originalItem) ) {
+      changes.pushDeletion(index);
+    } else {
+      objTracker.addOldEntry(index);
+    }
+    index++;
+  }
+
+  var entries = objTracker.entries;
+  for(var key in entries) {
+    if ( !entries.hasOwnProperty(key) ) {
+      continue;
+    }
+    var entry = entries[key];
+    index = 0;
+    while(index < entry.oldIndexes.length && index < entry.newIndexes.length) {
+      changes.pushMove(entry.oldIndexes[index], entry.newIndexes[index]);
+      index++;
+    }
+    while(index < entry.oldIndexes.length) {
+      changes.pushDeletion(entry.oldIndexes[index]);
+      index++;
+    }
+    while(index < entry.newIndexes.length) {
+      changes.pushAddition(entry.newIndexes[index]);
+      index++;
+    }
+  }
+  return changes;
+};
+
+function $WhatChangedProvider() {
+  this.$get = function() {
+    return function(original, changed) {
+      var flattened;
+      if ( isArray(original) && isArray(changed) ) {
+        flattened = new FlattenedChanges(whatChanged(new WrappedArray(original), new WrappedArray(changed)));
+      } else {
+        flattened = new FlattenedChanges(whatChanged(new WrappedObject(original), new WrappedObject(changed)));
+      }
+      return flattened.changes;
+    };
+  };
+}

--- a/test/ApiSpecs.js
+++ b/test/ApiSpecs.js
@@ -60,5 +60,243 @@ describe('api', function() {
       expect(map[hashKey(null)]).toEqual(['e']);
     });
   });
+
+  describe('WrappedArray', function() {
+    it('should have same length as wrapped array', function() {
+      var array = [0,1,2,3,4,5];
+      var wrapped = new WrappedArray(array);
+      expect(wrapped.length()).toBe(array.length);
+    });
+
+    it('should have same elements as wrapped array', function() {
+      var array = [0,1,2,3,4,5];
+      var wrapped = new WrappedArray(array);
+      expect(wrapped.get(0)).toBe(array[0]);
+      expect(wrapped.get(1)).toBe(array[1]);
+      expect(wrapped.get(2)).toBe(array[2]);
+      expect(wrapped.get(3)).toBe(array[3]);
+      expect(wrapped.get(4)).toBe(array[4]);
+      expect(wrapped.get(5)).toBe(array[5]);
+    });
+
+    it('should return a copy of the array, with a new wrapper', function() {
+      var array = [0,1,2,3,4,5];
+      var wrapped = new WrappedArray(array);
+      var copy = wrapped.copy();
+      expect(copy).not.toBe(wrapped);
+      expect(copy.collection).not.toBe(wrapped.collection);
+      expect(copy.collection).toEqual(wrapped.collection);
+    });
+  });
+
+  describe('WrappedObject', function() {
+    it('should have same length as wrapped array', function() {
+      var object = {a:0,b:1,c:2,d:3,e:4,f:5};
+      var wrapped = new WrappedObject(object);
+      expect(wrapped.length()).toBe(6);
+    });
+
+    it('should have same elements as wrapped object', function() {
+      var object = {a:0,b:1,c:2,d:3,e:4,f:5};
+      var wrapped = new WrappedObject(object);
+      expect(wrapped.get(0)).toBe(object['a']);
+      expect(wrapped.get(1)).toBe(object['b']);
+      expect(wrapped.get(2)).toBe(object['c']);
+      expect(wrapped.get(3)).toBe(object['d']);
+      expect(wrapped.get(4)).toBe(object['e']);
+      expect(wrapped.get(5)).toBe(object['f']);
+    });
+
+    it('should return a copy of the array, with a new wrapper', function() {
+      var object = {a:0,b:1,c:2,d:3,e:4,f:5};
+      var wrapped = new WrappedObject(object);
+      var copy = wrapped.copy();
+      expect(copy).not.toBe(wrapped);
+      expect(copy.collection).not.toBe(wrapped.collection);
+      expect(copy.collection).toEqual(wrapped.collection);
+    });
+  });
+
+  describe('ObjectTracker', function() {
+    it ('should initialize correctly', function() {
+      var original = new WrappedArray([]);
+      var changed = new WrappedArray([]);
+      var tracker = new ObjectTracker(original, changed);
+      expect(tracker.original).toBe(original);
+      expect(tracker.changed).toBe(changed);
+      expect(tracker.entries).toEqual([]);
+    });
+
+    it('should track a new entry', function() {
+      var newEntry = {};
+      var original = new WrappedArray([]);
+      var changed = new WrappedArray([newEntry]);
+      var tracker = new ObjectTracker(original, changed);
+      tracker.addNewEntry(0);
+      expect(tracker.getEntry(newEntry).obj).toBe(newEntry);
+      expect(tracker.getEntry(newEntry).newIndexes[0]).toBe(0);
+      expect(tracker.getEntry(newEntry).oldIndexes).toEqual([]);
+    });
+
+    it('should track an old entry', function() {
+      var oldEntry = {};
+      var original = new WrappedArray([oldEntry]);
+      var changed = new WrappedArray([]);
+      var tracker = new ObjectTracker(original, changed);
+      tracker.addOldEntry(0);
+      expect(tracker.getEntry(oldEntry).obj).toBe(oldEntry);
+      expect(tracker.getEntry(oldEntry).oldIndexes[0]).toBe(0);
+      expect(tracker.getEntry(oldEntry).newIndexes).toEqual([]);
+    });
+  });
+
+  describe('ChangeTracker', function() {
+    it('should initialize correctly', function() {
+      var original = new WrappedArray([]);
+      var changed = new WrappedArray([]);
+      var tracker = new ChangeTracker(original, changed);
+      expect(tracker.original).toBe(original);
+      expect(tracker.changed).toBe(changed);
+      expect(tracker.additions).toEqual([]);
+      expect(tracker.deletions).toEqual([]);
+      expect(tracker.modifications).toEqual([]);
+      expect(tracker.moves).toEqual([]);
+    });
+
+    it('should track additions', function() {
+      var original = new WrappedArray([]);
+      var changed = new WrappedArray(['newItem']);
+      var tracker = new ChangeTracker(original, changed);
+      tracker.pushAddition(0);
+      expect(tracker.additions[0]).toEqual({index: 0, value: 'newItem'});
+    });
+
+    it('should track deletions', function() {
+      var original = new WrappedArray(['oldItem']);
+      var changed = new WrappedArray([]);
+      var tracker = new ChangeTracker(original, changed);
+      tracker.pushDeletion(0);
+      expect(tracker.deletions[0]).toEqual({index: 0, oldValue: 'oldItem'});
+    });
+
+    it('should track modifications', function() {
+      var original = new WrappedArray(['oldItem']);
+      var changed = new WrappedArray(['newItem']);
+      var tracker = new ChangeTracker(original, changed);
+      tracker.pushModification(0);
+      expect(tracker.modifications[0]).toEqual({index: 0, newValue: 'newItem', oldValue: 'oldItem'});
+    });
+
+    it('should track moves', function() {
+      var item1 = {};
+      var item2 = {};
+      var original = new WrappedArray([item1, item2]);
+      var changed = new WrappedArray([item2, item1]);
+      var tracker = new ChangeTracker(original, changed);
+      tracker.pushMove(0,1);
+      tracker.pushMove(1,0);
+      expect(tracker.moves[0]).toEqual({oldIndex: 0, index: 1, value: item1});
+      expect(tracker.moves[1]).toEqual({oldIndex: 1, index: 0, value: item2});
+    });
+  });
+
+  describe('FlattenedChanges', function() {
+    it('should flatten changes into a single indexed array', function() {
+      var changes = {
+        additions: [],
+        deletions: [],
+        modifications: [],
+        moves: []
+      };
+
+      var flattened = new FlattenedChanges(changes);
+      expect(flattened.changes.length).toBe(0);
+
+      changes.additions.push({ index: 2, value: 'someVal'});
+      flattened = new FlattenedChanges(changes);
+      expect(flattened.changes.length).toBe(3);
+      expect(flattened.changes[0]).toBeUndefined();
+      expect(flattened.changes[1]).toBeUndefined();
+      expect(flattened.changes[2].added).toBe(true);
+      expect(flattened.changes[2].value).toBe('someVal');
+
+      changes.deletions.push({ index: 2, oldValue: {}});
+      flattened = new FlattenedChanges(changes);
+      expect(flattened.changes.length).toBe(3);
+      expect(flattened.changes[0]).toBeUndefined();
+      expect(flattened.changes[1]).toBeUndefined();
+      expect(flattened.changes[2].added).toBe(true);
+      expect(flattened.changes[2].value).toBe('someVal');
+      expect(flattened.changes[2].deleted).toBe(true);
+
+      changes.modifications.push({ index: 4, oldValue: 'something', newValue: 23 });
+      flattened = new FlattenedChanges(changes);
+      expect(flattened.changes.length).toBe(5);
+      expect(flattened.changes[0]).toBeUndefined();
+      expect(flattened.changes[1]).toBeUndefined();
+      expect(flattened.changes[2].added).toBe(true);
+      expect(flattened.changes[2].value).toBe('someVal');
+      expect(flattened.changes[2].deleted).toBe(true);
+      expect(flattened.changes[4].modified).toBe(true);
+      expect(flattened.changes[4].oldValue).toBe('something');
+      expect(flattened.changes[4].newValue).toBe(23);
+
+      changes.moves.push({ oldIndex: 3, index: 1, value: {} });
+      flattened = new FlattenedChanges(changes);
+      expect(flattened.changes.length).toBe(5);
+      expect(flattened.changes[0]).toBeUndefined();
+      expect(flattened.changes[1].moved).toBe(true);
+      expect(flattened.changes[1].value).toEqual({});
+      expect(flattened.changes[1].oldIndex).toBe(3);
+      expect(flattened.changes[1].index).toBe(1);
+      expect(flattened.changes[2].added).toBe(true);
+      expect(flattened.changes[2].value).toBe('someVal');
+      expect(flattened.changes[2].deleted).toBe(true);
+      expect(flattened.changes[4].modified).toBe(true);
+      expect(flattened.changes[4].oldValue).toBe('something');
+      expect(flattened.changes[4].newValue).toBe(23);
+    });
+
+    it('should be able to identify if an object is deleted from the front', function() {
+      var obj1 = {}, obj2 = {}, obj3 = {};
+      var changes = {
+        additions:[],
+        deletions: [
+          {index: 0, oldValue: obj1 }
+        ],
+        moves: [
+          { value: obj2, oldIndex: 1, index: 0 },
+          { value: obj3, oldIndex: 2, index: 1 }
+        ],
+        modifications: []
+      };
+      var flattened = new FlattenedChanges(changes);
+      expect(flattened.changes.length).toBe(2);
+      expect(flattened.changes[0].deleted).toBe(true);
+      expect(flattened.changes[0].moved).toBe(true);
+      expect(flattened.changes[1].moved).toBe(true);
+    });
+
+    it('should not be affected by previous calls', function() {
+      var changes = {
+        additions: [],
+        deletions: [],
+        modifications: [],
+        moves: []
+      };
+
+      var flattened = new FlattenedChanges(changes);
+      expect(flattened.changes.length).toBe(0);
+
+      changes.additions.push({ index: 2, value: 'someVal'});
+      flattened = new FlattenedChanges(changes);
+      expect(flattened.changes.length).toBe(3);
+
+      changes.additions = [];
+      flattened = new FlattenedChanges(changes);
+      expect(flattened.changes.length).toBe(0);
+    });
+  });
+
 });
 

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -448,7 +448,7 @@ describe('ngRepeat', function() {
     });
 
 
-    it('should reuse elements even when model is composed of primitives', function() {
+    xit('should reuse elements even when model is composed of primitives', function() {
       // rebuilding repeater from scratch can be expensive, we should try to avoid it even for
       // model that is composed of primitives.
 
@@ -464,5 +464,18 @@ describe('ngRepeat', function() {
       expect(newLis[1]).toEqual(lis[0]);
       expect(newLis[2]).toEqual(lis[1]);
     });
+
+    it('should not reorder elements that have primitive model changes, since this causes loss of focus on input elements', function() {
+      scope.items = ['hello', 'cau', 'ahoj'];
+      scope.$digest();
+      lis = element.find('li');
+
+      scope.items = ['hello', 'ahoj', 'ahoj'];
+      scope.$digest();
+      var newLis = element.find('li');
+      expect(newLis.length).toEqual(3);
+      expect(newLis[2]).toEqual(lis[2]);
+    });
+
   });
 });

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -226,6 +226,50 @@ describe('ngRepeat', function() {
     expect(element.text()).toEqual('misko:0|shyam:1|frodo:2|');
   });
 
+  it('should expose correct $index and key when array shrinks', function() {
+    element = $compile(
+      '<ul>' +
+        '<li ng-repeat="(key, item) in items">{{item.name}}:{{key}}:{{$index}}|</li>' +
+      '</ul>')(scope);
+    
+    // INIT
+    scope.items = [{name: 'misko'}, {name:'shyam'}, {name:'frodo'}, {name: 'yukko'}];
+    scope.$digest();
+    expect(element.text()).toEqual('misko:0:0|shyam:1:1|frodo:2:2|yukko:3:3|');
+    
+    // SHRINK
+    scope.items.pop();
+    scope.$digest();
+    expect(element.find('li').length).toEqual(3);
+    expect(element.text()).toEqual('misko:0:0|shyam:1:1|frodo:2:2|');
+    
+    scope.items.shift();
+    scope.$digest();
+    expect(element.find('li').length).toEqual(2);
+    expect(element.text()).toEqual('shyam:0:0|frodo:1:1|');
+  });
+
+  it('should expose correct $index and key when object shrinks', function() {
+    element = $compile(
+      '<ul>' +
+        '<li ng-repeat="(key, val) in items">{{val.name}}:{{key}}:{{$index}}|</li>' +
+      '</ul>')(scope);
+    scope.items = {'m': {name: 'misko'}, 's': {name:'shyam'},
+                   'f': {name:'frodo'}, 'y': {name: 'yukko'}};
+    scope.$digest();
+    expect(element.text()).toEqual('frodo:f:0|misko:m:1|shyam:s:2|yukko:y:3|');
+  
+    // SHRINK
+    delete scope.items['y'];
+    scope.$digest();
+    expect(element.find('li').length).toEqual(3);
+    expect(element.text()).toEqual('frodo:f:0|misko:m:1|shyam:s:2|');
+  
+    delete scope.items['f'];
+    scope.$digest();
+    expect(element.find('li').length).toEqual(2);
+    expect(element.text()).toEqual('misko:m:0|shyam:s:1|');
+  });
 
   it('should expose iterator offset as $index when iterating over objects', function() {
     element = $compile(

--- a/test/ng/whatChangedSpec.js
+++ b/test/ng/whatChangedSpec.js
@@ -1,0 +1,199 @@
+describe('whatChanged - arrays', function() {
+  describe('primitive changes', function() {
+    var original = new WrappedArray([0,1,2,3,4]);
+    it('should have nothing changed if primitive items are the same', function() {
+      var changed = new WrappedArray([0,1,2,3,4]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([]);
+      expect(changes.deletions).toEqual([]);
+      expect(changes.moves).toEqual([]);
+      expect(changes.modifications).toEqual([]);
+    });
+
+    it('should be able to identify indexes of primitives that have changed', function() {
+      var changed = new WrappedArray([0,1,3,4,2]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([]);
+      expect(changes.deletions).toEqual([]);
+      expect(changes.moves).toEqual([]);
+      expect(changes.modifications).toEqual([
+        { index: 2, oldValue: 2, newValue: 3 },
+        { index: 3, oldValue: 3, newValue: 4 },
+        { index: 4, oldValue: 4, newValue: 2 }
+      ]);
+    });
+
+    it('should be able to identify added primitives', function() {
+      var changed = new WrappedArray([0,1,2,3,4,5,6]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([
+        { index: 5, value: 5 },
+        { index: 6, value: 6 }
+      ]);
+      expect(changes.deletions).toEqual([]);
+      expect(changes.moves).toEqual([]);
+      expect(changes.modifications).toEqual([]);
+    });
+
+    it('should be able to identify removed primitives', function() {
+      var changed = new WrappedArray([0,1,2]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([]);
+      expect(changes.deletions).toEqual([
+        { index: 3, oldValue: 3 },
+        { index: 4, oldValue: 4 }
+      ]);
+      expect(changes.moves).toEqual([]);
+      expect(changes.modifications).toEqual([]);
+    });
+
+    it('should be able to identify modifications and additions', function () {
+      var changed = new WrappedArray([0,7,8,3,4,5,6]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([
+        { index: 5, value: 5 },
+        { index: 6, value: 6 }
+      ]);
+      expect(changes.deletions).toEqual([]);
+      expect(changes.moves).toEqual([]);
+      expect(changes.modifications).toEqual([
+        { index: 1, oldValue: 1, newValue: 7 },
+        { index: 2, oldValue: 2, newValue: 8 }
+      ]);
+    });
+
+    it('should be able to identify modifications and deletions', function () {
+      var changed = new WrappedArray([0,7,8]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([]);
+      expect(changes.deletions).toEqual([
+        { index: 3, oldValue: 3 },
+        { index: 4, oldValue: 4 }
+      ]);
+      expect(changes.moves).toEqual([]);
+      expect(changes.modifications).toEqual([
+        { index: 1, oldValue: 1, newValue: 7 },
+        { index: 2, oldValue: 2, newValue: 8 }
+      ]);
+    });
+  });
+
+  describe('object changes', function() {
+    var obj1, obj2, obj3;
+    var original;
+    beforeEach(function() {
+      obj1 = {};
+      obj2 = ['a','b'];
+      obj3 = {};
+      original = new WrappedArray([obj1, obj2, obj3]);
+    });
+
+    it('should have nothing changed if the objects are identical', function() {
+      var changed = new WrappedArray([obj1, obj2, obj3]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([]);
+      expect(changes.deletions).toEqual([]);
+      expect(changes.moves).toEqual([]);
+      expect(changes.modifications).toEqual([]);
+    });
+
+    it('should be able to identify if an object moves', function() {
+      var changed = new WrappedArray([obj1, obj3, obj2]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([]);
+      expect(changes.deletions).toEqual([]);
+      expect(changes.moves).toEqual([
+        { value: obj2, oldIndex: 1, index: 2 },
+        { value: obj3, oldIndex: 2, index: 1 }
+      ]);
+      expect(changes.modifications).toEqual([]);
+    });
+
+    it('should be able to identify if a new object is added', function() {
+      var obj4 = {};
+      var changed = new WrappedArray([obj1, obj2, obj3, obj4]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([
+        {index: 3, value: obj4 }
+      ]);
+      expect(changes.deletions).toEqual([]);
+      expect(changes.moves).toEqual([]);
+      expect(changes.modifications).toEqual([]);
+    });
+
+    it('should be able to identify if an object is deleted from the end', function() {
+      var changed = new WrappedArray([obj1, obj2]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([]);
+      expect(changes.deletions).toEqual([
+        {index: 2, oldValue: obj3 }
+      ]);
+      expect(changes.moves).toEqual([]);
+      expect(changes.modifications).toEqual([]);
+    });
+
+    it('should be able to identify if an object is deleted from the front', function() {
+      var changed = new WrappedArray([obj2, obj3]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([]);
+      expect(changes.deletions).toEqual([
+        {index: 0, oldValue: obj1 }
+      ]);
+      expect(changes.moves).toEqual([
+        { value: obj2, oldIndex: 1, index: 0 },
+        { value: obj3, oldIndex: 2, index: 1 }
+        ]);
+      expect(changes.modifications).toEqual([]);
+    });
+
+    it('should be able to identify if an object is deleted causing others to move', function() {
+      var changed = new WrappedArray([obj1, obj3]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([]);
+      expect(changes.deletions).toEqual([
+        {index: 1, oldValue: obj2 }
+      ]);
+      expect(changes.moves).toEqual([
+        {value: obj3, oldIndex: 2, index: 1}
+      ]);
+      expect(changes.modifications).toEqual([]);
+    });
+
+    it('should be able to cope with multiple copies of the same object', function() {
+      original = new WrappedArray([obj1, obj1, obj1]);
+      var changed = new WrappedArray([obj1, obj1, obj1]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([]);
+      expect(changes.deletions).toEqual([]);
+      expect(changes.moves).toEqual([]);
+      expect(changes.modifications).toEqual([]);
+    });
+
+    it('should be able to cope with addition when there are multiple copies', function() {
+      original = new WrappedArray([obj1, obj1, obj1]);
+      var changed = new WrappedArray([obj1, obj2, obj1]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([
+        { index: 1, value: obj2 }
+      ]);
+      expect(changes.deletions).toEqual([
+        { index: 1, oldValue: obj1 }
+      ]);
+      expect(changes.moves).toEqual([]);
+      expect(changes.modifications).toEqual([]);
+    });
+
+    it('should be able to cope with changing when there are multiple copies', function() {
+      original = new WrappedArray([obj1, obj1, obj1]);
+      var changed = new WrappedArray([obj1, obj1]);
+      var changes = whatChanged(original, changed);
+      expect(changes.additions).toEqual([]);
+      expect(changes.deletions).toEqual([
+        { index: 2, oldValue: obj1 }
+      ]);
+      expect(changes.moves).toEqual([]);
+      expect(changes.modifications).toEqual([]);
+    });
+  });
+});
+


### PR DESCRIPTION
# ng-repeat Directive

This complete rewrite of ng-repeat tracks element/scope pairing for objects since they can be tracked by object identity but tracks element/scope pairings for primitive values by the index position in the collection since there is no consistent way of tracking if a primitive has moved.
## Fixes primitive issues

It solves various problems including:
- Input element losing focus on each change. See this broken Plnker based on master - http://plnkr.co/edit/bFxHW4?p=preview - and this fixed version - http://plnkr.co/edit/zh5P9Y?p=preview.
- Incorrect model updating when item is a primitive. Fixes #1389 and this fixed version of the example fiddle: http://jsfiddle.net/nMjet/
## Tests

I have added a new test to `ng-repeatSpec.js` to test for this but x-ed out the test that demonstrates the incorrect behaviour.
## Algorithm

The algorithm checks the following, for `original` collection and `changed` collection, at each `index`.
1. If `changed[index] === original[index]` then simply reuse element/scope pairing.
2. If both `changed[index]` and `original[index]` are primitives then leave the element alone but update the scope model.  _This will trigger changes in the this iteration's template bindings and DOM. We can't try to guess if this primitive moved from elsewhere but since we are reusing the element/scope pairing there will be minimal DOM updates._
3. If a known object has moved then move its element and scope accordingly. _This reuse ensures minimal disruption to the bindings and DOM._
4. if an object moved leaving a primitive in its place then create a new element and scope for this primitive. 
5. if an object moved into a position where a primitive was before, then destroy the old element/scope for that primitive.
## WhatChanged service

I factored out the algorithm that works out what has changed into its own function (`whatChanged`).  Since there is potential for this to be reused, I also exposed it as a service, `$whatChanged`, in the `ng` module.
## Helper Classes

Further to facilitate repeating over object key, the whatChanged algorithm works on a "generic collection", which are created by the internal classes ArrayWrapper and ObjectWrapper.  These classes expose a common API of `get(index)`, `key(index)`, `length()` and `copy()`, which allows the whatChanged algorithm to work either with a straight array or iterating over the keys of an object, cleanly.  _The array wrapper is very thin and should not be a great impact on performance._

These (and a couple of other helper classes `ObjectTracker`, `ChangeTracker` and `FlattenedChanged`) can be found in `apis.js`.  These new classes replace the need for HashQueueMap, which could be removed.
## To Do

There is work to be done on the documentation.

I have done no performance testing.  There are more lines of code and probably in most scenarios the repeater may perform worse than before.  But I reckon there is lots of room for optimization.
