### PR TITLE
Being able to override url in resource actions

### DIFF
--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -699,6 +699,19 @@ describe("resource", function() {
   });
 
   it('should support overriding url template (action specific)', function() {
+  //  no url parameter in action
+      $httpBackend.expect('GET', '/Customer/123').respond({id: 'abc'});
+      var TypeItem = $resource('/:type/:typeId', {type: 'Order'}, {
+          get: {
+              method: 'GET',
+              params: {type: 'Customer'}
+          }
+      });
+      var item = TypeItem.get({typeId: 123});
+      $httpBackend.flush();
+      expect(item).toEqualData({id: 'abc'});
+
+  //    url parameter in action, parameter ending the string
       $httpBackend.expect('GET', '/Customer/123').respond({id: 'abc'});
       var TypeItem = $resource('', {type: 'Order'}, {
           get: {
@@ -711,6 +724,7 @@ describe("resource", function() {
       $httpBackend.flush();
       expect(item).toEqualData({id: 'abc'});
 
+  //    url parameter in action, parameter not ending the string
       $httpBackend.expect('GET', '/Customer/123/pay').respond({id: 'abc'});
       var TypeItem = $resource('', {type: 'Order'}, {
           get: {

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -697,4 +697,30 @@ describe("resource", function() {
     $httpBackend.flush();
     expect(person.id).toEqual(456);
   });
+
+  it('should support overriding url template (action specific)', function() {
+      $httpBackend.expect('GET', '/Customer/123').respond({id: 'abc'});
+      var TypeItem = $resource('', {type: 'Order'}, {
+          get: {
+              method: 'GET',
+              params: {type: 'Customer'},
+              url: '/:type/:typeId'
+          }
+      });
+      var item = TypeItem.get({typeId: 123});
+      $httpBackend.flush();
+      expect(item).toEqualData({id: 'abc'});
+
+      $httpBackend.expect('GET', '/Customer/123/pay').respond({id: 'abc'});
+      var TypeItem = $resource('', {type: 'Order'}, {
+          get: {
+              method: 'GET',
+              params: {type: 'Customer'},
+              url: '/:type/:typeId/pay'
+          }
+      });
+      var item = TypeItem.get({typeId: 123});
+      $httpBackend.flush();
+      expect(item).toEqualData({id: 'abc'});
+  });
 });


### PR DESCRIPTION
A pull request already existed (https://github.com/angular/angular.js/pull/1890)
but i found out that the url set up in the action would not have their params replaced.

This is what I intent to do here:

``` javascript
      var TypeItem = $resource('', {type: 'Order'}, {
          get: {
              method: 'GET',
              params: {type: 'Customer'},
              url: '/:type/:typeId'
          }
      });
      var item = TypeItem.get({typeId: 123});
```

will call `/Customer/123`
