### PR TITLE
feat($location): add queryString method

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -215,7 +215,7 @@ function nextUid() {
 
 /**
  * Set or clear the hashkey for an object.
- * @param obj object 
+ * @param obj object
  * @param h the hashkey (!truthy to delete the hashkey)
  */
 function setHashKey(obj, h) {

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -385,10 +385,11 @@ describe('$location', function() {
   });
 
 
-  function initService(html5Mode, hashPrefix, supportHistory) {
+  function initService(html5Mode, hashPrefix, supportHistory, queryString) {
     return module(function($provide, $locationProvider){
       $locationProvider.html5Mode(html5Mode);
       $locationProvider.hashPrefix(hashPrefix);
+      $locationProvider.queryString(queryString);
       $provide.value('$sniffer', {history: supportHistory});
     });
   }
@@ -648,6 +649,25 @@ describe('$location', function() {
         }
       );
     });
+  });
+
+
+  describe('setting a custom query string parser', function() {
+    var qs = {stringify: toJson, parse: fromJson};
+    beforeEach(initService(true, '', true, qs));
+    beforeEach(inject(initBrowser('http://domain.com/?{"foo": "bar"}', '/')));
+
+    it('should change how query string is parsed', inject(function($location) {
+      expect($location.search()).toEqual({foo: "bar"});
+    }));
+
+    it('should use parser when setting params', inject(function($location, $browser, $rootScope) {
+      $location.search('foo', ["bar"]);
+      $rootScope.$apply();
+      expect($browser.url()).toEqual('http://domain.com/?{"foo":["bar"]}')
+    }));
+
+    afterEach
   });
 
 


### PR DESCRIPTION
Added new queyString method to locationProvider to allow for custom query string parsers. The method expects an object with a stringify function for encoding and a parse function for decoding.

For example you could use node-querystring:

``` javascript
var qs = require('qs');
$locationProvider.queryString(qs);
```

or JSON:

``` javascript
$locationProvider.queryString(JSON);
```
