### PR TITLE
fix(chore): Remove code duplication (Issue #2890 Fix)

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -256,12 +256,6 @@ function inherit(parent, extra) {
   return extend(new (extend(function() {}, {prototype:parent}))(), extra);
 }
 
-var START_SPACE = /^\s*/;
-var END_SPACE = /\s*$/;
-function stripWhitespace(str) {
-  return isString(str) ? str.replace(START_SPACE, '').replace(END_SPACE, '') : str;
-}
-
 /**
  * @ngdoc function
  * @name angular.noop


### PR DESCRIPTION
Fixed issue #2890 by removing code duplication.

The stripWhitespace function, which is the exact same as the trim function, is not even used, so it was removed.
