### PR TITLE
Fix prototype methods in docs examples

### DIFF
--- a/docs/content/cookbook/buzz.ngdoc
+++ b/docs/content/cookbook/buzz.ngdoc
@@ -21,12 +21,12 @@ to retrieve Buzz activity and comments.
       { get:     {method: 'JSONP', params: {visibility: '@self'}},
         replies: {method: 'JSONP', params: {visibility: '@self', comments: '@comments'}}
       });
-    }
-    BuzzController.prototype = {
-     fetch: function() {
+
+     $scope.fetch = function() {
       $scope.activities = $scope.Activity.get({userId:this.userId});
-     },
-     expandReplies: function(activity) {
+     }
+
+     $scope.expandReplies = function(activity) {
       activity.replies = $scope.Activity.replies({userId: this.userId, activityId: activity.id});
      }
     };

--- a/docs/content/guide/di.ngdoc
+++ b/docs/content/guide/di.ngdoc
@@ -32,12 +32,12 @@ The third option is the most viable, since it removes the responsibility of loca
 dependency from the component. The dependency is simply handed to the component.
 
 <pre>
-  function SomeClass(greeter) {
-    this.greeter = greeter
-  }
-  
-  SomeClass.prototype.doSomething = function(name) {
-    this.greeter.greet(name);
+  function SomeClass($scope, greeter) {
+    $scope.greeter = greeter
+
+    $scope.doSomething = function(name) {
+      $scope.greeter.greet(name);
+    }
   }
 </pre>
 
@@ -197,14 +197,13 @@ Controllers are classes which are responsible for application behavior. Recommen
 declaring controllers is:
 
 <pre>
-  var MyController = function(dep1, dep2) {
+  var MyController = function($scope, dep1, dep2) {
     ...
+    $scope.aMethod = function() {
+      ...
+    }
   }
-  MyController.$inject = ['dep1', 'dep2'];
-  
-  MyController.prototype.aMethod = function() {
-    ...
-  }
+  MyController.$inject = ['$scope', 'dep1', 'dep2'];
 </pre>
 
 


### PR DESCRIPTION
When first learning Angular I got confused by the use of the prototype for methods in some parts of the docs and $scope in others. I finally found the 'Understanding Controllers' page which clarified that the $scope way is the right way, so here are some corrections to help future newbies.

[This PR contains is the same as #1807 but with better commit message]
