### PR TITLE
feat($parse):resolve promises returned from functions

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -613,10 +613,24 @@ function parser(text, json, $filter, csp){
         args.push(argsFn[i](self, locals));
       }
       var fnPtr = fn(self, locals) || noop;
+
       // IE stupidity!
-      return fnPtr.apply
+      var valOrPromise = fnPtr.apply
           ? fnPtr.apply(context, args)
           : fnPtr(args[0], args[1], args[2], args[3], args[4]);
+      var promise;
+
+      if (valOrPromise && valOrPromise.then) {
+        if (!("$$v" in valOrPromise)) {
+          promise = valOrPromise;
+          promise.$$v = undefined;
+          promise.then(function(val) {
+            promise.$$v = val;
+          });
+        }
+        valOrPromise = valOrPromise.$$v;
+      }
+      return valOrPromise;
     };
   }
 

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -524,6 +524,26 @@ describe('parser', function() {
             expect(scope.$eval('greeting')).toBe('hello!');
           });
 
+          it('should evaluate a nested promise and eventualy get its value', function() {
+            var nestedDeferred = q.defer();
+            var nestedPromise = nestedDeferred.promise;
+
+            scope.greeting = promise;
+            expect(scope.$eval('greeting')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('greeting')).toBe(undefined);
+
+            deferred.resolve(nestedPromise);
+            expect(scope.$eval('greeting')).toBe(undefined);
+            scope.$digest();
+            expect(scope.$eval('greeting')).toBe(undefined);
+
+            nestedDeferred.resolve('hello!');
+            expect(scope.$eval('greeting')).toBe(undefined);
+            scope.$digest();
+            expect(scope.$eval('greeting')).toBe('hello!');
+          });
 
           it('should evaluate a promise and eventualy ignore its rejection', function() {
             scope.greeting = promise;
@@ -588,6 +608,42 @@ describe('parser', function() {
             expect(scope.$eval('greetings[0][0]')).toBe('Hi!');
           });
 
+          it('should evaluate and dereference promises returned by functions', function() {
+            scope.returnsPromise = function() { return promise; };
+            expect(scope.$eval('returnsPromise()')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('returnsPromise()')).toBe(undefined);
+
+            deferred.resolve('hello!');
+            expect(scope.$eval('returnsPromise()')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('returnsPromise()')).toBe('hello!');
+          });
+
+          it('should evaluate and dereference nested promises returned by functions', function() {
+            var nestedDeferred = q.defer()
+            var nestedPromise = nestedDeferred.promise
+
+            scope.returnsPromise = function() { return promise; };
+            expect(scope.$eval('returnsPromise()')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('returnsPromise()')).toBe(undefined);
+
+            deferred.resolve(nestedPromise);
+            expect(scope.$eval('returnsPromise()')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('returnsPromise()')).toBe(undefined);
+
+            nestedDeferred.resolve('hello!')
+            expect(scope.$eval('returnsPromise()')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('returnsPromise()')).toBe('hello!');
+          });
 
           it('should evaluate and dereference promises used as function arguments', function() {
             scope.greet = function(name) { return 'Hi ' + name + '!'; };


### PR DESCRIPTION
change parser to resolve promises returned from functions on a scope.

Closes #990

after reading the discussion on https://github.com/angular/angular.js/pull/1676 i'm not sure how folks will feel about this, but the existing behavior was not what i expected and the change is nearly identical to how property level promises are resolved so figure i'll give it a shot.
