### PR TITLE
fix(jqLite): Added optional name arg in removeData

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -203,11 +203,16 @@ function JQLiteUnbind(element, type, fn) {
   }
 }
 
-function JQLiteRemoveData(element) {
+function JQLiteRemoveData(element, name) {
   var expandoId = element[jqName],
       expandoStore = jqCache[expandoId];
 
   if (expandoStore) {
+    if (name) {
+      delete jqCache[expandoId].data[name];
+      return;
+    }
+
     if (expandoStore.handle) {
       expandoStore.events.$destroy && expandoStore.handle({}, '$destroy');
       JQLiteUnbind(element);

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -226,6 +226,7 @@ describe('jqLite', function() {
 
       expect(selected.data('prop')).toBeUndefined();
       expect(selected.data('prop', 'value')).toBe(selected);
+      expect(!!jqLite(a).data('prop2', 'doublevalue')).toBe(true);
       expect(selected.data('prop')).toBe('value');
       expect(jqLite(a).data('prop')).toBe('value');
       expect(jqLite(b).data('prop')).toBe('value');
@@ -233,11 +234,13 @@ describe('jqLite', function() {
 
       jqLite(a).data('prop', 'new value');
       expect(jqLite(a).data('prop')).toBe('new value');
+      expect(jqLite(a).data('prop2')).toBe('doublevalue');
       expect(selected.data('prop')).toBe('new value');
       expect(jqLite(b).data('prop')).toBe('value');
       expect(jqLite(c).data('prop')).toBe('value');
 
       expect(selected.removeData('prop')).toBe(selected);
+      expect(jqLite(a).data('prop2')).toBe('doublevalue');
       expect(jqLite(a).data('prop')).toBeUndefined();
       expect(jqLite(b).data('prop')).toBeUndefined();
       expect(jqLite(c).data('prop')).toBeUndefined();

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -10,7 +10,6 @@ describe('jqLite', function() {
     c = jqLite('<div>C</div>')[0];
   });
 
-
   beforeEach(inject(function($rootScope) {
     scope = $rootScope;
     this.addMatchers({
@@ -85,7 +84,6 @@ describe('jqLite', function() {
 
 
   describe('inheritedData', function() {
-
     it('should retrieve data attached to the current element', function() {
       var element = jqLite('<i>foo</i>');
       element.data('myData', 'abc');
@@ -226,7 +224,7 @@ describe('jqLite', function() {
 
       expect(selected.data('prop')).toBeUndefined();
       expect(selected.data('prop', 'value')).toBe(selected);
-      expect(!!jqLite(a).data('prop2', 'doublevalue')).toBe(true);
+      
       expect(selected.data('prop')).toBe('value');
       expect(jqLite(a).data('prop')).toBe('value');
       expect(jqLite(b).data('prop')).toBe('value');
@@ -234,16 +232,33 @@ describe('jqLite', function() {
 
       jqLite(a).data('prop', 'new value');
       expect(jqLite(a).data('prop')).toBe('new value');
-      expect(jqLite(a).data('prop2')).toBe('doublevalue');
       expect(selected.data('prop')).toBe('new value');
       expect(jqLite(b).data('prop')).toBe('value');
       expect(jqLite(c).data('prop')).toBe('value');
 
       expect(selected.removeData('prop')).toBe(selected);
-      expect(jqLite(a).data('prop2')).toBe('doublevalue');
       expect(jqLite(a).data('prop')).toBeUndefined();
       expect(jqLite(b).data('prop')).toBeUndefined();
       expect(jqLite(c).data('prop')).toBeUndefined();
+    });
+
+    it('should only remove the specified value when providing a property name to removeData', function () {
+      var selected = jqLite(a);
+
+      expect(selected.data('prop1')).toBeUndefined();
+      
+      selected.data('prop1', 'value');
+      selected.data('prop2', 'doublevalue');
+      
+      expect(selected.data('prop1')).toBe('value');
+      expect(selected.data('prop2')).toBe('doublevalue');
+
+      selected.removeData('prop1');
+
+      expect(selected.data('prop1')).toBeUndefined();
+      expect(selected.data('prop2')).toBe('doublevalue');
+
+      selected.removeData('prop2');
     });
 
     it('should emit $destroy event if element removed via remove()', function() {

--- a/test/ng/animatorSpec.js
+++ b/test/ng/animatorSpec.js
@@ -336,6 +336,24 @@ describe("$animator", function() {
       expect(element.children().length).toBe(0);
     }));
 
+    it("should NOT clobber all data on element when calling done", inject(function($animator, $rootScope) {
+      var parent = jqLite('<div>');
+      var child = jqLite('<div>');
+      child.data('foo', 123);
+
+      $animator.enabled(true);
+
+      animator = $animator($rootScope, {
+        ngAnimate : '\'custom-delay\''
+      });
+
+      animator.enter(parent, child);
+      window.setTimeout.expect(1).process();
+      expect(child.data('foo')).toEqual(123);
+      child.removeData();
+      parent.removeData();
+    }));
+
     it("should call the cancel callback when another animation is called on the same element",
       inject(function($animator, $rootScope) {
       $animator.enabled(true);

--- a/test/ng/animatorSpec.js
+++ b/test/ng/animatorSpec.js
@@ -336,24 +336,6 @@ describe("$animator", function() {
       expect(element.children().length).toBe(0);
     }));
 
-    it("should NOT clobber all data on element when calling done", inject(function($animator, $rootScope) {
-      var parent = jqLite('<div>');
-      var child = jqLite('<div>');
-      child.data('foo', 123);
-
-      $animator.enabled(true);
-
-      animator = $animator($rootScope, {
-        ngAnimate : '\'custom-delay\''
-      });
-
-      animator.enter(parent, child);
-      window.setTimeout.expect(1).process();
-      expect(child.data('foo')).toEqual(123);
-      child.removeData();
-      parent.removeData();
-    }));
-
     it("should call the cancel callback when another animation is called on the same element",
       inject(function($animator, $rootScope) {
       $animator.enabled(true);
@@ -363,11 +345,33 @@ describe("$animator", function() {
       });
 
       child.css('display','none');
+      element.data('foo', 'bar');
       animator.show(element);
       window.setTimeout.expect(1).process();
+      
       animator.hide(element);
 
       expect(element.hasClass('animation-cancelled')).toBe(true);
+      expect(element.data('foo')).toEqual('bar');
+    }));
+
+    it("should NOT clobber all data on an element when animation is finished",
+      inject(function($animator, $rootScope) {
+      $animator.enabled(true);
+
+      animator = $animator($rootScope, {
+        ngAnimate : '{hide: \'custom-delay\', show: \'custom-delay\'}'
+      });
+
+      child.css('display','none');
+      element.data('foo', 'bar');
+
+      animator.show(element);
+      window.setTimeout.expect(1).process();
+      
+      animator.hide(element);
+
+      expect(element.data('foo')).toEqual('bar');
     }));
 
 


### PR DESCRIPTION
jQuery's API for removeData allows a second 'name' argument to just remove the property by that name from an element's data. The absence of this argument was causing some features not to work correctly when combining multiple directives, such as ng-click, ng-show, and ng-animate.
