### PR TITLE
fix($browser): cookiePath now defaults to '' when basePath is undefined

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -237,7 +237,7 @@ function Browser(window, document, $log, $sniffer) {
    */
   self.baseHref = function() {
     var href = baseElement.attr('href');
-    return href ? href.replace(/^https?\:\/\/[^\/]*/, '') : href;
+    return href ? href.replace(/^https?\:\/\/[^\/]*/, '') : '';
   };
 
   //////////////////////////////////////////////////////////////
@@ -245,7 +245,7 @@ function Browser(window, document, $log, $sniffer) {
   //////////////////////////////////////////////////////////////
   var lastCookies = {};
   var lastCookieString = '';
-  var cookiePath = self.baseHref() || '';
+  var cookiePath = self.baseHref();
 
   /**
    * @name ng.$browser#cookies

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -245,7 +245,7 @@ function Browser(window, document, $log, $sniffer) {
   //////////////////////////////////////////////////////////////
   var lastCookies = {};
   var lastCookieString = '';
-  var cookiePath = self.baseHref();
+  var cookiePath = self.baseHref() || '';
 
   /**
    * @name ng.$browser#cookies

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -279,6 +279,18 @@ describe('browser', function() {
       });
     });
 
+    describe('put via cookies(cookieName, string), if no <base href> ', function () {
+      beforeEach(function () {
+        fakeDocument.basePath = undefined;
+      });
+
+      it('should default path in cookie to \'\'(empty string)', function () {
+        browser.cookies('cookie', 'bender');
+        // This only fails in Safari and IE when cookiePath returns undefined
+        // Where it now succeeds since baseHref return '' instead of undefined         
+        expect(document.cookie).toEqual('cookie=bender');
+      });
+    });
 
     describe('get via cookies()[cookieName]', function() {
 
@@ -555,9 +567,9 @@ describe('browser', function() {
       expect(browser.baseHref()).toEqual('/base/path/');
     });
 
-    it('should return undefined if no <base href>', function() {
+    it('should return \'\' (empty string) if no <base href>', function() {
       fakeDocument.basePath = undefined;
-      expect(browser.baseHref()).toBeUndefined();
+      expect(browser.baseHref()).toEqual('');
     });
 
     it('should remove domain from <base href>', function() {


### PR DESCRIPTION
As described in issue https://github.com/angular/angular.js/issues/1191 Safari and IE fails if the cookiePath is undefined.
