### PR TITLE
feat($parse): implementation of $parse on ngModelController

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1021,18 +1021,42 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
 
   /**
    * @ngdoc function
+   * @name ng.directive:ngModel.NgModelController#parse
+   * @methodOf ng.directive:ngModel.NgModelController
+   *
+   * @description
+   * Parse the arbitrary input value according to the current `$parsers` array, good for
+   * code reuse without acessing the `$parsers` array manually. 
+   * 
+   * This method should be called from inside a directive, that inherits data and configurations
+   * from another directive(s).
+   * 
+   * @param {string=} value Value from the view. If no value is passed, it uses the current $viewValue
+   */
+  this.$parse = function(value) {
+    value = value || this.$viewValue;
+    
+    forEach(this.$parsers, function(fn) {
+      value = fn(value);
+    });
+    
+    return value;
+  };
+      
+  /**
+   * @ngdoc function
    * @name ng.directive:ngModel.NgModelController#$setViewValue
    * @methodOf ng.directive:ngModel.NgModelController
    *
    * @description
-   * Read a value from view.
+   * Set a value on the view.
    *
    * This method should be called from within a DOM event handler.
    * For example {@link ng.directive:input input} or
    * {@link ng.directive:select select} directives call it.
    *
-   * It internally calls all `parsers` and if resulted value is valid, updates the model and
-   * calls all registered change listeners.
+   * It internally calls the `$parse` function that calls all `parsers` and if resulted value is 
+   * valid, updates the model and calls all registered change listeners.
    *
    * @param {string} value Value from the view.
    */
@@ -1046,10 +1070,8 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
       $element.removeClass(PRISTINE_CLASS).addClass(DIRTY_CLASS);
       parentForm.$setDirty();
     }
-
-    forEach(this.$parsers, function(fn) {
-      value = fn(value);
-    });
+  
+    value = this.$parse();
 
     if (this.$modelValue !== value) {
       this.$modelValue = value;

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -182,6 +182,23 @@ describe('NgModelController', function() {
       ctrl.$setViewValue('bbbb');
       expect(ctrl.$modelValue).toBeUndefined();
     });
+    
+    it('should returned the parsed data', function() {
+      ctrl.$setViewValue('aaaa');
+      expect(ctrl.$modelValue).toBe('aaaa');
+
+      // add a validator that will make any input invalid
+      ctrl.$parsers.push(function() {return undefined;});
+      expect(ctrl.$modelValue).toBe('aaaa');
+      expect(ctrl.$parse()).toBeUndefined();
+      expect(ctrl.$parse('aaa')).toBeUndefined();
+      
+      delete ctrl.$parsers[0];
+      
+      ctrl.$parsers.push(function(value) {return value.replace(/a/g, 'b');});
+      expect(ctrl.$parse()).toBe('bbbb');
+      expect(ctrl.$parse('abb')).toBe('bbb');
+    });
 
 
     it('should call parentForm.$setDirty only when pristine', function() {


### PR DESCRIPTION
This addition that promotes code reuse and executing parsers from parent/sibling models. it's merely an exposed function that was took from inside the `$setViewValue`. It's useful to execute the parsers from the current ngModel $viewValue or an arbitrary string, without messing with the `$viewValue` and `$modelValue`, without triggering the events that `$setViewValue` triggers.

For example:

``` js
var test = angular.module('test', []);
test.directive('test', function(){
  return {
    'require': 'ngModel',
    'link': function($scope, $el, attrs, model){
      model.$parsers.push(function(value){
        return value.replace(/-/g, '|');
      });
      model.$setViewValue('loop-hole');
    }
  };
});

test.directive('test2', function(){
  return {
    'require': 'ngModel',
    'template': '<input type="button" data-value="{{x}}" value="{{$parent.value}}">',
    'link': function($scope, $el, attrs, model){
      $scope.x = '';

      $el.on('click', function(){
        $scope.x = model.$parse($el.val()); // arbitrary value, if the value is COOL-GANG, it returns to COOL|GANG
        //$scope.x = model.$parse(); // current $viewValue, loop-hole, that returns loop|hole, which is obviously the current $modelValue, so not much of use
      });
    }
  };
});
```
