### PR TITLE
More jQuery-like jqlite.triggerHandler

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -741,7 +741,8 @@ forEach({
 
   clone: JQLiteClone,
 
-  triggerHandler: function(element, eventName) {
+  triggerHandler: function(element, event) {
+    var eventName = event.type || event;
     var eventFns = (JQLiteExpandoStore(element, 'events') || {})[eventName];
 
     forEach(eventFns, function(fn) {

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1128,6 +1128,18 @@ describe('jqLite', function() {
       expect(clickSpy1).toHaveBeenCalledOnce();
       expect(clickSpy2).toHaveBeenCalledOnce();
     });
+
+
+    it('should support ui-event objects a-la {type: "type"}', function() {
+      var element = jqLite('<span>poke</span>'),
+          pokeSpy = jasmine.createSpy('poke');
+
+      element.bind('poke', pokeSpy);
+      expect(pokeSpy).not.toHaveBeenCalled();
+
+      element.triggerHandler({type: 'poke'});
+      expect(pokeSpy).toHaveBeenCalledOnce();
+    });
   });
 
 


### PR DESCRIPTION
Old version did not work with AngularUI's ui-event, since instead of
an event name it passes object `{type: 'event-name'}`. jQuery itself
tries to get `type` and then falls back to whole object (which, it
seems, can be a string). So this change matches jQuery behavior.
