### PR TITLE
fix(ngModel): handle interpolated names for ngModel

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1110,7 +1110,21 @@ var ngModelDirective = function() {
       var modelCtrl = ctrls[0],
           formCtrl = ctrls[1] || nullFormCtrl;
 
-      formCtrl.$addControl(modelCtrl);
+      // Support of the interpolation in the name attribute,
+      // when the name changes, the control is republished in the form.
+      // We rely on the behaviour of the attribute interpolation directive,
+      // which sets the value to undefined during compilation.
+      if (attr.name) {
+        formCtrl.$addControl(modelCtrl);
+      } else {
+        attr.$observe('name', function(name) {
+          if (modelCtrl.$name) {
+            formCtrl.$removeControl(modelCtrl);
+          }
+          modelCtrl.$name = name;
+          formCtrl.$addControl(modelCtrl);
+        });
+      }
 
       element.bind('$destroy', function() {
         formCtrl.$removeControl(modelCtrl);

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -111,8 +111,7 @@ describe('form', function() {
     expect(scope.formB.$error.required).toBe(false);
   });
 
-
-  it('should publish widgets', function() {
+  it('should publish widgets with static names', function() {
     doc = jqLite('<form name="form"><input type="text" name="w1" ng-model="some" /></form>');
     $compile(doc)(scope);
 
@@ -124,6 +123,21 @@ describe('form', function() {
     expect(widget.$invalid).toBe(false);
   });
 
+  it('should publish widgets with dynamic names', function() {
+    doc = jqLite('<form name="form"><input type="text" name="{{name}}" ng-model="some" /></form>');
+    $compile(doc)(scope);
+
+    scope.name = 'w1';
+    scope.$digest();
+    var widget = scope.form.w1;
+    expect(widget).toBeDefined();
+
+    scope.name = 'w2';
+    scope.$digest();
+    expect(scope.form.w1).toBeUndefined();
+    expect(scope.form.w2).toBeDefined();
+    expect(scope.form.w2).toBe(widget);
+  });
 
   describe('preventing default submission', function() {
 


### PR DESCRIPTION
Fix that controls with interpolated names don't publish
themselves to the form, cause the name isn't known at
publishing time.

Refers #1404
