### PR TITLE
Fixed injector.js comment sentence.

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -96,7 +96,7 @@ function annotate(fn) {
  * # Injection Function Annotation
  *
  * JavaScript does not have annotations, and annotations are needed for dependency injection. The
- * following ways are all valid way of annotating function with injection arguments and are equivalent.
+ * following ways are all valid ways of annotating a function with injection arguments and are equivalent.
  *
  * <pre>
  *   // inferred (only works if code not minified/obfuscated)


### PR DESCRIPTION
The following ways are all valid **ways** of annotating **a** function with injection arguments and are equivalent.
