### PR TITLE
$scope.$watch listener expressions can access $newVal & $oldVal

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -296,7 +296,12 @@ function $RootScopeProvider(){
         // in the case user pass string, we need to compile it, do we really need this ?
         if (!isFunction(listener)) {
           var listenFn = compileToFn(listener || noop, 'listener');
-          watcher.fn = function(newVal, oldVal, scope) {listenFn(scope);};
+          watcher.fn = function(newVal, oldVal, scope) {
+            listenFn(scope, {
+              $newVal: newVal,
+              $oldVal: oldVal
+            });
+          };
         }
 
         if (!array) {

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -99,6 +99,19 @@ describe('Scope', function() {
       expect(spy).wasCalled();
     }));
 
+    it('should watch and evaluate a listener expression', inject(function($rootScope) {
+      var spy = $rootScope.spy = jasmine.createSpy();
+      $rootScope.$watch('name', 'spy($newVal, $oldVal)');
+      $rootScope.$digest();
+      spy.reset();
+
+      expect(spy).not.wasCalled();
+      $rootScope.$digest();
+      expect(spy).not.wasCalled();
+      $rootScope.name = 'misko';
+      $rootScope.$digest();
+      expect(spy).wasCalledWith('misko', undefined);
+    }));
 
     it('should delegate exceptions', function() {
       module(function($exceptionHandlerProvider) {


### PR DESCRIPTION
a string listener expression can evaluate $newVal and $oldVal

example:

``` javascript
$scope.$watch('foo', 'foo = $newVal');
```
