### PR TITLE
Fix to unexpected behavior when passing null to $location.search

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -361,7 +361,7 @@ LocationHashbangInHtml5Url.prototype =
         this.$$search[search] = paramValue;
       }
     } else {
-      this.$$search = isString(search) ? parseKeyValue(search) : search;
+      this.$$search = isString(search) ? parseKeyValue(search) : search || {};
     }
 
     this.$$compose();


### PR DESCRIPTION
When using $location.search, I made an error when attempting to clear a search value:

Erroneous Usage:

```
  $location.search(null);
```

Proper Usage:

```
  $location.search('myParam', null);
```

This winds up setting the entire search object to null and caused errors on subsequent calls to set a search parameter(since it was trying to set it on null).

While this was my accidental misuse of $location.search, I think calling 

```
  $location.search(null);
```

should reset the search object to an empty object. I made this minor change in location.js:

```
  this.$$search = isString(search) ? parseKeyValue(search) : search || {};
```

This way, passing null would wipe out the entire search object. This is a more reasonable behavior than actually setting the search object to null. It also has the added benefit of not yielding difficult-to-trace errors if you later attempt to set a search parameter.
