### PR TITLE
feat($injector): allow loading of modules to an existing injector

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -422,7 +422,7 @@ function createInjector(modulesToLoad) {
           }));
 
 
-  forEach(loadModules(modulesToLoad), function(fn) { instanceInjector.invoke(fn || noop); });
+  loadModules(modulesToLoad);
 
   return instanceInjector;
 
@@ -478,14 +478,14 @@ function createInjector(modulesToLoad) {
   ////////////////////////////////////
   // Module Loading
   ////////////////////////////////////
-  function loadModules(modulesToLoad){
+  function getModuleBlocks(modulesToLoad){
     var runBlocks = [];
     forEach(modulesToLoad, function(module) {
       if (loadedModules.get(module)) return;
       loadedModules.put(module, true);
       if (isString(module)) {
         var moduleFn = angularModule(module);
-        runBlocks = runBlocks.concat(loadModules(moduleFn.requires)).concat(moduleFn._runBlocks);
+        runBlocks = runBlocks.concat(getModuleBlocks(moduleFn.requires)).concat(moduleFn._runBlocks);
 
         try {
           for(var invokeQueue = moduleFn._invokeQueue, i = 0, ii = invokeQueue.length; i < ii; i++) {
@@ -517,6 +517,10 @@ function createInjector(modulesToLoad) {
       }
     });
     return runBlocks;
+  }
+
+  function loadModules(modulesToLoad) {
+    forEach(getModuleBlocks(modulesToLoad), function(fn) { instanceInjector.invoke(fn || noop); });
   }
 
   ////////////////////////////////////
@@ -597,7 +601,8 @@ function createInjector(modulesToLoad) {
       invoke: invoke,
       instantiate: instantiate,
       get: getService,
-      annotate: annotate
+      annotate: annotate,
+      load: loadModules
     };
   }
 }


### PR DESCRIPTION
When working on larger applications it is desirable to have individual parts loaded on demand, rather than loading everything at once in the beginning.

Unfortunately, there is no way to load a new module to an existing injector after the injector has been instantiated. And we also can't create a new injector because we would have a separate `$rootScope` and separate instances of services etc.

As far as I understand dynamically loading modules is planned for Angular 2.x, but our project needs the functionality now.

This patch exposes the module loading functionality in the injector. With access to this low-level function, applications can implement their own loading behavior.

I'm happy to add docs and tests to this pull request, but I wanted to get a reaction from the Angular devs first.

Related discussion:
https://groups.google.com/d/topic/angular/rs1dj097oHA/discussion
