### PR TITLE
fix(date): parse string input as local time unless TZ is specified

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -330,18 +330,22 @@ function dateFilter($locale) {
 
 
   var R_ISO8601_STR = /^(\d{4})-?(\d\d)-?(\d\d)(?:T(\d\d)(?::?(\d\d)(?::?(\d\d)(?:\.(\d+))?)?)?(Z|([+-])(\d\d):?(\d\d))?)?$/;
-  function jsonStringToDate(string){
+                     // 1        2       3         4          5          6          7          8  9     10      11
+  function jsonStringToDate(string) {
     var match;
     if (match = string.match(R_ISO8601_STR)) {
       var date = new Date(0),
           tzHour = 0,
-          tzMin  = 0;
+          tzMin  = 0,
+          dateSetter = match[8] ? date.setUTCFullYear : date.setFullYear,
+          timeSetter = match[8] ? date.setUTCHours : date.setHours;
+
       if (match[9]) {
         tzHour = int(match[9] + match[10]);
         tzMin = int(match[9] + match[11]);
       }
-      date.setUTCFullYear(int(match[1]), int(match[2]) - 1, int(match[3]));
-      date.setUTCHours(int(match[4]||0) - tzHour, int(match[5]||0) - tzMin, int(match[6]||0), int(match[7]||0));
+      dateSetter.call(date, int(match[1]), int(match[2]) - 1, int(match[3]));
+      timeSetter.call(date, int(match[4]||0) - tzHour, int(match[5]||0) - tzMin, int(match[6]||0), int(match[7]||0));
       return date;
     }
     return string;

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -253,32 +253,37 @@ describe('filters', function() {
     });
 
 
-    it('should support various iso8061 date strings as input', function() {
-      var format = 'yyyy-MM ss';
+    it('should support various iso8061 date strings with timezone as input', function() {
+      var format = 'yyyy-MM-dd ss';
 
       //full ISO8061
-      expect(date('2003-09-10T13:02:03.000Z', format)).toEqual('2003-09 03');
+      expect(date('2003-09-10T13:02:03.000Z', format)).toEqual('2003-09-10 03');
 
-      expect(date('2003-09-10T13:02:03.000+00:00', format)).toEqual('2003-09 03');
+      expect(date('2003-09-10T13:02:03.000+00:00', format)).toEqual('2003-09-10 03');
 
-      expect(date('2003-09-10T13:02:03-08:00', format)).toEqual('2003-09 03');
-
-      expect(date('20030910T033203-0930', format)).toEqual('2003-09 03');
-
-      //no timezone
-      expect(date('2003-09-10T13:02:03.000', format)).toEqual('2003-09 03');
+      expect(date('20030910T033203-0930', format)).toEqual('2003-09-10 03');
 
       //no millis
-      expect(date('2003-09-10T13:02:03Z', format)).toEqual('2003-09 03');
+      expect(date('2003-09-10T13:02:03Z', format)).toEqual('2003-09-10 03');
 
       //no seconds
-      expect(date('2003-09-10T13:02Z', format)).toEqual('2003-09 00');
+      expect(date('2003-09-10T13:02Z', format)).toEqual('2003-09-10 00');
 
       //no minutes
-      expect(date('2003-09-10T13Z', format)).toEqual('2003-09 00');
+      expect(date('2003-09-10T13Z', format)).toEqual('2003-09-10 00');
+    });
+
+
+    it('should parse iso8061 date strings without timezone as local time', function() {
+      var format = 'yyyy-MM-dd HH-mm-ss';
+
+      //full ISO8061 without timezone
+      expect(date('2003-09-10T03:02:04.000', format)).toEqual('2003-09-10 03-02-04');
+
+      expect(date('20030910T030204', format)).toEqual('2003-09-10 03-02-04');
 
       //no time
-      expect(date('2003-09-10', format)).toEqual('2003-09 00');
+      expect(date('2003-09-10', format)).toEqual('2003-09-10 00-00-00');
     });
 
     it('should support different degrees of subsecond precision', function () {


### PR DESCRIPTION
previously we were always parsing the string input as UTC which cased issues like:

{{ '2012-04-01' | date:'d MMM yyyy' }} renders as 31 Mar 2012

BREAKING CHANGE: string input without timezone info is now parsed as local time/date

Closes #847
