### PR TITLE
fix(jqLite): pass in a dummy event with triggerHandler

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -54,7 +54,7 @@
  * - [replaceWith()](http://api.jquery.com/replaceWith/)
  * - [text()](http://api.jquery.com/text/)
  * - [toggleClass()](http://api.jquery.com/toggleClass/)
- * - [triggerHandler()](http://api.jquery.com/triggerHandler/) - Doesn't pass native event objects to handlers.
+ * - [triggerHandler()](http://api.jquery.com/triggerHandler/) - Passes a dummy event object to handlers.
  * - [unbind()](http://api.jquery.com/unbind/) - Does not support namespaces
  * - [val()](http://api.jquery.com/val/)
  * - [wrap()](http://api.jquery.com/wrap/)
@@ -743,9 +743,18 @@ forEach({
 
   triggerHandler: function(element, eventName) {
     var eventFns = (JQLiteExpandoStore(element, 'events') || {})[eventName];
+    var event;
+
+    if (document.createEventObject) {
+      event = document.createEventObject();
+      event.type = eventName;
+    } else {
+      event = document.createEvent('HTMLEvents');
+      event.initEvent(eventName, false, true);
+    }
 
     forEach(eventFns, function(fn) {
-      fn.call(element, null);
+      fn.call(element, event);
     });
   }
 }, function(fn, name){

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1128,6 +1128,19 @@ describe('jqLite', function() {
       expect(clickSpy1).toHaveBeenCalledOnce();
       expect(clickSpy2).toHaveBeenCalledOnce();
     });
+
+    it('should pass a dummy event', function() {
+      var element = jqLite('<a>poke</a>'),
+          pokeSpy = jasmine.createSpy('poke'),
+	  event;
+
+      element.bind('poke', pokeSpy);
+
+      element.triggerHandler('poke');
+      event = pokeSpy.mostRecentCall.args[0];
+      expect(event.type).toEqual('poke');
+      expect(event.preventDefault).toBeDefined();
+    });
   });
 
 


### PR DESCRIPTION
Previously, anchor elements could not be used with triggerHandler because
triggerHandler passes null as the event, and any anchor element with an empty
href automatically calls event.preventDefault(). Instead, pass a dummy event
when using triggerHandler, similar to what full jQuery does. Modified from
PR #2379.
