### PR TITLE
fix($compile): mark urls unsafe in IE6 and IE7

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -289,6 +289,10 @@ function $CompileProvider($provide) {
 
           // href property always returns normalized absolute url, so we can match against that
           normalizedVal = urlSanitizationNode.href;
+          //except in the case of IE6/7.  The url is missing the protocol and host.
+          if (msie < 8) {
+              normalizedVal = document.location.protocol + '//' + document.location.host + normalizedVal
+          }
           if (!normalizedVal.match(urlSanitizationWhitelist)) {
             this[key] = value = 'unsafe:' + normalizedVal;
           }


### PR DESCRIPTION
IE6 and IE7 do not return absolute URLs when querying the href property.
The white list comparison requires a full URL so this tests for
IE7 and below and adds the protocol and host back to the URL.

Closes #2901
