### PR TITLE
Fixes broken build when building not from git repository

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -14,7 +14,9 @@ module.exports = {
     var package = JSON.parse(fs.readFileSync('package.json', 'UTF-8'));
     var match = package.version.match(/^([^\-]*)(-snapshot)?$/);
     var semver = match[1].split('.');
-    var hash = shell.exec('git rev-parse --short HEAD', {silent: true}).output.replace('\n', '');
+    var gitExecResult = shell.exec('git rev-parse --short HEAD', {silent: true});
+    var hash = (gitExecResult.code==0) ? 
+            gitExecResult.output.replace('\n', '') : "";
 
     var version = {
       full: (match[1] + (match[2] ? '-' + hash : '')),


### PR DESCRIPTION
Otherwise, the builded .js files are going to be invalid if building not from git repo.
