### PR TITLE
fix(ngAnimator): correct polyfillSetup activation and memento generation

### DIFF
--- a/src/ng/animator.js
+++ b/src/ng/animator.js
@@ -240,7 +240,7 @@ var $AnimatorProvider = function() {
             beforeFn(element, parent, after);
             if (element.length == 0) return done();
 
-            var memento = (noop || polyfillSetup)(element);
+            var memento = (polyfillSetup || noop)(element);
 
             // $window.setTimeout(beginAnimation, 0); this was causing the element not to animate
             // keep at 1 for animation dom rerender

--- a/test/ng/animatorSpec.js
+++ b/test/ng/animatorSpec.js
@@ -76,6 +76,17 @@ describe("$animator", function() {
             }
           }
         });
+       $animationProvider.register('setup-memo', function() {
+          return {
+            setup: function(element) {
+              return "memento";
+            },
+            start: function(element, done, memento) {
+              element.text(memento);
+              done();
+            }
+          }
+        });
       })
       inject(function($animator, $compile, $rootScope) {
         element = $compile('<div></div>')($rootScope);
@@ -184,6 +195,16 @@ describe("$animator", function() {
       window.setTimeout.expect(1).process();
       expect(child.attr('class')).toContain('custom-leave-start');
       window.setTimeout.expect(0).process();
+    }));
+
+    it("should run polyfillSetup and return the memento", inject(function($animator, $rootScope) {
+      animator = $animator($rootScope, {
+        ngAnimate : '{show: \'setup-memo\'}'
+      });
+      expect(element.text()).toEqual('');
+      animator.show(element);
+      window.setTimeout.expect(1).process();
+      expect(element.text()).toBe('memento');
     }));
   });
 


### PR DESCRIPTION
polyfillSetup never runs; memento always returning undefined

The order of the functions should be switched for the proper return value

line 243 of /src/ng/animator.js
