### PR TITLE
Correct verifyNoOutstandingExpectation example

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1318,7 +1318,7 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
    * "afterEach" clause.
    *
    * <pre>
-   *   afterEach($httpBackend.verifyExpectations);
+   *   afterEach($httpBackend.verifyNoOutstandingExpectation);
    * </pre>
    */
   $httpBackend.verifyNoOutstandingExpectation = function() {


### PR DESCRIPTION
The example provided for `ngMock.$httpBackend.verifyNoOutstandingExpectation` suggests calling `$httpBackend.verifyExpectations` which results in an error.
