### PR TITLE
feat(trim): Publish trim() to external API

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -390,7 +390,17 @@ function isBoolean(value) {
   return typeof value == 'boolean';
 }
 
-
+/**
+ * @ngdoc function
+ * @name angular.trim
+ * @function
+ *
+ * @description
+ * Trims whitespace from `value`
+ *
+ * @param {String} value String to remove whitespace from.
+ * @returns {String} Trimmed string.
+ */
 function trim(value) {
   return isString(value) ? value.replace(/^\s*/, '').replace(/\s*$/, '') : value;
 }

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -48,6 +48,7 @@ function publishExternalAPI(angular){
     'isDate': isDate,
     'lowercase': lowercase,
     'uppercase': uppercase,
+    'trim': trim,
     'callbacks': {counter: 0}
   });
 


### PR DESCRIPTION
I've found myself placing this function in $rootScope as it's used so frequently.  Would be nice to simply expose it as part of the angular API.

I've submitted a Pull Request (and signed CLA) if you all agree
