### PR TITLE
docs($injector): correct misuse of $inject

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -100,15 +100,15 @@ function annotate(fn) {
  *
  * <pre>
  *   // inferred (only works if code not minified/obfuscated)
- *   $inject.invoke(function(serviceA){});
+ *   $injector.invoke(function(serviceA){});
  *
  *   // annotated
  *   function explicit(serviceA) {};
  *   explicit.$inject = ['serviceA'];
- *   $inject.invoke(explicit);
+ *   $injector.invoke(explicit);
  *
  *   // inline
- *   $inject.invoke(['serviceA', function(serviceA){}]);
+ *   $injector.invoke(['serviceA', function(serviceA){}]);
  * </pre>
  *
  * ## Inference


### PR DESCRIPTION
`$inject` was used where `$injector` was appropriate; confusing and misleading.
