### PR TITLE
fix select: with ngOptions and ngMultiple

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -231,7 +231,15 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
         });
       }
 
-      if (optionsExp) Options(scope, element, ngModelCtrl);
+
+      if (optionsExp) {
+        scope.$watch(function() {
+          return jqLite(element).attr('multiple');
+        }, function(newMultiple) {
+          multiple = newMultiple;
+        });
+        Options(scope, element, ngModelCtrl);
+      }
       else if (multiple) Multiple(scope, element, ngModelCtrl);
       else Single(scope, element, ngModelCtrl, selectCtrl);
 

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -490,6 +490,14 @@ describe('select', function() {
       }, blank, unknown);
     }
 
+    function createNgMultiSelect(blank, unknown) {
+      createSelect({
+          'ng-model':'selected',
+          'ng-multiple':'multi',
+          'ng-options':'value.id as value.name for value in values'
+      }, blank, unknown);
+    }
+
 
     it('should throw when not formated "? for ? in ?"', function() {
       expect(function() {
@@ -1105,6 +1113,37 @@ describe('select', function() {
         expect(element.find('option').length).toEqual(2);
         expect(element.find('option')[0].selected).toBeTruthy();
         expect(element.find('option')[1].selected).toBeTruthy();
+      });
+
+      it('should work with ng-multiple and ng-options', function(){
+        createNgMultiSelect();
+
+        scope.$apply(function(){
+          scope.values = [{name: 'A', id: 'A'}, {name: 'B', id: 'A'}];
+          scope.selected = [];
+          scope.multi = false;
+        });
+
+        expect(element.attr('multiple')).toBeFalsy();
+
+        scope.$apply(function(){
+          scope.multi = true;
+        });
+
+        expect(element.attr('multiple')).toBeTruthy();
+
+        element.find('option')[0].selected = true;
+        element.find('option')[1].selected = true;
+        browserTrigger(element, 'change');
+
+        expect(scope.selected.length).toBe(2);
+
+        scope.$apply(function(){
+          scope.selected = ['A'];
+        });
+
+        expect(element.find('option')[0].selected).toBeTruthy();
+        expect(element.find('option')[1].selected).toBeFalsy();
       });
 
 


### PR DESCRIPTION
This is, I think, a fix for issue #2113 (https://github.com/angular/angular.js/issues/2113)

Previously, <select ngMultiple='...'> would only work with hard-coded
<option> elements underneath, not with ngOptions attribute. This is
because the boolean attribute is only actually applied inside a
scope.$watch, which happens after the link function for select is called.

The fix is to scope.$watch on the multiple attribute in the select
directive, and refresh the directive when it changes.

The problem is demonstrated with these two plunks:
Before patch: http://plnkr.co/edit/YCiJYpx5tq0pdc8Bp7Nb?p=preview
After patch: http://plnkr.co/edit/hyi91xNSgg3cQ96jCBPy?p=preview

I've signed the online contributor licence form, but I'm not sure how to link it with this pull request.

EDIT: At least on my machine, one of the unit tests fails: "filters date should support various iso8061 date strings with timezone as input". It came that way when I downloaded it before I made any changes, I promise!
