### PR TITLE
docs(minErr): Build minErr doc site

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "components-font-awesome": "3.1.0",
     "bootstrap": "https://raw.github.com/twitter/bootstrap/v2.0.2/docs/assets/bootstrap.zip",
     "closure-compiler": "https://closure-compiler.googlecode.com/files/compiler-20130603.zip",
-    "ng-closure-runner": "https://raw.github.com/angular/ng-closure-runner/v0.1.1/assets/ng-closure-runner.zip"
+    "ng-closure-runner": "https://raw.github.com/angular/ng-closure-runner/v0.2.0/assets/ng-closure-runner.zip"
   }
 }

--- a/docs/component-spec/errorDisplaySpec.js
+++ b/docs/component-spec/errorDisplaySpec.js
@@ -1,0 +1,68 @@
+describe("errorDisplay", function () {
+
+  var $location, compileHTML;
+
+  beforeEach(module('docsApp'));
+
+  beforeEach(inject(function ($injector) {
+    var $rootScope = $injector.get('$rootScope'),
+      $compile = $injector.get('$compile');
+    
+    $location = $injector.get('$location');
+
+    compileHTML = function (code) {
+      var elm = angular.element(code);
+      $compile(elm)($rootScope);
+      $rootScope.$digest();
+      return elm;
+    };
+
+    this.addMatchers({
+      toInterpolateTo: function (expected) {
+        // Given a compiled DOM node with a minerr-display attribute,
+        // assert that its interpolated string matches the expected text.
+        return this.actual.text() === expected;
+      }
+    });
+  }));
+
+  it('should interpolate a template with no parameters', function () {
+    var elm;
+
+    spyOn($location, 'search').andReturn({});
+    elm = compileHTML('<div error-display="This is a test"></div>');
+    expect(elm).toInterpolateTo('This is a test');
+  });
+
+  it('should interpolate a template with no parameters when search parameters are present', function () {
+    var elm;    
+
+    spyOn($location, 'search').andReturn({ p0: 'foobaz' });
+    elm = compileHTML('<div error-display="This is a test"></div>');
+    expect(elm).toInterpolateTo('This is a test');
+  });
+
+  it('should correctly interpolate search parameters', function () {
+    var elm;    
+
+    spyOn($location, 'search').andReturn({ p0: '42' });
+    elm = compileHTML('<div error-display="The answer is {0}"></div>');
+    expect(elm).toInterpolateTo('The answer is 42');
+  });
+
+  it('should interpolate parameters in the specified order', function () {
+    var elm;
+
+    spyOn($location, 'search').andReturn({ p0: 'second', p1: 'first' });
+    elm = compileHTML('<div error-display="{1} {0}"></div>');
+    expect(elm).toInterpolateTo('first second');
+  });
+
+  it('should preserve interpolation markers when fewer arguments than needed are provided', function () {
+    var elm;
+
+    spyOn($location, 'search').andReturn({ p0: 'Fooooo' });
+    elm = compileHTML('<div error-display="This {0} is {1} on {2}"></div>');
+    expect(elm).toInterpolateTo('This Fooooo is {1} on {2}');
+  });
+});

--- a/docs/content/error/cacheFactory/iid.ngdoc
+++ b/docs/content/error/cacheFactory/iid.ngdoc
@@ -1,0 +1,7 @@
+@ngdoc error
+@name $cacheFactory:iid
+@fullName Invalid ID
+@description
+
+This error occurs when trying to create a new `cacheFactory` object with a 
+specified cache ID, but the cache ID is already taken.

--- a/docs/content/error/compile/ctreq.ngdoc
+++ b/docs/content/error/compile/ctreq.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $compile:ctreq
+@fullName Missing Required Controller
+@description

--- a/docs/content/error/compile/iscp.ngdoc
+++ b/docs/content/error/compile/iscp.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $compile:iscp
+@fullName Invalid Isolate Scope
+@description

