### PR TITLE
Directives doc: update obsolete reference

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -376,8 +376,8 @@ compiler}. The attributes are:
     * `M` - Comment: `<!-- directive: my-directive exp -->`
 
   * `template` - replace the current element with the contents of the HTML. The replacement process
-    migrates all of the attributes / classes from the old element to the new one. See Creating
-    Widgets section below for more information.
+    migrates all of the attributes / classes from the old element to the new one. See the
+    {@link guide/directives#Components Creating Components} section below for more information.
 
   * `templateUrl` - Same as `template` but the template is loaded from the specified URL. Because
     the template loading is asynchronous the compilation/linking is suspended until the template
@@ -601,6 +601,7 @@ restrict: 'E',
 replace: true
 </pre>
 
+<a name="Components"></a>
 # Creating Components
 
 It is often desirable to replace a single directive with a more complex DOM structure. This

--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -377,7 +377,7 @@ compiler}. The attributes are:
 
   * `template` - replace the current element with the contents of the HTML. The replacement process
     migrates all of the attributes / classes from the old element to the new one. See the
-    {@link guide/directives#Components Creating Components} section below for more information.
+    {@link guide/directive#Components Creating Components} section below for more information.
 
   * `templateUrl` - Same as `template` but the template is loaded from the specified URL. Because
     the template loading is asynchronous the compilation/linking is suspended until the template


### PR DESCRIPTION
Replace an obsolete reference to a nonexistent "Creating Widgets"
section with a real link to "Creating Components".
