### PR TITLE
Doc: Remove empty "Type" page in guide

### DIFF
--- a/docs/content/guide/type.ngdoc
+++ b/docs/content/guide/type.ngdoc
@@ -1,3 +1,0 @@
-@ngdoc overview
-@name Developer Guide: Type
-@description


### PR DESCRIPTION
This fixes #1316.
