### PR TITLE
feat(httpBackend) Patch for Firefox bug w/ CORS and resonse headers

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -65,10 +65,28 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
       // always async
       xhr.onreadystatechange = function() {
         if (xhr.readyState == 4) {
+          var responseHeaders = xhr.getAllResponseHeaders();
+          // begin: workaround to overcome firefox CORS http response headers bug 
+          // https://bugzilla.mozilla.org/show_bug.cgi?id=608735
+          // CORS "simple response headers" http://www.w3.org/TR/cors/
+          var value,
+              simpleHeaders = ["Cache-Control", "Content-Language", "Content-Type",
+                                  "Expires", "Last-Modified", "Pragma"];
+          if (!responseHeaders) {
+            responseHeaders = "";
+            forEach(simpleHeaders, function (header) {
+              var value = xhr.getResponseHeader(header);
+              if (value) {
+                  responseHeaders += header + ": " + value + "\n";
+              }
+            });
+          }
+          // end workaround.              
           completeRequest(callback, status || xhr.status, xhr.response || xhr.responseText,
-                          xhr.getAllResponseHeaders());
+                          responseHeaders);
         }
       };
+
 
       if (withCredentials) {
         xhr.withCredentials = true;

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -66,8 +66,11 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
       xhr.onreadystatechange = function() {
         if (xhr.readyState == 4) {
           var responseHeaders = xhr.getAllResponseHeaders();
-          // begin: workaround to overcome firefox CORS http response headers bug 
+          
+          // begin: workaround to overcome Firefox CORS http response headers bug 
           // https://bugzilla.mozilla.org/show_bug.cgi?id=608735
+          // Firefox already patched in nightly. Should land in Firefox 21.
+          
           // CORS "simple response headers" http://www.w3.org/TR/cors/
           var value,
               simpleHeaders = ["Cache-Control", "Content-Language", "Content-Type",
@@ -82,6 +85,7 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
             });
           }
           // end workaround.              
+
           completeRequest(callback, status || xhr.status, xhr.response || xhr.responseText,
                           responseHeaders);
         }

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -116,7 +116,8 @@ describe('$httpBackend', function() {
       };
 
       this.getAllResponseHeaders = valueFn('');
-      // for temporary FF CORS workaround
+      // for temporary Firefox CORS workaround
+	  // see https://github.com/angular/angular.js/issues/1468
       this.getResponseHeader = valueFn('');
     }
 

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -116,6 +116,8 @@ describe('$httpBackend', function() {
       };
 
       this.getAllResponseHeaders = valueFn('');
+      // for temporary FF CORS workaround
+      this.getResponseHeader = valueFn('');
     }
 
     callback.andCallFake(function(status, response) {


### PR DESCRIPTION
A workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=608735
In FF getAllResponseHeaders() returns null if the request is the result of CORS.

Tried to format the code so that when a FF patch is released and gains enough
traction it can easily be selected and deleted. Heavily inspired by jQuery's
patch for the same bug. This patch falls short of passing through custom headers
but covers all of the "simple response headers" in the spec at
http://www.w3.org/TR/cors/

Closes #1468
