### PR TITLE
Crash fix with <object> in DOM

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -380,7 +380,7 @@ function $CompileProvider($provide) {
             ? applyDirectivesToNode(directives, nodeList[i], attrs, transcludeFn, $rootElement)
             : null;
 
-        childLinkFn = (nodeLinkFn && nodeLinkFn.terminal || !nodeList[i].childNodes.length)
+        childLinkFn = (nodeLinkFn && nodeLinkFn.terminal || !nodeList[i].childNodes || !nodeList[i].childNodes.length)
             ? null
             : compileNodes(nodeList[i].childNodes,
                  nodeLinkFn ? nodeLinkFn.transclude : transcludeFn);


### PR DESCRIPTION
When <object> elements in the DOM are bound to browser plugins, the properties of this DOM element are defined by the plugin and thus the attribute childNode may not exist.

Without this fix, angular crashes when it encounters an element without the childNodes property.
