### PR TITLE
Fixed an error in the scope inheritance example.

### DIFF
--- a/docs/content/guide/dev_guide.mvc.understanding_controller.ngdoc
+++ b/docs/content/guide/dev_guide.mvc.understanding_controller.ngdoc
@@ -268,7 +268,7 @@ describe('state', function() {
         var mainCtrl = $controller(MainCtrl, {$scope: mainScope});
         childScope = mainScope.$new();
         var childCtrl = $controller(ChildCtrl, {$scope: childScope});
-        babyScope = childCtrl.$new();
+        babyScope = childScope.$new();
         var babyCtrl = $controller(BabyCtrl, {$scope: babyScope});
     }));
 


### PR DESCRIPTION
The chained scope creation example at the bottom of this document was using the childCtrl to create the babyScope, instead of the childScope.
