### PR TITLE
fix(noConflict): replaced direct reference to $window.angular

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -25,7 +25,7 @@ var XHR = window.XMLHttpRequest || function() {
  */
 function $HttpBackendProvider() {
   this.$get = ['$browser', '$window', '$document', function($browser, $window, $document) {
-    return createHttpBackend($browser, XHR, $browser.defer, $window.angular.callbacks,
+    return createHttpBackend($browser, XHR, $browser.defer, angular.callbacks,
         $document[0], $window.location.protocol.replace(':', ''));
   }];
 }


### PR DESCRIPTION
Simple change. Tests passed before and after. I didn't add a test since the proper way to test this is probably to run the entire test suite with `noConflict` to catch any reference bugs like this and that would be a much larger pull request.
