### PR TITLE
fix(ngScenario): select(...).option(val) should select exact value match

### DIFF
--- a/src/ngScenario/dsl.js
+++ b/src/ngScenario/dsl.js
@@ -295,7 +295,12 @@ angular.scenario.dsl('select', function() {
       if (option.length) {
         select.val(value);
       } else {
-        option = select.find('option:contains("' + value + '")');
+        option = select.find('option').filter(function(){
+          return _jQuery(this).text() === value;
+        });
+        if (!option.length) {
+          option = select.find('option:contains("' + value + '")');
+        }
         if (option.length) {
           select.val(option.val());
         } else {

--- a/test/ngScenario/dslSpec.js
+++ b/test/ngScenario/dslSpec.js
@@ -227,6 +227,7 @@ describe("angular.scenario.dsl", function() {
         $root.dsl.select('test').option('A');
         expect(doc.find('[data-ng-model="test"]').val()).toEqual('A');
       });
+
       it('should select single option using x-ng', function() {
         doc.append(
           '<select x-ng-model="test">' +
@@ -238,14 +239,25 @@ describe("angular.scenario.dsl", function() {
         expect(doc.find('[x-ng-model="test"]').val()).toEqual('A');
       });
 
-
-
-
-      it('should select option by name', function() {
+      it('should select option by exact name', function() {
         doc.append(
             '<select ng-model="test">' +
-            '  <option value=A>one</option>' +
+            '  <option value=A>twenty one</option>' +
             '  <option value=B selected>two</option>' +
+            '  <option value=C>thirty one</option>' +
+            '  <option value=D>one</option>' +
+            '</select>'
+          );
+          $root.dsl.select('test').option('one');
+          expect(doc.find('[ng-model="test"]').val()).toEqual('D');
+      });
+
+      it('should select option by name if no exact match and name contains value', function() {
+        doc.append(
+            '<select ng-model="test">' +
+            '  <option value=A>twenty one</option>' +
+            '  <option value=B selected>two</option>' +
+            '  <option value=C>thirty one</option>' +
             '</select>'
           );
           $root.dsl.select('test').option('one');


### PR DESCRIPTION
This pull requests modifies ngScenario's `select(...).option(val)` such that it closes #2855.

This fix prefers exact matches when available, otherwise it reverts to the previous 'contains' behaviour for backwards compatibility.

This pull request also updates the dslSpec tests to ensure proper behaviour going forward for both the exact text match and the :contains text match.
