### PR TITLE
fix($sniffer): olders Android/Phonegap transitions/animations detection

### DIFF
--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -37,6 +37,11 @@ function $SnifferProvider() {
       }
       transitions = !!(('transition' in bodyStyle) || (vendorPrefix + 'Transition' in bodyStyle));
       animations  = !!(('animation' in bodyStyle) || (vendorPrefix + 'Animation' in bodyStyle));
+
+      if (android && (!transitions||!animations)) {
+        transitions = isString(document.body.style.webkitTransition);
+        animations = isString(document.body.style.webkitAnimation);
+      }
     }
 
 

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -179,6 +179,28 @@ describe('$sniffer', function() {
         expect($sniffer.animations).toBe(true);
       });
     });
+
+    it('should be true on android with older body style properties', function() {
+      module(function($provide) {
+        var doc = {
+          body : {
+            style : {
+              webkitAnimation: ''
+            }
+          }
+        };
+        var win = {
+          navigator: {
+            userAgent: 'android 2'
+          }
+        };
+        $provide.value('$document', jqLite(doc));
+        $provide.value('$window', win);
+      });
+      inject(function($sniffer) {
+        expect($sniffer.animations).toBe(true);
+      });
+    });
   });
 
   describe('transitions', function() {
@@ -232,6 +254,28 @@ describe('$sniffer', function() {
           }
         };
         $provide.value('$document', jqLite(doc));
+      });
+      inject(function($sniffer) {
+        expect($sniffer.transitions).toBe(true);
+      });
+    });
+
+    it('should be true on android with older body style properties', function() {
+      module(function($provide) {
+        var doc = {
+          body : {
+            style : {
+              webkitTransition: ''
+            }
+          }
+        };
+        var win = {
+          navigator: {
+            userAgent: 'android 2'
+          }
+        };
+        $provide.value('$document', jqLite(doc));
+        $provide.value('$window', win);
       });
       inject(function($sniffer) {
         expect($sniffer.transitions).toBe(true);


### PR DESCRIPTION
The stock Android browser doesn't support the current for-in body/style detection but we can manually fix this.
This is useful for Phonegap webviews or traditionnal webapps using the stock browser.
