### PR TITLE
feat(directive): support as instance syntax

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -399,6 +399,10 @@ compiler}. The attributes are:
     controller: ['$scope', '$element', '$attrs', '$transclude', function($scope, $element, $attrs, $transclude) { ... }]
     </pre>
 
+  * `controllerAs` - Controller alias at the directive scope. An alias for the controller so it
+    can be referenced at the directive template. The directive needs to define a scope for this
+    configuration to be used.
+
   * `require` - Require another controller be passed into current directive linking function. The
     `require` takes a name of the directive controller to pass in. If no such controller can be
     found an error is raised. The name can be prefixed with:

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -860,16 +860,25 @@ function $CompileProvider($provide) {
               $element: $element,
               $attrs: attrs,
               $transclude: boundTranscludeFn
-            };
+            }, controllerInstance;
 
             controller = directive.controller;
             if (controller == '@') {
               controller = attrs[directive.name];
             }
 
+            controllerInstance = $controller(controller, locals);
             $element.data(
                 '$' + directive.name + 'Controller',
-                $controller(controller, locals));
+                controllerInstance);
+            if (directive.controllerAs) {
+              if (typeof locals.$scope !== 'object') {
+                throw new Error('Can not export controller as "' + identifier + '". ' +
+                    'No scope object provided!');
+              }
+
+              locals.$scope[directive.controllerAs] = controllerInstance;
+            }
           });
         }
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2208,6 +2208,51 @@ describe('$compile', function() {
     });
 
 
+    it('should support controllerAs', function() {
+      module(function() {
+        directive('main', function() {
+          return {
+            templateUrl: 'main.html',
+            scope: {},
+            controller: function() {
+              this.name = 'lucas';
+            },
+            controllerAs: 'mainCtrl'
+          };
+        });
+      });
+      inject(function($templateCache, $compile, $rootScope) {
+        $templateCache.put('main.html', '<span>{{mainCtrl.name}}</span>');
+        element = $compile('<div main></div>')($rootScope);
+        $rootScope.$apply();
+        expect(element.text()).toBe('lucas');
+      });
+    });
+
+
+    it('should support controller alias', function() {
+      module(function($controllerProvider) {
+        $controllerProvider.register('MainCtrl', function() {
+          this.name = 'lucas';
+        });
+        directive('main', function() {
+          return {
+            templateUrl: 'main.html',
+            scope: {},
+            controller: 'MainCtrl as mainCtrl'
+          };
+        });
+      });
+      inject(function($templateCache, $compile, $rootScope) {
+        $templateCache.put('main.html', '<span>{{mainCtrl.name}}</span>');
+        element = $compile('<div main></div>')($rootScope);
+        $rootScope.$apply();
+        expect(element.text()).toBe('lucas');
+      });
+    });
+
+
+
     it('should require controller on parent element',function() {
       module(function() {
         directive('main', function(log) {


### PR DESCRIPTION
Support controller: 'MyController as my' syntax for directives which publishes
the controller instance to the directive scope.

Support controllerAs syntax to define an alias to the controller within the
directive scope.

Note: The syntax `controller: 'MyController as my'` was already working as a side-effect of the existing changes to support this syntax on a route
