### PR TITLE
doc(tutorial): Fix confusing test filter injection

### DIFF
--- a/docs/content/tutorial/step_09.ngdoc
+++ b/docs/content/tutorial/step_09.ngdoc
@@ -99,7 +99,8 @@ describe('filter', function() {
   describe('checkmark', function() {
 
     it('should convert boolean values to unicode checkmark or cross',
-        inject(function(checkmarkFilter) {
+        inject(function($filter) {
+      var checkmarkFilter = $filter("checkmarkFilter");
       expect(checkmarkFilter(true)).toBe('\u2713');
       expect(checkmarkFilter(false)).toBe('\u2718');
     }));


### PR DESCRIPTION
While doing some TDD, I've noticed that you can't really inject controllers, directives and filters.
So Went over the tutorial and didn't understand how is this unit test passing, 
Checked, and in my runner it throws an error.

Shouldn't we use the $filter instead of asking directly the filter name? (like controllers?)
