### PR TITLE
fix(equals): fix #1648 correctly compare objects with undefined member variables 

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -627,7 +627,13 @@ function equals(o1, o2) {
           keySet[key] = true;
         }
         for(key in o2) {
-          if (!keySet[key] && key.charAt(0) !== '$' && !isFunction(o2[key])) return false;
+          if (!keySet[key] && 
+              key.charAt(0) !== '$' && 
+              !isFunction(o2[key]) && 
+              !isUndefined(o2[key])
+          ) {
+            return false;
+          }
         }
         return true;
       }

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -126,6 +126,11 @@ describe('angular', function() {
       expect(equals(['misko'], ['misko', 'adam'])).toEqual(false);
     });
 
+    it('should ignore undefined member variables', function() {
+      expect(equals({name:'misko'}, {name:'misko', undefinedvar:undefined})).toEqual(true);
+      expect(equals({name:'misko', undefinedvar:undefined}, {name:'misko'})).toEqual(true);
+    });
+
     it('should ignore $ member variables', function() {
       expect(equals({name:'misko', $id:1}, {name:'misko', $id:2})).toEqual(true);
       expect(equals({name:'misko'}, {name:'misko', $id:2})).toEqual(true);


### PR DESCRIPTION
given a = {} and b = {x:undefined} then
angular.equals(a, b) should be true
angular.equals(b, a) should be true (this happened before)

Closes: #1648
