### PR TITLE
fix(forEach): refined treatment of objects with numeric length property

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -101,13 +101,15 @@ function forEach(obj, iterator, context) {
       }
     } else if (obj.forEach && obj.forEach !== forEach) {
       obj.forEach(iterator, context);
-    } else if (isObject(obj) && isNumber(obj.length)) {
+    } else if (isArrayLike(obj)) {
       for (key = 0; key < obj.length; key++)
         iterator.call(context, obj[key], key);
     } else {
-      for (key in obj) {
-        if (obj.hasOwnProperty(key)) {
-          iterator.call(context, obj[key], key);
+      if(obj.hasOwnProperty) {
+        for (key in obj) {
+          if (obj.hasOwnProperty(key)) {
+            iterator.call(context, obj[key], key);
+          }
         }
       }
     }
@@ -348,6 +350,18 @@ function isArray(value) {
   return toString.apply(value) == '[object Array]';
 }
 
+function isArrayLike(obj) {
+  var length = obj.length;
+  if (isWindow(obj)) {
+    return false;
+  }
+  return isArray(obj) ||
+    (
+      isObject(obj) && 
+      isNumber(length) && 
+      (length === 0 || length > 0 && (length - 1) in obj)
+    );
+}
 
 /**
  * @ngdoc function

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -267,6 +267,64 @@ describe('angular', function() {
 
       expect(log).toEqual(['bar:barVal', 'baz:bazVal']);
     });
+
+    it('should iterate identify and iterate array like objects', function() {
+      var log;
+
+      log = [];
+      forEach(
+          [1,2,3], 
+          function(value, key) { log.push(key + ':' + value) }
+      );
+      expect(log).toEqual(['0:1', '1:2', '2:3']);
+
+      log = [];
+      forEach(
+          {
+            'bar' : 'bar',
+            'length': 2
+          }, 
+          function(value, key) { log.push(key + ':' + value) }
+      );
+      expect(log).toEqual(['bar:bar', 'length:2']);
+      
+      log = [];
+      forEach(
+          jqLite("<p><span>s1</span><span>s2</span></p>").find("span"), 
+          function(value, key) { log.push(key + ':' + value.innerHTML) }
+      );
+      expect(log).toEqual(['0:s1', '1:s2']);
+
+      log = [];
+      forEach(
+          jqLite("<p><span>s1</span><span>s2</span></p>").find("b"), 
+          function(value, key) { log.push(key + ':' + value.innerHTML); }
+      );
+      expect(log.length).toBe(0);
+      
+      log = [];
+      forEach(
+          document.getElementsByTagName("x"), 
+          function(value, key) { log.push(true) }
+      );
+      expect(log.length).toBe(0);
+      
+      log = [];
+      forEach(
+          window, 
+          function(value, key) { log.push(true) }
+      );
+      expect(log.length).toBeGreaterThan(0);
+
+      //a plain old object with length property with 0 value is treated like an array
+      log = [];
+      forEach(
+          {"prop1":"value1","length":0}, 
+          function(value, key) { log.push(true) }
+      );
+      expect(log.length).toBe(0);
+
+    });
   });
 
 


### PR DESCRIPTION
fixes #1840
to iterate the object like an array, it must verify one of these rules:
- it comes from jquery so it must have at least a context property
- every other property is a number between 0 and the value of
  length property
