### PR TITLE
fix($location): default to / for the url base if no base[href]

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -496,12 +496,12 @@ function $LocationProvider(){
       function( $rootScope,   $browser,   $sniffer,   $rootElement) {
     var $location,
         LocationMode,
-        baseHref = $browser.baseHref(),
+        baseHref = $browser.baseHref(), // if base[href] is undefined, it defaults to ''
         initialUrl = $browser.url(),
         appBase;
 
     if (html5Mode) {
-      appBase = baseHref ? serverBase(initialUrl) + baseHref : initialUrl;
+      appBase = serverBase(initialUrl) + (baseHref || '/');
       LocationMode = $sniffer.history ? LocationHtml5Url : LocationHashbangInHtml5Url;
     } else {
       appBase = stripHash(initialUrl);

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -635,6 +635,19 @@ describe('$location', function() {
         }
       );
     });
+
+
+    it('should set appBase to serverBase if base[href] is missing', function() {
+      initService(true, '!', true);
+      inject(
+          initBrowser('http://domain.com/my/view1#anchor1', ''),
+          function($rootScope, $location, $browser) {
+            expect($browser.url()).toBe('http://domain.com/my/view1#anchor1');
+            expect($location.path()).toBe('/my/view1');
+            expect($location.hash()).toBe('anchor1');
+          }
+      );
+    });
   });
 
 


### PR DESCRIPTION
With the recent refactoring of $location service we changed this behavior
resulting in a regression.

Previously we thought that html5 mode always required base[href]
to be set in order for urls to resolve properly. It turns out that
base[href] is problematic because it makes anchor urls (#foo) to
always resolve to the base url, which is almost always incorrect
and results in all anchors links and other anchor urls (e.g. svg
references) to be broken.

For this reason, we should now start recommending that people just
deploy to root context (/) and not set the base[href] when using
the html5 mode (push/pop history state).

If it's impossible to deploy to the root context then either all
urls in the app must be absolute or base[href] must be set with the
caveat that anchor urls in such app won't work.

Closes #2762
