### PR TITLE
Added support for ngModel to be used seemless with isolate scope

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -843,10 +843,9 @@ var VALID_CLASS = 'ng-valid',
  * specifically does not contain any logic which deals with DOM rendering or listening to
  * DOM events. The `NgModelController` is meant to be extended by other directives where, the
  * directive provides DOM manipulation and the `NgModelController` provides the data-binding.
- * Note that you cannot use `NgModelController` in a directive with an isolated scope,
- * as, in that case, the `ng-model` value gets put into the isolated scope and does not get
- * propogated to the parent scope.
- * 
+ * If you want to use `NgModelController` in a directive with an isolated scope,
+ * you need to set the `NgModelController` scope to parent `ngModel.$setScope(scope.$parent);` 
+ * from within your directive to ensure that ngModel assigned value is visible outside.  
  *
  * This example shows how to use `NgModelController` with a custom control to achieve
  * data-binding. Notice how different directives (`contenteditable`, `ng-model`, and `required`)
@@ -936,7 +935,21 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
     throw minErr('ngModel')('noass', "Expression '{0}' is non-assignable. Element: {1}", 
         $attr.ngModel, startingTag($element));
   }
-
+  
+  /**
+   * @ngdoc function
+   * @name ng.directive:ngModel.NgModelController#$setScope
+   * @methodOf ng.directive:ngModel.NgModelController
+   *
+   * @description
+   * Sets the scope where the attr.ngModel expression has be getted/setted
+   * Useful for directives with isolate scopes where ngModel expresion 
+   * should be evaluated from the parent scope
+   */  
+  this.$setScope = function(context) {
+     $scope = context;
+  };
+  
   /**
    * @ngdoc function
    * @name ng.directive:ngModel.NgModelController#$render


### PR DESCRIPTION
Fix for https://github.com/angular/angular.js/issues/1924 

Added implementation + Updated documentation.

You no longer need to do 

``` html
<my-component ng-model="$parent.my.model"></my-component>
```

And can instead write directives using isolate scope that behave as you would expect: 

``` html
<my-component ng-model="my.model"></my-component>
```

Additional discussion: https://github.com/angular/angular.js/issues/1924#issuecomment-20547402
