### PR TITLE
fix(ngPluralize): Handle the empty string as a valid override

### DIFF
--- a/src/ng/directive/ngPluralize.js
+++ b/src/ng/directive/ngPluralize.js
@@ -194,7 +194,7 @@ var ngPluralizeDirective = ['$locale', '$interpolate', function($locale, $interp
         if (!isNaN(value)) {
           //if explicit number rule such as 1, 2, 3... is defined, just use it. Otherwise,
           //check it against pluralization rules in $locale service
-          if (!whens[value]) value = $locale.pluralCat(value - offset);
+          if (!(value in whens)) value = $locale.pluralCat(value - offset);
            return whensExpFns[value](scope, element, true);
         } else {
           return '';

--- a/test/ng/directive/ngPluralizeSpec.js
+++ b/test/ng/directive/ngPluralizeSpec.js
@@ -99,6 +99,21 @@ describe('ngPluralize', function() {
   });
 
 
+  describe('edge cases', function() {
+    it('should be able to handle empty strings as possible values', inject(function($rootScope, $compile) {
+      element = $compile(
+          '<ng:pluralize count="email"' +
+                         "when=\"{'0': ''," +
+                                 "'one': 'Some text'," +
+                                 "'other': 'Some text'}\">" +
+          '</ng:pluralize>')($rootScope);
+      $rootScope.email = '0';
+      $rootScope.$digest();
+      expect(element.text()).toBe('');
+    }));
+  });
+
+
   describe('deal with pluralized strings with offset', function() {
     it('should show single/plural strings with offset', inject(function($rootScope, $compile) {
       element = $compile(


### PR DESCRIPTION
Fix the check for overrides so it is able to handle the empty string

Closes #2575
