### PR TITLE
fix(docs): Fix warning: 'end is deprecated, use done instead.'

### DIFF
--- a/docs/src/gen-docs.js
+++ b/docs/src/gen-docs.js
@@ -36,7 +36,7 @@ writer.makeDir('build/docs/', true).then(function() {
   });
 }).then(function printStats() {
   console.log('DONE. Generated ' + docs.length + ' pages in ' + (now()-start) + 'ms.' );
-}).end();
+}).done();
 
 
 function writeTheRest(writesFuture) {


### PR DESCRIPTION
There's a warning due to ./node_modules/q-fs@0.1.36 --> node_modules/q@0.8.11

This may also be due to AngularJS's package.json not being restrictive enough on the q-fs version.

In any case, q-fs is being retired for q-io/fs, so this fix is probably necssary eventually.
