### PR TITLE
Fixing timeZoneGetter to fix for IST

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -214,7 +214,7 @@ function timeZoneGetter(date) {
   var zone = -1 * date.getTimezoneOffset();
   var paddedZone = (zone >= 0) ? "+" : "";
 
-  paddedZone += padNumber((zone>0?Math.floor(zone / 60):Math.ceiling(zone / 60)), 2) + padNumber(Math.abs(zone % 60), 2);
+  paddedZone += padNumber((zone>0?Math.floor(zone / 60):Math.ceil(zone / 60)), 2) + padNumber(Math.abs(zone % 60), 2);
 
   return paddedZone;
 }

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -214,7 +214,7 @@ function timeZoneGetter(date) {
   var zone = -1 * date.getTimezoneOffset();
   var paddedZone = (zone >= 0) ? "+" : "";
 
-  paddedZone += padNumber(zone / 60, 2) + padNumber(Math.abs(zone % 60), 2);
+  paddedZone += padNumber((zone>0?Math.floor(zone / 60):Math.ceiling(zone / 60)), 2) + padNumber(Math.abs(zone % 60), 2);
 
   return paddedZone;
 }

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -249,10 +249,10 @@ describe('filters', function() {
                     toEqual('2010-09-03T07:05:08-0500')
 
       expect(date(eastOfUTCPartial, "yyyy-MM-ddTHH:mm:ssZ")).
-                    toEqual('2010-09-03T17:05:08+0530')
+                    toEqual('2010-09-03T17:35:08+0530')
 
       expect(date(westOfUTCPartial, "yyyy-MM-ddTHH:mm:ssZ")).
-                    toEqual('2010-09-03T07:05:08-0530')
+                    toEqual('2010-09-03T06:35:08-0530')
     });
 
     it('should treat single quoted strings as string literals', function() {

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -1,4 +1,4 @@
-'use strict';
+//'use strict';
 
 describe('filters', function() {
 
@@ -236,6 +236,8 @@ describe('filters', function() {
       var utc       = new angular.mock.TzDate( 0, '2010-09-03T12:05:08.000Z');
       var eastOfUTC = new angular.mock.TzDate(-5, '2010-09-03T12:05:08.000Z');
       var westOfUTC = new angular.mock.TzDate(+5, '2010-09-03T12:05:08.000Z');
+      var eastOfUTCPartial = new angular.mock.TzDate(-5.5, '2010-09-03T12:05:08.000Z');
+      var westOfUTCPartial = new angular.mock.TzDate(+5.5, '2010-09-03T12:05:08.000Z');
 
       expect(date(utc, "yyyy-MM-ddTHH:mm:ssZ")).
                     toEqual('2010-09-03T12:05:08+0000')
@@ -245,6 +247,12 @@ describe('filters', function() {
 
       expect(date(westOfUTC, "yyyy-MM-ddTHH:mm:ssZ")).
                     toEqual('2010-09-03T07:05:08-0500')
+
+      expect(date(eastOfUTCPartial, "yyyy-MM-ddTHH:mm:ssZ")).
+                    toEqual('2010-09-03T17:05:08+0530')
+
+      expect(date(westOfUTCPartial, "yyyy-MM-ddTHH:mm:ssZ")).
+                    toEqual('2010-09-03T07:05:08-0530')
     });
 
     it('should treat single quoted strings as string literals', function() {


### PR DESCRIPTION
When using the Angular date filter for Indian Standard Time the output received was +5.530 rather than the expect +0530. This is because on Line 217 the hour part of the paddedZone definition is a decimal number (5.5) rather than an integer for most timezones. Fixed this by applying floor/ceiling based on whether the zone is positive or negative.
