### PR TITLE
Allow for reverse check box state without a lot of unnecessaries

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -643,7 +643,7 @@ function checkboxInputType(scope, element, attr, ctrl) {
   };
 
   ctrl.$formatters.push(function(value) {
-    return value === trueValue;
+    return value === trueValue || String(value) === trueValue;
   });
 
   ctrl.$parsers.push(function(value) {


### PR DESCRIPTION
More information here:
 - http://stackoverflow.com/questions/13925462/angularjs-reverse-checkbox-state

It seems like a simple use case that could be implemented with 1 elegant change (line 646).

I went with the change to $formatters instead of changing the trueValue/falseValue detection on lines 632-633, because this seemed less janky.

I chose not to String(trueValue) to save some unnecessary casting.  I believe this handles all scenarios.
