### PR TITLE
fix($parse) - Allow setterFn to bind correctly to promise results

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -705,6 +705,20 @@ function parser(text, json, $filter, csp){
 // Parser helper functions
 //////////////////////////////////////////////////
 
+// Unwrap values from a promise
+function unwrapPromise(obj){
+  
+  // If we'v been passed a promise
+  if( obj.then ){
+
+    // Then unwrap the value. If the value has not been returned yet, bind to a throwaway object. This will simulate a read-only field.
+    return obj.$$v || {}
+  }
+
+  return obj;
+}
+
+
 function setter(obj, path, setValue) {
   var element = path.split('.');
   for (var i = 0; element.length > 1; i++) {
@@ -714,7 +728,7 @@ function setter(obj, path, setValue) {
       propertyObj = {};
       obj[key] = propertyObj;
     }
-    obj = propertyObj;
+    obj = unwrapPromise( propertyObj );
   }
   obj[element.shift()] = setValue;
   return setValue;

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -714,7 +714,7 @@ function unwrapPromise(obj){
   
   // If we'v been passed a promise then unwrap it. 
   // If the value has not been resolved yet, bind to a throwaway object. This will simulate a read-only field.
-  if( obj && obj.then )    
+  if(obj && obj.then)
     return obj.$$v || {}
   else
     return obj;

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -705,17 +705,19 @@ function parser(text, json, $filter, csp){
 // Parser helper functions
 //////////////////////////////////////////////////
 
-// Unwrap values from a promise
+/**
+ * Unwrap values from a promise
+ * @param {Object} obj object to unwrap
+ * @returns if passed a promise, the inner value. Otherwise original object.
+ */
 function unwrapPromise(obj){
   
-  // If we'v been passed a promise
-  if( obj.then ){
-
-    // Then unwrap the value. If the value has not been returned yet, bind to a throwaway object. This will simulate a read-only field.
+  // If we'v been passed a promise then unwrap it. 
+  // If the value has not been resolved yet, bind to a throwaway object. This will simulate a read-only field.
+  if( obj && obj.then )    
     return obj.$$v || {}
-  }
-
-  return obj;
+  else
+    return obj;
 }
 
 

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -679,6 +679,51 @@ describe('parser', function() {
             expect(scope.$eval('greeting')).toBe('hello!');
           });
 
+          it('should evaluate a resolved object promise and set its value', inject(function($parse) {
+            var person = {'name': 'Bill Gates'};
+
+            deferred.resolve(person);
+            scope.person = promise;
+            
+            var getter = $parse( 'person.name' );
+
+            expect(getter(scope)).toBe(undefined);
+            scope.$digest();
+            expect(getter(scope)).toBe('Bill Gates');
+
+            getter.assign(scope, 'Warren Buffet');
+            expect(getter(scope)).toBe('Warren Buffet');
+          }));
+
+          it('should evaluate a resolved primitive type promise and set its value', inject(function($parse) {            
+            deferred.resolve("Salut!");
+            scope.greeting = promise;
+            
+            var getter = $parse( 'greeting' );
+
+            expect(getter(scope)).toBe(undefined);
+            scope.$digest();
+            expect(getter(scope)).toBe('Salut!');
+
+            getter.assign(scope, 'Bonjour');
+            expect(getter(scope)).toBe('Bonjour');
+          }));
+
+          it('should evaluate an unresolved promise and *not* set its value', inject(function($parse) {
+            
+
+            scope.person = promise;
+            
+            var getter = $parse( 'person.name' );
+
+            expect(getter(scope)).toBe(undefined);
+            scope.$digest();
+            expect(getter(scope)).toBe(undefined);
+
+            getter.assign(scope, 'Warren Buffet');
+            expect(getter(scope)).toBe(undefined);
+          }));
+
 
           it('should evaluated rejected promise and ignore the rejection reason', function() {
             deferred.reject('sorry');


### PR DESCRIPTION
When binding the result of a promise directly to an ng:model directive,
getterFn successfully extracts the data from the promise by traversing
the '$$v' attribute.

However the setterFn was not successfully traversing to the $$v
attribute, and instead writing model updates directly on the promise
itself.

The subsequent apply/digest phase of Angular was then pulling the
original value from the promise and applying it back into the viewState,
thus simulating a read-only field.

In summary, setterFn was writing to the root of the promise, while
getterFn was reading from the '$$v' component.

Fixed by modifying setterFn to unwrap promises if found and read $$v.

If promises have not been resolved yet, bindings will function as they
previously did (act as a read-only field). This appears to be more of a
side effect than intentional design in the existing codebase, however
I kept this behaviour in this patch to minimize the chance of breaking
existing projects.

Closes #1827

This issue affects the 1.0.x branch as well and would be worth backporting.
(Cleanly cherry-picks against 1.0.7 with all tests passing).

Also see: http://stackoverflow.com/questions/16883239/angularjs-ngmodel-
field-is-readonly-when-bound-to-q-promise/16883387
