### PR TITLE
chore(Rakefile): force 32bit JVM mode only when java supports it

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -273,14 +273,22 @@ def path_to(filename)
 end
 
 
+##
+# returns the 32-bit mode force flags for java compiler if supported, this makes the build much
+# faster
+#
+def java32flags
+  return '-d32 -client' unless Rake::Win32.windows? || `java -version -d32 2>&1`.match(/Error/i)
+end
+
+
 def closure_compile(filename)
   puts "Minifying #{filename} ..."
 
   min_path = path_to(filename.gsub(/\.js$/, '.min.js'))
 
   %x(java \
-        -client \
-        -d32 \
+        #{java32flags()} \
         -jar lib/closure-compiler/compiler.jar \
         --compilation_level SIMPLE_OPTIMIZATIONS \
         --language_in ECMASCRIPT5_STRICT \


### PR DESCRIPTION
Some Java installs don't have '-d32' flag (e.g. OpenJDK which is standard
for some Linux systems), and the closure_compile fails because of forcing
that flag. Test, and only run in faster 32bit mode if supported, or
else just run with no flag (default mode).
