### PR TITLE
feat(ngForm): Supports expressions in form name

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -299,7 +299,7 @@ function FormController(element, attrs) {
     </doc:example>
  */
 var formDirectiveFactory = function(isNgForm) {
-  return ['$timeout', function($timeout) {
+  return ['$timeout', '$parse', function($timeout, $parse) {
     var formDirective = {
       name: 'form',
       restrict: 'E',
@@ -335,13 +335,13 @@ var formDirectiveFactory = function(isNgForm) {
                 alias = attr.name || attr.ngForm;
 
             if (alias) {
-              scope[alias] = controller;
+              $parse(alias).assign(scope, controller);
             }
             if (parentFormCtrl) {
               formElement.on('$destroy', function() {
                 parentFormCtrl.$removeControl(controller);
                 if (alias) {
-                  scope[alias] = undefined;
+                  $parse(alias).assign(scope, undefined);
                 }
                 extend(controller, nullFormCtrl); //stop propagating child destruction handlers upwards
               });

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -72,10 +72,11 @@ describe('form', function() {
   });
 
 
-  it('should allow form name to be an expression', function() {
+  it('should support expression in form name', function() {
     doc = $compile('<form name="obj.myForm"></form>')(scope);
 
-    expect(scope['obj.myForm']).toBeTruthy();
+    expect(scope.obj).toBeDefined();
+    expect(scope.obj.myForm).toBeTruthy();
   });
 
 
@@ -310,6 +311,30 @@ describe('form', function() {
 
       expect(parent.child).toBeUndefined();
       expect(scope.child).toBeUndefined();
+      expect(parent.$error.required).toBe(false);
+    });
+
+
+    it('should deregister a child form whose name is an expression when its DOM is removed', function() {
+      doc = jqLite(
+        '<form name="parent">' +
+          '<div class="ng-form" name="child.form">' +
+          '<input ng:model="modelA" name="inputA" required>' +
+          '</div>' +
+          '</form>');
+      $compile(doc)(scope);
+      scope.$apply();
+
+      var parent = scope.parent,
+        child = scope.child.form;
+
+      expect(parent).toBeDefined();
+      expect(child).toBeDefined();
+      expect(parent.$error.required).toEqual([child]);
+      doc.children().remove(); //remove child
+
+      expect(parent.child).toBeUndefined();
+      expect(scope.child.form).toBeUndefined();
       expect(parent.$error.required).toBe(false);
     });
 


### PR DESCRIPTION
Now it is possible to access a form from a controller using the new `controller as` syntax, without having to access `$scope`:

Old way:

``` html
<div ng-controller="MainCtrl as main">
  <form name="form" ng-submit="main.submit()">
  </form>
</div>
```

...

``` javascript
.controller('MainCtrl', function($scope) {
  this.submit = function() {
    if $scope.form.$valid {
      // do something!
    }
  }
})
```

New way:

``` html
<div ng-controller="MainCtrl as main">
  <form name="main.form" ng-submit="main.submit()">
  </form>
</div>
```

...

``` javascript
.controller('MainCtrl', function() {
  this.submit = function() {
    if this.form.$valid {
      // do something!
    }
  }
})
```
