### PR TITLE
fix(compile): Collecting directives from tags that will be replaced

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -510,10 +510,8 @@ function $CompileProvider($provide) {
 
       switch(nodeType) {
         case 1: /* Element */
-          // use the node name: <directive>
-          addDirective(directives,
-              directiveNormalize(nodeName_(node).toLowerCase()), 'E', maxPriority);
-
+          var attributesDirectives = [];
+          var hasReplaceAttributeDirective = false;
           // iterate over the attributes
           for (var attr, name, nName, ngAttrName, value, nAttrs = node.attributes,
                    j = 0, jj = nAttrs && nAttrs.length; j < jj; j++) {
@@ -534,7 +532,7 @@ function $CompileProvider($provide) {
                 attrs[nName] = true; // presence means true
               }
               addAttrInterpolateDirective(node, directives, value, nName);
-              addDirective(directives, nName, 'A', maxPriority);
+              addDirective(attributesDirectives, nName, 'A', maxPriority);
             }
           }
 
@@ -543,12 +541,24 @@ function $CompileProvider($provide) {
           if (isString(className) && className !== '') {
             while (match = CLASS_DIRECTIVE_REGEXP.exec(className)) {
               nName = directiveNormalize(match[2]);
-              if (addDirective(directives, nName, 'C', maxPriority)) {
+              if (addDirective(attributesDirectives, nName, 'C', maxPriority)) {
                 attrs[nName] = trim(match[3]);
               }
               className = className.substr(match.index + match[0].length);
             }
           }
+
+          forEach(attributesDirectives, function(directive) {
+            hasReplaceAttributeDirective |= directive.replace;
+          });
+          if (!hasReplaceAttributeDirective) {
+            // use the node name: <directive>
+            addDirective(directives,
+                directiveNormalize(nodeName_(node).toLowerCase()), 'E', maxPriority);
+          }
+          forEach(attributesDirectives, function(directive) {
+            directives.push(directive);
+          });
           break;
         case 3: /* Text Node */
           addTextInterpolateDirective(directives, node.nodeValue);

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -489,6 +489,10 @@ describe('$compile', function() {
               expect(element).toBe(attr.$$element);
             }
           }));
+          directive('replaceDirective', valueFn({
+            replace: true,
+            template: '<input ng-maxlength="3" />'
+          }));
         }));
 
 
@@ -572,6 +576,19 @@ describe('$compile', function() {
           element = $compile('<div replace-with-interpolated-class></div>')($rootScope);
           $rootScope.$digest();
           expect(element).toHaveClass('class_2');
+        }));
+
+
+        it('should not collect the directive from an element if the element has a' +
+           ' replace directive', inject(function($compile, $rootScope, $sniffer, $browser) {
+          var element = $compile('<form name="form"><input ng-model="name" name="alias" replace-directive /></form>')($rootScope);
+
+          element.find('input').val('aaaa');
+          browserTrigger(element.find('input'), ($sniffer.hasEvent('input')) ? 'input' : 'change');
+          expect($rootScope.name).toBe(undefined);
+          expect($rootScope.form.alias.$valid).toBe(false);
+
+          dealoc(element);
         }));
 
 


### PR DESCRIPTION
Fix the collecting of element directives from tags that will get replaced
by another directive on an attribute. If the element has an attribute
or class directive that will replace the entire element, then do not
collect the element directive on the tag

Closes #2573

BREAKING CHANGE:
- Will break directives that made the assumption that any element directive
  on the replaced tag would get collected
- Will break element directives that expect to be collected twice when they
  were replaced by another directive
