### PR TITLE
feat(ngValidityChange): create new directive ngValidityChange

### DIFF
--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -100,6 +100,7 @@ function publishExternalAPI(angular){
             ngModel: ngModelDirective,
             ngList: ngListDirective,
             ngChange: ngChangeDirective,
+            ngValidityChange: ngValidityChangeDirective,
             required: requiredDirective,
             ngRequired: requiredDirective,
             ngValue: ngValueDirective

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1206,7 +1206,6 @@ var ngChangeDirective = valueFn({
 /**
  * @ngdoc directive
  * @name ng.directive:ngValidityChange
- * @restrict E
  *
  * @description
  * Evaluate given expression when model validity changes.
@@ -1220,25 +1219,39 @@ var ngChangeDirective = valueFn({
  *   <doc:source>
  *     <script>
  *       function Controller($scope) {
- *         $scope.counter = 0;
+ *         $scope.validityCounter = 0;
  *         $scope.validityChange = function() {
- *           $scope.counter++;
+ *           $scope.validityCounter++;
  *         };
  *       }
  *     </script>
  *     <div ng-controller="Controller">
- *       <input type="checkbox" ng-model="confirmed" required ng-validity-change="validityChange()" id="ng-example1" />
- *       <label for="ng-example1">Confirmed</label><br />
- *       debug = {{confirmed}}<br />
- *       counter = {{counter}}
+ *       <input type="text" ng-model="name" required ng-validity-change="validityChange()" id="name"/>
+ *       <label for="input">First name</label><br />
+ *       debug = {{name}}<br />
+ *       validity changes count = {{validityCounter}}
  *     </div>
  *   </doc:source>
  *   <doc:scenario>
  *     it('should evaluate the expression when the validity changes', function() {
- *       expect(binding('counter')).toEqual('0');
- *       element('#ng-example1').click();
- *       expect(binding('counter')).toEqual('1');
- *       expect(binding('confirmed')).toEqual('true');
+ *       input('name').enter('');
+ *       expect(binding('validityCounter')).toEqual('1');
+ * 
+ *       input('name').enter('Misko');
+ *       expect(binding('validityCounter')).toEqual('2');
+ *       expect(binding('name')).toEqual('Misko');
+ *
+ *       input('name').enter('Vojta');
+ *       expect(binding('validityCounter')).toEqual('2');
+ *       expect(binding('name')).toEqual('Vojta');
+ *
+ *       input('name').enter('Igor');
+ *       expect(binding('validityCounter')).toEqual('2');
+ *       expect(binding('name')).toEqual('Igor');
+ *
+ *       input('name').enter('');
+ *       expect(binding('validityCounter')).toEqual('3');
+ *       expect(binding('name')).toEqual('');
  *     });
  *   </doc:scenario>
  * </doc:example>

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -909,6 +909,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
   this.$parsers = [];
   this.$formatters = [];
   this.$viewChangeListeners = [];
+  this.$validityChangeListeners = [];
   this.$pristine = true;
   this.$dirty = false;
   this.$valid = true;
@@ -988,6 +989,14 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
 
     $error[validationErrorKey] = !isValid;
     toggleValidCss(isValid, validationErrorKey);
+
+    forEach(this.$validityChangeListeners, function(listener) {
+      try {
+        listener();
+      } catch(e) {
+        $exceptionHandler(e);
+      }
+    });
 
     parentForm.$setValidity(validationErrorKey, isValid, this);
   };
@@ -1189,6 +1198,56 @@ var ngChangeDirective = valueFn({
   link: function(scope, element, attr, ctrl) {
     ctrl.$viewChangeListeners.push(function() {
       scope.$eval(attr.ngChange);
+    });
+  }
+});
+
+
+/**
+ * @ngdoc directive
+ * @name ng.directive:ngValidityChange
+ * @restrict E
+ *
+ * @description
+ * Evaluate given expression when model validity changes.
+ *
+ * Note, this directive requires `ngModel` to be present.
+ *
+ * @element input
+ *
+ * @example
+ * <doc:example>
+ *   <doc:source>
+ *     <script>
+ *       function Controller($scope) {
+ *         $scope.counter = 0;
+ *         $scope.validityChange = function() {
+ *           $scope.counter++;
+ *         };
+ *       }
+ *     </script>
+ *     <div ng-controller="Controller">
+ *       <input type="checkbox" ng-model="confirmed" required ng-validity-change="validityChange()" id="ng-example1" />
+ *       <label for="ng-example1">Confirmed</label><br />
+ *       debug = {{confirmed}}<br />
+ *       counter = {{counter}}
+ *     </div>
+ *   </doc:source>
+ *   <doc:scenario>
+ *     it('should evaluate the expression when the validity changes', function() {
+ *       expect(binding('counter')).toEqual('0');
+ *       element('#ng-example1').click();
+ *       expect(binding('counter')).toEqual('1');
+ *       expect(binding('confirmed')).toEqual('true');
+ *     });
+ *   </doc:scenario>
+ * </doc:example>
+ */
+var ngValidityChangeDirective = valueFn({
+  require: 'ngModel',
+  link: function(scope, element, attr, ctrl) {
+    ctrl.$validityChangeListeners.push(function() {
+      scope.$eval(attr.ngValidityChange);
     });
   }
 });

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1142,6 +1142,39 @@ describe('input', function() {
   });
 
 
+  describe('ngValidityChange', function() {
+
+    it('should $eval expression after model validity changes', function() {
+      compileInput('<input type="text" ng-model="value" required ng-validity-change="validityChange()" />');
+
+      scope.validityChange = jasmine.createSpy('validityChange');
+      changeInputValueTo('new value');
+      expect(scope.validityChange).toHaveBeenCalledOnce();
+    });
+
+    it('should not $eval expression twice if validity does not change', function() {
+      compileInput('<input type="text" ng-model="value" required ng-validity-change="validityChange()" />');
+
+      scope.validityChange = jasmine.createSpy('validityChange');
+      changeInputValueTo('first value');
+      changeInputValueTo('new value');
+      expect(scope.validityChange).toHaveBeenCalledOnce();
+    });
+
+    it('should not $eval expression after model changes if validity does not change', function() {
+      compileInput('<input type="text" ng-model="value" required ng-validity-change="validityChange()" />');
+
+      scope.$apply(function() {
+        scope.value = 'valid';
+      });
+      
+      scope.validityChange = jasmine.createSpy('validityChange');
+      changeInputValueTo('new value');
+      expect(scope.validityChange).not.toHaveBeenCalled();
+    });
+  });
+
+
   describe('ngValue', function() {
 
     it('should evaluate and set constant expressions', function() {


### PR DESCRIPTION
ngValidityChange evaluates given expression when model validity changes.

At the moment form validation is mostly done binding the $viewValue via ngChange, checking the model, or binding some events (blur, change) on the DOM element. Those approaches might fail if the validity is set without changing the model, like by a custom directive that update asynchronously the validity.

I made a demo to show how ngChange fail in this use case: http://plnkr.co/edit/8NilSQDuxCz1YvxT78Ip?p=preview

ngValidityChange directive makes form validation very easy allowing developers to be notified on the fly when something happens to the form values.
