### PR TITLE
Makes example directive controller minification-safe

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -269,7 +269,8 @@ Here's an example directive declared with a Directive Definition Object:
       transclude: false,
       restrict: 'A',
       scope: false,
-      controller: function($scope, $element, $attrs, $transclude, otherInjectables) { ... },
+      controller: ["$scope", "$element", "$attrs", "$transclude", "otherInjectables",
+        function($scope, $element, $attrs, $transclude, otherInjectables) { ... }],
       compile: function compile(tElement, tAttrs, transclude) {
         return {
           pre: function preLink(scope, iElement, iAttrs, controller) { ... },


### PR DESCRIPTION
I've helped a few people who were stuck on minification errors with directive controller functions. Most of them are using the first example in "Writing directives (long version)" as a quick reference. I think it would be better to emphasize that the "controller" property needs to be min safe in there, rather than further down.
