### PR TITLE
fix(ngRepeat): parsing of repeat_expression

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -200,7 +200,7 @@ var ngRepeatDirective = ['$parse', '$animator', function($parse, $animator) {
       return function($scope, $element, $attr){
         var animate = $animator($scope, $attr);
         var expression = $attr.ngRepeat;
-        var match = expression.match(/^\s*(.+)\s+in\s+(.*?)\s*(\s+track\s+by\s+(.+)\s*)?$/),
+        var match = expression.match(/^\s*(.+)\s+in\s+(.*?)\s*(track\s+by\s+(.+?))?(\s*\|.*)?$/),
           trackByExp, trackByExpGetter, trackByIdFn, lhs, rhs, valueIdentifier, keyIdentifier,
           hashFnLocals = {$id: hashKey};
 
@@ -211,6 +211,13 @@ var ngRepeatDirective = ['$parse', '$animator', function($parse, $animator) {
 
         lhs = match[1];
         rhs = match[2];
+
+        // match[5] will contain any remaining filter references (e.g ' | filter:search')
+        // need to append to rhs for proper filtering (if applicable)
+        if (match[5]) {
+            rhs += match[5];
+        }
+
         trackByExp = match[4];
 
         if (trackByExp) {
@@ -282,7 +289,7 @@ var ngRepeatDirective = ['$parse', '$animator', function($parse, $animator) {
            value = collection[key];
            trackById = trackByIdFn(key, value, index);
            if(lastBlockMap.hasOwnProperty(trackById)) {
-             block = lastBlockMap[trackById]
+             block = lastBlockMap[trackById];
              delete lastBlockMap[trackById];
              nextBlockMap[trackById] = block;
              nextBlockOrder[index] = block;

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -67,8 +67,7 @@ describe('ngRepeat', function() {
                                       "<a name='x'>c</a>" +
                                     "</p>";
 
-    var htmlCollection = document.getElementsByTagName('a')
-    scope.items = htmlCollection;
+    scope.items = document.getElementsByTagName('a');
     scope.$digest();
     expect(element.find('li').length).toEqual(3);
     expect(element.text()).toEqual('x;y;x;');
@@ -442,7 +441,7 @@ describe('ngRepeat', function() {
     scope.array = ['b', 'a'];
     scope.$digest();
 
-    var lis = element.find('li');
+    lis = element.find('li');
     expect(lis.eq(0).data('mark')).toEqual('b');
     expect(lis.eq(1).data('mark')).toEqual('a');
   });
@@ -492,7 +491,7 @@ describe('ngRepeat', function() {
 
       scope.items = [];
       scope.$digest();
-      var newElements = element.find('li');
+      newElements = element.find('li');
       expect(newElements.length).toEqual(0);
     });
 
@@ -512,7 +511,7 @@ describe('ngRepeat', function() {
 
       scope.items = [];
       scope.$digest();
-      var newElements = element.find('li');
+      newElements = element.find('li');
       expect(newElements.length).toEqual(0);
     });
 
@@ -548,6 +547,57 @@ describe('ngRepeat', function() {
       expect(newLis[0]).toEqual(lis[2]);
       expect(newLis[1]).toEqual(lis[0]);
       expect(newLis[2]).toEqual(lis[1]);
+    });
+  });
+
+  describe('filter', function() {
+    beforeEach(function() {
+      scope.items = [{
+          name: 'ABC',
+          num: 1
+      }, {
+          name: 'ABD',
+          num: 2
+      }, {
+          name: 'BBC',
+          num: 3
+      }, {
+          name: 'CCC',
+          num: 4
+      }, {
+          name: 'ZBB',
+          num: 5
+      }];
+    });
+
+    it('should pass collection to filter', function() {
+      element = $compile(
+          '<ul>' +
+              '<li ng-repeat="item in items | filter:\'A\'">{{item.name}};</li>' +
+          '</ul>')(scope);
+
+      scope.$digest();
+      expect(element.text()).toEqual('ABC;ABD;');
+    });
+
+    it('should track collection and pass collection to filter', function() {
+      element = $compile(
+          '<ul>' +
+              '<li ng-repeat="item in items track by $id(item) | filter:\'Z\'">{{item.name}};</li>' +
+          '</ul>')(scope);
+
+      scope.$digest();
+      expect(element.text()).toEqual('ZBB;');
+    });
+
+    it('should iterate using key,value and pass collection to filter', function() {
+      element = $compile(
+          '<ul>' +
+              '<li ng-repeat="(key, value) in items | filter:\'C\'">{{value.name}};</li>' +
+          '</ul>')(scope);
+
+      scope.$digest();
+      expect(element.text()).toEqual('ABC;BBC;CCC;');
     });
   });
 });
@@ -691,7 +741,7 @@ describe('ngRepeat ngAnimate', function() {
       $rootScope.$digest();
 
       //the last element gets pushed down when it animates
-      var kids  = element.children();
+      kids  = element.children();
       var first = jqLite(kids[0]);
       var left  = jqLite(kids[1]);
       var right = jqLite(kids[2]);


### PR DESCRIPTION
Tweaked the regex used for tokenizing the repeat_expression.  Subsequently tweaked the assignment to rhs as a result of the new regex.

Closes #3018
