### PR TITLE
docs(overview) - fix typo in overview doc

### DIFF
--- a/docs/content/guide/overview.ngdoc
+++ b/docs/content/guide/overview.ngdoc
@@ -134,7 +134,7 @@ These input widgets look normal enough, but consider these points:
     Model-View-Controller design pattern.
   * Note that the HTML widget {@link api/ng.directive:input input}
     has special powers. The input invalidates itself by turning red when you enter invalid data or
-    leave the the input fields blank. These new widget behaviors make it easier to implement field
+    leave the input fields blank. These new widget behaviors make it easier to implement field
     validation common in CRUD applications.
 
 And finally, the mysterious `{{ double curly braces }}`:


### PR DESCRIPTION
Removed repeated "the" in the sentence: The input invalidates itself by turning red when you enter invalid data or leave "the" the input fields blank (Line 137).
