### PR TITLE
feat(ngName): allow interpolated name for form controls

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -924,6 +924,23 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
   this.$invalid = false;
   this.$name = $attr.name;
 
+  // model -> value
+  var ctrl = this;
+
+  if (isDefined($attr.ngName)) {
+    ctrl.$name = $scope.$eval($attr.ngName);
+    $attr.$set('name', ctrl.$name);
+    $attr.$observe('ngName', function() {
+      var newName = $scope.$eval($attr.ngName);
+      if (newName != ctrl.$name) {
+        parentForm.$removeControl(ctrl);
+        ctrl.$name = newName;
+        $attr.$set('name', ctrl.$name);
+        parentForm.$addControl(ctrl);
+      }
+    });
+  }
+
   var ngModelGet = $parse($attr.ngModel),
       ngModelSet = ngModelGet.assign;
 
@@ -1062,9 +1079,6 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
       })
     }
   };
-
-  // model -> value
-  var ctrl = this;
 
   $scope.$watch(function ngModelWatch() {
     var value = ngModelGet($scope);


### PR DESCRIPTION
ngName allows forms' fields to set their name dynamically, especially useful with ngRepeat.
Right now is not possible to validate form controls like this: `<input type="text" name="{{field.name}}" ng-model="field.data">`
The current work-around is to use one nested form for each field but indeed it's an hack rather than a solution.

This implementation could be moved inside the directive `ngModel` or within its own directive `ngName`, I left intentionally it in the NgModelController because it's slightly faster, however I can refactor it as you prefer.

this fixes also the issues #1404 and #2426
