### PR TITLE
Don't call $window.getComputedStyle on non-element

### DIFF
--- a/src/ng/animator.js
+++ b/src/ng/animator.js
@@ -280,7 +280,9 @@ var $AnimatorProvider = function() {
                   var duration = 0;
                   //we want all the styles defined before and after
                   forEach(element, function(element) {
-                    var globalStyles = $window.getComputedStyle(element) || {};
+                    if (element.nodeType !== 1 /* ELEMENT_NODE */) return;
+                    var globalStyles = $window.getComputedStyle(element);
+                    if (!globalStyles) return;
                     duration = Math.max(
                         parseFloat(globalStyles[w3cTransitionProp    + durationKey]) ||
                         parseFloat(globalStyles[vendorTransitionProp + durationKey]) ||


### PR DESCRIPTION
This throws an exception at least in some versions of FF, and is declared
as taking only an Element and not an arbitrary Node in the W3C spec.

One place where this can happen easily is with ng-view if the template
contains more than just a single top-level node (even just a trailing
newline can trigger the problem).

Also short-circuit the case where getComputedStyle doesn't return anything.
