### PR TITLE
fix(ngMobile): prevent ngClick when item disabled

### DIFF
--- a/src/ngMobile/directive/ngClick.js
+++ b/src/ngMobile/directive/ngClick.js
@@ -44,7 +44,7 @@ ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
   var TAP_DURATION = 750; // Shorter than 750ms is a tap, longer is a taphold or drag.
   var MOVE_TOLERANCE = 12; // 12px seems to work in most mobile browsers.
   var PREVENT_DURATION = 2500; // 2.5 seconds maximum from preventGhostClick call to click
-  var CLICKBUSTER_THRESHOLD = 25; // 25 pixels in any dimension is the limit for busting clicks.
+  var CLICKBUSTER_THRESHOLD = 0; // 25 pixels in any dimension is the limit for busting clicks. WTH ?
 
   var ACTIVE_CLASS_NAME = 'ng-click-active';
   var lastPreventedTime;
@@ -180,6 +180,12 @@ ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
         touchStartX,
         touchStartY;
 
+    function disabled() {
+      // check the HTML disabled attribute
+      var domDisabled = (isDefined(attr.disabled) && attr.disabled!==false);
+      return domDisabled;
+    }
+
     function resetState() {
       tapping = false;
       element.removeClass(ACTIVE_CLASS_NAME);
@@ -234,7 +240,7 @@ ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
 
         scope.$apply(function() {
           // TODO(braden): This is sending the touchend, not a tap or click. Is that kosher?
-          clickHandler(scope, {$event: event});
+          if (!disabled()) clickHandler(scope, {$event: event});
         });
       }
 

--- a/test/ngMobile/directive/ngClickSpec.js
+++ b/test/ngMobile/directive/ngClickSpec.js
@@ -310,4 +310,52 @@ describe('ngClick (mobile)', function() {
   });
 
 
+  describe('disabled state', function() {
+    it('should not trigger click if ngDisabled is true', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-click="event = $event" ng-disabled="disabled"></div>')($rootScope);
+      $rootScope.disabled = true;
+      $rootScope.$digest();
+
+      browserTrigger(element, 'touchstart', [], 10, 10);
+      browserTrigger(element, 'touchend', [], 10, 10);
+
+      expect($rootScope.event).toBeUndefined();
+    }));
+    it('should trigger click if ngDisabled is false', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-click="event = $event" ng-disabled="disabled"></div>')($rootScope);
+      $rootScope.disabled = false;
+      $rootScope.$digest();
+
+      browserTrigger(element, 'touchstart', [], 10, 10);
+      browserTrigger(element, 'touchend', [], 10, 10);
+
+      expect($rootScope.event).toBeDefined();
+    }));
+    it('should not trigger click if regular disabled is true', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-click="event = $event" disabled="true"></div>')($rootScope);
+
+      browserTrigger(element, 'touchstart', [], 10, 10);
+      browserTrigger(element, 'touchend', [], 10, 10);
+
+      expect($rootScope.event).toBeUndefined();
+    }));
+    it('should not trigger click if regular disabled is present', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-click="event = $event" disabled ></div>')($rootScope);
+
+      browserTrigger(element, 'touchstart', [], 10, 10);
+      browserTrigger(element, 'touchend', [], 10, 10);
+
+      expect($rootScope.event).toBeUndefined();
+    }));
+    it('should trigger click if regular disabled is not present', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-click="event = $event" ></div>')($rootScope);
+
+      browserTrigger(element, 'touchstart', [], 10, 10);
+      browserTrigger(element, 'touchend', [], 10, 10);
+
+      expect($rootScope.event).toBeDefined();
+    }));
+  });
+
+
 });


### PR DESCRIPTION
- the ngClick attribute was always triggered, regardless the ngDisabled/disabled attributes
- we now check the ngDisabled status before triggering the original click event
- and also check the DOM disabled attribute to be homogenous with the regular HTML disabled behavior (disable presence makes the element and click disabled)
- deals with #3124 #3132 /cc @shepheb
