### PR TITLE
fix(jqLite): next() should return the sibling element

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -718,7 +718,7 @@ forEach({
   },
 
   next: function(element) {
-    return element.nextSibling;
+    return element.nextElementSibling;
   },
 
   find: function(element, selector) {


### PR DESCRIPTION
`nextSibling()` returns a text node. By replacing it with `nextElementSibling()`, issue [#1730](https://github.com/angular/angular.js/issues/1730) would be fixed.

Example showing wrong behavior: http://jsbin.com/exosoz/1/edit
