### PR TITLE
docs(contribute) adding npm install to step-by-step

### DIFF
--- a/docs/content/misc/contribute.ngdoc
+++ b/docs/content/misc/contribute.ngdoc
@@ -123,7 +123,11 @@ minified AngularJS files:
 
         git remote add upstream https://github.com/angular/angular.js.git
 
-4. To build AngularJS, run:
+4. To add node.js dependencies
+
+        npm install
+
+5. To build AngularJS, run:
 
         rake package
 


### PR DESCRIPTION
`npm install` is listed in the dependencies section of the contribute guide but
is missing from the step-by-step. This adds it as step 4.

Tiny tweak for something that tripped me up. 
