### PR TITLE
Fixing a documentation issue so PhpStorm/WebStorm quits complaining about a syntax error

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -90,8 +90,8 @@
  *   - **`withCredentials`** - `{boolean}` - whether to to set the `withCredentials` flag on the
  *     XHR object. See {@link https://developer.mozilla.org/en/http_access_control#section_5
  *     requests with credentials} for more information.
- *   - **`responseType`** - `{string}` - see {@link
- *     https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest#responseType requestType}.
+ *   - **`responseType`** - `{string}` - see
+ *     {@link https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest#responseType requestType}.
  *   - **`interceptor`** - `{Object=}` - The interceptor object has two optional methods -
  *     `response` and `responseError`. Both `response` and `responseError` interceptors get called
  *     with `http response` object. See {@link ng.$http $http interceptors}.


### PR DESCRIPTION
When breaking a `{@link foo}` over multiple lines, PhpStorm/WebStorm complain that the file has broken syntax and highlights the file in your project explorer with a red.
