### PR TITLE
doc(ng.directive:input): fix small typo in code example

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -739,7 +739,7 @@ function checkboxInputType(scope, element, attr, ctrl) {
          <tt>myForm.userName.$valid = {{myForm.userName.$valid}}</tt><br>
          <tt>myForm.userName.$error = {{myForm.userName.$error}}</tt><br>
          <tt>myForm.lastName.$valid = {{myForm.lastName.$valid}}</tt><br>
-         <tt>myForm.userName.$error = {{myForm.lastName.$error}}</tt><br>
+         <tt>myForm.lastName.$error = {{myForm.lastName.$error}}</tt><br>
          <tt>myForm.$valid = {{myForm.$valid}}</tt><br>
          <tt>myForm.$error.required = {{!!myForm.$error.required}}</tt><br>
          <tt>myForm.$error.minlength = {{!!myForm.$error.minlength}}</tt><br>


### PR DESCRIPTION
Noticed a small typo in the code example, and it's also mentioned in a Disqus comment on the same page: http://docs.angularjs.org/api/ng.directive:input
