### PR TITLE
feat(ngRepeat): add support for hash for item in items

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -33,6 +33,24 @@
  *
  *     For example: `(name, age) in {'adam':10, 'amalie':12}`.
  *
+ *   * `hash_expression from variable in expression` – You can also provide an optional hashing function
+ *     which can be used to associate the objects in the collection with the DOM elements. If no hashing function
+ *     is specified the ng-repeat associates elements by position in the collection. items. It is an error to have
+ *     more then one item hash resolve to the same key. (This would mean that two distinct objects are mapped to
+ *     the same DOM element, which is not possible.)
+ *
+ *     For example: `item in items` is equivalent to `$index from item in items'. This implies that the DOM elements
+ *     will be associated by item position in array.
+ *
+ *     For example: `$hash(item) from item in items`. A built in `$hash()` function can be used to assign a unique
+ *     `$$hashKey` property to each item in the array. This property is then used as a key to associated DOM elements
+ *     with the corresponding item in the array by identity. Moving the same object in array would move the DOM
+ *     element in the same way in the DOM.
+ *
+ *     For example: `item.id from item it items` Is a typical pattern when the items come from the database. In this
+ *     case the object identity does not matter. Two objects are considered the equivalent as long as their `id`
+ *     is same.
+ *
  * @example
  * This example initializes the scope to a list of names and
  * then uses `ngRepeat` to display every person:
@@ -57,133 +75,195 @@
       </doc:scenario>
     </doc:example>
  */
-var ngRepeatDirective = ngDirective({
-  transclude: 'element',
-  priority: 1000,
-  terminal: true,
-  compile: function(element, attr, linker) {
-    return function(scope, iterStartElement, attr){
-      var expression = attr.ngRepeat;
-      var match = expression.match(/^\s*(.+)\s+in\s+(.*)\s*$/),
-        lhs, rhs, valueIdent, keyIdent;
-      if (! match) {
-        throw Error("Expected ngRepeat in form of '_item_ in _collection_' but got '" +
-          expression + "'.");
-      }
-      lhs = match[1];
-      rhs = match[2];
-      match = lhs.match(/^(?:([\$\w]+)|\(([\$\w]+)\s*,\s*([\$\w]+)\))$/);
-      if (!match) {
-        throw Error("'item' in 'item in collection' should be identifier or (key, value) but got '" +
-            lhs + "'.");
-      }
-      valueIdent = match[3] || match[1];
-      keyIdent = match[2];
+var ngRepeatDirective = ['$parse', function($parse) {
+  return {
+    transclude: 'element',
+    priority: 1000,
+    terminal: true,
+    compile: function(element, attr, linker) {
+      return function(scope, iterStartElement, attr){
+        var expression = attr.ngRepeat;
+        var match = expression.match(/^((.+)\s+from)?\s*(.+)\s+in\s+(.*)\s*$/),
+          hashExp, hashExpFn, hashFn, lhs, rhs, valueIdent, keyIdent,
+          hashFnLocals = {$hash: hashKey};
 
-      // Store a list of elements from previous run. This is a hash where key is the item from the
-      // iterator, and the value is an array of objects with following properties.
-      //   - scope: bound scope
-      //   - element: previous element.
-      //   - index: position
-      // We need an array of these objects since the same object can be returned from the iterator.
-      // We expect this to be a rare case.
-      var lastOrder = new HashQueueMap();
+        if (! match) {
+          throw Error("Expected ngRepeat in form of '(_hash_ from) _item_ in _collection_' but got '" +
+            expression + "'.");
+        }
 
-      scope.$watch(function ngRepeatWatch(scope){
-        var index, length,
-            collection = scope.$eval(rhs),
-            cursor = iterStartElement,     // current position of the node
-            // Same as lastOrder but it has the current state. It will become the
-            // lastOrder on the next iteration.
-            nextOrder = new HashQueueMap(),
-            arrayLength,
-            childScope,
-            key, value, // key/value of iteration
-            array,
-            last;       // last object information {scope, element, index}
+        hashExp = match[2];
+        lhs = match[3];
+        rhs = match[4];
 
-
-
-        if (!isArray(collection)) {
-          // if object, extract keys, sort them and use to determine order of iteration over obj props
-          array = [];
-          for(key in collection) {
-            if (collection.hasOwnProperty(key) && key.charAt(0) != '$') {
-              array.push(key);
-            }
-          }
-          array.sort();
+        if (hashExp) {
+          hashExpFn = $parse(hashExp);
+          hashFn = function(key, value) {
+            if (keyIdent) hashFnLocals[keyIdent] = key;
+            hashFnLocals[valueIdent] = value;
+            return hashExpFn(scope, hashFnLocals);
+          };
         } else {
-          array = collection || [];
+          hashFn = function(key, value) {
+            return key;
+          }
         }
+        
+        match = lhs.match(/^(?:([\$\w]+)|\(([\$\w]+)\s*,\s*([\$\w]+)\))$/);
+        if (!match) {
+          throw Error("'item' in 'item in collection' should be identifier or (key, value) but got '" +
+              lhs + "'.");
+        }
+        valueIdent = match[3] || match[1];
+        keyIdent = match[2];
 
-        arrayLength = array.length;
+        // Store a list of elements from previous run. This is a hash where key is the item from the
+        // iterator, and the value is objects with following properties.
+        //   - scope: bound scope
+        //   - element: previous element.
+        //   - index: position
+        var lastOrder = new HashMap();
 
-        // we are not using forEach for perf reasons (trying to avoid #call)
-        for (index = 0, length = array.length; index < length; index++) {
-          key = (collection === array) ? index : array[index];
-          value = collection[key];
+        // Store the list of item orders. Need so that we can compute moves. When an item at position
+        // #2 gets removed then item ot old position #3 becomes #2, but that is not considered a move
+        var blockHead = {
+              element: iterStartElement,
+              next: null
+            },
+            blockRemove = function(block) {
+              var right = block.next;
+              var left = block.prev;
 
-          last = lastOrder.shift(value);
+              if (right) right.prev = left;
+              left.next = right;
+            },
+            blockInsertAfter = function(afterBlock, newBlock) {
+              var right = afterBlock.next;
 
-          if (last) {
-            // if we have already seen this object, then we need to reuse the
-            // associated scope/element
-            childScope = last.scope;
-            nextOrder.push(value, last);
+              newBlock.next = right;
+              newBlock.prev = afterBlock;
 
-            if (index === last.index) {
-              // do nothing
-              cursor = last.element;
-            } else {
-              // existing item which got moved
-              last.index = index;
-              // This may be a noop, if the element is next, but I don't know of a good way to
-              // figure this out,  since it would require extra DOM access, so let's just hope that
-              // the browsers realizes that it is noop, and treats it as such.
-              cursor.after(last.element);
-              cursor = last.element;
-            }
+              afterBlock.next = newBlock;
+              if (right) right.prev = newBlock;
+            },
+            iterStartBlock = {element: iterStartElement, next: null, prev: null};
+
+        //watch props
+        scope.$watchProps(rhs, function ngRepeatWatch(collection){
+          var index, length,
+              cursor = iterStartElement,     // current position of the node
+              // Same as lastOrder but it has the current state. It will become the
+              // lastOrder on the next iteration.
+              nextOrder = new HashMap(), //use HashMap
+              arrayLength,
+              childScope,
+              key, value, // key/value of iteration
+              hashCode,
+              collectionKeys,
+              block,       // last object information {scope, element, index}
+              blocks = [],
+              lastBlock = iterStartBlock;
+
+
+          if (isArray(collection)) {
+            collectionKeys = collection || [];
           } else {
-            // new item which we don't know about
-            childScope = scope.$new();
+            // if object, extract keys, sort them and use to determine order of iteration over obj props
+            collectionKeys = [];
+            for (key in collection) {
+              if (collection.hasOwnProperty(key) && key.charAt(0) != '$') {
+                collectionKeys.push(key);
+              }
+            }
+            collectionKeys.sort();
           }
 
-          childScope[valueIdent] = value;
-          if (keyIdent) childScope[keyIdent] = key;
-          childScope.$index = index;
+          arrayLength = collectionKeys.length;
 
-          childScope.$first = (index === 0);
-          childScope.$last = (index === (arrayLength - 1));
-          childScope.$middle = !(childScope.$first || childScope.$last);
+          // locate existing items
+          length = blocks.length = collectionKeys.length;
+          for(index = 0; index < length; index++) {
+           key = (collection === collectionKeys) ? index : collectionKeys[index];
+           value = collection[key];
+           hashCode = hashFn(key, value);
+           if((block = lastOrder.remove(hashCode))) {
+             nextOrder.put(hashCode, block);
+             blocks[index] = block;
+           } else if (nextOrder.get(hashCode)) {
+             // restore lastOrder
+             forEach(blocks, function(block) {
+               if (block && block.element) lastOrder.put(block.hash, block);
+             });
+             // This is a duplicate and we need to throw an error
+             throw new Error('Duplicate hashes in the repeater are not allowed.');
+           } else {
+             // new never before seen block
+             blocks[index] = { hash: hashCode };
+           }
+         }
 
-          if (!last) {
-            linker(childScope, function(clone){
-              cursor.after(clone);
-              last = {
-                  scope: childScope,
-                  element: (cursor = clone),
-                  index: index
-                };
-              nextOrder.push(value, last);
-            });
-          }
-        }
-
-        //shrink children
-        for (key in lastOrder) {
-          if (lastOrder.hasOwnProperty(key)) {
-            array = lastOrder[key];
-            while(array.length) {
-              value = array.pop();
-              value.element.remove();
-              value.scope.$destroy();
+          // remove existing items
+          for (key in lastOrder) {
+            if (lastOrder.hasOwnProperty(key)) {
+              block = lastOrder[key];
+              block.element.remove();
+              block.scope.$destroy();
+              blockRemove(block);
             }
           }
-        }
 
-        lastOrder = nextOrder;
-      });
-    };
-  }
-});
+          // we are not using forEach for perf reasons (trying to avoid #call)
+          for (index = 0, length = collectionKeys.length; index < length; index++) {
+            key = (collection === collectionKeys) ? index : collectionKeys[index];
+            value = collection[key];
+            block = blocks[index];
+
+            if (block.element) {
+              // if we have already seen this object, then we need to reuse the
+              // associated scope/element
+              childScope = block.scope;
+
+              if (block.element == cursor) {
+                // do nothing
+                cursor = block.element;
+              } else {
+                // existing item which got moved
+                blockRemove(block);
+                blockInsertAfter(lastBlock, block);
+                cursor.after(block.element);
+                cursor = block.element;
+              }
+            } else {
+              // new item which we don't know about
+              childScope = scope.$new();
+            }
+
+            childScope[valueIdent] = value;
+            if (keyIdent) childScope[keyIdent] = key;
+            childScope.$index = index;
+            childScope.$first = (index === 0);
+            childScope.$last = (index === (arrayLength - 1));
+            childScope.$middle = !(childScope.$first || childScope.$last);
+
+            if (!block.element) {
+              linker(childScope, function(clone){
+                cursor.after(clone);
+                cursor = clone;
+                block.scope = childScope;
+                block.element = clone;
+                blockInsertAfter(lastBlock, block);
+                nextOrder.put(block.hash, block);
+              });
+            }
+          }
+          if (block) {
+            block.next = null;
+          } else {
+            iterStartBlock.next = null;
+          }
+          lastOrder = nextOrder;
+        });
+      };
+    }
+  };
+}];

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -327,9 +327,8 @@ function $RootScopeProvider(){
        * @methodOf ng.$rootScope.Scope
        * @function
        *
-       * @description
-       * Shallow watches the properties of an object and fires whenever any of the properties change.
-       * (For arrays this implies watching the array items, for object maps this implies watching the properties.)
+       * Shallow watches the properties of an object and fires whenever any of the properties change
+       * (for arrays this implies watching the array items, for object maps this implies watching the properties).
        * If a change is detected the `listener` callback is fired.
        *
        * - The `obj` object is observed via standard $watch operation and is examined on every call to $digest() to
@@ -340,38 +339,38 @@ function $RootScopeProvider(){
        *
        * # Example
        * <pre>
-          var scope = $rootScope;
-          scope.names = ['igor', 'matias', 'misko', 'james'];
-          scope.dataCount = 4;
+          $scope.names = ['igor', 'matias', 'misko', 'james'];
+          $scope.dataCount = 4;
 
-          scope.$watchProps('names', function(newNames, oldNames) {
-            scope.dataCount = newNames.length;
+          $scope.$watchProps('names', function(newNames, oldNames) {
+            $scope.dataCount = newNames.length;
           });
 
-          expect(scope.dataCount).toEqual(4);
-          scope.$digest();
+          expect($scope.dataCount).toEqual(4);
+          $scope.$digest();
 
           //still at 4 ... no changes
-          expect(scope.dataCount).toEqual(4);
+          expect($scope.dataCount).toEqual(4);
 
-          scope.names.pop();
-          scope.$digest();
+          $scope.names.pop();
+          $scope.$digest();
 
           //now there's been a change
-          expect(scope.dataCount).toEqual(3);
+          expect($scope.dataCount).toEqual(3);
        * </pre>
        *
        *
-       * @param {string} Evaluated as {@link guide/expression expression}. The expression value should evaluate to
-       *    An object or an array which is observed on each {@link ng.$rootScope.Scope#$digest $digest} cycle.
-       *    Any change within the obj collection will trigger call to the `listener`.
+       * @param {string} watchExpression evaluated as {@link guide/expression expression}. The expression value should evaluate to
+       *    an object or an array which is observed on each {@link ng.$rootScope.Scope#$digest $digest} cycle.
+       *    Any change within the `obj` collection will trigger call to the `listener`.
        *
        * @param {function(newCollection, oldCollection)} listener a callback function that is fired with both
        *    the `newCollection` and `oldCollection` as parameters.
        *    The `newCollection` object is the newly modified data obtained from the `obj` expression and the `oldCollection`
        *    object is a copy of the former collection data.
        *
-       * @returns {function()} Returns a de-registration function for this listener.
+       * @returns {function()} Returns a de-registration function for this listener. When the de-registration function is executed
+       * then the internal watch operation is terminated.
        */
       $watchProps: function(obj, listener) {
         var self = this;

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -320,6 +320,145 @@ function $RootScopeProvider(){
         };
       },
 
+
+      /**
+       * @ngdoc function
+       * @name ng.$rootScope.Scope#$watchProps
+       * @methodOf ng.$rootScope.Scope
+       * @function
+       *
+       * @description
+       * Shallow watches the properties of an object and fires whenever any of the properties change.
+       * (For arrays this implies watching the array items, for object maps this implies watching the properties.)
+       * If a change is detected the `listener` callback is fired.
+       *
+       * - The `obj` object is observed via standard $watch operation and is examined on every call to $digest() to
+       *   see if anything has been modified within it's contents.
+       * - The `listener` is called whenever anything within the `obj` has changed. Examples include adding new items
+       *   into the object or array, removing and moving items around.
+       *
+       *
+       * # Example
+       * <pre>
+          var scope = $rootScope;
+          scope.names = ['igor', 'matias', 'misko', 'james'];
+          scope.dataCount = 4;
+
+          scope.$watchProps('names', function(newNames, oldNames) {
+            scope.dataCount = newNames.length;
+          });
+
+          expect(scope.dataCount).toEqual(4);
+          scope.$digest();
+
+          //still at 4 ... no changes
+          expect(scope.dataCount).toEqual(4);
+
+          scope.names.pop();
+          scope.$digest();
+
+          //now there's been a change
+          expect(scope.dataCount).toEqual(3);
+       * </pre>
+       *
+       *
+       * @param {string} Evaluated as {@link guide/expression expression}. The expression value should evaluate to
+       *    An object or an array which is observed on each {@link ng.$rootScope.Scope#$digest $digest} cycle.
+       *    Any change within the obj collection will trigger call to the `listener`.
+       *
+       * @param {function(newCollection, oldCollection)} listener a callback function that is fired with both
+       *    the `newCollection` and `oldCollection` as parameters.
+       *    The `newCollection` object is the newly modified data obtained from the `obj` expression and the `oldCollection`
+       *    object is a copy of the former collection data.
+       *
+       * @returns {function()} Returns a de-registration function for this listener.
+       */
+      $watchProps: function(obj, listener) {
+        var self = this;
+        var oldValue;
+        var newValue;
+        var changeDetected = 0;
+        var objGetter = $parse(obj);
+        var myArray = [];
+        var myObject = [];
+        var oldLength = 0;
+
+        return this.$watch(
+          function() {
+            newValue = objGetter(self);
+            var newLength, key;
+
+            if (!newValue || typeof newValue !== 'object') {
+              if (oldValue !== newValue) {
+                oldValue = newValue;
+                changeDetected++;
+              }
+            } else if (isArray(newValue)) {
+              if (oldValue != myArray) {
+                // we are transitioning from something which was not an array into array.
+                oldValue = myArray;
+                oldLength = oldValue.length = 0;
+                changeDetected++;
+              }
+
+              newLength = newValue.length;
+
+              if (oldLength !== newLength) {
+                // if counts do not match we need to render
+                changeDetected++;
+                oldValue.length = oldLength = newLength;
+              }
+              // copy the items to oldValue and look for changes.
+              for (var i = 0; i < newLength; i++) {
+                if (oldValue[i] !== newValue[i]) {
+                  changeDetected++;
+                  oldValue[i] = newValue[i];
+                }
+              }
+            } else {
+              if (oldValue != myObject) {
+                // we are transitioning from something which was not an object into object.
+                oldValue = myObject = {};
+                oldLength = 0;
+                changeDetected++;
+              }
+              // copy the items to oldValue and look for changes.
+              newLength = 0;
+              for (key in newValue) {
+                if (newValue.hasOwnProperty(key)) {
+                  newLength++;
+                  if (oldValue.hasOwnProperty(key)) {
+                    if (oldValue[key] !== newValue[key]) {
+                      changeDetected++;
+                      oldValue[key] = newValue[key];
+                    }
+                  } else {
+                    oldLength++;
+                    oldValue[key] = newValue[key];
+                    changeDetected++;
+                  }
+                }
+              }
+              if (oldLength > newLength) {
+                // we used to have more keys, need to find them and destroy them.
+                changeDetected++;
+                for(key in oldValue) {
+                  if (oldValue.hasOwnProperty(key)) {
+                    if (!newValue.hasOwnProperty(key)) {
+                      oldLength--;
+                      delete oldValue[key];
+                    }
+                  }
+                }
+              }
+            }
+            return changeDetected;
+          },
+          function() {
+            listener(newValue, oldValue, self);
+          });
+      },
+
       /**
        * @ngdoc function
        * @name ng.$rootScope.Scope#$digest

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -362,6 +362,102 @@ describe('Scope', function() {
       $rootScope.$digest();
       expect(log).toEqual([]);
     }));
+
+    describe('$watchProps', function() {
+      var log, $rootScope;
+
+      beforeEach(inject(function(_$rootScope_) {
+        log = [];
+        $rootScope = _$rootScope_;
+        $rootScope.$watchProps('obj', function logger(obj) {
+          log.push(toJson(obj));
+        });
+      }));
+
+
+      it('should not trigger if nothing change', inject(function($rootScope) {
+        $rootScope.$digest();
+        expect(log).toEqual([undefined]);
+
+        $rootScope.$digest();
+        expect(log).toEqual([undefined]);
+      }));
+
+
+      it('should trigger when object changes ref', function() {
+        $rootScope.obj = 'test';
+        $rootScope.$digest();
+        expect(log).toEqual(['"test"']);
+
+        $rootScope.obj = [];
+        $rootScope.$digest();
+        expect(log).toEqual(['"test"', '[]']);
+      });
+
+
+      it('should watch array properties', function() {
+        $rootScope.obj = [];
+        $rootScope.$digest();
+        expect(log).toEqual(['[]']);
+
+        $rootScope.obj.push('a');
+        $rootScope.$digest();
+        expect(log).toEqual(['[]', '["a"]']);
+
+        $rootScope.obj[0] = 'b';
+        $rootScope.$digest();
+        expect(log).toEqual(['[]', '["a"]', '["b"]']);
+
+        $rootScope.obj.push([]);
+        $rootScope.obj.push({});
+        log = [];
+        $rootScope.$digest();
+        expect(log).toEqual(['["b",[],{}]']);
+
+        var temp = $rootScope.obj[1];
+        $rootScope.obj[1] = $rootScope.obj[2];
+        $rootScope.obj[2] = temp;
+        $rootScope.$digest();
+        expect(log).toEqual([ '["b",[],{}]', '["b",{},[]]' ]);
+
+        $rootScope.obj.shift()
+        log = [];
+        $rootScope.$digest();
+        expect(log).toEqual([ '[{},[]]' ]);
+      });
+
+
+      it('should watch object properties', function() {
+        $rootScope.obj = {};
+        $rootScope.$digest();
+        expect(log).toEqual(['{}']);
+
+        $rootScope.obj.a= 'A';
+        $rootScope.$digest();
+        expect(log).toEqual(['{}', '{"a":"A"}']);
+
+        $rootScope.obj.a = 'B';
+        $rootScope.$digest();
+        expect(log).toEqual(['{}', '{"a":"A"}', '{"a":"B"}']);
+
+        $rootScope.obj.b = [];
+        $rootScope.obj.c = {};
+        log = [];
+        $rootScope.$digest();
+        expect(log).toEqual(['{"a":"B","b":[],"c":{}}']);
+
+        var temp = $rootScope.obj.a;
+        $rootScope.obj.a = $rootScope.obj.b;
+        $rootScope.obj.c = temp;
+        $rootScope.$digest();
+        expect(log).toEqual([ '{"a":"B","b":[],"c":{}}', '{"a":[],"b":[],"c":"B"}' ]);
+
+        delete $rootScope.obj.a;
+        log = [];
+        $rootScope.$digest();
+        expect(log).toEqual([ '{"b":[],"c":"B"}' ]);
+      });
+    });
   });
 
 


### PR DESCRIPTION
BREAKING CHANGE:

Default behavior for hg-repeat is to associate the
DOM elements by position rather then by identity.
(Previously it was associate by object identity)

It is considered an error to have two items produce
the same hash key. (This was tolerated before.)

To get the old behavior one can simply add the
$hash call to the hg-repeat expressions:
item in items => $hash(item) for item in items
