### PR TITLE
feat(controller): support as instance syntax

### DIFF
--- a/src/ng/directive/ngController.js
+++ b/src/ng/directive/ngController.js
@@ -22,7 +22,8 @@
  * @scope
  * @param {expression} ngController Name of a globally accessible constructor function or an
  *     {@link guide/expression expression} that on the current scope evaluates to a
- *     constructor function.
+ *     constructor function. The controller instance can further be published into the scope
+ *     by adding `as localName` the controller name attribute.
  *
  * @example
  * Here is a simple form for editing user contact information. Adding, removing, clearing, and
@@ -30,7 +31,8 @@
  * easily be called from the angular markup. Notice that the scope becomes the `this` for the
  * controller's instance. This allows for easy access to the view data from the controller. Also
  * notice that any changes to the data are automatically reflected in the View without the need
- * for a manual update.
+ * for a manual update. The example is included int two different declaration styles based on
+ * your style preferences.
    <doc:example>
      <doc:source>
       <script>
@@ -79,6 +81,70 @@
      </doc:source>
      <doc:scenario>
        it('should check controller', function() {
+         expect(element('.doc-example-live div>:input').val()).toBe('John Smith');
+         expect(element('.doc-example-live li:nth-child(1) input').val())
+           .toBe('408 555 1212');
+         expect(element('.doc-example-live li:nth-child(2) input').val())
+           .toBe('john.smith@example.org');
+
+         element('.doc-example-live li:first a:contains("clear")').click();
+         expect(element('.doc-example-live li:first input').val()).toBe('');
+
+         element('.doc-example-live li:last a:contains("add")').click();
+         expect(element('.doc-example-live li:nth-child(3) input').val())
+           .toBe('yourname@example.org');
+       });
+     </doc:scenario>
+   </doc:example>
+
+   <doc:example>
+     <doc:source>
+      <script>
+        function SettingsAltController() {
+          this.name = "John Smith";
+          this.contacts = [
+            {type:'phone', value:'408 555 1212'},
+            {type:'email', value:'john.smith@example.org'} ];
+
+          this.greet = function() {
+           alert(this.name);
+          };
+
+          this.addContact = function() {
+           this.contacts.push({type:'email', value:'yourname@example.org'});
+          };
+
+          this.removeContact = function(contactToRemove) {
+           var index = this.contacts.indexOf(contactToRemove);
+           this.contacts.splice(index, 1);
+          };
+
+          this.clearContact = function(contact) {
+           contact.type = 'phone';
+           contact.value = '';
+          };
+        }
+      </script>
+      <div ng-controller="SettingsAltController as settings">
+        Name: <input type="text" ng-model="settings.name"/>
+        [ <a href="" ng-click="settings.greet()">greet</a> ]<br/>
+        Contact:
+        <ul>
+          <li ng-repeat="contact in settings.contacts">
+            <select ng-model="contact.type">
+               <option>phone</option>
+               <option>email</option>
+            </select>
+            <input type="text" ng-model="contact.value"/>
+            [ <a href="" ng-click="settings.clearContact(contact)">clear</a>
+            | <a href="" ng-click="settings.removeContact(contact)">X</a> ]
+          </li>
+          <li>[ <a href="" ng-click="settings.addContact()">add</a> ]</li>
+       </ul>
+      </div>
+     </doc:source>
+     <doc:scenario>
+       it('should check controller alternate style', function() {
          expect(element('.doc-example-live div>:input').val()).toBe('John Smith');
          expect(element('.doc-example-live li:nth-child(1) input').val())
            .toBe('408 555 1212');

--- a/test/ng/controllerSpec.js
+++ b/test/ng/controllerSpec.js
@@ -88,4 +88,15 @@ describe('$controller', function() {
 
     expect(ctrl.$scope).toBe(scope);
   });
+
+
+  it('should publish controller instance into scope', function() {
+    var scope = {};
+
+    $controllerProvider.register('FooCtrl', function() { this.mark = 'foo'; });
+
+    var foo = $controller('FooCtrl as foo', {$scope: scope});
+    expect(scope.foo).toBe(foo);
+    expect(scope.foo.mark).toBe('foo');
+  });
 });

--- a/test/ng/directive/ngControllerSpec.js
+++ b/test/ng/directive/ngControllerSpec.js
@@ -27,6 +27,10 @@ describe('ngController', function() {
     $window.Child = function($scope) {
       $scope.name = 'Adam';
     };
+
+    $window.Public = function() {
+      this.mark = 'works';
+    }
   }));
 
   afterEach(function() {
@@ -38,6 +42,13 @@ describe('ngController', function() {
     element = $compile('<div ng-controller="Greeter">{{greet(name)}}</div>')($rootScope);
     $rootScope.$digest();
     expect(element.text()).toBe('Hello Misko!');
+  }));
+
+
+  it('should publish controller into scope', inject(function($compile, $rootScope) {
+    element = $compile('<div ng-controller="Public as p">{{p.mark}}</div>')($rootScope);
+    $rootScope.$digest();
+    expect(element.text()).toBe('works');
   }));
 
 


### PR DESCRIPTION
Support `ng-controller="MyController as my"` syntax
which publishes the controller instance to the
current scope.

Also supports exporting a controller defined with route:

``` javascript
angular.module('routes', [], function($routeProvider) {
  $routeProvider.when('/home', {controller: 'Ctrl as home', templateUrl: '...'});
});
```
## I think we should change the docs to recommend only single way of doing this.
