### PR TITLE
NgModelController demo fix for html injection into contenteditable directive

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -876,7 +876,7 @@ var VALID_CLASS = 'ng-valid',
 
               // Specify how UI should be updated
               ngModel.$render = function() {
-                element.html(ngModel.$viewValue || '');
+                element.text(ngModel.$viewValue || '');
               };
 
               // Listen for change events to enable binding
@@ -887,7 +887,7 @@ var VALID_CLASS = 'ng-valid',
 
               // Write data to the model
               function read() {
-                ngModel.$setViewValue(element.html());
+                ngModel.$setViewValue(element.text());
               }
             }
           };


### PR DESCRIPTION
The 'contenteditable' div and the textarea should be passing their text values between each other not their escaped inner html. This breaks the demo as the 'required' class is not applied when the 'contenteditable' div is cleared.
