### PR TITLE
Update dev_guide.services.$location.ngdoc

### DIFF
--- a/docs/content/guide/dev_guide.services.$location.ngdoc
+++ b/docs/content/guide/dev_guide.services.$location.ngdoc
@@ -628,9 +628,9 @@ example:
 $scope.$watch('locationPath', function(path) {
   $location.path(path);
 });
-
-$scope.$watch('$location.path()', function(path) {
-  scope.locationPath = path;
+// watch the path changes, and push to model
+$scope.$watch(function () { $location.path(); }, function(path) {
+  $scope.locationPath = path;
 });
 </pre>
 


### PR DESCRIPTION
Updating the last example for watching the $location.path(), has to be wrapped in a function since if you pass a string to $scope.$watch it is evaluated against the $scope, which $location is not attached to and won't correctly $watch.
