### PR TITLE
[bug fix] Date formatting for ISODate string fails on Android 2.1 stock browser, #2275

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -192,6 +192,7 @@ function padNumber(num, digits, trim) {
 
 
 function dateGetter(name, size, offset, trim) {
+  if (!offset) { offset = 0; }
   return function(date) {
     var value = date['get' + name]();
     if (offset > 0 || value > -offset)


### PR DESCRIPTION
if "offset" is not specified, it messes up the calculations that follow. Apparently, it does not default to 0 in arithmetic context on some older browsers. 
