### PR TITLE
chore(grunt): give closure-compiler 2g of memory

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -125,7 +125,7 @@ module.exports = {
     shell.exec(
         'java ' +
             this.java32flags() + ' ' +
-            '-jar lib/closure-compiler/compiler.jar ' +
+            '-Xmx2g -jar lib/closure-compiler/compiler.jar ' +
             '--compilation_level SIMPLE_OPTIMIZATIONS ' +
             '--language_in ECMASCRIPT5_STRICT ' +
             '--js ' + file + ' ' +


### PR DESCRIPTION
Every now and then Travis fails for the lack of memory when running the closure compiler. Force it to use 2g of memory so it never fails
