### PR TITLE
feat(ngInclude): $includeContentRequested event

### DIFF
--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -116,6 +116,16 @@
 
 /**
  * @ngdoc event
+ * @name ng.directive:ngInclude#$includeContentRequested
+ * @eventOf ng.directive:ngInclude
+ * @eventType emit on the current ngInclude scope
+ * @description
+ * Emitted every time the ngInclude content is requested.
+ */
+
+
+/**
+ * @ngdoc event
  * @name ng.directive:ngInclude#$includeContentLoaded
  * @eventOf ng.directive:ngInclude
  * @eventType emit on the current ngInclude scope
@@ -170,7 +180,7 @@ var ngIncludeDirective = ['$http', '$templateCache', '$anchorScroll', '$compile'
             }).error(function() {
               if (thisChangeId === changeCounter) clearContent();
             });
-              childScope.$emit('$includeContentRequested', {element: element});
+            scope.$emit('$includeContentRequested', {element: element});
           } else {
             clearContent();
           }

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -165,11 +165,12 @@ var ngIncludeDirective = ['$http', '$templateCache', '$anchorScroll', '$compile'
                 $anchorScroll();
               }
 
-              childScope.$emit('$includeContentLoaded');
+              childScope.$emit('$includeContentLoaded', {element: element});
               scope.$eval(onloadExp);
             }).error(function() {
               if (thisChangeId === changeCounter) clearContent();
             });
+              childScope.$emit('$includeContentRequested', {element: element});
           } else {
             clearContent();
           }

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -118,7 +118,7 @@
  * @ngdoc event
  * @name ng.directive:ngInclude#$includeContentRequested
  * @eventOf ng.directive:ngInclude
- * @eventType emit on the current ngInclude scope
+ * @eventType emit on the scope ngInclude was declared in
  * @description
  * Emitted every time the ngInclude content is requested.
  */
@@ -175,12 +175,12 @@ var ngIncludeDirective = ['$http', '$templateCache', '$anchorScroll', '$compile'
                 $anchorScroll();
               }
 
-              childScope.$emit('$includeContentLoaded', {element: element});
+              childScope.$emit('$includeContentLoaded');
               scope.$eval(onloadExp);
             }).error(function() {
               if (thisChangeId === changeCounter) clearContent();
             });
-            scope.$emit('$includeContentRequested', {element: element});
+            scope.$emit('$includeContentRequested');
           } else {
             clearContent();
           }

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -61,7 +61,7 @@ describe('ngInclude', function() {
 
   it('should fire $includeContentRequested event on scope after making the xhr call', inject(
       function ($rootScope, $compile, $templateCache) {
-    var contentRequestedSpy = jasmine.createSpy('content requested').andCallFake(function (event, data) {
+    var contentRequestedSpy = jasmine.createSpy('content requested').andCallFake(function (event) {
         expect(event.targetScope).toBe($rootScope);
     });
 
@@ -76,7 +76,7 @@ describe('ngInclude', function() {
 
   it('should fire $includeContentLoaded event on child scope after linking the content', inject(
       function($rootScope, $compile, $templateCache) {
-    var contentLoadedSpy = jasmine.createSpy('content loaded').andCallFake(function(event, data) {
+    var contentLoadedSpy = jasmine.createSpy('content loaded').andCallFake(function(event) {
       expect(event.targetScope.$parent).toBe($rootScope);
       expect(element.text()).toBe('partial content');
     });

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -63,7 +63,6 @@ describe('ngInclude', function() {
       function ($rootScope, $compile, $templateCache) {
     var contentRequestedSpy = jasmine.createSpy('content requested').andCallFake(function (event, data) {
         expect(event.targetScope).toBe($rootScope);
-        expect(data.element[0]).toBe(element[0]);
     });
 
     $templateCache.put('url', [200, 'partial content', {}]);
@@ -80,7 +79,6 @@ describe('ngInclude', function() {
     var contentLoadedSpy = jasmine.createSpy('content loaded').andCallFake(function(event, data) {
       expect(event.targetScope.$parent).toBe($rootScope);
       expect(element.text()).toBe('partial content');
-      expect(data.element[0]).toBe(element[0]);
     });
 
     $templateCache.put('url', [200, 'partial content', {}]);

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -59,12 +59,28 @@ describe('ngInclude', function() {
     expect(element.text()).toEqual('');
   }));
 
+  it('should fire $includeContentRequested event on scope after making the xhr call', inject(
+      function ($rootScope, $compile, $templateCache) {
+    var contentRequestedSpy = jasmine.createSpy('content requested').andCallFake(function (event, data) {
+        expect(event.targetScope).toBe($rootScope);
+        expect(data.element[0]).toBe(element[0]);
+    });
+
+    $templateCache.put('url', [200, 'partial content', {}]);
+    $rootScope.$on('$includeContentRequested', contentRequestedSpy);
+
+    element = $compile('<ng:include src="\'url\'"></ng:include>')($rootScope);
+    $rootScope.$digest();
+
+    expect(contentRequestedSpy).toHaveBeenCalledOnce();
+  }));
 
   it('should fire $includeContentLoaded event on child scope after linking the content', inject(
       function($rootScope, $compile, $templateCache) {
-    var contentLoadedSpy = jasmine.createSpy('content loaded').andCallFake(function(event) {
+    var contentLoadedSpy = jasmine.createSpy('content loaded').andCallFake(function(event, data) {
       expect(event.targetScope.$parent).toBe($rootScope);
       expect(element.text()).toBe('partial content');
+      expect(data.element[0]).toBe(element[0]);
     });
 
     $templateCache.put('url', [200, 'partial content', {}]);


### PR DESCRIPTION
Adding a $includeContentRequested event allow us to keep track of how many includes are sent and compare it with how many have finished.
