### PR TITLE
fix(ngIf): destroy scope before removing element

### DIFF
--- a/src/ng/directive/ngIf.js
+++ b/src/ng/directive/ngIf.js
@@ -87,13 +87,13 @@ var ngIfDirective = ['$animator', function($animator) {
         var animate = $animator($scope, $attr);
         var childElement, childScope;
         $scope.$watch($attr.ngIf, function ngIfWatchAction(value) {
-          if (childElement) {
-            animate.leave(childElement);
-            childElement = undefined;
-          }
           if (childScope) {
             childScope.$destroy();
             childScope = undefined;
+          }
+          if (childElement) {
+            animate.leave(childElement);
+            childElement = undefined;
           }
           if (toBoolean(value)) {
             childScope = $scope.$new();

--- a/test/ng/directive/ngIfSpec.js
+++ b/test/ng/directive/ngIfSpec.js
@@ -14,7 +14,7 @@ describe('ngIf', function () {
   });
 
   function makeIf(expr) {
-    element.append($compile('<div class="my-class" ng-if="' + expr + '"><div>Hi</div></div>')($scope));
+    element.append($compile('<div id="testElement" class="my-class" ng-if="' + expr + '"><div>Hi</div></div>')($scope));
     $scope.$apply();
   }
 
@@ -71,6 +71,21 @@ describe('ngIf', function () {
     $scope.$apply('value = true');
     expect(element.children().length).toBe(1);
     expect(element.children()[0].className).toContain('my-class');
+  });
+
+  it('should still have the directive element attached to the DOM in the $destroy handler', function() {
+    $scope.value = true;
+    makeIf('value');
+    expect(element.children().length).toBe(1);
+    // Attach a $destroy handler to the test element that will be removed
+    var destroyHandler = jasmine.createSpy('$destroy handler').andCallFake(function() {
+      expect(element.children().length).toBe(1);
+    });
+    var ifScope = element.children().scope();
+    ifScope.$on('$destroy', destroyHandler);
+    $scope.$apply('value = false');
+    expect(element.children().length).toBe(0);
+    expect(destroyHandler).toHaveBeenCalled();
   });
 
 });


### PR DESCRIPTION
Sometimes you want to work with the element that is being destroyed
from inside the $destroy handler for the scope.  For instance you may
want to unbind a rd party library from an element.  If the element is
already removed from the DOM before the $destroy handler is called
then you can no longer get hold of the element by id, for instance.

Closes #3237
