### PR TITLE
fix($browser): should use first value for a cookie.

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -297,7 +297,13 @@ function Browser(window, document, $log, $sniffer) {
           cookie = cookieArray[i];
           index = cookie.indexOf('=');
           if (index > 0) { //ignore nameless cookies
-            lastCookies[unescape(cookie.substring(0, index))] = unescape(cookie.substring(index + 1));
+            var name = unescape(cookie.substring(0, index));
+            // the first value that is seen for a cookie is the most
+            // specific one.  values for the same cookie name that
+            // follow are for less specific paths.
+            if (lastCookies[name] === undefined) {
+              lastCookies[name] = unescape(cookie.substring(index + 1));
+            }
           }
         }
       }

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -304,6 +304,13 @@ describe('browser', function() {
         expect(browser.cookies().foo).toEqual('bar=baz');
       });
 
+      it('should return the the first value provided for a cookie', function() {
+        // For a cookie that has different values that differ by path, the
+        // value for the most specific path appears first.  browser.cookies()
+        // should provide that value for the cookie.
+        document.cookie = 'foo="first"; foo="second"';
+        expect(browser.cookies()['foo']).toBe('"first"');
+      });
 
       it ('should unescape cookie values that were escaped by puts', function() {
         document.cookie = "cookie2%3Dbar%3Bbaz=val%3Due;path=/";


### PR DESCRIPTION
With this change, $browser.cookies()["foo"] will behave like
docCookies.getItem("foo") where docCookies is defined at
https://developer.mozilla.org/en-US/docs/DOM/document.cookie

Ref: https://github.com/angular/angular.js/issues/2635

This fixes the issue where, if there's a value for the XSRF-TOKEN cookie
value with the path /, then that value is used for all applications in
the domain even if they set path specific values for XSRF-TOKEN.
