### PR TITLE
Add angularjs tag to plunks and make private

### DIFF
--- a/docs/src/templates/js/docs.js
+++ b/docs/src/templates/js/docs.js
@@ -190,7 +190,9 @@ docsApp.serviceFactory.openPlunkr = function(templateMerge, formPostData, angula
     });
 
     postData['files[index.html]'] = templateMerge(indexHtmlContent, indexProp);
-
+    postData['tags[]'] = "angularjs";
+    
+    postData.private = true;
     postData.description = 'AngularJS Example Plunkr';
 
     formPostData('http://plnkr.co/edit/?p=preview', postData);


### PR DESCRIPTION
This is a minor edit to allow Plunks created by way of the docs.angularjs.org site to be appropriately tagged as `angularjs`.

Also, make these generated Plunks private by default.
