### PR TITLE
Fix html() set in IE

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -502,7 +502,11 @@ forEach({
     for (var i = 0, childNodes = element.childNodes; i < childNodes.length; i++) {
       JQLiteDealoc(childNodes[i]);
     }
-    element.innerHTML = value;
+    try {
+      element.innerHTML = value;
+    } catch (e) {
+      element.appendChild(value);
+    }
   }
 }, function(fn, name){
   /**


### PR DESCRIPTION
There is an issue here: https://github.com/angular/angular.js/issues/3050.
This commit should fix the IE8 issue.

IE doesn't like using innerHTML as seen here:
http://msdn.microsoft.com/en-us/library/ms532998%28v=vs.85%29.aspx#TOM_Create
