### PR TITLE
fix(ngList) Fix model to view rendering when using a custom separator

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1267,8 +1267,8 @@ var ngListDirective = function() {
     link: function(scope, element, attr, ctrl) {
       // Get the attribute values directly from the element rather than the
       // attr map otherwise the attribute values will be trimmed of whitespace
-      var separatorAttribute = element[0].getAttribute("ng-list")
-      var joinAttribute = element[0].getAttribute("ng-list-join")
+      var separatorAttribute = element[0].getAttribute(attr.$attr['ngList'])
+      var joinAttribute = element[0].getAttribute(attr.$attr['ngListJoin'])
       var separator, joinedby;
       var match = /\/(.*)\//.exec(separatorAttribute);
       if (match) {

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1225,6 +1225,8 @@ var requiredDirective = function() {
  * @element input
  * @param {string=} ngList optional delimiter that should be used to split the value. If
  *   specified in form `/something/` then the value will be converted into a regular expression.
+ * @param {string=} ngListJoinedBy optional string to use when joining elements of the array.
+ * This is especially useful when the delimeter is a regular expression. The default value is ', '.
  *
  * @example
     <doc:example>

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1225,7 +1225,7 @@ var requiredDirective = function() {
  * @element input
  * @param {string=} ngList optional delimiter that should be used to split the value. If
  *   specified in form `/something/` then the value will be converted into a regular expression.
- * @param {string=} ngListJoinedBy optional string to use when joining elements of the array.
+ * @param {string=} ngListJoin optional string to use when joining elements of the array.
  * This is especially useful when the delimeter is a regular expression. The default value is ', '.
  *
  * @example
@@ -1268,16 +1268,16 @@ var ngListDirective = function() {
       // Get the attribute values directly from the element rather than the
       // attr map otherwise the attribute values will be trimmed of whitespace
       var separatorAttribute = element[0].getAttribute("ng-list")
-      var joinedByAttribute = element[0].getAttribute("ng-list-joined-by")
+      var joinAttribute = element[0].getAttribute("ng-list-join")
       var separator, joinedby;
       var match = /\/(.*)\//.exec(separatorAttribute);
       if (match) {
-        // This is a regex pattern - always use ', ' to join elements when ngListJoinedBy is undefined
+        // This is a regex pattern - always use ', ' to join elements when ngListJoin is undefined
         separator = new RegExp(match[1])
-        joinedby = joinedByAttribute || ', ';
+        joinedby = joinAttribute || ', ';
       }else{
         separator = separatorAttribute || ','
-        joinedby = joinedByAttribute || separatorAttribute || ', ';
+        joinedby = joinAttribute || separatorAttribute || ', ';
       }
 
       var parse = function(viewValue) {

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1263,8 +1263,20 @@ var ngListDirective = function() {
   return {
     require: 'ngModel',
     link: function(scope, element, attr, ctrl) {
-      var match = /\/(.*)\//.exec(attr.ngList),
-          separator = match && new RegExp(match[1]) || attr.ngList || ',';
+      // Get the attribute values directly from the element rather than the
+      // attr map otherwise the attribute values will be trimmed of whitespace
+      var separatorAttribute = element[0].getAttribute("ng-list")
+      var joinedByAttribute = element[0].getAttribute("ng-list-joined-by")
+      var separator, joinedby;
+      var match = /\/(.*)\//.exec(separatorAttribute);
+      if (match) {
+        // This is a regex pattern - always use ', ' to join elements when ngListJoinedBy is undefined
+        separator = new RegExp(match[1])
+        joinedby = joinedByAttribute || ', ';
+      }else{
+        separator = separatorAttribute || ','
+        joinedby = joinedByAttribute || separatorAttribute || ', ';
+      }
 
       var parse = function(viewValue) {
         var list = [];
@@ -1281,7 +1293,7 @@ var ngListDirective = function() {
       ctrl.$parsers.push(parse);
       ctrl.$formatters.push(function(value) {
         if (isArray(value)) {
-          return value.join(', ');
+          return value.join(joinedby);
         }
 
         return undefined;

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1009,22 +1009,74 @@ describe('input', function() {
     it('should allow custom separator', function() {
       compileInput('<input type="text" ng-model="list" ng-list=":" />');
 
-      changeInputValueTo('a,a');
-      expect(scope.list).toEqual(['a,a']);
+      // model -> view
+      scope.$apply(function() {
+        scope.list = ['x', 'y', 'z'];
+      });
+      expect(inputElm.val()).toBe('x:y:z'); //Should use the separator as the join string
 
+      // view -> model
       changeInputValueTo('a:b');
       expect(scope.list).toEqual(['a', 'b']);
+    });
+
+
+    it('should allow custom separator with whitespace', function() {
+      compileInput('<input type="text" ng-model="list" ng-list=" or " />');
+
+      changeInputValueTo('House or Door or Chair');
+      expect(scope.list).toEqual(['House', 'Door', 'Chair']);
+    });
+
+
+    it('should allow custom join string', function() {
+      compileInput('<input type="text" ng-model="list" ng-list ng-list-joined-by=" and "/>');
+
+      // model -> view
+      scope.$apply(function() {
+        scope.list = ['x', 'y', 'z'];
+      });
+      expect(inputElm.val()).toBe('x and y and z');
+    });
+
+
+    it('should allow custom separator and custom join string', function() {
+      compileInput('<input type="text" ng-model="list" ng-list=":" ng-list-joined-by=" and "/>');
+
+      // model -> view
+      scope.$apply(function() {
+        scope.list = ['x', 'y', 'z'];
+      });
+      expect(inputElm.val()).toBe('x and y and z');
     });
 
 
     it('should allow regexp as a separator', function() {
       compileInput('<input type="text" ng-model="list" ng-list="/:|,/" />');
 
+      // model -> view
+      scope.$apply(function() {
+        scope.list = ['x', 'y', 'z'];
+      });
+      expect(inputElm.val()).toBe('x, y, z'); //Should use ', ' as the default join string
+
+      // view -> model
       changeInputValueTo('a,b');
       expect(scope.list).toEqual(['a', 'b']);
 
       changeInputValueTo('a,b: c');
       expect(scope.list).toEqual(['a', 'b', 'c']);
+    });
+
+
+    it('should allow regexp as a separator and custom join string', function() {
+      compileInput('<input type="text" ng-model="list" ng-list="/:|,/" ng-list-joined-by="; " />');
+
+      // model -> view
+      scope.$apply(function() {
+        scope.list = ['x', 'y', 'z'];
+      });
+      expect(inputElm.val()).toBe('x; y; z');
     });
   });
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1030,7 +1030,7 @@ describe('input', function() {
 
 
     it('should allow custom join string', function() {
-      compileInput('<input type="text" ng-model="list" ng-list ng-list-joined-by=" and "/>');
+      compileInput('<input type="text" ng-model="list" ng-list ng-list-join=" and "/>');
 
       // model -> view
       scope.$apply(function() {
@@ -1041,7 +1041,7 @@ describe('input', function() {
 
 
     it('should allow custom separator and custom join string', function() {
-      compileInput('<input type="text" ng-model="list" ng-list=":" ng-list-joined-by=" and "/>');
+      compileInput('<input type="text" ng-model="list" ng-list=":" ng-list-join=" and "/>');
 
       // model -> view
       scope.$apply(function() {
@@ -1070,7 +1070,7 @@ describe('input', function() {
 
 
     it('should allow regexp as a separator and custom join string', function() {
-      compileInput('<input type="text" ng-model="list" ng-list="/:|,/" ng-list-joined-by="; " />');
+      compileInput('<input type="text" ng-model="list" ng-list="/:|,/" ng-list-join="; " />');
 
       // model -> view
       scope.$apply(function() {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1048,6 +1048,25 @@ describe('input', function() {
         scope.list = ['x', 'y', 'z'];
       });
       expect(inputElm.val()).toBe('x and y and z');
+
+      // view -> model
+      changeInputValueTo('a:b');
+      expect(scope.list).toEqual(['a', 'b']);
+    });
+
+
+    it('should allow custom separator and custom join string in alternative attribute form', function() {
+      compileInput('<input type="text" ng-model="list" ng:list=":" data-ng-list-join=" and "/>');
+
+      // model -> view
+      scope.$apply(function() {
+          scope.list = ['x', 'y', 'z'];
+      });
+      expect(inputElm.val()).toBe('x and y and z');
+
+      // view -> model
+      changeInputValueTo('a:b');
+      expect(scope.list).toEqual(['a', 'b']);
     });
 
 


### PR DESCRIPTION
This change adds a new ng-list-joined-by attribute to the ngList directive.
This allows you to specify a custom string to join elements of the model
array together which is useful when you are also using a custom separator.

Example:

```
<input type="text" ng-model="model.values" ng-list="|", ng-list-joined-by=" | ">
```

This will split an input string such as "Cat | Mouse | Dog" into the array
["Cat", "Mouse", "Dog"] and vice versa.
