### PR TITLE
fix($resource): return result from prototype methods

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -499,7 +499,7 @@ angular.module('ngResource', ['ng']).
               arguments.length + " arguments.";
           }
           var data = hasBody ? this : undefined;
-          Resource[name].call(this, params, data, success, error);
+          return Resource[name].call(this, params, data, success, error);
         };
       });
 


### PR DESCRIPTION
1. `Resource[name]` returns `value` that contains `$then` and other useful things. [#L476](https://github.com/angular/angular.js/blob/master/src/ngResource/resource.js#L476)
2. `Resource.prototype['$' + name]` invokes `Resource[name]` at the end but returns nothing. [#L502](https://github.com/angular/angular.js/blob/master/src/ngResource/resource.js#L502)

**Possible fix:**  add `return` state to the end of the `Resource.prototype['$' + name]` definition.
