### PR TITLE
Remove call to trim when processing attribute values for directives

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -527,9 +527,9 @@ function $CompileProvider($provide) {
               }
               nName = directiveNormalize(name.toLowerCase());
               attrsMap[nName] = name;
-              attrs[nName] = value = trim((msie && name == 'href')
+              attrs[nName] = value = (msie && name == 'href')
                 ? decodeURIComponent(node.getAttribute(name, 2))
-                : attr.value);
+                : attr.value;
               if (getBooleanAttrName(node, nName)) {
                 attrs[nName] = true; // presence means true
               }

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1017,6 +1017,14 @@ describe('input', function() {
     });
 
 
+    it('should allow custom separator with whitespace', function() {
+      compileInput('<input type="text" ng-model="list" ng-list=" or " />');
+
+      changeInputValueTo('House or Door or Chair');
+      expect(scope.list).toEqual(['House', 'Door', 'Chair']);
+    });
+
+
     it('should allow regexp as a separator', function() {
       compileInput('<input type="text" ng-model="list" ng-list="/:|,/" />');
 


### PR DESCRIPTION
The line modified by this pull request calls trim() on attribute values when processing a directive. This means that if your directive expects an attribute value with whitespace it will get removed by angular. For example, when using ng-list, both these instances behave in the same way:

```
<input type="text" ng-model="mymodel" ng-list="or">

<input type="text" ng-model="mymodel" ng-list=" or ">
```

Which means that when using the separator " or ", an input of "House or Door or Chair" gets incorrectly split into the array ["House","Do","","Chair"].

The change in the request removes the call to trim and includes a test that verifies the above use case works as expected. However, this is potentially a breaking change for applications that rely on whitespace being trimmed.
