### PR TITLE
fix(ngMobile) arrange angularFiles so as to not skip modules tests

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -144,12 +144,11 @@ angularFiles = {
     'lib/jasmine/jasmine.js',
     'lib/jasmine-jstd-adapter/JasmineAdapter.js',
     'build/angular.js',
-    'build/angular-scenario.js',
     'src/ngMock/angular-mocks.js',
     'src/ngCookies/cookies.js',
     'src/ngResource/resource.js',
     'src/ngMobile/mobile.js',
-    'src/ngMobile/directive/ngClick.js',
+    'src/ngMobile/directive/*.js',
     'src/ngSanitize/sanitize.js',
     'src/ngSanitize/directive/ngBindHtml.js',
     'src/ngSanitize/filter/linky.js',
@@ -159,8 +158,7 @@ angularFiles = {
     'test/ngResource/*.js',
     'test/ngSanitize/*.js',
     'test/ngSanitize/directive/*.js',
-    'test/ngSanitize/filter/*.js',
-    'test/ngMobile/directive/*.js'
+    'test/ngSanitize/filter/*.js'
   ],
 
   'jstdPerf': [


### PR DESCRIPTION
707c65d5a228b added 'build/angular-scenario.js' to the jstdModules list, which caused all the `grunt test:modules` to skip. Moving that file to the bottom fixes the issue. 
