### PR TITLE
feat($http): Pass http config to response interceptors

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -541,7 +541,7 @@ function $HttpProvider() {
 
       // apply interceptors
       forEach(responseInterceptors, function(interceptor) {
-        promise = interceptor(promise);
+        promise = interceptor(promise, config);
       });
 
       promise.success = function(fn) {

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -314,12 +314,13 @@ function $HttpProvider() {
      * The interceptors are service factories that are registered with the $httpProvider by
      * adding them to the `$httpProvider.responseInterceptors` array. The factory is called and
      * injected with dependencies (if specified) and returns the interceptor  — a function that
-     * takes a {@link ng.$q promise} and returns the original or a new promise.
+     * takes a {@link ng.$q promise} and a config object, which is the same object that was 
+     * passed to $http and returns the original or a new promise.
      *
      * <pre>
      *   // register the interceptor as a service
      *   $provide.factory('myHttpInterceptor', function($q, dependency1, dependency2) {
-     *     return function(promise) {
+     *     return function(promise, config) {
      *       return promise.then(function(response) {
      *         // do something on success
      *       }, function(response) {

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -99,6 +99,34 @@ describe('$http', function() {
           expect(response).toBe('HELLO!');
         });
       });
+
+
+      it('should pass the http config through to the interceptors', function(){
+        var interceptedConfig;
+        var httpConfig = {
+          method: 'GET',
+          url: '/test'
+        }
+        module(function($httpProvider){
+          $httpProvider.responseInterceptors.push(function(){
+            return function(httpPromise, config){
+              return httpPromise.then(function(response){
+                interceptedConfig = config;
+                return httpPromise;
+              });
+            };
+          });
+        });
+        inject(function($http, $httpBackend){
+          $httpBackend.expect('GET', '/test').respond('hello!');
+          debugger;
+          $http(httpConfig);
+          expect(interceptedConfig).toBeUndefined();
+
+          $httpBackend.flush();
+          expect(interceptedConfig).toBe(httpConfig);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Allow response interceptors to use the config object passed to the
$http call that the response originated from

---

This arose from a use case where I needed a global loading indicator with loading messages that were customized for each endpoint.

Here is a jsfiddle I created that demonstrates this use case with a build of angular including this change: http://jsfiddle.net/ashelvey/UJ2Xx/ 

You can use Charles, Fiddler, etc.. to throttle http calls for a more realistic demo.

(CLA signed)
