### PR TITLE
fix(ngRepeat): handle iteration over identical obj values

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -175,8 +175,16 @@ var ngRepeatDirective = ['$parse', '$animator', function($parse, $animator) {
             return trackByExpGetter($scope, hashFnLocals);
           };
         } else {
-          trackByIdFn = function(key, value) {
-            return hashKey(value);
+          trackByIdFn = function(key, value, index) {
+            var valType = typeof value;
+
+            // if value is a primitive and key != index (case for arrays)
+            // then append key to value to ensure uniqueness for identical values
+            if(valType != 'object' && !(typeof key === 'number' || key === index)) {
+              return hashKey(key + ':' + value);
+            } else {
+              return hashKey(value);
+            }
           }
         }
 

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -85,6 +85,15 @@ describe('ngRepeat', function() {
     expect(element.text()).toEqual('misko:swe|shyam:set|');
   });
 
+  it('should iterate over an object/map with identical values', function() {
+    element = $compile(
+      '<ul>' +
+        '<li ng-repeat="(key, value) in items">{{key}}:{{value}}|</li>' +
+      '</ul>')(scope);
+    scope.items = {age:20, wealth:20, prodname: "Bingo", dogname: "Bingo", codename: "20"};
+    scope.$digest();
+    expect(element.text()).toEqual('age:20|codename:20|dogname:Bingo|prodname:Bingo|wealth:20|');
+  });
 
   describe('track by', function() {
     it('should track using expression function', function() {


### PR DESCRIPTION
Modifies default trackByIdFn to factor both key and value into hashKey
for non-array primitive (i.e. index not provided) values

Closes #2787
