### PR TITLE
feat(Future): add ready function to Future object

### DIFF
--- a/src/ngScenario/Future.js
+++ b/src/ngScenario/Future.js
@@ -14,6 +14,22 @@ angular.scenario.Future = function(name, behavior, line) {
   this.value = undefined;
   this.parser = angular.identity;
   this.line = line || function() { return ''; };
+  this.readyHandler = undefined;
+};
+
+/**
+ * Adds a callback function to be executed when the future has been fulfilled.
+ * Example:
+ * <code>
+ * element('#myElement').html().ready(function(value) {
+ *    window.console.log(value);//value will be the result of the future which n this case is the innerHTML of the element.
+ * });
+ * </code>
+ *
+ * @param {function()} The callback function to be executed after the future has been fulfilled.
+ */
+angular.scenario.Future.prototype.ready = function(fn) {
+  this.readyHandler = fn;
 };
 
 /**
@@ -34,6 +50,11 @@ angular.scenario.Future.prototype.execute = function(doneFn) {
     }
     self.value = error || result;
     doneFn(error, result);
+
+    if (self.readyHandler) {
+      self.readyHandler(self.value);
+    }
+
   });
 };
 

--- a/test/ngScenario/FutureSpec.js
+++ b/test/ngScenario/FutureSpec.js
@@ -74,4 +74,25 @@ describe('angular.scenario.Future', function() {
       expect(error).toBeDefined();
     });
   });
+
+  it('should call the ready function after the future is fulfilled, and verify it\'s value', function() {
+    var future = new angular.scenario.Future('test name', function(done) {
+          done(null, 'somedata');
+        });
+    future.ready(function(value) {
+      expect(value).toEqual('somedata');
+    });
+    future.execute(angular.noop);
+  });
+
+  it('should pass an error to the ready function', function() {
+    var future = new angular.scenario.Future('test name', function(done) {
+          done(null, '{');
+        });
+    future.ready(function(error) {
+      expect(error).toBeDefined();
+    });
+    future.fromJson().execute(angular.noop);
+  });
+
 });


### PR DESCRIPTION
The ready function allows you to execute a callback function after the Future has been fulfilled.  This facilitates deeply nested e2e tests.  The ready function takes one argument, either the value of the fulfilled future or an error

Example:

```
element('#myButton').click().ready(function() {
    expect(element('#someElement').html()).toContain('expected value');
});
```

This will help with an issue like #882

Before(doesn't work):

```
expect(element('#NavList').text()).toContain(activeLink.text());
```

After(works):

```
activeLink.text().ready(function(value) {
    expect(element('#NavList').text()).toContain(value);
});
```
