### PR TITLE
fix(equals): {} and [] should not be considered equivalent 

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -670,18 +670,26 @@ function equals(o1, o2) {
   if (o1 === o2) return true;
   if (o1 === null || o2 === null) return false;
   if (o1 !== o1 && o2 !== o2) return true; // NaN === NaN
+
   var t1 = typeof o1, t2 = typeof o2, length, key, keySet;
   if (t1 == t2) {
     if (t1 == 'object') {
-      if (isArray(o1)) {
+
+      var a1 = isArray(o1), a2 = isArray(o2);
+      if (a1 != a2) {
+        return false
+
+      } else if (a1) {
         if ((length = o1.length) == o2.length) {
           for(key=0; key<length; key++) {
             if (!equals(o1[key], o2[key])) return false;
           }
           return true;
         }
+
       } else if (isDate(o1)) {
         return isDate(o2) && o1.getTime() == o2.getTime();
+
       } else {
         if (isScope(o1) || isScope(o2) || isWindow(o1) || isWindow(o2)) return false;
         keySet = {};
@@ -690,12 +698,14 @@ function equals(o1, o2) {
           if (!equals(o1[key], o2[key])) return false;
           keySet[key] = true;
         }
+
         for(key in o2) {
           if (!keySet[key] &&
               key.charAt(0) !== '$' &&
               o2[key] !== undefined &&
               !isFunction(o2[key])) return false;
         }
+
         return true;
       }
     }

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -270,6 +270,11 @@ describe('angular', function() {
       expect(equals(new Date(0), 0)).toBe(false);
       expect(equals(0, new Date(0))).toBe(false);
     });
+
+    it('should return false when comparing an object and an array', function() {
+      expect(equals({}, [])).toBe(false);
+      expect(equals([], {})).toBe(false);
+    });
   });
 
   describe('size', function() {


### PR DESCRIPTION
angular.equals was returning inconsistent values for the comparison between
{} and []:

```
angular.equals({}, []) // true
angular.equals([], {}) // false
```

Since these object are not of the same type, they should not be considered
equivalent.

Fixes #2851
