### PR TITLE
feat($rootScope): stopDescent method added to broadcast event

### DIFF
--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -907,6 +907,24 @@ describe('Scope', function() {
           expect(result.name).toBe('some');
           expect(result.targetScope).toBe(child1);
         });
+
+        it('should allow stopping event descent from root scope', inject(function($rootScope) {
+          child2.$on('myEvent', function(event) { event.stopDescent(); });
+          $rootScope.$broadcast('myEvent');
+          expect(log).toEqual('0>1>11>2>3>');
+        }));
+
+        it('should allow stopping event descent from child scope', function() {
+          grandChild21.$on('myEvent', function(event) { event.stopDescent(); });
+          child2.$broadcast('myEvent');
+          expect(log).toEqual('2>21>22>23>');
+        });
+
+        it('should not stop descent on sibling scopes', inject(function($rootScope) {
+          child1.$on('myEvent', function(event) { event.stopDescent(); });
+          $rootScope.$broadcast('myEvent');
+          expect(log).toEqual('0>1>2>21>211>22>23>3>');
+        }));
       });
 
 


### PR DESCRIPTION
Add `stopDescent` to event object.

stopDescent - {function=}: calling stopDescent function will cancel further event propagation to children (available only for events that were $broadcasted-ed).
