### PR TITLE
Fix PasswordCtrl example

### DIFF
--- a/docs/content/guide/dev_guide.unit-testing.ngdoc
+++ b/docs/content/guide/dev_guide.unit-testing.ngdoc
@@ -249,7 +249,7 @@ and the test is straight forward
 
 <pre>
 var pc = new PasswordCtrl();
-pc.password('abc');
+pc.password = 'abc';
 pc.grade();
 expect(pc.strength).toEqual('weak');
 </pre>


### PR DESCRIPTION
Unless I'm misunderstanding things, `password` doesn't seem to be a function here.
