### PR TITLE
Small improvement of lists in index page of tutorial

### DIFF
--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -13,23 +13,27 @@
   Work through the tutorial to see how Angular makes browsers smarter — without the use of extensions
   or plug-ins. As you work through the tutorial, you will:
 
-  * See examples of how to use client-side data binding and dependency injection to build dynamic
-  views of data that change immediately in response to user actions.
-  * See how Angular creates listeners on your data without the need for DOM manipulation.
-  * Learn a better, easier way to test your web apps.
-  * Learn how to use Angular services to make common web tasks, such as getting data into your app,
-  easier.
-
+  <ul>
+    <li>See examples of how to use client-side data binding and dependency injection to build dynamic
+      views of data that change immediately in response to user actions.</li>
+    <li>See how Angular creates listeners on your data without the need for DOM manipulation.</li>
+    <li>Learn a better, easier way to test your web apps.</li>
+    <li>Learn how to use Angular services to make common web tasks, such as getting data into your app,
+      easier.</li>
+  </ul>
+  
   And all of this works in any browser without modification to the browser!
 
   When you finish the tutorial you will be able to:
 
-  * Create a dynamic application that works in any browser.
-  * Define the differences between Angular and common JavaScript frameworks.
-  * Understand how data binding works in AngularJS.
-  * Use the angular-seed project to quickly boot-strap your own projects.
-  * Create and run tests.
-  * Identify resources for learning more about AngularJS.
+  <ul>
+    <li>Create a dynamic application that works in any browser.</li>
+    <li>Define the differences between Angular and common JavaScript frameworks.</li>
+    <li>Understand how data binding works in AngularJS.</li>
+    <li>Use the angular-seed project to quickly boot-strap your own projects.</li>
+    <li>Create and run tests.</li>
+    <li>Identify resources for learning more about AngularJS.</li>
+  </ul>
 
   The tutorial guides you through the entire process of building a simple application, including
   writing and running unit and end-to-end tests. Experiments at the end of each step provide

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -3,6 +3,15 @@
 ////////////////////////////////////
 
 /**
+ * hasOwnProperty may be overriden by a property of the same name, or entirely
+ * absent from an object that does not inherit Object.prototype; this copy is
+ * used instead
+ */
+var hasOwnProperty = function(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+};
+
+/**
  * @ngdoc function
  * @name angular.lowercase
  * @function
@@ -685,7 +694,7 @@ function equals(o1, o2) {
           keySet[key] = true;
         }
         for(key in o2) {
-          if (!keySet[key] &&
+          if (!keySet.hasOwnProperty(key) &&
               key.charAt(0) !== '$' &&
               o2[key] !== undefined &&
               !isFunction(o2[key])) return false;

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -270,6 +270,14 @@ describe('angular', function() {
       expect(equals(new Date(0), 0)).toBe(false);
       expect(equals(0, new Date(0))).toBe(false);
     });
+
+    it('should correctly test for keys that are present on Object.prototype', function() {
+      // MS IE8 just doesn't work for this kind of thing, since "for ... in" doesn't return
+      // things like hasOwnProperty even if it is explicitly defined on the actual object!
+      if (msie<=8) return;
+      expect(equals({}, {hasOwnProperty: 1})).toBe(false);
+      expect(equals({}, {toString: null})).toBe(false);
+    });
   });
 
   describe('size', function() {


### PR DESCRIPTION
The bullet list looks fine in the source version, but in html the line breaks get lost. I replaced the stars with a regular html unordered list
