### PR TITLE
Add Angular license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,11 @@
     "shelljs": "0.1.2",
     "testacular": "0.5.9",
     "yaml-js": "0.0.5"
-  }
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/angular/angular.js/blob/master/LICENSE"
+    }
+  ]
 }

--- a/src/ng/exceptionHandler.js
+++ b/src/ng/exceptionHandler.js
@@ -19,7 +19,7 @@
  *
  */
 function $ExceptionHandlerProvider() {
-  this.$get = ['$log', function($log){
+  this.$get = ['$log', function($log) {
     return function(exception, cause) {
       $log.error.apply($log, arguments);
     };


### PR DESCRIPTION
NPM spec allows for Angular's license in the package.json, so for completeness, I added it in :)

https://npmjs.org/doc/json.html
