### PR TITLE
JQLite.ready() now checks if document already is ready when first called

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -327,9 +327,14 @@ var JQLitePrototype = JQLite.prototype = {
       fn();
     }
 
-    this.bind('DOMContentLoaded', trigger); // works for modern browsers and IE9
-    // we can not use jqLite since we are not done loading and jQuery could be loaded later.
-    JQLite(window).bind('load', trigger); // fallback to window.onload for others
+    // check if document already is loaded
+    if (document.readyState === 'complete'){
+      setTimeout(trigger);
+    } else {
+      this.bind('DOMContentLoaded', trigger); // works for modern browsers and IE9
+      // we can not use jqLite since we are not done loading and jQuery could be loaded later.
+      JQLite(window).bind('load', trigger); // fallback to window.onload for others
+    }
   },
   toString: function() {
     var value = [];


### PR DESCRIPTION
If you call angular.element(document).ready(...) after the dom is ready, nothing happens. This patch will check the state of the document when ready() is called. 

This solution is based on the jQuery.ready() function (https://github.com/jquery/jquery/blob/master/src/core.js#L775)
