### PR TITLE
fix(ngdocs): move duplicate 'class' attribute

### DIFF
--- a/docs/src/templates/index.html
+++ b/docs/src/templates/index.html
@@ -263,7 +263,7 @@
             </ul>
 
 
-            <ul class="nav nav-list well" ng-repeat="module in modules track by module.url" class="api-list-item">
+            <ul class="nav nav-list well api-list-item" ng-repeat="module in modules track by module.url">
               <li class="nav-header module">
                 <a class="guide" href="{{URL.module}}">module</a>
                 <a class="code" href="{{module.url}}">{{module.name}}</a>


### PR DESCRIPTION
Contents of two 'class' attributes combined into one.
