### PR TITLE
fix(location): correctly rewrite Html5 urls

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -119,13 +119,14 @@ function LocationHtml5Url(appBase, basePrefix) {
   };
 
   this.$$rewrite = function(url) {
-    var appUrl;
+    var appUrl, prevAppUrl;
 
     if ( (appUrl = beginsWith(appBase, url)) !== undefined ) {
+      prevAppUrl = appUrl;
       if ( (appUrl = beginsWith(basePrefix, appUrl)) !== undefined ) {
         return appBaseNoFile + (beginsWith('/', appUrl) || appUrl);
       } else {
-        return appBase;
+        return appBase + prevAppUrl;
       }
     } else if ( (appUrl = beginsWith(appBaseNoFile, url)) ) {
       return appBaseNoFile + appUrl;

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -177,6 +177,15 @@ describe('$location', function() {
       expect(url.absUrl()).toBe('http://www.domain.com:9877/a');
     });
 
+    it('should not rewrite when hashbang url is not given', function() {
+      initService(true, '!', true);
+      inject(
+        initBrowser('http://domain.com/base/a/b', '/base'),
+        function($rootScope, $location, $browser) {
+          expect($browser.url()).toBe('http://domain.com/base/a/b');
+        }
+      );
+    });
 
     it('should prepend path with basePath', function() {
       url = new LocationHtml5Url('http://server/base/');


### PR DESCRIPTION
This commit to master - https://github.com/angular/angular.js/commit/58ef32308f45141c8f7f7cc32a6156cd328ba692 - introduced a regression where deep link Html5 urls were being rewritten with the part after the appBase being removing.
For example:

```
http://localhost:8000/build/docs/api/ng.directive:input.number
```

was always being rewritten to

```
http://localhost:8000/build/docs/
```

This was evident when trying to run the documentation on a local machine. These commits fix that.
