### PR TITLE
chore(angular.module): improve the 'No module' error message

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -70,7 +70,8 @@ function setupModuleLoader(window) {
       }
       return ensure(modules, name, function() {
         if (!requires) {
-          throw Error('No module: ' + name);
+          throw Error('No module: ' + name + '. If attempting to register a ' +
+            'module, you must at least specify an empty array of requirements.');
         }
 
         /** @type {!Array.<Array.<*>>} */

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -580,7 +580,7 @@ describe('angular', function() {
 
       expect(function() {
         angularInit(appElement, bootstrap);
-      }).toThrow('No module: doesntexist');
+      }).toMatchThrow(/^No module: doesntexist/);
     });
   });
 
@@ -724,7 +724,7 @@ describe('angular', function() {
 
       expect(function() {
         angular.bootstrap(element, ['doesntexist']);
-      }).toThrow('No module: doesntexist');
+      }).toMatchThrow(/^No module: doesntexist/);
 
       expect(element.html()).toBe('{{1+2}}');
       dealoc(element);

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -268,7 +268,7 @@ describe('injector', function() {
     it('should error on invalid module name', function() {
       expect(function() {
         createInjector(['IDontExist'], {});
-      }).toThrow("No module: IDontExist");
+      }).toMatchThrow(/^No module: IDontExist/);
     });
 
 

--- a/test/loaderSpec.js
+++ b/test/loaderSpec.js
@@ -68,6 +68,6 @@ describe('module loader', function() {
   it('should complain of no module', function() {
     expect(function() {
       window.angular.module('dontExist');
-    }).toThrow('No module: dontExist');
+    }).toMatchThrow(/^No module: dontExist/);
   });
 });

--- a/test/matchers.js
+++ b/test/matchers.js
@@ -75,6 +75,36 @@ beforeEach(function() {
       return this.actual.name == 'Error' && messageRegexp.test(this.actual.message);
     },
 
+    toMatchThrow: function(messageRegexp) {
+      if (typeof this.actual != 'function') {
+        throw new Error('Actual is not a function');
+      }
+
+      var exception;
+
+      try {
+        this.actual();
+      } catch (e) {
+        exception = e;
+      }
+
+      if (exception) {
+        result = messageRegexp.test(exception.message);
+      }
+
+      this.message = function() {
+        if (!exception) {
+          return 'Expected function to throw an exception.';
+        } else if (result) {
+
+          return 'Expected function to throw an error matching ' + angular.toJson(messageRegexp) +
+            ', but was ' + exception.message;
+        }
+      };
+
+      return result;
+    },
+
     toHaveBeenCalledOnce: function() {
       if (arguments.length > 0) {
         throw new Error('toHaveBeenCalledOnce does not take arguments, use toHaveBeenCalledWith');


### PR DESCRIPTION
Whether or not the 'requires' parameter of 'angular.module' is optional
depends on the state of the application. The thrown error message is
not very descriptive and can be improved. For instance, the error
could contain a hint that the parameter is required for initial
module creation.

The improvement is based on comments under the angular.module documentation.
