### PR TITLE
chore(travis): speed up the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ before_script:
   - ./lib/sauce/sauce_connect_setup.sh
   - npm install -g grunt-cli
   - grunt package
-  - grunt webserver > /dev/null &
   - ./lib/sauce/sauce_connect_block.sh
 
 script:
-  - grunt test --reporters dots --browsers SL_Chrome
+  - grunt parallel:travis --reporters dots --browsers SL_Chrome

--- a/karma-shared.conf.js
+++ b/karma-shared.conf.js
@@ -5,6 +5,7 @@ module.exports = function(config) {
     logLevel: config.LOG_INFO,
     logColors: true,
     browsers: ['Chrome'],
+    runnerPort: 0,
 
     // config for Travis CI
     sauceLabs: {

--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -33,11 +33,13 @@ module.exports = {
     var browsers = grunt.option('browsers');
     var reporters = grunt.option('reporters');
     var noColor = grunt.option('no-colors');
+    var port = grunt.option('port');
     var p = spawn('node', ['node_modules/karma/bin/karma', 'start', config,
       singleRun ? '--single-run=true' : '',
       reporters ? '--reporters=' + reporters : '',
       browsers ? '--browsers=' + browsers : '',
-      noColor ? '--no-colors' : ''
+      noColor ? '--no-colors' : '',
+      port ? '--port=' + port : ''
     ]);
     p.stdout.pipe(process.stdout);
     p.stderr.pipe(process.stderr);
@@ -170,5 +172,24 @@ module.exports = {
       }
       next();
     };
-  }
+  },
+
+  parallelTask: function(name) {
+    var args = [name, '--port=' + this.lastParallelTaskPort];
+
+    if (grunt.option('browsers')) {
+      args.push('--browsers=' + grunt.option('browsers'));
+    }
+
+    if (grunt.option('reporters')) {
+      args.push('--reporters=' + grunt.option('reporters'));
+    }
+
+    this.lastParallelTaskPort++;
+
+
+    return {grunt: true, args: args};
+  },
+
+  lastParallelTaskPort: 9876
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "grunt-contrib-compress": "0.4.1",
     "grunt-contrib-connect": "0.1.2",
     "grunt-contrib-copy": "0.4.1",
+    "grunt-parallel": "~0.2.0",
     "jasmine-node": "1.2.3",
     "q": "~0.9.2",
     "q-fs": "0.1.36",


### PR DESCRIPTION
Just wanna see the travis build...
- parallelize the tasks
- cache requests (e2e tests)

This reduces the time from ~18min to ~12min.

It makes the output little messy. We could buffer output of each task and display it once it's fully finished, nicely. I think giving instant feedback is better.

Conflicts:
    Gruntfile.js
    package.json
