### PR TITLE
Fix use of Mocha as test framework around ngMock

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -430,7 +430,7 @@ angular.mock.$LogProvider = function() {
    *
    * *NOTE*: this is not an injectable instance, just a globally available mock class of `Date`.
    *
-   * Mock of the Date type which has its timezone specified via constroctor arg.
+   * Mock of the Date type which has its timezone specified via constructor arg.
    *
    * The main purpose is to create Date-like instances with timezone fixed to the specified timezone
    * offset, so that we can test code that depends on local timezone settings without dependency on

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1677,7 +1677,7 @@ window.jstestdriver && (function(window) {
   });
 
   function isSpecRunning() {
-    return currentSpec && currentSpec.queue.running;
+    return currentSpec && (window.mocha || currentSpec.queue.running);
   }
 
   /**

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1686,7 +1686,6 @@ window.jstestdriver && (function(window) {
    * @description
    *
    * *NOTE*: This is function is also published on window for easy access.<br>
-   * *NOTE*: Only available with {@link http://pivotal.github.com/jasmine/ jasmine}.
    *
    * This function registers a module configuration code. It collects the configuration information
    * which will be used when the injector is created by {@link angular.mock.inject inject}.
@@ -1719,7 +1718,6 @@ window.jstestdriver && (function(window) {
    * @description
    *
    * *NOTE*: This is function is also published on window for easy access.<br>
-   * *NOTE*: Only available with {@link http://pivotal.github.com/jasmine/ jasmine}.
    *
    * The inject function wraps a function into an injectable function. The inject() creates new
    * instance of {@link AUTO.$injector $injector} per test, which is then used for


### PR DESCRIPTION
Issue #1467 describes a real problem when trying to use the Mocha support that was introduced in 1.1.1 as pull request #1253. It seems the code actually merged for #1253 differed from the original author's proposal in one key regard.

This pull request fixes #1467, and, I believe, that's also the reason for issue #1589 and why #1253 kept attracting comments after it was closed.

While I was there, I fixed a couple comments.
