### PR TITLE
fixes tutorial lists markdown

### DIFF
--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -12,27 +12,27 @@ details for any device.
 Work through the tutorial to see how Angular makes browsers smarter — without the use of extensions
 or plug-ins. As you work through the tutorial, you will:
 
-* See examples of how to use client-side data binding and dependency injection to build dynamic
-views of data that change immediately in response to user actions.
-* See how Angular creates listeners on your data without the need for DOM manipulation.
-* Learn a better, easier way to test your web apps.
-* Learn how to use Angular services to make common web tasks, such as getting data into your app,
-easier.
+ * See examples of how to use client-side data binding and dependency injection to build dynamic views of data that change immediately in response to user actions.
+ * See how Angular creates listeners on your data without the need for DOM manipulation.
+ * Learn a better, easier way to test your web apps.
+ * Learn how to use Angular services to make common web tasks, such as getting data into your app, easier.
 
 And all of this works in any browser without modification to the browser!
 
+
 When you finish the tutorial you will be able to:
 
-* Create a dynamic application that works in any browser.
-* Define the differences between Angular and common JavaScript frameworks.
-* Understand how data binding works in AngularJS.
-* Use the angular-seed project to quickly boot-strap your own projects.
-* Create and run tests.
-* Identify resources for learning more about AngularJS.
+ * Create a dynamic application that works in any browser.
+ * Define the differences between Angular and common JavaScript frameworks.
+ * Understand how data binding works in AngularJS.
+ * Use the angular-seed project to quickly boot-strap your own projects.
+ * Create and run tests.
+ * Identify resources for learning more about AngularJS.
 
 The tutorial guides you through the entire process of building a simple application, including
 writing and running unit and end-to-end tests. Experiments at the end of each step provide
 suggestions for you to learn more about AngularJS and the application you are building.
+
 
 You can go through the whole tutorial in a couple of hours or you may want to spend a pleasant day
 really digging into it. If you're looking for a shorter introduction to AngularJS, check out the


### PR DESCRIPTION
I visited http://docs.angularjs.org/tutorial and noticed that lists were marked with \* only.
