### PR TITLE
Warning in a case $routeParams may be unpopulated

### DIFF
--- a/src/ng/routeParams.js
+++ b/src/ng/routeParams.js
@@ -14,6 +14,10 @@
  *
  * The service guarantees that the identity of the `$routeParams` object will remain unchanged
  * (but its properties will likely change) even when a route change occurs.
+ * 
+ * Note that routeParams are only generated when an ng-view will be rendered. In
+ * the absence of a view, routeParams may be unpopulated. You will be able to
+ * retrieve the extracted parameters from $route.current.params instead.
  *
  * @example
  * <pre>


### PR DESCRIPTION
~~I don't think this ought to happen. It was very surprising when I learned about it the hard way, so perhaps the warning should be here.~~

Please disregard this, it was just my misunderstanding.
