### PR TITLE
Export buildUrl in the global angular namespace

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1140,3 +1140,21 @@ function getter(obj, path, bindFnToScope) {
   }
   return obj;
 }
+
+function buildUrl(url, params) {
+  if (!params) return url;
+  var parts = [];
+  forEachSorted(params, function(value, key) {
+    if (value == null || value == undefined) return;
+    if (!isArray(value)) value = [value];
+
+    forEach(value, function(v) {
+      if (isObject(v)) {
+        v = toJson(v);
+      }
+      parts.push(encodeUriQuery(key) + '=' +
+        encodeUriQuery(v));
+    });
+  });
+  return url + ((url.indexOf('?') == -1) ? '?' : '&') + parts.join('&');
+}

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -25,6 +25,7 @@ var version = {
 function publishExternalAPI(angular){
   extend(angular, {
     'bootstrap': bootstrap,
+    'buildUrl' : buildUrl,
     'copy': copy,
     'extend': extend,
     'equals': equals,

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -997,26 +997,5 @@ function $HttpProvider() {
         if (idx !== -1) $http.pendingRequests.splice(idx, 1);
       }
     }
-
-
-    function buildUrl(url, params) {
-          if (!params) return url;
-          var parts = [];
-          forEachSorted(params, function(value, key) {
-            if (value == null || value == undefined) return;
-            if (!isArray(value)) value = [value];
-
-            forEach(value, function(v) {
-              if (isObject(v)) {
-                v = toJson(v);
-              }
-              parts.push(encodeUriQuery(key) + '=' +
-                         encodeUriQuery(v));
-            });
-          });
-          return url + ((url.indexOf('?') == -1) ? '?' : '&') + parts.join('&');
-        }
-
-
   }];
 }


### PR DESCRIPTION
buildUrl could be used outside of $http too, for example if the user needs
to create urls for APIs that are not natively supported in angular (EventSource for ex.)

potentionally if it's not hidden in a closure inside $http,
it might be used in other parts of angular too
