### PR TITLE
fix(httpBackend): use of reponseText is redundant and buggy

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -87,7 +87,7 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
           }
           // end of the workaround.
 
-          completeRequest(callback, status || xhr.status, xhr.response || xhr.responseText,
+          completeRequest(callback, status || xhr.status, xhr.response,
                           responseHeaders);
         }
       };

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -110,7 +110,7 @@ describe('$httpBackend', function() {
 
       this.send = function() {
         this.status = 200;
-        this.responseText = 'response';
+        this.response = 'response';
         this.readyState = 4;
         this.onreadystatechange();
       };
@@ -248,7 +248,7 @@ describe('$httpBackend', function() {
     function respond(status, content) {
       xhr = MockXhr.$$lastInstance;
       xhr.status = status;
-      xhr.responseText = content;
+      xhr.response = content;
       xhr.readyState = 4;
       xhr.onreadystatechange();
     }


### PR DESCRIPTION
fixes #1922
http://www.w3.org/TR/XMLHttpRequest/#dom-xmlhttprequest-responsetext
in some cases `responseText` may throw an error, but if it correctly returns a value so does `response`, which will also correctly handle other kind of response types
