### PR TITLE
fix($compile): support text inside multi-element directive

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -591,8 +591,8 @@ function $CompileProvider($provide) {
           if (!node) {
             throw ngError(51, "Unterminated attribute, found '{0}' but no matching '{1}' found.", attrStart, attrEnd);
           }
-          if (node.hasAttribute(attrStart)) depth++;
-          if (node.hasAttribute(attrEnd)) depth--;
+          if (node.hasAttribute && node.hasAttribute(attrStart)) depth++;
+          if (node.hasAttribute && node.hasAttribute(attrEnd)) depth--;
           nodes.push(node);
           node = node.nextSibling;
         } while (depth > 0);

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2746,6 +2746,17 @@ describe('$compile', function() {
       expect(element.text()).toEqual('1A1B;2A2B;');
     }));
 
+    it('should group on embedded text nodes', inject(function($compile, $rootScope) {
+      $rootScope.show = false;
+      element = $compile(
+        '<div>' +
+          '<span ng-repeat-start="i in [1,2]">{{i}}A</span>' +
+          'X' +
+          '<span ng-repeat-end>{{i}}B;</span>' +
+          '</div>')($rootScope);
+      $rootScope.$digest();
+      expect(element.text()).toEqual('1AX1B;2AX2B;');
+    }));
 
     it('should group on $root compile function', inject(function($compile, $rootScope) {
       $rootScope.show = false;


### PR DESCRIPTION
Fixed problems with text inside multi-element directives which resulted in a TypeError: Object #<Text> has no method 'hasAttribute'
