### PR TITLE
feat(ngMobile): trigger ngClick event on element

### DIFF
--- a/src/ngMobile/directive/ngClick.js
+++ b/src/ngMobile/directive/ngClick.js
@@ -234,6 +234,7 @@ ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
 
         scope.$apply(function() {
           // TODO(braden): This is sending the touchend, not a tap or click. Is that kosher?
+          angular.element(tapElement).triggerHandler('ngClick', event);
           clickHandler(scope, {$event: event});
         });
       }


### PR DESCRIPTION
With this patch, people can bind to the 'ngClick'
event in directives so that they can run code
on the non native mobile tap/click event which
is controlled by the click directive from the
ngMobile module.

Fixes #3218
