### PR TITLE
feat($http): add promise.cancel support

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -33,6 +33,7 @@ function $HttpBackendProvider() {
 function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument, locationProtocol) {
   // TODO(vojta): fix the signature
   return function(method, url, post, callback, headers, timeout, withCredentials, responseType) {
+    var status;
     $browser.$$incOutstandingRequestCount();
     url = url || $browser.url();
 
@@ -42,12 +43,12 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
         callbacks[callbackId].data = data;
       };
 
-      jsonpReq(url.replace('JSON_CALLBACK', 'angular.callbacks.' + callbackId),
+      var jsonpDone = jsonpReq(url.replace('JSON_CALLBACK', 'angular.callbacks.' + callbackId),
           function() {
         if (callbacks[callbackId].data) {
           completeRequest(callback, 200, callbacks[callbackId].data);
         } else {
-          completeRequest(callback, -2);
+          completeRequest(callback, status || -2);
         }
         delete callbacks[callbackId];
       });
@@ -57,8 +58,6 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
       forEach(headers, function(value, key) {
         if (value) xhr.setRequestHeader(key, value);
       });
-
-      var status;
 
       // In IE6 and 7, this might be called synchronously when xhr.send below is called and the
       // response is in the cache. the promise api will ensure that to the app code the api is
@@ -105,19 +104,24 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
       }
 
       xhr.send(post || '');
+    }
 
-      if (timeout > 0) {
-        $browserDefer(function() {
-          status = -1;
-          xhr.abort();
-        }, timeout);
-      }
+
+    if (timeout > 0) {
+      var timeoutId = $browserDefer(function() {
+        status = -1;
+        jsonpDone && jsonpDone();
+        xhr && xhr.abort();
+      }, timeout);
     }
 
 
     function completeRequest(callback, status, response, headersString) {
       // URL_MATCH is defined in src/service/location.js
       var protocol = (url.match(SERVER_MATCH) || ['', locationProtocol])[1];
+
+      // cancel timeout
+      timeoutId && $browserDefer.cancel(timeoutId);
 
       // fix status code for file protocol (it's always 0)
       status = (protocol == 'file') ? (response ? 200 : 404) : status;
@@ -152,5 +156,6 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
     }
 
     rawDocument.body.appendChild(script);
+    return doneWrapper;
   }
 }

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -96,6 +96,51 @@ describe('$httpBackend', function() {
   });
 
 
