### PR TITLE
Tighten up a few spots to run on SES

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -49,8 +49,7 @@ if ('i' !== 'I'.toLowerCase()) {
 function fromCharCode(code) {return String.fromCharCode(code);}
 
 
-var Error             = window.Error,
-    /** holds major version number for IE or NaN for real browsers */
+var /** holds major version number for IE or NaN for real browsers */
     msie              = int((/msie (\d+)/.exec(lowercase(navigator.userAgent)) || [])[1]),
     jqLite,           // delay binding since jQuery could be loaded after us.
     jQuery,           // delay binding

--- a/test/ngSanitize/directive/ngBindHtmlSpec.js
+++ b/test/ngSanitize/directive/ngBindHtmlSpec.js
@@ -2,7 +2,7 @@ describe('ngBindHtml', function() {
   beforeEach(module('ngSanitize'));
 
   it('should set html', inject(function($rootScope, $compile) {
-    element = $compile('<div ng-bind-html="html"></div>')($rootScope);
+    var element = $compile('<div ng-bind-html="html"></div>')($rootScope);
     $rootScope.html = '<div unknown>hello</div>';
     $rootScope.$digest();
     expect(angular.lowercase(element.html())).toEqual('<div>hello</div>');
@@ -10,7 +10,7 @@ describe('ngBindHtml', function() {
 
 
   it('should reset html when value is null or undefined', inject(function($compile, $rootScope) {
-    element = $compile('<div ng-bind-html="html"></div>')($rootScope);
+    var element = $compile('<div ng-bind-html="html"></div>')($rootScope);
 
     angular.forEach([null, undefined, ''], function(val) {
       $rootScope.html = 'some val';


### PR DESCRIPTION
window.Error is a read-only property under Caja, so assigning to it fails.  Igor also says it was hurting after gzip.

Assigning to undeclared globals is prohibited in Caja (and ES5 strict mode) so I added "var"s at the beginning of some "element = ..." statements.
