### PR TITLE
Ignore parameters starting with digit in $resource

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -30,9 +30,7 @@
  * and you are ready to get started!
  *
  * @param {string} url A parametrized URL template with parameters prefixed by `:` as in
- *   `/user/:username`. If you are using a URL with a port number (e.g.
- *   `http://example.com:8080/api`), you'll need to escape the colon character before the port
- *   number, like this: `$resource('http://example.com\\:8080/api')`.
+ *   `/user/:username`.
  *
  *   If you are using a url with a suffix, just add the suffix, like this:
  *   `$resource('http://example.com/resource.json')` or `$resource('http://example.com/:id.json')
@@ -346,7 +344,9 @@ angular.module('ngResource', ['ng']).
         var urlParams = self.urlParams = {};
         forEach(url.split(/\W/), function(param){
           if (param && (new RegExp("(^|[^\\\\]):" + param + "(\\W|$)").test(url))) {
-              urlParams[param] = true;
+              if(new RegExp("^[^0-9].*$").test(param)) {
+                  urlParams[param] = true;
+              }
           }
         });
         url = url.replace(/\\:/g, ':');

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -73,6 +73,28 @@ describe("resource", function() {
     R.get({a:6, b:7, c:8});
   });
 
+  it('should ignore parameters starting with digit', function() {
+    var R = $resource('http://www.example.com:8080/Path/:4a/:a');
+
+    $httpBackend.when('GET', 'http://www.example.com:8080/Path/:4a').respond('{}');
+    $httpBackend.when('GET', 'http://www.example.com:8080/Path/:4a/0').respond('{}');
+    $httpBackend.when('GET', 'http://www.example.com:8080/Path/:4a?8080=1').respond('{}');
+
+    R.get({});
+    R.get({a:0});
+    R.get({"8080":1});
+  });
+
+  it('should not ignore parameters that contain digits but do not start with digit', function() {
+    var R = $resource('/Path/:a42');
+
+    $httpBackend.when('GET', '/Path').respond('{}');
+    $httpBackend.when('GET', '/Path/7').respond('{}');
+
+    R.get({});
+    R.get({a42: 7});
+  });
+
   it('should not ignore leading slashes of undefinend parameters that have non-slash trailing sequence', function() {
     var R = $resource('/Path/:a.foo/:b.bar/:c.baz');
 


### PR DESCRIPTION
Currently URLs like http://example.com:8080/some/path
do not work with $resource without tricks because port number
:8080 is handled as path parameter. This commit changes $resource to
ignore parameters that start with a digit. Fixes #1243.
