### PR TITLE
chore(docs): Up and down keys should highlight and select filtered resul...

### DIFF
--- a/docs/src/templates/js/docs.js
+++ b/docs/src/templates/js/docs.js
@@ -426,18 +426,40 @@ docsApp.controller.DocsController = function($scope, $location, $window, $cookie
   if (!$location.path() || INDEX_PATH.test($location.path())) {
     $location.path('/api').replace();
   }
-  // bind escape to hash reset callback
   angular.element(window).bind('keydown', function(e) {
     if (e.keyCode === 27) {
+      // bind escape to hash reset callback
       $scope.$apply(function() {
         $scope.subpage = false;
       });
+    } else if (e.keyCode == 40) {
+      changeHighlight(1);
+    } else if (e.keyCode == 38) {
+      changeHighlight(-1);
     }
   });
 
   /**********************************
    Private methods
    ***********************************/
+  function changeHighlight(direction) {
+    if (direction === 1) { 
+      if ($scope.bestMatchIndex < $scope.results.length - 1) {
+        $scope.bestMatchIndex += 1
+        updateHighlight();
+      }
+    } else if (direction === -1) {
+      if ($scope.bestMatchIndex > 0) {
+        $scope.bestMatchIndex -= 1;
+        updateHighlight();
+      }
+    }
+    function updateHighlight() {
+      $scope.$apply(function() {
+        $scope.currentPage = $scope.results[$scope.bestMatchIndex];
+      });
+    }
+  }
 
   function updateSearch() {
     var cache = {},
@@ -453,10 +475,14 @@ docsApp.controller.DocsController = function($scope, $location, $window, $cookie
 
       if (!(match = rank(page, search))) return;
 
+      $scope.results = [];
+      
       if (match.rank > bestMatch.rank) {
         bestMatch = match;
       }
 
+      var page = match.page;
+      var id = page.id;
       if (page.id == 'index') {
         //skip
       } else if (page.section != 'api') {
@@ -480,9 +506,32 @@ docsApp.controller.DocsController = function($scope, $location, $window, $cookie
       } else if (match = id.match(MODULE_MOCK)) {
         module('ngMock').globals.push(page);
       }
-
     });
 
+    for (var i=0; i < modules.length; i++) {
+      var services = [];
+      for (var x=0; x < modules[i].services.length; x++) {
+        var service = modules[i].services[x];
+        if (service.hasOwnProperty('instance')) {
+          services.push(service.instance);
+        } else if (service.hasOwnProperty('provider')) {
+          services.push(service.provider);
+        }
+      }
+      $scope.results = $scope.results.concat(
+          modules[i].directives,
+          modules[i].filters,
+          services,
+          modules[i].types,
+          modules[i].globals)
+    }
+    for (var i=0; i < $scope.results.length; i++) {
+      if (bestMatch.page != null && $scope.results[i] != null) {
+        if ($scope.results[i].id === bestMatch.page.id) {
+          $scope.bestMatchIndex = i;
+        }
+      }
+    }
     $scope.bestMatch = bestMatch;
 
     /*************/


### PR DESCRIPTION
Improve AngularJS doc navigation by allowing users to press down to select, highlight and go to the next filtered result, or up to select, highlight and go to the previous filtered result.

Glad to work with any feedback or code reviews. From a UX perspective: No page is loaded until a key is pressed. Enter to visit the top match, down to visit the next, or up to visit the previous. A link is only highlighted when you are actually on the page. Do others also find this intuitive? If so, I will move on to tidying up the autocomplete.

Unit tests (in Chrome and Firefox, on OSX latest) and scenario tests pass.

Closes #1615
