### PR TITLE
Allow duplicate objects in ngRepeat.

### DIFF
--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -457,44 +457,45 @@ describe('ngRepeat', function() {
     });
 
 
-    it('should throw error on adding existing duplicates and recover', function() {
-      scope.items = [a, a, a];
-      scope.$digest();
-      expect($exceptionHandler.errors.shift().message).
-          toEqual('Duplicates in a repeater are not allowed. Repeater: item in items key: object:003');
+    it('should not throw error on adding existing duplicates', function() {
+        scope.items = [a, a, a];
+        scope.$digest();
+        expect($exceptionHandler.errors.shift()).toBeUndefined();
+        var newElements = element.find('li');
+        expect(newElements.length).toEqual(3);
 
-      // recover
-      scope.items = [a];
-      scope.$digest();
-      var newElements = element.find('li');
-      expect(newElements.length).toEqual(1);
-      expect(newElements[0]).toEqual(lis[0]);
+        scope.items.push(a);
+        scope.$digest();
+        newElements = element.find('li');
+        expect(newElements.length).toEqual(4);
+     });
 
-      scope.items = [];
-      scope.$digest();
-      var newElements = element.find('li');
-      expect(newElements.length).toEqual(0);
-    });
+    it('should not throw error on removing a duplicate', function() {
+        scope.items = [a, a, a];
+        scope.$digest();
+        expect($exceptionHandler.errors.shift()).toBeUndefined();
+        var newElements = element.find('li');
+        expect(newElements.length).toEqual(3);
 
+        scope.items.splice(1,1);
+        scope.$digest();
+        newElements = element.find('li');
+        expect(newElements.length).toEqual(2);
+     });
 
-    it('should throw error on new duplicates and recover', function() {
-      scope.items = [d, d, d];
-      scope.$digest();
-      expect($exceptionHandler.errors.shift().message).
-          toEqual('Duplicates in a repeater are not allowed. Repeater: item in items key: object:009');
+    it('should not throw error on moving a duplicate', function() {
+        scope.items = [a,a,a,c];
+        scope.$digest();
+        expect($exceptionHandler.errors.shift()).toBeUndefined();
+        var newElements = element.find('li');
+        expect(newElements.length).toEqual(4);
 
-      // recover
-      scope.items = [a];
-      scope.$digest();
-      var newElements = element.find('li');
-      expect(newElements.length).toEqual(1);
-      expect(newElements[0]).toEqual(lis[0]);
-
-      scope.items = [];
-      scope.$digest();
-      var newElements = element.find('li');
-      expect(newElements.length).toEqual(0);
-    });
+        scope.items[2] = c;
+        scope.items[3] = a;
+        scope.$digest();
+        newElements = element.find('li');
+        expect(newElements.length).toEqual(4);
+     });
 
 
     it('should reverse items when the collection is reversed', function() {


### PR DESCRIPTION
Currently, ngRepeat doesn't allow modification of a list that contains
duplicates. For example, while ng-repeat='i in [1,1,1]' is allowed, it
is not possible to add a 1 to the list after it has been iterated at
least once. This patch addresses this issue.
Just by observing a change from [1,1,1] to [1,1,1,1] it is not possible
to know the position where the additional 1 was inserted (vice versa for
removal of 1). For the purposes of this patch, we assume that the item
was inserted after all other duplicates (or is the last duplicate to be
removed).
This patch does have a visible effect when using animations. Consider
the following list [a,b,a] and inserting a in position 0 to yield
[a,a,b,a]. Since we're assuming that a was added, we need to apply a
series of moves to yield the desired list:
- a in position 0 does not change
- a moves from position 2 to position 1
- b moves from position 1 to position 2
- a new a is added in position 3
  It is probably possible to minimize the number of moves necessary, but that
  would come at some cost.
  This patch assumes that no two objects that are not occupying the same
  memory location will have the same $$hashKey (which is the same
  assumption of the previous implementation but it was not stated!)
