### PR TITLE
feat($q): $q.all() now accepts hash

### DIFF
--- a/src/ng/route.js
+++ b/src/ng/route.js
@@ -414,14 +414,13 @@ function $RouteProvider(){
         $q.when(next).
           then(function() {
             if (next) {
-              var keys = [],
-                  values = [],
+              var locals = extend({}, next.resolve),
                   template;
 
-              forEach(next.resolve || {}, function(value, key) {
-                keys.push(key);
-                values.push(isString(value) ? $injector.get(value) : $injector.invoke(value));
+              forEach(locals, function(value, key) {
+                locals[key] = isString(value) ? $injector.get(value) : $injector.invoke(value);
               });
+              
               if (isDefined(template = next.template)) {
                 if (isFunction(template)) {
                   template = template(next.params);
@@ -437,16 +436,9 @@ function $RouteProvider(){
                 }
               }
               if (isDefined(template)) {
-                keys.push('$template');
-                values.push(template);
+                locals['$template'] = template
               }
-              return $q.all(values).then(function(values) {
-                var locals = {};
-                forEach(values, function(value, index) {
-                  locals[keys[index]] = value;
-                });
-                return locals;
-              });
+              return $q.all(locals);
             }
           }).
           // after route change


### PR DESCRIPTION
When waiting for several promises at once, it is often desirable to
have them by name, not just by index in array.

Example of this kind of interface already implemented would be a
`$routeProvider.when(url, {resolve: <hash of promises>})`, where
resources/promises are given by names, and then results accessed
by names in controller.

The CLA is signed.
