### PR TITLE
fix(bootstrap): bug of tabbable viewValue unexpected change

### DIFF
--- a/src/bootstrap/bootstrap.js
+++ b/src/bootstrap/bootstrap.js
@@ -69,14 +69,13 @@ directive.tabbable = function() {
         var $viewValue = this.$viewValue;
 
         if (selectedTab ? (selectedTab.value != $viewValue) : $viewValue) {
-          if(selectedTab) {
-            selectedTab.paneElement.removeClass('active');
-            selectedTab.tabElement.removeClass('active');
-            selectedTab = null;
-          }
           if($viewValue) {
             for(var i = 0, ii = tabs.length; i < ii; i++) {
               if ($viewValue == tabs[i].value) {
+                if(selectedTab) {
+                  selectedTab.paneElement.removeClass('active');
+                  selectedTab.tabElement.removeClass('active');
+                }
                 selectedTab = tabs[i];
                 break;
               }


### PR DESCRIPTION
move the tabbable un-active code into the check loop to make sure the new viewValue is in the tabs list

I work with angularJs & angular-ui/bootstrap
in one case i want to use tab inside a popmodal, but the popmodal cannot select anyone 
event I write code to change the value of ngModel viewValue

I thought it might be caught by something wrong inside angular-ui,
and also the code in src/bootstrap/bootstrap.js is not reasonable

I think the code for un-active a tab should be run when a new, exist tab is select.

here is the plnkr
http://plnkr.co/edit/IIYvIYTMeCzDQZlOPxWm
