### PR TITLE
Making element() selectors jQuery compatible

### DIFF
--- a/src/ngScenario/SpecRunner.js
+++ b/src/ngScenario/SpecRunner.js
@@ -117,7 +117,7 @@ angular.scenario.SpecRunner.prototype.addFutureAction = function(name, behavior,
         angular.forEach(args, function(value, index) {
           selector = selector.replace('$' + (index + 1), value);
         });
-        var result = $document.find(selector);
+        var result = angular.element(selector);
         if (selector.match(NG)) {
           angular.forEach(['[ng-','[data-ng-','[x-ng-'], function(value, index){
             result = result.add(selector.replace(NG, value), $document);


### PR DESCRIPTION
Changing $document.find to angular.element permits more complex selectors when using jQuery. Otherwise you're limited to selecting only by ID's and element tags which is very restricting in the real life testing scenarios.

The fact that the current state of this library leaves users at mercy of selecting only by jQueryLite standards makes me think that: 
a) no real e2e tests have been done
b) people manually code id's where they shouldn't just to test
c) people use something else for e2e tests.
