### PR TITLE
fix(Angular.js): Improve logic powering isArrayLike()

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -98,7 +98,8 @@ function isArrayLike(obj) {
     return obj instanceof JQLite ||                      // JQLite
            (jQuery && obj instanceof jQuery) ||          // jQuery
            toString.call(obj) !== '[object Object]' ||   // some browser native object
-           typeof obj.callee === 'function';              // arguments (on IE8 looks like regular obj)
+           typeof obj.callee === 'function' ||           // arguments (on IE8 looks like regular obj)
+           obj.constructor === [].constructor;           // various one-off objects (like subclasses) of array
   }
 }
 


### PR DESCRIPTION
Enable isArrayLike() to correctly identify one-off-arrays (aka
'subclasses').
Thus array-like objects with enhanced prototypes can be used with
ng-repeat.
Previously, they would be misidentified as objects and not iterate
correctly.
