### PR TITLE
fix(docs:dom.js): fix bag with non-latin heading

### DIFF
--- a/docs/src/dom.js
+++ b/docs/src/dom.js
@@ -77,13 +77,16 @@ DOM.prototype = {
     this.tag('div', attr, text);
   },
 
-  h: function(heading, content, fn){
+  h: function(heading, content, fn, name){
     if (content==undefined || (content instanceof Array && content.length == 0)) return;
     this.headingDepth++;
     var className = null,
         anchor = null;
     if (typeof heading == 'string') {
-      var id = heading.
+      if (name==undefined){
+          var name = heading;
+      }
+      var id = name.
           replace(/\(.*\)/mg, '').
           replace(/[^\d\w\$]/mg, '.').
           replace(/-+/gm, '-').


### PR DESCRIPTION
When heading is translated with non-latin characters, this is broken design of api pages, because all classes become "-----"
