### PR TITLE
testacular upgrade (wf fails build on node >= 0.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "AngularJS",
   "version": "0.0.0",
   "dependencies": {
-    "testacular": "0.5.9",
+    "testacular": "0.6.0",
     "jasmine-node": "1.2.3",
     "q-fs": "0.1.36",
     "qq": "0.3.5",


### PR DESCRIPTION
testacular 0.5.9 depends on socket.io 0.9.0 which is about a year old and depends on socket.io-client which itself depends on wf 0.4.0 and this last guy wants node-waf to build when node-gyp replaces it in nodejs since 0.8.
