### PR TITLE
prevents unwanted opening of the soft keyboard

### DIFF
--- a/src/ngMobile/directive/ngClick.js
+++ b/src/ngMobile/directive/ngClick.js
@@ -135,6 +135,9 @@ ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     // If we didn't find an allowable region, bust the click.
     event.stopPropagation();
     event.preventDefault();
+    
+    // Blur focused form elements
+    event.target && event.target.blur();
   }
 
 


### PR DESCRIPTION
Ghost clicks are busted but the corresponding form elements are still focused. This means that for example on smartphones the soft keyboard will be opened. This pull request prevents the unwanted opening of the soft keyboard.
