### PR TITLE
fix(date): date filter now correctly formats high precision date-times

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -355,7 +355,11 @@ function dateFilter($locale) {
         tzMin = int(match[9] + match[11]);
       }
       dateSetter.call(date, int(match[1]), int(match[2]) - 1, int(match[3]));
-      timeSetter.call(date, int(match[4]||0) - tzHour, int(match[5]||0) - tzMin, int(match[6]||0), int(match[7]||0));
+      var h = int(match[4]||0) - tzHour;
+      var m = int(match[5]||0) - tzMin
+      var s = int(match[6]||0);
+      var ms = Math.round(parseFloat('0.' + (match[7]||0)) * 1000);
+      timeSetter.call(date, h, m, s, ms);
       return date;
     }
     return string;

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -300,21 +300,23 @@ describe('filters', function() {
     it('should support various iso8061 date strings with timezone as input', function() {
       var format = 'yyyy-MM-dd ss';
 
+      var localDay = new Date(Date.UTC(2003, 9, 10, 13, 2, 3, 0)).getDate();
+
       //full ISO8061
-      expect(date('2003-09-10T13:02:03.000Z', format)).toEqual('2003-09-10 03');
+      expect(date('2003-09-10T13:02:03.000Z', format)).toEqual('2003-09-' + localDay + ' 03');
 
-      expect(date('2003-09-10T13:02:03.000+00:00', format)).toEqual('2003-09-10 03');
+      expect(date('2003-09-10T13:02:03.000+00:00', format)).toEqual('2003-09-' + localDay + ' 03');
 
-      expect(date('20030910T033203-0930', format)).toEqual('2003-09-10 03');
+      expect(date('20030910T033203-0930', format)).toEqual('2003-09-' + localDay + ' 03');
 
       //no millis
-      expect(date('2003-09-10T13:02:03Z', format)).toEqual('2003-09-10 03');
+      expect(date('2003-09-10T13:02:03Z', format)).toEqual('2003-09-' + localDay + ' 03');
 
       //no seconds
-      expect(date('2003-09-10T13:02Z', format)).toEqual('2003-09-10 00');
+      expect(date('2003-09-10T13:02Z', format)).toEqual('2003-09-' + localDay + ' 00');
 
       //no minutes
-      expect(date('2003-09-10T13Z', format)).toEqual('2003-09-10 00');
+      expect(date('2003-09-10T13Z', format)).toEqual('2003-09-' + localDay + ' 00');
     });
 
 
@@ -333,14 +335,16 @@ describe('filters', function() {
     it('should support different degrees of subsecond precision', function () {
       var format = 'yyyy-MM-dd';
 
-      expect(date('2003-09-10T13:02:03.12345678Z', format)).toEqual('2003-09-10');
-      expect(date('2003-09-10T13:02:03.1234567Z', format)).toEqual('2003-09-10');
-      expect(date('2003-09-10T13:02:03.123456Z', format)).toEqual('2003-09-10');
-      expect(date('2003-09-10T13:02:03.12345Z', format)).toEqual('2003-09-10');
-      expect(date('2003-09-10T13:02:03.1234Z', format)).toEqual('2003-09-10');
-      expect(date('2003-09-10T13:02:03.123Z', format)).toEqual('2003-09-10');
-      expect(date('2003-09-10T13:02:03.12Z', format)).toEqual('2003-09-10');
-      expect(date('2003-09-10T13:02:03.1Z', format)).toEqual('2003-09-10');
+      var localDay = new Date(Date.UTC(2003, 9-1, 10, 13, 2, 3, 123)).getDate();
+
+      expect(date('2003-09-10T13:02:03.12345678Z', format)).toEqual('2003-09-' + localDay);
+      expect(date('2003-09-10T13:02:03.1234567Z', format)).toEqual('2003-09-' + localDay);
+      expect(date('2003-09-10T13:02:03.123456Z', format)).toEqual('2003-09-' + localDay);
+      expect(date('2003-09-10T13:02:03.12345Z', format)).toEqual('2003-09-' + localDay);
+      expect(date('2003-09-10T13:02:03.1234Z', format)).toEqual('2003-09-' + localDay);
+      expect(date('2003-09-10T13:02:03.123Z', format)).toEqual('2003-09-' + localDay);
+      expect(date('2003-09-10T13:02:03.12Z', format)).toEqual('2003-09-' + localDay);
+      expect(date('2003-09-10T13:02:03.1Z', format)).toEqual('2003-09-' + localDay);
     });
   });
 });

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -333,18 +333,18 @@ describe('filters', function() {
     });
 
     it('should support different degrees of subsecond precision', function () {
-      var format = 'yyyy-MM-dd';
+      var format = 'yyyy-MM-dd ss';
 
       var localDay = new Date(Date.UTC(2003, 9-1, 10, 13, 2, 3, 123)).getDate();
 
-      expect(date('2003-09-10T13:02:03.12345678Z', format)).toEqual('2003-09-' + localDay);
-      expect(date('2003-09-10T13:02:03.1234567Z', format)).toEqual('2003-09-' + localDay);
-      expect(date('2003-09-10T13:02:03.123456Z', format)).toEqual('2003-09-' + localDay);
-      expect(date('2003-09-10T13:02:03.12345Z', format)).toEqual('2003-09-' + localDay);
-      expect(date('2003-09-10T13:02:03.1234Z', format)).toEqual('2003-09-' + localDay);
-      expect(date('2003-09-10T13:02:03.123Z', format)).toEqual('2003-09-' + localDay);
-      expect(date('2003-09-10T13:02:03.12Z', format)).toEqual('2003-09-' + localDay);
-      expect(date('2003-09-10T13:02:03.1Z', format)).toEqual('2003-09-' + localDay);
+      expect(date('2003-09-10T13:02:03.12345678Z', format)).toEqual('2003-09-' + localDay + ' 03');
+      expect(date('2003-09-10T13:02:03.1234567Z', format)).toEqual('2003-09-' + localDay + ' 03');
+      expect(date('2003-09-10T13:02:03.123456Z', format)).toEqual('2003-09-' + localDay + ' 03');
+      expect(date('2003-09-10T13:02:03.12345Z', format)).toEqual('2003-09-' + localDay + ' 03');
+      expect(date('2003-09-10T13:02:03.1234Z', format)).toEqual('2003-09-' + localDay + ' 03');
+      expect(date('2003-09-10T13:02:03.123Z', format)).toEqual('2003-09-' + localDay + ' 03');
+      expect(date('2003-09-10T13:02:03.12Z', format)).toEqual('2003-09-' + localDay + ' 03');
+      expect(date('2003-09-10T13:02:03.1Z', format)).toEqual('2003-09-' + localDay + ' 03');
     });
   });
 });


### PR DESCRIPTION
Fix the date filter so fractional seconds are processed correctly. For example `{{2003-09-10T13:02:03.987654Z | date: yyyy-mm-dd ss}}` is now formatted as `2003-09-10 03`. Prior to this fix it was formatted as `2003-09-10 30` because the code treated `.987654` as 987.654s / 60s = 16 minutes 27.654 seconds so 27 seconds were added to the second component of the date.

The fractional seconds are rounded to the nearest millisecond.

I've also fixed a couple of tests so they work correctly when they are run in any time zone. I tested them in UTC+1300.

See:
- https://github.com/angular/angular.js/pull/989.
- https://github.com/steinjak/angular.js/commit/2df31b5e4c1e23461b62ecf9789645bcfc3451c5
