### PR TITLE
fix($browser): $watch() & url() breaks on async location.href updates

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -877,6 +877,17 @@ function encodeUriQuery(val, pctEncodeSpaces) {
 }
 
 
+var sanitizeUrl = function() {
+  var a = document.createElement('a');
+
+  return function(url) {
+    a.setAttribute('href', url);
+    // href property always returns normalized absolute url, so we can match against that
+    return a.href;
+  };
+}();
+
+
 /**
  * @ngdoc directive
  * @name ng.directive:ngApp

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -124,7 +124,8 @@ function Browser(window, document, $log, $sniffer) {
   //////////////////////////////////////////////////////////////
 
   var lastBrowserUrl = location.href,
-      baseElement = document.find('base');
+      baseElement = document.find('base'),
+      locationHref;
 
   /**
    * @name ng.$browser#url
@@ -149,8 +150,10 @@ function Browser(window, document, $log, $sniffer) {
   self.url = function(url, replace) {
     // setter
     if (url) {
-      if (lastBrowserUrl == url) return;
-      lastBrowserUrl = url;
+      url = sanitizeUrl(url);
+      if (lastBrowserUrl === url) return;
+      var lastHref = location.href;
+      locationHref = lastBrowserUrl = url;
       if ($sniffer.history) {
         if (replace) history.replaceState(null, '', url);
         else {
@@ -162,11 +165,17 @@ function Browser(window, document, $log, $sniffer) {
         if (replace) location.replace(url);
         else location.href = url;
       }
+      var timerId = setInterval(function() {
+        if (location.href !== lastHref) {
+          locationHref = undefined;
+          clearInterval(timerId);
+        }
+      }, 100);
       return self;
     // getter
     } else {
       // the replacement is a workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=407172
-      return location.href.replace(/%27/g,"'");
+      return (locationHref || location.href).replace(/%27/g,"'");
     }
   };
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -242,9 +242,9 @@ function $CompileProvider($provide) {
 
   this.$get = [
             '$injector', '$interpolate', '$exceptionHandler', '$http', '$templateCache', '$parse',
-            '$controller', '$rootScope', '$document',
+            '$controller', '$rootScope',
     function($injector,   $interpolate,   $exceptionHandler,   $http,   $templateCache,   $parse,
-             $controller,   $rootScope,   $document) {
+             $controller,   $rootScope) {
 
     var Attributes = function(element, attr) {
       this.$$element = element;
@@ -289,10 +289,7 @@ function $CompileProvider($provide) {
 
         // sanitize a[href] values
         if (nodeName_(this.$$element[0]) === 'A' && key === 'href') {
-          urlSanitizationNode.setAttribute('href', value);
-
-          // href property always returns normalized absolute url, so we can match against that
-          normalizedVal = urlSanitizationNode.href;
+          normalizedVal = sanitizeUrl(value);
           if (!normalizedVal.match(urlSanitizationWhitelist)) {
             this[key] = value = 'unsafe:' + normalizedVal;
           }
@@ -342,8 +339,7 @@ function $CompileProvider($provide) {
       }
     };
 
-    var urlSanitizationNode = $document[0].createElement('a'),
-        startSymbol = $interpolate.startSymbol(),
+    var startSymbol = $interpolate.startSymbol(),
         endSymbol = $interpolate.endSymbol(),
         denormalizeTemplate = (startSymbol == '{{' || endSymbol  == '}}')
             ? identity


### PR DESCRIPTION
On at least IE8 & IE9, location.href is updated asynchronously.
$watch() for $browser.url updates will loop until it breaks.
