### PR TITLE
Issue #2456 Fix -- number filter handles exponentially small numbers

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -169,6 +169,8 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
     }
 
     if (fractionSize && fractionSize !== "0") formatedText += decimalSep + fraction.substr(0, fractionSize);
+  } else {
+    formatedText = number.toFixed(fractionSize);
   }
 
   parts.push(isNegative ? pattern.negPre : pattern.posPre);

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -145,9 +145,19 @@ describe('filters', function() {
       expect(number(1234.567, 2)).toEqual("1,234.57");
     });
 
-    it('should filter exponential numbers', function() {
+    it('should filter exponentially large numbers', function() {
       expect(number(1e50, 0)).toEqual('1e+50');
       expect(number(-2e50, 2)).toEqual('-2e+50');
+    });
+
+    it('should filter exponentially small numbers', function() {
+      expect(number(1e-50, 0)).toEqual('0');
+      expect(number(1e-6, 6)).toEqual('0.000001');
+      expect(number(1e-7, 6)).toEqual('0.000000');
+
+      expect(number(-1e-50, 0)).toEqual('-0');
+      expect(number(-1e-6, 6)).toEqual('-0.000001');
+      expect(number(-1e-7, 6)).toEqual('-0.000000');
     });
   });
 


### PR DESCRIPTION
When using the number filter with small exponentially small numbers (those in scientific notation), the filter was previously taking no action on the input. 

This would result in output that is not actually filtered to a certain number of decimal places. Since the filter already detects when a number has an exponent, the simplest solution for this was to use toFixed() on the number. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed

Included in this pull request are the updated specs, and the fix to make them pass. Feedback greatly appreciated!

Cheers
