### PR TITLE
fix($compile) empty href should pass sanitation check

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -293,7 +293,7 @@ function $CompileProvider($provide) {
 
           // href property always returns normalized absolute url, so we can match against that
           normalizedVal = urlSanitizationNode.href;
-          if (!normalizedVal.match(urlSanitizationWhitelist)) {
+          if (normalizedVal !== '' && !normalizedVal.match(urlSanitizationWhitelist)) {
             this[key] = value = 'unsafe:' + normalizedVal;
           }
         }


### PR DESCRIPTION
The htmlAnchorDirective sets an empty href attribute on <a> tags.
This should pass sanitation check in $compile.

Closes #2219
