### PR TITLE
fix(ng:list) : ng-list directive separator bug fix.

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1270,7 +1270,7 @@ var ngListDirective = function() {
       ctrl.$parsers.push(parse);
       ctrl.$formatters.push(function(value) {
         if (isArray(value)) {
-          return value.join(separator + ' ');
+          return value.join(separator);
         }
 
         return undefined;

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1270,7 +1270,7 @@ var ngListDirective = function() {
       ctrl.$parsers.push(parse);
       ctrl.$formatters.push(function(value) {
         if (isArray(value)) {
-          return value.join(', ');
+          return value.join(separator + ' ');
         }
 
         return undefined;

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1270,7 +1270,7 @@ var ngListDirective = function() {
       ctrl.$parsers.push(parse);
       ctrl.$formatters.push(function(value) {
         if (isArray(value)) {
-          return value.join(separator);
+          return value.join(separator + ' ');
         }
 
         return undefined;


### PR DESCRIPTION
Issue : ng-list separator getting overridden by ',' .
