### PR TITLE
Doc comment to point out you cannot use `NgModelController` in a directive with an isolated scope

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -843,6 +843,9 @@ var VALID_CLASS = 'ng-valid',
  * specifically does not contain any logic which deals with DOM rendering or listening to
  * DOM events. The `NgModelController` is meant to be extended by other directives where, the
  * directive provides DOM manipulation and the `NgModelController` provides the data-binding.
+ * Note that you cannot use `NgModelController` in a directive with an isolated scope,
+ * as in that case the values would not get propogated to the parent.
+ * 
  *
  * This example shows how to use `NgModelController` with a custom control to achieve
  * data-binding. Notice how different directives (`contenteditable`, `ng-model`, and `required`)


### PR DESCRIPTION
Based on experience and hard learnt fact. Wished it was mentioned in the documentation. 
