### PR TITLE
doc(guide): In DI, add missing greet method to greeter service in $scope...

### DIFF
--- a/docs/content/guide/di.ngdoc
+++ b/docs/content/guide/di.ngdoc
@@ -92,7 +92,7 @@ dependency lookup responsibility to the injector by declaring the dependencies a
   // And this controller definition
   function MyController($scope, greeter) {
     $scope.sayHello = function() {
-      greeter('Hello World');
+      greeter.greet('Hello World');
     };
   }
   


### PR DESCRIPTION
doc(guide): In DI, add missing greet method to greeter service in $scope.sayHello

MyController defines a $scope.sayHello function to demo the greeter service. But the actual greet method was omitted in the example code. Now instead of greeter('Hello World') we call greeter.greet('Hello World') to match the object returned from the greeter factory.
