### PR TITLE
Changes to the Rakefile to help new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Running Tests
 -------------
 Running tests requires installation of [Testacular](http://vojtajina.github.com/testacular):
 
-    sudo npm install -g testacular
+    sudo npm install testacular
 
 To execute all unit tests, use:
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ Building AngularJS
 
 Running Tests
 -------------
-Running tests requires installation of [Testacular](http://vojtajina.github.com/testacular):
-
-    sudo npm install testacular
-
 To execute all unit tests, use:
 
     rake test:unit

--- a/Rakefile
+++ b/Rakefile
@@ -94,6 +94,10 @@ task :concat => :init do
   end
 end
 
+desc 'Fetch dependencies'
+task :deps do
+  %x(npm install)
+end
 
 desc 'Minify JavaScript'
 task :minify => [:init, :concat, :concat_scenario] do
@@ -150,7 +154,7 @@ end
 
 
 desc 'Create angular distribution'
-task :package => [:clean, :minify, :version, :docs] do
+task :package => [:deps, :clean, :minify, :version, :docs] do
   zip_dir = "angular-#{NG_VERSION.full}"
   zip_file = "#{zip_dir}.zip"
 
@@ -185,7 +189,7 @@ end
 namespace :test do
 
   desc 'Run all unit tests (single run)'
-  task :unit, :browsers, :misc_options do |t, args|
+  task :unit, [:browsers, :misc_options] => [:deps] do |t, args|
     [ 'test:jqlite',
       'test:jquery',
       'test:modules'


### PR DESCRIPTION
Hey, I made `rake` responsible for installing the npm dependencies, which allows the `test:unit` and `package` tasks to depend on it. This cuts down a little on the documentation and ensures that people who just skip the "setting up your system" document like I did will still be able to package angular and run the tests.
