### PR TITLE
Support extracting resources from wrapped responses and storing metadata.

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -75,6 +75,10 @@
  *     for the resource-level urls.
  *   - **`isArray`** – {boolean=} – If true then the returned object for this action is an array, see
  *     `returns` section.
+ *   - **`dataKey`** - {string} - If set, resource(s) will be extracted from the specified key in the
+ *     response body.  If `isArray` is also true, any other properties on the response will be copied
+ *     over as members of the Array containing the resulting resources.  Useful for dealing with APIs
+ *     which wrap responses with additional metadata, such as paging, sorting, and so on.
  *   - **`transformRequest`** – `{function(data, headersGetter)|Array.<function(data, headersGetter)>}` –
  *     transform function or an array of such functions. The transform function takes the http
  *     request body and headers and returns its transformed (typically serialized) version.
@@ -459,7 +463,7 @@ angular.module('ngResource', ['ng']).
           var responseErrorInterceptor = action.interceptor && action.interceptor.responseError || undefined;
 
           forEach(action, function(value, key) {
-            if (key != 'params' && key != 'isArray' && key != 'interceptor') {
+            if (key != 'params' && key != 'isArray' && key != 'interceptor' && key != 'dataKey') {
               httpConfig[key] = copy(value);
             }
           });
@@ -469,18 +473,27 @@ angular.module('ngResource', ['ng']).
 
           var promise = $http(httpConfig).then(function(response) {
             var data = response.data,
-                promise = value.$promise;
+                promise = value.$promise,
+                target = data && action.dataKey ? data[action.dataKey] : data;
 
-            if (data) {
+            if (target) {
               if (action.isArray) {
                 value.length = 0;
-                forEach(data, function(item) {
+                forEach(target, function(item) {
                   value.push(new Resource(item));
                 });
               } else {
-                copy(data, value);
+                copy(target, value);
                 value.$promise = promise;
               }
+            }
+
+            if (data && action.dataKey && action.isArray) {
+              forEach(data, function(val, key) {
+                if (key !== action.dataKey) {
+                  value[key] = val;
+                }
+              });
             }
 
             value.$resolved = true;

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1026,4 +1026,49 @@ describe("resource", function() {
       expect(item).toEqualData({id: 'abc'});
     });
   });
+
+  describe('action-level dataKey option', function() {
+    it ('should remove items from a response wrapper if the dataKey option is present', function() {
+      $httpBackend.expect('GET', '/posts/1').respond({
+        post: { id: 1, title: 'hello world' }
+      });
+
+      var Post = $resource('/posts/:id', {id: '@id'}, {
+        get: {
+          method: 'GET',
+          dataKey: 'post'
+        }
+      });
+
+      var post = Post.get({id: 1});
+      $httpBackend.flush();
+      expect(post).toEqualData({id: 1, title: 'hello world'});
+    });
+
+    it ('should copy metadata out to the container when isArray is true', function() {
+      $httpBackend.expect('GET', '/posts').respond({
+        page: 1,
+        page_size: 3,
+        total: 200,
+        posts: [{id: 1}, {id: 2}, {id: 3}]
+      });
+
+      var Post = $resource('/posts/:id', {id: '@id'}, {
+        query: {
+          method: 'GET',
+          isArray: true,
+          dataKey: 'posts'
+        }
+      });
+
+      var posts = Post.query();
+      $httpBackend.flush();
+
+      expect(posts).toEqualData([{id: 1}, {id: 2}, {id: 3}]);
+
+      expect(posts.page).toEqual(1);
+      expect(posts.page_size).toEqual(3);
+      expect(posts.total).toEqual(200);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a `dataKey` option to the `actions` hash passed to `$resource`.

When a dataKey is provided, the resources are extracted from the specified key on the response object.  This is basically the same as providing:

```
transformResponse: function(data, headers) {
    return angular.fromJson(data)[dataKey];
}
```

However, this PR also adds the following functionality:  when a dataKey is provided, and `isArray == true`, any properties on the response object besides the dataKey itself will be copied over to the collection returned.  For example:

```
$resource('/api/items/:id', {id: '@id'}, {
  query: {
    isArray: true,
    dataKey: 'items'
  }
}

/* suppose the server responds with: */
{
  page_size: 3,
  page: 1,
  total_items: 1900,
  items: [ { ... }, { ...} , {... } ]
}

/* in our controller, Items.query() returns an array as expected... */
$scope.items = Items.query();
/* but we can now also access: */
$scope.items.total_items; // 1900
$scope.items.page; // 1
$scope.items.page_size; // 3
```

Obviously this is an issue if your response contains a key that already exists (`length`?).  The alternative is to wrap these items in an object (`$scope.posts.meta.total_items`).  

I've tried to adhere to the contribution guidelines as best I can.  Love to get some feedback or direction on this.  This addresses #1318, and perhaps #412 (although that one seems vaguer to me).
