### PR TITLE
recursive directive templates

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -54,6 +54,7 @@ angularFiles = {
     'src/ng/directive/ngInit.js',
     'src/ng/directive/ngNonBindable.js',
     'src/ng/directive/ngPluralize.js',
+    'src/ng/directive/ngRecursive.js',
     'src/ng/directive/ngRepeat.js',
     'src/ng/directive/ngShowHide.js',
     'src/ng/directive/ngStyle.js',

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -87,6 +87,7 @@ function publishExternalAPI(angular){
             ngInit: ngInitDirective,
             ngNonBindable: ngNonBindableDirective,
             ngPluralize: ngPluralizeDirective,
+            ngRecursive: ngRecursiveDirective,
             ngRepeat: ngRepeatDirective,
             ngShow: ngShowDirective,
             ngSubmit: ngSubmitDirective,

--- a/src/ng/directive/ngRecursive.js
+++ b/src/ng/directive/ngRecursive.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name ng.directive:ngRecursive
+ * @restrict ECA
+ *
+ * @description
+ * Compiles a document subtree for recursive transclusion.
+ */
+var ngRecursiveDirective = ['$compile',
+                    function($compile) {
+  return {
+    restrict: 'ECA',
+    terminal: true,
+    compile: function(element, attr) {
+      var $template = element.clone().contents();
+      element.html(''); // clear contents
+
+      var linkFn = $compile($template, function(scope, cloneAttachFn) {
+        return linkFn(scope, cloneAttachFn);
+      });
+      return function($scope, $element, $attr) {
+        linkFn($scope, function(contents) {
+          $element.append(contents);
+        });
+      };
+    }
+  };
+}];


### PR DESCRIPTION
Here's a pull request to introduce a new directive, ngRecursive.

I spoke with @jbdeboer and @mhevery at last night's meetup at Google SF about it and chatting with several others validated the usefulness of such a thing. I've been using something similar in my project for about six months.

At this point it is still very early. I have not written tests yet because I would like feedback on the approach. mhevery suggested that perhaps there's a root problem that should be fixed instead: templates might notice recursive inclusions and "do the right thing". On the other hand, the approach here doesn't dictate that a recursive bit of template be in its own file, so perhaps that's nice.

Here's an example: http://plnkr.co/edit/WdnOMZ7IwbeBCFcfu7Fh

This is incredibly convenient for creating tree views of all kinds and similar recursive page structures.

One issue right now is that intervening directives cause the transclusion to break. For instance, if an ng-class is added to the ordered list element in the example above then everything breaks. I can dive into compile.js and figure out if there's a good way to address this, but again, I wanted some early feedback before I went too deep.
