### PR TITLE
feat($http): Added method to abort a pending request. (2nd attempt)

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -52,13 +52,16 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
         delete callbacks[callbackId];
       });
     } else {
-      var xhr = new XHR();
+      var status, xhr = new XHR(),
+          abortRequest = function() {
+            status = -1;
+            xhr.abort();
+          };
+
       xhr.open(method, url, true);
       forEach(headers, function(value, key) {
         if (value) xhr.setRequestHeader(key, value);
       });
-
-      var status;
 
       // In IE6 and 7, this might be called synchronously when xhr.send below is called and the
       // response is in the cache. the promise api will ensure that to the app code the api is
@@ -99,11 +102,10 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
       xhr.send(post || '');
 
       if (timeout > 0) {
-        $browserDefer(function() {
-          status = -1;
-          xhr.abort();
-        }, timeout);
+        $browserDefer(abortRequest, timeout);
       }
+
+      return abortRequest;
     }
 
 

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -81,6 +81,48 @@ describe('$httpBackend', function() {
   });
 
 
+  it('should return an abort function', function() {
+    callback.andCallFake(function(status, response) {
+      expect(status).toBe(-1);
+    });
+
+    var abort = $backend('GET', '/url', null, callback);
+    xhr = MockXhr.$$lastInstance;
+    spyOn(xhr, 'abort');
+
+    expect(typeof abort).toBe('function');
+
+    abort();
+    expect(xhr.abort).toHaveBeenCalledOnce();
+
+    xhr.status = 200;
+    xhr.readyState = 4;
+    xhr.onreadystatechange();
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+
+  it('should not abort a completed request', function() {
+    callback.andCallFake(function(status, response) {
+      expect(status).toBe(200);
+    });
+
+    var abort = $backend('GET', '/url', null, callback);
+    xhr = MockXhr.$$lastInstance;
+    spyOn(xhr, 'abort');
+
+    expect(typeof abort).toBe('function');
+
+    xhr.status = 200;
+    xhr.readyState = 4;
+    xhr.onreadystatechange();
+
+    abort();
+    expect(xhr.abort).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+
   it('should abort request on timeout', function() {
     callback.andCallFake(function(status, response) {
       expect(status).toBe(-1);
@@ -218,6 +260,11 @@ describe('$httpBackend', function() {
 
       $backend('JSONP', '', null, callback);
       expect(fakeDocument.$$scripts[0].src).toBe($browser.url());
+    });
+
+
+    it('should respond undefined', function() {
+      expect($backend('JSONP', '/url')).toBeUndefined();
     });
 
 

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -790,6 +790,37 @@ describe('ngMock', function() {
     });
 
 
+    it('should return an abort function', function() {
+      hb.when('GET', '/url').respond(200, '', {});
+
+      var abortFn = hb('GET', '/url', null, callback);
+      expect(abortFn()).toBe(true);
+      expect(abortFn()).toBe(true);
+
+      expect(function() {
+        hb.flush();
+      }).toThrow('No pending request to flush !');
+      expect(callback).toHaveBeenCalledOnceWith(-1, null, null);
+      hb.verifyNoOutstandingRequest();
+    });
+
+
+    it('should not abort a completed request', function() {
+      hb.when('GET', '/url').respond(200, '', {});
+
+      var abortFn = hb('GET', '/url', null, callback);
+      hb.flush();
+      expect(abortFn()).toBe(false);
+      expect(abortFn()).toBe(false);
+
+      expect(function() {
+        hb.flush();
+      }).toThrow('No pending request to flush !');
+      expect(callback).toHaveBeenCalledOnceWith(200, '', '');
+      hb.verifyNoOutstandingRequest();
+    });
+
+
     it('should respond undefined when JSONP method', function() {
       hb.when('JSONP', '/url1').respond(200);
       hb.expect('JSONP', '/url2').respond(200);


### PR DESCRIPTION
Fixes issue #1159. Was pull request #1623.

Addressed issues brought up by Miško:
1. After calling .abort(), the promise is guaranteed to be resolved with a rejection (unless it has already been resolved).
2. The .abort() method now returns a boolean:
   - True - if successfully aborted (or already aborted).
   - False - if abort failed because the promise is already resolved.
3. Updated $httpBackend mock to support aborting.
