### PR TITLE
Minor $timeout doc cleanup

### DIFF
--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -17,17 +17,17 @@ function $TimeoutProvider() {
       * block and delegates any exceptions to
       * {@link ng.$exceptionHandler $exceptionHandler} service.
       *
-      * The return value of registering a timeout function is a promise which will be resolved when
+      * The return value of registering a timeout function is a promise, which will be resolved when
       * the timeout is reached and the timeout function is executed.
       *
-      * To cancel a the timeout request, call `$timeout.cancel(promise)`.
+      * To cancel a timeout request, call `$timeout.cancel(promise)`.
       *
       * In tests you can use {@link ngMock.$timeout `$timeout.flush()`} to
       * synchronously flush the queue of deferred functions.
       *
-      * @param {function()} fn A function, who's execution should be delayed.
+      * @param {function()} fn A function, whose execution should be delayed.
       * @param {number=} [delay=0] Delay in milliseconds.
-      * @param {boolean=} [invokeApply=true] If set to false skips model dirty checking, otherwise
+      * @param {boolean=} [invokeApply=true] If set to `false` skips model dirty checking, otherwise
       *   will invoke `fn` within the {@link ng.$rootScope.Scope#$apply $apply} block.
       * @returns {Promise} Promise that will be resolved when the timeout is reached. The value this
       *   promise will be resolved with is the return value of the `fn` function.
@@ -67,7 +67,7 @@ function $TimeoutProvider() {
       * @methodOf ng.$timeout
       *
       * @description
-      * Cancels a task associated with the `promise`. As a result of this the promise will be
+      * Cancels a task associated with the `promise`. As a result of this, the promise will be
       * resolved with a rejection.
       *
       * @param {Promise=} promise Promise returned by the `$timeout` function.


### PR DESCRIPTION
Minor cleanups on $timeout documentation
- Added a comma separator in the  statement
  The return value of registering a timeout function is a promise`,` which will be resolved when the timeout is reached and the timeout function is executed.
- Removed the word `the` from the statement 
  To cancel a the timeout request, call $timeout.cancel(promise).
- Used `whose` instead of `who's` in the following statement
  fn – {function()} – A function, who's execution should be delayed.
- Italicized `false` in the statement
  invokeApply(optional=true) – {boolean=} – If set to false skips model dirty checking, otherwise will invoke fn within the $apply block.
- Used a comma separator in the statement
  Cancels a task associated with the promise. As a result of this`,` the promise will be resolved with a rejection.
