### PR TITLE
feat(retina): Directive ng-src supports Retina displays

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -83,6 +83,7 @@ task :concat => :init do
 
   concat_module('resource', ['src/ngResource/resource.js'])
   concat_module('cookies', ['src/ngCookies/cookies.js'])
+  concat_module('retina', ['src/ngRetina/retina.js'])
   concat_module('bootstrap', ['src/bootstrap/bootstrap.js'])
   concat_module('bootstrap-prettify', ['src/bootstrap/bootstrap-prettify.js',
                                        'src/bootstrap/google-prettify/prettify.js'],
@@ -101,6 +102,7 @@ desc 'Minify JavaScript'
 task :minify => [:init, :concat, :concat_scenario] do
   [ 'angular.js',
     'angular-cookies.js',
+    'angular-retina.js',
     'angular-loader.js',
     'angular-resource.js',
     'angular-sanitize.js',

--- a/angularFiles.js
+++ b/angularFiles.js
@@ -147,13 +147,15 @@ angularFiles = {
     'src/ngSanitize/sanitize.js',
     'src/ngSanitize/directive/ngBindHtml.js',
     'src/ngSanitize/filter/linky.js',
+    'src/ngRetina/retina.js',
     'test/matchers.js',
     'test/ngMock/*.js',
     'test/ngCookies/*.js',
     'test/ngResource/*.js',
     'test/ngSanitize/*.js',
     'test/ngSanitize/directive/*.js',
-    'test/ngSanitize/filter/*.js'
+    'test/ngSanitize/filter/*.js',
+    'test/ngRetina/*.js'
   ],
 
   'jstdPerf': [

--- a/src/ngRetina/retina.js
+++ b/src/ngRetina/retina.js
@@ -1,0 +1,109 @@
+(function(angular, undefined) {
+'use strict';
+
+/**
+ * @ngdoc overview
+ * @name ngRetina
+ * @description
+ */
+
+/*
+ * ngRetina by Jacob Rief <jacob.rief@gmail.com>
+ * 
+ * Add support for Retina displays when using element attribute "ng-src".
+ * This module overrides the built-in directive "ng-src" with one which 
+ * distinguishes between standard or high-resolution (Retina) displays.
+ */
+
+/**
+ * @ngdoc service
+ * @name ngRetina
+ * @function
+ *
+ * @description
+ *   To make use of this feature, include this file just after including the main
+ *   angular.js file.
+ * 
+ *   Applications supporting Retina displays should include two separate files for
+ *   each image resource. One file provides a standard-resolution version of a
+ *   given image, and the second provides a high-resolution version of the same
+ *   image. The naming conventions for each pair of image files is as follows:
+ *   - Standard: <image_name>.<filename_extension>
+ *   - High resolution: <image_name>@2x.<filename_extension>
+ *
+ *   If the browser runs on a high-resolution display, and if the referenced image
+ *   is available in high-resolution, the corresponding <img ng-src="..."> tag is
+ *   interpreted, such that the image in high-resolution is referenced.
+ *   This module also rewrites <img ng-src="..."> tags, which contain a static
+ *   image url, ie. one without any mark-up directives.
+ *
+ *   Note that when using this module, adding the element attributes 'width="..."'
+ *   and 'height="..."' becomes mandatory, as the displayed high-resolution image
+ *   otherwise gets scaled to the double size.
+ */
+
+angular.module('ngRetina', []).config(function($provide) {
+  $provide.decorator('ngSrcDirective', function($delegate) {
+    $delegate[0].compile = function(element, attrs) {
+      // intentionally empty to override the built-in directive ng-src
+    };
+    return $delegate;
+  });
+})
+.directive('ngSrc', function($window, $http, $cacheFactory) {
+  var cache = $cacheFactory('retinaImageURLs');
+  var mediaQuery = "(-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), "
+    + "(-o-min-device-pixel-ratio: 3/2), (min-resolution: 1.5dppx)";
+  var msie = parseInt(((/msie (\d+)/.exec($window.navigator.userAgent.toLowerCase()) || [])[1]), 10);
+
+  function isRetina() {
+    if ($window.devicePixelRatio > 1)
+      return true;
+    return ($window.matchMedia && $window.matchMedia(mediaQuery).matches);
+  };
+
+  function getHighResolutionURL(url) {
+    var parts = url.split('.');
+    if (parts.length < 2)
+      return url;
+    parts[parts.length - 2] += '@2x';
+    return parts.join('.');
+  }
+
+  return function(scope, element, attrs) {
+    function setImgSrc(img_url) {
+      attrs.$set('src', img_url);
+      if (msie) element.prop('src', img_url);
+    }
+
+    function set2xVariant(img_url) {
+      var img_url_2x = cache.get(img_url);
+      if (img_url_2x === undefined) {
+        img_url_2x = getHighResolutionURL(img_url);
+        $http.head(img_url_2x).
+        success(function(data, status) {
+          setImgSrc(img_url_2x);
+          cache.put(img_url, img_url_2x);
+        }).
+        error(function(data, status, headers, config) {
+          setImgSrc(img_url);
+          cache.put(img_url, img_url);
+        });
+      } else {
+        setImgSrc(img_url_2x);
+      }
+    }
+
+    attrs.$observe('ngSrc', function(value) {
+      if (!value)
+        return;
+      if (isRetina()) {
+        set2xVariant(value);
+      } else {
+        setImgSrc(value);
+      }
+    });
+  };
+});
+
+})(window.angular);

--- a/test/ngRetina/ngRetinaSpec.js
+++ b/test/ngRetina/ngRetinaSpec.js
@@ -1,0 +1,146 @@
+'use strict';
+
+describe('test module angular-retina', function() {
+  var $window;
+
+  describe('on high resolution displays', function() {
+    var $httpBackend, scope;
+
+    beforeEach(function() {
+      module(function($provide) {
+        $provide.provider('$window', function() {
+          this.$get = function() {
+            try {
+              window.devicePixelRatio = 2;
+            } catch (TypeError) {
+              // in Firefox window.devicePixelRatio only has a getter
+            }
+            window.matchMedia = function(query) {
+              return {matches: true};
+            };
+            return window;
+          };
+        });
+      });
+      module('ngRetina');
+    });
+
+    beforeEach(inject(function($injector, $rootScope) {
+      scope = $rootScope.$new();
+      $httpBackend = $injector.get('$httpBackend');
+    }));
+
+    describe('for static "ng-src" tags', function() {
+      it('should set src tag with a highres image', inject(function($compile) {
+        var element = angular.element('<input ng-src="/image.png">');
+        $httpBackend.when('HEAD', '/image@2x.png').respond(200);
+        $compile(element)(scope);
+        scope.$digest();
+        $httpBackend.flush();
+        expect(element.attr('src')).toBe('/image@2x.png');
+      }));
+    });
+
+    describe('for marked up "ng-src" tags', function() {
+      var element;
+
+      beforeEach(inject(function($compile) {
+        element = angular.element('<input ng-src="/{{image_url}}">');
+        scope.image_url = 'image.png';
+        $httpBackend.when('HEAD', '/image@2x.png').respond(200);
+        $compile(element)(scope);
+        scope.$digest();
+        $httpBackend.flush();
+      }));
+
+      it('should copy content from "ng-src" to "src" tag', function() {
+        expect(element.attr('src')).toBe('/image@2x.png');
+      });
+
+      describe('should observe scope.image_url', function() {
+        beforeEach(function() {
+          $httpBackend.when('HEAD', '/picture@2x.png').respond(200);
+          scope.image_url = 'picture.png';
+          scope.$digest();
+          $httpBackend.flush();
+        });
+
+        it('and replace src tag with another picture', function() {
+          expect(element.attr('src')).toBe('/picture@2x.png');
+        });
+
+        it('and check if the client side cache is working', function() {
+          scope.image_url = 'image.png';
+          scope.$digest();
+          expect(element.attr('src')).toBe('/image@2x.png');
+        });
+      });
+    });
+
+    describe('if the high resolution image is not available', function() {
+      beforeEach(function() {
+        $httpBackend.when('HEAD', '/image@2x.png').respond(404);
+      });
+
+      it('should copy content from "ng-src" to "src" tag', inject(function($compile) {
+        var element = angular.element('<input ng-src="/image.png">');
+        $compile(element)(scope);
+        scope.$digest();
+        $httpBackend.flush();
+        expect(element.attr('src')).toBe('/image.png');
+      }));
+
+      it('should copy content from scope object to "src" tag', inject(function($compile) {
+        var element = angular.element('<input ng-src="/{{image_url}}">');
+        scope.image_url = 'image.png';
+        $compile(element)(scope);
+        scope.$digest();
+        $httpBackend.flush();
+        expect(element.attr('src')).toBe('/image.png');
+      }));
+    });
+  });
+
+  describe('on standard resolution displays using images in their low resolution version', function() {
+    var $httpBackend, scope;
+
+    beforeEach(function() {
+      module(function($provide) {
+        $provide.provider('$window', function() {
+          this.$get = function() {
+            try {
+              window.devicePixelRatio = 1;
+            } catch (TypeError) {
+              // in Firefox window.devicePixelRatio only has a getter
+            }
+            window.matchMedia = function(query) {
+              return {matches: false};
+            };
+            return window;
+          };
+        });
+      });
+      module('ngRetina');
+    });
+
+    beforeEach(inject(function($injector, $rootScope) {
+      scope = $rootScope.$new();
+    }));
+
+    it('should copy content from "ng-src" to "src" tag', inject(function($compile) {
+      var element = angular.element('<input ng-src="/image.png">');
+      $compile(element)(scope);
+      scope.$digest();
+      expect(element.attr('src')).toBe('/image.png');
+    }));
+
+    it('should copy content from scope object to "src" tag', inject(function($compile) {
+      var element = angular.element('<input ng-src="/{{image_url}}">');
+      scope.image_url = 'image.png';
+      $compile(element)(scope);
+      scope.$digest();
+      expect(element.attr('src')).toBe('/image.png');
+    }));
+  });
+
+});


### PR DESCRIPTION
A port of the Javascript library http://retinajs.com/ for AngularJS with the possibility to use angular markups.
Elements containing `<img ng-src="...">` now can handle high resolution images, if the browser runs on a high resolution (Retina) display. Otherwise, or, if the hires image can't be found, the default image is loaded.
This module is very useful for everybody optimizing their application for Retina display such as the newer iPhone's, iPad's and MacBookPro's.

This is a rebased version of #2032
