### PR TITLE
fix(a): Anchor with empty href causing unintended reload

### DIFF
--- a/src/ng/directive/a.js
+++ b/src/ng/directive/a.js
@@ -26,6 +26,7 @@ var htmlAnchorDirective = valueFn({
       element.bind('click', function(event){
         // if we have no href url, then don't navigate anywhere.
         if (!element.attr('href')) {
+          event.stopPropagation();
           event.preventDefault();
         }
       });


### PR DESCRIPTION
Anchor with no href shouldn't navigate anywhere, but click event bubbles to root element and location provider resolve as new route.

Closes #1225