--- a/docs/content/error/compile/multidir.ngdoc
+++ b/docs/content/error/compile/multidir.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $compile:multidir
+@fullName Multiple Directive Resource Contention
+@description

--- a/docs/content/error/compile/noass.ngdoc
+++ b/docs/content/error/compile/noass.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $compile:noass
+@fullName Non-Assignable Expression
+@description

--- a/docs/content/error/compile/nodomevents.ngdoc
+++ b/docs/content/error/compile/nodomevents.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $compile:nodomevents
+@fullName Interpolated Event Attributes
+@description

--- a/docs/content/error/compile/tpload.ngdoc
+++ b/docs/content/error/compile/tpload.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $compile:tpload
+@fullName Template Loader Error
+@description

--- a/docs/content/error/compile/tplrt.ngdoc
+++ b/docs/content/error/compile/tplrt.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $compile:tplrt
+@fullName Invalid Template Root
+@description

--- a/docs/content/error/compile/utrat.ngdoc
+++ b/docs/content/error/compile/utrat.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $compile:utrat
+@fullName Unterminated Attribute
+@description

--- a/docs/content/error/controller/noscp.ngdoc
+++ b/docs/content/error/controller/noscp.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $controller:noscp
+@fullName Missing $scope object
+@description

--- a/docs/content/error/httpBackend/noxhr.ngdoc
+++ b/docs/content/error/httpBackend/noxhr.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $httpBackend:noxhr
+@fullName Unsupported XHR
+@description

--- a/docs/content/error/index.ngdoc
+++ b/docs/content/error/index.ngdoc
@@ -1,0 +1,13 @@
+@ngdoc overview
+@name Error Reference
+@description
+
+Use the Error Reference manual to find information about error conditions in
+your AngularJS app. Errors thrown in production builds of AngularJS will log
+links to this site on the console.
+
+Other useful references for debugging your app include:
+
+- {@link api/ API Reference} for detailed information about specific features
+- {@link guide/ Developer Guide} for AngularJS concepts
+- {@link tutorial/ Tutorial} for getting started

--- a/docs/content/error/injector/cdep.ngdoc
+++ b/docs/content/error/injector/cdep.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $injector:cdep
+@fullName Circular Dependency
+@description

--- a/docs/content/error/injector/itkn.ngdoc
+++ b/docs/content/error/injector/itkn.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $injector:itkn
+@fullName Bad Injection Token
+@description

--- a/docs/content/error/injector/modulerr.ngdoc
+++ b/docs/content/error/injector/modulerr.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $injector:modulerr
+@fullName Module Error
+@description

--- a/docs/content/error/injector/nomod.ngdoc
+++ b/docs/content/error/injector/nomod.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $injector:nomod
+@fullName Module Unavailable
+@description

--- a/docs/content/error/injector/pget.ngdoc
+++ b/docs/content/error/injector/pget.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $injector:pget
+@fullName Provider Missing $get
+@description

--- a/docs/content/error/injector/unpr.ngdoc
+++ b/docs/content/error/injector/unpr.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $injector:unpr
+@fullName Unknown Provider
+@description

--- a/docs/content/error/interpolate/interr.ngdoc
+++ b/docs/content/error/interpolate/interr.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $interpolate:interr
+@fullName Interpolation Error
+@description

--- a/docs/content/error/interpolate/noconcat.ngdoc
+++ b/docs/content/error/interpolate/noconcat.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $interpolate:noconcat
+@fullName Multiple Expressions
+@description

--- a/docs/content/error/jqLite/nosel.ngdoc
+++ b/docs/content/error/jqLite/nosel.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name jqLite:nosel
+@fullName Unsupported Selector Lookup
+@description

--- a/docs/content/error/jqLite/off_args.ngdoc
+++ b/docs/content/error/jqLite/off_args.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name jqLite:off_args
+@fullName Invalid jqLite#off() parameter
+@description

--- a/docs/content/error/jqLite/on_args.ngdoc
+++ b/docs/content/error/jqLite/on_args.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name jqLite:on_args
+@fullName Invalid jqLite#on() Parameters
+@description

