### PR TITLE
Support for 'extending' data

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -478,7 +478,14 @@ angular.module('ngResource', ['ng']).
                   value.push(new Resource(item));
                 });
               } else {
-                copy(data, value);
+                if(!action.params.extend)
+                {
+                  copy(data,value);
+                }
+                else
+                {
+                  $.extend(true,value, data);
+                }                
                 value.$promise = promise;
               }
             }


### PR DESCRIPTION
By adding 'extend:true' to action params you can have the data returned from server extend (deeply) the client side object rather than overwrite it.

This is useful primarily for updates - e.g. when you save the object and get a returned object with some of the data changed and yet have client data which must be kept.

One possible flow:
You have an object on the client which has an array displayed by a carousel - thus each item has an 'isActive' property on the client side.
When saving the object you need to return the object for many reasons one of which ,ight be to get updated IDs when some items are new and must be created on server side - getting an ID.
This scenario would normally overwrite the entire client object making the carousel slide to the first slide - rather than maintaining the selected slide as needed.
By extending the client data with the server data you can avoid that.
