### PR TITLE
feat(jqLite): switch bind/unbind to more recent jQuery on/off

### DIFF
--- a/docs/components/angular-bootstrap/bootstrap-prettify.js
+++ b/docs/components/angular-bootstrap/bootstrap-prettify.js
@@ -221,7 +221,7 @@ directive.ngEmbedApp = ['$templateCache', '$browser', '$rootScope', '$location',
       }]);
       if (attrs.ngEmbedApp)  modules.push(attrs.ngEmbedApp);
 
-      element.bind('click', function(event) {
+      element.on('click', function(event) {
         if (event.target.attributes.getNamedItem('ng-click')) {
           event.preventDefault();
         }

--- a/docs/components/angular-bootstrap/bootstrap.js
+++ b/docs/components/angular-bootstrap/bootstrap.js
@@ -13,11 +13,11 @@ directive.dropdownToggle =
           close && close();
         });
 
-        element.parent().bind('click', function(event) {
+        element.parent().on('click', function(event) {
           close && close();
         });
 
-        element.bind('click', function(event) {
+        element.on('click', function(event) {
           event.preventDefault();
           event.stopPropagation();
 
@@ -35,13 +35,13 @@ directive.dropdownToggle =
             close = function (event) {
               event && event.preventDefault();
               event && event.stopPropagation();
-              $document.unbind('click', close);
+              $document.off('click', close);
               element.parent().removeClass('open');
               close = null;
               openElement = null;
             }
 
-            $document.bind('click', close);
+            $document.on('click', close);
           }
         });
       }
@@ -161,7 +161,7 @@ directive.tabbable = function() {
         }
 
         navTabs.append(li);
-        li.bind('click', function(event) {
+        li.on('click', function(event) {
           event.preventDefault();
           event.stopPropagation();
           if (ngModel.$setViewValue) {
@@ -203,7 +203,7 @@ directive.tabPane = function() {
     require: '^tabbable',
     restrict: 'C',
     link: function(scope, element, attrs, tabsCtrl) {
-      element.bind('$remove', tabsCtrl.addPane(element, attrs));
+      element.on('$remove', tabsCtrl.addPane(element, attrs));
     }
   };
 };

--- a/docs/content/guide/compiler.ngdoc
+++ b/docs/content/guide/compiler.ngdoc
@@ -77,13 +77,13 @@ Here is a directive which makes any element draggable. Notice the `draggable` at
            backgroundColor: 'lightgrey',
            cursor: 'pointer'
           });
-          element.bind('mousedown', function(event) {
+          element.on('mousedown', function(event) {
             // Prevent default dragging of selected content
             event.preventDefault();
             startX = event.screenX - x;
             startY = event.screenY - y;
-            $document.bind('mousemove', mousemove);
-            $document.bind('mouseup', mouseup);
+            $document.on('mousemove', mousemove);
+            $document.on('mouseup', mouseup);
           });
 
           function mousemove(event) {

--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -303,7 +303,7 @@ in HTML.
         require: 'ngModel',
         link: function(scope, elm, attrs, ctrl) {
           // view -> model
-          elm.bind('blur', function() {
+          elm.on('blur', function() {
             scope.$apply(function() {
               ctrl.$setViewValue(elm.html());
             });

--- a/docs/content/guide/dev_guide.services.$location.ngdoc
+++ b/docs/content/guide/dev_guide.services.$location.ngdoc
@@ -450,7 +450,7 @@ In this examples we use `<base href="/base/index.html" />`
               input = angular.element('<input type="text">').val(browser.url()),
               delay;
 
-          input.bind('keypress keyup keydown', function() {
+          input.on('keypress keyup keydown', function() {
             if (!delay) {
               delay = setTimeout(fireUrlChange, 250);
             }
@@ -469,7 +469,7 @@ In this examples we use `<base href="/base/index.html" />`
         };
       });
     }]);
-    root.bind('click', function(e) {
+    root.on('click', function(e) {
       e.stopPropagation();
     });
   }

--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -232,7 +232,7 @@ In this example we will build a directive that displays the current time.
 
            // listen on DOM destroy (removal) event, and cancel the next UI update
            // to prevent updating time after the DOM element was removed.
-           element.bind('$destroy', function() {
+           element.on('$destroy', function() {
              $timeout.cancel(timeoutId);
            });
 
@@ -687,7 +687,7 @@ Following is an example of building a reusable widget.
                  opened = true;
 
              // Clicking on title should open/close the zippy
-             title.bind('click', toggle);
+             title.on('click', toggle);
 
              // Toggle the closed/opened state
              function toggle() {

--- a/docs/content/guide/forms.ngdoc
+++ b/docs/content/guide/forms.ngdoc
@@ -293,7 +293,7 @@ The following example shows how to add two-way data-binding to contentEditable e
       require: 'ngModel',
       link: function(scope, elm, attrs, ctrl) {
         // view -> model
-        elm.bind('blur', function() {
+        elm.on('blur', function() {
           scope.$apply(function() {
             ctrl.$setViewValue(elm.html());
           });

--- a/docs/src/templates/js/docs.js
+++ b/docs/src/templates/js/docs.js
@@ -124,10 +124,10 @@ docsApp.serviceFactory.fullTextSearch = ['$q', '$rootScope', function($q, $rootS
 docsApp.directive.focused = function($timeout) {
   return function(scope, element, attrs) {
     element[0].focus();
-    element.bind('focus', function() {
+    element.on('focus', function() {
       scope.$apply(attrs.focused + '=true');
     });
-    element.bind('blur', function() {
+    element.on('blur', function() {
       // have to use $timeout, so that we close the drop-down after the user clicks,
       // otherwise when the user clicks we process the closing before we process the click.
       $timeout(function() {
@@ -545,7 +545,7 @@ docsApp.controller.DocsController = function($scope, $location, $window, $cookie
     $location.path('/api').replace();
   }
   // bind escape to hash reset callback
-  angular.element(window).bind('keydown', function(e) {
+  angular.element(window).on('keydown', function(e) {
     if (e.keyCode === 27) {
       $scope.$apply(function() {
         $scope.subpage = false;

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -453,7 +453,7 @@ function trim(value) {
 function isElement(node) {
   return node &&
     (node.nodeName  // we are a direct element
-    || (node.bind && node.find));  // we have a bind and find method part of jQuery API
+    || (node.on && node.find));  // we have an on and find method part of jQuery API
 }
 
 /**

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -32,7 +32,7 @@
  * - [after()](http://api.jquery.com/after/)
  * - [append()](http://api.jquery.com/append/)
  * - [attr()](http://api.jquery.com/attr/)
- * - [bind()](http://api.jquery.com/bind/) - Does not support namespaces
+ * - [bind()](http://api.jquery.com/on/) - Does not support namespaces
  * - [children()](http://api.jquery.com/children/) - Does not support selectors
  * - [clone()](http://api.jquery.com/clone/)
  * - [contents()](http://api.jquery.com/contents/)
@@ -43,6 +43,8 @@
  * - [hasClass()](http://api.jquery.com/hasClass/)
  * - [html()](http://api.jquery.com/html/)
  * - [next()](http://api.jquery.com/next/) - Does not support selectors
+ * - [on()](http://api.jquery.com/on/) - Does not support namespaces
+ * - [off()](http://api.jquery.com/off/) - Does not support namespaces
  * - [parent()](http://api.jquery.com/parent/) - Does not support selectors
  * - [prepend()](http://api.jquery.com/prepend/)
  * - [prop()](http://api.jquery.com/prop/)
@@ -55,7 +57,7 @@
  * - [text()](http://api.jquery.com/text/)
  * - [toggleClass()](http://api.jquery.com/toggleClass/)
  * - [triggerHandler()](http://api.jquery.com/triggerHandler/) - Passes a dummy event object to handlers.
- * - [unbind()](http://api.jquery.com/unbind/) - Does not support namespaces
+ * - [unbind()](http://api.jquery.com/off/) - Does not support namespaces
  * - [val()](http://api.jquery.com/val/)
  * - [wrap()](http://api.jquery.com/wrap/)
  *
@@ -183,7 +185,7 @@ function JQLiteDealoc(element){
   }
 }
 
-function JQLiteUnbind(element, type, fn) {
+function JQLiteOff(element, type, fn) {
   var events = JQLiteExpandoStore(element, 'events'),
       handle = JQLiteExpandoStore(element, 'handle');
 
@@ -216,7 +218,7 @@ function JQLiteRemoveData(element, name) {
 
     if (expandoStore.handle) {
       expandoStore.events.$destroy && expandoStore.handle({}, '$destroy');
-      JQLiteUnbind(element);
+      JQLiteOff(element);
     }
     delete jqCache[expandoId];
     element[jqName] = undefined; // ie does not allow deletion of attributes on elements.
@@ -338,9 +340,9 @@ var JQLitePrototype = JQLite.prototype = {
     if (document.readyState === 'complete'){
       setTimeout(trigger);
     } else {
-      this.bind('DOMContentLoaded', trigger); // works for modern browsers and IE9
+      this.on('DOMContentLoaded', trigger); // works for modern browsers and IE9
       // we can not use jqLite since we are not done loading and jQuery could be loaded later.
-      JQLite(window).bind('load', trigger); // fallback to window.onload for others
+      JQLite(window).on('load', trigger); // fallback to window.onload for others
     }
   },
   toString: function() {
@@ -609,7 +611,7 @@ forEach({
 
   dealoc: JQLiteDealoc,
 
-  bind: function bindFn(element, type, fn){
+  on: function onFn(element, type, fn){
     var events = JQLiteExpandoStore(element, 'events'),
         handle = JQLiteExpandoStore(element, 'handle');
 
@@ -649,8 +651,8 @@ forEach({
           // http://www.quirksmode.org/js/events_mouse.html#link8
           var eventmap = { mouseleave : "mouseout", mouseenter : "mouseover"};
 
-          bindFn(element, eventmap[type], function(event) {
-            var ret, target = this, related = event.relatedTarget;
+          onFn(element, eventmap[type], function(event) {
+            var target = this, related = event.relatedTarget;
             // For mousenter/leave call the handler if related is outside the target.
             // NB: No relatedTarget if the mouse left/entered the browser window
             if ( !related || (related !== target && !contains(target, related)) ){
@@ -668,7 +670,7 @@ forEach({
     });
   },
 
-  unbind: JQLiteUnbind,
+  off: JQLiteOff,
 
   replaceWith: function(element, replaceNode) {
     var index, parent = element.parentNode;
@@ -777,7 +779,6 @@ forEach({
 
   triggerHandler: function(element, eventName) {
     var eventFns = (JQLiteExpandoStore(element, 'events') || {})[eventName];
-    var event;
 
     forEach(eventFns, function(fn) {
       fn.call(element, {preventDefault: noop});
@@ -802,4 +803,8 @@ forEach({
     }
     return value == undefined ? this : value;
   };
+
+  // bind legacy bind/unbind to on/off
+  JQLite.prototype.bind = JQLite.prototype.on;
+  JQLite.prototype.unbind = JQLite.prototype.off;
 });

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -212,9 +212,9 @@ function Browser(window, document, $log, $sniffer) {
       // changed by push/replaceState
 
       // html5 history api - popstate event
-      if ($sniffer.history) jqLite(window).bind('popstate', fireUrlChange);
+      if ($sniffer.history) jqLite(window).on('popstate', fireUrlChange);
       // hashchange event
-      if ($sniffer.hashchange) jqLite(window).bind('hashchange', fireUrlChange);
+      if ($sniffer.hashchange) jqLite(window).on('hashchange', fireUrlChange);
       // polling
       else self.addPollFn(fireUrlChange);
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -470,7 +470,7 @@ function $CompileProvider($provide) {
                       transcludeScope.$$transcluded = true;
 
                       return transcludeFn(transcludeScope, cloneFn).
-                          bind('$destroy', bind(transcludeScope, transcludeScope.$destroy));
+                          on('$destroy', bind(transcludeScope, transcludeScope.$destroy));
                     };
                   })(childTranscludeFn || transcludeFn)
               );

--- a/src/ng/directive/a.js
+++ b/src/ng/directive/a.js
@@ -33,7 +33,7 @@ var htmlAnchorDirective = valueFn({
     }
 
     return function(scope, element) {
-      element.bind('click', function(event){
+      element.on('click', function(event){
         // if we have no href url, then don't navigate anywhere.
         if (!element.attr('href')) {
           event.preventDefault();

--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -283,7 +283,7 @@ var formDirectiveFactory = function(isNgForm) {
 
               // unregister the preventDefault listener so that we don't not leak memory but in a
               // way that will achieve the prevention of the default action.
-              formElement.bind('$destroy', function() {
+              formElement.on('$destroy', function() {
                 $timeout(function() {
                   removeEventListenerFn(formElement[0], 'submit', preventDefaultListener);
                 }, 0, false);
@@ -297,7 +297,7 @@ var formDirectiveFactory = function(isNgForm) {
               scope[alias] = controller;
             }
             if (parentFormCtrl) {
-              formElement.bind('$destroy', function() {
+              formElement.on('$destroy', function() {
                 parentFormCtrl.$removeControl(controller);
                 if (alias) {
                   scope[alias] = undefined;

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -411,7 +411,7 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   // if the browser does support "input" event, we are fine - except on IE9 which doesn't fire the
   // input event on backspace, delete or cut
   if ($sniffer.hasEvent('input')) {
-    element.bind('input', listener);
+    element.on('input', listener);
   } else {
     var timeout;
 
@@ -424,7 +424,7 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
       }
     };
 
-    element.bind('keydown', function(event) {
+    element.on('keydown', function(event) {
       var key = event.keyCode;
 
       // ignore
@@ -435,11 +435,11 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
     });
 
     // if user paste into input using mouse, we need "change" event to catch it
-    element.bind('change', listener);
+    element.on('change', listener);
 
     // if user modifies input value using context menu in IE, we need "paste" and "cut" events to catch it
     if ($sniffer.hasEvent('paste')) {
-      element.bind('paste cut', deferListener);
+      element.on('paste cut', deferListener);
     }
   }
 
@@ -623,7 +623,7 @@ function radioInputType(scope, element, attr, ctrl) {
     element.attr('name', nextUid());
   }
 
-  element.bind('click', function() {
+  element.on('click', function() {
     if (element[0].checked) {
       scope.$apply(function() {
         ctrl.$setViewValue(attr.value);
@@ -646,7 +646,7 @@ function checkboxInputType(scope, element, attr, ctrl) {
   if (!isString(trueValue)) trueValue = true;
   if (!isString(falseValue)) falseValue = false;
 
-  element.bind('click', function() {
+  element.on('click', function() {
     scope.$apply(function() {
       ctrl.$setViewValue(element[0].checked);
     });
@@ -866,7 +866,7 @@ var VALID_CLASS = 'ng-valid',
               };
 
               // Listen for change events to enable binding
-              element.bind('blur keyup change', function() {
+              element.on('blur keyup change', function() {
                 scope.$apply(read);
               });
               read(); // initialize
@@ -1128,7 +1128,7 @@ var ngModelDirective = function() {
 
       formCtrl.$addControl(modelCtrl);
 
-      element.bind('$destroy', function() {
+      element.on('$destroy', function() {
         formCtrl.$removeControl(modelCtrl);
       });
     }

--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -43,7 +43,7 @@ forEach(
     ngEventDirectives[directiveName] = ['$parse', function($parse) {
       return function(scope, element, attr) {
         var fn = $parse(attr[directiveName]);
-        element.bind(lowercase(name), function(event) {
+        element.on(lowercase(name), function(event) {
           scope.$apply(function() {
             fn(scope, {$event:event});
           });
@@ -264,7 +264,7 @@ forEach(
    </doc:example>
  */
 var ngSubmitDirective = ngDirective(function(scope, element, attrs) {
-  element.bind('submit', function() {
+  element.on('submit', function() {
     scope.$apply(attrs.ngSubmit);
   });
 });

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -257,7 +257,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
           }
         };
 
-        selectElement.bind('change', function() {
+        selectElement.on('change', function() {
           scope.$apply(function() {
             if (unknownOption.parent()) unknownOption.remove();
             ngModelCtrl.$setViewValue(selectElement.val());
@@ -283,7 +283,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
           }
         });
 
-        selectElement.bind('change', function() {
+        selectElement.on('change', function() {
           scope.$apply(function() {
             var array = [];
             forEach(selectElement.find('option'), function(option) {
@@ -334,7 +334,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
         // clear contents, we'll add what's needed based on the model
         selectElement.html('');
 
-        selectElement.bind('change', function() {
+        selectElement.on('change', function() {
           scope.$apply(function() {
             var optionGroup,
                 collection = valuesFn(scope) || [],
@@ -598,7 +598,7 @@ var optionDirective = ['$interpolate', function($interpolate) {
           selectCtrl.addOption(attr.value);
         }
 
-        element.bind('$destroy', function() {
+        element.on('$destroy', function() {
           selectCtrl.removeOption(attr.value);
         });
       };

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -510,7 +510,7 @@ function $LocationProvider(){
     $location = new LocationMode(appBase, '#' + hashPrefix);
     $location.$$parse($location.$$rewrite(initialUrl));
 
-    $rootElement.bind('click', function(event) {
+    $rootElement.on('click', function(event) {
       // TODO(vojta): rewrite link when opening in new tab/window (in legacy browser)
       // currently we open nice url link and redirect then
 

--- a/src/ngMobile/directive/ngClick.js
+++ b/src/ngMobile/directive/ngClick.js
@@ -185,7 +185,7 @@ ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
       element.removeClass(ACTIVE_CLASS_NAME);
     }
 
-    element.bind('touchstart', function(event) {
+    element.on('touchstart', function(event) {
       tapping = true;
       tapElement = event.target ? event.target : event.srcElement; // IE uses srcElement.
       // Hack for Safari, which can target text nodes instead of containers.
@@ -203,15 +203,15 @@ ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
       touchStartY = e.clientY;
     });
 
-    element.bind('touchmove', function(event) {
+    element.on('touchmove', function(event) {
       resetState();
     });
 
-    element.bind('touchcancel', function(event) {
+    element.on('touchcancel', function(event) {
       resetState();
     });
 
-    element.bind('touchend', function(event) {
+    element.on('touchend', function(event) {
       var diff = Date.now() - startTime;
 
       var touches = (event.changedTouches && event.changedTouches.length) ? event.changedTouches :
@@ -248,17 +248,17 @@ ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     // Fallback click handler.
     // Busted clicks don't get this far, and adding this handler allows ng-tap to be used on
     // desktop as well, to allow more portable sites.
-    element.bind('click', function(event) {
+    element.on('click', function(event) {
       scope.$apply(function() {
         clickHandler(scope, {$event: event});
       });
     });
 
-    element.bind('mousedown', function(event) {
+    element.on('mousedown', function(event) {
       element.addClass(ACTIVE_CLASS_NAME);
     });
 
-    element.bind('mousemove mouseup', function(event) {
+    element.on('mousemove mouseup', function(event) {
       element.removeClass(ACTIVE_CLASS_NAME);
     });
 

--- a/src/ngMobile/swipe.js
+++ b/src/ngMobile/swipe.js
@@ -75,7 +75,7 @@ ngMobile.factory('$swipe', [function() {
       // Whether a swipe is active.
       var active = false;
 
-      element.bind('touchstart mousedown', function(event) {
+      element.on('touchstart mousedown', function(event) {
         startCoords = getCoordinates(event);
         active = true;
         totalX = 0;
@@ -84,12 +84,12 @@ ngMobile.factory('$swipe', [function() {
         eventHandlers['start'] && eventHandlers['start'](startCoords);
       });
 
-      element.bind('touchcancel', function(event) {
+      element.on('touchcancel', function(event) {
         active = false;
         eventHandlers['cancel'] && eventHandlers['cancel']();
       });
 
-      element.bind('touchmove mousemove', function(event) {
+      element.on('touchmove mousemove', function(event) {
         if (!active) return;
 
         // Android will send a touchcancel if it thinks we're starting to scroll.
@@ -124,7 +124,7 @@ ngMobile.factory('$swipe', [function() {
         }
       });
 
-      element.bind('touchend mouseup', function(event) {
+      element.on('touchend mouseup', function(event) {
         if (!active) return;
         active = false;
         eventHandlers['end'] && eventHandlers['end'](getCoordinates(event));

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1709,7 +1709,7 @@ angular.mock.clearDataCache = function() {
     if (cache.hasOwnProperty(key)) {
       var handle = cache[key].handle;
 
-      handle && angular.element(handle.elem).unbind();
+      handle && angular.element(handle.elem).off();
       delete cache[key];
     }
   }
@@ -1749,7 +1749,7 @@ window.jstestdriver && (function(window) {
     currentSpec = null;
 
     if (injector) {
-      injector.get('$rootElement').unbind();
+      injector.get('$rootElement').off();
       injector.get('$browser').pollFns.length = 0;
     }
 

--- a/src/ngScenario/Application.js
+++ b/src/ngScenario/Application.js
@@ -64,7 +64,7 @@ angular.scenario.Application.prototype.navigateTo = function(url, loadFn, errorF
     frame = self.getFrame_();
 
     frame.load(function() {
-      frame.unbind();
+      frame.off();
       try {
         var $window = self.getWindow_();
 

--- a/test/jQueryPatchSpec.js
+++ b/test/jQueryPatchSpec.js
@@ -14,8 +14,8 @@ if (window.jQuery) {
       spy1 = jasmine.createSpy('span1.$destroy');
       spy2 = jasmine.createSpy('span2.$destroy');
       doc = $('<div><span class=first>abc</span><span class=second>xyz</span></div>');
-      doc.find('span.first').bind('$destroy', spy1);
-      doc.find('span.second').bind('$destroy', spy2);
+      doc.find('span.first').on('$destroy', spy1);
+      doc.find('span.second').on('$destroy', spy2);
     });
 
     afterEach(function() {

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -268,7 +268,7 @@ describe('jqLite', function() {
     it('should emit $destroy event if element removed via remove()', function() {
       var log = '';
       var element = jqLite(a);
-      element.bind('$destroy', function() {log+= 'destroy;';});
+      element.on('$destroy', function() {log+= 'destroy;';});
       element.remove();
       expect(log).toEqual('destroy;');
     });
@@ -276,7 +276,7 @@ describe('jqLite', function() {
 
     it('should emit $destroy event if an element is removed via html()', inject(function(log) {
       var element = jqLite('<div><span>x</span></div>');
-      element.find('span').bind('$destroy', log.fn('destroyed'));
+      element.find('span').on('$destroy', log.fn('destroyed'));
 
       element.html('');
 
@@ -343,7 +343,7 @@ describe('jqLite', function() {
             span = div.find('span'),
             log = '';
 
-        span.bind('click', function() { log+= 'click;'});
+        span.on('click', function() { log+= 'click;'});
         browserTrigger(span);
         expect(log).toEqual('click;');
 
@@ -727,7 +727,7 @@ describe('jqLite', function() {
           detachEvent: noop
       };
       var log;
-      var jWindow = jqLite(window).bind('hashchange', function() {
+      var jWindow = jqLite(window).on('hashchange', function() {
         log = 'works!';
       });
       eventFn({type: 'hashchange'});
@@ -739,7 +739,7 @@ describe('jqLite', function() {
     it('should bind to all elements and return functions', function() {
       var selected = jqLite([a, b]);
       var log = '';
-      expect(selected.bind('click', function() {
+      expect(selected.on('click', function() {
         log += 'click on: ' + jqLite(this).text() + ';';
       })).toEqual(selected);
       browserTrigger(a, 'click');
@@ -752,8 +752,8 @@ describe('jqLite', function() {
       var elm = jqLite(a),
           callback = jasmine.createSpy('callback');
 
-      elm.bind('click keypress', callback);
-      elm.bind('click', callback);
+      elm.on('click keypress', callback);
+      elm.on('click', callback);
 
       browserTrigger(a, 'click');
       expect(callback).toHaveBeenCalled();
@@ -767,7 +767,7 @@ describe('jqLite', function() {
 
     it('should set event.target on IE', function() {
       var elm = jqLite(a);
-      elm.bind('click', function(event) {
+      elm.on('click', function(event) {
         expect(event.target).toBe(a);
       });
 
@@ -775,7 +775,7 @@ describe('jqLite', function() {
     });
 
     it('should have event.isDefaultPrevented method', function() {
-      jqLite(a).bind('click', function(e) {
+      jqLite(a).on('click', function(e) {
         expect(function() {
           expect(e.isDefaultPrevented()).toBe(false);
           e.preventDefault();
@@ -796,11 +796,11 @@ describe('jqLite', function() {
         sibling = root.find('ul');
         child = parent.find('span');
 
-        parent.bind('mouseenter', function() { log += 'parentEnter;'; });
-        parent.bind('mouseleave', function() { log += 'parentLeave;'; });
+        parent.on('mouseenter', function() { log += 'parentEnter;'; });
+        parent.on('mouseleave', function() { log += 'parentLeave;'; });
 
-        child.bind('mouseenter', function() { log += 'childEnter;'; });
-        child.bind('mouseleave', function() { log += 'childLeave;'; });
+        child.on('mouseenter', function() { log += 'childEnter;'; });
+        child.on('mouseleave', function() { log += 'childLeave;'; });
       });
 
       afterEach(function() {
@@ -861,9 +861,9 @@ describe('jqLite', function() {
     it('should do nothing when no listener was registered with bound', function() {
       var aElem = jqLite(a);
 
-      aElem.unbind();
-      aElem.unbind('click');
-      aElem.unbind('click', function() {});
+      aElem.off();
+      aElem.off('click');
+      aElem.off('click', function() {});
     });
 
 
@@ -872,8 +872,8 @@ describe('jqLite', function() {
           clickSpy = jasmine.createSpy('click'),
           mouseoverSpy = jasmine.createSpy('mouseover');
 
-      aElem.bind('click', clickSpy);
-      aElem.bind('mouseover', mouseoverSpy);
+      aElem.on('click', clickSpy);
+      aElem.on('mouseover', mouseoverSpy);
 
       browserTrigger(a, 'click');
       expect(clickSpy).toHaveBeenCalledOnce();
@@ -883,7 +883,7 @@ describe('jqLite', function() {
       clickSpy.reset();
       mouseoverSpy.reset();
 
-      aElem.unbind();
+      aElem.off();
 
       browserTrigger(a, 'click');
       expect(clickSpy).not.toHaveBeenCalled();
@@ -897,8 +897,8 @@ describe('jqLite', function() {
           clickSpy = jasmine.createSpy('click'),
           mouseoverSpy = jasmine.createSpy('mouseover');
 
-      aElem.bind('click', clickSpy);
-      aElem.bind('mouseover', mouseoverSpy);
+      aElem.on('click', clickSpy);
+      aElem.on('mouseover', mouseoverSpy);
 
       browserTrigger(a, 'click');
       expect(clickSpy).toHaveBeenCalledOnce();
@@ -908,7 +908,7 @@ describe('jqLite', function() {
       clickSpy.reset();
       mouseoverSpy.reset();
 
-      aElem.unbind('click');
+      aElem.off('click');
 
       browserTrigger(a, 'click');
       expect(clickSpy).not.toHaveBeenCalled();
@@ -917,7 +917,7 @@ describe('jqLite', function() {
 
       mouseoverSpy.reset();
 
-      aElem.unbind('mouseover');
+      aElem.off('mouseover');
       browserTrigger(a, 'mouseover');
       expect(mouseoverSpy).not.toHaveBeenCalled();
     });
@@ -928,8 +928,8 @@ describe('jqLite', function() {
           clickSpy1 = jasmine.createSpy('click1'),
           clickSpy2 = jasmine.createSpy('click2');
 
-      aElem.bind('click', clickSpy1);
-      aElem.bind('click', clickSpy2);
+      aElem.on('click', clickSpy1);
+      aElem.on('click', clickSpy2);
 
       browserTrigger(a, 'click');
       expect(clickSpy1).toHaveBeenCalledOnce();
@@ -938,7 +938,7 @@ describe('jqLite', function() {
       clickSpy1.reset();
       clickSpy2.reset();
 
-      aElem.unbind('click', clickSpy1);
+      aElem.off('click', clickSpy1);
 
       browserTrigger(a, 'click');
       expect(clickSpy1).not.toHaveBeenCalled();
@@ -946,7 +946,7 @@ describe('jqLite', function() {
 
       clickSpy2.reset();
 
-      aElem.unbind('click', clickSpy2);
+      aElem.off('click', clickSpy2);
       browserTrigger(a, 'click');
       expect(clickSpy2).not.toHaveBeenCalled();
     });
@@ -1159,9 +1159,9 @@ describe('jqLite', function() {
           clickSpy1 = jasmine.createSpy('clickSpy1'),
           clickSpy2 = jasmine.createSpy('clickSpy2');
 
-      element.bind('poke', pokeSpy);
-      element.bind('click', clickSpy1);
-      element.bind('click', clickSpy2);
+      element.on('poke', pokeSpy);
+      element.on('click', clickSpy1);
+      element.on('click', clickSpy2);
 
       expect(pokeSpy).not.toHaveBeenCalled();
       expect(clickSpy1).not.toHaveBeenCalled();
@@ -1185,7 +1185,7 @@ describe('jqLite', function() {
           pokeSpy = jasmine.createSpy('poke'),
           event;
 
-      element.bind('click', pokeSpy);
+      element.on('click', pokeSpy);
 
       element.triggerHandler('click');
       event = pokeSpy.mostRecentCall.args[0];

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -247,7 +247,7 @@ describe('form', function() {
       });
 
       doc = $compile('<form action="some.py"></form>')(scope);
-      doc.bind('submit', callback);
+      doc.on('submit', callback);
 
       browserTrigger(doc, 'submit');
       expect(callback).toHaveBeenCalledOnce();

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -7,7 +7,7 @@ describe('$location', function() {
   afterEach(function() {
     // link rewriting used in html5 mode on legacy browsers binds to document.onClick, so we need
     // to clean this up after each test.
-    jqLite(document).unbind('click');
+    jqLite(document).off('click');
   });
 
   describe('NewUrl', function() {
@@ -770,7 +770,7 @@ describe('$location', function() {
         originalBrowser = $browser.url();
         // we have to prevent the default operation, as we need to test absolute links (http://...)
         // and navigating to these links would kill jstd
-        $rootElement.bind('click', function(e) {
+        $rootElement.on('click', function(e) {
           lastEventPreventDefault = e.isDefaultPrevented();
           e.preventDefault();
         });
@@ -825,7 +825,7 @@ describe('$location', function() {
 
           jqLite(link).
               attr('href', 'http://host.com/base/foo').
-              bind('click', function(e) { e.preventDefault(); });
+              on('click', function(e) { e.preventDefault(); });
           browserTrigger(link, 'click');
           expect($browser.url()).toBe('http://host.com/base/');
         }
@@ -1116,11 +1116,11 @@ describe('$location', function() {
       var base, clickHandler;
       module(function($provide) {
         $provide.value('$rootElement', {
-          bind: function(event, handler) {
+          on: function(event, handler) {
             expect(event).toEqual('click');
             clickHandler = handler;
           },
-          unbind: noop
+          off: noop
         });
         return function($browser) {
           $browser.url(base = 'http://server/');
@@ -1146,11 +1146,11 @@ describe('$location', function() {
       var base, clickHandler;
       module(function($provide) {
         $provide.value('$rootElement', {
-          bind: function(event, handler) {
+          on: function(event, handler) {
             expect(event).toEqual('click');
             clickHandler = handler;
           },
-          unbind: angular.noop
+          off: angular.noop
         });
         return function($browser) {
           $browser.url(base = 'http://server/');
@@ -1180,7 +1180,7 @@ describe('$location', function() {
       $rootElement.html('<button></button>');
       var button = $rootElement.find('button');
 
-      button.bind('click', function() {
+      button.on('click', function() {
         button.remove();
       });
       browserTrigger(button, 'click');

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -425,9 +425,9 @@ describe('ngMock', function() {
       // through the code makes the test pass. Viva IE!!!
       angular.element(document.body).append(div)
 
-      div.bind('click', function() { log += 'click1;'});
-      div.bind('click', function() { log += 'click2;'});
-      div.bind('mousemove', function() { log += 'mousemove;'});
+      div.on('click', function() { log += 'click1;'});
+      div.on('click', function() { log += 'click2;'});
+      div.on('mousemove', function() { log += 'mousemove;'});
 
       browserTrigger(div, 'click');
       browserTrigger(div, 'mousemove');

--- a/test/ngScenario/ApplicationSpec.js
+++ b/test/ngScenario/ApplicationSpec.js
@@ -17,7 +17,7 @@ describe('angular.scenario.Application', function() {
 
 
   afterEach(function() {
-    _jQuery('iframe').unbind(); // cleanup any leftover onload handlers
+    _jQuery('iframe').off(); // cleanup any leftover onload handlers
     document.body.innerHTML = '';
   });
 

--- a/test/ngScenario/dslSpec.js
+++ b/test/ngScenario/dslSpec.js
@@ -306,7 +306,7 @@ describe("angular.scenario.dsl", function() {
             elm = jqLite('<a href="#foo"></a>');
 
         doc.append(elm);
-        elm.bind('click', function(event) {
+        elm.on('click', function(event) {
           event.preventDefault();
         });
 
@@ -338,7 +338,7 @@ describe("angular.scenario.dsl", function() {
             elm = jqLite('<a href="#foo"></a>');
 
         doc.append(elm);
-        elm.bind('dblclick', function(event) {
+        elm.on('dblclick', function(event) {
           event.preventDefault();
         });
 

--- a/test/testabilityPatch.js
+++ b/test/testabilityPatch.js
@@ -106,7 +106,7 @@ function dealoc(obj) {
   }
 
   function cleanup(element) {
-    element.unbind().removeData();
+    element.off().removeData();
     for ( var i = 0, children = element.contents() || []; i < children.length; i++) {
       cleanup(angular.element(children[i]));
     }


### PR DESCRIPTION
jQuery switched to a completely new event binding implementation as of
1.7.0, centering around on/off methods instead of previous bind/unbind.
This patch makes jqLite match this implementation while still supporting
previous bind/unbind methods.
