### PR TITLE
Switched package.json Dependencies to be devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "AngularJS",
-  "version": "0.0.0",
-  "dependencies": {
+  "version": "1.0.6",
+  "devDependencies": {
     "grunt": "0.4.0",
     "grunt-contrib-clean": "0.4.0",
     "grunt-contrib-compress": "0.4.1",


### PR DESCRIPTION
None of the dependencies are necessary for using the library, so they should all be devDependencies.

This allows the Angular library to be fetched with npm (e.g., `npm install --save https://github.com/angular/angular.js.git#v1.0.x`).

You can also apply this patch to HEAD, and just fix the version number, or I can submit a new pull request.
