### PR TITLE
fix(Scenario): correct bootstrap issue on IE

### DIFF
--- a/src/ngScenario/Application.js
+++ b/src/ngScenario/Application.js
@@ -63,8 +63,6 @@ angular.scenario.Application.prototype.navigateTo = function(url, loadFn, errorF
     self.context.find('#test-frames').append('<iframe>');
     frame = self.getFrame_();
 
-    frame[0].contentWindow.name = "NG_DEFER_BOOTSTRAP!";
-
     frame.load(function() {
       frame.unbind();
       try {
@@ -88,6 +86,9 @@ angular.scenario.Application.prototype.navigateTo = function(url, loadFn, errorF
         errorFn(e);
       }
     }).attr('src', url);
+
+    // for IE compatibility set the name *after* setting the frame url
+    frame[0].contentWindow.name = "NG_DEFER_BOOTSTRAP!";
   }
   self.context.find('> h2 a').attr('href', url).text(url);
 };


### PR DESCRIPTION
we need to set the deferred bootstrap flag via window.name after the iframe's
src has been set, otherwise IE will reset it to empty string

this change was sufficient to get the angular-seed tests to pass for angular 1.0.6
