### PR TITLE
doc(ngTransclude): replace scope definition with modern one

### DIFF
--- a/src/ng/directive/ngTransclude.js
+++ b/src/ng/directive/ngTransclude.js
@@ -23,8 +23,7 @@
              return {
                restrict: 'E',
                transclude: true,
-               scope: 'isolate',
-               locals: { title:'bind' },
+               scope: { title:'@' },
                template: '<div style="border: 1px solid black;">' +
                            '<div style="background-color: gray">{{title}}</div>' +
                            '<div ng-transclude></div>' +


### PR DESCRIPTION
I've stumbled upon `scope: 'isolate', locals: { title:'bind' }` notation in ngTransclude doc. Replace with `scope: {isolate: '@'}`
