### PR TITLE
Added support for numerical ngTrueValue and ngFalseValue attributes

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -663,12 +663,13 @@ function checkboxInputType(scope, element, attr, ctrl) {
   });
 }
 
-function typedValue(val, defaultVal) {
-  return isString(val)
-    ? !isNaN(parseFloat(val)) && isFinite(val)
-      ? parseFloat(val)
-      : val
-    : defaultVal;
+function typedValue(value, defaultValue) {
+  if(isString(value)) {
+      var number = parseFloat(value);
+      return !isNaN(number) && isFinite(number) ? number : value;
+  } else {
+      return defaultValue;
+  }
 }
 
 /**

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -340,8 +340,8 @@ var inputType = {
    *
    * @param {string} ngModel Assignable angular expression to data-bind to.
    * @param {string=} name Property name of the form under which the control is published.
-   * @param {string=} ngTrueValue The value to which the expression should be set when selected.
-   * @param {string=} ngFalseValue The value to which the expression should be set when not selected.
+   * @param {string=} ngTrueValue The string or number value to which the expression should be set when selected.
+   * @param {string=} ngFalseValue The string or number value to which the expression should be set when not selected.
    * @param {string=} ngChange Angular expression to be executed when input changes due to user
    *    interaction with the input element.
    *

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -641,11 +641,8 @@ function radioInputType(scope, element, attr, ctrl) {
 }
 
 function checkboxInputType(scope, element, attr, ctrl) {
-  var trueValue = attr.ngTrueValue,
-      falseValue = attr.ngFalseValue;
-
-  if (!isString(trueValue)) trueValue = true;
-  if (!isString(falseValue)) falseValue = false;
+  var trueValue = typedValue(attr.ngTrueValue, true),
+      falseValue = typedValue(attr.ngFalseValue, false);
 
   element.on('click', function() {
     scope.$apply(function() {
@@ -666,6 +663,13 @@ function checkboxInputType(scope, element, attr, ctrl) {
   });
 }
 
+function typedValue(val, defaultVal) {
+  return isString(val)
+    ? !isNaN(parseFloat(val)) && isFinite(val)
+      ? parseFloat(val)
+      : val
+    : defaultVal;
+}
 
 /**
  * @ngdoc directive

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -876,7 +876,7 @@ describe('input', function() {
     });
 
 
-    it('should allow custom enumeration', function() {
+    it('should allow custom string enumeration', function() {
       compileInput('<input type="checkbox" ng-model="name" ng-true-value="y" ' +
           'ng-false-value="n">');
 
@@ -902,6 +902,31 @@ describe('input', function() {
       expect(scope.name).toEqual('n');
     });
 
+      it('should allow custom numerical enumeration', function() {
+        compileInput('<input type="checkbox" ng-model="name" ng-true-value="1" ' +
+            'ng-false-value="0">');
+
+        scope.$apply(function() {
+          scope.name = 1;
+        });
+        expect(inputElm[0].checked).toBe(true);
+
+        scope.$apply(function() {
+          scope.name = 0;
+        });
+        expect(inputElm[0].checked).toBe(false);
+
+        scope.$apply(function() {
+          scope.name = 'something else';
+        });
+        expect(inputElm[0].checked).toBe(false);
+
+        browserTrigger(inputElm, 'click');
+        expect(scope.name).toEqual(1);
+
+        browserTrigger(inputElm, 'click');
+        expect(scope.name).toEqual(0);
+      });
 
     it('should be required if false', function() {
       compileInput('<input type="checkbox" ng:model="value" required />');

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -876,33 +876,62 @@ describe('input', function() {
     });
 
 
-    it('should allow custom string enumeration', function() {
-      compileInput('<input type="checkbox" ng-model="name" ng-true-value="y" ' +
-          'ng-false-value="n">');
+    describe('should allow custom string enumeration', function() {
+      it('with non empty strings', function() {
+        compileInput('<input type="checkbox" ng-model="name" ng-true-value="y" ' +
+            'ng-false-value="n">');
 
-      scope.$apply(function() {
-        scope.name = 'y';
+        scope.$apply(function() {
+          scope.name = 'y';
+        });
+        expect(inputElm[0].checked).toBe(true);
+
+        scope.$apply(function() {
+          scope.name = 'n';
+        });
+        expect(inputElm[0].checked).toBe(false);
+
+        scope.$apply(function() {
+          scope.name = 'something else';
+        });
+        expect(inputElm[0].checked).toBe(false);
+
+        browserTrigger(inputElm, 'click');
+        expect(scope.name).toEqual('y');
+
+        browserTrigger(inputElm, 'click');
+        expect(scope.name).toEqual('n');
       });
-      expect(inputElm[0].checked).toBe(true);
 
-      scope.$apply(function() {
-        scope.name = 'n';
-      });
-      expect(inputElm[0].checked).toBe(false);
+      it('with empty strings', function() {
+        compileInput('<input type="checkbox" ng-model="name" ng-true-value="something" ' +
+            'ng-false-value="">');
 
-      scope.$apply(function() {
-        scope.name = 'something else';
-      });
-      expect(inputElm[0].checked).toBe(false);
+        scope.$apply(function() {
+          scope.name = 'something';
+        });
+        expect(inputElm[0].checked).toBe(true);
 
-      browserTrigger(inputElm, 'click');
-      expect(scope.name).toEqual('y');
+        scope.$apply(function() {
+          scope.name = '';
+        });
+        expect(inputElm[0].checked).toBe(false);
 
-      browserTrigger(inputElm, 'click');
-      expect(scope.name).toEqual('n');
+        scope.$apply(function() {
+          scope.name = 'something else';
+        });
+        expect(inputElm[0].checked).toBe(false);
+
+        browserTrigger(inputElm, 'click');
+        expect(scope.name).toEqual('something');
+
+        browserTrigger(inputElm, 'click');
+          expect(scope.name).toEqual('');
+        });
     });
 
-      it('should allow custom numerical enumeration', function() {
+    describe('should allow custom numerical enumeration', function() {
+      it('with positive numbers', function() {
         compileInput('<input type="checkbox" ng-model="name" ng-true-value="1" ' +
             'ng-false-value="0">');
 
@@ -927,6 +956,85 @@ describe('input', function() {
         browserTrigger(inputElm, 'click');
         expect(scope.name).toEqual(0);
       });
+
+      it('with negative numbers', function() {
+        compileInput('<input type="checkbox" ng-model="name" ng-true-value="-1" ' +
+            'ng-false-value="-0">');
+
+        scope.$apply(function() {
+          scope.name = -1;
+        });
+        expect(inputElm[0].checked).toBe(true);
+
+        scope.$apply(function() {
+          scope.name = 0;
+        });
+        expect(inputElm[0].checked).toBe(false);
+
+        scope.$apply(function() {
+          scope.name = 'something else';
+        });
+        expect(inputElm[0].checked).toBe(false);
+
+        browserTrigger(inputElm, 'click');
+        expect(scope.name).toEqual(-1);
+
+        browserTrigger(inputElm, 'click');
+          expect(scope.name).toEqual(0);
+      });
+
+      it('with floating point numbers', function() {
+        compileInput('<input type="checkbox" ng-model="name" ng-true-value="1.3" ' +
+            'ng-false-value="-1.3">');
+
+        scope.$apply(function() {
+          scope.name = 1.3;
+        });
+        expect(inputElm[0].checked).toBe(true);
+
+        scope.$apply(function() {
+          scope.name = -1.3;
+        });
+        expect(inputElm[0].checked).toBe(false);
+
+        scope.$apply(function() {
+          scope.name = 'something else';
+        });
+        expect(inputElm[0].checked).toBe(false);
+
+        browserTrigger(inputElm, 'click');
+        expect(scope.name).toEqual(1.3);
+
+        browserTrigger(inputElm, 'click');
+          expect(scope.name).toEqual(-1.3);
+      });
+
+      it('with exponential numbers', function() {
+        compileInput('<input type="checkbox" ng-model="name" ng-true-value="1e3" ' +
+            'ng-false-value="1e-3">');
+
+        scope.$apply(function() {
+          scope.name = 1e3;
+        });
+        expect(inputElm[0].checked).toBe(true);
+
+        scope.$apply(function() {
+          scope.name = 1e-3;
+        });
+        expect(inputElm[0].checked).toBe(false);
+
+        scope.$apply(function() {
+          scope.name = 'something else';
+        });
+        expect(inputElm[0].checked).toBe(false);
+
+        browserTrigger(inputElm, 'click');
+        expect(scope.name).toEqual(1e3);
+
+        browserTrigger(inputElm, 'click');
+          expect(scope.name).toEqual(1e-3);
+      });
+    });
 
     it('should be required if false', function() {
       compileInput('<input type="checkbox" ng:model="value" required />');


### PR DESCRIPTION
feat(ng): support for numerical ngTrueValue and ngFalseValue attributes

Checkbox input fields may now be declared with numerical ng-true-value and ng-false-value settings.
The input's corresponding model will be interpreted as a number rather than a string representation.
Regular string configurations which do not parse as numbers will be treated as before.

BREAKING CHANGE: numeric values for ngTrueValue and ngFalseValue attributes are
now interpreted as numbers rather than their string representation. This may affect
cases where a string representation of a number is expected in a checkbox field's
associated model and the identity operator (===) is used for comparison.

To migrate the code, make comparisons with the numerical typed value or use the
equality operator (==) in place of the identity operator to ensure type invariant value
comparison.

Before:

```
    if(scope.value === '1') {
      ...
    }
```

After:

```
    if(scope.value === 1) {
      …
    }
    // or
    if(scope.value == 1) {
      ...
    }
    // or
    if(scope.value == '1') {
      ...
    }
```
