### PR TITLE
fix($sniffer): olders IOS transitions/animations detection

### DIFF
--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -38,7 +38,7 @@ function $SnifferProvider() {
       transitions = !!(('transition' in bodyStyle) || (vendorPrefix + 'Transition' in bodyStyle));
       animations  = !!(('animation' in bodyStyle) || (vendorPrefix + 'Animation' in bodyStyle));
       
-      if (android && (!transitions||!animations)) {
+      if ((!transitions||!animations)) {
         transitions = isString(document.body.style.webkitTransition); 
         animations = isString(document.body.style.webkitAnimation); 
       }


### PR DESCRIPTION
Removed the android detection because isn't only on old Android device, we have the same issue on IOS 5.1.1 and lower
