### PR TITLE
chore(gitignore): add libpeerconnection.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ angular.js.tmproj
 angular.xcodeproj
 .idea
 .agignore
+libpeerconnection.log


### PR DESCRIPTION
Google chrome (when tested using karma) spits out a log file called libpeerconnection.log
