### PR TITLE
Add build of angular for node.js server environment

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,10 @@ module.exports = function(grunt) {
 
 
     build: {
+      server: {
+        dest: 'build/angular-server.js',
+        src: util.wrap([files['angularServer']], 'server')
+      },
       scenario: {
         dest: 'build/angular-scenario.js',
         src: [

--- a/angularFiles.js
+++ b/angularFiles.js
@@ -1,4 +1,16 @@
 angularFiles = {
+  'angularServer': [
+    'src/Angular.js',
+    'src/loader.js',
+    'src/AngularPublic.js',
+    'src/apis.js',
+    'src/ngError.js',
+    'src/auto/injector.js',
+    'src/ng/interpolate.js',
+    'src/ng/parse.js',
+    'src/ng/locale.js',
+    'src/ng/cacheFactory.js',
+  ],
   'angularSrc': [
     'src/Angular.js',
     'src/loader.js',

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -987,24 +987,29 @@ function angularInit(element, bootstrap) {
  * @param {Array<String|Function>=} modules an array of module declarations. See: {@link angular.module modules}
  * @returns {AUTO.$injector} Returns the newly created injector for this app.
  */
-function bootstrap(element, modules) {
+function bootstrap(element, modules, server) {
   var resumeBootstrapInternal = function() {
-    element = jqLite(element);
     modules = modules || [];
-    modules.unshift(['$provide', function($provide) {
-      $provide.value('$rootElement', element);
-    }]);
-    modules.unshift('ng');
-    var injector = createInjector(modules);
-    injector.invoke(['$rootScope', '$rootElement', '$compile', '$injector', '$animator',
-       function(scope, element, compile, injector, animator) {
-        scope.$apply(function() {
-          element.data('$injector', injector);
-          compile(element)(scope);
-        });
-        animator.enabled(true);
-      }]
-    );
+    var injector;
+    if(! server) {
+      element = jqLite(element);
+      modules.unshift(['$provide', function($provide) {
+        $provide.value('$rootElement', element);
+      }]);
+      modules.unshift('ng');
+      injector = createInjector(modules);
+      injector.invoke(['$rootScope', '$rootElement', '$compile', '$injector', '$animator',
+         function(scope, element, compile, injector, animator) {
+          scope.$apply(function() {
+            element.data('$injector', injector);
+            compile(element)(scope);
+          });
+          animator.enabled(true);
+        }]
+      );
+    } else
+      injector = createInjector(modules);
+
     return injector;
   };
 


### PR DESCRIPTION
I've created a build that works in node with minimal changes.  I've been using a version of this for a while now and it is really nice to be able to share some of my modules between the client and the server without any special code to make that work.

EDIT: I should add its essentially just the DI interface.  It does not include any of the directives or scoping code.  But just having the same DI interface can be very useful for sharing code nicely.
