### PR TITLE
fix($compile): rename $compileNote to compileNode

### DIFF
--- a/docs/content/misc/contribute.ngdoc
+++ b/docs/content/misc/contribute.ngdoc
@@ -222,7 +222,8 @@ To run the E2E test suite:
 
 To create and submit a change:
 
-1. Please sign our Contributor License Agreement (CLA) before sending pull requests. For any code changes to be
+1. <a name="CLA"></a>
+   Please sign our Contributor License Agreement (CLA) before sending pull requests. For any code changes to be
    accepted, the CLA must be signed. It's a quick process, we promise!
 
    For individuals we have a [simple click-through form](http://code.google.com/legal/individual-cla-v1.0.html). For

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -938,7 +938,7 @@ function $CompileProvider($provide) {
           }
 
           directives.unshift(derivedSyncDirective);
-          afterTemplateNodeLinkFn = applyDirectivesToNode(directives, $compileNode, tAttrs, childTranscludeFn);
+          afterTemplateNodeLinkFn = applyDirectivesToNode(directives, compileNode, tAttrs, childTranscludeFn);
           afterTemplateChildLinkFn = compileNodes($compileNode.contents(), childTranscludeFn);
 
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1538,6 +1538,25 @@ describe('$compile', function() {
         expect(element.text()).toEqual('WORKS');
       });
     });
+
+    it('should support $observe inside link function on directive object', function() {
+      module(function() {
+        directive('testLink', valueFn({
+          templateUrl: 'test-link.html',
+          link: function(scope, element, attrs) {
+            attrs.$observe( 'testLink', function ( val ) {
+              scope.testAttr = val;
+            });
+          }
+        }));
+      });
+      inject(function($compile, $rootScope, $templateCache) {
+        $templateCache.put('test-link.html', '{{testAttr}}' );
+        element = $compile('<div test-link="{{1+2}}"></div>')($rootScope);
+        $rootScope.$apply();
+        expect(element.text()).toBe('3');
+      });
+    });
   });
 
 


### PR DESCRIPTION
Directives was observing different instances of Attributes than the one that interpolation was registered with.

Closes #1941
