### PR TITLE
test(browser/compile): fix calls to Jasmine fail()

### DIFF
--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -271,8 +271,8 @@ describe('browser', function() {
         browser.cookies('x', longVal + longVal + longVal); //should be too long for all browsers
 
         if (document.cookie !== cookieStr) {
-          fail("browser didn't drop long cookie when it was expected. make the cookie in this " +
-              "test longer");
+          this.fail(Error("browser didn't drop long cookie when it was expected. make the " +
+              "cookie in this test longer"));
         }
 
         expect(browser.cookies().x).toEqual('shortVal');

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -541,7 +541,7 @@ describe('$compile', function() {
         it('should prevent multiple templates per element', inject(function($compile) {
           try {
             $compile('<div><span replace class="replace"></span></div>')
-            fail();
+            this.fail(Error());
           } catch(e) {
             expect(e.message).toMatch(/Multiple directives .* asking for template/);
           }


### PR DESCRIPTION
The Jasmine fail() calls in `browserSpec.js` and `compileSpec.js` are causing `ReferenceError: Can't find variable: fail`. In both cases the call to `fail()` should be `this.fail(Error())`.

This was discussed in [jasmine-node issue #81](https://github.com/mhevery/jasmine-node/issues/81)

The `browserSpec.js` case was triggered for me because PhantomJS wasn't dropping cookies over 4kb.
