### PR TITLE
feat($parse): Support getter/setter functions in parse expression.

### DIFF
--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -334,6 +334,22 @@ describe('input', function() {
   });
 
 
+  it('should bind to property accessors', function() {
+    compileInput('<input type="text" ng-model="foo.@bar">');
+    var bar = 'hello';
+    scope.$apply(function() {
+      scope.foo = {
+        getBar: function() { return bar; },
+        setBar: function(value) { bar = value; }
+      };
+    });
+
+    expect(inputElm.val()).toBe('hello');
+    changeInputValueTo('goodbye');
+    expect(bar).toBe('goodbye');
+  });
+
+
   it('should not set readonly or disabled property on ie7', function() {
     this.addMatchers({
       toBeOff: function(attributeName) {


### PR DESCRIPTION
Adds support for a syntax to define a property accessor in expressions, i.e.
a getter/setter pair. The straw man syntax is @foo supporting getFoo and
setFoo. Property accessors can be used in ng-model bindings, e.g.
`<input ng-model="obj.@foo">`
Binding to obj.getFoo() and obj.setFoo(value) respectively.

Closes #768
