### PR TITLE
Extend function fix

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -233,7 +233,9 @@ function extend(dst) {
   forEach(arguments, function(obj){
     if (obj !== dst) {
       forEach(obj, function(value, key){
-        dst[key] = value;
+        if(value !== undefined) {
+          dst[key] = value;
+        }
       });
     }
   });

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -375,7 +375,7 @@ var inputType = {
    */
   'checkbox': checkboxInputType,
 
-  'hidden': noop,
+  'hidden': textInputType,
   'button': noop,
   'submit': noop,
   'reset': noop

--- a/src/ngScenario/SpecRunner.js
+++ b/src/ngScenario/SpecRunner.js
@@ -117,7 +117,7 @@ angular.scenario.SpecRunner.prototype.addFutureAction = function(name, behavior,
         angular.forEach(args, function(value, index) {
           selector = selector.replace('$' + (index + 1), value);
         });
-        var result = $document.find(selector);
+        var result = angular.element(selector);
         if (selector.match(NG)) {
           angular.forEach(['[ng-','[data-ng-','[x-ng-'], function(value, index){
             result = result.add(selector.replace(NG, value), $document);


### PR DESCRIPTION
Extend function of Angular blindly overwrites destination values even if source value is undefined. This fix allows "default" values to remain intact if new value is undefined.
