### PR TITLE
Make ng-cloak work even when CSS 'display' is set.

### DIFF
--- a/css/angular.css
+++ b/css/angular.css
@@ -2,7 +2,7 @@
 
 [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak],
 .ng-cloak, .x-ng-cloak {
-  display: none;
+  display: none !important;
 }
 
 ng\:form {

--- a/src/ng/directive/ngCloak.js
+++ b/src/ng/directive/ngCloak.js
@@ -17,7 +17,7 @@
  *
  * <pre>
  * [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
- *   display: none;
+ *   display: none !important;
  * }
  * </pre>
  *


### PR DESCRIPTION
Previously an element like
&lt;div class="foo ng-cloak">...&lt;/div>
would still be annoyingly visible if it matched a CSS rule like
.foo { display: inline-block; }, overriding ng-cloak's display: none.
