### PR TITLE
Allow directives to modify interpolated attributes

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1084,11 +1084,9 @@ function $CompileProvider($provide) {
         compile: valueFn(function attrInterpolateLinkFn(scope, element, attr) {
           var $$observers = (attr.$$observers || (attr.$$observers = {}));
 
-          if (name === 'class') {
-            // we need to interpolate classes again, in the case the element was replaced
-            // and therefore the two class attrs got merged - we want to interpolate the result
-            interpolateFn = $interpolate(attr[name], true);
-          }
+          // we need to interpolate again, in case the attribute has been replaced
+          // (e.g. by a directive's compile function)
+          interpolateFn = $interpolate(attr[name], true) || interpolateFn;
 
           attr[name] = interpolateFn(scope);
           ($$observers[name] || ($$observers[name] = [])).$$inter = true;
@@ -1185,7 +1183,7 @@ function directiveNormalize(name) {
  * @param {string} name Normalized element attribute name of the property to modify. The name is
  *          revers translated using the {@link ng.$compile.directive.Attributes#$attr $attr}
  *          property to the original name.
- * @param {string} value Value to set the attribute to.
+ * @param {string} value Value to set the attribute to. The value can be an interpolated string.
  */
 
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1387,6 +1387,12 @@ describe('$compile', function() {
           expect(attr.$observe('someAttr', observeSpy)).toBe(observeSpy);
         };
       });
+      directive('replaceSomeAttr', valueFn({
+        compile: function(element, attr) {
+          attr.$set('someAttr', 'bar-{{1+1}}');
+          expect(element).toBe(attr.$$element);
+        }
+      }));
     }));
 
 
@@ -1427,6 +1433,12 @@ describe('$compile', function() {
       expect(directiveAttrs.someAttr).toBe($rootScope.whatever);
     }));
 
+    it('should allow directive to replace interpolated attributes', inject(
+        function($compile, $rootScope) {
+      element = $compile('<div some-attr="foo-{{1+1}}" replace-some-attr></div>')($rootScope);
+      $rootScope.$digest();
+      expect(element.attr('some-attr')).toEqual('bar-2');
+    }));
 
     it('should call observer of non-interpolated attr through $evalAsync',
       inject(function($rootScope, $compile) {


### PR DESCRIPTION
In some case, we want a directive to be able do change the value of an interpolated attribute. It wasn't possible because the interpolate function was computed once before the compile time. I fixed this by computing again the interpolate function at link time.