--- a/docs/content/error/location/istart.ngdoc
+++ b/docs/content/error/location/istart.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $location:istart
+@fullName Invalid URL
+@description

--- a/docs/content/error/location/nohash.ngdoc
+++ b/docs/content/error/location/nohash.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $location:nohash
+@fullName Missing Hash Prefix
+@description

--- a/docs/content/error/location/nopp.ngdoc
+++ b/docs/content/error/location/nopp.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $location:nopp
+@fullName Missing Path Prefix
+@description

--- a/docs/content/error/ng/areq.ngdoc
+++ b/docs/content/error/ng/areq.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name ng:areq
+@fullName Bad Argument
+@description

--- a/docs/content/error/ng/cpi.ngdoc
+++ b/docs/content/error/ng/cpi.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name ng:cpi
+@fullName Bad Copy
+@description

--- a/docs/content/error/ng/cpws.ngdoc
+++ b/docs/content/error/ng/cpws.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name ng:cpws
+@fullName Copying Window or Scope
+@description

--- a/docs/content/error/ngModel/noass.ngdoc
+++ b/docs/content/error/ngModel/noass.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name ngModel:noass
+@fullName Non-Assignable Expression
+@description

--- a/docs/content/error/ngOptions/iexp.ngdoc
+++ b/docs/content/error/ngOptions/iexp.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name ngOptions:iexp
+@fullName Invalid Expression
+@description

--- a/docs/content/error/ngPattern/noregexp.ngdoc
+++ b/docs/content/error/ngPattern/noregexp.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name ngPattern:noregexp
+@fullName Expected Regular Expression
+@description

--- a/docs/content/error/ngRepeat/dupes.ngdoc
+++ b/docs/content/error/ngRepeat/dupes.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name ngRepeat:dupes
+@fullName Duplicate Repeater Key
+@description

--- a/docs/content/error/ngRepeat/iexp.ngdoc
+++ b/docs/content/error/ngRepeat/iexp.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name ngRepeat:iexp
+@fullName Invalid Expression
+@description

--- a/docs/content/error/ngRepeat/iidexp.ngdoc
+++ b/docs/content/error/ngRepeat/iidexp.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name ngRepeat:iidexp
+@fullName Invalid Identifier
+@description

--- a/docs/content/error/ngResource/badargs.ngdoc
+++ b/docs/content/error/ngResource/badargs.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name ngResource:badargs
+@fullName Too Many Arguments
+@description

--- a/docs/content/error/ngSanitize/badparse.ngdoc
+++ b/docs/content/error/ngSanitize/badparse.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name ngSanitize:badparse
+@fullName Parsing Error
+@description

--- a/docs/content/error/parse/isecfld.ngdoc
+++ b/docs/content/error/parse/isecfld.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $parse:isecfld
+@fullName Referencing constructor Field
+@description

--- a/docs/content/error/parse/isecfn.ngdoc
+++ b/docs/content/error/parse/isecfn.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $parse:isecfn
+@fullName Referencing Function Disallowed
+@description

--- a/docs/content/error/parse/lexerr.ngdoc
+++ b/docs/content/error/parse/lexerr.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $parse:lexerr
+@fullName Lexer Error
+@description

--- a/docs/content/error/parse/syntax.ngdoc
+++ b/docs/content/error/parse/syntax.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $parse:syntax
+@fullName Syntax Error
+@description

--- a/docs/content/error/parse/ueoe.ngdoc
+++ b/docs/content/error/parse/ueoe.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $parse:ueoe
+@fullName Unexpected End of Expression
+@description

--- a/docs/content/error/rootScope/infdig.ngdoc
+++ b/docs/content/error/rootScope/infdig.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $rootScope:infdig
+@fullName Infinite $digest Loop
+@description

--- a/docs/content/error/rootScope/inprog.ngdoc
+++ b/docs/content/error/rootScope/inprog.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $rootScope:inprog
+@fullName Action Already In Progress
+@description

