### PR TITLE
Update dev_guide.unit-testing.ngdoc

### DIFF
--- a/docs/content/guide/dev_guide.unit-testing.ngdoc
+++ b/docs/content/guide/dev_guide.unit-testing.ngdoc
@@ -97,7 +97,7 @@ function MyClass() {
 
 While no new instance of the dependency is being created, it is fundamentally the same as `new`, in
 that there is no good way to intercept the call to `global.xhr` for testing purposes, other then
-through monkey patching. The basic issue for testing is that global variable needs to be mutated in
+through monkey patching. The basic issue for testing is that a global variable needs to be mutated in
 order to replace it with call to a mock method. For further explanation why this is bad see: {@link
 http://misko.hevery.com/code-reviewers-guide/flaw-brittle-global-state-singletons/ Brittle Global
 State & Singletons}


### PR DESCRIPTION
missing 'a' before 'global variable'
