### PR TITLE
Update tutorial docs to use Karma instead of Testacular.

### DIFF
--- a/docs/content/misc/contribute.ngdoc
+++ b/docs/content/misc/contribute.ngdoc
@@ -174,7 +174,7 @@ made available a local web server based on Node.js.
 <a name="unit-tests"></a>
 ## Running the Unit Test Suite
 
-Our unit and integration tests are written with Jasmine and executed with Testacular.  To run all of the
+Our unit and integration tests are written with Jasmine and executed with Karma.  To run all of the
 tests once on Chrome run:
 
     grunt test:unit
@@ -188,12 +188,12 @@ Note there should be _no spaces between browsers_. `Opera, Firefox` is INVALID.
 During development it's however more productive to continuously run unit tests every time the source or test files
 change. To execute tests in this mode run:
 
-1. To start the Testacular server, capture Chrome browser and run unit tests, run:
+1. To start the Karma server, capture Chrome browser and run unit tests, run:
 
         grunt autotest:jqlite
 
 2. To capture more browsers, open this url in the desired browser (url might be different if you have multiple instance
-   of Testacular running, read Testacular's console output for the correct url):
+   of Karma running, read Karma's console output for the correct url):
 
         http://localhost:9876/
 

--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -54,14 +54,14 @@ and follow the instructions for setting up your computer.
 <div class="tabbable" show="true">
   <div class="tab-pane well" id="git-mac" title="Git on Mac/Linux">
     <ol>
-      <li><p>You will need Node.js and Testacular to run unit tests, so please verify that you have
+      <li><p>You will need Node.js and Karma to run unit tests, so please verify that you have
       <a href="http://nodejs.org/">Node.js</a> v0.8 or better installed
       and that the <code>node</code> executable is on your <code>PATH</code> by running the following
       command in a terminal window:</p>
       <pre>node --version</pre>
-      <p>Additionally install <a href="http://vojtajina.github.com/testacular">Testacular</a> if you
+      <p>Additionally install <a href="http://karma-runner.github.io/">Karma</a> if you
       don't have it already:</p>
-      <pre>npm install -g testacular</pre>
+      <pre>npm install -g karma</pre>
       <li><p>You'll also need Git, which you can get from
          <a href="http://git-scm.com/download">the Git site</a>.</p></li>
       <li><p>Clone the angular-phonecat repository located at <a
@@ -81,14 +81,14 @@ to run <code>scripts/web-server.js</code>,  a simple bundled http server.</p></l
 
   <div class="tab-pane well" id="git-win" title="Git on Windows">
     <ol>
-      <li><p>You will need Node.js and Testacular to run unit tests, so please verify that you have
+      <li><p>You will need Node.js and Karma to run unit tests, so please verify that you have
         <a href="http://nodejs.org/">Node.js</a> v0.8 or better installed
         and that the <code>node</code> executable is on your <code>PATH</code> by running the following
         command in a terminal window:</p>
         <pre>node --version</pre>
-        <p>Additionally install <a href="http://vojtajina.github.com/testacular">Testacular</a> if you
+        <p>Additionally install <a href="http://karma-runner.github.io/">Karma</a> if you
            don't have it already:</p>
-        <pre>npm install -g testacular</pre>
+        <pre>npm install -g karma</pre>
       </li>
       <li><p>You'll also need Git, which you can get from
                <a href="http://git-scm.com/download">the Git site</a>.</p></li>

--- a/docs/content/tutorial/step_02.ngdoc
+++ b/docs/content/tutorial/step_02.ngdoc
@@ -146,24 +146,25 @@ http://pivotal.github.com/jasmine/ Jasmine home page} and on the {@link
 https://github.com/pivotal/jasmine/wiki Jasmine wiki}.
 
 The angular-seed project is pre-configured to run all unit tests using {@link
-http://vojtajina.github.com/testacular/ Testacular}. To run the test, do the following:
+http://karma-runner.github.io/ Karma}. To run the test, do the following:
 
 1. In a _separate_ terminal window or tab, go to the `angular-phonecat` directory and run
-`./scripts/test.sh` to start the Testacular server.
+`./scripts/test.sh` to start the Karma server (the config file necessary to start the server
+is located at `./config/testacular.conf.js`).
 
-2. Testacular will start a new instance of Chrome browser automatically. Just ignore it and let it run in
-   the background. Testacular will use this browser for test execution.
+2. Karma will start a new instance of Chrome browser automatically. Just ignore it and let it run in
+   the background. Karma will use this browser for test execution.
 
 3. You should see the following or similar output in the terminal:
 
-             info: Testacular server started at http://localhost:9876/
+             info: Karma server started at http://localhost:9876/
              info (launcher): Starting  browser "Chrome"
              info (Chrome 22.0): Connected on socket id tPUm9DXcLHtZTKbAEO-n
              Chrome 22.0: Executed 1 of 1 SUCCESS (0.093 secs / 0.004 secs)
 
   Yay! The test passed! Or not...
 
-4. To rerun the tests, just change any of the source or test files. Testacular will notice the change
+4. To rerun the tests, just change any of the source or test files. Karma will notice the change
   and will rerun the tests for you. Now isn't that sweet?
 
 # Experiments

--- a/docs/content/tutorial/step_03.ngdoc
+++ b/docs/content/tutorial/step_03.ngdoc
@@ -122,9 +122,9 @@ To run the end-to-end test, open one of the following in a new browser tab:
 `http://localhost:[port-number]/[context-path]/test/e2e/runner.html`
 * casual reader: {@link http://angular.github.com/angular-phonecat/step-3/test/e2e/runner.html}
 
-Previously we've seen how Testacular can be used to execute unit tests. Well, it can also run the
+Previously we've seen how Karma can be used to execute unit tests. Well, it can also run the
 end-to-end tests! Use `./scripts/e2e-test.sh` script for that. End-to-end tests are slow, so unlike
-with unit tests, Testacular will exit after the test run and will not automatically rerun the test
+with unit tests, Karma will exit after the test run and will not automatically rerun the test
 suite on every file change. To rerun the test suite, execute the `e2e-test.sh` script again.
 
 This test verifies that the search box and the repeater are correctly wired together. Notice how

--- a/docs/content/tutorial/step_04.ngdoc
+++ b/docs/content/tutorial/step_04.ngdoc
@@ -134,7 +134,7 @@ The unit test now verifies that the default ordering property is set.
 We used Jasmine's API to extract the controller construction into a `beforeEach` block, which is
 shared by all tests in the parent `describe` block.
 
-You should now see the following output in the Testacular tab:
+You should now see the following output in the Karma tab:
 
         Chrome 22.0: Executed 2 of 2 SUCCESS (0.021 secs / 0.001 secs)
 

--- a/docs/content/tutorial/step_05.ngdoc
+++ b/docs/content/tutorial/step_05.ngdoc
@@ -208,7 +208,7 @@ Finally, we verify that the default value of `orderProp` is set correctly:
 });
 </pre>
 
-You should now see the following output in the Testacular tab:
+You should now see the following output in the Karma tab:
 
        Chrome 22.0: Executed 2 of 2 SUCCESS (0.028 secs / 0.007 secs)
 

--- a/docs/content/tutorial/step_08.ngdoc
+++ b/docs/content/tutorial/step_08.ngdoc
@@ -147,7 +147,7 @@ __`test/unit/controllersSpec.js`:__
 ...
 </pre>
 
-You should now see the following output in the Testacular tab:
+You should now see the following output in the Karma tab:
 
     Chrome 22.0: Executed 3 of 3 SUCCESS (0.039 secs / 0.012 secs)
 

--- a/docs/content/tutorial/step_09.ngdoc
+++ b/docs/content/tutorial/step_09.ngdoc
@@ -110,7 +110,7 @@ describe('filter', function() {
 Note that you need to configure our test injector with the `phonecatFilters` module before any of
 our filter tests execute.
 
-You should now see the following output in the Testacular tab:
+You should now see the following output in the Karma tab:
 
         Chrome 22.0: Executed 4 of 4 SUCCESS (0.034 secs / 0.012 secs)
 

--- a/docs/content/tutorial/step_11.ngdoc
+++ b/docs/content/tutorial/step_11.ngdoc
@@ -214,7 +214,7 @@ describe('PhoneCat controllers', function() {
 });
 </pre>
 
-You should now see the following output in the Testacular tab:
+You should now see the following output in the Karma tab:
 
     Chrome 22.0: Executed 4 of 4 SUCCESS (0.038 secs / 0.01 secs)
 

--- a/init-repo.sh
+++ b/init-repo.sh
@@ -2,7 +2,7 @@
 #
 # Script to initialize angular repo
 # - install required node packages
-# - install Testacular
+# - install Karma
 # - install git hooks
 
 
@@ -22,10 +22,10 @@ fi
 echo "Installing required npm packages..."
 npm install
 
-testacular=`which testacular 2>&1`
+karma=`which karma 2>&1`
 if [ $? -ne 0 ]; then
-  echo "Installing Testacular..."
-  npm install -g testacular
+  echo "Installing Karma..."
+  npm install -g karma
 fi
 
 echo "Installing git hooks..."


### PR DESCRIPTION
Replaced instances of 'Testacular' with 'Karma' to reflect name change of test runner.
Replaced instances of 'testacular' with 'karma' to reflect name change of test runner.

Replaced instances of 'http://vojtajina.github.com/testacular' with 'http://karma-runner.github.io/' to reflect dedicated page for Karma Test Runner.

Added location of config file needed to start the Karma server in step 2. This is still labeled 'testacular.conf.js' and needs file name to be updated in the phone example repo.
