### PR TITLE
feat(angular.isRegExp): check object type for regular expressions

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -215,7 +215,7 @@ function nextUid() {
 
 /**
  * Set or clear the hashkey for an object.
- * @param obj object 
+ * @param obj object
  * @param h the hashkey (!truthy to delete the hashkey)
  */
 function setHashKey(obj, h) {
@@ -392,6 +392,22 @@ function isNumber(value){return typeof value == 'number';}
  */
 function isDate(value){
   return toString.apply(value) == '[object Date]';
+}
+
+
+/**
+ * @ngdoc function
+ * @name angular.isRegExp
+ * @function
+ *
+ * @description
+ * Determines if a value is a regular expression object.
+ *
+ * @param {*} value Reference to check.
+ * @returns {boolean} True if `value` is a `RegExp`.
+ */
+function isRegExp(value) {
+  return toString.apply(value) == '[object RegExp]';
 }
 
 

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -46,6 +46,7 @@ function publishExternalAPI(angular){
     'isArray': isArray,
     'version': version,
     'isDate': isDate,
+    'isRegExp': isRegExp,
     'lowercase': lowercase,
     'uppercase': uppercase,
     'callbacks': {counter: 0},

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -619,6 +619,23 @@ describe('angular', function() {
     });
   });
 
+
+  describe('isRegExp', function() {
+    it('should return true for RegExp object', function() {
+      expect(isRegExp(/^foobar$/)).toBe(true);
+      expect(isRegExp(new RegExp('^foobar$/'))).toBe(true);
+    });
+
+    it('should return false for non RegExp objects', function() {
+      expect(isRegExp([])).toBe(false);
+      expect(isRegExp('')).toBe(false);
+      expect(isRegExp(23)).toBe(false);
+      expect(isRegExp({})).toBe(false);
+      expect(isRegExp(new Date())).toBe(false);
+    });
+  });
+
+
   describe('compile', function() {
     it('should link to existing node and create scope', inject(function($rootScope, $compile) {
       var template = angular.element('<div>{{greeting = "hello world"}}</div>');


### PR DESCRIPTION
In order to fix #2685, we need to differentiate between regular
expression objects and other types. Angular could expose a public
function 'angular.isRegExp' through which this could be done.

This serves as a preparation for a follow-up pull request for a change to `angular.equals` (which will fix #2685).
