### PR TITLE
fix ($orderBy): fix orderBy filter to sort Date objects correctly

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -124,13 +124,14 @@ function orderByFilter($parse){
     function compare(v1, v2){
       var t1 = typeof v1;
       var t2 = typeof v2;
-      if (t1 == t2) {
-        if (t1 == "string") v1 = v1.toLowerCase();
-        if (t1 == "string") v2 = v2.toLowerCase();
-        if (v1 === v2) return 0;
-        return v1 < v2 ? -1 : 1;
+      if (t1 == "string") v1 = v1.toLowerCase();
+      if (t1 == "string") v2 = v2.toLowerCase();
+      if (v1 < v2) {
+        return -1;
+      } else if (v1 > v2) {
+        return 1;
       } else {
-        return t1 < t2 ? -1 : 1;
+        return 0;
       }
     }
   }

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -31,4 +31,9 @@ describe('Filter: orderBy', function() {
     toEqual([{a:2, b:1},{a:15, b:1}]);
   });
 
+  it('should sort array of Date objects', function(){
+    expect(orderBy([{a:new Date('1/12/1980'), b: 1}, {a:new Date('1/6/1980'), b: 2}],['a'])).
+      toEqualData([{a:new Date('1/6/1980'), b:2}, {a:new Date('1/12/1980'), b: 1}]);
+  })
+
 });


### PR DESCRIPTION
Re-order the conditional statements in compare method to compare Date objects
correctly. Since Date object does not equal Date object even the dates are the
same, so it can be safely assumed than one is not less than nor greater than
the other, it is the same as the other.

test
http://jsfiddle.net/lvo811/hkbY3/
