### PR TITLE
chore(scenario): reduce duplication of Describe by Runner

### DIFF
--- a/src/ngScenario/Describe.js
+++ b/src/ngScenario/Describe.js
@@ -42,6 +42,12 @@ angular.scenario.Describe.id = 0;
 // Shared Unique ID generator for every it (spec)
 angular.scenario.Describe.specId = 0;
 
+// Methods that lead to a new describe
+angular.scenario.Describe.traversalMethods = [];
+
+// Methods that run on the current describe
+angular.scenario.Describe.nonTraversalMethods = [];
+
 /**
  * Defines a block to execute before each it or nested describe.
  *
@@ -50,6 +56,7 @@ angular.scenario.Describe.specId = 0;
 angular.scenario.Describe.prototype.beforeEach = function(body) {
   this.beforeEachFns.push(body);
 };
+angular.scenario.Describe.nonTraversalMethods.push('beforeEach');
 
 /**
  * Defines a block to execute after each it or nested describe.
@@ -59,6 +66,7 @@ angular.scenario.Describe.prototype.beforeEach = function(body) {
 angular.scenario.Describe.prototype.afterEach = function(body) {
   this.afterEachFns.push(body);
 };
+angular.scenario.Describe.nonTraversalMethods.push('afterEach');
 
 /**
  * Creates a new describe block that's a child of this one.
@@ -71,6 +79,7 @@ angular.scenario.Describe.prototype.describe = function(name, body) {
   this.children.push(child);
   body.call(child);
 };
+angular.scenario.Describe.traversalMethods.push('describe');
 
 /**
  * Same as describe() but makes ddescribe blocks the only to run.
@@ -84,11 +93,13 @@ angular.scenario.Describe.prototype.ddescribe = function(name, body) {
   this.children.push(child);
   body.call(child);
 };
+angular.scenario.Describe.traversalMethods.push('ddescribe');
 
 /**
  * Use to disable a describe block.
  */
 angular.scenario.Describe.prototype.xdescribe = noop;
+angular.scenario.Describe.traversalMethods.push('xdescribe');
 
 /**
  * Defines a test.
@@ -107,6 +118,7 @@ angular.scenario.Describe.prototype.it = function(name, body) {
     after: this.setupAfter
   });
 };
+angular.scenario.Describe.nonTraversalMethods.push('it');
 
 /**
  * Same as it() but makes iit tests the only test to run.
@@ -118,11 +130,13 @@ angular.scenario.Describe.prototype.iit = function(name, body) {
   this.it.apply(this, arguments);
   this.its[this.its.length-1].only = true;
 };
+angular.scenario.Describe.nonTraversalMethods.push('iit');
 
 /**
  * Use to disable a test block.
  */
 angular.scenario.Describe.prototype.xit = noop;
+angular.scenario.Describe.nonTraversalMethods.push('xit');
 
 /**
  * Gets an array of functions representing all the tests (recursively).

--- a/src/ngScenario/Describe.js
+++ b/src/ngScenario/Describe.js
@@ -88,7 +88,7 @@ angular.scenario.Describe.prototype.ddescribe = function(name, body) {
 /**
  * Use to disable a describe block.
  */
-angular.scenario.Describe.prototype.xdescribe = angular.noop;
+angular.scenario.Describe.prototype.xdescribe = noop;
 
 /**
  * Defines a test.
@@ -122,7 +122,7 @@ angular.scenario.Describe.prototype.iit = function(name, body) {
 /**
  * Use to disable a test block.
  */
