### PR TITLE
docs($resource): fix bad indentation producing a code block

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -170,9 +170,9 @@
      });
    </pre>
  *
- *     It's worth noting that the success callback for `get`, `query` and other method gets passed
- *     in the response that came from the server as well as $http header getter function, so one
- *     could rewrite the above example and get access to http headers as:
+ * It's worth noting that the success callback for `get`, `query` and other method gets passed
+ * in the response that came from the server as well as $http header getter function, so one
+ * could rewrite the above example and get access to http headers as:
  *
    <pre>
      var User = $resource('/user/:userId', {userId:'@id'});


### PR DESCRIPTION
Fix bad indentation producing a code block on the api/ngResource page: http://docs.angularjs.org/api/ngResource.$resource

I signed the CLA (Cédric Soulas)
