### PR TITLE
Treat range inputs the same as number inputs

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -152,7 +152,7 @@ var inputType = {
       </doc:example>
    */
   'number': numberInputType,
-
+  'range': numberInputType,
 
   /**
    * @ngdoc inputType

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -150,6 +150,47 @@ var inputType = {
           });
         </doc:scenario>
       </doc:example>
+   * @example
+      <doc:example>
+        <doc:source>
+         <script>
+           function Ctrl($scope) {
+             $scope.value = 12;
+           }
+         </script>
+         <form name="myForm" ng-controller="Ctrl">
+           Number: <input type="range" name="input" ng-model="value"
+                          min="0" max="99" required>
+           <span class="error" ng-show="myForm.list.$error.required">
+             Required!</span>
+           <span class="error" ng-show="myForm.list.$error.number">
+             Not valid number!</span>
+           <tt>value = {{value}}</tt><br/>
+           <tt>myForm.input.$valid = {{myForm.input.$valid}}</tt><br/>
+           <tt>myForm.input.$error = {{myForm.input.$error}}</tt><br/>
+           <tt>myForm.$valid = {{myForm.$valid}}</tt><br/>
+           <tt>myForm.$error.required = {{!!myForm.$error.required}}</tt><br/>
+          </form>
+        </doc:source>
+        <doc:scenario>
+          it('should initialize to model', function() {
+           expect(binding('value')).toEqual('12');
+           expect(binding('myForm.input.$valid')).toEqual('true');
+          });
+
+          it('should be invalid if empty', function() {
+           input('value').enter('');
+           expect(binding('value')).toEqual('');
+           expect(binding('myForm.input.$valid')).toEqual('false');
+          });
+
+          it('should be invalid if over max', function() {
+           input('value').enter('123');
+           expect(binding('value')).toEqual('');
+           expect(binding('myForm.input.$valid')).toEqual('false');
+          });
+        </doc:scenario>
+      </doc:example>
    */
   'number': numberInputType,
   'range': numberInputType,


### PR DESCRIPTION
I've simply added range as to the list of input types that can be treated as a number type. It has the same properties (min, max) and should be capable of behaving exactly the same way.

I'm not too comfortable with the docs/examples yet so I may have done something wrong. Please let me know if I need to fix anything.

 This fixes issue #1189
