### PR TITLE
ngResource: fix cannot read property 'charAt' of null

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -377,7 +377,7 @@ angular.module('ngResource', ['ng']).
         actionParams = extend({}, paramDefaults, actionParams);
         forEach(actionParams, function(value, key){
           if (isFunction(value)) { value = value(); }
-          ids[key] = value.charAt && value.charAt(0) == '@' ? getter(data, value.substr(1)) : value;
+          ids[key] = value && value.charAt && value.charAt(0) == '@' ? getter(data, value.substr(1)) : value;
         });
         return ids;
       }

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -205,6 +205,16 @@ describe("resource", function() {
   });
 
 
+  it('should not throw TypeError on null default params', function() {
+    $httpBackend.expect('GET', '/Path?').respond('{}');
+    var R = $resource('/Path', {param: null}, {get: {method: 'GET'}});
+
+    expect(function() {
+      R.get({});
+    }).not.toThrow();
+  });
+
+
   it('should handle multiple params with same name', function() {
     var R = $resource('/:id/:id');
 


### PR DESCRIPTION
Fixes issue when setting a default param as `null` error `TypeError: Cannot read property 'charAt' of null`
