### PR TITLE
docs(directive/script): escape `</script>`

### DIFF
--- a/src/ng/directive/script.js
+++ b/src/ng/directive/script.js
@@ -16,7 +16,7 @@
     <doc:source>
       <script type="text/ng-template" id="/tpl.html">
         Content of the template.
-      </script>
+      &lt;/script>
 
       <a ng-click="currentTpl='/tpl.html'" id="tpl-link">Load inlined template</a>
       <div id="tpl-content" ng-include src="currentTpl"></div>


### PR DESCRIPTION
This is a possible solution so that the documentation won't jump out of the `<script>`
template on [1]. I currently don't have the possibility to execute the documentation generation. If anyone could verify if this works, that would be great.

This commit fixes (hopefully!) #2820.

[1] http://docs.angularjs.org/api/ng.directive:script
