### PR TITLE
feat(ngToggle): add directive to show and hide two DOM elements

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -58,6 +58,7 @@ angularFiles = {
     'src/ng/directive/ngShowHide.js',
     'src/ng/directive/ngStyle.js',
     'src/ng/directive/ngSwitch.js',
+    'src/ng/directive/ngToggle.js',
     'src/ng/directive/ngTransclude.js',
     'src/ng/directive/ngView.js',
     'src/ng/directive/script.js',

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -96,6 +96,7 @@ function publishExternalAPI(angular){
             ngSwitchDefault: ngSwitchDefaultDirective,
             ngOptions: ngOptionsDirective,
             ngView: ngViewDirective,
+            ngToggle: ngToggleDirective,
             ngTransclude: ngTranscludeDirective,
             ngModel: ngModelDirective,
             ngList: ngListDirective,

--- a/src/ng/directive/ngToggle.js
+++ b/src/ng/directive/ngToggle.js
@@ -1,0 +1,121 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name ng.directive:ngToggle
+ *
+ * @description
+ * The `ngToggle` directives is used to conditionally swap DOM visibility on your template based on a
+ * scope expression.
+ *
+ * ngToggle simply choose the first or the second child and make it visible based on "truthy" / "falsy" value
+ * evaluated within an {expression}.
+ * In other word, if the expression assigned to ngToggle evaluates to true, then the first child is set to visible and
+ * the second is set to hidden, otherwise the first child is set to hidden and the second is set to visible.
+ *
+ * Additionally, you can also provide animations via the ngAnimate attribute to animate the show and hide effects.
+ *
+ * @usage
+ * <ANY ng-toggle="matchValue1">
+ *   <ANY>...</ANY>
+ *   <ANY>...</ANY>
+ * </ANY>
+ *
+ * @animations
+ * hide - happens just after the ngToggle contents change and just before the matched child is set to hidden
+ * show - happens after the ngToggle contents change and just before the matched child is set to visible
+ *
+ * @element ANY
+ * @param {expression} ngToggle|on If the {@link guide/expression expression} is truthy then
+ *     the first child of element is shown and the second is hidden, otherwise the first child is
+ *     hidden and the second is shown.
+ *
+ * @example
+  <example animations="true">
+    <file name="index.html">
+      Click me: <input type="checkbox" ng-model="checked"><br/>
+      <div>
+        Toggle:
+        <div class="example-animate-container"
+              ng-toggle="checked"
+              ng-animate="{show: 'example-show', hide: 'example-hide'}">
+          <span class="icon-thumbs-up"> Checkbox is checked.</span>
+          <span class="icon-thumbs-up"> Checkbox is not checked.</span>
+        </div>
+      </div>
+    </file>
+    <file name="animations.css">
+      .example-show, .example-hide {
+        -webkit-transition:all cubic-bezier(0.250, 0.460, 0.450, 0.940) 0.5s;
+        -moz-transition:all cubic-bezier(0.250, 0.460, 0.450, 0.940) 0.5s;
+        -ms-transition:all cubic-bezier(0.250, 0.460, 0.450, 0.940) 0.5s;
+        -o-transition:all cubic-bezier(0.250, 0.460, 0.450, 0.940) 0.5s;
+        transition:all cubic-bezier(0.250, 0.460, 0.450, 0.940) 0.5s;
+
+        position:absolute;
+        top:0;
+        left:0;
+        right:0;
+        bottom:0;
+      }
+
+      .example-animate-container > * {
+        display:block;
+        padding:10px;
+      }
+
+      .example-show {
+        top:-50px;
+      }
+      .example-show.example-show-active {
+        top:0;
+      }
+
+      .example-hide {
+        top:0;
+      }
+      .example-hide.example-hide-active {
+        top:50px;
+      }
+    </file>
+    <file name="scenario.js">
+       it('should check ng-toggle', function() {
+         expect(element('.doc-example-live .icon-thumbs-up:first:hidden').count()).toEqual(1);
+         expect(element('.doc-example-live .icon-thumbs-up:last:visible').count()).toEqual(1);
+
+         input('checked').check();
+
+         expect(element('.doc-example-live .icon-thumbs-up:first:visible').count()).toEqual(1);
+         expect(element('.doc-example-live .icon-thumbs-up:last:hidden').count()).toEqual(1);
+       });
+    </file>
+  </example>
+ */
+var ngToggleDirective = ['$animator', function($animator) {
+  return {
+    restrict: 'EA',
+    link: function ($scope, $element, $attr) {
+      var animate = $animator($scope, $attr),
+          watchExpr = $attr.ngToggle || $attr.on,
+          children = $element.children(),
+          elements = [ children.eq(0), children.eq(1) ],
+          currentVisible;
+
+      // Hide children
+      // The child to show will be set to visible in the watcher
+      children.css('display', 'none');
+
+      $scope.$watch(watchExpr, function ngToggleWatchAction(value) {
+        var idx = toBoolean(value) ? 0 : 1;
+
+        if (currentVisible) {
+          animate.hide(currentVisible);
+          currentVisible = undefined;
+        }
+
+        currentVisible = elements[idx];
+        animate.show(currentVisible);
+      });
+    }
+  };
+}];

--- a/test/ng/directive/ngToggleSpec.js
+++ b/test/ng/directive/ngToggleSpec.js
@@ -1,0 +1,177 @@
+'use strict';
+
+describe('ngToggle', function() {
+  var element;
+
+  afterEach(function() {
+    dealoc(element);
+  });
+
+  it('should toggle contents of an element', inject(function($rootScope, $compile) {
+    element = jqLite(
+      '<ng-toggle on="exp">' +
+        '<div id="foo">foo</div>' +
+        '<div id="bar">bar</div>' +
+      '</ng-toggle>'
+    );
+
+    element = $compile(element)($rootScope);
+    $rootScope.$digest();
+
+    var div1 = element.children()[0];
+    var div2 = element.children()[1];
+
+    expect(div1.style.display).toEqual('none');
+    expect(div2.style.display).toEqual('');
+
+    $rootScope.exp = true;
+    $rootScope.$digest();
+    expect(div1.style.display).toEqual('');
+    expect(div2.style.display).toEqual('none');
+  }));
+
+  it('should toggle contents of an element without on attribute', inject(function($rootScope, $compile) {
+    element = jqLite(
+      '<div ng-toggle="exp">' +
+        '<div id="foo">foo</div>' +
+        '<div id="bar">bar</div>' +
+      '</div>'
+    );
+    element = $compile(element)($rootScope);
+    $rootScope.$digest();
+
+    var div1 = element.children()[0];
+    var div2 = element.children()[1];
+
+    expect(div1.style.display).toEqual('none');
+    expect(div2.style.display).toEqual('');
+
+    $rootScope.exp = true;
+    $rootScope.$digest();
+    expect(div1.style.display).toEqual('');
+    expect(div2.style.display).toEqual('none');
+  }));
+});
+
+
+describe('ngToggle - ngAnimate', function() {
+  var window;
+  var vendorPrefix;
+  var body, element, $rootElement;
+
+  function html(html) {
+    body.append($rootElement);
+    $rootElement.html(html);
+    element = $rootElement.children().eq(0);
+    return element;
+  }
+
+  beforeEach(function() {
+    // we need to run animation on attached elements;
+    body = jqLite(document.body);
+  });
+
+  afterEach(function(){
+    dealoc(body);
+    dealoc(element);
+    body.removeAttr('ng-animation-running');
+  });
+
+  beforeEach(module(function($animationProvider, $provide) {
+    $provide.value('$window', window = angular.mock.createMockWindow());
+    return function($sniffer, _$rootElement_, $animator) {
+      vendorPrefix = '-' + $sniffer.vendorPrefix + '-';
+      $rootElement = _$rootElement_;
+      $animator.enabled(true);
+    };
+  }));
+
+  describe('ngToggle', function() {
+    it('should fire off the animator.show and animator.hide animation', inject(function($compile, $rootScope, $sniffer) {
+      var $scope = $rootScope.$new();
+      $scope.on = true;
+      var style = vendorPrefix + 'transition: 1s linear all';
+      element = $compile(html(
+        '<div ng-toggle="on" ng-animate="{show: \'custom-show\', hide: \'custom-hide\'}">' +
+          '<div id="foo" style="' + style + '">foo</div>' +
+          '<div id="bar" style="' + style + '">bar</div>' +
+        '</div>'
+      ))($scope);
+
+      var div1 = element.children()[0];
+      var div2 = element.children()[1];
+
+      $scope.$digest();
+
+      if ($sniffer.transitions) {
+        expect(div1.className).toContain('custom-show');
+        window.setTimeout.expect(1).process();
+
+        expect(div1.className).toContain('custom-show-active');
+        window.setTimeout.expect(1000).process();
+      }
+
+      expect(window.setTimeout.queue).toEqual([]);
+
+      expect(div1.className).not.toContain('custom-show-active');
+      expect(div1.className).not.toContain('custom-show');
+
+      $scope.on = false;
+      $scope.$digest();
+      if ($sniffer.transitions) {
+        expect(div1.className).toContain('custom-hide');
+        expect(div2.className).toContain('custom-show');
+
+        window.setTimeout.expect(1).process();
+        expect(div1.className).toContain('custom-hide-active');
+
+        window.setTimeout.expect(1).process();
+        expect(div2.className).toContain('custom-show-active');
+
+        window.setTimeout.expect(1000).process();
+        window.setTimeout.expect(1000).process();
+      }
+
+      expect(window.setTimeout.queue).toEqual([]);
+
+      expect(div1.className).not.toContain('custom-hide-active');
+      expect(div1.className).not.toContain('custom-hide');
+      expect(div1.style.display).toEqual('none');
+
+      expect(div2.className).not.toContain('custom-show-active');
+      expect(div2.className).not.toContain('custom-show');
+      expect(div2.style.display).toEqual('');
+
+    }));
+
+    it('should skip animation if parent animation running', function() {
+      var fired = false;
+      inject(function($animator, $compile, $rootScope) {
+        $animator.enabled(true);
+        $rootScope.$digest();
+        $rootScope.val = true;
+
+        var style = vendorPrefix + 'transition: 1s linear all';
+        element = $compile(html(
+          '<div ng-toggle="val" ng-animate="{show: \'custom-show\', hide: \'custom-hide\'}">' +
+            '<div id="foo" style="' + style + '">foo</div>' +
+            '<div id="bar" style="' + style + '">bar</div>' +
+          '</div>'
+        ))($rootScope);
+
+        $rootElement.controller('ngAnimate').running = true;
+
+        var div1 = element.children()[0];
+        var div2 = element.children()[1];
+
+        $rootScope.$digest();
+
+        expect(div1.style.display).toBe('');
+        expect(div2.style.display).toBe('none');
+        expect(fired).toBe(false);
+
+        expect(window.setTimeout.queue).toEqual([]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This directive provide a complement for ng-show and ng-hide directives
and change the visibility of two DOM elements depending on an expression.
ngToggle is a frequently used operation and can be implemented like the
following example:

Example:

```
<ng:toggle on="exp">
    <div id="A"></div>
    <div id="B"></div>
</ng:toggle>
```

If exp is evaluated to true then only #A is set to visible, otherwise
only #B is set to visible.

Closes [#228](https://github.com/angular/angular.js/issues/228)
