### PR TITLE
feat(ngInclude): Added support for selectors #2994

### DIFF
--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -23,6 +23,13 @@
  *
  * @param {string} ngInclude|src angular expression evaluating to URL. If the source is a string constant,
  *                 make sure you wrap it in quotes, e.g. `src="'myPartialTemplate.html'"`.
+ *                 If one or more space characters are included in the string,
+ *                 the portion of the string following the first space is
+ *                 assumed to be a selector that determines a fragment of the
+ *                 content to load, e.g. `src="{{myURL}} + ' div'"`.  If jQuery
+ *                 is available, the selector can be a full jQuery selector,
+ *                 but otherwise it falls back to jqLite which only supports
+ *                 element-name selectors.
  * @param {string=} onload Expression to evaluate when a new partial is loaded.
  *
  * @param {string=} autoscroll Whether `ngInclude` should call {@link ng.$anchorScroll

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -159,6 +159,13 @@ var ngIncludeDirective = ['$http', '$templateCache', '$anchorScroll', '$compile'
           var thisChangeId = ++changeCounter;
 
           if (src) {
+            var selector;
+            var off = src.indexOf(" ");
+            if (off >= 0) {
+              selector = trim(src.slice(off));
+              src = src.slice(0, off);
+            }
+
             $http.get(src, {cache: $templateCache}).success(function(response) {
               if (thisChangeId !== changeCounter) return;
 
@@ -166,7 +173,13 @@ var ngIncludeDirective = ['$http', '$templateCache', '$anchorScroll', '$compile'
               childScope = scope.$new();
               animate.leave(element.contents(), element);
 
-              var contents = jqLite('<div/>').html(response).contents();
+              var contents;
+              if (selector) {
+                  contents = jqLite('<div/>').html(response).find(selector);
+              }
+              else {
+                  contents = jqLite('<div/>').html(response).contents();
+              }
 
               animate.enter(contents, element);
               $compile(contents)(childScope);

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -182,10 +182,9 @@ var ngIncludeDirective = ['$http', '$templateCache', '$anchorScroll', '$compile'
 
               var contents;
               if (selector) {
-                  contents = jqLite('<div/>').html(response).find(selector);
-              }
-              else {
-                  contents = jqLite('<div/>').html(response).contents();
+                contents = jqLite('<div/>').html(response).find(selector);
+              } else {
+                contents = jqLite('<div/>').html(response).contents();
               }
 
               animate.enter(contents, element);

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -295,6 +295,18 @@ describe('ngInclude', function() {
       expect(autoScrollSpy).not.toHaveBeenCalled();
     }));
   });
+
+  it('should work with a selector', inject(putIntoCache('myUrl', '<a>foo {{name}}</a><b>bar {{name}}</b><c>baz {{name}}</c>'),
+      function($rootScope, $compile) {
+    element = jqLite('<ng:include src="url + \' b\'"></ng:include>');
+    jqLite(document.body).append(element);
+    element = $compile(element)($rootScope);
+    $rootScope.name = 'misko';
+    $rootScope.url = 'myUrl';
+    $rootScope.$digest();
+    expect(element.text()).toEqual('bar misko');
+    jqLite(document.body).html('');
+  }));
 });
 
 describe('ngInclude ngAnimate', function() {


### PR DESCRIPTION
Implements optional selector appended to src. If selector is found, uses .find(selector) to filter the result. Because Angular's jqLite/element .find() API, only element-name selectors are available unless jQuery is available with its enhanced .find() API.
