### PR TITLE
docs(ngCloak) - Update the CSS rule with data-ng-cloak

### DIFF
--- a/src/ng/directive/ngCloak.js
+++ b/src/ng/directive/ngCloak.js
@@ -16,7 +16,7 @@
  *  `angular.min.js` files. Following is the css rule:
  *
  * <pre>
- * [ng\:cloak], [ng-cloak], .ng-cloak {
+ * [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
  *   display: none;
  * }
  * </pre>


### PR DESCRIPTION
In our project we had to add `[data-ng-cloak]` in order for it to work.
In this PR I also included other properties from the Angular.js source that should have a `display: none`.
