### PR TITLE
Fix failing test in IE 10

### DIFF
--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -228,8 +228,8 @@ describe('form', function() {
                                        // the issue in the wild, I'm not going to bother to do it
                                        // now. (i)
 
-        // IE9 is special and it doesn't fire submit event when form was destroyed
-        if (msie != 9) {
+        // IE9 and IE10 are special and don't fire submit event when form was destroyed
+        if (msie < 9) {
           expect(reloadPrevented).toBe(true);
           $timeout.flush();
         }


### PR DESCRIPTION
formSpec test
- should prevent the default when the form is destroyed by a submission via a click event

was failing in IE10. 

This was because of a check that was checking only for IE9, which has now been changed to include IE10, which behaves the same way.
