### PR TITLE
Update angular-mocks.js

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -322,7 +322,7 @@ angular.mock.$LogProvider = function() {
        * @propertyOf ngMock.$log
        *
        * @description
-       * Array of logged messages.
+       * Array of logged messages using $log.log.
        */
       $log.log.logs = [];
       /**
@@ -331,7 +331,7 @@ angular.mock.$LogProvider = function() {
        * @propertyOf ngMock.$log
        *
        * @description
-       * Array of logged messages.
+       * Array of logged messages using $log.warn.
        */
       $log.warn.logs = [];
       /**
@@ -340,7 +340,7 @@ angular.mock.$LogProvider = function() {
        * @propertyOf ngMock.$log
        *
        * @description
-       * Array of logged messages.
+       * Array of logged messages using $log.info.
        */
       $log.info.logs = [];
       /**
@@ -349,7 +349,7 @@ angular.mock.$LogProvider = function() {
        * @propertyOf ngMock.$log
        *
        * @description
-       * Array of logged messages.
+       * Array of logged messages using $log.error.
        */
       $log.error.logs = [];
     };


### PR DESCRIPTION
Updated the `$log.*` descriptions to clean up the ngMock `$log` information. Currently each `$log.[error|warn|log...]` has the same description and is confusing in the docs.
