### PR TITLE
test($compile): use FQDN for img[src]

### DIFF
--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2620,21 +2620,21 @@ describe('$compile', function() {
       $rootScope.$apply();
       expect(element.attr('src')).toBe('#foo');
 
-      $rootScope.testUrl = "http://foo/bar";
+      $rootScope.testUrl = "http://foo.com/bar";
       $rootScope.$apply();
-      expect(element.attr('src')).toBe('http://foo/bar');
+      expect(element.attr('src')).toBe('http://foo.com/bar');
 
-      $rootScope.testUrl = " http://foo/bar";
+      $rootScope.testUrl = " http://foo.com/bar";
       $rootScope.$apply();
-      expect(element.attr('src')).toBe(' http://foo/bar');
+      expect(element.attr('src')).toBe(' http://foo.com/bar');
 
-      $rootScope.testUrl = "https://foo/bar";
+      $rootScope.testUrl = "https://foo.com/bar";
       $rootScope.$apply();
-      expect(element.attr('src')).toBe('https://foo/bar');
+      expect(element.attr('src')).toBe('https://foo.com/bar');
 
-      $rootScope.testUrl = "ftp://foo/bar";
+      $rootScope.testUrl = "ftp://foo.com/bar";
       $rootScope.$apply();
-      expect(element.attr('src')).toBe('ftp://foo/bar');
+      expect(element.attr('src')).toBe('ftp://foo.com/bar');
 
       // Fails on IE < 10 with "TypeError: Access is denied" when trying to set img[src]
       if (!msie || msie > 10) {


### PR DESCRIPTION
img[src]="https://foo" has the unfortunate problem that the browser will
actually try retrieving the resource the non FQDN foo.  The local DNS
might suffix a domain to this, resolve it, and try to present a
certificate for the https request and prompt the user to pick a
certificate. This commit avoids that by making foo a FQDN.  Note that it
might be better to replace foo with example.com (ref
http://tools.ietf.org/html/rfc2606#section-3).
