### PR TITLE
docs (index) there should be no autofocus when docs are read

### DIFF
--- a/docs/src/templates/js/docs.js
+++ b/docs/src/templates/js/docs.js
@@ -123,7 +123,6 @@ docsApp.serviceFactory.fullTextSearch = ['$q', '$rootScope', function($q, $rootS
 
 docsApp.directive.focused = function($timeout) {
   return function(scope, element, attrs) {
-    element[0].focus();
     element.bind('focus', function() {
       scope.$apply(attrs.focused + '=true');
     });


### PR DESCRIPTION
The search box should not receive autofocus when browsing the docs as the primary purpose of the docs it to convey information, not search.
