### PR TITLE
fix($parse): unwrap promise when setting a field

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -766,6 +766,17 @@ function setter(obj, path, setValue, fullExp) {
       obj[key] = propertyObj;
     }
     obj = propertyObj;
+    if (obj.then) {
+      if (!("$$v" in obj)) {
+        (function(promise) {
+          promise.then(function(val) { promise.$$v = val; }); }
+        )(obj);
+      }
+      if (obj.$$v === undefined) {
+        obj.$$v = {};
+      }
+      obj = obj.$$v;
+    }
   }
   key = ensureSafeMemberName(element.shift(), fullExp);
   obj[key] = setValue;


### PR DESCRIPTION
This fixes an inconsistency where you can't call the setter function
when the expression resolves to a top level field name on a promise.

Setting a field on an unresolved promise will throw an exception.  (This
shouldn't really happen in your template/js code and points to a
programming error.)

Closes #1827
