### PR TITLE
fix(a): Opera click event (Bootstrap DropDownToggle and so on)

### DIFF
--- a/src/ng/directive/a.js
+++ b/src/ng/directive/a.js
@@ -26,6 +26,9 @@ var htmlAnchorDirective = valueFn({
       element.bind('click', function(event){
         // if we have no href url, then don't navigate anywhere.
         if (!element.attr('href')) {
+          if (this.bubbles === false) {
+            event.stopPropagation();
+          }
           event.preventDefault();
         }
       });


### PR DESCRIPTION
Prevents Opera from incorrectly navigating on link click and fixes Bootstrap DropDown behavior.
