### PR TITLE
Doc: Compile function returns post-link function

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -480,8 +480,8 @@ done in a linking function rather than in a compile function.
 
 A compile function can have a return value which can be either a function or an object.
 
-* returning a function - is equivalent to registering the linking function via the `link` property
-  of the config object when the compile function is empty.
+* returning a (post-link) function - is equivalent to registering the linking function via the
+  `link` property of the config object when the compile function is empty.
 
 * returning an object with function(s) registered via `pre` and `post` properties - allows you to
   control when a linking function should be called during the linking phase. See info about


### PR DESCRIPTION
Judging from source code[1], if a compile function (within a directive)
returns a function, it is a post-link function.

[1] https://github.com/angular/angular.js/blob/master/src/ng/compile.js#L709
