### PR TITLE
feat(input): allow templates on the `name` attribute of an <input>

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -678,7 +678,7 @@ function checkboxInputType(scope, element, attr, ctrl) {
  * {@link ng.directive:input input element}.
  *
  * @param {string} ngModel Assignable angular expression to data-bind to.
- * @param {string=} name Property name of the form under which the control is published.
+ * @param {template} name Property name of the form under which the control is published.
  * @param {string=} required Sets `required` validation error key if the value is not entered.
  * @param {string=} ngRequired Adds `required` attribute and `required` validation constraint to
  *    the element when the ngRequired expression evaluates to true. Use `ngRequired` instead of
@@ -916,8 +916,8 @@ var VALID_CLASS = 'ng-valid',
  * </example>
  *
  */
-var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$parse',
-    function($scope, $exceptionHandler, $attr, $element, $parse) {
+var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$parse', '$interpolate',
+    function($scope, $exceptionHandler, $attr, $element, $parse, $interpolate) {
   this.$viewValue = Number.NaN;
   this.$modelValue = Number.NaN;
   this.$parsers = [];
@@ -927,7 +927,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
   this.$dirty = false;
   this.$valid = true;
   this.$invalid = false;
-  this.$name = $attr.name;
+  this.$name = $interpolate($attr.name || '')($scope) || undefined;
 
   var ngModelGet = $parse($attr.ngModel),
       ngModelSet = ngModelGet.assign;

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -64,6 +64,18 @@ describe('form', function() {
   });
 
 
+  it('should support a template as an alias', function() {
+    scope.alias = 'foo';
+    doc = $compile(
+      '<div ng-form="myForm">' +
+        '<input type="text" name="{{alias}}" ng-model="value"/>' +
+      '</div>')(scope);
+
+    expect(scope.myForm).toBeDefined();
+    expect(scope.myForm.foo).toBeDefined();
+  });
+
+
   it('should publish form to scope when name attr is defined', function() {
     doc = $compile('<form name="myForm"></form>')(scope);
     expect(scope.myForm).toBeTruthy();


### PR DESCRIPTION
Handle the `name` attribute on an `<input>` as a template
