### PR TITLE
feat ($compile) optimize bi-directional bind

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -813,26 +813,17 @@ function $CompileProvider($provide) {
                 }
                 parentGet = $parse(attrs[attrName]);
                 parentSet = parentGet.assign || function() {
-                  // reset the change, or we will throw this exception on every $digest
-                  lastValue = scope[scopeName] = parentGet(parentScope);
                   throw Error(NON_ASSIGNABLE_MODEL_EXPRESSION + attrs[attrName] +
                       ' (directive: ' + newIsolateScopeDirective.name + ')');
                 };
-                lastValue = scope[scopeName] = parentGet(parentScope);
-                scope.$watch(function parentValueWatch() {
-                  var parentValue = parentGet(parentScope);
 
-                  if (parentValue !== scope[scopeName]) {
-                    // we are out of sync and need to copy
-                    if (parentValue !== lastValue) {
-                      // parent changed and it has precedence
-                      lastValue = scope[scopeName] = parentValue;
-                    } else {
-                      // if the parent can be assigned then do so
-                      parentSet(parentScope, parentValue = lastValue = scope[scopeName]);
-                    }
+                Object.defineProperty(scope, scopeName, {
+                  get: function() {
+                    return parentGet(parentScope);
+                  },
+                  set: function(value) {
+                    parentSet(parentScope, value);
                   }
-                  return parentValue;
                 });
                 break;
               }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2048,18 +2048,18 @@ describe('$compile', function() {
       }));
 
 
-      it('should update local when both change', inject(function() {
+      it('should stay in sync when both change', inject(function() {
         compile('<div><span my-component ref="name">');
         $rootScope.name = {mark:123};
         componentScope.ref = 'misko';
 
         $rootScope.$apply();
-        expect($rootScope.name).toEqual({mark:123})
+        expect($rootScope.name).toEqual('misko');
         expect(componentScope.ref).toBe($rootScope.name);
         expect(componentScope.refAlias).toBe($rootScope.name);
 
-        $rootScope.name = 'igor';
         componentScope.ref = {};
+        $rootScope.name = 'igor';
         $rootScope.$apply();
         expect($rootScope.name).toEqual('igor')
         expect(componentScope.ref).toBe($rootScope.name);
@@ -2072,9 +2072,9 @@ describe('$compile', function() {
         $rootScope.$apply();
         expect(componentScope.ref).toBe('hello world');
 
-        componentScope.ref = 'ignore me';
-        expect($rootScope.$apply).
-            toThrow("Non-assignable model expression: 'hello ' + name (directive: myComponent)");
+        expect(function() {
+          componentScope.ref = 'ignore me';
+        }).toThrow("Non-assignable model expression: 'hello ' + name (directive: myComponent)");
         expect(componentScope.ref).toBe('hello world');
         // reset since the exception was rethrown which prevented phase clearing
         $rootScope.$$phase = null;


### PR DESCRIPTION
Uses property getter and setter to eliminate the $watch in bi-directional bind.

The getter setter approach has two advantages:
- scopes are always in sync
- reduces number of $watches

Can't think of any disadvantages.
