### PR TITLE
Adding `always` method to `$q` service.

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -91,6 +91,11 @@
  *   This method *returns a new promise* which is resolved or rejected via the return value of the
  *   `successCallback` or `errorCallback`.
  *
+ * - `always(callback)` – allows you to observe either the fulfillment or rejection of a promise,
+ *   but to do so without modifying the final value. This is useful to release resources or do some
+ *   clean-up that needs to be done whether the promise was rejected or resolved. See the [full
+ *   specification](https://github.com/kriskowal/q/wiki/API-Reference#promisefinallycallback) for
+ *   more information.
  *
  * # Chaining promises
  *
@@ -236,6 +241,42 @@ function qFactory(nextTick, exceptionHandler) {
           }
 
           return result.promise;
+        },
+        always: function(callback) {
+          
+          function makePromise(value, resolved) {
+            var result = defer();
+            if (resolved) {
+              result.resolve(value);
+            } else {
+              result.reject(value);
+            }
+            return result.promise;
+          }
+          
+          function handleCallback(value, isResolved) {
+            var callbackOutput = null;            
+            try {
+              callbackOutput = (callback ||defaultCallback)();
+            } catch(e) {
+              return makePromise(e, false);
+            }            
+            if (callbackOutput && callbackOutput.then) {
+              return callbackOutput.then(function() {
+                return makePromise(value, isResolved);
+              }, function(error) {
+                return makePromise(error, false);
+              });
+            } else {
+              return makePromise(value, isResolved);
+            }
+          }
+          
+          return this.then(function(value) {
+            return handleCallback(value, true);
+          }, function(error) {
+            return handleCallback(error, false);
+          });
         }
       }
     };


### PR DESCRIPTION
The current implementation of `$q` doesn't support the [always()](http://api.jquery.com/deferred.always/) method. This is a very useful method since it can avoid creating duplicate code when you do not care about the outcome of a promise. Here's some sample code:

```
// Cover the app with an overlay to disable user input. We
// want to remove it whether the initialization was successful
// or not.
LoadingOverlay.start();
Auth.initialize().then(function() {
    LoadingOverlay.stop();
}, function() {
    LoadingOverlay.stop(); // duplicate code!!
});
```

With an `always` method it could be simplified to just this:

```
LoadingOverlay.start();
Auth.initialize().always(function() {
    LoadingOverlay.stop();
});
```

The proposed implementation is to add an `always()` method to the `promise` object. This method simply re-uses the existing `then()` method, which means it won't bloat the `$q` implementation.

If there's any interest in this implementation, I'd be glad to add the tests for it.
