### PR TITLE
fix(jqLite): children() should only return elements.

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -647,14 +647,14 @@ forEach({
   children: function(element) {
     var children = [];
     forEach(element.childNodes, function(element){
-      if (element.nodeName != '#text')
+      if (element.nodeType === 1)
         children.push(element);
     });
     return children;
   },
 
   contents: function(element) {
-    return element.childNodes;
+    return element.childNodes || [];
   },
 
   append: function(element, node) {

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -925,8 +925,8 @@ describe('jqLite', function() {
 
 
   describe('children', function() {
-    it('should select non-text children', function() {
-      var root = jqLite('<div>').html('before-<div></div>after-<span></span>');
+    it('should only select element nodes', function() {
+      var root = jqLite('<div><!-- some comment -->before-<div></div>after-<span></span>');
       var div = root.find('div');
       var span = root.find('span');
       expect(root.children()).toJqEqual([div, span]);
@@ -936,10 +936,11 @@ describe('jqLite', function() {
 
   describe('contents', function() {
     it('should select all children nodes', function() {
-      var root = jqLite('<div>').html('before-<div></div>after-<span></span>');
+      var root = jqLite('<div>').html('<!-- some comment -->before-<div></div>after-<span></span>');
       var contents = root.contents();
-      expect(contents.length).toEqual(4);
-      expect(jqLite(contents[0]).text()).toEqual('before-');
+      expect(contents.length).toEqual(5);
+      expect(contents[0].textContent).toEqual(' some comment ');
+      expect(contents[1].textContent).toEqual('before-');
     });
   });
 

--- a/test/testabilityPatch.js
+++ b/test/testabilityPatch.js
@@ -78,7 +78,7 @@ function dealoc(obj) {
 
   function cleanup(element) {
     element.unbind().removeData();
-    for ( var i = 0, children = element.children() || []; i < children.length; i++) {
+    for ( var i = 0, children = element.contents() || []; i < children.length; i++) {
       cleanup(jqLite(children[i]));
     }
   }


### PR DESCRIPTION
The jQuery implementation of `children()` only returns child nodes of the given element that are elements themselves. The previous jqLite implementation was returning all nodes except those that are text nodes.

[One should use `jQLite.contents()` to get all the child nodes]

The testabilityPatch was incorrectly using `children()` rather than `contents()` inside `cleanup()` to iterate down through all the child nodes of the element to clean up.

The _"bind should bind to window on hashchange"_ jqLiteSpec had not defined a `childNodes` property when it was mocking out the `window` object, so `contents()` was blowing up with a stack overflow in that test.

This fixes https://github.com/angular/angular.js/issues/1413
