### PR TITLE
feat(select,ng-options): New expression (identify by) in ng-options

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -39,6 +39,8 @@
  *     * `select` **`as`** `label` **`for`** `value` **`in`** `array`
  *     * `label`  **`group by`** `group` **`for`** `value` **`in`** `array`
  *     * `select` **`as`** `label` **`group by`** `group` **`for`** `value` **`in`** `array`
+ *     * `select` **`identify by`** `ident` **`as`** `label` **`group by`** `group`
+ *         **`for`** `value` **`in`** `array`
  *   * for object data sources:
  *     * `label` **`for (`**`key` **`,`** `value`**`) in`** `object`
  *     * `select` **`as`** `label` **`for (`**`key` **`,`** `value`**`) in`** `object`
@@ -52,6 +54,9 @@
  *   * `value`: local variable which will refer to each item in the `array` or each property value
  *      of `object` during iteration.
  *   * `key`: local variable which will refer to a property name in `object` during iteration.
+ *   * `ident`: Used when working with an array of objects. The result of this expression will be
+ *      used to identify the objects in the array. The `expression` will most likely refer to the
+ *     `value` variable (e.g. `value.propertyName`).
  *   * `label`: The result of this expression will be the label for `<option>` element. The
  *     `expression` will most likely refer to the `value` variable (e.g. `value.propertyName`).
  *   * `select`: The result of this expression will be bound to the model of the parent `<select>`
@@ -122,8 +127,8 @@
 
 var ngOptionsDirective = valueFn({ terminal: true });
 var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
-                         //0000111110000000000022220000000000000000000000333300000000000000444444444444444440000000005555555555555555500000006666666666666666600000000000000077770
-  var NG_OPTIONS_REGEXP = /^\s*(.*?)(?:\s+as\s+(.*?))?(?:\s+group\s+by\s+(.*))?\s+for\s+(?:([\$\w][\$\w\d]*)|(?:\(\s*([\$\w][\$\w\d]*)\s*,\s*([\$\w][\$\w\d]*)\s*\)))\s+in\s+(.*)$/,
+                         //00001111100000000000222200000000000000000000003333000000000000044444444444444444000000000555555555555555550000000666666666666666660000000000000007777
+  var NG_OPTIONS_REGEXP = /^\s*(.*?)(?:\s+identify\s+by\s+(.*?))?(?:\s+as\s+(.*?))?(?:\s+group\s+by\s+(.*))?\s+for\s+(?:([\$\w][\$\w\d]*)|(?:\(\s*([\$\w][\$\w\d]*)\s*,\s*([\$\w][\$\w\d]*)\s*\)))\s+in\s+(.*)$/,
       nullModelCtrl = {$setViewValue: noop};
 
   return {
@@ -297,16 +302,18 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
 
         if (! (match = optionsExp.match(NG_OPTIONS_REGEXP))) {
           throw Error(
-            "Expected ngOptions in form of '_select_ (as _label_)? for (_key_,)?_value_ in _collection_'" +
+            "Expected ngOptions in form of '_select_ (identify by _ident_)? (as _label_)? for (_key_,)?_value_ in _collection_'" +
             " but got '" + optionsExp + "'.");
         }
 
-        var displayFn = $parse(match[2] || match[1]),
-            valueName = match[4] || match[6],
-            keyName = match[5],
-            groupByFn = $parse(match[3] || ''),
-            valueFn = $parse(match[2] ? match[1] : valueName),
-            valuesFn = $parse(match[7]),
+        var displayFn = $parse(match[3] || match[1]),
+            valueName = match[5] || match[7],
+            keyName = match[6],
+            ident = match[2],
+            identFn = ident ? $parse(match[2]) : null,
+            groupByFn = $parse(match[4] || ''),
+            valueFn = $parse(match[3] ? match[1] : valueName),
+            valuesFn = $parse(match[8]),
             // This is an array of array of existing option groups in DOM. We try to reuse these if possible
             // optionGroupsCache[0] is the options with no option group
             // optionGroupsCache[?][0] is the parent: either the SELECT or OPTGROUP element
@@ -347,7 +354,14 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
                   if ((optionElement = optionGroup[index].element)[0].selected) {
                     key = optionElement.val();
                     if (keyName) locals[keyName] = key;
-                    locals[valueName] = collection[key];
+                    if (identFn) {
+                      for (var identIndex = 0; identIndex < collection.length; identIndex++) {
+                        locals[valueName] = collection[identIndex];
+                        if (identFn(scope, locals) == key) break;
+                      } 
+                    } else {
+                      locals[valueName] = collection[key];
+                    }
                     value.push(valueFn(scope, locals));
                   }
                 }
@@ -359,9 +373,19 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
               } else if (key == ''){
                 value = null;
               } else {
-                locals[valueName] = collection[key];
-                if (keyName) locals[keyName] = key;
-                value = valueFn(scope, locals);
+                if (identFn) {
+                  for (var identIndex = 0; identIndex < collection.length; identIndex++) {
+                    locals[valueName] = collection[identIndex];
+                    if (identFn(scope, locals) == key) {
+                      value = valueFn(scope, locals);
+                      break;
+                    }
+                  }
+                } else {
+                  locals[valueName] = collection[key];
+                  if (keyName) locals[keyName] = key;
+                  value = valueFn(scope, locals);
+                }
               }
             }
             ctrl.$setViewValue(value);
