### PR TITLE
fix($http): ensure case-insens. header overriding

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -649,53 +649,11 @@ function $HttpProvider() {
         transformRequest: defaults.transformRequest,
         transformResponse: defaults.transformResponse
       };
-      var headers = {};
+      var headers = mergeHeaders(requestConfig);
 
       extend(config, requestConfig);
       config.headers = headers;
       config.method = uppercase(config.method);
-
-      extend(headers,
-          defaults.headers.common,
-          defaults.headers[lowercase(config.method)],
-          requestConfig.headers);
-      /*
-      var reqTransformFn = config.transformRequest || defaults.transformRequest,
-          respTransformFn = config.transformResponse || defaults.transformResponse,
-          xsrfHeader = {},
-          xsrfCookieName = config.xsrfCookieName || defaults.xsrfCookieName,
-          xsrfHeaderName = config.xsrfHeaderName || defaults.xsrfHeaderName,
-          xsrfToken = isSameDomain(config.url, $browser.url()) ? 
-            $browser.cookies()[xsrfCookieName] : undefined;
-      xsrfHeader[xsrfHeaderName] = xsrfToken;
-
-      var reqHeaders = extend(xsrfHeader, config.headers),
-          defHeaders = defaults.headers,
-          reqData = transformData(config.data, headersGetter(reqHeaders), reqTransformFn),
-          promise, found, lowercaseHeader;
-
-      defHeaders = extend(defHeaders.common, defHeaders[lowercase(config.method)]);
-      
-      forEach(defHeaders, function(defValue, defHeader) {
-        found = false;
-        lowercaseHeader = lowercase(defHeader);
-
-        forEach(reqHeaders, function(reqValue, reqHeader) {
-          found = found || lowercase(reqHeader) === lowercaseHeader;
-        });
-
-        !found && (reqHeaders[defHeader] = defValue);
-      });
-
-      // strip content-type if data is undefined
-      if (isUndefined(config.data)) {
-        forEach(reqHeaders, function(value, header) {
-          if (lowercase(header) === 'content-type') {
-              delete reqHeaders[header];
-          }
-        });
-      }
-      */
 
       var xsrfValue = isSameDomain(config.url, $browser.url())
           ? $browser.cookies()[config.xsrfCookieName || defaults.xsrfCookieName]
@@ -710,7 +668,11 @@ function $HttpProvider() {
 
         // strip content-type if data is undefined
         if (isUndefined(config.data)) {
-          delete headers['Content-Type'];
+          forEach(headers, function(value, header) {
+            if (lowercase(header) === 'content-type') {
+                delete headers[header];
+            }
+          });
         }
 
         if (isUndefined(config.withCredentials) && !isUndefined(defaults.withCredentials)) {
@@ -765,6 +727,30 @@ function $HttpProvider() {
         return (isSuccess(response.status))
           ? resp
           : $q.reject(resp);
+      }
+
+      function mergeHeaders(config) {
+        var defHeaders = defaults.headers,
+            reqHeaders = extend({}, config.headers),
+            defHeaderName, lowercaseDefHeaderName, reqHeaderName;
+
+        defHeaders = extend({}, defHeaders.common, defHeaders[lowercase(config.method)]);
+
+        // using for-in instead of forEach to avoid unecessary iteration after header has been found
+        defaultHeadersIteration:
+        for (defHeaderName in defHeaders) {
+          lowercaseDefHeaderName = lowercase(defHeaderName);
+
+          for (reqHeaderName in reqHeaders) {
+            if (lowercase(reqHeaderName) === lowercaseDefHeaderName) {
+              continue defaultHeadersIteration;
+            }
+          }
+
+          reqHeaders[defHeaderName] = defHeaders[defHeaderName];
+        }
+
+        return reqHeaders;
       }
     }
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -717,6 +717,21 @@ describe('$http', function() {
         $httpBackend.flush();
       });
 
+      it('should override default headers with custom in a case insensitive manner', function() {
+        $httpBackend.expect('POST', '/url', 'messageBody', function(headers) {
+          return headers['accept'] == 'Rewritten' &&
+                 headers['content-type'] == 'Rewritten' &&
+                 headers['Accept'] === undefined &&
+                 headers['Content-Type'] === undefined;
+        }).respond('');
+
+        $http({url: '/url', method: 'POST', data: 'messageBody', headers: {
+          'accept': 'Rewritten',
+          'content-type': 'Rewritten'
+        }});
+        $httpBackend.flush();
+      });
+
       it('should not set XSRF cookie for cross-domain requests', inject(function($browser) {
         $browser.cookies('XSRF-TOKEN', 'secret');
         $browser.url('http://host.com/base');

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -720,14 +720,14 @@ describe('$http', function() {
       it('should override default headers with custom in a case insensitive manner', function() {
         $httpBackend.expect('POST', '/url', 'messageBody', function(headers) {
           return headers['accept'] == 'Rewritten' &&
-                 headers['content-type'] == 'Rewritten' &&
+                 headers['content-type'] == 'Content-Type Rewritten' &&
                  headers['Accept'] === undefined &&
                  headers['Content-Type'] === undefined;
         }).respond('');
 
         $http({url: '/url', method: 'POST', data: 'messageBody', headers: {
           'accept': 'Rewritten',
-          'content-type': 'Rewritten'
+          'content-type': 'Content-Type Rewritten'
         }});
         $httpBackend.flush();
       });
@@ -749,7 +749,12 @@ describe('$http', function() {
           return !headers.hasOwnProperty('Content-Type');
         }).respond('');
 
+        $httpBackend.expect('POST', '/url2', undefined, function(headers) {
+          return !headers.hasOwnProperty('content-type');
+        }).respond('');
+        
         $http({url: '/url', method: 'POST'});
+        $http({url: '/url2', method: 'POST', headers: {'content-type': 'Rewritten'}});
         $httpBackend.flush();
       });
 


### PR DESCRIPTION
If user send content-type header, both content-type and default
Content-Type headers were sent. Now default header overriding is
case-insensitive.

As per [RFC 2616](http://www.ietf.org/rfc/rfc2616.txt), "[header] Field 
names are case-insensitive".

Before this fix, the following test would fail:

``` javascript
it('should override default headers with custom in a case insensitive manner', function() {
  $httpBackend.expect('POST', '/url', 'messageBody', function(headers) {
    return headers['accept'] == 'Rewritten' &&
           headers['content-type'] == 'Rewritten' &&
           headers['Accept'] === undefined &&
           headers['Content-Type'] === undefined;
  }).respond('');

  $http({url: '/url', method: 'POST', data: 'messageBody', headers: {
    'accept': 'Rewritten',
    'content-type': 'Rewritten'
  }});
  $httpBackend.flush();
});
```
