### PR TITLE
Fix typo in Injector call inlining example

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -225,7 +225,7 @@ function annotate(fn) {
  *     // ...
  *   };
  *   tmpFn.$inject = ['$compile', '$rootScope'];
- *   injector.invoke(tempFn);
+ *   injector.invoke(tmpFn);
  *
  *   // To better support inline function the inline annotation is supported
  *   injector.invoke(['$compile', '$rootScope', function(obfCompile, obfRootScope) {


### PR DESCRIPTION
the actual invoke call in the documentation was referring to the non-existent `tempFn` instead of `tmpFn`