+  it('should return a cancel function', function() {
+    callback.andCallFake(function(status, response) {
+      expect(status).toBe(-1);
+    });
+
+    var cancel = $backend('GET', '/url', null, callback);
+    expect(typeof cancel).toBe('function');
+
+    xhr = MockXhr.$$lastInstance;
+    spyOn(xhr, 'abort');
+
+    cancel();
+    cancel();
+    expect(xhr.abort).toHaveBeenCalledOnce();
+
+    xhr.status = 0;
+    xhr.readyState = 4;
+    xhr.onreadystatechange();
+
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+
+  it('should not cancel a completed request', function() {
+    callback.andCallFake(function(status, response) {
+      expect(status).toBe(200);
+    });
+
+    var cancel = $backend('GET', '/url', null, callback);
+    expect(typeof cancel).toBe('function');
+
+    xhr = MockXhr.$$lastInstance;
+    spyOn(xhr, 'abort');
+
+    xhr.status = 200;
+    xhr.readyState = 4;
+    xhr.onreadystatechange();
+
+    cancel();
+    expect(xhr.abort).not.toHaveBeenCalled();
+
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+
   it('should abort request on timeout', function() {
     callback.andCallFake(function(status, response) {
       expect(status).toBe(-1);

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -1,20 +1,35 @@
 describe('$httpBackend', function() {
 
   var $backend, $browser, callbacks,
-      xhr, fakeDocument, callback;
+      xhr, fakeDocument, callback,
+      fakeTimeoutId = 0;
 
   // TODO(vojta): should be replaced by $defer mock
   function fakeTimeout(fn, delay) {
     fakeTimeout.fns.push(fn);
     fakeTimeout.delays.push(delay);
+    fakeTimeout.ids.push(++fakeTimeoutId);
+    return fakeTimeoutId;
   }
 
   fakeTimeout.fns = [];
   fakeTimeout.delays = [];
+  fakeTimeout.ids = [];
   fakeTimeout.flush = function() {
     var len = fakeTimeout.fns.length;
     fakeTimeout.delays = [];
+    fakeTimeout.ids = [];
     while (len--) fakeTimeout.fns.shift()();
+  };
+  fakeTimeout.cancel = function(id) {
+    var i = indexOf(fakeTimeout.ids, id);
+    if (i >= 0) {
+      fakeTimeout.fns.splice(i, 1);
+      fakeTimeout.delays.splice(i, 1);
+      fakeTimeout.ids.splice(i, 1);
+      return true;
+    }
+    return false;
   };
 
 
@@ -99,6 +114,27 @@ describe('$httpBackend', function() {
     xhr.readyState = 4;
     xhr.onreadystatechange();
     expect(callback).toHaveBeenCalledOnce();
+  });
+
+
+  it('should cancel timeout on completion', function() {
+    callback.andCallFake(function(status, response) {
+      expect(status).toBe(200);
+    });
+
+    $backend('GET', '/url', null, callback, {}, 2000);
+    xhr = MockXhr.$$lastInstance;
+    spyOn(xhr, 'abort');
+
+    expect(fakeTimeout.delays[0]).toBe(2000);
+
+    xhr.status = 200;
+    xhr.readyState = 4;
+    xhr.onreadystatechange();
+    expect(callback).toHaveBeenCalledOnce();
+
+    expect(fakeTimeout.delays.length).toBe(0);
+    expect(xhr.abort).not.toHaveBeenCalled();
   });
 
 
@@ -236,6 +272,20 @@ describe('$httpBackend', function() {
 
       $backend('JSONP', '', null, callback);
       expect(fakeDocument.$$scripts[0].src).toBe($browser.url());
+    });
+
+
+    it('should abort request on timeout', function() {
+      callback.andCallFake(function(status, response) {
+        expect(status).toBe(-1);
+      });
+
+      $backend('JSONP', 'http://example.org/path?cb=JSON_CALLBACK', null, callback, null, 2000);
+      expect(fakeDocument.$$scripts.length).toBe(1);
+      expect(fakeTimeout.delays[0]).toBe(2000);
+
+      fakeTimeout.flush();
+      expect(callback).toHaveBeenCalledOnce();
     });
 
 

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -818,8 +818,46 @@ describe('ngMock', function() {
       hb.when('JSONP', '/url1').respond(200);
       hb.expect('JSONP', '/url2').respond(200);
 
-      expect(hb('JSONP', '/url1')).toBeUndefined();
-      expect(hb('JSONP', '/url2')).toBeUndefined();
+      hb('JSONP', '/url1', null, callback);
+      hb('JSONP', '/url2', null, callback);
+
+      hb.flush();
+      expect(callback).toHaveBeenCalledWith(200, undefined, '');
+      hb.verifyNoOutstandingRequest();
+    });
+
+
+    it('should return a cancel function', function() {
+      hb.when('GET', '/url').respond(200, '', {});
+
+      var cancel = hb('GET', '/url', null, callback);
+      expect(typeof cancel).toBe('function');
+
+      cancel();
+      cancel();
+
+      expect(function() {
+        hb.flush();
+      }).toThrow('No pending request to flush !');
+      expect(callback).toHaveBeenCalledOnceWith(-1, null, null);
+      hb.verifyNoOutstandingRequest();
+    });
+
+
+    it('should not cancel a completed request', function() {
+      hb.when('GET', '/url').respond(200, '', {});
+
+      var cancel = hb('GET', '/url', null, callback);
+      expect(typeof cancel).toBe('function');
+
+      hb.flush();
+      cancel();
+
+      expect(function() {
+        hb.flush();
+      }).toThrow('No pending request to flush !');
+      expect(callback).toHaveBeenCalledOnceWith(200, '', '');
+      hb.verifyNoOutstandingRequest();
     });
 
 


### PR DESCRIPTION
Implement the canceler option of `$q.defer` to allow interrupting requests.

Closes #1159

Depends on #2452 and #2503
