### PR TITLE
Allow promise returned by $http to be decorated

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -168,6 +168,8 @@ function $HttpProvider() {
    */
   var responseInterceptorFactories = this.responseInterceptors = [];
 
+  var promiseDecorators = this.promiseDecorators = [];
+
   this.$get = ['$httpBackend', '$browser', '$cacheFactory', '$rootScope', '$q', '$injector',
       function($httpBackend, $browser, $cacheFactory, $rootScope, $q, $injector) {
 
@@ -703,6 +705,10 @@ function $HttpProvider() {
 
         promise = promise.then(thenFn, rejectFn);
       }
+
+      forEach(promiseDecorators, function(decorator) {
+        decorator(promise);
+      });
 
       promise.success = function(fn) {
         promise.then(function(response) {

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -367,6 +367,20 @@ describe('$http', function() {
         });
       });
     });
+
+    describe('promise decorators', function () {
+      it('should allow decorators to modify the returned promise', function() {
+        module(function($httpProvider) {
+          $httpProvider.promiseDecorators.push(function(promise) {
+            promise.custom = callback;
+          });
+        });
+        inject(function($http) {
+          var promise = $http.get('/url');
+          expect(promise.custom).toBe(callback);
+        });
+      });
+    })
   });
 
 


### PR DESCRIPTION
Exposes a `promiseDecorators` array on `$httpProvider` that can have functions pushed onto it. When `$http` is invoked, each decorator function will be called with the promise object that will be returned to the caller as an argument, allowing the decorator to add "flavor" methods, similar to `success()` and `error()`.

This is an implementation for the issue I created earlier this week, #2982. It's such a small change I figured I'd just throw it out there and see if there's any interest.

If you don't feel like clicking to the issue, here's the rationale: formerly you could decorate the promise object returned by `$http` using a response interceptor, but since the request interceptor refactoring that's no longer possible. This change allows users to add their own application domain–specific handler methods that can integrate with such non-standard cross-cutting concerns as validation and security handling. At present, the only ways to accomplish this are wrapping `$http`, putting it behind a proxy service, or replacing it completely.
