### PR TITLE
feat(q): make $q.resolve() and $q.reject() return the promise object

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -65,9 +65,9 @@
  * **Methods**
  *
  * - `resolve(value)` – resolves the derived promise with the `value`. If the value is a rejection
- *   constructed via `$q.reject`, the promise will be rejected instead.
+ *   constructed via `$q.reject`, the promise will be rejected instead. Returns the promise object.
  * - `reject(reason)` – rejects the derived promise with the `reason`. This is equivalent to
- *   resolving it with a rejection constructed via `$q.reject`.
+ *   resolving it with a rejection constructed via `$q.reject`. Returns the promise object.
  *
  * **Properties**
  *
@@ -204,11 +204,12 @@ function qFactory(nextTick, exceptionHandler) {
             });
           }
         }
+        return this.promise;
       },
 
 
       reject: function(reason) {
-        deferred.resolve(reject(reason));
+        return deferred.resolve(reject(reason));
       },
 
 

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -251,6 +251,10 @@ describe('q', function() {
         mockNextTick.flush();
         expect(logStr()).toBe('success1(foo); success2(foo)');
       });
+
+      it('should return the promise object', function() {
+        expect(deferred.resolve()).toBe(promise);
+      });
     });
 
 
@@ -337,6 +341,10 @@ describe('q', function() {
         rejector('detached');
         mockNextTick.flush();
         expect(logStr()).toBe('error(detached)');
+      });
+
+      it('should return the promise object', function() {
+        expect(deferred.reject()).toBe(promise);
       });
     });
 


### PR DESCRIPTION
This will allow people to be slightly more elegant:

instead of:

```
var deferred = $q.defer();
deferred.resolve('foobar');
return deferred.promise;
```

we can now do:

```
return $q.defer().resolve('foobar');
```

This also slightly makes `$q.reject()` redundant:

```
return $q.defer().reject('barfoo');
```
