### PR TITLE
fix(directive): Scope fields with '=' should check for object equality

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -822,9 +822,9 @@ function $CompileProvider($provide) {
                 scope.$watch(function parentValueWatch() {
                   var parentValue = parentGet(parentScope);
 
-                  if (parentValue !== scope[scopeName]) {
+                  if (!angular.equals(parentValue, scope[scopeName])) {
                     // we are out of sync and need to copy
-                    if (parentValue !== lastValue) {
+                    if (!angular.equals(parentValue, lastValue)) {
                       // parent changed and it has precedence
                       lastValue = scope[scopeName] = parentValue;
                     } else {
@@ -833,7 +833,7 @@ function $CompileProvider($provide) {
                     }
                   }
                   return parentValue;
-                });
+                }, undefined, true);
                 break;
               }
 


### PR DESCRIPTION
Scope fields that are set to '=' should be checked with object equality and not with reference. Otherwise, if you're setting to that field an
 element with a filter and that filter always creates a new object based on input information, it'll throw $digest being called more than 10
times error

Fixes #2750
