### PR TITLE
fix(filter:date) Timezone formatting issues.

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -211,8 +211,12 @@ function dateStrGetter(name, shortForm) {
 }
 
 function timeZoneGetter(date) {
-  var offset = date.getTimezoneOffset();
-  return padNumber(offset / 60, 2) + padNumber(Math.abs(offset % 60), 2);
+  var zone = -1 * date.getTimezoneOffset();
+  var paddedZone = (zone >= 0) ? "+" : "";
+
+  paddedZone += padNumber(zone / 60, 2) + padNumber(Math.abs(zone % 60), 2);
+
+  return paddedZone;
 }
 
 function ampmGetter(date, formats) {
@@ -319,7 +323,7 @@ var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+
          expect(binding("1288323623006 | date:'medium'")).
             toMatch(/Oct 2\d, 2010 \d{1,2}:\d{2}:\d{2} (AM|PM)/);
          expect(binding("1288323623006 | date:'yyyy-MM-dd HH:mm:ss Z'")).
-            toMatch(/2010\-10\-2\d \d{2}:\d{2}:\d{2} \-?\d{4}/);
+            toMatch(/2010\-10\-2\d \d{2}:\d{2}:\d{2} (\-|\+)?\d{4}/);
          expect(binding("'1288323623006' | date:'MM/dd/yyyy @ h:mma'")).
             toMatch(/10\/2\d\/2010 @ \d{1,2}:\d{2}(AM|PM)/);
        });

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -193,13 +193,13 @@ describe('filters', function() {
                       toEqual('10-09-03 07:05:08');
 
       expect(date(midnight, "yyyy-M-d h=H:m:saZ")).
-                      toEqual('2010-9-3 12=0:5:8AM0500');
+                      toEqual('2010-9-3 12=0:5:8AM-0500');
 
       expect(date(midnight, "yyyy-MM-dd hh=HH:mm:ssaZ")).
-                      toEqual('2010-09-03 12=00:05:08AM0500');
+                      toEqual('2010-09-03 12=00:05:08AM-0500');
 
       expect(date(noon, "yyyy-MM-dd hh=HH:mm:ssaZ")).
-                      toEqual('2010-09-03 12=12:05:08PM0500');
+                      toEqual('2010-09-03 12=12:05:08PM-0500');
 
       expect(date(noon, "EEE, MMM d, yyyy")).
                       toEqual('Fri, Sep 3, 2010');
@@ -211,14 +211,30 @@ describe('filters', function() {
                       toEqual('September 03, 1');
     });
 
+    it('should format timezones correctly (as per ISO_8601)', function() {
+      //Note: TzDate's first argument is offset, _not_ timezone.
+      var utc       = new angular.mock.TzDate( 0, '2010-09-03T12:05:08.000Z');
+      var eastOfUTC = new angular.mock.TzDate(-5, '2010-09-03T12:05:08.000Z');
+      var westOfUTC = new angular.mock.TzDate(+5, '2010-09-03T12:05:08.000Z');
+
+      expect(date(utc, "yyyy-MM-ddTHH:mm:ssZ")).
+                    toEqual('2010-09-03T12:05:08+0000')
+
+      expect(date(eastOfUTC, "yyyy-MM-ddTHH:mm:ssZ")).
+                    toEqual('2010-09-03T17:05:08+0500')
+
+      expect(date(westOfUTC, "yyyy-MM-ddTHH:mm:ssZ")).
+                    toEqual('2010-09-03T07:05:08-0500')
+    });
+
     it('should treat single quoted strings as string literals', function() {
       expect(date(midnight, "yyyy'de' 'a'x'dd' 'adZ' h=H:m:saZ")).
-                      toEqual('2010de axdd adZ 12=0:5:8AM0500');
+                      toEqual('2010de axdd adZ 12=0:5:8AM-0500');
     });
 
     it('should treat a sequence of two single quotes as a literal single quote', function() {
       expect(date(midnight, "yyyy'de' 'a''dd' 'adZ' h=H:m:saZ")).
-                      toEqual("2010de a'dd adZ 12=0:5:8AM0500");
+                      toEqual("2010de a'dd adZ 12=0:5:8AM-0500");
     });
 
     it('should accept default formats', function() {


### PR DESCRIPTION
This commit fixes #1261 and #1532. This covers two separate issues:
- Positive timezones were being formatted without a leading `+` resulting in a formatting string like: "HH:MM:ssZ" giving "12:13:141000" instead of "12:13:14+1000". Fixed by checking if timezone is > 0 and adding a leading "+".
- Timezone output signs were inverted. mock.TzDate expects the timezone _offset_ as it's first argument, _not_ the timezone. This means that a mock.TzDate with a positive offset should result in a date string with a negative timezone,
  and vice-versa.

I've tried to stick to the style as much as possible. I have one question about this commit though: [ISO_8601](http://en.wikipedia.org/wiki/ISO_8601) states:

> An offset of zero, in addition to having the special representation "Z", can also be stated numerically as "+00:00", "+0000", or "+00". However, it is not permitted to state it numerically with a negative sign, as "-00:00", "-0000", or "-00".

I have chosen that a UTC/0 offset timezone is represented with a Z, like: "12:13:14Z" as that seems to be more normal. Is that okay, or would "12:13:14+0000" be better for some reason?

**I have signed the CLA, I am Philip Roberts from Scotland :smile:**
