### PR TITLE
fix(jqLite): IE8 no longer replaces link text content with mailto value

### DIFF
--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -406,6 +406,35 @@ describe('jqLite', function() {
       expect(elm.attr('readOnly')).toBeUndefined();
       expect(elm.attr('disabled')).toBeUndefined();
     });
+
+    it('should prevent IE for changing text content when setting attribute', function(){
+      var unchanged = true,
+          values = ["http:/","http://","https://","ftp://","mailto:","mailto","@","a@b"],
+          contents = [
+            "text with @arroba starting word",
+            "text with @ arroba starting word",
+            "text with @",
+            "text with (space at end) @ ",
+            "@ empty before",
+            " @ space before",
+            "- @ dash before",
+            "\n @ line feed before"
+          ];
+
+          function testValueWithTextContent(value, textContent){
+            var link = angular.element("<a>" + textContent + "</a>")
+                linkText = link.text();
+            link.attr("href", value);
+            unchanged = unchanged && (linkText == link.text());
+          }
+
+      forEach(values, function (value) {
+        forEach(contents, function (content) {
+          testValueWithTextContent(value, content);
+        });
+      });
+      expect(unchanged).toBe(true);
+    });
   });
 
 


### PR DESCRIPTION
fixes #1949

IE bug: http://webbugtrack.blogspot.com.es/2008/07/bug-140-changing-mailto-links-error-in.html

Only happens when the link has only text nodes. To prevent IE from replacing the text content, the text nodes must be detached before setting the href value and reattached afterwards.

I tried to make a unit test, but I'm not able to reproduce the bug inside the test. I tried something like:

``` javascript
var link = angular.element('<a href="">text</a>');
link.attr("href", "mailto:name@domain.com");
expect(link.text()).toBe("text");
```

but with this the test doesn't fail before applying the change.
