### PR TITLE
feat(ngResource): headers passed can be now also a function

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -371,12 +371,14 @@ angular.module('ngResource', ['ng']).
               arguments.length + " arguments.";
           }
 
-          var value = this instanceof Resource ? this : (action.isArray ? [] : new Resource(data));
+          var value = this instanceof Resource ? this : (action.isArray ? [] : new Resource(data)),
+            url = route.url(extend({}, extractParams(data, action.params || {}), params)),
+            headers = angular.isFunction(action.headers) ? action.headers(action.method, url) : action.headers;
           $http({
             method: action.method,
-            url: route.url(extend({}, extractParams(data, action.params || {}), params)),
+            url: url,
             data: data,
-            headers: extend({}, action.headers || {})
+            headers: extend({}, headers || {})
           }).then(function(response) {
               var data = response.data;
 

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -375,7 +375,7 @@ angular.module('ngResource', ['ng']).
 
           var value = this instanceof Resource ? this : (action.isArray ? [] : new Resource(data)),
             url = route.url(extend({}, extractParams(data, action.params || {}), params)),
-            headers = angular.isFunction(action.headers) ? action.headers(action.method, url) : action.headers;
+            headers = isFunction(action.headers) ? action.headers(action.method, url) : action.headers;
           $http({
             method: action.method,
             url: url,

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -373,12 +373,14 @@ angular.module('ngResource', ['ng']).
               arguments.length + " arguments.";
           }
 
-          var value = this instanceof Resource ? this : (action.isArray ? [] : new Resource(data));
+          var value = this instanceof Resource ? this : (action.isArray ? [] : new Resource(data)),
+            url = route.url(extend({}, extractParams(data, action.params || {}), params)),
+            headers = angular.isFunction(action.headers) ? action.headers(action.method, url) : action.headers;
           $http({
             method: action.method,
-            url: route.url(extend({}, extractParams(data, action.params || {}), params)),
+            url: url,
             data: data,
-            headers: extend({}, action.headers || {})
+            headers: extend({}, headers || {})
           }).then(function(response) {
               var data = response.data;
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -20,7 +20,17 @@ describe("resource", function() {
         headers: {
           'If-None-Match': '*'
         }
+      },
+      conditionalPutWithHeaderAsFunction: {
+        method: 'PUT',
+        headers: function (a, b) {
+          return {
+            'X-Method': a,
+            'X-Url': b
+          }
+        }
       }
+
 
     });
     callback = jasmine.createSpy();
@@ -201,6 +211,15 @@ describe("resource", function() {
     }).respond({id:123});
 
     CreditCard.conditionalPut({id: {key:123}});
+  });
+
+
+  it('should send headers as a function', function() {
+    $httpBackend.expectPUT('/CreditCard/123', undefined, function(headers) {
+       return headers['X-Method'] == "PUT" && headers['X-Url'] == "/CreditCard/123";
+    }).respond({id:123});
+
+    CreditCard.conditionalPutWithHeaderAsFunction({id: {key:123}});
   });
 
 


### PR DESCRIPTION
When creating a new resource, you can also pass a function as header to be executed when the ajax request is called; this is useful when you have to provide some headers that have to change dinamically.
