### PR TITLE
feat($formData): function to access the form controls (plus the filter) on ngModelController

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -128,6 +128,35 @@ function FormController(element, attrs) {
 
   /**
    * @ngdoc function
+   * @name ng.directive:form.FormController#$formData
+   * @methodOf ng.directive:form.FormController
+   *
+   * @description
+   * Get the form data in a object, depending on the filter and the member you want to return
+   * 
+   * This method is mainly used to transmit data, either to emit an event, send data through 
+   * AJAX, to use on $watch and test the validity of certain forms in an easy way
+   *
+   * @param {string|Object|function()|null|undefined} filter The predicate to be used for selecting 
+   * items from. See filterFilter for more
+   * 
+   * @param {string=} member The member of the NgModelController, defaults to '$modelValue'. 
+   * Another useful string for this param is '$viewValue'
+   */
+  form.$formData = function(filter, member) {
+    member = member || '$modelValue';
+    var out = {}, ctrls;
+    ctrls = filter ? filterFilter()(controls, filter) : controls;
+    
+    forEach(ctrls, function(control){
+      out[control.$name] = control[member];
+    });
+    
+    return out;
+  };
+
+  /**
+   * @ngdoc function
    * @name ng.directive:form.FormController#$setPristine
    * @methodOf ng.directive:form.FormController
    *

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -377,7 +377,7 @@ describe('form', function() {
       expect(parent.$error.myRule).toBe(false);
       expect(child.$error.myRule).toBe(false);
     });
-  })
+  });
 
 
   describe('validation', function() {
@@ -432,6 +432,46 @@ describe('form', function() {
   });
 
 
+  describe('$formData', function() {
+    
+    beforeEach(function (){
+      doc = $compile(
+        '<form name="form">' +
+          '<input ng-model="model.name" name="name" value="Hello input" />' +
+          '<input ng-model="model.number" name="number" value="10" />' +
+          '<textarea ng-model="model.textarea" name="textarea">Hello textarea</textarea>' +
+        '</form>')(scope);
+      
+      scope.model = {
+        name: 'Hello input',
+        number: '10',
+        textarea: 'Hello textarea'
+      };
+      
+      scope.$digest();
+    });
+
+    it('should return all the controllers from the form without any parameters', function(){
+      var form = scope.form;
+      expect(form.$formData()).toEqualData({name:'Hello input','number': '10','textarea':'Hello textarea'});
+    });
+    
+    it('should return filter the $dirty controllers from the inputs', function(){
+      var form = scope.form;
+      form.number.$setViewValue('another value');
+      expect(form.$formData({'$dirty': true})).toEqualData({'number': 'another value'});
+    });
+    
+    it('should return the correct attribute from each input', function(){
+      var form = scope.form;
+      form.name.$modelValue = 'hello_input';
+      form.number.$modelValue = 'ten';
+      form.textarea.$modelValue = 'textarea';
+      expect(form.$formData(false, '$modelValue')).toEqualData({name: 'hello_input', 'number': 'ten', 'textarea': 'textarea'});
+      expect(form.$formData(false, '$viewValue')).toEqualData({name: 'Hello input', 'number': '10', 'textarea': 'Hello textarea'});
+    });
+  });
+	
   describe('$setPristine', function() {
 
     it('should reset pristine state of form and controls', function() {


### PR DESCRIPTION
Implements #2791

Usage is:

``` js
$scope.myForm.$formData() // return all controls on the current form
$scope.myForm.$formData({'$dirty': true}) // return only dirty controls  on the current form
$scope.myForm.$formData({'$pristine': true}, '$viewValue') // return only pristine controls  on the current form but instead, return their $viewValue
```

This is mainly useful when dealing with directives that alter the $modelValue but not the $viewValue (like the ui-mask), submitting AJAX, fetching non-DOM representations of controllers, etc
