### PR TITLE
Pick the right attribute value for form.$name if ng-form directive is used as an attribute

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -42,7 +42,7 @@ function FormController(element, attrs) {
       controls = [];
 
   // init state
-  form.$name = attrs.name;
+  form.$name = attrs.name || attrs.ngForm;
   form.$dirty = false;
   form.$pristine = true;
   form.$valid = true;


### PR DESCRIPTION
Pick the right attribute value for form.$name if ng-form directive is used as an attribute.

This is especially important when you want your inner form to be published as a control of its parent form. 

Currently, if you have this code snippet:

``` html
<form name="mainForm">
  <div ng-form="subForm">
    ...
  </div>
</form>
```

-> mainForm.subForm will not be available

---

``` html
<form name="mainForm">
  <div ng-form="whateverValue" name="subForm">
    ...
  </div>
</form>
```

-> while it will work in this case.
