### PR TITLE
chore(build): add check for merge conflicts, ddescribe, and iit

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,6 +8,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-contrib-compress');
   grunt.loadNpmTasks('grunt-contrib-jasmine-node');
+  grunt.loadNpmTasks('grunt-ddescribe-iit');
+  grunt.loadNpmTasks('grunt-merge-conflict');
   grunt.loadNpmTasks('grunt-shell');
   grunt.loadNpmTasks('grunt-parallel');
   grunt.loadTasks('lib/grunt');
@@ -194,6 +196,22 @@ module.exports = function(grunt) {
       run: { spec: 'docs/spec' }
     },
 
+    "ddescribe-iit": {
+      files: [
+        'test/**/*.js',
+        '!test/ngScenario/DescribeSpec.js'
+      ]
+    },
+
+    "merge-conflict": {
+      files: [
+        'src/**/*',
+        'test/**/*',
+        'docs/**/*',
+        'css/**/*'
+      ]
+    },
+
     copy: {
       i18n: {
         files: [
@@ -225,5 +243,6 @@ module.exports = function(grunt) {
   grunt.registerTask('test:e2e', ['connect:testserver', 'test:end2end']);
   grunt.registerTask('webserver', ['connect:devserver']);
   grunt.registerTask('package', ['shell:bower','clean', 'buildall', 'minall', 'collect-errors', 'docs', 'copy', 'write', 'compress']);
+  grunt.registerTask('ci-prebuild-checks', ['ddescribe-iit', 'merge-conflict']);
   grunt.registerTask('default', ['package']);
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "showdown": "0.3.1",
     "rewire": "1.1.3",
     "grunt-contrib-jasmine-node": "~0.1.1",
-    "grunt-parallel": "~0.2.0"
+    "grunt-parallel": "~0.2.0",
+    "grunt-ddescribe-iit": "~0.0.1",
+    "grunt-merge-conflict": "~0.0.1"
   },
   "licenses": [
     {


### PR DESCRIPTION
FYI, the build currently fails due to [test/ng/directive/inputSpec.js](https://github.com/angular/angular.js/blob/master/test/ng/directive/inputSpec.js#L993):

```
Running "ddescribe-iit:files" (ddescribe-iit) task
>> test/ng/directive/inputSpec.js has `xit` at line 993
```
