### PR TITLE
feat(routing): Allow matching for case insensitive routes

### DIFF
--- a/src/ng/route.js
+++ b/src/ng/route.js
@@ -347,7 +347,7 @@ function $RouteProvider(){
     /**
      * @param on {string} current url
      * @param when {string} route when template to match the url against
-     * @param whenProperties {Object} properties to define how when's matching behavior
+     * @param whenProperties {Object} properties to define when's matching behavior
      * @return {?Object}
      */
     function switchRouteMatcher(on, when, whenProperties) {

--- a/src/ng/route.js
+++ b/src/ng/route.js
@@ -129,6 +129,24 @@ function $RouteProvider(){
     return this;
   };
 
+  var caseSensitive = true;
+  /**
+   * @ngdoc method
+   * @name ng.$routeProvider#caseSensitive
+   * @methodOf ng.$routeProvider
+   *
+   * @description
+   * Defines whether matching of routes is case sensitive or not (defaults to case sensitive)
+   * 
+   *
+   * @param {boolean} isCaseSensitive Whether future routing matches should be case sensitive or not.
+   * @returns {Object} self
+   */
+  this.caseSensitive = function(isCaseSensitive) {
+    caseSensitive = isCaseSensitive;
+
+    return this;
+  }
 
   this.$get = ['$rootScope', '$location', '$routeParams', '$q', '$injector', '$http', '$templateCache',
       function( $rootScope,   $location,   $routeParams,   $q,   $injector,   $http,   $templateCache) {
@@ -351,6 +369,7 @@ function $RouteProvider(){
 
       // Escape regexp special characters.
       when = '^' + when.replace(/[-\/\\^$:*+?.()|[\]{}]/g, "\\$&") + '$';
+
       var regex = '',
           params = [],
           dst = {};
@@ -377,7 +396,7 @@ function $RouteProvider(){
       // Append trailing path part.
       regex += when.substr(lastMatchedIndex);
 
-      var match = on.match(new RegExp(regex));
+      var match = on.match(new RegExp(regex, !caseSensitive ? 'i' : ''));
       if (match) {
         forEach(params, function(name, index) {
           dst[name] = match[index + 1];

--- a/test/ng/routeSpec.js
+++ b/test/ng/routeSpec.js
@@ -24,7 +24,6 @@ describe('$route', function() {
       $routeProvider.when('/Book/:book/Chapter/:chapter',
           {controller: noop, templateUrl: 'Chapter.html'});
       $routeProvider.when('/Blank', {});
-      $routeProvider.caseSensitive(true);
     });
     inject(function($route, $location, $rootScope) {
       $rootScope.$on('$routeChangeStart', function(event, next, current) {
@@ -45,12 +44,6 @@ describe('$route', function() {
       $httpBackend.flush();
       expect(log).toEqual('before();after();');
       expect($route.current.params).toEqual({book:'Moby', chapter:'Intro', p:'123'});
-
-      log = '';
-      $location.path('/BOOK/Moby/CHAPTER/Intro').search('p=123');
-      $rootScope.$digest();
-      expect(log).toEqual('before();after();');
-      expect($route.current).toEqual(null);
 
       log = '';
       $location.path('/Blank').search('ignore');
@@ -125,18 +118,17 @@ describe('$route', function() {
     });
   });
 
-  it('should route and fire change event correctly when the case insensitive flag is triggered', function() {
+  it('should route and fire change event correctly whenever the case insensitive flag is utilized', function() {
     var log = '',
         lastRoute,
         nextRoute;
 
     module(function($routeProvider) {
       $routeProvider.when('/Book1/:book/Chapter/:chapter/*highlight/edit',
-          {controller: noop, templateUrl: 'Chapter.html'});
+          {controller: noop, templateUrl: 'Chapter.html', caseInsensitiveMatch: true});
       $routeProvider.when('/Book2/:book/*highlight/Chapter/:chapter',
           {controller: noop, templateUrl: 'Chapter.html'});
       $routeProvider.when('/Blank', {});
-      $routeProvider.caseSensitive(false);
     });
     inject(function($route, $location, $rootScope) {
       $rootScope.$on('$routeChangeStart', function(event, next, current) {
@@ -159,7 +151,7 @@ describe('$route', function() {
       expect($route.current.params).toEqual({book:'Moby', chapter:'Intro', highlight:'one', p:'123'});
 
       log = '';
-      $location.path('/book1/Moby/chapter/Intro/one/EDIT').search('p=123');
+      $location.path('/BOOK1/Moby/CHAPTER/Intro/one/EDIT').search('p=123');
       $rootScope.$digest();
       expect(log).toEqual('before();after();');
       expect($route.current.params).toEqual({book:'Moby', chapter:'Intro', highlight:'one', p:'123'});
@@ -171,19 +163,19 @@ describe('$route', function() {
       expect($route.current.params).toEqual({ignore:true});
 
       log = '';
-      $location.path('/Book1/Moby/Chapter/Intro/one/two/edit').search('p=123');
+      $location.path('/BLANK');
+      $rootScope.$digest();
+      expect(log).toEqual('before();after();');
+      expect($route.current).toEqual(null);
+
+      log = '';
+      $location.path('/Book2/Moby/one/two/Chapter/Intro').search('p=123');
       $rootScope.$digest();
       expect(log).toEqual('before();after();');
       expect($route.current.params).toEqual({book:'Moby', chapter:'Intro', highlight:'one/two', p:'123'});
 
       log = '';
       $location.path('/BOOK2/Moby/one/two/CHAPTER/Intro').search('p=123');
-      $rootScope.$digest();
-      expect(log).toEqual('before();after();');
-      expect($route.current.params).toEqual({book:'Moby', chapter:'Intro', highlight:'one/two', p:'123'});
-
-      log = '';
-      $location.path('/NONE');
       $rootScope.$digest();
       expect(log).toEqual('before();after();');
       expect($route.current).toEqual(null);


### PR DESCRIPTION
In response to: https://github.com/angular/angular.js/issues/1383

I added a function to the RouteProvider called caseSensitive to take a boolean value that can be taken into consideration when matching routes - the matching will either be case sensitive or not case sensitive, and defaults to case sensitive.

I understand, from chad-configit@, if this is not the direction the AngularJS team would like to approach this.
