### PR TITLE
fix(ngPattern): allow modifiers on inline ng-pattern

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -439,7 +439,8 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 
   // pattern validator
   var pattern = attr.ngPattern,
-      patternValidator;
+      patternValidator,
+      match;
 
   var validate = function(regexp, value) {
     if (isEmpty(value) || regexp.test(value)) {
@@ -452,8 +453,9 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   };
 
   if (pattern) {
-    if (pattern.match(/^\/(.*)\/$/)) {
-      pattern = new RegExp(pattern.substr(1, pattern.length - 2));
+    match = pattern.match(/^\/(.*)\/([gim]*)$/);
+    if (match) {
+      pattern = new RegExp(match[1], match[2]);
       patternValidator = function(value) {
         return validate(pattern, value)
       };

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -476,6 +476,18 @@ describe('input', function() {
     });
 
 
+    it('should validate in-lined pattern with modifiers', function() {
+      compileInput('<input type="text" ng-model="value" ng-pattern="/^abc?$/i" />');
+      scope.$digest();
+
+      changeInputValueTo('aB');
+      expect(inputElm).toBeValid();
+
+      changeInputValueTo('xx');
+      expect(inputElm).toBeInvalid();
+    });
+
+
     it('should validate pattern from scope', function() {
       compileInput('<input type="text" ng-model="value" ng-pattern="regexp" />');
       scope.regexp = /^\d\d\d-\d\d-\d\d\d\d$/;
@@ -496,9 +508,9 @@ describe('input', function() {
       changeInputValueTo('x');
       expect(inputElm).toBeInvalid();
 
-      scope.regexp = /abc?/;
+      scope.regexp = /abc?/i;
 
-      changeInputValueTo('ab');
+      changeInputValueTo('aB');
       expect(inputElm).toBeValid();
 
       changeInputValueTo('xx');


### PR DESCRIPTION
Add support for regex modifiers on inline ng-pattern. `ng-pattern="/abc/i"`

Closes #1437
