### PR TITLE
fix($eval): simple assignments (without . or []) should overwrite closest definition...

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -659,16 +659,30 @@ function parser(text, json, $filter, csp){
 
 function setter(obj, path, setValue) {
   var element = path.split('.');
-  for (var i = 0; element.length > 1; i++) {
-    var key = element.shift();
-    var propertyObj = obj[key];
-    if (!propertyObj) {
-      propertyObj = {};
-      obj[key] = propertyObj;
+
+  var isIsolate = obj.hasOwnProperty('$root');
+
+  if(element.length === 1 && !isIsolate) {
+    // Simple assignments (without . or []) should overwrite closest definition in parent chain
+    var key = element[0];
+    var target = obj;
+    while(target && !target.hasOwnProperty(key)) {
+      target = target.$parent;
     }
-    obj = propertyObj;
+    (target || obj)[key] = setValue;
+
+  } else {
+    for (var i = 0; element.length > 1; i++) {
+      var key = element.shift();
+      var propertyObj = obj[key];
+      if (!propertyObj) {
+        propertyObj = {};
+        obj[key] = propertyObj;
+      }
+      obj = propertyObj;
+    }
+    obj[element.shift()] = setValue;
   }
-  obj[element.shift()] = setValue;
   return setValue;
 }
 

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -663,12 +663,15 @@ function setter(obj, path, setValue) {
   var isIsolate = obj.hasOwnProperty('$root');
 
   if(element.length === 1 && !isIsolate) {
-    // Simple assignments (without . or []) should overwrite closest definition in parent chain
+    // Simple assignment (no "." on LHS of assignment)
     var key = element[0];
     var target = obj;
+    // Find closest definition of variable in current or ancestor scope.
     while(target && !target.hasOwnProperty(key)) {
       target = target.$parent;
     }
+    // If definition exists, override it in the scope that declares it.
+    // Otherwise define the variable on the current scope.
     (target || obj)[key] = setValue;
 
   } else {

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -286,6 +286,31 @@ describe('parser', function() {
         expect(scope.b).toEqual(234);
       });
 
+      it('simple assignments (without . or []) should overwrite closest definition in parent chain', function() {
+        var child = scope.$new();
+        scope.a = 12;
+        child.$eval("a=13");
+        expect(scope.a).toEqual(13);
+
+        child.$eval("b=13");
+        expect(child.b).toEqual(13);
+        expect(scope.b).toBe(undefined);
+
+        // child already defines b above.
+        scope.b = 12;
+        child.$eval("b=13");
+        expect(scope.b).toEqual(12);
+        expect(child.b).toEqual(13);
+      });
+
+      it('simple assignments in isolate should not overwrite parent scope', function() {
+        var child = scope.$new(true);
+        scope.a = 12;
+        child.$eval("a=13");
+        expect(scope.a).toEqual(12);
+        expect(child.a).toEqual(13);
+      });
+
       it('should evaluate function call without arguments', function() {
         scope['const'] =  function(a,b){return 123;};
         expect(scope.$eval("const()")).toEqual(123);


### PR DESCRIPTION
... in parent scope chain. If no such definition exists, "declare" the variable on the current scope.

This PR makes angular scope work more like expected (more like ruby / coffeescript). I've taken care to check if scope is an isolate.

It feels a little wrong to put scope-specific functionality ($parent and $root) in parse.js, but when you think about it, parse has to have a concept of scope in order to provide $eval.

On a not unrelated note, as I try to wrap my head around angular, I've been using this model of angular world: 
- A directive with an isolate is like a js library function defined in its own file. It's scope is lexically isolated. 
- Transclusions are like closures passed to a library function (directive): when called/wrapped inside the library function a closure is bound to its "native" scope. 

Feedback wanted, as always.
