### PR TITLE
fix(compile): compiling replace:true directives in external template

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -936,7 +936,7 @@ function $CompileProvider($provide) {
 
           directives.unshift(derivedSyncDirective);
           afterTemplateNodeLinkFn = applyDirectivesToNode(directives, $compileNode, tAttrs, childTranscludeFn);
-          afterTemplateChildLinkFn = compileNodes($compileNode.contents(), childTranscludeFn);
+          afterTemplateChildLinkFn = compileNodes($compileNode[0].childNodes, childTranscludeFn);
 
 
           while(linkQueue.length) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -627,6 +627,11 @@ describe('$compile', function() {
               }
             }));
 
+            directive('replace', valueFn({
+              restrict:'CAM',
+              replace: true,
+              template: '<span>Hello, {{name}}!</span>'
+            }));
           }
         ));
 
@@ -732,6 +737,19 @@ describe('$compile', function() {
                   toEqual('<div><span class="i-hello">Hello, Elvis!</span></div>');
             }
         ));
+        
+
+        it('should compile template when replacing element in another template',
+            inject(function($compile, $templateCache, $rootScope) {
+          $templateCache.put('hello.html', '<div class="replace"></div>');
+          $rootScope.name = 'Elvis';
+          element = $compile('<div><b class="hello"></b></div>')($rootScope);
+
+          $rootScope.$digest();
+
+          expect(sortedHtml(element)).
+            toEqual('<div><b class="hello"><span class="replace">Hello, Elvis!</span></b></div>');
+        }));
 
 
         it('should resolve widgets after cloning in append mode', function() {


### PR DESCRIPTION
Passing DOMNode#childNodes to compileNodes when compiling remote
template, so that directives with replace:true can be compiled.
The previous version used jqLite#contents which returned collection
that was not updated during the compilation.

Closes #1859
