### PR TITLE
feat(filterFilter): provide support for an array as values to pattern objects

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -128,8 +128,15 @@ function filterFilter() {
         }
       default:
         comperator = function(obj, text) {
+          obj = (''+obj).toLowerCase();
+          if (isArray(text)) {
+            for ( var i = 0; i < text.length; i++ ) {
+              if (obj.indexOf((''+text[i]).toLowerCase()) > -1) return true;
+            }
+            return false;
+          }          
           text = (''+text).toLowerCase();
-          return (''+obj).toLowerCase().indexOf(text) > -1
+          return obj.indexOf(text) > -1
         };
     }
     var search = function(obj, text){


### PR DESCRIPTION
Arrays are now supported for pattern object values of filterFilter. For
example: `ng-repeat="item in items | filter:{name:['alex', 'john',
'simon']}"`

In my example, I use this to filter by "types" from a list of checkboxes. Only the selected "types" are shown.
