### PR TITLE
Updating ng-submit doc

### DIFF
--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -220,7 +220,8 @@ forEach(
  * Enables binding angular expressions to onsubmit events.
  *
  * Additionally it prevents the default action (which for form means sending the request to the
- * server and reloading the current page).
+ * server and reloading the current page). In order for this to work the form must not 
+ * contain the "action" attribute.
  *
  * @element form
  * @param {expression} ngSubmit {@link guide/expression Expression} to eval.


### PR DESCRIPTION
I think it is worth explicitly mentioning that the "action" attribute must not be present on a form in order for the default action prevention to work.
