### PR TITLE
fix(compile): Do not wrap empty root text nodes in spans

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -318,7 +318,7 @@ function $CompileProvider($provide) {
       // We can not compile top level text elements since text nodes can be merged and we will
       // not be able to attach scope data to them, so we will wrap them in <span>
       forEach($compileNodes, function(node, index){
-        if (node.nodeType == 3 /* text node */) {
+        if (node.nodeType == 3 /* text node */ && node.nodeValue.match(/\S+/) /* non-empty */ ) {
           $compileNodes[index] = jqLite(node).wrap('<span></span>').parent()[0];
         }
       });

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -125,6 +125,17 @@ describe('$compile', function() {
       expect(element.find('span').text()).toEqual('A<a>B</a>C');
     }));
 
+    it('should not wrap root whitespace text nodes in spans', function() {
+      element = jqLite(
+        '<div>   <div>A</div>\n  '+ // The spaces and newlines here should not get wrapped
+        '<div>B</div>C\t\n  '+  // The "C", tabs and spaces here will be wrapped
+        '</div>');
+      $compile(element.contents())($rootScope);
+      var spans = element.find('span');
+      expect(spans.length).toEqual(1);
+      expect(spans.text().indexOf('C')).toEqual(0);
+    });
+
     describe('multiple directives per element', function() {
       it('should allow multiple directives per element', inject(function($compile, $rootScope, log){
         element = $compile(


### PR DESCRIPTION
Fixes https://github.com/angular/angular.js/issues/1059
