### PR TITLE
Fix for race condition bug in the "traverse the scopes" loop.

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -520,7 +520,7 @@ function $RootScopeProvider(){
                   watch = watchers[length];
                   // Most common watches are on primitives, in which case we can short
                   // circuit it with === operator, only when === fails do we use .equals
-                  if ((value = watch.get(current)) !== (last = watch.last) &&
+                  if (watch && (value = watch.get(current)) !== (last = watch.last) &&
                       !(watch.eq
                           ? equals(value, last)
                           : (typeof value == 'number' && typeof last == 'number'


### PR DESCRIPTION
Calls to Scope.$watch returns a deregistration function for this listener.

Sometimes a listener may be removed by this function between the call `length = watchers.length;` on line 517 and `watch = watchers[length];` on line 520; in this case, `watch` will be undefined and the call to `watch.get` at line 523 will fail.

This is a real bug and I was bitten when writing a huge directive (using d3.js). The case must be obvious enough and the fix too small to bother creating a reproducible test case - reproducing race conditions is hard and testing for the existence of `watch` before calling `watch.get` will not hurt, anyway. 
