### PR TITLE
fix(select): placeholder (empty option) is lost in IE9

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -468,7 +468,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
                 if (existingOption.id !== option.id) {
                   lastElement.val(existingOption.id = option.id);
                 }
-                if (existingOption.element.selected !== option.selected) {
+                if (!!lastElement.selected !== option.selected) {
                   lastElement.prop('selected', (existingOption.selected = option.selected));
                 }
               } else {

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -977,6 +977,19 @@ describe('select', function() {
         expect(option.attr('id')).toBe('road-runner');
         expect(option.attr('custom-attr')).toBe('custom-attr');
       });
+
+      it ('should select the null option, if it\'s available and no other option is selected', inject(function($timeout) {
+        // selectedIndex is used here because jqLite incorrectly reports element.val()
+        scope.$apply(function() {
+          scope.values = [{name: 'A'}];
+        });
+        createSingleSelect(true);
+        // ensure the first option (the null option) is selected
+        expect(element[0].selectedIndex).toEqual(0);
+        scope.$digest();
+        // ensure the option has not changed following the digest
+        expect(element[0].selectedIndex).toEqual(0);
+      }));
     });
 
 


### PR DESCRIPTION
Fixes a check inside render for select elements with ngOptions, which compares the selected property of an element with it's desired state.
In instances where no element should be selected, this resulted in the first option in the select element having it's selected attribute set from undefined to false.
In most browsers, this has the effect of displaying the first item in the list. In IE9 however, this causes the select to display nothing.
In other browsers this would still cause unnecessary changes in selected state, but no visible issue would manifest.

Closes #2150, #1826
