### PR TITLE
If you use html5mode on IE9, IE8 it fails with 10 $digest() iterations r...

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -123,8 +123,9 @@ function Browser(window, document, $log, $sniffer) {
   // URL API
   //////////////////////////////////////////////////////////////
 
-  var lastBrowserUrl = location.href,
-      baseElement = document.find('base');
+  var lastBrowserUrl = location.href,			
+      baseElement = document.find('base'),
+      replacedUrl = null;
 
   /**
    * @name ng.$browser#url
@@ -159,14 +160,20 @@ function Browser(window, document, $log, $sniffer) {
           baseElement.attr('href', baseElement.attr('href'));
         }
       } else {
-        if (replace) location.replace(url);
-        else location.href = url;
+        if (replace) {
+          location.replace(url);
+          replacedUrl = url;
+        } else {
+          location.href = url;
+          replacedUrl = null;
+        }
       }
       return self;
     // getter
     } else {
+      // the replacedUrl is a workaround for an issue with location.replace method isn't changing the location.href immediately
       // the replacement is a workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=407172
-      return location.href.replace(/%27/g,"'");
+      return replacedUrl || location.href.replace(/%27/g,"'");
     }
   };
 


### PR DESCRIPTION
There was an issue with location.replace method isn't changing the location.href immediately.

This pull-request is the same like this one https://github.com/angular/angular.js/pull/2782 but for 1.0.x branch.
