### PR TITLE
fix(noConflict): resolve global JSONP conflicts and window.angular cannibalization

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -58,7 +58,7 @@ var /** holds major version number for IE or NaN for real browsers */
 
     _angular          = window.angular,
     /** @name angular */
-    angular           = window.angular || (window.angular = {}),
+    angular           = window.angular = {},
     angularModule,
     nodeName_,
     uid               = ['0', '0', '0'];


### PR DESCRIPTION
Eliminate `window.angular.callbacks` and use random callback handles on `window` to eliminate multiple angular version conflicts.

Also sure to start with an empty `window.angular` object rather than polluting existing `window.angular`. Prior, even though a reference to `window.angular` was kept in a local variable `_angular`, angular would load itself onto `window.angular` anyway polluting `_angular` in the process.

This is a follow-up to this rejected pull request: https://github.com/angular/angular.js/pull/2731 and this thread on the mailing list: https://groups.google.com/forum/?fromgroups#!searchin/angular/noConflict/angular/G8xPyD1F8d0/7m96EbK2l1oJ

Thanks!
Mike
