### PR TITLE
docs(validate-commit-msg): fix incorrect comment

### DIFF
--- a/validate-commit-msg.js
+++ b/validate-commit-msg.js
@@ -6,7 +6,7 @@
  *
  * Installation:
  * >> cd <angular-repo>
- * >> ln -s ../../validate-commit-msg.js .git/hooks/commit-msg
+ * >> ln -s validate-commit-msg.js .git/hooks/commit-msg
  */
 var fs = require('fs');
 var util = require('util');


### PR DESCRIPTION
If you `cd` into the repo, `validate-commit-msg.js` will be in the root
of it.
