### PR TITLE
fix(Rakefile) Remove -d32 as argument to closure-compiler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -274,7 +274,6 @@ def closure_compile(filename)
 
   %x(java \
         -client \
-        -d32 \
         -jar lib/closure-compiler/compiler.jar \
         --compilation_level SIMPLE_OPTIMIZATIONS \
         --language_in ECMASCRIPT5_STRICT \


### PR DESCRIPTION
Closes #1765
