### PR TITLE
This fixes some 

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -413,7 +413,8 @@ angular.module('ngResource', ['ng']).
             }
           });
           httpConfig.data = data;
-          httpConfig.url = route.url(extend({}, extractParams(data, action.params || {}), params))
+          var ep = extractParams(data, action.params || {});
+          httpConfig.url = route.url(extend({}, ep, params));
 
           function markResolved() { value.$resolved = true; };
 


### PR DESCRIPTION
for some reason, some posts work only when you seperate the url generation into discrete steps; before I did this, this model 

``` javascript
angular.module('memberServices', ['ngResource']).factory('Members',
    function ($resource) {
        return  $resource('/member/rest/member/:_id', {_id: '@_id'},
            {
                add:    {method: 'PUT'},
                update: {method: 'POST', params: {_id: '@_id'}},
                exists: {method: 'GET'},
                get:    {method: 'GET'},
                query:  {method: 'GET', isArray: true}
            });
    });
```

would not accept the _id value of an update. 