--- a/docs/src/templates/css/docs.css
+++ b/docs/src/templates/css/docs.css
@@ -476,3 +476,12 @@ pre ol li {
   width:180px;
   margin-bottom:20px;
 }
+
+.minerr-errmsg {
+  clear: both;
+  position: relative;
+  top: 10px;
+  font-size: 16px;
+  word-break: normal;
+  word-wrap: normal;
+}

--- a/docs/src/templates/index.html
+++ b/docs/src/templates/index.html
@@ -18,7 +18,7 @@
     // before the base attribute is added, causing 404 and terribly slow loading of the docs app.
     (function() {
       var indexFile = (location.pathname.match(/\/(index[^\.]*\.html)/) || ['', ''])[1],
-          rUrl = /(#!\/|api|guide|misc|tutorial|cookbook|index[^\.]*\.html).*$/,
+          rUrl = /(#!\/|api|guide|misc|tutorial|cookbook|error|index[^\.]*\.html).*$/,
           baseUrl = location.href.replace(rUrl, indexFile),
           jQuery = /index-jq[^\.]*\.html$/.test(baseUrl),
           debug = /index[^\.]*-debug\.html$/.test(baseUrl),
@@ -150,6 +150,7 @@
                 <li><a href="./tutorial/">Tutorial</a></li>
                 <li><a href="./guide/">Developer Guide</a></li>
                 <li><a href="./api/">API Reference</a></li>
+                <li><a href="./error/">Error Reference</a></li>
                 <li><a href="http://docs.angularjs.org/misc/contribute">Contribute</a></li>
                 <li><a href="http://code.angularjs.org/">Download</a></li>
               </ul>
@@ -263,7 +264,16 @@
               </li>
             </ul>
 
+            <ul class="nav nav-list well api-list-item" ng-repeat="namespace in namespaces track by namespace.url">
+              <li class="nav-header module">
+                <a class="code" href="{{namespace.url}}">{{namespace.name}}</a>
+              </li>
 
+              <li ng-repeat="page in namespace.errors track by page.url" ng-class="navClass(page)" ng-animate="'expand'" class="api-list-item">
+                <a href="{{page.url}}" tabindex="2">{{page.shortName}}</a>
+              </li>
+            </ul>
+            
             <ul class="nav nav-list well api-list-item" ng-repeat="module in modules track by module.url">
               <li class="nav-header module">
                 <a class="guide" href="{{URL.module}}">module</a>

--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -154,7 +154,7 @@ module.exports = {
             '--language_in ECMASCRIPT5_STRICT ' +
             '--minerr_pass ' +
             '--minerr_errors ' + errorFileName + ' ' +
-            '--minerr_url http://docs.angularjs.org/minerr/ ' +
+            '--minerr_url http://errors.angularjs.org/ ' +
             '--source_map_format=V3 ' +
             '--create_source_map ' + mapFile + ' ' +
             '--js ' + file + ' ' +
@@ -233,7 +233,7 @@ module.exports = {
   //rewrite connect middleware
   rewrite: function(){
     return function(req, res, next){
-      var REWRITE = /\/(guide|api|cookbook|misc|tutorial).*$/,
+      var REWRITE = /\/(guide|api|cookbook|misc|tutorial|error).*$/,
           IGNORED = /(\.(css|js|png|jpg)$|partials\/.*\.html$)/,
           match;
 


### PR DESCRIPTION
The minErr doc site is ready for review. 

Changes in this PR:
- Include ngdoc files for each minErr that we throw in angular core
- Extend ngdoc parser to handle new ngdoc type
- Rearrange page headers for ALL of docs.angularjs.org
  - The "view source" and "improve this doc" buttons have been moved above the header
  - The module note has been moved from a h1 level span to a subheading
  - This was done because minErr pages tend to have longer headers
- Add `minerrDisplay` attribute directive to interpolate minErr parameters
- Display minErr types in namespaces under docs.angularjs.org/minerr/ (like API modules)
- Add rewrite rule to make /minerr/ accessible from `grunt webserver`
