### PR TITLE
ng-cookie directive

### DIFF
--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -160,4 +160,28 @@ angular.module('ngCookies', ['ng']).
         }
       };
 
+    }]).
+
+
+  /**
+   * @ngdoc directive
+   * @name ngCookies.directive:ngCookie
+   *
+   * @description
+   * Syncs a model to a cookie.
+   *
+   * @element ANY
+   *
+   * @example
+   */
+   directive('ngCookie', ['$cookieStore', function($cookieStore) {
+
+      return function(scope, element, attr) {
+        scope[attr.ngModel] = $cookieStore.get(attr.ngCookie);
+
+        scope.$watch(attr.ngModel, function(value) {
+          $cookieStore.put(attr.ngCookie, value);
+        });
+      };
+
     }]);

--- a/test/ngCookies/cookiesSpec.js
+++ b/test/ngCookies/cookiesSpec.js
@@ -126,3 +126,36 @@ describe('$cookieStore', function() {
     expect($browser.cookies()).toEqual({});
   }));
 });
+
+
+describe('ngCookie', function() {
+  var element;
+
+
+  beforeEach(module('ngCookies'));
+
+
+  it('should set initial model from cookie', inject(function($rootScope, $compile, $browser) {
+    $browser.cookieHash['name'] = '"foo"';
+    $browser.poll();
+    element = $compile('<input ng-model="name" ng-cookie="name">')($rootScope);
+    $rootScope.$digest();
+    expect($rootScope.name).toEqual('foo');
+  }));
+
+
+  it('should set cookie when model is set', inject(function($rootScope, $compile, $browser) {
+    element = $compile('<input ng-model="name" ng-cookie="name">')($rootScope);
+    $rootScope.name = 'foo';
+    $rootScope.$digest();
+    expect($browser.cookies()).toEqual({'name': '"foo"'});
+  }));
+
+
+  it('should remove cookie when model is empty', inject(function($rootScope, $compile, $browser) {
+    element = $compile('<input ng-model="name" ng-cookie="name">')($rootScope);
+    delete $rootScope.name;
+    $rootScope.$digest();
+    expect($browser.cookies()).toEqual({});
+  }));
+});


### PR DESCRIPTION
```
<input ng-model="name" ng-cookie="name">
```

This persists `$scope.name` to cookie['name'] whenever the model changes, deletes the cookie when the model goes undefined, and sets the initial value of `$scope.name` to cookie['name']. 

(The cookie name is isn't generated from the model name because cookies have bigger scope (domain, path) than models (controller).)
