### PR TITLE
Element data missing during $destroy

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -305,9 +305,12 @@ var ngRepeatDirective = ['$parse', '$animator', function($parse, $animator) {
           for (key in lastBlockMap) {
             if (lastBlockMap.hasOwnProperty(key)) {
               block = lastBlockMap[key];
+
+              // destroy scope before removing element from the DOM.
+              block.scope.$destroy();
+
               animate.leave(block.elements);
               forEach(block.elements, function(element) { element[NG_REMOVED] = true});
-              block.scope.$destroy();
             }
           }
 


### PR DESCRIPTION
Changed the scope destroy to occur before the element is removed
from the DOM.  This will ensure that things like the element.data()
structure aren't destroyed before scope.$destroy() is called.

Related to issue https://github.com/angular/angular.js/issues/2658
