### PR TITLE
do not insert the undefined item if the attribute size greater than one

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -423,8 +423,8 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
               selected: selected                   // determine if we should be selected
             });
           }
-          if (!multiple && !selectedSet) {
-            // nothing was selected, we have to insert the undefined item
+          if (!multiple && !selectedSet && !(attr.size>1)) {
+            // nothing was selected or attribute size > 1, we have to insert the undefined item
             optionGroups[''].unshift({id:'?', label:'', selected:true});
           }
 


### PR DESCRIPTION
No need to add a empty option in the select if it has the attribute of size, and it is greater than 1.
