### PR TITLE
fix(jqLite): support space-seperated events in off

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -200,12 +200,14 @@ function JQLiteOff(element, type, fn) {
       delete events[type];
     });
   } else {
-    if (isUndefined(fn)) {
-      removeEventListenerFn(element, type, events[type]);
-      delete events[type];
-    } else {
-      arrayRemove(events[type], fn);
-    }
+    forEach(type.split(' '), function(type) {
+      if (isUndefined(fn)) {
+        removeEventListenerFn(element, type, events[type]);
+        delete events[type];
+      } else {
+        arrayRemove(events[type], fn);
+      }
+    });
   }
 }
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -946,6 +946,29 @@ describe('jqLite', function() {
       expect(mouseoverSpy).not.toHaveBeenCalled();
     });
 
+    it('should deregister all listeners for types seperated by spaces', function() {
+      var aElem = jqLite(a),
+          clickSpy = jasmine.createSpy('click'),
+          mouseoverSpy = jasmine.createSpy('mouseover');
+
+      aElem.on('click', clickSpy);
+      aElem.on('mouseover', mouseoverSpy);
+
+      browserTrigger(a, 'click');
+      expect(clickSpy).toHaveBeenCalledOnce();
+      browserTrigger(a, 'mouseover');
+      expect(mouseoverSpy).toHaveBeenCalledOnce();
+
+      clickSpy.reset();
+      mouseoverSpy.reset();
+
+      aElem.off('click mouseover');
+
+      browserTrigger(a, 'click');
+      expect(clickSpy).not.toHaveBeenCalled();
+      browserTrigger(a, 'mouseover');
+      expect(mouseoverSpy).not.toHaveBeenCalled();
+    });
 
     it('should deregister specific listener', function() {
       var aElem = jqLite(a),
@@ -973,6 +996,31 @@ describe('jqLite', function() {
       aElem.off('click', clickSpy2);
       browserTrigger(a, 'click');
       expect(clickSpy2).not.toHaveBeenCalled();
+    });
+
+    it('should deregister specific listener for multiple types seperated by spaces', function() {
+      var aElem = jqLite(a),
+          masterSpy = jasmine.createSpy('master'),
+          extraSpy = jasmine.createSpy('extra');
+
+      aElem.on('click', masterSpy);
+      aElem.on('click', extraSpy);
+      aElem.on('mouseover', masterSpy);
+
+      browserTrigger(a, 'click');
+      browserTrigger(a, 'mouseover');
+      expect(masterSpy.callCount).toBe(2);
+      expect(extraSpy).toHaveBeenCalledOnce();
+
+      masterSpy.reset();
+      extraSpy.reset();
+
+      aElem.off('click mouseover', masterSpy);
+
+      browserTrigger(a, 'click');
+      browserTrigger(a, 'mouseover');
+      expect(masterSpy).not.toHaveBeenCalled();
+      expect(extraSpy).toHaveBeenCalledOnce();
     });
   });
 


### PR DESCRIPTION
jqLite.on/bind supported eventNames seperated by spaces, but jqLite.off/unbind didn't.
