### PR TITLE
feat(http): set custom default cache in $http.defaults.cache

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -302,6 +302,9 @@ function $HttpProvider() {
      * cache, but the cache is not populated yet, only one request to the server will be made and
      * the remaining requests will be fulfilled using the response for the first request.
      *
+     * A custom default cache built with $cacheFactory can be provided in $http.defaults.cache.
+     * To skip it, set configuration property `cache` to `false`.
+     * 
      *
      * # Response interceptors
      *
@@ -729,8 +732,10 @@ function $HttpProvider() {
       promise.then(removePendingReq, removePendingReq);
 
 
-      if (config.cache && config.method == 'GET') {
-        cache = isObject(config.cache) ? config.cache : defaultCache;
+      if ((config.cache || defaults.cache) && config.cache !== false && config.method == 'GET') {
+        cache = isObject(config.cache) ? config.cache 
+              : isObject(defaults.cache) ? defaults.cache 
+              : defaultCache;
       }
 
       if (cache) {


### PR DESCRIPTION
When we need more control over http caching, we may want to provide
a custom cache to be used in all http requests by default.

To skip default cache, set {cache: false} in request configuration.
To use other cache, set {cache: cache} as before.

See #2079
