### PR TITLE
fix(ngRepeat): correctly iterate over array-like objects

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -212,7 +212,7 @@ var ngRepeatDirective = ['$parse', '$animator', function($parse, $animator) {
               nextBlockOrder = [];
 
 
-          if (isArray(collection)) {
+          if (isArrayLike(collection)) {
             collectionKeys = collection;
           } else {
             // if object, extract keys, sort them and use to determine order of iteration over obj props

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -376,7 +376,7 @@ function $RootScopeProvider(){
               oldValue = newValue;
               changeDetected++;
             }
-          } else if (isArray(newValue)) {
+          } else if (isArrayLike(newValue)) {
             if (oldValue !== internalArray) {
               // we are transitioning from something which was not an array into array.
               oldValue = internalArray;

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -55,6 +55,26 @@ describe('ngRepeat', function() {
   });
 
 
+  it('should iterate over an array-like object', function() {
+    element = $compile(
+      '<ul>' +
+        '<li ng-repeat="item in items">{{item.name}};</li>' +
+      '</ul>')(scope);
+
+    document.body.innerHTML = "<p>" +
+                                      "<a name='x'>a</a>" +
+                                      "<a name='y'>b</a>" +
+                                      "<a name='x'>c</a>" +
+                                    "</p>";
+
+    var htmlCollection = document.getElementsByTagName('a');
+    scope.items = htmlCollection;
+    scope.$digest();
+    expect(element.find('li').length).toEqual(3);
+    expect(element.text()).toEqual('x;y;x;');
+  });
+
+
   it('should iterate over on object/map', function() {
     element = $compile(
       '<ul>' +

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -463,6 +463,23 @@ describe('Scope', function() {
           $rootScope.$digest();
           expect(log).toEqual([ '[{},[]]' ]);
         });
+
+        it('should watch array-like objects like arrays', function () {
+          var arrayLikelog = [];
+          $rootScope.$watchCollection('arrayLikeObject', function logger(obj) {
+            forEach(obj, function (element){
+              arrayLikelog.push(element.name);
+            })
+          });
+          document.body.innerHTML = "<p>" +
+                                      "<a name='x'>a</a>" +
+                                      "<a name='y'>b</a>" +
+                                    "</p>";
+
+          $rootScope.arrayLikeObject =  document.getElementsByTagName('a')
+          $rootScope.$digest();
+          expect(arrayLikelog).toEqual(['x', 'y']);
+        });
       });
 
 


### PR DESCRIPTION
Check if the object is array-like to iterate over it like it's done with arrays.

Closes #2546
