### PR TITLE
fix(jqLite): Fix next() and its test

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -718,7 +718,14 @@ forEach({
   },
 
   next: function(element) {
-    return element.nextElementSibling;
+    if (element.nextElementSibling) {
+      return element.nextElementSibling;
+    }
+    var elm = element.nextSibling;
+    while (elm != null && elm.nodeType !== 1) {
+      elm = elm.nextSibling;
+    }
+    return elm;
   },
 
   find: function(element, selector) {

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -718,7 +718,7 @@ forEach({
   },
 
   next: function(element) {
-    return element.nextSibling;
+    return element.nextElementSibling;
   },
 
   find: function(element, selector) {

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1,4 +1,3 @@
-
 describe('jqLite', function() {
   var scope, a, b, c;
 
@@ -1068,7 +1067,7 @@ describe('jqLite', function() {
 
   describe('next', function() {
     it('should return next sibling', function() {
-      var element = jqLite('<div><b>b</b><i>i</i></div>');
+      var element = jqLite('<div><b>b</b>TextNode<i>i</i></div>');
       var b = element.find('b');
       var i = element.find('i');
       expect(b.next()).toJqEqual([i]);


### PR DESCRIPTION
next() must return the next sibling element and it should ignore text nodes between elements. In the sample element that was prepared for testing, there was no text or space between the two elements (`<b>b</b>` and `<i>i</i>`) to check if next() was ignoring text nodes properly.

To get the next sibling element, `nextElementSibling` must be used instead of `nextSibling` because `nextSibling` doesn't ignore text nodes.
