### PR TITLE
Fix Bug in Dragable example

### DIFF
--- a/docs/content/guide/compiler.ngdoc
+++ b/docs/content/guide/compiler.ngdoc
@@ -86,6 +86,7 @@ Here is a directive which makes any element draggable. Notice the `draggable` at
           });
 
           function mousemove(event) {
+            event.preventDefault();
             y = event.screenY - startY;
             x = event.screenX - startX;
             element.css({


### PR DESCRIPTION
**Tested in Tested in latest Chrome 26.0.1410.65 for OS X**
In the example with draggable, the mouseDown handler needs to start with an `event.preventDefault()`.  Otherwise the following bug occurs:

1) Select the text of the draggable span by clicking outside the span and dragging the mouse to the left or right through the span. Release the mouse button.
2) Now click on the span's inner text, and start to Drag it.  The browser's default functionality that drags highlighted text so that it can be pasted into something else (say a document in a text editor) is invoked.
3) Release the mouse button. Now suddenly, you'll be dragging the span. But you won't be able to place it down on the page.  It'll just follow the mouse around until the page is refreshed.

The added line fixes this.  
