### PR TITLE
fix(Angular.js): allow query parameter arrays

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -827,29 +827,25 @@ function startingTag(element) {
  */
 function parseKeyValue(/**string*/keyValue) {
   var obj = {}, key_value, key;
-  forEach((keyValue || "").split('&'), function(keyValue){
+  forEach((keyValue || "").split('&'), function(keyValue) {
     if (keyValue) {
       key_value = keyValue.split('=');
       key = decodeURIComponent(key_value[0]);
       
-      if (obj.hasOwnProperty(key) )
-      {
+      if (obj.hasOwnProperty(key)) {
         var innerObj = obj[key];
         var value = isDefined(key_value[1]) ? decodeURIComponent(key_value[1]) : true;
-        if (isArray(innerObj))
-        {
+        if (isArray(innerObj)) {
           innerObj.push(value);                    
         }
-        else
-        {
+        else {
           var newArray = [];
           newArray.push(innerObj);
           newArray.push(value);
           obj[key] = newArray;
         }
       }
-      else
-      {
+      else {
         obj[key] = isDefined(key_value[1]) ? decodeURIComponent(key_value[1]) : true;
       }
     }
@@ -858,11 +854,18 @@ function parseKeyValue(/**string*/keyValue) {
 }
 
 function toKeyValue(obj) {
-  var parts = [];
-  forEach(obj, function(value, key) {
-    parts.push(encodeUriQuery(key, true) + (value === true ? '' : '=' + encodeUriQuery(value, true)));
-  });
-  return parts.length ? parts.join('&') : '';
+    var parts = [];
+    forEach(obj, function(value, key) {
+        if (isArray(value)) {
+            forEach(value, function(arrayValue) {
+                parts.push(encodeUriQuery(key, true) + (arrayValue === true ? '' : '=' + encodeUriQuery(arrayValue, true)));
+            });
+        }
+        else {
+            parts.push(encodeUriQuery(key, true) + (value === true ? '' : '=' + encodeUriQuery(value, true)));
+        }
+    });
+    return parts.length ? parts.join('&') : '';
 }
 
 

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -831,7 +831,27 @@ function parseKeyValue(/**string*/keyValue) {
     if (keyValue) {
       key_value = keyValue.split('=');
       key = decodeURIComponent(key_value[0]);
-      obj[key] = isDefined(key_value[1]) ? decodeURIComponent(key_value[1]) : true;
+      
+      if (obj.hasOwnProperty(key) )
+      {
+        var innerObj = obj[key];
+        var value = isDefined(key_value[1]) ? decodeURIComponent(key_value[1]) : true;
+        if (isArray(innerObj))
+        {
+          innerObj.push(value);                    
+        }
+        else
+        {
+          var newArray = [];
+          newArray.push(innerObj);
+          newArray.push(value);
+          obj[key] = newArray;
+        }
+      }
+      else
+      {
+        obj[key] = isDefined(key_value[1]) ? decodeURIComponent(key_value[1]) : true;
+      }
     }
   });
   return obj;

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -311,6 +311,7 @@ describe('angular', function() {
       expect(parseKeyValue('emptyKey=')).toEqual({emptyKey: ''});
       expect(parseKeyValue('flag1&key=value&flag2')).
       toEqual({flag1: true, key: 'value', flag2: true});
+      expect(parseKeyValue('key=value1&key=value2')).toEqual({key: ['value1','value2]'});
     });
   });
 
@@ -322,6 +323,7 @@ describe('angular', function() {
       expect(toKeyValue({'escaped key': 'escaped value'})).
       toEqual('escaped%20key=escaped%20value');
       expect(toKeyValue({emptyKey: ''})).toEqual('emptyKey=');
+      expect(toKeyValue({key: ['value1','value2]'}).toEqual('key=value1&key=value2');
     });
 
     it('should parse true values into flags', function() {


### PR DESCRIPTION
Allow url?key=value1&key=value2, to be parsed into an object with an array {key: ['value1,'value2']}.
