### PR TITLE
Respect PORT from URL without escaping

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -31,8 +31,7 @@
  *
  * @param {string} url A parametrized URL template with parameters prefixed by `:` as in
  *   `/user/:username`. If you are using a URL with a port number (e.g.
- *   `http://example.com:8080/api`), you'll need to escape the colon character before the port
- *   number, like this: `$resource('http://example.com\\:8080/api')`.
+ *   `http://example.com:8080/api`), it will be respected.
  *
  * @param {Object=} paramDefaults Default values for `url` parameters. These can be overridden in
  *   `actions` methods. If any of the parameter value is a function, it will be executed every time
@@ -331,7 +330,7 @@ angular.module('ngResource', ['ng']).
 
         var urlParams = self.urlParams = {};
         forEach(url.split(/\W/), function(param){
-          if (param && (new RegExp("(^|[^\\\\]):" + param + "(\\W|$)").test(url))) {
+          if (!(new RegExp("^\\d+","g").test(param)) && param && (new RegExp("(^|[^\\\\]):" + param + "(\\W|$)").test(url))) {
               urlParams[param] = true;
           }
         });

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -106,6 +106,13 @@ describe("resource", function() {
     R.get({a: 'foo', b: 'bar'});
   });
 
+  it('should support por unescaped url', function() {
+    var R = $resource('http://localhost:8080/Path/:a');
+
+    $httpBackend.expect('GET', 'http://localhost:8080/Path/foo').respond();
+    R.get({a: 'foo'});
+  });
+
 
   it('should correctly encode url params', function() {
     var R = $resource('/Path/:a');


### PR DESCRIPTION
Allows to write a URL normally.

Escaping the port does not comply with the [URL syntax](http://en.wikipedia.org/wiki/Uniform_resource_locator#Syntax)

Regular Expression and it's position in the if clause are meant to short-circuit ASAP.
