### PR TITLE
Exposed $event for use with ng-submit

### DIFF
--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -89,7 +89,6 @@ function publishExternalAPI(angular){
             ngPluralize: ngPluralizeDirective,
             ngRepeat: ngRepeatDirective,
             ngShow: ngShowDirective,
-            ngSubmit: ngSubmitDirective,
             ngStyle: ngStyleDirective,
             ngSwitch: ngSwitchDirective,
             ngSwitchWhen: ngSwitchWhenDirective,

--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -37,7 +37,7 @@
  */
 var ngEventDirectives = {};
 forEach(
-  'click dblclick mousedown mouseup mouseover mouseout mousemove mouseenter mouseleave keydown keyup keypress'.split(' '),
+  'click dblclick mousedown mouseup mouseover mouseout mousemove mouseenter mouseleave keydown keyup keypress submit'.split(' '),
   function(name) {
     var directiveName = directiveNormalize('ng-' + name);
     ngEventDirectives[directiveName] = ['$parse', function($parse) {
@@ -263,8 +263,3 @@ forEach(
      </doc:scenario>
    </doc:example>
  */
-var ngSubmitDirective = ngDirective(function(scope, element, attrs) {
-  element.bind('submit', function() {
-    scope.$apply(attrs.ngSubmit);
-  });
-});

--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -223,7 +223,7 @@ forEach(
  * server and reloading the current page).
  *
  * @element form
- * @param {expression} ngSubmit {@link guide/expression Expression} to eval.
+ * @param {expression} ngSubmit {@link guide/expression Expression} to eval. (Event object is available as `$event`
  *
  * @example
    <doc:example>

--- a/test/ng/directive/ngEventDirsSpec.js
+++ b/test/ng/directive/ngEventDirsSpec.js
@@ -21,5 +21,22 @@ describe('event directives', function() {
       browserTrigger(element.children()[0]);
       expect($rootScope.submitted).toEqual(true);
     }));
+
+    it('should expose event on form submit', inject(function($rootScope, $compile) {
+      $rootScope.formSubmission = function(e) {
+        if (e) {
+          $rootScope.formSubmitted = 'foo';
+        }
+      };
+
+      element = $compile('<form action="" ng-submit="formSubmission($event)">' +
+        '<input type="submit"/>' +
+        '</form>')($rootScope);
+      $rootScope.$digest();
+      expect($rootScope.formSubmitted).not.toBeDefined();
+
+      browserTrigger(element.children()[0]);
+      expect($rootScope.formSubmitted).toEqual('foo');
+    }));
   });
 });


### PR DESCRIPTION
Added support for accessing $event with ng-submit.

Example:

```
<div ng-controller="submitCtrl">
    <form ng-submit="submitCallback($event)">
        <input type="submit">
    </form>
</div>

function submitCtrl($scope) {
    $scope.submitCallback = function(e) {
        console.log(e);
    };
}
```
