### PR TITLE
 Removed call to $httpBackend.verifyNoOutstandingExpectation() in $httpBackend.flush()

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1276,7 +1276,6 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
         responses.shift()();
       }
     }
-    $httpBackend.verifyNoOutstandingExpectation();
   };
 
 


### PR DESCRIPTION
Part of the use of flush() is that one can flush one or more expectations at a time.
Having a call to verifyNoOutstandingExpectation() does not facilitate this objective
as if you don't flush all your expectations then your test will fail.

It my particular project I'm writing an AJAX poller with $timeout.

I think it should be at the end of the test where verifyNoOutstandingExpectation() is called (and in my afterEach I do just that).