@@ -393,7 +417,15 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
               label;
 
           if (multiple) {
-            selectedSet = new HashMap(modelValue);
+            if (identFn && isArray(modelValue)) {
+              selectedSet = new HashMap([]);
+              for (var identIndex = 0; identIndex < modelValue.length; identIndex++) {
+                locals[valueName] = modelValue[identIndex];
+                selectedSet.put(identFn(scope, locals), modelValue[identIndex]);
+              }
+            } else {
+              selectedSet = new HashMap(modelValue);
+            }
           } else if (modelValue === null || nullOption) {
             // if we are not multiselect, and we are null then we have to add the nullOption
             optionGroups[''].push({selected:modelValue === null, id:'', label:''});
@@ -409,15 +441,21 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
               optionGroupNames.push(optionGroupName);
             }
             if (multiple) {
-              selected = selectedSet.remove(valueFn(scope, locals)) != undefined;
+              selected = selectedSet.remove(identFn ? identFn(scope, locals) : valueFn(scope, locals)) != undefined;
             } else {
-              selected = modelValue === valueFn(scope, locals);
+              if (identFn) {
+                var modelCast = {};
+                modelCast[valueName] = modelValue;
+                selected = identFn(scope, modelCast) === identFn(scope, locals);
+              } else {
+                selected = modelValue === valueFn(scope, locals);
+              }
               selectedSet = selectedSet || selected; // see if at least one item is selected
             }
             label = displayFn(scope, locals); // what will be seen by the user
             label = label === undefined ? '' : label; // doing displayFn(scope, locals) || '' overwrites zero values
             optionGroup.push({
-              id: keyName ? keys[index] : index,   // either the index into array or key from object
+              id: identFn ? identFn(scope, locals) : (keyName ? keys[index] : index),   // either the index into array or key from object
               label: label,
               selected: selected                   // determine if we should be selected
             });

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -494,8 +494,8 @@ describe('select', function() {
     it('should throw when not formated "? for ? in ?"', function() {
       expect(function() {
         compile('<select ng-model="selected" ng-options="i dont parse"></select>');
-      }).toThrow("Expected ngOptions in form of '_select_ (identify by _ident_)? (as _label_)? for (_key_,)?_value_ in" +
-                 " _collection_' but got 'i dont parse'.");
+      }).toThrow("Expected ngOptions in form of '_select_ (as _label_)? for (_key_,)?_value_ in" +
+                 " _collection_ (track by _expr_)?' but got 'i dont parse'.");
     });
 
 
@@ -753,10 +753,10 @@ describe('select', function() {
       });
 
 
-      it('should bind to scope value and identify objects', function() {
+      it('should bind to scope value and track/identify objects', function() {
         createSelect({
           'ng-model': 'selected',
-          'ng-options': 'item identify by item.id as item.name for item in values'
+          'ng-options': 'item as item.name for item in values track by item.id'
         });
 
         scope.$apply(function() {

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -494,7 +494,7 @@ describe('select', function() {
     it('should throw when not formated "? for ? in ?"', function() {
       expect(function() {
         compile('<select ng-model="selected" ng-options="i dont parse"></select>');
-      }).toThrow("Expected ngOptions in form of '_select_ (as _label_)? for (_key_,)?_value_ in" +
+      }).toThrow("Expected ngOptions in form of '_select_ (identify by _ident_)? (as _label_)? for (_key_,)?_value_ in" +
                  " _collection_' but got 'i dont parse'.");
     });
 
@@ -750,6 +750,37 @@ describe('select', function() {
         });
 
         expect(element.val()).toEqual('0');
+      });
+
+
+      it('should bind to scope value and identify objects', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'ng-options': 'item identify by item.id as item.name for item in values'
+        });
+
+        scope.$apply(function() {
+          scope.values = [{id: 1, name: 'first'},
+                          {id: 2, name: 'second'},
+                          {id: 3, name: 'third'},
+                          {id: 4, name: 'forth'}];
+          scope.selected = {id: 2};
+        });
+
+        expect(element.val()).toEqual('2');
+
+        var first = jqLite(element.find('option')[0]);
+        expect(first.text()).toEqual('first');
+        expect(first.attr('value')).toEqual('1');
+        var forth = jqLite(element.find('option')[3]);
+        expect(forth.text()).toEqual('forth');
+        expect(forth.attr('value')).toEqual('4');
+
+        scope.$apply(function() {
+          scope.selected = scope.values[3];
+        });
+
+        expect(element.val()).toEqual('4');
       });
 
 


### PR DESCRIPTION
Add a new expression (identify by) in ng-options.
This can be used when working with objects. Instead of objects comparing by reference
it will compare by ex. a property.

So you can write:

``` javascript
ng-options="obj identify by obj.id as obj.name for obj in objects"
```

The identify part will be used when checking for equality of objects.

Example:
If you get an json object from server with nested objects and a collection of those nested
objects you can use this to select correct object.

``` javascript
<select
    ng-model="user.building"
    ng-options="building identify by building.id as building.name 
                      for building in buildings"
    >
</select>

//scope.user comes as json from server
//scope.buildings comes as jsonarray from server
scope: {
  user: { 
      name: 'Test user', 
      building: { id: 1, name: 'Office 1', address: 'Bla bla 12', rooms: 4 } 
  }
  buildings: [
    { id: 1, name: 'Office 1', address: 'Bla bla 12', rooms: 4 }, 
    { id: 2, name: 'Office 2', address: 'Bla bla 13', rooms: 5 },
    ... 
  ]
}
```

This will correctly select building with id 1 in the select and when select is changed
it will populate the user with the building object selected.
