### PR TITLE
Quick quote style fix in directive doc.

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -95,7 +95,7 @@ Compilation of HTML happens in three phases:
   var $compile = ...; // injected into your code
   var scope = ...;
 
-  var html = '<div ng-bind='exp'></div>';
+  var html = '<div ng-bind="exp"></div>';
 
   // Step 1: parse HTML into DOM element
   var template = angular.element(html);


### PR DESCRIPTION
Using double quotes to maintain consistency with other HTML in the documentation.
