### PR TITLE
Added support for file inputs with input directive

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -375,6 +375,8 @@ var inputType = {
    */
   'checkbox': checkboxInputType,
 
+  'file': fileInputType,
+
   'hidden': noop,
   'button': noop,
   'submit': noop,
@@ -659,6 +661,19 @@ function checkboxInputType(scope, element, attr, ctrl) {
 
   ctrl.$parsers.push(function(value) {
     return value ? trueValue : falseValue;
+  });
+}
+
+function fileInputType(scope, element, attr, ctrl) {
+  element.bind('change', function() {
+    var files = [];
+
+    for (var i = 0; i < element[0].files.length; i++) {
+      files.push(element[0].files[i]);
+    }
+    scope.$apply(function() {
+      ctrl.$setViewValue(files);
+    });
   });
 }
 


### PR DESCRIPTION
Note:  I am opening this PR for some discussion before finishing it off, since I have come upon a problem of testability of this feature.

This feature is for adding support for the input directive for inputs with type file.  This is meant to address [#2568](https://github.com/angular/angular.js/issues/2568).  As far as my hands-on testing with this has gone, what I have here works for updating ngModel with the file data, as well as adding support for ngChange callbacks.  However, unit testing these features causes a problem since you cannot manually set the file property of an input with type file due to official specification.

I would like some guidance on how to best approach this issue so this feature can get implemented.
