### PR TITLE
fix($q): Make $q more compatible with $http

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -198,6 +198,8 @@ function qFactory(nextTick, exceptionHandler) {
               }
             });
           }
+
+          return deferred.promise;
         }
       },
 
@@ -236,6 +238,18 @@ function qFactory(nextTick, exceptionHandler) {
           }
 
           return result.promise;
+        },
+
+        success: function(fn) {
+          return this.then(function(value) {
+            fn(value);
+          });
+        },
+
+        error: function(fn) {
+          return this.then(null, function(value) {
+            fn(value);
+          });
         }
       }
     };


### PR DESCRIPTION
Brings the deferred functionality of $q in sync with $http. Previously, the functions available to each differed between them, making interoperability less straightforward.

A simple example would be if you want to work with an object that may or may not have been created on the server yet. This patch allows you to write code like this:

``` javascript
function example(obj) {
  var defer = obj ? $q.defer().resolve(obj) : $http.get("/makeObj");

  defer.success(function(obj) {
    //run various operations on the object
  });
}
```

Previously, working with $q and $http was unintuitive since $q lacks the success/error functions. Also added a promise return to resolve().
