### PR TITLE
Give PATCH requests the same default headers as PUT and POST

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -147,8 +147,9 @@ function $HttpProvider() {
       common: {
         'Accept': 'application/json, text/plain, */*'
       },
-      post: {'Content-Type': 'application/json;charset=utf-8'},
-      put:  {'Content-Type': 'application/json;charset=utf-8'}
+      post:   {'Content-Type': 'application/json;charset=utf-8'},
+      put:    {'Content-Type': 'application/json;charset=utf-8'},
+      patch:  {'Content-Type': 'application/json;charset=utf-8'}
     },
 
     xsrfCookieName: 'XSRF-TOKEN',

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -684,6 +684,15 @@ describe('$http', function() {
         $httpBackend.flush();
       });
 
+      it('should set default headers for PATCH request', function() {
+        $httpBackend.expect('PATCH', '/url', 'messageBody', function(headers) {
+          return headers['Accept'] == 'application/json, text/plain, */*' &&
+                 headers['Content-Type'] == 'application/json;charset=utf-8';
+        }).respond('');
+
+        $http({url: '/url', method: 'PATCH', headers: {}, data: 'messageBody'});
+        $httpBackend.flush();
+      });
 
       it('should set default headers for custom HTTP method', function() {
         $httpBackend.expect('FOO', '/url', undefined, function(headers) {


### PR DESCRIPTION
Is there any reason why PATCH requests shouldn't be sent with a content-type of application/json as well as PUT and POST?

It caused me some problems I wasn't expecting when working with a rails 4 application (PATCH is the new preferred verb for update operations).
