### PR TITLE
fixed docs link to api/ng.$route

### DIFF
--- a/src/ng/directive/ngController.js
+++ b/src/ng/directive/ngController.js
@@ -15,8 +15,7 @@
  * * Controller — The `ngController` directive specifies a Controller class; the class has
  *   methods that typically express the business logic behind the application.
  *
- * Note that an alternative way to define controllers is via the `{@link ng.$route}`
- * service.
+ * Note that an alternative way to define controllers is via the {@link ng.$route $route} service.
  *
  * @element ANY
  * @scope


### PR DESCRIPTION
anchor href to "api/ng.$route" was displaying incorrectly
