### PR TITLE
fix($locale): Polish negative number format

### DIFF
--- a/src/ngLocale/angular-locale_pl-pl.js
+++ b/src/ngLocale/angular-locale_pl-pl.js
@@ -85,8 +85,8 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "(",
-        "negSuf": "\u00a0\u00a4)",
+        "negPre": "-",
+        "negSuf": "\u00a0\u00a4",
         "posPre": "",
         "posSuf": "\u00a0\u00a4"
       }

--- a/src/ngLocale/angular-locale_pl.js
+++ b/src/ngLocale/angular-locale_pl.js
@@ -85,8 +85,8 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "(",
-        "negSuf": "\u00a0\u00a4)",
+        "negPre": "-",
+        "negSuf": "\u00a0\u00a4",
         "posPre": "",
         "posSuf": "\u00a0\u00a4"
       }


### PR DESCRIPTION
Polish negative number format should be: "-42" and not "(42)". Repairing a mistake made in 96b13bbee17819fb28c9a4e1e22e426b1b07a554. This issue affected currency filter, making it display negative values wrong while using locales pl and pl-pl.
