### PR TITLE
feat(dateFilter): Add 'EE' formatter for shorter day string

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -205,7 +205,7 @@ function dateGetter(name, size, offset, trim) {
 function dateStrGetter(name, shortForm) {
   return function(date, formats) {
     var value = date['get' + name]();
-    var get = uppercase(shortForm ? ('SHORT' + name) : name);
+    var get = uppercase((shortForm || '') + name);
 
     return formats[get][value];
   };
@@ -230,7 +230,7 @@ var DATE_FORMATS = {
     yy: dateGetter('FullYear', 2, 0, true),
      y: dateGetter('FullYear', 1),
   MMMM: dateStrGetter('Month'),
-   MMM: dateStrGetter('Month', true),
+   MMM: dateStrGetter('Month', 'SHORT'),
     MM: dateGetter('Month', 2, 1),
      M: dateGetter('Month', 1, 1),
     dd: dateGetter('Date', 2),
@@ -247,7 +247,8 @@ var DATE_FORMATS = {
      // we can be just safely rely on using `sss` since we currently don't support single or two digit fractions
    sss: dateGetter('Milliseconds', 3),
   EEEE: dateStrGetter('Day'),
-   EEE: dateStrGetter('Day', true),
+   EEE: dateStrGetter('Day', 'SHORT'),
+    EE: dateStrGetter('Day', 'SHORTER'),
      a: ampmGetter,
      Z: timeZoneGetter
 };
@@ -276,6 +277,7 @@ var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+
  *   * `'d'`: Day in month (1-31)
  *   * `'EEEE'`: Day in Week,(Sunday-Saturday)
  *   * `'EEE'`: Day in Week, (Sun-Sat)
+ *   * `'EE'`: Day in Week, (Su-Sa)
  *   * `'HH'`: Hour in day, padded (00-23)
  *   * `'H'`: Hour in day (0-23)
  *   * `'hh'`: Hour in am/pm, padded (01-12)

--- a/src/ng/locale.js
+++ b/src/ng/locale.js
@@ -50,6 +50,7 @@ function $LocaleProvider(){
         SHORTMONTH:  'Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec'.split(','),
         DAY: 'Sunday,Monday,Tuesday,Wednesday,Thursday,Friday,Saturday'.split(','),
         SHORTDAY: 'Sun,Mon,Tue,Wed,Thu,Fri,Sat'.split(','),
+        SHORTERDAY: 'Su,Mo,Tu,We,Th,Fr,Sa'.split(','),
         AMPMS: ['AM','PM'],
         medium: 'MMM d, y h:mm:ss a',
         short: 'M/d/yy h:mm a',

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -221,6 +221,9 @@ describe('filters', function() {
       expect(date(noon, "yyyy-MM-dd hh=HH:mm:ss.sssaZ")).
                       toEqual('2010-09-03 12=12:05:08.012PM-0500');
 
+      expect(date(noon, "EE, MMM d, yyyy")).
+                      toEqual('Fr, Sep 3, 2010');
+
       expect(date(noon, "EEE, MMM d, yyyy")).
                       toEqual('Fri, Sep 3, 2010');
 


### PR DESCRIPTION
Also added corresponding documentation and tests. Some applications require
more concise calendars. This will also help with directives like UI Bootstap's
Datepicker [1], for example, which only allows you to specify the
"day-header-format" with these pre-defined formatters.

[1] http://angular-ui.github.io/bootstrap/#/datepicker
