### PR TITLE
fix(jqLite): prepend array in correct order

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -715,12 +715,7 @@ forEach({
     if (element.nodeType === 1) {
       var index = element.firstChild;
       forEach(new JQLite(node), function(child){
-        if (index) {
-          element.insertBefore(child, index);
-        } else {
-          element.appendChild(child);
-          index = child;
-        }
+        element.insertBefore(child, index);
       });
     }
   },

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1078,12 +1078,14 @@ describe('jqLite', function() {
     it('should prepend array to empty in the right order', function() {
       var root = jqLite('<div>');
       expect(root.prepend([a, b, c])).toEqual(root);
-      expect(root.html().toLowerCase()).toEqual('<div>a</div><div>b</div><div>c</div>');
+      expect(root.html().toLowerCase().replace(/\s/g, '')).
+        toEqual('<div>a</div><div>b</div><div>c</div>');
     });
     it('should prepend array to content in the right order', function() {
       var root = jqLite('<div>text</div>');
       expect(root.prepend([a, b, c])).toEqual(root);
-      expect(root.html().toLowerCase()).toEqual('<div>a</div><div>b</div><div>c</div>text');
+      expect(root.html().toLowerCase().replace(/\s/g, '')).
+        toEqual('<div>a</div><div>b</div><div>c</div>text');
     });
   });
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1075,6 +1075,16 @@ describe('jqLite', function() {
       expect(root.prepend('abc')).toEqual(root);
       expect(root.html().toLowerCase()).toEqual('abctext');
     });
+    it('should prepend array to empty in the right order', function() {
+      var root = jqLite('<div>');
+      expect(root.prepend([a, b, c])).toEqual(root);
+      expect(root.html().toLowerCase()).toEqual('<div>a</div><div>b</div><div>c</div>');
+    });
+    it('should prepend array to content in the right order', function() {
+      var root = jqLite('<div>text</div>');
+      expect(root.prepend([a, b, c])).toEqual(root);
+      expect(root.html().toLowerCase()).toEqual('<div>a</div><div>b</div><div>c</div>text');
+    });
   });
 
 


### PR DESCRIPTION
Match jQuery behavior when prepending array into empty element
