### PR TITLE
fix for #1929 to provide a hook so controllers can override the service instances injected into their children via a $$scopeInjections property on the $scope

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -790,6 +790,18 @@ function $CompileProvider($provide) {
               $transclude: boundTranscludeFn
             };
 
+            // Lets allow a child scope to provide its own local implementations of services
+            // which are used in preference to the global services in the cache.
+            //
+            // This behavior is only enabled if the $scope has a $$scopeInjections object
+            // containing the local services to use in preference when injecting the controller.
+            if (scope && scope.$$scopeInjections) {
+              forEach(scope.$$scopeInjections, function (value, key) {
+                if (!locals.hasOwnProperty(key)) {
+                  locals[key] = value;
+                }
+              });
+            }
             controller = directive.controller;
             if (controller == '@') {
               controller = attrs[directive.name];


### PR DESCRIPTION
...ontroller to override injection values on its child controllers created via ng-include or explicit template compilation
