### PR TITLE
not rewriting duplicate params in url

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -827,7 +827,14 @@ function parseKeyValue(/**string*/keyValue) {
     if (keyValue) {
       key_value = keyValue.split('=');
       key = decodeURIComponent(key_value[0]);
-      obj[key] = isDefined(key_value[1]) ? decodeURIComponent(key_value[1]) : true;
+      var val = isDefined(key_value[1]) ? decodeURIComponent(key_value[1]) : true;
+      if(!obj[key]){
+        obj[key] = val;
+      } else if(isArray(obj[key])){
+        obj[key].push[obj[key]];
+      } else{
+        obj[key] = [obj[key],val];
+      }
     }
   });
   return obj;
@@ -836,7 +843,13 @@ function parseKeyValue(/**string*/keyValue) {
 function toKeyValue(obj) {
   var parts = [];
   forEach(obj, function(value, key) {
-    parts.push(encodeUriQuery(key, true) + (value === true ? '' : '=' + encodeUriQuery(value, true)));
+    if(isArray(value)){
+      forEach(value, function(value2){
+        parts.push(encodeUriQuery(key, true) + (value2 === true ? '' : '=' + encodeUriQuery(value2, true)));
+      });
+    }else{
+      parts.push(encodeUriQuery(key, true) + (value === true ? '' : '=' + encodeUriQuery(value, true)));
+    }
   });
   return parts.length ? parts.join('&') : '';
 }

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -253,6 +253,16 @@ describe('angular', function() {
       expect(parseKeyValue('flag1&key=value&flag2')).
       toEqual({flag1: true, key: 'value', flag2: true});
     });
+
+    it('should parse a string into key-value pairs even duplicates', function() {
+      expect(parseKeyValue('')).toEqual({});
+      expect(parseKeyValue('duplicate=pair')).toEqual({duplicate: 'pair'});
+      expect(parseKeyValue('first=1&first=2')).toEqual({first: ['1','2']});
+      expect(parseKeyValue('escaped%20key=escaped%20value&&escaped%20key=escaped%20value2')).
+      toEqual({'escaped key': ['escaped value','escaped value2']});
+      expect(parseKeyValue('flag1&key=value&flag1')).
+      toEqual({flag1: [true,true], key: 'value'});
+    });
   });
 
   describe('toKeyValue', function() {
@@ -267,6 +277,10 @@ describe('angular', function() {
 
     it('should parse true values into flags', function() {
       expect(toKeyValue({flag1: true, key: 'value', flag2: true})).toEqual('flag1&key=value&flag2');
+    });
+
+    it('should parse duplicates into duplicate param strings', function() {
+      expect(toKeyValue({key: [323,'value',true]})).toEqual('key=323&key=value&key');
     });
   });
 


### PR DESCRIPTION
The urls are currently rewritten if duplicate params are added. 

parseKeyValue and toKeyValue have been altered slightly to allow for duplicate fields that are in the url as strings. 
