### PR TITLE
fix($routeProvider): fix #1501 wrong mapping of $routeParams

### DIFF
--- a/src/ng/route.js
+++ b/src/ng/route.js
@@ -321,12 +321,12 @@ function $RouteProvider(){
       var regex = '^' + when.replace(/([\.\\\(\)\^\$])/g, "\\$1") + '$',
           params = [],
           dst = {};
-      forEach(when.split(/\W/), function(param) {
-        if (param) {
-          var paramRegExp = new RegExp(":" + param + "([\\W])");
+      forEach(when.split(/[^\w:]/), function(param) {
+        if (param && param.charAt(0) === ':') {
+          var paramRegExp = new RegExp(param + "([\\W])");
           if (regex.match(paramRegExp)) {
             regex = regex.replace(paramRegExp, "([^\\/]*)$1");
-            params.push(param);
+            params.push(param.substr(1));
           }
         }
       });

--- a/test/ng/routeParamsSpec.js
+++ b/test/ng/routeParamsSpec.js
@@ -17,4 +17,16 @@ describe('$routeParams', function() {
       expect($routeParams).toEqual({barId:'123', x:'abc'});
     });
   });
+
+  it('should correctly extract the params when a param name is part of the route',  function() {
+    module(function($routeProvider) {
+      $routeProvider.when('/bar/:foo/:bar', {});
+    });
+
+    inject(function($rootScope, $route, $location, $routeParams) {
+      $location.path('/bar/foovalue/barvalue');
+      $rootScope.$digest();
+      expect($routeParams).toEqual({bar:'barvalue', foo:'foovalue'});
+    });
+  });
 });


### PR DESCRIPTION
Routes like '/bar/foovalue/barvalue' matching '/bar/:foo/:bar'
now are well mapped in $routeParams to:
{bar:'barvalue', foo:'foovalue'}

Closes: #1501
Signed-off-by: Gonzalo Ruiz de Villa gonzaloruizdevilla@gmail.com
