### PR TITLE
fix($location): correctly rewrite search params when html5 mode is enabled and not supported by browser

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -79,7 +79,8 @@ function convertToHashbangUrl(url, basePath, hashPrefix) {
   var match = matchUrl(url);
 
   // already hashbang url
-  if (decodeURIComponent(match.path) == basePath) {
+  if (decodeURIComponent(match.path) == basePath && !isUndefined(match.hash) &&
+        match.hash.indexOf(hashPrefix) === 0) {
     return url;
   // convert html5 url -> hashbang url
   } else {

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -549,6 +549,16 @@ describe('$location', function() {
         }
       );
     });
+
+    it('should convert html5 url with search param to hashbang', function () {
+      initService(true, '!', false);
+      inject(
+        initBrowser('http://domain.com/base/index.html?a', '/base/index.html'),
+        function($browser, $location) {
+          expect($browser.url()).toBe('http://domain.com/base/index.html#!/index.html?a');
+        }
+      );
+    });
   });
 
 


### PR DESCRIPTION
The conversion from html5 url to hashbang url failed to take into account search params if the path wasn't modified. I used the same test that the one used in the conversion of a hashbang url to an html5 url (https://github.com/tleruitte/angular.js/blob/master/src/ng/location.js#L67).
