### PR TITLE
fix(a): allow jqLite triggerHandler('click') on anchors

### DIFF
--- a/src/ng/directive/a.js
+++ b/src/ng/directive/a.js
@@ -36,7 +36,7 @@ var htmlAnchorDirective = valueFn({
       element.bind('click', function(event){
         // if we have no href url, then don't navigate anywhere.
         if (!element.attr('href')) {
-          event.preventDefault();
+          event && event.preventDefault();
         }
       });
     }

--- a/test/ng/directive/aSpec.js
+++ b/test/ng/directive/aSpec.js
@@ -58,4 +58,12 @@ describe('a', function() {
 
     expect(element.text()).toBe('hello@you');
   });
+
+  it('should not cause failures with triggerHandler', function() {
+    element = jqLite('<a href="" ng-click="foo=\'bar\'">link</a>"');
+    element = $compile(element)($rootScope);
+
+    element.triggerHandler('click');
+    expect($rootScope.foo).toEqual('bar');
+  });
 });


### PR DESCRIPTION
Previously, anchor elements could not be used with triggerHandler because
triggerHandler passes null as the event, and any anchor element with an empty
href automatically calls event.preventDefault(). Add a check that event
exists before calling preventDefault.
