### PR TITLE
(doc) Fix select documentation

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -27,7 +27,7 @@
  * `select` model to be bound to a non-string value. This is because an option element can currently
  * be bound to string values only.
  *
- * @param {string} name assignable expression to data-bind to.
+ * @param {string} ngModel assignable expression to data-bind to.
  * @param {string=} required The control is considered valid only if value is entered.
  * @param {string=} ngRequired Adds `required` attribute and `required` validation constraint to
  *    the element when the ngRequired expression evaluates to true. Use `ngRequired` instead of


### PR DESCRIPTION
Select documentation was still referring to binding to name, when it should be ng-model instead. Fixed it.
