### PR TITLE
fix(jqLite): mouseenter/-leave should not trigger on child elements

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -607,20 +607,20 @@ forEach({
 
       if (!eventFns) {
         if (type == 'mouseenter' || type == 'mouseleave') {
-          var counter = 0;
+          var entered = false;
 
           events.mouseenter = [];
           events.mouseleave = [];
 
           bindFn(element, 'mouseover', function(event) {
-            counter++;
-            if (counter == 1) {
+            if (!entered) {
+              entered = true;
               handle(event, 'mouseenter');
             }
           });
           bindFn(element, 'mouseout', function(event) {
-            counter --;
-            if (counter == 0) {
+            if (entered && indexOf(element.getElementsByTagName('*'), (event.toElement || event.relatedTarget)) === -1) {
+              entered = false;
               handle(event, 'mouseleave');
             }
           });

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -799,8 +799,6 @@ describe('jqLite', function() {
         expect(log).toEqual('parentEnter;childEnter;');
 
         child.mouseout();
-        expect(log).toEqual('parentEnter;childEnter;');
-        child.mouseout();
         expect(log).toEqual('parentEnter;childEnter;childLeave;');
         parent.mouseout();
         expect(log).toEqual('parentEnter;childEnter;childLeave;parentLeave;');


### PR DESCRIPTION
Mouseenter and mouseleave events were triggered on children of the
element they were bound to.
Change this to the expected behaviour, to only be triggered when
leaving/entering the actual element, not its children.

Closes #2131
