### PR TITLE
feat($compile): '=' binding can now be optional

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -336,7 +336,9 @@ compiler}. The attributes are:
         Given `<widget my-attr="parentModel">` and widget definition of
         `scope: { localModel:'=myAttr' }`, then widget scope property `localModel` will reflect the
         value of `parentModel` on the parent scope. Any changes to `parentModel` will be reflected
-        in `localModel` and any changes in `localModel` will reflect in `parentModel`.
+        in `localModel` and any changes in `localModel` will reflect in `parentModel`. If the parent
+        scope property doesn't exist, it will throw a NON_ASSIGNABLE_MODEL_EXPRESSION exception. You
+        can avoid this behavior using `=?` or `=?attr` in order to flag the property as optional.
 
       * `&` or `&attr` - provides a way to execute an expression in the context of the parent scope.
         If no `attr` name is specified then the attribute name is assumed to be the same as the

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -714,13 +714,14 @@ function $CompileProvider($provide) {
         $element = attrs.$$element;
 
         if (newIsolateScopeDirective) {
-          var LOCAL_REGEXP = /^\s*([@=&])\s*(\w*)\s*$/;
+          var LOCAL_REGEXP = /^\s*([@=&])(\??)\s*(\w*)\s*$/;
 
           var parentScope = scope.$parent || scope;
 
           forEach(newIsolateScopeDirective.scope, function(definiton, scopeName) {
             var match = definiton.match(LOCAL_REGEXP) || [],
-                attrName = match[2]|| scopeName,
+                attrName = match[3] || scopeName,
+                optional = (match[2] == '?'),
                 mode = match[1], // @, =, or &
                 lastValue,
                 parentGet, parentSet;
@@ -736,6 +737,9 @@ function $CompileProvider($provide) {
               }
 
               case '=': {
+                if (optional && (attrs[attrName] == null)) {
+                  return;
+                }
                 parentGet = $parse(attrs[attrName]);
                 parentSet = parentGet.assign || function() {
                   // reset the change, or we will throw this exception on every $digest


### PR DESCRIPTION
If you bind using `'='` to a non-existant parent property, the compiler will throw a `NON_ASSIGNABLE_MODEL_EXPRESSION` exception, which is right because the model doesn't exist.

This enhancement allow to specify that a binding is optional so it won't complain if the parent property is not defined. In order to keep backward compability, the new behaviour must be specified using `'=?'` instead of `'='`. The local property will be undefined is these cases.

Closes #909
Closes #1435
