### PR TITLE
Fix examples of $location.html5mode in the documentation

### DIFF
--- a/docs/content/guide/dev_guide.services.$location.ngdoc
+++ b/docs/content/guide/dev_guide.services.$location.ngdoc
@@ -212,7 +212,7 @@ In this mode, `$location` uses Hashbang URLs in all browsers.
 <pre>
 it('should show example', inject(
   function($locationProvider) {
-    $locationProvider.html5mode = false;
+    $locationProvider.html5Mode(false);
     $locationProvider.hashPrefix = '!';
   },
   function($location) {
@@ -261,7 +261,7 @@ having to worry about whether the browser displaying your app supports the histo
 <pre>
 it('should show example', inject(
   function($locationProvider) {
-    $locationProvider.html5mode = true;
+    $locationProvider.html5Mode(true);
     $locationProvider.hashPrefix = '!';
   },
   function($location) {

--- a/docs/content/guide/dev_guide.unit-testing.ngdoc
+++ b/docs/content/guide/dev_guide.unit-testing.ngdoc
@@ -10,7 +10,7 @@ angular which makes testing your angular applications easy. So there is no excus
 Unit testing as the name implies is about testing individual units of code. Unit tests try to
 answer the question: Did I think about the logic correctly. Does the sort function order the list
 in the right order. In order to answer such question it is very important that we can isolate it.
-That is because when we are testing the sort function we don't want to be forced into crating
+That is because when we are testing the sort function we don't want to be forced into creating
 related pieces such as the DOM elements, or making any XHR calls in getting the data to sort. While
 this may seem obvious it usually is very difficult to be able to call an individual function on a
 typical project. The reason is that the developers often time mix concerns, and they end up with a
@@ -23,17 +23,17 @@ apply the function, and assert that the resulting model is in the correct order.
 have to wait for XHR, or create the right kind of DOM, or assert that your function has mutated the
 DOM in the right way. Angular is written with testability in mind, but it still requires that you
 do the right thing. We tried to make the right thing easy, but angular is not magic, which means if
-you don't follow these, you may very well end up with an untestable application.
+you don't follow these rules, you may very well end up with an untestable application.
 
 ## Dependency Inject
 There are several ways in which you can get a hold of a dependency:
 1. You could create it using the `new` operator.
-2. You could look for it in a well know place, also known as global singleton.
+2. You could look for it in a well known place, also known as global singleton.
 3. You could ask a registry (also known as service registry) for it. (But how do you get a hold of
-the registry? Must likely by looking it up in a well know place. See #2)
+the registry? Most likely by looking it up in a well know place. See #2)
 4. You could expect that the it be handed to you.
 
-Out of the list above only the last of is testable. Lets look at why:
+Out of the list above only the last one is testable. Lets look at why:
 
 ### Using the `new` operator
 
@@ -119,7 +119,7 @@ function MyClass() {
 }
 </pre>
 
-However, where dose the serviceRegistry come from? if it is:
+However, where does the serviceRegistry come from? if it is:
 * `new`-ed up, the the test has no chance to reset the services for testing
 *  global look-up, then the service returned is global as well (but resetting is easier, since
 there is only one global variable to be reset).
@@ -239,7 +239,7 @@ and the tests is straight forward
 var pc = new PasswordController();
 pc.password('abc');
 pc.grade();
-expect(span.strength).toEqual('weak');
+expect(pc.strength).toEqual('weak');
 </pre>
 
 Notice that the test is not only much shorter but it is easier to follow what is going on. We say


### PR DESCRIPTION
While learning about the $location service, I read the docs on:

http://docs.angularjs.org/guide/dev_guide.services.$location

In one of the examples, it was written in the config setter was: 

$locationProvider.html5mode = true;

So I tried it, and debugged it and couldn't get it to work.
Only after continuing to read on, I saw another version of the same config flag:

$.locationProvider.html5Mode( true )

and that one worked.

So I changed the examples to the working one.
Shai
