### PR TITLE
feat($http) Add support for custom event hooks (progress, etc)

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -905,7 +905,7 @@ function $HttpProvider() {
       // if we won't have the response in cache, send the request to the backend
       if (!cachedResp) {
         $httpBackend(config.method, url, reqData, done, reqHeaders, config.timeout,
-            config.withCredentials, config.responseType);
+            config.withCredentials, config.responseType, config.hooks);
       }
 
       return promise;

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -61,8 +61,13 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
 
       // Add listeners for events such as progress
       hooks = hooks || {};
+      var uploadHooks = hooks.upload || {};
+      delete hooks.upload;
       forEach(Object.keys(hooks), function(event) {
         xhr.addEventListener(event, hooks[event], false);
+      });
+      forEach(Object.keys(uploadHooks), function(event) {
+        xhr.upload.addEventListener(event, uploadHooks[event], false);
       });
 
       // In IE6 and 7, this might be called synchronously when xhr.send below is called and the

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -32,7 +32,7 @@ function $HttpBackendProvider() {
 
 function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument, locationProtocol) {
   // TODO(vojta): fix the signature
-  return function(method, url, post, callback, headers, timeout, withCredentials, responseType) {
+  return function(method, url, post, callback, headers, timeout, withCredentials, responseType, hooks) {
     var status;
     $browser.$$incOutstandingRequestCount();
     url = url || $browser.url();
@@ -59,9 +59,16 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
         if (value) xhr.setRequestHeader(key, value);
       });
 
+      // Add listeners for events such as progress
+      hooks = hooks || {};
+      forEach(Object.keys(hooks), function(event) {
+        xhr.addEventListener(event, hooks[event], false);
+      });
+
       // In IE6 and 7, this might be called synchronously when xhr.send below is called and the
       // response is in the cache. the promise api will ensure that to the app code the api is
       // always async
+
       xhr.onreadystatechange = function() {
         if (xhr.readyState == 4) {
           var responseHeaders = xhr.getAllResponseHeaders();


### PR DESCRIPTION
In response to https://github.com/angular/angular.js/issues/1934
This is far from complete, I just wanted to open a preliminary implementation so we can discuss implementation details.
I'm neither an expert at Angular, nor in the HTTP protocol itself.

The current implementation of `$http` doesn't allow us to attach event handlers for anything except success and failure. There are a large number of well supported (and maybe non standard) events for XHR that are very useful, the most popular being the progress events.

This PR implements the feature by extending the `config` object passed to `$http` to add a `hooks` keyword, which maps events to event handler.
Example:

``` javascript
var configObject = {
  method: 'GET',
  url: '/specs.html',
  cache: $templateCache,
  hooks: {
    progress: function(data) {
      return $scope.progress = data;
    }
  }
};
$http(configObject).success(successHandler);
```

To add event handlers for upload events, nest the key mapping under a `upload` key:

``` javascript
hooks: {
  upload: {
    progress: uploadProgressHandler;
  }
}
```

Please suggest/discuss improvements to the syntax and/or implementation errors.
I believe the code in the PR currently works, but I haven't thoroughly tested it.
