### PR TITLE
fix(angular.equals): regular expressions are never considered equal

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -215,7 +215,7 @@ function nextUid() {
 
 /**
  * Set or clear the hashkey for an object.
- * @param obj object 
+ * @param obj object
  * @param h the hashkey (!truthy to delete the hashkey)
  */
 function setHashKey(obj, h) {
@@ -392,6 +392,22 @@ function isNumber(value){return typeof value == 'number';}
  */
 function isDate(value){
   return toString.apply(value) == '[object Date]';
+}
+
+
+/**
+ * @ngdoc function
+ * @name angular.isRegExp
+ * @function
+ *
+ * @description
+ * Determines if a value is a regular expression object.
+ *
+ * @param {*} value Reference to check.
+ * @returns {boolean} True if `value` is a `RegExp`.
+ */
+function isRegExp(value) {
+  return toString.apply(value) == '[object RegExp]';
 }
 
 
@@ -644,14 +660,17 @@ function shallowCopy(src, dst) {
  * @function
  *
  * @description
- * Determines if two objects or two values are equivalent. Supports value types, arrays and
- * objects.
+ * Determines if two objects or two values are equivalent. Supports value types, regular
+ * expressions, arrays and objects.
  *
  * Two objects or values are considered equivalent if at least one of the following is true:
  *
  * * Both objects or values pass `===` comparison.
  * * Both objects or values are of the same type and all of their properties pass `===` comparison.
  * * Both values are NaN. (In JavasScript, NaN == NaN => false. But we consider two NaN as equal)
+ * * Both values represent the same regular expression (In JavasScript,
+ *   /abc/ == /abc/ => false. But we consider two regular expressions as equal when their textual
+ *   representation matches).
  *
  * During a property comparison, properties of `function` type and properties with names
  * that begin with `$` are ignored.
@@ -678,6 +697,8 @@ function equals(o1, o2) {
         }
       } else if (isDate(o1)) {
         return isDate(o2) && o1.getTime() == o2.getTime();
+      } else if (isRegExp(o1) && isRegExp(o2)) {
+        return o1.toString() == o2.toString();
       } else {
         if (isScope(o1) || isScope(o2) || isWindow(o1) || isWindow(o2)) return false;
         keySet = {};

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -46,6 +46,7 @@ function publishExternalAPI(angular){
     'isArray': isArray,
     'version': version,
     'isDate': isDate,
+    'isRegExp': isRegExp,
     'lowercase': lowercase,
     'uppercase': uppercase,
     'callbacks': {counter: 0},

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -268,6 +268,17 @@ describe('angular', function() {
       expect(equals(new Date(0), 0)).toBe(false);
       expect(equals(0, new Date(0))).toBe(false);
     });
+
+    it('should compare regular expressions', function() {
+      expect(equals(/abc/, /abc/)).toBe(true);
+      expect(equals(/abc/i, new RegExp('abc', 'i'))).toBe(true);
+      expect(equals(new RegExp('abc', 'i'), new RegExp('abc', 'i'))).toBe(true);
+      expect(equals(new RegExp('abc', 'i'), new RegExp('abc'))).toBe(false);
+      expect(equals(/abc/i, /abc/)).toBe(false);
+      expect(equals(/abc/, /def/)).toBe(false);
+      expect(equals(/^abc/, /abc/)).toBe(false);
+      expect(equals(/^abc/, '/^abc/')).toBe(false);
+    });
   });
 
   describe('size', function() {
@@ -618,6 +629,23 @@ describe('angular', function() {
       expect(isDate({})).toBe(false);
     });
   });
+
+
+  describe('isRegExp', function() {
+    it('should return true for RegExp object', function() {
+      expect(isRegExp(/^foobar$/)).toBe(true);
+      expect(isRegExp(new RegExp('^foobar$/'))).toBe(true);
+    });
+
+    it('should return false for non RegExp objects', function() {
+      expect(isRegExp([])).toBe(false);
+      expect(isRegExp('')).toBe(false);
+      expect(isRegExp(23)).toBe(false);
+      expect(isRegExp({})).toBe(false);
+      expect(isRegExp(new Date())).toBe(false);
+    });
+  });
+
 
   describe('compile', function() {
     it('should link to existing node and create scope', inject(function($rootScope, $compile) {


### PR DESCRIPTION
Regular expression objects are never considered to be equal when using
'angular.equals'. Dirty checking therefore fails to recognize a
property modification.

Closes #2685
