### PR TITLE
Route functions (no templates)

### DIFF
--- a/src/ng/directive/ngView.js
+++ b/src/ng/directive/ngView.js
@@ -157,7 +157,11 @@ var ngViewDirective = ['$http', '$templateCache', '$route', '$anchorScroll', '$c
           // $anchorScroll might listen on event...
           $anchorScroll();
         } else {
-          clearContent();
+          if ($route.current && $route.current['$route'] && $route.current['$route'].functionRoute) {
+            // don't clear content when the route is just a function
+          } else {
+            clearContent();
+          }
         }
       }
     }

--- a/src/ng/route.js
+++ b/src/ng/route.js
@@ -472,8 +472,17 @@ function $RouteProvider(){
           match.$route = route;
         }
       });
+
       // No route matched; fallback to "otherwise" route
-      return match || routes[null] && inherit(routes[null], {params: {}, pathParams:{}});
+      if (match == null) {
+        var route = routes[null];
+        match = route && inherit(route, {params: {}, pathParams:{}});
+        if (match) {
+          match.$route = route;
+        }
+      }
+
+      return match;
     }
 
     /**

--- a/test/ng/directive/ngViewSpec.js
+++ b/test/ng/directive/ngViewSpec.js
@@ -459,4 +459,23 @@ describe('ngView', function() {
       expect(div.controller()).toBe($route.current.scope.ctrl);
     });
   });
+
+  it('should not remove the previous routes content if the current route is a function', function() {
+    module(function($routeProvider) {
+      $routeProvider.when('/foo', {template: 'angular is da best'});
+      $routeProvider.when('/bar', {fn: function() {}});
+    });
+
+    inject(function($rootScope, $compile, $location, $route) {
+      expect(element.text()).toEqual('');
+
+      $location.path('/foo');
+      $rootScope.$digest();
+      expect(element.text()).toEqual('angular is da best');
+
+      $location.path('/bar');
+      $rootScope.$digest();
+      expect(element.text()).toEqual('angular is da best');
+    });
+  });
 });

--- a/test/ng/routeSpec.js
+++ b/test/ng/routeSpec.js
@@ -793,4 +793,27 @@ describe('$route', function() {
       });
     });
   });
+
+
+  describe('route functions', function() {
+    var routeFunctionSpy = jasmine.createSpy('route function spy');
+
+    function routeFunction(routePathParams) {
+      routeFunctionSpy(routePathParams);
+    }
+
+    beforeEach(module(function($routeProvider) {
+      $routeProvider.when('/foo/:id', {templateUrl: 'foo.html'});
+      $routeProvider.when('/bar/:id/:subId', {fn: routeFunction});
+    }));
+
+    it ('should allow using a function as a route', function() {
+      inject(function($route, $location, $rootScope) {
+        $location.path('/bar/id3/id4');
+        $rootScope.$digest();
+
+        expect(routeFunctionSpy).toHaveBeenCalledWith({id: 'id3', subId: 'id4'});
+      });
+    });
+  });
 });


### PR DESCRIPTION
Hi,

I've committed a change that gives us the possibility to add routes that will just evaluate a function when matched instead of rendering a template. I hope you find it useful and bring it into master as it really helped us when refactoring a project into angular and I'm surprised it something that hasn't been implemented yet (if it has, please show me how)

One could basically do something like

``` javascript
angular.module('example', [], function($routeProvider) {
  $routeProvider.when('/foo', {fn: function() {
    console.log('foo!')
  }});
  $routeProvider.when('/bar/:id', {fn: function(params) {
    console.log('bar! with params ' + params)
  }});
});
```

Regards
