### PR TITLE
fix(angular.encodeUriQuery): fix encoding of string "null" to '+'

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -875,7 +875,7 @@ function encodeUriQuery(val, pctEncodeSpaces) {
              replace(/%3A/gi, ':').
              replace(/%24/g, '$').
              replace(/%2C/gi, ',').
-             replace((pctEncodeSpaces ? null : /%20/g), '+');
+             replace(/%20/g, (pctEncodeSpaces ? '%20' : '+'));
 }
 
 

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -300,7 +300,7 @@ angular.module('ngResource', ['ng']).
         replace(/%3A/gi, ':').
         replace(/%24/g, '$').
         replace(/%2C/gi, ',').
-        replace((pctEncodeSpaces ? null : /%20/g), '+');
+        replace(/%20/g, (pctEncodeSpaces ? '%20' : '+'));
     }
 
     function Route(template, defaults) {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -415,6 +415,14 @@ describe('angular', function() {
       //encode ' ' as '%20' when a flag is used
       expect(encodeUriQuery('  ', true)).
         toEqual('%20%20');
+
+      //bugfix: do not encode 'null' as '+' when flag is used
+      expect(encodeUriQuery('null', true)).
+        toEqual('null');
+
+      //do not encode 'null' with no flag
+      expect(encodeUriQuery('null')).
+        toEqual('null');
     });
   });
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -136,6 +136,14 @@ describe("resource", function() {
     R.get({a: 'doh&foo', bar: ['baz1', 'baz2']});
   });
 
+  it('should not encode string "null" to + in url params', function() {
+   //bugfix: encodeUriQuery is encoding the string 'null'
+
+   var R = $resource('/Path/:a');
+   $httpBackend.expect('GET', '/Path/null').respond('{}');
+   R.get({a: 'null'});
+  });
+
   it('should allow relative paths in resource url', function () {
     var R = $resource(':relativePath');
     $httpBackend.expect('GET', 'data.json').respond('{}');


### PR DESCRIPTION
Fixes issue in encodeUriQuery that treats null as a string and replaces
the characters "null" with "+".

This is a fix for issue:  https://github.com/angular/angular.js/issues/1978
