### PR TITLE
chore(gitignore): add .agignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ angular.js.tmproj
 /components/
 angular.xcodeproj
 .idea
+.agignore


### PR DESCRIPTION
I use a .agignore file to skip the build directory and some other files
while searching using Ag (see
https://github.com/ggreer/the_silver_searcher).
