### PR TITLE
Change router so route can be a callback function

### DIFF
--- a/src/ng/route.js
+++ b/src/ng/route.js
@@ -105,7 +105,9 @@ function $RouteProvider(){
    * Adds a new route definition to the `$route` service.
    */
   this.when = function(path, route) {
-    routes[path] = extend({reloadOnSearch: true, caseInsensitiveMatch: false}, route);
+      routes[path] = isFunction(route) 
+        ? route
+        : extend({reloadOnSearch: true, caseInsensitiveMatch: false}, route);
 
     // create redirection for trailing slashes
     if (path) {
@@ -477,8 +479,16 @@ function $RouteProvider(){
       var params, match;
       forEach(routes, function(route, path) {
         if (!match && (params = switchRouteMatcher($location.path(), path, route))) {
+          var search = $location.search();
+          
+          if (isFunction(route)) {
+            // route is a function, call it to get the actual route to use
+            // route function can update params or search
+            route = route(params, search);
+          }
+          
           match = inherit(route, {
-            params: extend({}, $location.search(), params),
+            params: extend({}, search, params),
             pathParams: params});
           match.$$route = route;
         }


### PR DESCRIPTION
Thinking about feedback from #2571 which I submitted a few weeks ago, here is another idea for making routing extensible. It has the benefit of allowing you to use the existing router for routes it is good at.

The premise is that no router is likely to meet everyone's requirements, so make it plugable. It turns out it already is. You can register another service with the name '$router'. However, I would argue that that is a lot of work when the current router almost does what you want. It turns out other routers exist, but I have not found one that meets my requirements.

This pull requests allows you to pass a callback function as a route. Below is an example. It is a simplification of what I need to do, in fact cat is a path like x/y/ or x/y/123 so more parsing is done. Excuse the coffescript:

``` coffeescript
categoryRoute = (params, search) ->
  if params.cat.match(/^\d+$/)
    return { templateUrl: '/t/item.html', controller: ItemCtrl, resolve: ItemCtrl.resolve }
  else  
    return { templateUrl: '/t/category.html', controller: CategoryCtrl, resolve: CategoryCtrl.resolve }

...
...

$routeProvider.when '/category/*cat', categoryRoute 
```

Another feature not shown here is that params and search can be updated by the route function - though I have not tested this for search.

Any feedback would be appreciated. Let me know if this is likely to be merged, then I can add documentation and do more thorough testing.

It would also be helpful to get some idea whether updating the router is a priority of the core developers of angular and if so what they see as key priorities.
