### PR TITLE
docs(guide): Fixed typo in DI. angualar -> angular

### DIFF
--- a/docs/content/guide/di.ngdoc
+++ b/docs/content/guide/di.ngdoc
@@ -213,7 +213,7 @@ services, and filters. The factory methods are registered with the module, and t
 of declaring factories is:
 
 <pre>
-  angualar.module('myModule', []).
+  angular.module('myModule', []).
     config(['depProvider', function(depProvider){
       ...
     }]).


### PR DESCRIPTION
Fixed typo in developer guide for dependency injection. 

angualar -> angular
