### PR TITLE
Delay $anchorScroll() to handle `autoscroll` for nested ng-includes. 

### DIFF
--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -172,7 +172,7 @@ var ngIncludeDirective = ['$http', '$templateCache', '$anchorScroll', '$compile'
               $compile(contents)(childScope);
 
               if (isDefined(autoScrollExp) && (!autoScrollExp || scope.$eval(autoScrollExp))) {
-                $anchorScroll();
+                scope.$evalAsync($anchorScroll);
               }
 
               childScope.$emit('$includeContentLoaded');


### PR DESCRIPTION
This resolves an issue where the contents of an `ng-include` also contain an ng-include with autoscroll, like this `<div ng-repeat=".." ng-include=".." autoscroll="">`. 

In issue #2637 the element to scroll to by using `#some-anchor-name` in the url, e.g. `<a name="some-anchor-name"></a>`, is not present in the dom by the time `$anchorScroll()` is called from the ngIncludeDirective.