-angular.scenario.Describe.prototype.xit = angular.noop;
+angular.scenario.Describe.prototype.xit = noop;
 
 /**
  * Gets an array of functions representing all the tests (recursively).

--- a/src/ngScenario/Runner.js
+++ b/src/ngScenario/Runner.js
@@ -11,18 +11,14 @@ angular.scenario.Runner = function($window) {
   this.$window = $window;
   this.rootDescribe = new angular.scenario.Describe();
   this.currentDescribe = this.rootDescribe;
-  this.api = {
-    it: this.it,
-    iit: this.iit,
-    xit: angular.noop,
-    describe: this.describe,
-    ddescribe: this.ddescribe,
-    xdescribe: angular.noop,
-    beforeEach: this.beforeEach,
-    afterEach: this.afterEach
-  };
-  angular.forEach(this.api, angular.bind(this, function(fn, key) {
-    this.$window[key] = angular.bind(this, fn);
+
+  this.api = {};
+  var methods = [];
+  methods = methods.concat(angular.scenario.Describe.traversalMethods);
+  methods = methods.concat(angular.scenario.Describe.nonTraversalMethods);
+  angular.forEach(methods, angular.bind(this, function(key) {
+    this.api[key] = this[key];
+    this.$window[key] = angular.bind(this, this[key]);
   }));
 };
 
@@ -55,95 +51,26 @@ angular.scenario.Runner.prototype.on = function(eventName, listener) {
   this.listeners[eventName].push(listener);
 };
 
-/**
- * Defines a describe block of a spec.
- *
- * @see Describe.js
- *
- * @param {string} name Name of the block
- * @param {function()} body Body of the block
- */
-angular.scenario.Runner.prototype.describe = function(name, body) {
-  var self = this;
-  this.currentDescribe.describe(name, function() {
-    var parentDescribe = self.currentDescribe;
-    self.currentDescribe = this;
-    try {
-      body.call(this);
-    } finally {
-      self.currentDescribe = parentDescribe;
-    }
-  });
-};
+forEach(angular.scenario.Describe.traversalMethods, function(method) {
+  angular.scenario.Runner.prototype[method] = function(name, body) {
+    var self = this;
+    this.currentDescribe[method](name, function() {
+      var parentDescribe = self.currentDescribe;
+      self.currentDescribe = this;
+      try {
+        body.call(this);
+      } finally {
+        self.currentDescribe = parentDescribe;
+      }
+    });
+  };
+});
 
-/**
- * Same as describe, but makes ddescribe the only blocks to run.
- *
- * @see Describe.js
- *
- * @param {string} name Name of the block
- * @param {function()} body Body of the block
- */
-angular.scenario.Runner.prototype.ddescribe = function(name, body) {
-  var self = this;
-  this.currentDescribe.ddescribe(name, function() {
-    var parentDescribe = self.currentDescribe;
-    self.currentDescribe = this;
-    try {
-      body.call(this);
-    } finally {
-      self.currentDescribe = parentDescribe;
-    }
-  });
-};
-
-/**
- * Defines a test in a describe block of a spec.
- *
- * @see Describe.js
- *
- * @param {string} name Name of the block
- * @param {function()} body Body of the block
- */
-angular.scenario.Runner.prototype.it = function(name, body) {
-  this.currentDescribe.it(name, body);
-};
-
-/**
- * Same as it, but makes iit tests the only tests to run.
- *
- * @see Describe.js
- *
- * @param {string} name Name of the block
- * @param {function()} body Body of the block
- */
-angular.scenario.Runner.prototype.iit = function(name, body) {
-  this.currentDescribe.iit(name, body);
-};
-
-/**
- * Defines a function to be called before each it block in the describe
- * (and before all nested describes).
- *
- * @see Describe.js
- *
- * @param {function()} Callback to execute
- */
-angular.scenario.Runner.prototype.beforeEach = function(body) {
-  this.currentDescribe.beforeEach(body);
-};
-
-/**
- * Defines a function to be called after each it block in the describe
- * (and before all nested describes).
- *
- * @see Describe.js
- *
- * @param {function()} Callback to execute
- */
-angular.scenario.Runner.prototype.afterEach = function(body) {
-  this.currentDescribe.afterEach(body);
-};
+forEach(angular.scenario.Describe.nonTraversalMethods, function(method) {
+  angular.scenario.Runner.prototype[method] = function() {
+    this.currentDescribe[method].apply(this.currentDescribe, arguments);
+  };
+});
 
 /**
  * Creates a new spec runner.


### PR DESCRIPTION
Runner has a lot of boilerplate code to a) update current describe, and b) delegate calls to the current describe. Abstract these out with factories.

By doing so, we also prevent Runner from second-guessing Describe's implementation (eg. marking methods as `noop`), which breaks abstraction.

Additionally, this pull request contains a bug fix for Describe (patch 1), which was revealed now that Runner's wrapping of Describe was made even thinner.
