### PR TITLE
fix(numberFilter): fix formatting when "0" passed as fractionSize

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -168,7 +168,7 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
       fraction += '0';
     }
 
-    if (fractionSize) formatedText += decimalSep + fraction.substr(0, fractionSize);
+    if (fractionSize && fractionSize !== "0") formatedText += decimalSep + fraction.substr(0, fractionSize);
   }
 
   parts.push(isNegative ? pattern.negPre : pattern.posPre);

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -71,6 +71,17 @@ describe('filters', function() {
       var num = formatNumber(123.1116, pattern, ',', '.');
       expect(num).toBe('123.112');
     });
+
+		it('should format the same with string as well as numeric fractionSize', function(){
+			var num = formatNumber(123.1, pattern, ',', '.', "0");
+      expect(num).toBe('123');
+			var num = formatNumber(123.1, pattern, ',', '.', 0);
+      expect(num).toBe('123');
+			var num = formatNumber(123.1, pattern, ',', '.', "3");
+      expect(num).toBe('123.100');
+			var num = formatNumber(123.1, pattern, ',', '.', 3);
+      expect(num).toBe('123.100');
+		});
   });
 
   describe('currency', function() {


### PR DESCRIPTION
When checking to add decimal and trialing 0s number filter checks trueness of fractionSize. "0" evaluating to true causes "123" to return "123."
