### PR TITLE
Add support for all mobile devices

### DIFF
--- a/src/ngMobile/directive/ngClick.js
+++ b/src/ngMobile/directive/ngClick.js
@@ -81,7 +81,7 @@ ngMobile.directive('ngClick', ['$parse', '$mobile', function($parse, $mobile) {
             dist = Math.sqrt( Math.pow(x - touchStartX, 2) + Math.pow(y - touchStartY, 2) );
 
           try {
-            if (diff < TAP_DURATION && dist < MOVE_TOLERANCE) {
+            if (event.type == 'touchend' && diff < TAP_DURATION && dist < MOVE_TOLERANCE) {
               $mobile.preventGhostClick(x, y);
 
               // Blur the focused element (the button, probably) before firing the callback.

--- a/src/ngMobile/directive/ngClick.js
+++ b/src/ngMobile/directive/ngClick.js
@@ -1,8 +1,202 @@
 'use strict';
 
+
+ngMobile.config(['$provide', '$mobileProvider', function($provide, $mobile) {
+  $provide.decorator('ngClickDirective', ['$delegate', function($delegate) {
+    // drop the default ngClick directive
+    $delegate.shift();
+    return $delegate;
+  }]);
+
+  var CLICKBUSTER_THRESHOLD = 25,  // 25 pixels in any dimension is the limit for busting clicks.
+    PREVENT_DURATION = 2500,     // 2.5 seconds maximum from preventGhostClick call to click
+    lastPreventedTime,
+    touchCoordinates,
+
+
+    // TAP EVENTS AND GHOST CLICKS
+    //
+    // Why tap events?
+    // Mobile browsers detect a tap, then wait a moment (usually ~300ms) to see if you're
+    // double-tapping, and then fire a click event.
+    //
+    // This delay sucks and makes mobile apps feel unresponsive.
+    // So we detect touchstart, touchmove, touchcancel and touchend ourselves and determine when
+    // the user has tapped on something.
+    //
+    // What happens when the browser then generates a click event?
+    // The browser, of course, also detects the tap and fires a click after a delay. This results in
+    // tapping/clicking twice. So we do "clickbusting" to prevent it.
+    //
+    // How does it work?
+    // We attach global touchstart and click handlers, that run during the capture (early) phase.
+    // So the sequence for a tap is:
+    // - global touchstart: Sets an "allowable region" at the point touched.
+    // - element's touchstart: Starts a touch
+    // (- touchmove or touchcancel ends the touch, no click follows)
+    // - element's touchend: Determines if the tap is valid (didn't move too far away, didn't hold
+    //   too long) and fires the user's tap handler. The touchend also calls preventGhostClick().
+    // - preventGhostClick() removes the allowable region the global touchstart created.
+    // - The browser generates a click event.
+    // - The global click handler catches the click, and checks whether it was in an allowable region.
+    //     - If preventGhostClick was called, the region will have been removed, the click is busted.
+    //     - If the region is still there, the click proceeds normally. Therefore clicks on links and
+    //       other elements without ngTap on them work normally.
+    //
+    // This is an ugly, terrible hack!
+    // Yeah, tell me about it. The alternatives are using the slow click events, or making our users
+    // deal with the ghost clicks, so I consider this the least of evils. Fortunately Angular
+    // encapsulates this ugly logic away from the user.
+    //
+    // Why not just put click handlers on the element?
+    // We do that too, just to be sure. The problem is that the tap event might have caused the DOM
+    // to change, so that the click fires in the same position but something else is there now. So
+    // the handlers are global and care only about coordinates and not elements.
+
+
+    // Checks if the coordinates are close enough to be within the region.
+    hit = function(x1, y1, x2, y2) {
+      return Math.abs(x1 - x2) < CLICKBUSTER_THRESHOLD && Math.abs(y1 - y2) < CLICKBUSTER_THRESHOLD;
+    },
+
+    // Checks a list of allowable regions against a click location.
+    // Returns true if the click should be allowed.
+    // Splices out the allowable region from the list after it has been used.
+    checkAllowableRegions = function(touchCoordinates, x, y) {
+      for (var i = 0; i < touchCoordinates.length; i += 2) {
+        if (hit(touchCoordinates[i], touchCoordinates[i+1], x, y)) {
+          touchCoordinates.splice(i, i + 2);
+          return true; // allowable region
+        }
+      }
+      return false; // No allowable region; bust it.
+    },
+
+    // Global click handler that prevents the click if it's in a bustable zone and preventGhostClick
+    // was called recently.
+    onClick = function(event) {
+      if (Date.now() - lastPreventedTime > PREVENT_DURATION) {
+        return; // Too old.
+      }
+
+      var touches = event.touches && event.touches.length ? event.touches : [event],
+        x = touches[0].clientX,
+        y = touches[0].clientY;
+      // Work around desktop Webkit quirk where clicking a label will fire two clicks (on the label
+      // and on the input element). Depending on the exact browser, this second click we don't want
+      // to bust has either (0,0) or negative coordinates.
+      if (x < 1 && y < 1) {
+        return; // offscreen
+      }
+
+      // Look for an allowable region containing this click.
+      // If we find one, that means it was created by touchstart and not removed by
+      // preventGhostClick, so we don't bust it.
+      if (checkAllowableRegions(touchCoordinates, x, y)) {
+        return;
+      }
+
+      // If we didn't find an allowable region, bust the click.
+      event.stopPropagation();
+      event.preventDefault();
+    },
+
+    // Global touchstart handler that creates an allowable region for a click event.
+    // This allowable region can be removed by preventGhostClick if we want to bust it.
+    onTouchStart = function(event) {
+      var touches = event.touches && event.touches.length ? event.touches : [event],
+        x = touches[0].clientX,
+        y = touches[0].clientY;
+
+      touchCoordinates.push(x, y);
+
+      setTimeout(function() {
+        // Remove the allowable region.
+        for (var i = 0; i < touchCoordinates.length; i += 2) {
+          if (touchCoordinates[i] == x && touchCoordinates[i+1] == y) {
+            touchCoordinates.splice(i, i + 2);
+            return;
+          }
+        }
+      }, PREVENT_DURATION);
+    },
+
+    // On the first call, attaches some event handlers. Then whenever it gets called, it creates a
+    // zone around the touchstart where clicks will get busted.
+    preventGhostClick = function(x, y) {
+      if (!touchCoordinates) {
+        angular.element(document).bind('click', onClick, true)
+          .bind('touchstart', onTouchStart, true);
+        touchCoordinates = [];
+      }
+      lastPreventedTime = Date.now();
+
+      checkAllowableRegions(touchCoordinates, x, y);
+    };
+
+  $mobile.register({
+    name: 'tap',
+    index: 100,
+    defaults: {
+      tap_max_pointers    : 1,
+      tap_max_duration    : 750,    // Shorter than 750ms is a tap, longer is a taphold or drag.
+      tap_move_tolerance  : 10,     // 10px doesn't overlap with drags move tolerance
+      tap_always          : true,   // tap on double tap (w3c way for click)
+      prevent_ghost_clicks: true,   // ignore virtual click events if click already handled
+      doubletap_tolerance : 20,     // allow for a bit of human error
+      doubletap_interval  : 400
+    },
+    setup: function(el, inst) {
+      // Use the setup function to check for IE8 or below
+      // As IE doesn't have a mouse down event for double taps
+      if(!document.addEventListener) {
+        element.bind('dblclick', function(ev) {
+          if(inst.options.tap_always) {
+            inst.trigger('tap', ev);
+          }
+          inst.trigger('doubletap', ev);
+        });
+      }
+    },
+    handler: function tapGesture(ev, inst) {
+      if(ev.eventType == $mobile.utils.EVENT_END) {
+        // previous gesture, for the double tap since these are two different gesture detections
+        var prev = inst.previous,
+          did_doubletap = false;
+
+        // when the touch time is higher then the max touch time
+        // or when the moving distance is too much
+        if(ev.deltaTime > inst.options.tap_max_duration ||
+          ev.distance > inst.options.tap_move_tolerance) {
+          return;
+        }
+
+        if (ev.srcEvent.type == 'touchend' && inst.options.prevent_ghost_clicks) {
+          preventGhostClick(ev.srcEvent.clientX, ev.srcEvent.clientY);
+        }
+
+        // check if double tap
+        if(prev && prev.name == 'tap' &&
+            (ev.timeStamp - prev.lastEvent.timeStamp) < inst.options.doubletap_interval &&
+            ev.distance < inst.options.doubletap_tolerance) {
+          inst.trigger('doubletap', ev);
+          did_doubletap = true;
+        }
+
+        // do a single tap
+        if(!did_doubletap || inst.options.tap_always) {
+          inst.current.name = 'tap';
+          inst.trigger(inst.current.name, ev);
+        }
+      }
+    }
+  });
+}]);
+
+
 /**
  * @ngdoc directive
- * @name ngMobile.directive:ngTap
+ * @name ngMobile.directive:ngClick
  *
  * @description
  * Specify custom behavior when element is tapped on a touchscreen device.
@@ -10,114 +204,71 @@
  *
  * @element ANY
  * @param {expression} ngClick {@link guide/expression Expression} to evaluate
- * upon tap. (Event object is available as `$event`)
+ * upon tap. (Event object is available as `$event`, Angular Element as '$element')
  *
  * @example
     <doc:example>
       <doc:source>
-        <button ng-tap="count = count + 1" ng-init="count=0">
-          Increment
+        <button ng-click="clicks = clicks + 1" ng-init="clicks=0">
+          Click to Increment
         </button>
-        count: {{ count }}
+        clicks: {{ clicks }}
       </doc:source>
     </doc:example>
  */
+ngMobile.directive('ngClick', ['$parse', '$mobile', function($parse, $mobile) {
+  return function(scope, element, attr) {
+    var clickHandler = $parse(attr['ngClick']);
 
-ngMobile.config(['$provide', function($provide) {
-  $provide.decorator('ngClickDirective', ['$delegate', function($delegate) {
-    // drop the default ngClick directive
-    $delegate.shift();
-    return $delegate;
-  }]);
+    // Hack for iOS Safari's benefit. It goes searching for onclick handlers and is liable to click
+    // something else nearby.
+    element[0].onclick = function(event) {};
+
+    $mobile.gestureOn(element, 'tap').bind('tap', function(eventdata) {
+      scope.$apply(function() {
+        clickHandler(scope, {$event: eventdata, $element: element});
+      });
+    });
+  };
 }]);
 
-ngMobile.directive('ngClick', ['$parse', '$mobile', function($parse, $mobile) {
-  var MOVE_TOLERANCE = $mobile.getPointSize() * 8, // 8pt
-    TAP_DURATION = 750; // Shorter than 750ms is a tap, longer is a taphold or drag.
 
-  
-  // Actual linking function.
-  return function(scope, element, attrs) {
-    var expressionFn = $parse(attrs.ngClick),
-      clickHandler = function(event) {
-        scope.$apply(function() {
-          // TODO(braden): This is sending the touchend, click or pointerup. Is that kosher?
-          expressionFn(scope, {$event: event});
-        });
-      };
 
-    if ("ontouchend" in document) {
-      var firstId,
-      tapElement, // Used to blur the element after a tap.
-      startTime,  // Used to check if the tap was held too long.
-      touchStartX,
-      touchStartY;
-      
-      $mobile.getPointerEvents(scope, element, {
-        down: function(id, pointer, event) {
-          if(!firstId && event.type != 'touchstart') {    // ignore any mouse events
-            firstId = id;
-            tapElement = event.target; //? event.target : event.srcElement;  // IE uses srcElement.
-  
-            // Hack for Safari, which can target text nodes instead of containers.
-            if(tapElement.nodeType == 3) {
-              tapElement = tapElement.parentNode;
-            }
-  
-            startTime = Date.now();
-  
-            touchStartX = pointer.clientX;
-            touchStartY = pointer.clientY;
-          }
-        },
-        move: function(id, pointer, event) {  // Resets the state
-          if(firstId === id) {
-            firstId = undefined;
-          }
-        },
-        up: function(id, pointer, event) {
-          if(firstId === id) {
-            var diff = Date.now() - startTime,
-              x = pointer.clientX,
-              y = pointer.clientY,
-              dist = Math.sqrt( Math.pow(x - touchStartX, 2) + Math.pow(y - touchStartY, 2) );
-  
-            try {
-              if (diff < TAP_DURATION && dist < MOVE_TOLERANCE) {
-                $mobile.preventGhostClick(x, y);
-  
-                // Blur the focused element (the button, probably) before firing the callback.
-                // This doesn't work perfectly on Android Chrome, but seems to work elsewhere.
-                // I couldn't get anything to work reliably on Android Chrome.
-                if (tapElement) {
-                  tapElement.blur();
-                }
-                
-                // Send the pointer as it has the clientX / Y set so more useful then the raw
-                //  event object on touch devices. Mouse / Pointers this is the event object.
-                clickHandler(pointer);
-              }
-            } finally {
-              firstId = undefined;    // Resets the state
-            }
-          }
-        },
-        cancel: function(id, event) {
-          if(firstId === id) {
-            firstId = undefined;      // Resets the state
-          }
-        }
+ /**
+ * @ngdoc directive
+ * @name ngMobile.directive:ngDblClick
+ *
+ * @description
+ * Specify custom behavior when element is tapped twice on a touchscreen device.
+ * A double tap is two taps with only a brief pause without much motion.
+ *
+ * @element ANY
+ * @param {expression} ngClick {@link guide/expression Expression} to evaluate
+ * upon double tap. (Event object is available as `$event`, Angular Element as '$element')
+ *
+ * @example
+    <doc:example>
+      <doc:source>
+        <button ng-dbl-click="dbl = dbl + 1" ng-init="dbl=0">
+          Double Click to Increment
+        </button>
+        Double Clicks: {{ dbl }}
+      </doc:source>
+    </doc:example>
+ */
+ngMobile.directive('ngDblClick', ['$parse', '$mobile', function($parse, $mobile) {
+  return function(scope, element, attr) {
+    var clickHandler = $parse(attr['ngDblClick']);
+
+    // Hack for iOS Safari's benefit. It goes searching for onclick handlers and is liable to click
+    // something else nearby.
+    element[0].onclick = function(event) {};
+
+    $mobile.gestureOn(element, 'tap').bind('doubletap', function(eventdata) {
+      scope.$apply(function() {
+        clickHandler(scope, {$event:eventdata, $element: element});
       });
-      
-      // Hack for iOS Safari's benefit. It goes searching for onclick handlers and is liable to click
-      // something else nearby.
-      element.onclick = function(event) { };
-    }
-
-    // Fallback click handler.
-    // Busted clicks don't get this far, and adding this handler allows ng-tap to be used on
-    // desktop as well, to allow more portable sites.
-    element.bind('click', clickHandler);
+    });
   };
 }]);
 

--- a/src/ngMobile/directive/ngClick.js
+++ b/src/ngMobile/directive/ngClick.js
@@ -38,12 +38,7 @@ ngMobile.directive('ngClick', ['$parse', '$mobile', function($parse, $mobile) {
   
   // Actual linking function.
   return function(scope, element, attrs) {
-    var firstId,
-      tapElement, // Used to blur the element after a tap.
-      startTime,  // Used to check if the tap was held too long.
-      touchStartX,
-      touchStartY,
-      expressionFn = $parse(attrs.ngClick),
+    var expressionFn = $parse(attrs.ngClick),
       clickHandler = function(event) {
         scope.$apply(function() {
           // TODO(braden): This is sending the touchend, click or pointerup. Is that kosher?
@@ -51,65 +46,73 @@ ngMobile.directive('ngClick', ['$parse', '$mobile', function($parse, $mobile) {
         });
       };
 
-    $mobile.getPointerEvents(scope, element, {
-      down: function(id, pointer, event) {
-        if(!firstId) {
-          firstId = id;
-          tapElement = event.target ? event.target : event.srcElement;  // IE uses srcElement.
-
-          // Hack for Safari, which can target text nodes instead of containers.
-          if(tapElement.nodeType == 3) {
-            tapElement = tapElement.parentNode;
-          }
-
-          startTime = Date.now();
-
-          touchStartX = pointer.clientX;
-          touchStartY = pointer.clientY;
-        }
-      },
-      move: function(id, pointer, event) {  // Resets the state
-        if(firstId === id) {
-          firstId = undefined;
-        }
-      },
-      up: function(id, pointer, event) {
-        if(firstId === id) {
-          var diff = Date.now() - startTime,
-            x = pointer.clientX,
-            y = pointer.clientY,
-            dist = Math.sqrt( Math.pow(x - touchStartX, 2) + Math.pow(y - touchStartY, 2) );
-
-          try {
-            if (event.type == 'touchend' && diff < TAP_DURATION && dist < MOVE_TOLERANCE) {
-              $mobile.preventGhostClick(x, y);
-
-              // Blur the focused element (the button, probably) before firing the callback.
-              // This doesn't work perfectly on Android Chrome, but seems to work elsewhere.
-              // I couldn't get anything to work reliably on Android Chrome.
-              if (tapElement) {
-                tapElement.blur();
-              }
-              
-              // Send the pointer as it has the clientX / Y set so more useful then the raw
-              //  event object on touch devices. Mouse / Pointers this is the event object.
-              clickHandler(pointer);
+    if ("ontouchend" in document) {
+      var firstId,
+      tapElement, // Used to blur the element after a tap.
+      startTime,  // Used to check if the tap was held too long.
+      touchStartX,
+      touchStartY;
+      
+      $mobile.getPointerEvents(scope, element, {
+        down: function(id, pointer, event) {
+          if(!firstId && event.type != 'touchstart') {    // ignore any mouse events
+            firstId = id;
+            tapElement = event.target; //? event.target : event.srcElement;  // IE uses srcElement.
+  
+            // Hack for Safari, which can target text nodes instead of containers.
+            if(tapElement.nodeType == 3) {
+              tapElement = tapElement.parentNode;
             }
-          } finally {
-            firstId = undefined;    // Resets the state
+  
+            startTime = Date.now();
+  
+            touchStartX = pointer.clientX;
+            touchStartY = pointer.clientY;
+          }
+        },
+        move: function(id, pointer, event) {  // Resets the state
+          if(firstId === id) {
+            firstId = undefined;
+          }
+        },
+        up: function(id, pointer, event) {
+          if(firstId === id) {
+            var diff = Date.now() - startTime,
+              x = pointer.clientX,
+              y = pointer.clientY,
+              dist = Math.sqrt( Math.pow(x - touchStartX, 2) + Math.pow(y - touchStartY, 2) );
+  
+            try {
+              if (diff < TAP_DURATION && dist < MOVE_TOLERANCE) {
+                $mobile.preventGhostClick(x, y);
+  
+                // Blur the focused element (the button, probably) before firing the callback.
+                // This doesn't work perfectly on Android Chrome, but seems to work elsewhere.
+                // I couldn't get anything to work reliably on Android Chrome.
+                if (tapElement) {
+                  tapElement.blur();
+                }
+                
+                // Send the pointer as it has the clientX / Y set so more useful then the raw
+                //  event object on touch devices. Mouse / Pointers this is the event object.
+                clickHandler(pointer);
+              }
+            } finally {
+              firstId = undefined;    // Resets the state
+            }
+          }
+        },
+        cancel: function(id, event) {
+          if(firstId === id) {
+            firstId = undefined;      // Resets the state
           }
         }
-      },
-      cancel: function(id, event) {
-        if(firstId === id) {
-          firstId = undefined;      // Resets the state
-        }
-      }
-    });
-    
-    // Hack for iOS Safari's benefit. It goes searching for onclick handlers and is liable to click
-    // something else nearby.
-    element.onclick = function(event) { };
+      });
+      
+      // Hack for iOS Safari's benefit. It goes searching for onclick handlers and is liable to click
+      // something else nearby.
+      element.onclick = function(event) { };
+    }
 
     // Fallback click handler.
     // Busted clicks don't get this far, and adding this handler allows ng-tap to be used on

--- a/src/ngMobile/directive/ngClick.js
+++ b/src/ngMobile/directive/ngClick.js
@@ -31,202 +31,80 @@ ngMobile.config(['$provide', function($provide) {
   }]);
 }]);
 
-ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
-    function($parse, $timeout, $rootElement) {
-  var TAP_DURATION = 750; // Shorter than 750ms is a tap, longer is a taphold or drag.
-  var MOVE_TOLERANCE = 12; // 12px seems to work in most mobile browsers.
-  var PREVENT_DURATION = 2500; // 2.5 seconds maximum from preventGhostClick call to click
-  var CLICKBUSTER_THRESHOLD = 25; // 25 pixels in any dimension is the limit for busting clicks.
-  var lastPreventedTime;
-  var touchCoordinates;
+ngMobile.directive('ngClick', ['$parse', '$mobile', function($parse, $mobile) {
+  var MOVE_TOLERANCE = $mobile.getPointSize() * 8, // 8pt
+    TAP_DURATION = 750; // Shorter than 750ms is a tap, longer is a taphold or drag.
 
-
-  // TAP EVENTS AND GHOST CLICKS
-  //
-  // Why tap events?
-  // Mobile browsers detect a tap, then wait a moment (usually ~300ms) to see if you're
-  // double-tapping, and then fire a click event.
-  //
-  // This delay sucks and makes mobile apps feel unresponsive.
-  // So we detect touchstart, touchmove, touchcancel and touchend ourselves and determine when
-  // the user has tapped on something.
-  //
-  // What happens when the browser then generates a click event?
-  // The browser, of course, also detects the tap and fires a click after a delay. This results in
-  // tapping/clicking twice. So we do "clickbusting" to prevent it.
-  //
-  // How does it work?
-  // We attach global touchstart and click handlers, that run during the capture (early) phase.
-  // So the sequence for a tap is:
-  // - global touchstart: Sets an "allowable region" at the point touched.
-  // - element's touchstart: Starts a touch
-  // (- touchmove or touchcancel ends the touch, no click follows)
-  // - element's touchend: Determines if the tap is valid (didn't move too far away, didn't hold
-  //   too long) and fires the user's tap handler. The touchend also calls preventGhostClick().
-  // - preventGhostClick() removes the allowable region the global touchstart created.
-  // - The browser generates a click event.
-  // - The global click handler catches the click, and checks whether it was in an allowable region.
-  //     - If preventGhostClick was called, the region will have been removed, the click is busted.
-  //     - If the region is still there, the click proceeds normally. Therefore clicks on links and
-  //       other elements without ngTap on them work normally.
-  //
-  // This is an ugly, terrible hack!
-  // Yeah, tell me about it. The alternatives are using the slow click events, or making our users
-  // deal with the ghost clicks, so I consider this the least of evils. Fortunately Angular
-  // encapsulates this ugly logic away from the user.
-  //
-  // Why not just put click handlers on the element?
-  // We do that too, just to be sure. The problem is that the tap event might have caused the DOM
-  // to change, so that the click fires in the same position but something else is there now. So
-  // the handlers are global and care only about coordinates and not elements.
-
-  // Checks if the coordinates are close enough to be within the region.
-  function hit(x1, y1, x2, y2) {
-    return Math.abs(x1 - x2) < CLICKBUSTER_THRESHOLD && Math.abs(y1 - y2) < CLICKBUSTER_THRESHOLD;
-  }
-
-  // Checks a list of allowable regions against a click location.
-  // Returns true if the click should be allowed.
-  // Splices out the allowable region from the list after it has been used.
-  function checkAllowableRegions(touchCoordinates, x, y) {
-    for (var i = 0; i < touchCoordinates.length; i += 2) {
-      if (hit(touchCoordinates[i], touchCoordinates[i+1], x, y)) {
-        touchCoordinates.splice(i, i + 2);
-        return true; // allowable region
-      }
-    }
-    return false; // No allowable region; bust it.
-  }
-
-  // Global click handler that prevents the click if it's in a bustable zone and preventGhostClick
-  // was called recently.
-  function onClick(event) {
-    if (Date.now() - lastPreventedTime > PREVENT_DURATION) {
-      return; // Too old.
-    }
-
-    var touches = event.touches && event.touches.length ? event.touches : [event];
-    var x = touches[0].clientX;
-    var y = touches[0].clientY;
-    // Work around desktop Webkit quirk where clicking a label will fire two clicks (on the label
-    // and on the input element). Depending on the exact browser, this second click we don't want
-    // to bust has either (0,0) or negative coordinates.
-    if (x < 1 && y < 1) {
-      return; // offscreen
-    }
-
-    // Look for an allowable region containing this click.
-    // If we find one, that means it was created by touchstart and not removed by
-    // preventGhostClick, so we don't bust it.
-    if (checkAllowableRegions(touchCoordinates, x, y)) {
-      return;
-    }
-
-    // If we didn't find an allowable region, bust the click.
-    event.stopPropagation();
-    event.preventDefault();
-  }
-
-
-  // Global touchstart handler that creates an allowable region for a click event.
-  // This allowable region can be removed by preventGhostClick if we want to bust it.
-  function onTouchStart(event) {
-    var touches = event.touches && event.touches.length ? event.touches : [event];
-    var x = touches[0].clientX;
-    var y = touches[0].clientY;
-    touchCoordinates.push(x, y);
-
-    $timeout(function() {
-      // Remove the allowable region.
-      for (var i = 0; i < touchCoordinates.length; i += 2) {
-        if (touchCoordinates[i] == x && touchCoordinates[i+1] == y) {
-          touchCoordinates.splice(i, i + 2);
-          return;
-        }
-      }
-    }, PREVENT_DURATION, false);
-  }
-
-  // On the first call, attaches some event handlers. Then whenever it gets called, it creates a
-  // zone around the touchstart where clicks will get busted.
-  function preventGhostClick(x, y) {
-    if (!touchCoordinates) {
-      $rootElement[0].addEventListener('click', onClick, true);
-      $rootElement[0].addEventListener('touchstart', onTouchStart, true);
-      touchCoordinates = [];
-    }
-
-    lastPreventedTime = Date.now();
-
-    checkAllowableRegions(touchCoordinates, x, y);
-  }
-
+  
   // Actual linking function.
-  return function(scope, element, attr) {
-    var expressionFn = $parse(attr.ngClick),
-        tapping = false,
-        tapElement,  // Used to blur the element after a tap.
-        startTime,   // Used to check if the tap was held too long.
-        touchStartX,
-        touchStartY;
-
-    function resetState() {
-      tapping = false;
-    }
-
-    element.bind('touchstart', function(event) {
-      tapping = true;
-      tapElement = event.target ? event.target : event.srcElement; // IE uses srcElement.
-      // Hack for Safari, which can target text nodes instead of containers.
-      if(tapElement.nodeType == 3) {
-        tapElement = tapElement.parentNode;
-      }
-
-      startTime = Date.now();
-
-      var touches = event.touches && event.touches.length ? event.touches : [event];
-      var e = touches[0].originalEvent || touches[0];
-      touchStartX = e.clientX;
-      touchStartY = e.clientY;
-    });
-
-    element.bind('touchmove', function(event) {
-      resetState();
-    });
-
-    element.bind('touchcancel', function(event) {
-      resetState();
-    });
-
-    element.bind('touchend', function(event) {
-      var diff = Date.now() - startTime;
-
-      var touches = (event.changedTouches && event.changedTouches.length) ? event.changedTouches :
-          ((event.touches && event.touches.length) ? event.touches : [event]);
-      var e = touches[0].originalEvent || touches[0];
-      var x = e.clientX;
-      var y = e.clientY;
-      var dist = Math.sqrt( Math.pow(x - touchStartX, 2) + Math.pow(y - touchStartY, 2) );
-
-      if (tapping && diff < TAP_DURATION && dist < MOVE_TOLERANCE) {
-        // Call preventGhostClick so the clickbuster will catch the corresponding click.
-        preventGhostClick(x, y);
-
-        // Blur the focused element (the button, probably) before firing the callback.
-        // This doesn't work perfectly on Android Chrome, but seems to work elsewhere.
-        // I couldn't get anything to work reliably on Android Chrome.
-        if (tapElement) {
-          tapElement.blur();
-        }
-
+  return function(scope, element, attrs) {
+    var firstId,
+      tapElement, // Used to blur the element after a tap.
+      startTime,  // Used to check if the tap was held too long.
+      touchStartX,
+      touchStartY,
+      expressionFn = $parse(attr.ngClick),
+      clickHandler = function(event) {
         scope.$apply(function() {
-          // TODO(braden): This is sending the touchend, not a tap or click. Is that kosher?
+          // TODO(braden): This is sending the touchend, click or pointerup. Is that kosher?
           expressionFn(scope, {$event: event});
         });
-      }
-      tapping = false;
-    });
+      };
 
+    $mobile.getPointerEvents(scope, element, {
+      down: function(id, pointer, event) {
+        if(!firstId) {
+          firstId = id;
+          tapElement = event.target ? event.target : event.srcElement;  // IE uses srcElement.
+
+          // Hack for Safari, which can target text nodes instead of containers.
+          if(tapElement.nodeType == 3) {
+            tapElement = tapElement.parentNode;
+          }
+
+          startTime = Date.now();
+
+          touchStartX = pointer.clientX;
+          touchStartY = pointer.clientY;
+        }
+      },
+      move: function(id, pointer, event) {  // Resets the state
+        if(firstId === id) {
+          firstId = undefined;
+        }
+      },
+      up: function(id, pointer, event) {
+        if(firstId === id) {
+          var diff = Date.now() - startTime,
+            x = pointer.clientX,
+            y = pointer.clientY,
+            dist = Math.sqrt( Math.pow(x - touchStartX, 2) + Math.pow(y - touchStartY, 2) );
+
+          try {
+            if (diff < TAP_DURATION && dist < MOVE_TOLERANCE) {
+              $mobile.preventGhostClick(x, y);
+
+              // Blur the focused element (the button, probably) before firing the callback.
+              // This doesn't work perfectly on Android Chrome, but seems to work elsewhere.
+              // I couldn't get anything to work reliably on Android Chrome.
+              if (tapElement) {
+                tapElement.blur();
+              }
+              
+              clickHandler(event);
+            }
+          } finally {
+            firstId = undefined;    // Resets the state
+          }
+        }
+      },
+      cancel: function(id, event) {
+        if(firstId === id) {
+          firstId = undefined;      // Resets the state
+        }
+      }
+    });
+    
     // Hack for iOS Safari's benefit. It goes searching for onclick handlers and is liable to click
     // something else nearby.
     element.onclick = function(event) { };
@@ -234,11 +112,7 @@ ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     // Fallback click handler.
     // Busted clicks don't get this far, and adding this handler allows ng-tap to be used on
     // desktop as well, to allow more portable sites.
-    element.bind('click', function(event) {
-      scope.$apply(function() {
-        expressionFn(scope, {$event: event});
-      });
-    });
+    element.bind('click', clickHandler);
   };
 }]);
 

--- a/src/ngMobile/directive/ngClick.js
+++ b/src/ngMobile/directive/ngClick.js
@@ -43,7 +43,7 @@ ngMobile.directive('ngClick', ['$parse', '$mobile', function($parse, $mobile) {
       startTime,  // Used to check if the tap was held too long.
       touchStartX,
       touchStartY,
-      expressionFn = $parse(attr.ngClick),
+      expressionFn = $parse(attrs.ngClick),
       clickHandler = function(event) {
         scope.$apply(function() {
           // TODO(braden): This is sending the touchend, click or pointerup. Is that kosher?

--- a/src/ngMobile/directive/ngClick.js
+++ b/src/ngMobile/directive/ngClick.js
@@ -91,7 +91,9 @@ ngMobile.directive('ngClick', ['$parse', '$mobile', function($parse, $mobile) {
                 tapElement.blur();
               }
               
-              clickHandler(event);
+              // Send the pointer as it has the clientX / Y set so more useful then the raw
+              //  event object on touch devices. Mouse / Pointers this is the event object.
+              clickHandler(pointer);
             }
           } finally {
             firstId = undefined;    // Resets the state

--- a/src/ngMobile/directive/ngSwipe.js
+++ b/src/ngMobile/directive/ngSwipe.js
@@ -1,31 +1,137 @@
 'use strict';
 
+
+// This defines the swipe gesture
+ngMobile.config(['$mobileProvider', function($mobile) {
+  $mobile.register({
+    name: 'swipe',
+    index: 40,
+    defaults: {
+      swipe_max_pointers     : 1,
+      swipe_min_velocity     : 0.7,
+      // The maximum vertical or horizontal delta for a swipe should be less than 75px.
+      swipe_max_orthogonality: 75,
+      // Vertical distance should not be more than a fraction of the horizontal distance
+      //  and vice versa.
+      swipe_xy_ratio         : 0.3,
+      // At least a 30px motion is necessary for a swipe.
+      swipe_min_distance     : 30,
+      // The total distance in any direction before we make the call on swipe vs scroll.
+      swipe_move_buffer      : 10
+    },
+    handler: function swipeGesture(ev, inst) {
+      switch (ev.eventType) {
+      case $mobile.utils.EVENT_START:
+        this.valid = true;
+        break;
+      case $mobile.utils.EVENT_MOVE:
+        if (!this.valid) { return };
+
+        var totalX = Math.abs(ev.deltaX), totalY = Math.abs(ev.deltaY); 
+
+        // Android will send a touchcancel if it thinks we're starting to scroll.
+        // So when the total distance (+ or - or both) exceeds 10px in either direction,
+        // we either:
+        // - send preventDefault() and treat this as a swipe.
+        // - or let the browser handle it as a scroll.
+
+        // Check we haven't exceeded our maximum orthogonality
+        //  Do this before the buffer check as it prevents default
+        //  and we don't want to prevent scrolling for no reason
+        if(totalX > totalY) {
+          if (totalY > inst.options.swipe_max_orthogonality) {
+            this.valid = false;
+            return;
+          }
+        } else {
+          if (totalX > inst.options.swipe_max_orthogonality) {
+            this.valid = false;
+            return;
+          }
+        }
+
+        // Don't prevent default until we clear the buffer
+        if (totalX < inst.options.swipe_move_buffer && totalY < inst.options.swipe_move_buffer) {
+          return;
+        } else if (inst.handlers[this.name] || inst.handlers[this.name + ev.direction]) {
+          // If a handler exists for this direction of swipe then prevent default
+          event.preventDefault();
+        } else {
+          // The swipe is invalid
+          this.valid = false;
+          return;
+        }
+        break;
+      case $mobile.utils.EVENT_END:
+        if (!this.valid) { return };
+        this.valid = false;
+
+        var totalX = Math.abs(ev.deltaX), totalY = Math.abs(ev.deltaY);
+
+        // Check the swipe meets the requirements
+        if(totalX > totalY) {
+          if (!(
+            totalY <= inst.options.swipe_max_orthogonality &&
+            totalX >  inst.options.swipe_min_distance &&
+            totalY / totalX < inst.options.swipe_xy_ratio &&
+            ev.velocityX >= inst.options.swipe_min_velocity
+          )) { return; }
+        } else {
+          if (!(
+            totalX <= inst.options.swipe_max_orthogonality &&
+            totalY >  inst.options.swipe_min_distance &&
+            totalX / totalY < inst.options.swipe_xy_ratio &&
+            ev.velocityY >= inst.options.swipe_min_velocity
+          )) { return; }
+        }
+
+        // trigger swipe events
+        if(inst.handlers[this.name] || inst.handlers[this.name + ev.direction]) {
+          event.stopPropagation();
+          inst.trigger(this.name, ev);
+          inst.trigger(this.name + ev.direction, ev);
+        }
+        break;
+      }
+    }
+  });
+}]);
+
+
 /**
  * @ngdoc directive
- * @name ngMobile.directive:ngSwipeLeft
+ * @name ngMobile.directive:ngSwipe
  *
  * @description
- * Specify custom behavior when an element is swiped to the left on a touchscreen device.
- * A leftward swipe is a quick, right-to-left slide of the finger.
- * Though ngSwipeLeft is designed for touch-based devices, it will work with a mouse click and drag too.
+ * Specify custom behavior when an element is swiped on a touchscreen device.
+ * A swipe is a quick slide of the finger across the screen, either up, down, left or right.
+ * Though ngSwipe is designed for touch-based devices, it will work with a mouse click and drag too.
  *
  * @element ANY
- * @param {expression} ngSwipeLeft {@link guide/expression Expression} to evaluate
- * upon left swipe. (Event object is available as `$event`)
+ * @param {expression} ngSwipe {@link guide/expression Expression} to evaluate
+ * upon swipe. (Event object is available as `$event`)
  *
  * @example
-    <doc:example>
-      <doc:source>
-        <div ng-show="!showActions" ng-swipe-left="showActions = true">
-          Some list content, like an email in the inbox
-        </div>
-        <div ng-show="showActions" ng-swipe-right="showActions = false">
-          <button ng-click="reply()">Reply</button>
-          <button ng-click="delete()">Delete</button>
-        </div>
-      </doc:source>
-    </doc:example>
+  <doc:example>
+    <doc:source>
+    <div ng-swipe="showAction = $event.direction">
+      Swipe me: {{showAction}}
+    </div>
+    </doc:source>
+  </doc:example>
  */
+ngMobile.directive('ngSwipe', ['$parse', '$mobile', function($parse, $mobile) {
+  return function(scope, element, attr) {
+    var swipeHandler = $parse(attr['ngSwipe']);
+
+    $mobile.gestureOn(element, 'swipe').bind('swipe', function(eventdata) {
+      scope.$apply(function() {
+          swipeHandler(scope, {$event:eventdata, $element:element});
+      });
+    });
+  };
+}]);
+
 
 /**
  * @ngdoc directive
@@ -41,142 +147,141 @@
  * upon right swipe. (Event object is available as `$event`)
  *
  * @example
-    <doc:example>
-      <doc:source>
-        <div ng-show="!showActions" ng-swipe-left="showActions = true">
-          Some list content, like an email in the inbox
-        </div>
-        <div ng-show="showActions" ng-swipe-right="showActions = false">
-          <button ng-click="reply()">Reply</button>
-          <button ng-click="delete()">Delete</button>
-        </div>
-      </doc:source>
-    </doc:example>
+  <doc:example>
+    <doc:source>
+    <div ng-show="!showActions" ng-swipe-left="showActions = true">
+      Some list content, like an email in the inbox
+    </div>
+    <div ng-show="showActions" ng-swipe-right="showActions = false">
+      <button ng-click="reply()">Reply</button>
+      <button ng-click="delete()">Delete</button>
+    </div>
+    </doc:source>
+  </doc:example>
  */
+ngMobile.directive('ngSwipeRight', ['$parse', '$mobile', function($parse, $mobile) {
+  return function(scope, element, attr) {
+    var swipeHandler = $parse(attr['ngSwipeRight']);
 
-function makeSwipeDirective(directiveName, direction) {
-  ngMobile.directive(directiveName, ['$parse', '$mobile', function($parse, $mobile) {
-    // The maximum vertical delta for a swipe should be less than 58pts.
-    var MAX_VERTICAL_DISTANCE = $mobile.getPointSize() * 58,
-    // Vertical distance should not be more than a fraction of the horizontal distance.
-      MAX_VERTICAL_RATIO = 0.3,
-    // At least a 24pt lateral motion is necessary for a swipe.
-      MIN_HORIZONTAL_DISTANCE = $mobile.getPointSize() * 24,
-    // The total distance in any direction before we make the call on swipe vs. scroll.
-      MOVE_BUFFER_RADIUS = 10;
-
-    return function(scope, element, attr) {
-      var swipeHandler = $parse(attr[directiveName]),
-        startCoords, valid,
-        totalX, totalY,
-        lastX, lastY,
-        firstId,
-
-
-        validSwipe = function(pointer) {
-          // Check that it's within the coordinates.
-          // Absolute vertical distance must be within tolerances.
-          // Horizontal distance, we take the current X - the starting X.
-          // This is negative for leftward swipes and positive for rightward swipes.
-          // After multiplying by the direction (-1 for left, +1 for right), legal swipes
-          // (ie. same direction as the directive wants) will have a positive delta and
-          // illegal ones a negative delta.
-          // Therefore this delta must be positive, and larger than the minimum.
-          var coords = {
-              x: pointer.clientX,
-              y: pointer.clientY
-            },
-            deltaY = Math.abs(coords.y - startCoords.y),
-            deltaX = (coords.x - startCoords.x) * direction;
-          return valid && // Short circuit for already-invalidated swipes.
-              deltaY < MAX_VERTICAL_DISTANCE &&
-              deltaX > 0 &&
-              deltaX > MIN_HORIZONTAL_DISTANCE &&
-              deltaY / deltaX < MAX_VERTICAL_RATIO;
-        };
-
-      $mobile.getPointerEvents(scope, element, {
-        down: function(id, pointer, event) {
-          if(!firstId) {
-            firstId = id;
-            startCoords = {
-              x: pointer.clientX,
-              y: pointer.clientY
-            };
-            valid = true;
-            totalX = 0;
-            totalY = 0;
-            lastX = startCoords.x;
-            lastY = startCoords.y;
-          }
-        },
-        move: function(id, pointer, event) {  // Resets the state
-          if(firstId === id && valid) {
-
-            // Android will send a touchcancel if it thinks we're starting to scroll.
-            // So when the total distance (+ or - or both) exceeds 10px in either direction,
-            // we either:
-            // - On totalX > totalY, we send preventDefault() and treat this as a swipe.
-            // - On totalY > totalX, we let the browser handle it as a scroll.
-
-            // Invalidate a touch while it's in progress if it strays too far away vertically.
-            // We don't want a scroll down and back up while drifting sideways to be a swipe just
-            // because you happened to end up vertically close in the end.
-            var coords = {
-              x: pointer.clientX,
-              y: pointer.clientY
-            };
-
-            if (Math.abs(coords.y - startCoords.y) > MAX_VERTICAL_DISTANCE) {
-              valid = false;
-              firstId = undefined;      // Resets the state
-              return;
-            }
-
-            totalX += Math.abs(coords.x - lastX);
-            totalY += Math.abs(coords.y - lastY);
-
-            lastX = coords.x;
-            lastY = coords.y;
-
-            if (totalX < MOVE_BUFFER_RADIUS && totalY < MOVE_BUFFER_RADIUS) {
-              return;
-            }
-
-            // One of totalX or totalY has exceeded the buffer, so decide on swipe vs. scroll.
-            if (totalY > totalX) {
-              valid = false;
-              firstId = undefined;      // Resets the state
-            } else {
-              event.preventDefault();
-            }
-          }
-        },
-        up: function(id, pointer, event) {
-          if(firstId === id) {
-            firstId = undefined;      // Resets the state
-
-            if (validSwipe(pointer)) {
-              // Prevent this swipe from bubbling up to any other elements with ngSwipes.
-              event.stopPropagation();
-              scope.$apply(function() {
-                swipeHandler(scope, {$event:pointer});
-              });
-            }
-          }
-        },
-        cancel: function(id, event) {
-          if(firstId === id) {
-            firstId = undefined;      // Resets the state
-            valid = false;
-          }
-        }
+    $mobile.gestureOn(element, 'swipe').bind('swiperight', function(eventdata) {
+      scope.$apply(function() {
+          swipeHandler(scope, {$event:eventdata, $element:element});
       });
-    };
-  }]);
-}
+    });
+  };
+}]);
 
-// Left is negative X-coordinate, right is positive.
-makeSwipeDirective('ngSwipeLeft', -1);
-makeSwipeDirective('ngSwipeRight', 1);
 
+/**
+ * @ngdoc directive
+ * @name ngMobile.directive:ngSwipeLeft
+ *
+ * @description
+ * Specify custom behavior when an element is swiped to the left on a touchscreen device.
+ * A leftward swipe is a quick, right-to-left slide of the finger.
+ * Though ngSwipeLeft is designed for touch-based devices, it will work with a mouse click and drag too.
+ *
+ * @element ANY
+ * @param {expression} ngSwipeLeft {@link guide/expression Expression} to evaluate
+ * upon left swipe. (Event object is available as `$event`)
+ *
+ * @example
+  <doc:example>
+    <doc:source>
+    <div ng-show="!showActions" ng-swipe-left="showActions = true">
+      Some list content, like an email in the inbox
+    </div>
+    <div ng-show="showActions" ng-swipe-right="showActions = false">
+      <button ng-click="reply()">Reply</button>
+      <button ng-click="delete()">Delete</button>
+    </div>
+    </doc:source>
+  </doc:example>
+ */
+ngMobile.directive('ngSwipeLeft', ['$parse', '$mobile', function($parse, $mobile) {
+  return function(scope, element, attr) {
+    var swipeHandler = $parse(attr['ngSwipeLeft']);
+
+    $mobile.gestureOn(element, 'swipe').bind('swipeleft', function(eventdata) {
+      scope.$apply(function() {
+          swipeHandler(scope, {$event:eventdata, $element:element});
+      });
+    });
+  };
+}]);
+
+
+/**
+ * @ngdoc directive
+ * @name ngMobile.directive:ngSwipeUp
+ *
+ * @description
+ * Specify custom behavior when an element is swiped up on a touchscreen device.
+ * An upward swipe is a quick, bottom-to-top slide of the finger.
+ * Though ngSwipeUp is designed for touch-based devices, it will work with a mouse click and drag too.
+ *
+ * @element ANY
+ * @param {expression} ngSwipeUp {@link guide/expression Expression} to evaluate
+ * upon upward swipe. (Event object is available as `$event`)
+ *
+ * @example
+  <doc:example>
+    <doc:source>
+    <div ng-show="!showActions" ng-swipe-down="showActions = true">
+      Swipe down to see notifications
+    </div>
+    <div style="height:150px" ng-show="showActions" ng-swipe-up="showActions = false">
+      Swipe up to hide this notification
+    </div>
+    </doc:source>
+  </doc:example>
+ */
+ngMobile.directive('ngSwipeUp', ['$parse', '$mobile', function($parse, $mobile) {
+  return function(scope, element, attr) {
+    var swipeHandler = $parse(attr['ngSwipeUp']);
+
+    $mobile.gestureOn(element, 'swipe').bind('swipeup', function(eventdata) {
+      scope.$apply(function() {
+          swipeHandler(scope, {$event:eventdata, $element:element});
+      });
+    });
+  };
+}]);
+
+
+/**
+ * @ngdoc directive
+ * @name ngMobile.directive:ngSwipeDown
+ *
+ * @description
+ * Specify custom behavior when an element is swiped down on a touchscreen device.
+ * A downward swipe is a quick, top-to-bottom slide of the finger.
+ * Though ngSwipeDown is designed for touch-based devices, it will work with a mouse click and drag too.
+ *
+ * @element ANY
+ * @param {expression} ngSwipeDown {@link guide/expression Expression} to evaluate
+ * upon downward swipe. (Event object is available as `$event`)
+ *
+ * @example
+  <doc:example>
+    <doc:source>
+    <div ng-show="!showActions" ng-swipe-down="showActions = true">
+      Swipe down to see notifications
+    </div>
+    <div style="height:150px" ng-show="showActions" ng-swipe-up="showActions = false">
+      Swipe up to hide this notification
+    </div>
+    </doc:source>
+  </doc:example>
+ */
+ngMobile.directive('ngSwipeDown', ['$parse', '$mobile', function($parse, $mobile) {
+  return function(scope, element, attr) {
+    var swipeHandler = $parse(attr['ngSwipeDown']);
+
+    $mobile.gestureOn(element, 'swipe').bind('swipedown', function(eventdata) {
+      scope.$apply(function() {
+          swipeHandler(scope, {$event:eventdata, $element:element});
+      });
+    });
+  };
+}]);

--- a/src/ngMobile/directive/ngSwipe.js
+++ b/src/ngMobile/directive/ngSwipe.js
@@ -69,27 +69,31 @@ function makeSwipeDirective(directiveName, direction) {
       var swipeHandler = $parse(attr[directiveName]),
         startCoords, valid,
         totalX, totalY,
-        lastX, lastY;
+        lastX, lastY,
+        firstId,
 
-      function validSwipe(event) {
-        // Check that it's within the coordinates.
-        // Absolute vertical distance must be within tolerances.
-        // Horizontal distance, we take the current X - the starting X.
-        // This is negative for leftward swipes and positive for rightward swipes.
-        // After multiplying by the direction (-1 for left, +1 for right), legal swipes
-        // (ie. same direction as the directive wants) will have a positive delta and
-        // illegal ones a negative delta.
-        // Therefore this delta must be positive, and larger than the minimum.
-        if (!startCoords) return false;
-        var coords = getCoordinates(event),
-          deltaY = Math.abs(coords.y - startCoords.y),
-          deltaX = (coords.x - startCoords.x) * direction;
-        return valid && // Short circuit for already-invalidated swipes.
-            deltaY < MAX_VERTICAL_DISTANCE &&
-            deltaX > 0 &&
-            deltaX > MIN_HORIZONTAL_DISTANCE &&
-            deltaY / deltaX < MAX_VERTICAL_RATIO;
-      }
+
+        validSwipe = function(pointer) {
+          // Check that it's within the coordinates.
+          // Absolute vertical distance must be within tolerances.
+          // Horizontal distance, we take the current X - the starting X.
+          // This is negative for leftward swipes and positive for rightward swipes.
+          // After multiplying by the direction (-1 for left, +1 for right), legal swipes
+          // (ie. same direction as the directive wants) will have a positive delta and
+          // illegal ones a negative delta.
+          // Therefore this delta must be positive, and larger than the minimum.
+          var coords = {
+              x: pointer.clientX,
+              y: pointer.clientY
+            },
+            deltaY = Math.abs(coords.y - startCoords.y),
+            deltaX = (coords.x - startCoords.x) * direction;
+          return valid && // Short circuit for already-invalidated swipes.
+              deltaY < MAX_VERTICAL_DISTANCE &&
+              deltaX > 0 &&
+              deltaX > MIN_HORIZONTAL_DISTANCE &&
+              deltaY / deltaX < MAX_VERTICAL_RATIO;
+        };
 
       $mobile.getPointerEvents(scope, element, {
         down: function(id, pointer, event) {
@@ -152,7 +156,7 @@ function makeSwipeDirective(directiveName, direction) {
           if(firstId === id) {
             firstId = undefined;      // Resets the state
 
-            if (validSwipe(event)) {
+            if (validSwipe(pointer)) {
               // Prevent this swipe from bubbling up to any other elements with ngSwipes.
               event.stopPropagation();
               scope.$apply(function() {

--- a/src/ngMobile/mobile.js
+++ b/src/ngMobile/mobile.js
@@ -7,363 +7,754 @@
  */
 
 /*
- * Touch events and other mobile helpers
+ * Provides a basis for gesture detection where multiple gestures can be
+ * applied to an element without clashing and multiple gestures can
+ * be active at the same time on different elements.
+ *
  * Based on jQuery Mobile touch event handling (jquerymobile.com)
- * and Microsoft PointerDraw http://ie.microsoft.com/testdrive/ieblog/2011/oct/PointerDraw.js.source.html
+ *   Microsoft PointerDraw http://ie.microsoft.com/testdrive/ieblog/2011/oct/PointerDraw.js.source.html
+ *   with substantial portions of code from Hammer.JS http://eightmedia.github.io/hammer.js/
  */
 
-// define ngMobile module and register $mobile factory
+/* Hammer.JS License:
+Copyright (C) 2013 by Jorik Tangelder (Eight Media)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+
+// define ngMobile module and register $mobile service
 var ngMobile = angular.module('ngMobile', []);
 
-ngMobile.factory('$mobile', ['$timeout', '$rootElement', '$window', function($timeout, $rootElement, $window) {
 
-  // Detects the screen resolution of devices for providing consistent clickbusting regions
-  var ptSize,
-  getPointSize = function() {
-    if (ptSize) return ptSize;
+/**
+ * @ngdoc object
+ * @name ngMobile.$mobile
+ * @requires $window $document
+ *
+ * @description
+ *   Provides an interface for configuring default gesture settings and
+ *   registering for gesture detection within directives. This is achieved
+ *   by normalizing browser mouse, touch and pointer events for gesture
+ *   detection.
+ *   Effectively mimicking touch events with element level isolation.
+ */
+ngMobile.provider('$mobile', function() {
 
-    if(window.document.defaultView) {
-      // create an empty element
-      var div = $window.document.createElement("div"),
-        body = $window.document.getElementsByTagName("body")[0],
-        ppi;
+  // Holds helper functions and constants useful for detecting mobile events
+  this.utils = {
+    // direction defines
+    DIRECTION_DOWN: 'down',
+    DIRECTION_LEFT: 'left',
+    DIRECTION_UP: 'up',
+    DIRECTION_RIGHT: 'right',
 
-      // give it an absolute size of one inch
-      div.style.width="1in";
-      // append it to the body
-      body.appendChild(div);
-      // read the computed width
-      ppi = $window.document.defaultView.getComputedStyle(div, null).getPropertyValue('width');
-      // remove it again
-      body.removeChild(div);
+    // touch event defines
+    EVENT_START: 'start',
+    EVENT_MOVE: 'move',
+    EVENT_END: 'end',
 
-      ptSize = parseFloat(ppi) / 72.0;
-      return ptSize;
-    } else {
-      // for IE8
-      ptSize = 1.3333;
-      return ptSize;
-    }
-  },
+    HAS_POINTEREVENTS: window.navigator.pointerEnabled || window.navigator.msPointerEnabled,
+    HAS_TOUCHEVENTS: ('ontouchend' in window),
 
-
-  // TAP EVENTS AND GHOST CLICKS
-  //
-  // Why tap events?
-  // Mobile browsers detect a tap, then wait a moment (usually ~300ms) to see if you're
-  // double-tapping, and then fire a click event.
-  //
-  // This delay sucks and makes mobile apps feel unresponsive.
-  // So we detect touchstart, touchmove, touchcancel and touchend ourselves and determine when
-  // the user has tapped on something.
-  //
-  // What happens when the browser then generates a click event?
-  // The browser, of course, also detects the tap and fires a click after a delay. This results in
-  // tapping/clicking twice. So we do "clickbusting" to prevent it.
-  //
-  // How does it work?
-  // We attach global touchstart and click handlers, that run during the capture (early) phase.
-  // So the sequence for a tap is:
-  // - global touchstart: Sets an "allowable region" at the point touched.
-  // - element's touchstart: Starts a touch
-  // (- touchmove or touchcancel ends the touch, no click follows)
-  // - element's touchend: Determines if the tap is valid (didn't move too far away, didn't hold
-  //   too long) and fires the user's tap handler. The touchend also calls preventGhostClick().
-  // - preventGhostClick() removes the allowable region the global touchstart created.
-  // - The browser generates a click event.
-  // - The global click handler catches the click, and checks whether it was in an allowable region.
-  //     - If preventGhostClick was called, the region will have been removed, the click is busted.
-  //     - If the region is still there, the click proceeds normally. Therefore clicks on links and
-  //       other elements without ngTap on them work normally.
-  //
-  // This is an ugly, terrible hack!
-  // Yeah, tell me about it. The alternatives are using the slow click events, or making our users
-  // deal with the ghost clicks, so I consider this the least of evils. Fortunately Angular
-  // encapsulates this ugly logic away from the user.
-  //
-  // Why not just put click handlers on the element?
-  // We do that too, just to be sure. The problem is that the tap event might have caused the DOM
-  // to change, so that the click fires in the same position but something else is there now. So
-  // the handlers are global and care only about coordinates and not elements.
+    // eventtypes per touchevent (start, move, end)
+    // are filled by this.event.determineEventTypes on setup
+    EVENT_TYPES: {},
 
 
-  CLICKBUSTER_THRESHOLD = Math.ceil(getPointSize() * 18),  // 18 points in any dimension is the limit for busting clicks. (apple status bar is 20pts in width)
-  PREVENT_DURATION = 2500,  // 2.5 seconds maximum from preventGhostClick call to click
-  lastPreventedTime = 0,
-  touchCoordinates,
-
-  // Checks if the coordinates are close enough to be within the region.
-  hit = function(x1, y1, x2, y2) {
-    return Math.abs(x1 - x2) < CLICKBUSTER_THRESHOLD && Math.abs(y1 - y2) < CLICKBUSTER_THRESHOLD;
-  },
-
-  // Checks a list of allowable regions against a click location.
-  // Returns true if the click should be allowed.
-  // Splices out the allowable region from the list after it has been used.
-  checkAllowableRegions = function(touchCoordinates, x, y) {
-    for (var i = 0; i < touchCoordinates.length; i += 2) {
-      if (hit(touchCoordinates[i], touchCoordinates[i+1], x, y)) {
-        touchCoordinates.splice(i, i + 2);
-        return true; // allowable region
-      }
-    }
-    return false; // No allowable region; bust it.
-  },
-
-  // Global click handler that prevents the click if it's in a bustable zone and preventGhostClick
-  // was called recently.
-  onClick = function(event) {
-    if (Date.now() - lastPreventedTime > PREVENT_DURATION) {
-      return; // Too old.
-    }
-
-    var touches = event.touches && event.touches.length ? event.touches : [event];
-    var x = touches[0].clientX;
-    var y = touches[0].clientY;
-    // Work around desktop Webkit quirk where clicking a label will fire two clicks (on the label
-    // and on the input element). Depending on the exact browser, this second click we don't want
-    // to bust has either (0,0) or negative coordinates.
-    if (x < 1 && y < 1) {
-      return; // offscreen
-    }
-
-    // Look for an allowable region containing this click.
-    // If we find one, that means it was created by touchstart and not removed by
-    // preventGhostClick, so we don't bust it.
-    if (checkAllowableRegions(touchCoordinates, x, y)) {
-      return;
-    }
-
-    // If we didn't find an allowable region, bust the click.
-    event.stopPropagation();
-    event.preventDefault();
-  },
-
-  // Global touchstart handler that creates an allowable region for a click event.
-  // This allowable region can be removed by preventGhostClick if we want to bust it.
-  onTouchStart = function(event) {
-    var touches = event.touches && event.touches.length ? event.touches : [event];
-    var x = touches[0].clientX;
-    var y = touches[0].clientY;
-    touchCoordinates.push(x, y);
-
-    $timeout(function() {
-      // Remove the allowable region.
-      for (var i = 0; i < touchCoordinates.length; i += 2) {
-        if (touchCoordinates[i] == x && touchCoordinates[i+1] == y) {
-          touchCoordinates.splice(i, i + 2);
-          return;
+    /**
+    * find if a node is in the given parent
+    * used for event delegation tricks
+    * @param   {HTMLElement}   node
+    * @param   {HTMLElement}   parent
+    * @returns {boolean}     has_parent
+    */
+    hasParent: function(node, parent) {
+      while(node){
+        if(node == parent) {
+          return true;
         }
+        node = node.parentNode;
       }
-    }, PREVENT_DURATION, false);
-  },
-
-  // On the first call, attaches some event handlers. Then whenever it gets called, it creates a
-  // zone around the touchstart where clicks will get busted.
-  preventGhostClick = function(x, y) {
-    if (!touchCoordinates) {
-      $rootElement.bind('click', onClick, true);
-      $rootElement.bind('touchstart', onTouchStart, true);
-      touchCoordinates = [];
-    }
-
-    lastPreventedTime = Date.now();
-
-    checkAllowableRegions(touchCoordinates, x, y);
-  },
+      return false;
+    },
 
 
+    /**
+    * get the center of all the touches
+    * @param   {Array}   touches
+    * @returns {Object}  center
+    */
+    getCenter: function getCenter(touches) {
+      var valuesX = [], valuesY = [];
 
-  // These functions effectively emulate pointer events for mice in desktop browsers
-  // that don't support pointer events
-  emulatedCapture,    // Stores the element and event handler
-  captureHandlers = [],
-  $document = angular.element($window.document),  // We attach the global events here
-  
-  // Run through all the event handlers associated with this element
-  triggerEmulatedCapture = function(event) {
-    var i;
-    for (i = 0; i < captureHandlers.length; i += 1) {
-      captureHandlers[i](event);
-    }
-  },
+      for(var t= 0,len=touches.length; t<len; t++) {
+        valuesX.push(touches[t].pageX);
+        valuesY.push(touches[t].pageY);
+      }
 
-  // Captures mouse events globally to emulate pointer capture
-  // We use IE's native support for legacy browsers
-  setEmulatedCapture = function(element, eventHandler) {
-    if (emulatedCapture && element[0] == emulatedCapture[0]) {   // Don't re-capture
-      captureHandlers.push(eventHandler);
-      return;
-    }
-    
-    try{
-      if(emulatedCapture) {
-        if($window.document.createEvent) {
-          // Standards based browsers:
-          var event = $window.document.createEvent('MouseEvents');
-          event.initMouseEvent('lostpointercapture', true, true, window, 0, 0, 0, 0, 0, false, false,
-            false, false, 0, emulatedCapture[0]);
-          triggerEmulatedCapture(event);
-        } else {
-          // IE <= 8
-          releaseEmulatedCapture(emulatedCapture);
-          element.bind('mousemove mouseup losecapture', triggerEmulatedCapture)
-          element[0].setCapture(false);
-        }
+      return {
+        pageX: ((Math.min.apply(Math, valuesX) + Math.max.apply(Math, valuesX)) / 2),
+        pageY: ((Math.min.apply(Math, valuesY) + Math.max.apply(Math, valuesY)) / 2)
+      };
+    },
+
+
+    /**
+    * calculate the velocity between two points
+    * @param   {Number}  delta_time
+    * @param   {Number}  delta_x
+    * @param   {Number}  delta_y
+    * @returns {Object}  velocity
+    */
+    getVelocity: function getVelocity(delta_time, delta_x, delta_y) {
+      return {
+        x: Math.abs(delta_x / delta_time) || 0,
+        y: Math.abs(delta_y / delta_time) || 0
+      };
+    },
+
+
+    /**
+    * calculate the angle between two coordinates
+    * @param   {Touch}   touch1
+    * @param   {Touch}   touch2
+    * @returns {Number}  angle
+    */
+    getAngle: function getAngle(touch1, touch2) {
+      var y = touch2.pageY - touch1.pageY,
+      x = touch2.pageX - touch1.pageX;
+
+      return Math.atan2(y, x) * 180 / Math.PI;
+    },
+
+
+    /**
+    * angle to direction define
+    * @param   {Touch}   touch1
+    * @param   {Touch}   touch2
+    * @returns {String}  direction constant, like this.DIRECTION_LEFT
+    */
+    getDirection: function getDirection(touch1, touch2) {
+      var x = Math.abs(touch1.pageX - touch2.pageX),
+      y = Math.abs(touch1.pageY - touch2.pageY);
+
+      if(x >= y) {
+        return touch1.pageX - touch2.pageX > 0 ? this.DIRECTION_LEFT : this.DIRECTION_RIGHT;
       } else {
-        if($window.document.createEvent) {
-          // Standards based browsers:
-          $document.bind('mousemove mouseup', triggerEmulatedCapture);
-        } else {
-          // IE <= 8
-          element.bind('mousemove mouseup losecapture', triggerEmulatedCapture)
-          element[0].setCapture(false);
+        return touch1.pageY - touch2.pageY > 0 ? this.DIRECTION_UP : this.DIRECTION_DOWN;
+      }
+    },
+
+
+    /**
+    * calculate the distance between two touches
+    * @param   {Touch}   touch1
+    * @param   {Touch}   touch2
+    * @returns {Number}  distance
+    */
+    getDistance: function getDistance(touch1, touch2) {
+      var x = touch2.pageX - touch1.pageX,
+      y = touch2.pageY - touch1.pageY;
+      return Math.sqrt((x*x) + (y*y));
+    },
+
+
+    /**
+    * calculate the scale factor between two touchLists (fingers)
+    * no scale is 1, and goes down to 0 when pinched together, and bigger when pinched out
+    * @param   {Array}   start
+    * @param   {Array}   end
+    * @returns {Number}  scale
+    */
+    getScale: function getScale(start, end) {
+      // need two fingers...
+      if(start.length >= 2 && end.length >= 2) {
+        return this.getDistance(end[0], end[1]) /
+        this.getDistance(start[0], start[1]);
+      }
+      return 1;
+    },
+
+
+    /**
+    * calculate the rotation degrees between two touchLists (fingers)
+    * @param   {Array}   start
+    * @param   {Array}   end
+    * @returns {Number}  rotation
+    */
+    getRotation: function getRotation(start, end) {
+      // need two fingers
+      if(start.length >= 2 && end.length >= 2) {
+        return this.getAngle(end[1], end[0]) -
+        this.getAngle(start[1], start[0]);
+      }
+      return 0;
+    },
+
+
+    /**
+    * boolean if the direction is vertical
+    * @param  {String}  direction
+    * @returns  {Boolean}   is_vertical
+    */
+    isVertical: function isVertical(direction) {
+      return (direction == this.DIRECTION_UP || direction == this.DIRECTION_DOWN);
+    },
+
+
+    /**
+    * stop browser default behavior with css props
+    * @param   {HtmlElement}   element
+    * @param   {Object}    css_props
+    */
+    stopDefaultBrowserBehavior: function stopDefaultBrowserBehavior(element, css_props) {
+      var prop,
+        vendors = ['webkit','khtml','moz','ms','o',''];
+
+      if(!css_props || !element.style) {
+        return;
+      }
+
+      // with css properties for modern browsers
+      for(var i = 0; i < vendors.length; i++) {
+        for(var p in css_props) {
+          if(css_props.hasOwnProperty(p)) {
+            prop = p;
+
+            // vender prefix at the property
+            if(vendors[i]) {
+              prop = vendors[i] + prop.substring(0, 1).toUpperCase() + prop.substring(1);
+            }
+
+            // set the style
+            element.style[prop] = css_props[p];
+          }
         }
       }
-    } finally {
-      captureHandlers = [eventHandler];
-      emulatedCapture = element;
-    }
-  },
 
-  // Stops tracking mouse events for the selected element
-  releaseEmulatedCapture = function(element) {
-    if (emulatedCapture && emulatedCapture === element) {
-      if($window.document.createEvent) {
-        // Standards based browsers: 
-        $document.unbind('mousemove', triggerEmulatedCapture);
-        $document.unbind('mouseup', triggerEmulatedCapture);
-      } else {
-        // IE <= 8
-        emulatedCapture[0].releaseCapture(); // This will trigger losecapture
-        emulatedCapture.unbind('mousemove', triggerEmulatedCapture);
-        emulatedCapture.unbind('mouseup', triggerEmulatedCapture);
-        emulatedCapture.unbind('losecapture', triggerEmulatedCapture);
+      // also the disable onselectstart
+      if(css_props.userSelect == 'none') {
+        element.onselectstart = function() {
+          return false;
+        };
+
+        // NOTE:: Only seems to have any effect on IE8 with jquery
+        // Behaves normally for all other browsers, jquery or not.
+        element.ondragstart = function() {
+          return false;
+        };
       }
-      emulatedCapture = undefined;
-      captureHandlers = [];
     }
-  },
+  };
 
-  // Pointer events ensures comminality across input types
-  pointerEvents = function(scope, element, callbacks) {
-    var tracker = {},
-      events,
-  
-      // common event handler for the mouse/pointer/touch models and their down/start, move, up/end, and cancel events
-      doEvent = function(event) {
-        
-        event = event.originalEvent || event;
-        var pointerList = (event.changedTouches && event.changedTouches.length) ? event.changedTouches :
-                  ((event.touches && event.touches.length) ? event.touches : [event]),
-          i;
+  this.defaults = {
+    set_browser_behaviors: true
+  };
 
-        for (i = 0; i < pointerList.length; ++i) {  // window.navigator.msPointerEnabled
-          var pointerObj = pointerList[i],
-            pointerId = (typeof pointerObj.identifier != 'undefined') ? pointerObj.identifier : (typeof pointerObj.pointerId != 'undefined') ? pointerObj.pointerId : 1;
-          
-          if (event.type.match(/(start|down)$/i)) {
-            // clause for processing MSPointerDown, touchstart, and mousedown
+  this.default_browser_behavior = {
+    // this also triggers onselectstart=false for IE
+    userSelect: 'none',
+    // this makes the element blocking in IE10 >, you could experiment with the value
+    // see for more options this issue; https://github.com/EightMedia/this.js/issues/241
+    touchAction: 'none',
+    touchCallout: 'none',
+    contentZooming: 'none',
+    userDrag: 'none',
+    tapHighlightColor: 'rgba(0,0,0,0)'
+  };
 
-            // protect against failing to get an up or end on this pointerId
-            if (tracker[pointerId]) {
-              try {
-                if (this.releasePointerCapture) {
-                  this.releasePointerCapture(pointerId);
-                } else if (event.type == 'mousedown') {
-                  releaseEmulatedCapture(element);
+
+  var gestureTypes = {}; // Gestures registered with $mobile
+  /**
+   * Gesture registration with default setting allocation
+   */
+  this.register = function(options) {
+    this.defaults = angular.extend(options.defaults || {}, this.defaults || {});  // We don't want to override any user defined defaults
+
+    delete options.defaults;
+
+    gestureTypes[options.name] = options;
+  };
+
+
+  this.$get = ['$window', '$document', function($window, $document) {
+    var self = this,     // Curry to provided config
+      instanceId = 0,    // id of last instance (for use in associative arrays)
+
+      pointer_allocation = {},  // PointerId => Instances (capture mapping)
+      event_pointers = {},      // Instance => Pointers (similar to touches list on iOS)
+      types,                    // Event types we are listening to
+
+      /**
+       * extend eventData for gestures
+       * @param   {Object}   inst
+       * @param   {Object}   ev
+       * @returns {Object}   ev
+       */
+      extendEventData = function(inst, ev) {
+        var startEv = inst.current.startEvent,
+          i = 0, len;
+
+        // if the touches change, set the new touches over the startEvent touches
+        // this because touchevents don't have all the touches on touchstart, or the
+        // user must place his fingers at the EXACT same time on the screen, which is not realistic
+        // but, sometimes it happens that both fingers are touching at the EXACT same time
+        if(startEv && (event_pointers[inst].length != startEv.touches.length || ev.touches === startEv.touches)) {
+          // extend 1 level deep to get the touchlist with the touch objects
+          startEv.touches = [];
+          for(len = ev.touches.length; i < len; i++) {
+            startEv.touches.push(ev.touches[i]);
+          }
+        }
+
+        var delta_time = ev.timeStamp - startEv.timeStamp,
+          delta_x = ev.center.pageX - startEv.center.pageX,
+          delta_y = ev.center.pageY - startEv.center.pageY,
+          velocity = self.utils.getVelocity(delta_time, delta_x, delta_y);
+
+        angular.extend(ev, {
+          deltaTime   : delta_time,
+
+          deltaX    : delta_x,
+          deltaY    : delta_y,
+
+          velocityX   : velocity.x,
+          velocityY   : velocity.y,
+
+          distance  : self.utils.getDistance(startEv.center, ev.center),
+          angle     : self.utils.getAngle(startEv.center, ev.center),
+          direction   : self.utils.getDirection(startEv.center, ev.center),
+
+          scale     : self.utils.getScale(startEv.touches, ev.touches),
+          rotation  : self.utils.getRotation(startEv.touches, ev.touches),
+
+          startEvent  : startEv
+        });
+
+        return ev;
+      },
+
+
+      /**
+       * touch event normalisation
+       * @param   {HTMLElement}   element
+       * @param   {String}    eventType
+       */
+      onTouch = function(element, eventType) {
+        element.bind(self.utils.EVENT_TYPES[eventType], function(event) {
+          // NOTE:: event.button is for IE8
+          if (event.type.match(/mouse/i) && (event.which || event.button) != 1) {
+            return;
+          }
+
+          event = event.originalEvent || event;
+
+          var pointerList = (event.changedTouches && event.changedTouches.length) ? event.changedTouches :
+              ((event.touches && event.touches.length) ? event.touches : [event]),
+            i, pointerObj, instance, instanceList = {};
+
+          // Normalise pointers, mice and touches with pointer lists
+          // Effectively emulates touch events with element level isolation
+          for (i = 0; i < pointerList.length; ++i) {
+            pointerObj = pointerList[i];
+            pointerObj.identifier = (typeof pointerObj.identifier != 'undefined') ? pointerObj.identifier : (typeof pointerObj.pointerId != 'undefined') ? pointerObj.pointerId : 1;
+
+            if (eventType === self.utils.EVENT_START) {
+              // protect against failing to get an up or end on this pointer
+              if (pointer_allocation[pointerObj.identifier]) {
+                pointer_allocation[pointerObj.identifier].stopDetect();
+              }
+
+              // Grab the gesture state
+              instance = element.data('__$mobile.config__');
+
+              // Check if the element can capture another pointer and assign the pointer to that element
+              if(instance && instance.enabled && instance.pointers_count < instance.pointers_max) {
+                pointer_allocation[pointerObj.identifier] = instance;
+                if (instance.pointers_count == 0) {
+                  event_pointers[instance] = {}
                 }
-              } catch(e) {}
-              delete tracker[pointerId];
-            }
-            
-            // Track the element the event started on and if we should execute the attached action
-            tracker[pointerId] = this;
-            
-            // in the Microsoft pointer model, set the capture for this pointer
-            // nothing is required for the iOS touch model because capture is implied on touchstart
-            if (this.pointerEnabled) {
-              this.setPointerCapture(pointerId);
-              event.preventDefault();  // This prevents mouse emulation events
-            } else if (event.type == 'mousedown') {
-              setEmulatedCapture(element, doEvent);
+                event_pointers[instance][pointerObj.identifier] = pointerObj;
+                instance.pointers_count = instance.pointers_count + 1;
+
+                // Keep track of gesture instances that these pointers touch
+                if(!instanceList[instance]) {
+                  instanceList[instance] = [instance];
+                }
+              } else {
+                continue;
+              }
+            } else if (pointer_allocation[pointerObj.identifier]) {
+              // NOTE:: we could attach pointers to elements if a user has missed the target element for the initial touch?
+              //  Might make this a configuration option in the future: gobble_pointers?
+              instance = pointer_allocation[pointerObj.identifier];
+              event_pointers[instance][pointerObj.identifier] = pointerObj;
+
+              // Keep track of gesture instances that these pointers touch
+              if(!instanceList[instance]) {
+                instanceList[instance] = [instance];
+              }
+
+              // Keep track of pointers that are leaving the screen
+              if (eventType === self.utils.EVENT_END) {
+                instanceList[instance].push(pointerObj.identifier);
+              }
+            } else {
+              continue;
             }
 
-            if(callbacks['down']) {
-              callbacks['down'](pointerId, pointerObj, event);
+            // Check for IE8 to add pageX and pageY
+            if(!pointerObj.pageX) {
+              pointerObj.pageX = pointerObj.clientX + $window.document.body.scrollLeft;
+              pointerObj.pageY = pointerObj.clientY + $window.document.body.scrollTop;
             }
-            
-          } else if (event.type.match(/move$/i)) {
-            // clause handles MSPointerMove and touchmove
+          }
 
-            if(tracker[pointerId] && callbacks['move']) {
-              callbacks['move'](pointerId, pointerObj, event);
+          // Detect gestures for the 
+          for (instance in instanceList) {
+            if (instanceList.hasOwnProperty(instance)) {
+              detect(event, eventType, instanceList[instance].shift(), instanceList[instance]);
             }
-            
-          
-          } else if (tracker[pointerId] && event.type.match(/(up|end|cancel|capture)$/i)) {
-            // clause handles up/end/cancel/capture lost
+          }
+        });
+      },
 
-            var target = tracker[pointerId];
-            delete tracker[pointerId];      // Delete here so we ignore the lost capture event we trigger
 
-            // in the Microsoft pointer model, release the capture for this pointer
-            // in the mouse model, release the capture or remove document-level event handlers if there are no down points
-            // nothing is required for the iOS touch model because capture is implied on touchstart
-            if (target.releasePointerCapture) {
-              target.releasePointerCapture(pointerId);
-            } else if (event.type == 'mouseup') {
-              releaseEmulatedCapture(element);
+      detect = function(event, eventType, instance, pointersEnding) {
+        if(instance.enabled) {
+          var touches = [];
+
+          // Get the touches related to this element
+          angular.forEach(event_pointers[instance], function(value) {
+            this.push(value);
+          }, touches);
+
+          // Make this a move event if there are still fingers on the screen
+          if (eventType === self.utils.EVENT_END && (pointersEnding.length - instance.pointers_count) > 0) {
+            eventType = self.utils.EVENT_MOVE;
+          }
+
+          instance.detect({
+            center    : self.utils.getCenter(touches),
+            timeStamp   : Date.now(),
+            target    : event.target,
+            touches   : touches,
+            eventType   : eventType,
+            srcEvent  : event,
+
+            /**
+             * prevent the browser default actions
+             * mostly used to disable scrolling of the browser
+             */
+            preventDefault: function() {
+              if(this.srcEvent.preventManipulation) {
+                this.srcEvent.preventManipulation();
+              }
+
+              if(this.srcEvent.preventDefault) {
+                this.srcEvent.preventDefault();
+              }
+            },
+
+            /**
+             * stop bubbling the event up to its parents
+             */
+            stopPropagation: function() {
+              this.srcEvent.stopPropagation();
+            },
+
+            /**
+             * immediately stop gesture detection
+             * might be useful after a swipe was detected
+             * @return {*}
+             */
+            stopDetect: function() {
+              return instance.stopDetect();
             }
-            
-            
-            if (event.type.match(/(cancel|capture)$/i) && callbacks['cancel']) {
-              callbacks['cancel'](pointerId, event);        // Cancel the gesture
-            } else if (callbacks['up']) {
-              callbacks['up'](pointerId, pointerObj, event);    // Apply the click, touch, point event
-            }
+          });
+        }
+
+        // on the end we reset everything
+        if(eventType === self.utils.EVENT_END) {
+          instance.stopDetect();
+        } else {
+          // We remove the pointers that are no longer on the screen
+          for (var i = 0; i < pointersEnding.length; ++i) {
+            delete pointer_allocation[pointersEnding[i]]
+            delete event_pointers[instance][pointersEnding[i]]
+            instance.pointers_count = instance.pointers_count - 1;
           }
         }
       };
 
-    if ($window.navigator.pointerEnabled) {
-      // Standards based pointer model http://www.w3.org/TR/pointerevents/
-      element[0].pointerEnabled = true;
-      events = 'pointerdown pointermove pointerup pointercancel lostpointercapture';
-      element.bind(events, doEvent);
-    } else if ($window.navigator.msPointerEnabled) {
-      // Microsoft IE10 pointer model
-      var el = element[0];
-      el.pointerEnabled = true;
-      el.setPointerCapture = el.msSetPointerCapture;
-      el.releasePointerCapture = el.msReleasePointerCapture;
-      events = 'MSPointerDown MSPointerMove MSPointerUp MSPointerCancel MSLostPointerCapture';
-      element.bind(events, doEvent);
+    // determine the eventtype we want to set
+    if(self.utils.HAS_POINTEREVENTS) {
+      // pointerEvents
+      types = [
+        'pointerdown MSPointerDown',
+        'pointermove MSPointerMove',
+        'pointerup pointercancel MSPointerUp MSPointerCancel'];
     } else {
-      // iOS touch model & mouse model
-      events = 'touchstart touchmove touchend touchcancel mousedown';
-      element.bind(events, doEvent);
+      // for non pointer events browsers
+      types = [
+        'touchstart mousedown',
+        'touchmove mousemove',
+        'touchend touchcancel mouseup'];
     }
-    
-    
-    // Clean up any event handlers on the element
-    // and ensure that any emulated captures are removed
-    scope.$on('$destroy', function() {
-      var evts = events.split(' '), 
-        i;
 
-      for (i = 0; i < evts.length; i += 1) {
-        element.unbind(evts[i], doEvent);
+    self.utils.EVENT_TYPES[self.utils.EVENT_START]  = types[0];
+    self.utils.EVENT_TYPES[self.utils.EVENT_MOVE]   = types[1];
+    self.utils.EVENT_TYPES[self.utils.EVENT_END]  = types[2];
+
+
+    // Add touch events on the document
+    onTouch($document, self.utils.EVENT_MOVE);
+    onTouch($document, self.utils.EVENT_END);
+
+
+    // Fix IE8
+    if (!Date.now) {
+      Date.now = function() {
+        return new Date().valueOf();
       }
-      
-      releaseEmulatedCapture(element);
-    });
-  };
+    }
 
-  
-  return {
-    getPointerEvents: pointerEvents,
-    getPointSize: getPointSize,
-    preventGhostClick: preventGhostClick
-  };
-}]);
+    return {
+      /**
+       * Shortcut to self.utils
+       */
+      utils: self.utils,
+
+      /**
+       * Associates a gesure instance to the current object
+       */
+      gestureOn: function(element, gestures, options) {
+        var i, gesture,
+          instance = element.data('__$mobile.config__') || {
+            id: undefined,
+            handlers: {},   // Event callbacks
+            registered: {}, // Gesture state data store
+            gestures: [],   // Gestures applied to this element
+
+            /**
+             * Provide a handler for an event
+             * I would have liked to use angulars.bind and triggered real events
+             * to simlify creating complex widgets via delegation or for stats etc
+             * however I couldn't do this and support IE8 at the same time so I
+             * used a similar interface to JQLite for when IE8 support is dropped
+             */
+            bind: function(event, handler) {
+              instance.handlers[event] = instance.handlers[event] || [];
+              instance.handlers[event].push(handler);
+            },
+
+            /**
+             * Remove a handler for an event
+             */
+            unbind: function(event, handler) {
+              if (handler === undefined) {
+                delete instance.handlers[event];
+              } else {
+                angular.arrayRemove(instance.handlers[event], handler);
+              }
+            },
+
+            toString: function() {
+              return instance.id;
+            },
+
+
+            /**
+             * gesture detection
+             * @param   {Object}  eventData
+             * @param   {Object}  eventData
+             */
+            detect: function(eventData) {
+              if(!instance.current) {
+                instance.stopped = false;
+
+                instance.current = {
+                  inst    : instance,   // reference to instance we're working for
+                  startEvent  : angular.extend({}, eventData), // start eventData for distances, timing etc
+                  lastEvent   : false,  // last eventData
+                  name    : ''          // current gesture we're in/detected, can be 'tap', 'hold' etc
+                };
+              } else if(instance.stopped) {
+                return;
+              }
+
+              // extend event data with calculations about scale, distance etc
+              eventData = extendEventData(instance, eventData);
+
+              var g = 0, len,
+                gesture;
+
+              // call gesture handlers
+              for(len = instance.gestures.length; g < len; g++) {
+                gesture = instance.gestures[g];
+
+                // only when the instance options have enabled this gesture
+                if(!instance.stopped) {
+                  // if a handler returns false, we stop with the detection
+                  if(gesture.handler.call(instance.registered[gesture.name], eventData, instance) === false) {
+                    tracker.stopDetect();
+                    break;
+                  }
+                }
+              }
+
+              // store as previous event event
+              if(instance.current) {
+                instance.current.lastEvent = eventData;
+              }
+
+              return eventData;
+            },
+
+
+            /**
+             * clear the gesture vars
+             * this is called on endDetect, but can also be used when a final gesture has been detected
+             * to stop other gestures from being fired
+             */
+            stopDetect: function() {
+              var pointers = event_pointers[instance];
+              if (pointers) {
+                delete event_pointers[instance];
+                angular.forEach(pointers, function(pointer, key) {
+                  delete pointer_allocation[key];
+                });
+
+                // stopped!
+                instance.stopped = true;
+                instance.pointers_count = 0;
+
+                // clone current data to the store as the previous gesture
+                // used for the double tap gesture, since this is an other gesture detect session
+                if (instance.current) {
+                  instance.previous = angular.extend({}, instance.current);
+
+                  // reset the current
+                  instance.current = null;
+                }
+              }
+            },
+
+
+            /**
+             * trigger gesture event
+             * @param   {String}    gesture
+             * @param   {Object}    eventData
+             */
+            trigger: function(gesture, eventData) {
+              if(instance.handlers[gesture]) {
+                var i, handlers = instance.handlers[gesture];
+
+                for (var i = 0; i < handlers.length; ++i) {
+                  handlers[i].call(element, eventData);
+                }
+              }
+            },
+
+            enabled: true,       // Can prevent elements triggering gestures
+            previous: undefined, // The previous gesture on this element
+            current: undefined,  // Are we currently gesturing
+
+            pointers_count: 0,   // Number of active pointers
+            pointers_max: 1,     // The max pointers this element could use to perform a gesture
+
+            options: undefined   // The gesture configuration associated with this element
+          };
+
+        if (!instance.id) {
+          options = angular.extend(
+            angular.copy(self.defaults),  // Clone the defaults
+            options || {}        // Merge in any overriding changes
+          );
+
+          instanceId = instanceId + 1;
+          instance.id = instanceId.toString();
+
+          instance.options = options;
+          element.data('__$mobile.config__', instance);
+
+          // add some css to the element to prevent the browser from doing its native behaviour
+          if(options.set_browser_behaviors) {
+            self.utils.stopDefaultBrowserBehavior(element[0], self.default_browser_behavior);
+          }
+
+          // The events are no longer required for the current element
+          element.scope().$on('$destroy', function() {
+            instance.stopDetect();
+            instance.enabled = false;
+          });
+
+          // start detection on touchstart
+          onTouch(element, self.utils.EVENT_START);
+        } else if (options) {
+          // This is not the first call to gestureOn
+          angular.extend(instance.options, options);
+        }
+
+        // Apply the gesture configuration for the selected gestures
+        if (gestures) {
+          gestures = gestures.split(' ');
+          for (i = 0; i < gestures.length; i += 1) {
+            gesture = gestureTypes[gestures[i]];
+
+            // instance.events checks if the gesture has been previously registered
+            if (!instance.registered[gesture.name]) {
+              // This is a sandbox that the gestures can use for persisted state
+              instance.registered[gesture.name] = {name: gesture.name};
+
+              // set its index
+              gesture.index = gesture.index || 1000;
+
+              // add gesture to the list
+              instance.gestures.push(gesture);
+
+              // sort the list by index
+              instance.gestures.sort(function(a, b) {
+                if (a.index < b.index) {
+                  return -1;
+                }
+                if (a.index > b.index) {
+                  return 1;
+                }
+                return 0;
+              });
+            }
+
+            // Provide a function for any additional configuration
+            if(gesture.setup) {
+              gesture.setup.call(instance.registered[gesture.name], element, instance);
+            }
+
+            if((instance.options[gesture.name + '_max_pointers'] || 1) > instance.pointers_max) {
+              instance.pointers_max = instance.options[gesture.name + '_max_pointers'] || 1;
+            }
+          }
+        }
+
+        return instance;
+      }
+    };
+  }];
+});

--- a/src/ngMobile/mobile.js
+++ b/src/ngMobile/mobile.js
@@ -7,10 +7,354 @@
  */
 
 /*
- * Touch events and other mobile helpers by Braden Shepherdson (braden.shepherdson@gmail.com)
+ * Touch events and other mobile helpers by Braden Shepherdson (braden.shepherdson@gmail.com) and Stephen von Takach (steve@cotag.me)
  * Based on jQuery Mobile touch event handling (jquerymobile.com)
+ * and Microsoft PointerDraw http://ie.microsoft.com/testdrive/ieblog/2011/oct/PointerDraw.js.source.html
  */
 
-// define ngSanitize module and register $sanitize service
+// define ngMobile module and register $mobile factory
 var ngMobile = angular.module('ngMobile', []);
 
+ngMobile.factory('$mobile', ['$timeout', '$rootElement', '$window', function($timeout, $rootElement, $window) {
+
+  // Detects the screen resolution of devices for providing consistent clickbusting regions
+  var ptSize,
+  getPointSize = function() {
+    if (ptSize) return ptSize;
+
+    // create an empty element
+    var div = $window.document.createElement("div"),
+      body = $window.document.getElementsByTagName("body")[0],
+      ppi;
+
+    // give it an absolute size of one inch
+    div.style.width="1in";
+    // append it to the body
+    body.appendChild(div);
+    // read the computed width
+    ppi = $window.document.defaultView.getComputedStyle(div, null).getPropertyValue('width');
+    // remove it again
+    body.removeChild(div);
+
+    ptSize = parseFloat(ppi) / 72.0;
+    return ptSize;
+  },
+
+
+  // TAP EVENTS AND GHOST CLICKS
+  //
+  // Why tap events?
+  // Mobile browsers detect a tap, then wait a moment (usually ~300ms) to see if you're
+  // double-tapping, and then fire a click event.
+  //
+  // This delay sucks and makes mobile apps feel unresponsive.
+  // So we detect touchstart, touchmove, touchcancel and touchend ourselves and determine when
+  // the user has tapped on something.
+  //
+  // What happens when the browser then generates a click event?
+  // The browser, of course, also detects the tap and fires a click after a delay. This results in
+  // tapping/clicking twice. So we do "clickbusting" to prevent it.
+  //
+  // How does it work?
+  // We attach global touchstart and click handlers, that run during the capture (early) phase.
+  // So the sequence for a tap is:
+  // - global touchstart: Sets an "allowable region" at the point touched.
+  // - element's touchstart: Starts a touch
+  // (- touchmove or touchcancel ends the touch, no click follows)
+  // - element's touchend: Determines if the tap is valid (didn't move too far away, didn't hold
+  //   too long) and fires the user's tap handler. The touchend also calls preventGhostClick().
+  // - preventGhostClick() removes the allowable region the global touchstart created.
+  // - The browser generates a click event.
+  // - The global click handler catches the click, and checks whether it was in an allowable region.
+  //     - If preventGhostClick was called, the region will have been removed, the click is busted.
+  //     - If the region is still there, the click proceeds normally. Therefore clicks on links and
+  //       other elements without ngTap on them work normally.
+  //
+  // This is an ugly, terrible hack!
+  // Yeah, tell me about it. The alternatives are using the slow click events, or making our users
+  // deal with the ghost clicks, so I consider this the least of evils. Fortunately Angular
+  // encapsulates this ugly logic away from the user.
+  //
+  // Why not just put click handlers on the element?
+  // We do that too, just to be sure. The problem is that the tap event might have caused the DOM
+  // to change, so that the click fires in the same position but something else is there now. So
+  // the handlers are global and care only about coordinates and not elements.
+
+
+  CLICKBUSTER_THRESHOLD = Math.ceil(getPointSize() * 18),  // 18 points in any dimension is the limit for busting clicks. (apple status bar is 20pts in width)
+  PREVENT_DURATION = 2500,  // 2.5 seconds maximum from preventGhostClick call to click
+  lastPreventedTime = 0,
+  touchCoordinates,
+
+  // Checks if the coordinates are close enough to be within the region.
+  hit = function(x1, y1, x2, y2) {
+    return Math.abs(x1 - x2) < CLICKBUSTER_THRESHOLD && Math.abs(y1 - y2) < CLICKBUSTER_THRESHOLD;
+  },
+
+  // Checks a list of allowable regions against a click location.
+  // Returns true if the click should be allowed.
+  // Splices out the allowable region from the list after it has been used.
+  checkAllowableRegions = function(touchCoordinates, x, y) {
+    for (var i = 0; i < touchCoordinates.length; i += 2) {
+      if (hit(touchCoordinates[i], touchCoordinates[i+1], x, y)) {
+        touchCoordinates.splice(i, i + 2);
+        return true; // allowable region
+      }
+    }
+    return false; // No allowable region; bust it.
+  },
+
+  // Global click handler that prevents the click if it's in a bustable zone and preventGhostClick
+  // was called recently.
+  onClick = function(event) {
+    if (Date.now() - lastPreventedTime > PREVENT_DURATION) {
+      return; // Too old.
+    }
+
+    var touches = event.touches && event.touches.length ? event.touches : [event];
+    var x = touches[0].clientX;
+    var y = touches[0].clientY;
+    // Work around desktop Webkit quirk where clicking a label will fire two clicks (on the label
+    // and on the input element). Depending on the exact browser, this second click we don't want
+    // to bust has either (0,0) or negative coordinates.
+    if (x < 1 && y < 1) {
+      return; // offscreen
+    }
+
+    // Look for an allowable region containing this click.
+    // If we find one, that means it was created by touchstart and not removed by
+    // preventGhostClick, so we don't bust it.
+    if (checkAllowableRegions(touchCoordinates, x, y)) {
+      return;
+    }
+
+    // If we didn't find an allowable region, bust the click.
+    event.stopPropagation();
+    event.preventDefault();
+  },
+
+  // Global touchstart handler that creates an allowable region for a click event.
+  // This allowable region can be removed by preventGhostClick if we want to bust it.
+  onTouchStart = function(event) {
+    var touches = event.touches && event.touches.length ? event.touches : [event];
+    var x = touches[0].clientX;
+    var y = touches[0].clientY;
+    touchCoordinates.push(x, y);
+
+    $timeout(function() {
+      // Remove the allowable region.
+      for (var i = 0; i < touchCoordinates.length; i += 2) {
+        if (touchCoordinates[i] == x && touchCoordinates[i+1] == y) {
+          touchCoordinates.splice(i, i + 2);
+          return;
+        }
+      }
+    }, PREVENT_DURATION, false);
+  },
+
+  // On the first call, attaches some event handlers. Then whenever it gets called, it creates a
+  // zone around the touchstart where clicks will get busted.
+  preventGhostClick = function(x, y) {
+    if (!touchCoordinates) {
+      $rootElement[0].addEventListener('click', onClick, true);
+      $rootElement[0].addEventListener('touchstart', onTouchStart, true);
+      $rootElement[0].addEventListener('MSPointerDown', onTouchStart, true);
+      $rootElement[0].addEventListener('pointerdown', onTouchStart, true);
+      touchCoordinates = [];
+    }
+
+    lastPreventedTime = Date.now();
+
+    checkAllowableRegions(touchCoordinates, x, y);
+  },
+
+
+
+  // These functions effectively emulate pointer events for mice in desktop browsers
+  // That don't support pointer events
+  emulatedCaptures,    // Maps mice to event handlers
+  emulatedCaptureCount,  // Counts the number of active handlers
+  $document = angular.element($window.document),  // We attach the global events here
+
+  // Passes global events to the elements event handler
+  captureListener = function(event) {
+    var key;
+    for (key in emulatedCaptures) {
+      if (emulatedCaptures.hasOwnProperty(key)) {
+        emulatedCaptures[key](event);
+      }
+    }
+  },
+
+  // Captures mouse events globally to emulate pointer capture
+  // Some IE's support this natively however this is standards compliant
+  setEmulatedCapture = function(pointerId, callback) {
+    if (!emulatedCaptures) {
+      emulatedCaptures = {};
+      emulatedCaptureCount = 0;
+    }
+
+    try {
+      if(emulatedCaptures[pointerId]) {
+        emulatedCaptures[pointerId]({identifier: pointerId, type: 'capture'});
+      }
+    } finally {
+      emulatedCaptures[pointerId] = callback;
+      if(emulatedCaptureCount <= 0) {
+        $document.bind('mousemove mouseup', captureListener);
+        emulatedCaptureCount = 1;
+      } else {
+        emulatedCaptureCount += 1;
+      }
+    }
+  },
+
+  // Removes the element event handler from the registry
+  releaseEmulatedCapture = function(pointerId) {
+    if (emulatedCaptures && emulatedCaptures[pointerId]) {
+      delete emulatedCaptures[pointerId];
+      emulatedCaptureCount -= 1;
+
+      if (emulatedCaptureCount <= 0) {
+        $document.unbind('mousemove', captureListener);
+        $document.unbind('mouseup', captureListener);
+      }
+    }
+  },
+
+  //
+  // A function for ensuring comminality across input types
+  //
+  pointerEvents = function(scope, element, callbacks) {
+    var tracker = {},
+      events,
+  
+      // common event handler for the mouse/pointer/touch models and their down/start, move, up/end, and cancel events
+      doEvent = function(event) {
+        
+        event = event.originalEvent || event;
+        var pointerList = (event.changedTouches && event.changedTouches.length) ? event.changedTouches :
+                  ((event.touches && event.touches.length) ? event.touches : [event]),
+          i;
+
+        for (i = 0; i < pointerList.length; ++i) {  // window.navigator.msPointerEnabled
+          var pointerObj = pointerList[i],
+            pointerId = (typeof pointerObj.identifier != 'undefined') ? pointerObj.identifier : (typeof pointerObj.pointerId != 'undefined') ? pointerObj.pointerId : 1;
+          
+          if (event.type.match(/(start|down)$/i)) {
+            // clause for processing MSPointerDown, touchstart, and mousedown
+
+            // protect against failing to get an up or end on this pointerId
+            if (tracker[pointerId]) {
+              try {
+                if (callbacks['cancel']) {
+                  callbacks['cancel'](pointerId, event);
+                } else if (callbacks['up']) {
+                  callbacks['up'](pointerId, pointerObj, event);
+                }
+              } catch(e) {
+              } finally {
+                delete tracker[pointerId];
+                if (this.releasePointerCapture) {
+                  this.releasePointerCapture(pointerId);
+                } else if (event.type == 'mousedown') {
+                  releaseEmulatedCapture(pointerId);
+                }
+              }
+            }
+            
+            // Track the element the event started on and if we should execute the attached action
+            tracker[pointerId] = this;
+            
+            // in the Microsoft pointer model, set the capture for this pointer
+            // nothing is required for the iOS touch model because capture is implied on touchstart
+            if (this.pointerEnabled) {
+              this.setPointerCapture(pointerId);
+              event.preventDefault();  // This prevents mouse emulation events
+            } else if (event.type == 'mousedown') {
+              setEmulatedCapture(pointerId, doEvent);
+            }
+
+            if(callbacks['down']) {
+              callbacks['down'](pointerId, pointerObj, event);
+            }
+            
+          } else if (event.type.match(/move$/i)) {
+            // clause handles MSPointerMove and touchmove
+
+            if(tracker[pointerId] && callbacks['move']) {
+              callbacks['move'](pointerId, pointerObj, event);
+            }
+            
+          
+          } else if (tracker[pointerId] && event.type.match(/(up|end|cancel|capture)$/i)) {
+            // clause handles up/end/cancel/capture lost
+
+            var target = tracker[pointerId];
+            delete tracker[pointerId];      // Delete here so we ignore the lost capture event we trigger
+
+            // in the Microsoft pointer model, release the capture for this pointer
+            // in the mouse model, release the capture or remove document-level event handlers if there are no down points
+            // nothing is required for the iOS touch model because capture is implied on touchstart
+            if (target.releasePointerCapture) {
+              target.releasePointerCapture(pointerId);
+            } else if (event.type == 'mouseup') {
+              releaseEmulatedCapture(pointerId);
+            }
+            
+            
+            if (event.type.match(/(cancel|capture)$/i) && callbacks['cancel']) {
+              callbacks['cancel'](pointerId, event);        // Cancel the gesture
+            } else if (callbacks['up']) {
+              callbacks['up'](pointerId, pointerObj, event);    // Apply the click, touch, point event
+            }
+          }
+        }
+      };
+
+    if ($window.navigator.pointerEnabled) {
+      // Standards based pointer model http://www.w3.org/TR/pointerevents/
+      element[0].pointerEnabled = true;
+      events = 'pointerdown pointermove pointerup pointercancel lostpointercapture';
+      element.bind(events, doEvent);
+    } else if ($window.navigator.msPointerEnabled) {
+      // Microsoft IE10 pointer model
+      var el = element[0];
+      el.pointerEnabled = true;
+      el.setPointerCapture = el.msSetPointerCapture;
+      el.releasePointerCapture = el.msReleasePointerCapture;
+      events = 'MSPointerDown MSPointerMove MSPointerUp MSPointerCancel MSLostPointerCapture';
+      element.bind(events, doEvent);
+    } else {
+      // iOS touch model & mouse model
+      events = 'touchstart touchmove touchend touchcancel mousedown';
+      element.bind(events, doEvent);
+    }
+    
+    
+    // Clean up any event handlers on the element
+    // and ensure that any emulated captures are removed
+    scope.$on('$destroy', function() {
+      var evts = events.split(' '), 
+        i;
+
+      for (i = 0; i < evts.length; i += 1) {
+        element.unbind(evts[i], doEvent);
+      }
+      
+      for (i in emulatedCaptures) {
+        if (emulatedCaptures.hasOwnProperty(i) && emulatedCaptures[i] === doEvent) {
+          releaseEmulatedCapture(i);
+          break;
+        }
+      }
+    });
+  };
+
+  
+  return {
+    getPointerEvents: pointerEvents,
+    getPointSize: getPointSize,
+    preventGhostClick: preventGhostClick
+  };
+}]);

--- a/test/ngMobile/directive/ngSwipeSpec.js
+++ b/test/ngMobile/directive/ngSwipeSpec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Wrapper to abstract over using touch events or mouse events.
-var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, endEvent) {
+var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, endEvent, altElement) {
   describe('ngSwipe with ' + description + ' events', function() {
     var element;
 
@@ -36,7 +36,7 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBeUndefined();
 
       browserTrigger(element, startEvent, [], 100, 20);
-      browserTrigger(element, endEvent, [], 20, 20);
+      browserTrigger(altElement || element, endEvent, [], 20, 20);
       expect($rootScope.swiped).toBe(true);
     }));
 
@@ -46,7 +46,7 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBeUndefined();
 
       browserTrigger(element, startEvent, [], 20, 20);
-      browserTrigger(element, endEvent, [], 90, 20);
+      browserTrigger(altElement || element, endEvent, [], 90, 20);
       expect($rootScope.swiped).toBe(true);
     }));
 
@@ -58,8 +58,8 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBeUndefined();
 
       browserTrigger(element, startEvent, [], 90, 20);
-      browserTrigger(element, moveEvent, [], 70, 200);
-      browserTrigger(element, endEvent, [], 20, 20);
+      browserTrigger(altElement || element, moveEvent, [], 70, 200);
+      browserTrigger(altElement || element, endEvent, [], 20, 20);
 
       expect($rootScope.swiped).toBeUndefined();
     }));
@@ -72,7 +72,7 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBeUndefined();
 
       browserTrigger(element, startEvent, [], 90, 20);
-      browserTrigger(element, endEvent, [], 80, 20);
+      browserTrigger(altElement || element, endEvent, [], 80, 20);
 
       expect($rootScope.swiped).toBeUndefined();
     }));
@@ -85,7 +85,7 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBeUndefined();
 
       browserTrigger(element, startEvent, [], 20, 20);
-      browserTrigger(element, moveEvent, [], 40, 20);
+      browserTrigger(altElement || element, moveEvent, [], 40, 20);
 
       expect($rootScope.swiped).toBeUndefined();
     }));
@@ -98,7 +98,7 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBeUndefined();
 
       browserTrigger(element, moveEvent, [], 10, 20);
-      browserTrigger(element, endEvent, [], 90, 20);
+      browserTrigger(altElement || element, endEvent, [], 90, 20);
 
       expect($rootScope.swiped).toBeUndefined();
     }));
@@ -106,5 +106,5 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
 }
 
 swipeTests('touch', true  /* restrictBrowers */, 'touchstart', 'touchmove', 'touchend');
-swipeTests('mouse', false /* restrictBrowers */, 'mousedown',  'mousemove', 'mouseup');
+swipeTests('mouse', false /* restrictBrowers */, 'mousedown',  'mousemove', 'mouseup', angular.element(window.document));
 


### PR DESCRIPTION
Adds support for windows 8 devices (IE 10 pointer events as well as the [W3C Version](http://www.w3.org/TR/pointerevents/)) and provides a factory for extending the input abstraction

See the following fiddle as an example of extending the mobile events for implementing draggable elements (which in turn can be extended to create sliders etc)
http://jsfiddle.net/Z6tN3/1/ (Try using multiple fingers on any mobile device)

All existing mobile test pass.

Contributes to angular/angular.js#1502 and builds on angular/angular.js#2017
