### PR TITLE
feat(batarang): expose transcluded and isolate scope info for batarang

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -420,6 +420,7 @@ function $CompileProvider($provide) {
                   (function(transcludeFn) {
                     return function(cloneFn) {
                       var transcludeScope = scope.$new();
+                      transcludeScope.$$transcluded = true;
 
                       return transcludeFn(transcludeScope, cloneFn).
                           bind('$destroy', bind(transcludeScope, transcludeScope.$destroy));
@@ -724,6 +725,8 @@ function $CompileProvider($provide) {
                 mode = match[1], // @, =, or &
                 lastValue,
                 parentGet, parentSet;
+
+            scope.$$isolateBindings[scopeName] = mode + attrName;
 
             switch (mode) {
 

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -137,6 +137,7 @@ function $RootScopeProvider(){
       this.$$destroyed = false;
       this.$$asyncQueue = [];
       this.$$listeners = {};
+      this.$$isolateBindings = {};
     }
 
     /**

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1938,6 +1938,21 @@ describe('$compile', function() {
         compile('<div><span bad-declaration>');
       }).toThrow('Invalid isolate scope definition for directive badDeclaration: xxx');
     }));
+
+    it('should expose a $$isolateBindings property onto the scope', inject(function() {
+      compile('<div><span my-component>');
+
+      expect(typeof componentScope.$$isolateBindings).toBe('object');
+
+      expect(componentScope.$$isolateBindings.attr).toBe('@attr');
+      expect(componentScope.$$isolateBindings.attrAlias).toBe('@attr');
+      expect(componentScope.$$isolateBindings.ref).toBe('=ref');
+      expect(componentScope.$$isolateBindings.refAlias).toBe('=ref');
+      expect(componentScope.$$isolateBindings.reference).toBe('=reference');
+      expect(componentScope.$$isolateBindings.expr).toBe('&expr');
+      expect(componentScope.$$isolateBindings.exprAlias).toBe('&expr');
+
+    }));
   });
 
 
@@ -2264,5 +2279,28 @@ describe('$compile', function() {
 
       expect(element.text()).toBe('-->|x|');
     }));
+
+
+    it('should add a $$transcluded property onto the transcluded scope', function() {
+      module(function() {
+        directive('trans', function() {
+          return {
+            transclude: true,
+            replace: true,
+            scope: true,
+            template: '<div><span>I:{{$$transcluded}}</span><div ng-transclude></div></div>'
+          };
+        });
+      });
+      inject(function(log, $rootScope, $compile) {
+        element = $compile('<div><div trans>T:{{$$transcluded}}</div></div>')
+            ($rootScope);
+        $rootScope.$apply();
+        expect(jqLite(element.find('span')[0]).text()).toEqual('I:');
+        expect(jqLite(element.find('span')[1]).text()).toEqual('T:true');
+      });
+    });
+
+
   });
 });


### PR DESCRIPTION
Exposes a value on the scope if the scope is transcluded, as well as a mapping from outer to inner scope matching the `scope` parameter of a directive.

This is what the current API looks like:

``` javascript
scope.$$isolateBindings = {
   innerValue: "=outerBinding"
};
```

``` javascript
scope.$$transcluded = true | false
```

I'd like some input from @IgorMinar and @mhevery on this.
