### PR TITLE
enables AngularJS to use any jQuery, implementing issue #608

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,6 +47,7 @@ module.exports = function(grunt) {
     test: {
       jqlite: 'testacular-jqlite.conf.js',
       jquery: 'testacular-jquery.conf.js',
+      forcejqlite: 'testacular-force-jqlite.conf.js',
       modules: 'testacular-modules.conf.js',
       //NOTE run grunt test:e2e instead and it will start a webserver for you
       end2end: 'testacular-e2e.conf.js'

--- a/angularFiles.js
+++ b/angularFiles.js
@@ -130,7 +130,8 @@ angularFiles = {
   'jstdExclude': [
     'test/jquery_alias.js',
     'src/angular-bootstrap.js',
-    'src/ngScenario/angular-bootstrap.js'
+    'src/ngScenario/angular-bootstrap.js',
+    'test/force_jqlite.js'
   ],
 
   'jstdScenario': [
@@ -194,12 +195,36 @@ angularFiles = {
 
     'example/personalLog/test/*.js'
   ],
+  
+  'jstdForceJqlite': [
+    'lib/jasmine/jasmine.js',
+    'lib/jasmine-jstd-adapter/JasmineAdapter.js',
+    'lib/jquery/jquery.js',
+    'test/force_jqlite.js',
+    '@angularSrc',
+    'src/publishExternalApis.js',
+    '@angularSrcModules',
+    '@angularScenario',
+    'src/ngScenario/jstd-scenario-adapter/Adapter.js',
+    '@angularTest',
+    'example/personalLog/*.js',
+
+    'example/personalLog/test/*.js'
+  ],
 
   'jstdJqueryExclude': [
     'src/angular-bootstrap.js',
     'src/ngScenario/angular-bootstrap.js',
-    'test/jquery_remove.js'
-  ]
+    'test/jquery_remove.js',
+    'test/force_jqlite.js'
+  ],
+  
+  'jstdForceJqliteExclude': [
+    'src/angular-bootstrap.js',
+    'src/ngScenario/angular-bootstrap.js',
+    'test/jquery_remove.js',
+    'test/jquery_alias.js'
+  ],
 };
 
 if (exports) {

--- a/docs/content/guide/bootstrap.ngdoc
+++ b/docs/content/guide/bootstrap.ngdoc
@@ -79,6 +79,10 @@ If you need to have more control over the initialization process, you can use a 
 bootstrapping method instead. Examples of when you'd need to do this include using script loaders
 or the need to perform an operation before Angular compiles a page.
 
+By default, Angular includes jQuery if it finds it, otherwise it reverts to using the included
+jQuery lite. You can override this behavior by using the `window.angularjsUseJquery` variable
+before the script tab loading Angular. You can make this variable point to any existing jQuery
+instance, or just set it to `"internal"` if you want to use the included jQuery anyway.
 
 Here is an example of manually initializing Angular. The example is equivalent to using the {@link
 api/ng.directive:ngApp ng-app} directive.

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1007,8 +1007,14 @@ function snake_case(name, separator){
 }
 
 function bindJQuery() {
-  // bind to jQuery if present;
-  jQuery = window.jQuery;
+  // bind to any given jQuery - useful to include the internal one anyway
+  if (!window.angularjsUseJquery) {
+	jQuery = window.jQuery;
+  } else if (window.angularjsUseJquery === 'internal') {
+	jQuery = null;
+  } else {
+	jQuery = window.angularjsUseJquery;
+  }
   // reset to jQuery or default to us.
   if (jQuery) {
     jqLite = jQuery;

--- a/test/force_jqlite.js
+++ b/test/force_jqlite.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var angularjsUseJquery = 'internal',
+    _jQuery = jQuery,
+    _jqLiteMode = true;

--- a/testacular-force-jqlite.conf.js
+++ b/testacular-force-jqlite.conf.js
@@ -1,0 +1,14 @@
+var angularFiles = require(__dirname + '/angularFiles.js');
+
+files = angularFiles.mergeFiles(JASMINE, JASMINE_ADAPTER, 'jstdForceJqlite');
+exclude = ['**/*jasmine*/**', '**/*jstd*/**'].concat(angularFiles.files.jstdForceJqliteExclude);
+
+autoWatch = true;
+logLevel = LOG_INFO;
+logColors = true;
+browsers = ['Chrome'];
+
+junitReporter = {
+  outputFile: 'test_out/jquery.xml',
+  suite: 'jQuery'
+};


### PR DESCRIPTION
Enables AngularJS to use any jQuery library by using the `window.angularjsUseJquery` variable, that can have the following values:
- `undefined` / `null` / `false` - the default behavior (try to use window.jQuery, if not, use internal)
- `"internal"` - use the internal jQuery lite, no matter which other jQuery is present in the page
- reference to any variable containing a jQuery instance

Also updated the documentation (manual bootstrapping guide) to include details about this feature.
