### PR TITLE
Update Angular.js toJson documentation

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -755,7 +755,8 @@ function toJsonReplacer(key, value) {
  * @function
  *
  * @description
- * Serializes input into a JSON-formatted string.
+ * Serializes input into a JSON-formatted string. Properties with leading $ characters will be
+ * stripped since angular uses this notation internally.
  *
  * @param {Object|Array|Date|string|number} obj Input to be serialized into JSON.
  * @param {boolean=} pretty If set to true, the JSON output will contain newlines and whitespace.


### PR DESCRIPTION
I included in angular.toJson's description that any properties with a leading '$' character will be stripped from the result since angular uses this notation internally for services.  There have been complaints of not knowing about this functionality until it breaks within their code.  It would be a nice addition to avoid any confusion in the future.

An example of a documentation update request is within a comment in issue #1463.
