### PR TITLE
In filters, use isArray instead of instanceof

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -82,7 +82,7 @@
  */
 function filterFilter() {
   return function(array, expression) {
-    if (!(array instanceof Array)) return array;
+    if (!(isArray(array))) return array;
     var predicates = [];
     predicates.check = function(value) {
       for (var j = 0; j < predicates.length; j++) {

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -89,7 +89,7 @@
 orderByFilter.$inject = ['$parse'];
 function orderByFilter($parse){
   return function(array, sortPredicate, reverseOrder) {
-    if (!(array instanceof Array)) return array;
+    if (!(isArray(array))) return array;
     if (!sortPredicate) return array;
     sortPredicate = isArray(sortPredicate) ? sortPredicate: [sortPredicate];
     sortPredicate = map(sortPredicate, function(predicate){


### PR DESCRIPTION
Use the built-in isArray instead of "instanceof Array". 
In the **node-webkit** framework, arrays may be created in the Node.js context, and for those arrays "instanceof Array" will return false, because the Array object of the browser context is a different reference. Using "Array.isArray" or the AngularJS function isArray fixes the problem.
