### PR TITLE
Remove extranneous 'the' from injector docs

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -254,7 +254,7 @@ function annotate(fn) {
  * @description
  *
  * Use `$provide` to register new providers with the `$injector`. The providers are the factories for the instance.
- * The providers share the same name as the instance they create with the `Provider` suffixed to them.
+ * The providers share the same name as the instance they create with `Provider` suffixed to them.
  *
  * A provider is an object with a `$get()` method. The injector calls the `$get` method to create a new instance of
  * a service. The Provider can have additional methods which would allow for configuration of the provider.


### PR DESCRIPTION
Just a small grammar change.
