### PR TITLE
Altered description of input(name) selector

### DIFF
--- a/docs/content/guide/dev_guide.e2e-testing.ngdoc
+++ b/docs/content/guide/dev_guide.e2e-testing.ngdoc
@@ -110,16 +110,16 @@ Scopes the next DSL element selection.
 Returns the value of the first binding matching the given `name`.
 
 ## input(name).enter(value)
-Enters the given `value` in the text field with the given `name`.
+Enters the given `value` in the text field with the corresponding ng-model `name`.
 
 ## input(name).check()
-Checks/unchecks the checkbox with the given `name`.
+Checks/unchecks the checkbox with the corresponding ng-model `name`.
 
 ## input(name).select(value)
-Selects the given `value` in the radio button with the given `name`.
+Selects the given `value` in the radio button with the corresponding ng-model `name`.
 
 ## input(name).val()
-Returns the current value of an input field with the given `name`.
+Returns the current value of an input field with the corresponding ng-model `name`.
 
 ## repeater(selector, label).count()
 Returns the number of rows in the repeater matching the given jQuery `selector`. The `label` is


### PR DESCRIPTION
Altered the description of the input selector in order to make it's use clearer. The original description made it seem that you were selecting an input element based upon it's name attribute. In reality, you are selecting an element by the ng-model name.

This became apparent when running new E2E tests. E2E spec file and a print out from my E2E tests available below. 

E2E spec 

``` javascript
input('merchant').enter('bob');
```

Error message printout from console. 

```
 input 'merchant' enter 'bob'
        Selector [ng\:model="merchant"] did not match any elements.
```
