### PR TITLE
feat(scenario): adds mousedown and mouseup event triggers to scenario

### DIFF
--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -236,7 +236,7 @@ function callerFile(offset) {
 (function(fn){
   var parentTrigger = fn.trigger;
   fn.trigger = function(type) {
-    if (/(click|change|keydown|blur|input)/.test(type)) {
+    if (/(click|change|keydown|blur|input|mousedown|mouseup)/.test(type)) {
       var processDefaults = [];
       this.each(function(index, node) {
         processDefaults.push(browserTrigger(node, type));

--- a/src/ngScenario/dsl.js
+++ b/src/ngScenario/dsl.js
@@ -328,6 +328,8 @@ angular.scenario.dsl('select', function() {
  *    element(selector, label).count() get the number of elements that match selector
  *    element(selector, label).click() clicks an element
  *    element(selector, label).mouseover() mouseover an element
+ *    element(selector, label).mousedown() mousedown an element
+ *    element(selector, label).mouseup() mouseup an element
  *    element(selector, label).query(fn) executes fn(selectedElements, done)
  *    element(selector, label).{method}() gets the value (as defined by jQuery, ex. val)
  *    element(selector, label).{method}(value) sets the value (as defined by jQuery, ex. val)
@@ -391,6 +393,22 @@ angular.scenario.dsl('element', function() {
       done();
     });
   };
+
+  chain.mousedown = function() {
+      return this.addFutureAction("element '" + this.label + "' mousedown", function($window, $document, done) {
+        var elements = $document.elements();
+        elements.trigger('mousedown');
+        done();
+      });
+    };
+
+  chain.mouseup = function() {
+      return this.addFutureAction("element '" + this.label + "' mouseup", function($window, $document, done) {
+        var elements = $document.elements();
+        elements.trigger('mouseup');
+        done();
+      });
+    };
 
   chain.query = function(fn) {
     return this.addFutureAction('element ' + this.label + ' custom query', function($window, $document, done) {

--- a/test/ngScenario/dslSpec.js
+++ b/test/ngScenario/dslSpec.js
@@ -367,6 +367,46 @@ describe("angular.scenario.dsl", function() {
         expect(mousedOver).toBe(true);
       });
 
+      it('should execute mousedown', function() {
+        var mousedDown;
+        doc.append('<div></div>');
+        doc.find('div').mousedown(function() {
+          mousedDown = true;
+        });
+        $root.dsl.element('div').mousedown();
+        expect(mousedDown).toBe(true);
+      });
+
+      it('should bubble up the mousedown event', function() {
+        var mousedDown;
+        doc.append('<div id="outer"><div id="inner"></div></div>');
+        doc.find('#outer').mousedown(function() {
+          mousedDown = true;
+        });
+        $root.dsl.element('#inner').mousedown();
+        expect(mousedDown).toBe(true);
+      });
+
+      it('should execute mouseup', function() {
+        var mousedUp;
+        doc.append('<div></div>');
+        doc.find('div').mouseup(function() {
+          mousedUp = true;
+        });
+        $root.dsl.element('div').mouseup();
+        expect(mousedUp).toBe(true);
+      });
+
+      it('should bubble up the mouseup event', function() {
+        var mousedUp;
+        doc.append('<div id="outer"><div id="inner"></div></div>');
+        doc.find('#outer').mouseup(function() {
+          mousedUp = true;
+        });
+        $root.dsl.element('#inner').mouseup();
+        expect(mousedUp).toBe(true);
+      });
+
       it('should count matching elements', function() {
         doc.append('<span></span><span></span>');
         $root.dsl.element('span').count();


### PR DESCRIPTION
Added mousedown and mouseup event triggers to scenadio dsl 'element' expression.
Added mousedown and mouseup to the custom jquery trigger method to generate real events.

Fixes issue #2585
