### PR TITLE
feat($filter): new date formats(timestamp, week in year, day in year)

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -223,6 +223,44 @@ function ampmGetter(date, formats) {
   return date.getHours() < 12 ? formats.AMPMS[0] : formats.AMPMS[1];
 }
 
+function timeStampGetter(milliseconds) {
+  return function(date) { 
+    return milliseconds ? Math.round(date.getTime() / 1000) : date.getTime();
+  }
+}
+
+function dayInYearGetter (date) {
+  var is_leap  = function (year) {
+    if (!(year % 4)) {
+      if (!(year % 100)) {
+        if (!(year%400)) {
+          return true;
+        } else return false;
+      } else return true;
+    } else  return false;
+  }, 
+  days = [31, (is_leap(date.getFullYear()) ? 29 : 28), 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+  passed = 0, i = 0;
+
+  for (; i < date.getMonth(); i++) {
+    passed += days[i];
+  }
+
+  return passed + date.getDate();
+}
+
+function weekInYearGetter(d) {
+  var temp = new Date(d);
+  temp.setHours(0,0,0);
+  temp.setDate(temp.getDate() + 4 - (temp.getDay()||7));
+
+  var yearStart = new Date(0,0,1);
+  yearStart.setFullYear(temp.getFullYear());
+  var weekNo = Math.ceil(( ( (temp - yearStart) / 86400000) + 1)/7);
+  
+  return weekNo;
+}
+
 var DATE_FORMATS = {
   yyyy: dateGetter('FullYear', 4),
     yy: dateGetter('FullYear', 2, 0, true),
@@ -247,10 +285,14 @@ var DATE_FORMATS = {
   EEEE: dateStrGetter('Day'),
    EEE: dateStrGetter('Day', true),
      a: ampmGetter,
-     Z: timeZoneGetter
-};
+     Z: timeZoneGetter,
+     U: timeStampGetter(true),
+     u: timeStampGetter(),
+     W: weekInYearGetter,
+     D: dayInYearGetter
+ };
 
-var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|Z))(.*)/,
+var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZEUuWD']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|Z|U|u|W|D))(.*)/,
     NUMBER_STRING = /^\d+$/;
 
 /**
@@ -285,6 +327,10 @@ var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+
  *   * `'.sss' or ',sss'`: Millisecond in second, padded (000-999)
  *   * `'a'`: am/pm marker
  *   * `'Z'`: 4 digit (+sign) representation of the timezone offset (-1200-+1200)
+ *   * `'U'`: Unix timestamp
+ *   * `'u'`: Unix timestamp in milliseconds as used in javascript
+ *   * `'W'`: Week in year
+ *   * `'D'`: Day in year
  *
  *   `format` string can also be one of the following predefined
  *   {@link guide/i18n localizable formats}:

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -223,6 +223,44 @@ function ampmGetter(date, formats) {
   return date.getHours() < 12 ? formats.AMPMS[0] : formats.AMPMS[1];
 }
 
+function timeStampGetter(milliseconds) {
+  return function(date) { 
+    return milliseconds ? Math.round(date.getTime() / 1000) : date.getTime();
+  }
+}
+
+function dayInYearGetter (date) {
+  var is_leap  = function (year) {
+    if (!(year % 4)) {
+      if (!(year % 100)) {
+        if (!(year%400)) {
+          return true;
+        } else return false;
+      } else return true;
+    } else  return false;
+  }, 
+  days = [31, (is_leap(date.getFullYear()) ? 29 : 28), 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+  passed = 0, i = 0;
+
+  for (; i < date.getMonth(); i++) {
+    passed += days[i];
+  }
+
+  return passed + date.getDate();
+}
+
+function weekInYearGetter(d) {
+  var temp = new Date(d.getTime());
+  temp.setHours(0,0,0);
+  temp.setDate(temp.getDate() + 4 - (temp.getDay()||7));
+
+  var yearStart = new Date(0,0,1);
+  yearStart.setFullYear(temp.getFullYear());
+  var weekNo = Math.ceil(( ( (temp - yearStart) / 86400000) + 1)/7);
+  
+  return weekNo;
+}
+
 var DATE_FORMATS = {
   yyyy: dateGetter('FullYear', 4),
     yy: dateGetter('FullYear', 2, 0, true),
@@ -247,10 +285,14 @@ var DATE_FORMATS = {
   EEEE: dateStrGetter('Day'),
    EEE: dateStrGetter('Day', true),
      a: ampmGetter,
-     Z: timeZoneGetter
-};
+     Z: timeZoneGetter,
+     U: timeStampGetter(true),
+     u: timeStampGetter(),
+     W: weekInYearGetter,
+     D: dayInYearGetter
+ };
 
-var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|Z))(.*)/,
+var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZEUuWD']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|Z|U|u|W|D))(.*)/,
     NUMBER_STRING = /^\d+$/;
 
 /**
@@ -285,6 +327,10 @@ var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+
  *   * `'.sss' or ',sss'`: Millisecond in second, padded (000-999)
  *   * `'a'`: am/pm marker
  *   * `'Z'`: 4 digit (+sign) representation of the timezone offset (-1200-+1200)
+ *   * `'U'`: Unix timestamp
+ *   * `'u'`: Unix timestamp in milliseconds as used in javascript
+ *   * `'W'`: Week in year
+ *   * `'D'`: Day in year
  *
  *   `format` string can also be one of the following predefined
  *   {@link guide/i18n localizable formats}:

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -485,6 +485,10 @@ angular.mock.$LogProvider = function() {
       return self.date.getTime() - self.offsetDiff;
     };
 
+    self.valueOf = function() {
+      return self.getTime();
+    };
+
     self.toLocaleDateString = function() {
       return self.date.toLocaleDateString();
     };
@@ -572,7 +576,7 @@ angular.mock.$LogProvider = function() {
         'setMinutes', 'setMonth', 'setSeconds', 'setTime', 'setUTCDate', 'setUTCFullYear',
         'setUTCHours', 'setUTCMilliseconds', 'setUTCMinutes', 'setUTCMonth', 'setUTCSeconds',
         'setYear', 'toDateString', 'toGMTString', 'toJSON', 'toLocaleFormat', 'toLocaleString',
-        'toLocaleTimeString', 'toSource', 'toString', 'toTimeString', 'toUTCString', 'valueOf'];
+        'toLocaleTimeString', 'toSource', 'toString', 'toTimeString', 'toUTCString'];
 
     angular.forEach(unimplementedMethods, function(methodName) {
       self[methodName] = function() {

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -72,16 +72,16 @@ describe('filters', function() {
       expect(num).toBe('123.112');
     });
 
-		it('should format the same with string as well as numeric fractionSize', function(){
-			var num = formatNumber(123.1, pattern, ',', '.', "0");
+    it('should format the same with string as well as numeric fractionSize', function(){
+      var num = formatNumber(123.1, pattern, ',', '.', "0");
       expect(num).toBe('123');
-			var num = formatNumber(123.1, pattern, ',', '.', 0);
+      var num = formatNumber(123.1, pattern, ',', '.', 0);
       expect(num).toBe('123');
-			var num = formatNumber(123.1, pattern, ',', '.', "3");
+      var num = formatNumber(123.1, pattern, ',', '.', "3");
       expect(num).toBe('123.100');
-			var num = formatNumber(123.1, pattern, ',', '.', 3);
+      var num = formatNumber(123.1, pattern, ',', '.', 3);
       expect(num).toBe('123.100');
-		});
+    });
   });
 
   describe('currency', function() {
@@ -200,11 +200,11 @@ describe('filters', function() {
     });
 
     it('should accept various format strings', function() {
-      expect(date(morning, "yy-MM-dd HH:mm:ss")).
-                      toEqual('10-09-03 07:05:08');
+      expect(date(morning, "yy-MM-dd - D/W -  HH:mm:ss")).
+                      toEqual('10-09-03 - 246/35 -  07:05:08');
 
-      expect(date(morning, "yy-MM-dd HH:mm:ss.sss")).
-                      toEqual('10-09-03 07:05:08.001');
+      expect(date(morning, "yy-MM-dd HH:mm:ss.sss / U")).
+                      toEqual('10-09-03 07:05:08.001 / 1283515508');
 
       expect(date(midnight, "yyyy-M-d h=H:m:saZ")).
                       toEqual('2010-9-3 12=0:5:8AM-0500');
@@ -227,8 +227,8 @@ describe('filters', function() {
       expect(date(noon, "EEEE, MMMM dd, yyyy")).
                       toEqual('Friday, September 03, 2010');
 
-      expect(date(earlyDate, "MMMM dd, y")).
-                      toEqual('September 03, 1');
+      expect(date(earlyDate, "MMMM dd, y - u:W")).
+                      toEqual('September 03, 1 - -62114410492000:36');
     });
 
     it('should format timezones correctly (as per ISO_8601)', function() {


### PR DESCRIPTION
Added new date formats to be used with date filter:
- 'u': Unix timestamp in milliseconds as used in javascript
- 'U': Unix timestamp (in seconds)
- 'W': Week in year
- 'D': Day in year
