### PR TITLE
fix(Angular): Angular.copy shouldn't copy $$hashKey or $$* properties

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -598,7 +598,9 @@ function copy(source, destination){
         delete destination[key];
       });
       for ( var key in source) {
-        destination[key] = copy(source[key]);
+        if (source.hasOwnProperty(key) && key.substr(0, 2) !== '$$') {
+          destination[key] = copy(source[key]);
+        }
       }
     }
   }

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -83,6 +83,15 @@ describe('angular', function() {
       expect(copy([{key:null}])).toEqual([{key:null}]);
     });
 
+    it('should not copy $$ properties or prototype properties', function() {
+      var original = {$$some: true, $$: true};
+      var clone = {};
+
+      expect(copy(original, clone)).toBe(clone);
+      expect(clone.$$some).toBeUndefined();
+      expect(clone.$$).toBeUndefined();
+    });
+
     it('should throw an exception if a Scope is being copied', inject(function($rootScope) {
       expect(function() { copy($rootScope.$new()); }).toThrow("Can't copy Window or Scope");
     }));


### PR DESCRIPTION
Fix for this issue: https://github.com/angular/angular.js/issues/1875

I copied the code from shallowCopy in to copy so that both should be consistent. Though that issue mentioned Angular.extend also copies $$hashkey, I though that would be appropriate, somewhat expected behavior.
