### PR TITLE
feat(Angular.js): skip JSON.stringify for undefined

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -762,6 +762,7 @@ function toJsonReplacer(key, value) {
  * @returns {string} Jsonified string representing `obj`.
  */
 function toJson(obj, pretty) {
+  if (typeof obj === 'undefined') return undefined;
   return JSON.stringify(obj, toJsonReplacer, pretty ? '  ' : null);
 }
 

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -881,6 +881,10 @@ describe('angular', function() {
     it('should not serialize scope instances', inject(function($rootScope) {
       expect(toJson({key: $rootScope})).toEqual('{"key":"$SCOPE"}');
     }));
+
+    it('should serialize undefined as undefined', function() {
+      expect(toJson(undefined)).toEqual(undefined);
+    });
   });
 
 });


### PR DESCRIPTION
Return early in `angular.toJson` if the object to be stringified is `undefined`.
IE8 stringifies `undefined` to `'undefined'` whereas other browsers return
`undefined`. This normalizes behavior and passes currently broken unit tests
in IE8.
