### PR TITLE
support for input type date and time - #1650

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -657,6 +657,12 @@ function urlInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 
 function dateInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   textInputType(scope, element, attr, ctrl, $sniffer, $browser);
+  
+  // as the input event doesn't trigger from the calendar dialog in chrome,
+  // we add a binding to the change event
+  element.bind('change', function() {
+  	element.triggerHandler('input');
+  });
 
   var dateValidator = function(value) {
     if (isEmpty(value) || DATE_REGEXP.test(value)) {

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -4,6 +4,7 @@ var URL_REGEXP = /^(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\
 var EMAIL_REGEXP = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$/;
 var NUMBER_REGEXP = /^\s*(\-|\+)?(\d+|(\d*(\.\d*)))\s*$/;
 var DATE_REGEXP = /^\d{4}[\/\-](0?[1-9]|1[012])[\/\-](0?[1-9]|[12][0-9]|3[01])$/;
+var TIME_REGEXP = /^([0-2]\d)(:)([0-5]\d)(:)?([0-5]\d)?(\.\d+)?$/;
 
 var inputType = {
 
@@ -289,6 +290,74 @@ var inputType = {
       </doc:example>
    */
   'date': dateInputType,
+  
+  
+  /**
+   * @ngdoc inputType
+   * @name ng.directive:input.time
+   *
+   * @description
+   * Text input with time validation. Sets the `time` validation error key if the content is not a
+   * valid time.
+   *
+   * @param {string} ngModel Assignable angular expression to data-bind to.
+   * @param {string=} name Property name of the form under which the control is published.
+   * @param {string=} required Sets `required` validation error key if the value is not entered.
+   * @param {string=} ngRequired Adds `required` attribute and `required` validation constraint to
+   *    the element when the ngRequired expression evaluates to true. Use `ngRequired` instead of
+   *    `required` when you want to data-bind to the `required` attribute.
+   * @param {number=} ngMinlength Sets `minlength` validation error key if the value is shorter than
+   *    minlength.
+   * @param {number=} ngMaxlength Sets `maxlength` validation error key if the value is longer than
+   *    maxlength.
+   * @param {string=} ngPattern Sets `pattern` validation error key if the value does not match the
+   *    RegExp pattern expression. Expected value is `/regexp/` for inline patterns or `regexp` for
+   *    patterns defined as scope expressions.
+   * @param {string=} ngChange Angular expression to be executed when input changes due to user
+   *    interaction with the input element.
+   *
+   * @example
+      <doc:example>
+        <doc:source>
+         <script>
+           function Ctrl($scope) {
+             $scope.text = '2012-08-14';
+           }
+         </script>
+         <form name="myForm" ng-controller="Ctrl">
+           Time: <input type="time" name="input" ng-model="text" required>
+           <span class="error" ng-show="myForm.input.$error.required">
+             Required!</span>
+           <span class="error" ng-show="myForm.input.$error.time">
+             Not valid time!</span>
+           <tt>text = {{text}}</tt><br/>
+           <tt>myForm.input.$valid = {{myForm.input.$valid}}</tt><br/>
+           <tt>myForm.input.$error = {{myForm.input.$error}}</tt><br/>
+           <tt>myForm.$valid = {{myForm.$valid}}</tt><br/>
+           <tt>myForm.$error.required = {{!!myForm.$error.required}}</tt><br/>
+           <tt>myForm.$error.time = {{!!myForm.$error.time}}</tt><br/>
+          </form>
+        </doc:source>
+        <doc:scenario>
+          it('should initialize to model', function() {
+            expect(binding('text')).toEqual('http://google.com');
+            expect(binding('myForm.input.$valid')).toEqual('true');
+          });
+
+          it('should be invalid if empty', function() {
+            input('text').enter('');
+            expect(binding('text')).toEqual('');
+            expect(binding('myForm.input.$valid')).toEqual('false');
+          });
+
+          it('should be invalid if not time', function() {
+            input('text').enter('xxx');
+            expect(binding('myForm.input.$valid')).toEqual('false');
+          });
+        </doc:scenario>
+      </doc:example>
+   */
+  'time': timeInputType,
   
 
   /**
@@ -697,6 +766,55 @@ function dateInputType(scope, element, attr, ctrl, $sniffer, $browser) {
     var max = Date.parse(attr.max);
     var maxValidator = function(value) {
       if (!isEmpty(value) && Date.parse(value) > max) {
+        ctrl.$setValidity('max', false);
+        return undefined;
+      } else {
+        ctrl.$setValidity('max', true);
+        return value;
+      }
+    };
+
+    ctrl.$parsers.push(maxValidator);
+    ctrl.$formatters.push(maxValidator);
+  }
+}
+
+function timeInputType(scope, element, attr, ctrl, $sniffer, $browser) {
+  textInputType(scope, element, attr, ctrl, $sniffer, $browser);
+  
+  var timeValidator = function(value) {
+    if (isEmpty(value) || TIME_REGEXP.test(value)) {
+      ctrl.$setValidity('time', true);
+      return value === '' ? null : value;
+    } else {
+      ctrl.$setValidity('time', false);
+      return undefined;
+    }
+  };
+
+  ctrl.$formatters.push(timeValidator);
+  ctrl.$parsers.push(timeValidator);
+  
+  if (attr.min) {
+    var min = Date.parse('2000-01-01T'+attr.min);
+    var minValidator = function(value) {
+      if (!isEmpty(value) && Date.parse('2000-01-01T'+value) < min) {
+        ctrl.$setValidity('min', false);
+        return undefined;
+      } else {
+        ctrl.$setValidity('min', true);
+        return value;
+      }
+    };
+
+    ctrl.$parsers.push(minValidator);
+    ctrl.$formatters.push(minValidator);
+  }
+  
+  if (attr.max) {
+    var max = Date.parse('2000-01-01T'+attr.max);
+    var maxValidator = function(value) {
+      if (!isEmpty(value) && Date.parse('2000-01-01T'+value) > max) {
         ctrl.$setValidity('max', false);
         return undefined;
       } else {

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -253,38 +253,39 @@ var inputType = {
         <doc:source>
          <script>
            function Ctrl($scope) {
-             $scope.text = '2012-08-14';
+             $scope.value = '2012-08-14';
            }
          </script>
          <form name="myForm" ng-controller="Ctrl">
-           Date: <input type="date" name="input" ng-model="text" required>
-           <span class="error" ng-show="myForm.input.$error.required">
+           Date: <input type="date" name="input" ng-model="value"
+                          min="2012-08-01" max="2012-08-31" required>
+           <span class="error" ng-show="myForm.list.$error.required">
              Required!</span>
-           <span class="error" ng-show="myForm.input.$error.date">
+           <span class="error" ng-show="myForm.list.$error.date">
              Not valid date!</span>
-           <tt>text = {{text}}</tt><br/>
+           <tt>value = {{value}}</tt><br/>
            <tt>myForm.input.$valid = {{myForm.input.$valid}}</tt><br/>
            <tt>myForm.input.$error = {{myForm.input.$error}}</tt><br/>
            <tt>myForm.$valid = {{myForm.$valid}}</tt><br/>
            <tt>myForm.$error.required = {{!!myForm.$error.required}}</tt><br/>
-           <tt>myForm.$error.date = {{!!myForm.$error.date}}</tt><br/>
           </form>
         </doc:source>
         <doc:scenario>
           it('should initialize to model', function() {
-            expect(binding('text')).toEqual('http://google.com');
-            expect(binding('myForm.input.$valid')).toEqual('true');
+           expect(binding('value')).toEqual('2012-08-14');
+           expect(binding('myForm.input.$valid')).toEqual('true');
           });
 
           it('should be invalid if empty', function() {
-            input('text').enter('');
-            expect(binding('text')).toEqual('');
-            expect(binding('myForm.input.$valid')).toEqual('false');
+           input('value').enter('');
+           expect(binding('value')).toEqual('');
+           expect(binding('myForm.input.$valid')).toEqual('false');
           });
 
-          it('should be invalid if not date', function() {
-            input('text').enter('xxx');
-            expect(binding('myForm.input.$valid')).toEqual('false');
+          it('should be invalid if over max', function() {
+           input('value').enter('2012-09-30');
+           expect(binding('value')).toEqual('');
+           expect(binding('myForm.input.$valid')).toEqual('false');
           });
         </doc:scenario>
       </doc:example>
@@ -321,38 +322,39 @@ var inputType = {
         <doc:source>
          <script>
            function Ctrl($scope) {
-             $scope.text = '2012-08-14';
+             $scope.value = '20:00';
            }
          </script>
          <form name="myForm" ng-controller="Ctrl">
-           Time: <input type="time" name="input" ng-model="text" required>
-           <span class="error" ng-show="myForm.input.$error.required">
+           Time: <input type="time" name="input" ng-model="value"
+                          min="18:00" max="22:00" required>
+           <span class="error" ng-show="myForm.list.$error.required">
              Required!</span>
-           <span class="error" ng-show="myForm.input.$error.time">
+           <span class="error" ng-show="myForm.list.$error.time">
              Not valid time!</span>
-           <tt>text = {{text}}</tt><br/>
+           <tt>value = {{value}}</tt><br/>
            <tt>myForm.input.$valid = {{myForm.input.$valid}}</tt><br/>
            <tt>myForm.input.$error = {{myForm.input.$error}}</tt><br/>
            <tt>myForm.$valid = {{myForm.$valid}}</tt><br/>
            <tt>myForm.$error.required = {{!!myForm.$error.required}}</tt><br/>
-           <tt>myForm.$error.time = {{!!myForm.$error.time}}</tt><br/>
           </form>
         </doc:source>
         <doc:scenario>
           it('should initialize to model', function() {
-            expect(binding('text')).toEqual('http://google.com');
-            expect(binding('myForm.input.$valid')).toEqual('true');
+           expect(binding('value')).toEqual('20:00');
+           expect(binding('myForm.input.$valid')).toEqual('true');
           });
 
           it('should be invalid if empty', function() {
-            input('text').enter('');
-            expect(binding('text')).toEqual('');
-            expect(binding('myForm.input.$valid')).toEqual('false');
+           input('value').enter('');
+           expect(binding('value')).toEqual('');
+           expect(binding('myForm.input.$valid')).toEqual('false');
           });
 
-          it('should be invalid if not time', function() {
-            input('text').enter('xxx');
-            expect(binding('myForm.input.$valid')).toEqual('false');
+          it('should be invalid if over max', function() {
+           input('value').enter('23:00');
+           expect(binding('value')).toEqual('');
+           expect(binding('myForm.input.$valid')).toEqual('false');
           });
         </doc:scenario>
       </doc:example>

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -763,34 +763,6 @@ describe('input', function() {
       expect(inputElm).toBeInvalid();
     });
 
-
-    it('should render as blank if null', function() {
-      compileInput('<input type="date" ng-model="from" />');
-
-      scope.$apply(function() {
-        scope.from = null;
-      });
-
-      expect(scope.from).toBeNull();
-      expect(inputElm.val()).toEqual('');
-    });
-
-
-    it('should come up blank when no value specified', function() {
-      compileInput('<input type="date" ng-model="from" />');
-
-      scope.$digest();
-      expect(inputElm.val()).toBe('');
-
-      scope.$apply(function() {
-        scope.from = null;
-      });
-
-      expect(scope.from).toBeNull();
-      expect(inputElm.val()).toBe('');
-    });
-
-
     it('should parse empty string to null', function() {
       compileInput('<input type="date" ng-model="from" />');
 
@@ -837,6 +809,81 @@ describe('input', function() {
         changeInputValueTo('2012-02-14');
         expect(inputElm).toBeValid();
         expect(scope.value).toBe('2012-02-14');
+        expect(scope.form.alias.$error.max).toBeFalsy();
+      });
+    });
+  });
+  
+  describe('time', function() {
+
+    it('should reset the model if view is invalid', function() {
+      compileInput('<input type="time" ng-model="from"/>');
+
+      scope.$apply(function() {
+        scope.from = '11:00';
+      });
+      expect(inputElm.val()).toBe('11:00');
+
+      try {
+        // to allow non-time values, we have to change type so that
+        // the browser which have number validation will not interfere with
+        // this test. IE8 won't allow it hence the catch.
+        inputElm[0].setAttribute('type', 'text');
+      } catch (e) {}
+
+      changeInputValueTo('11X');
+      expect(inputElm.val()).toBe('11X');
+      expect(scope.from).toBeUndefined();
+      expect(inputElm).toBeInvalid();
+    });
+
+
+    it('should parse empty string to null', function() {
+      compileInput('<input type="time" ng-model="from" />');
+
+      scope.$apply(function() {
+        scope.from = '11:10';
+      });
+
+      changeInputValueTo('');
+      expect(scope.from).toBeNull();
+      expect(inputElm).toBeValid();
+    });
+
+
+    describe('min', function() {
+
+      it('should validate', function() {
+        compileInput('<input type="time" ng-model="value" name="alias" min="11:00" />');
+        scope.$digest();
+
+        changeInputValueTo('01:59');
+        expect(inputElm).toBeInvalid();
+        expect(scope.value).toBeFalsy();
+        expect(scope.form.alias.$error.min).toBeTruthy();
+
+        changeInputValueTo('11:20');
+        expect(inputElm).toBeValid();
+        expect(scope.value).toBe('11:20');
+        expect(scope.form.alias.$error.min).toBeFalsy();
+      });
+    });
+
+
+    describe('max', function() {
+
+      it('should validate', function() {
+        compileInput('<input type="time" ng-model="value" name="alias" max="11:00" />');
+        scope.$digest();
+
+        changeInputValueTo('11:20');
+        expect(inputElm).toBeInvalid();
+        expect(scope.value).toBeFalsy();
+        expect(scope.form.alias.$error.max).toBeTruthy();
+
+        changeInputValueTo('01:59');
+        expect(inputElm).toBeValid();
+        expect(scope.value).toBe('01:59');
         expect(scope.form.alias.$error.max).toBeFalsy();
       });
     });

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -740,6 +740,108 @@ describe('input', function() {
   });
 
 
+  describe('date', function() {
+
+    it('should reset the model if view is invalid', function() {
+      compileInput('<input type="date" ng-model="from"/>');
+
+      scope.$apply(function() {
+        scope.from = '2012-08-14';
+      });
+      expect(inputElm.val()).toBe('2012-08-14');
+
+      try {
+        // to allow non-date values, we have to change type so that
+        // the browser which have number validation will not interfere with
+        // this test. IE8 won't allow it hence the catch.
+        inputElm[0].setAttribute('type', 'text');
+      } catch (e) {}
+
+      changeInputValueTo('2012X');
+      expect(inputElm.val()).toBe('2012X');
+      expect(scope.from).toBeUndefined();
+      expect(inputElm).toBeInvalid();
+    });
+
+
+    it('should render as blank if null', function() {
+      compileInput('<input type="date" ng-model="from" />');
+
+      scope.$apply(function() {
+        scope.from = null;
+      });
+
+      expect(scope.from).toBeNull();
+      expect(inputElm.val()).toEqual('');
+    });
+
+
+    it('should come up blank when no value specified', function() {
+      compileInput('<input type="date" ng-model="from" />');
+
+      scope.$digest();
+      expect(inputElm.val()).toBe('');
+
+      scope.$apply(function() {
+        scope.from = null;
+      });
+
+      expect(scope.from).toBeNull();
+      expect(inputElm.val()).toBe('');
+    });
+
+
+    it('should parse empty string to null', function() {
+      compileInput('<input type="date" ng-model="from" />');
+
+      scope.$apply(function() {
+        scope.from = '2012-08-14';
+      });
+
+      changeInputValueTo('');
+      expect(scope.from).toBeNull();
+      expect(inputElm).toBeValid();
+    });
+
+
+    describe('min', function() {
+
+      it('should validate', function() {
+        compileInput('<input type="date" ng-model="value" name="alias" min="2012-01-01" />');
+        scope.$digest();
+
+        changeInputValueTo('2011-12-31');
+        expect(inputElm).toBeInvalid();
+        expect(scope.value).toBeFalsy();
+        expect(scope.form.alias.$error.min).toBeTruthy();
+
+        changeInputValueTo('2012-02-01');
+        expect(inputElm).toBeValid();
+        expect(scope.value).toBe('2012-02-01');
+        expect(scope.form.alias.$error.min).toBeFalsy();
+      });
+    });
+
+
+    describe('max', function() {
+
+      it('should validate', function() {
+        compileInput('<input type="date" ng-model="value" name="alias" max="2012-04-14" />');
+        scope.$digest();
+
+        changeInputValueTo('2012-06-14');
+        expect(inputElm).toBeInvalid();
+        expect(scope.value).toBeFalsy();
+        expect(scope.form.alias.$error.max).toBeTruthy();
+
+        changeInputValueTo('2012-02-14');
+        expect(inputElm).toBeValid();
+        expect(scope.value).toBe('2012-02-14');
+        expect(scope.form.alias.$error.max).toBeFalsy();
+      });
+    });
+  });
+
   describe('radio', function() {
 
     it('should update the model', function() {


### PR DESCRIPTION
Added support for the new html5 input types date and time. As this is my first contribution to angular.js, i basically copied and then modified the code for input type number instead of refactoring the input.js for a more generic handling of the different input types.

related issues: #1650 #757
