### PR TITLE
Spelling fixes for documentation and JSDoc corrections

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -3,7 +3,7 @@
 ////////////////////////////////////
 
 /**
- * hasOwnProperty may be overriden by a property of the same name, or entirely
+ * hasOwnProperty may be overwritten by a property of the same name, or entirely
  * absent from an object that does not inherit Object.prototype; this copy is
  * used instead
  */
@@ -792,7 +792,7 @@ function toJsonReplacer(key, value) {
  *
  * @param {Object|Array|Date|string|number} obj Input to be serialized into JSON.
  * @param {boolean=} pretty If set to true, the JSON output will contain newlines and whitespace.
- * @returns {string|undefined} Jsonified string representing `obj`.
+ * @returns {string|undefined} JSON-ified string representing `obj`.
  */
 function toJson(obj, pretty) {
   if (typeof obj === 'undefined') return undefined;

--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -202,7 +202,7 @@ function annotate(fn) {
  *   expect(injector.annotate(MyController)).toEqual(['$scope', '$route']);
  * </pre>
  *
- * This method does not work with code minfication / obfuscation. For this reason the following annotation strategies
+ * This method does not work with code minification / obfuscation. For this reason the following annotation strategies
  * are supported.
  *
  * # The `$inject` property

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -315,7 +315,7 @@ function Browser(window, document, $log, $sniffer) {
   /**
    * @name ng.$browser#defer
    * @methodOf ng.$browser
-   * @param {function()} fn A function, who's execution should be defered.
+   * @param {function()} fn A function, who's execution should be deferred.
    * @param {number=} [delay=0] of milliseconds to defer the function execution.
    * @returns {*} DeferId that can be used to cancel the task via `$browser.defer.cancel()`.
    *
@@ -344,7 +344,7 @@ function Browser(window, document, $log, $sniffer) {
    * @methodOf ng.$browser.defer
    *
    * @description
-   * Cancels a defered task identified with `deferId`.
+   * Cancels a deferred task identified with `deferId`.
    *
    * @param {*} deferId Token returned by the `$browser.defer` function.
    * @returns {boolean} Returns `true` if the task hasn't executed yet and was successfully canceled.

--- a/src/ng/cacheFactory.js
+++ b/src/ng/cacheFactory.js
@@ -194,7 +194,7 @@ function $CacheFactoryProvider() {
  * @name ng.$templateCache
  *
  * @description
- * The first time a template is used, it is loaded in the tempalte cache for quick retrieval.  You can 
+ * The first time a template is used, it is loaded in the template cache for quick retrieval.  You can
  * load templates directly into the cache in a `script` tag, or by consuming the `$templateCache` 
  * service directly.
  * 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1308,7 +1308,7 @@ var PREFIX_REGEXP = /^(x[\:\-_]|data[\:\-_])/i;
 /**
  * Converts all accepted directives format into proper directive name.
  * All of these will become 'myDirective':
- *   my:DiRective
+ *   my:Directive
  *   my-directive
  *   x-my-directive
  *   data-my:directive

--- a/src/ng/filter.js
+++ b/src/ng/filter.js
@@ -30,7 +30,7 @@
  *   }
  * </pre>
  *
- * The filter function is registered with the `$injector` under the filter name suffixe with `Filter`.
+ * The filter function is registered with the `$injector` under the filter name suffix with `Filter`.
  * <pre>
  *   it('should be the same instance', inject(
  *     function($filterProvider) {

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -155,7 +155,7 @@ function $HttpProvider() {
 
       /**
        * Response interceptors go before "around" interceptors (no real reason, just
-       * had to pick one.) But they are already revesed, so we can't use unshift, hence
+       * had to pick one.) But they are already reversed, so we can't use unshift, hence
        * the splice.
        */
       reversedInterceptors.splice(index, 0, {

--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -86,7 +86,7 @@ function $InterpolateProvider() {
      *    embedded expression will return null for the interpolation function.
      * @param {boolean=} isTrustedContext when true, requires that the interpolation string does not
      *    contain any concatenations - i.e. the interpolation string is a single expression.
-     *    Interpolations for *[src] and *[ng-src] (except IMG, since itwhich sanitizes its value)
+     *    Interpolations for *[src] and *[ng-src] (except IMG, since it sanitizes its value)
      *    pass true for this parameter.  This helps avoid hunting through the template code to
      *    figure out of some iframe[src], object[src], etc. was interpolated with a concatenation
      *    that ended up introducing a XSS.

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -254,6 +254,7 @@ LocationHashbangInHtml5Url.prototype =
    * Change path, search and hash, when called with parameter and return `$location`.
    *
    * @param {string=} url New url without base prefix (e.g. `/path?a=b#hash`)
+   * @param {string=} replace The path that will be changed
    * @return {string} url
    */
   url: function(url, replace) {

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -20,7 +20,7 @@ var $parseMinErr = minErr('$parse');
 // the expression, which is a stronger but more expensive test. Since reflective calls are expensive anyway, this is not
 // such a big deal compared to static dereferencing.
 //
-// This sandboxing techniqueue is not perfect and doesn't aim to be. The goal is to prevent exploits against the
+// This sandboxing technique is not perfect and doesn't aim to be. The goal is to prevent exploits against the
 // expression language, but not to prevent exploits that were enabled by exposing sensitive JavaScript or browser apis
 // on Scope. Exposing such objects on a Scope is never a good practice and therefore we are not even trying to protect
 // against interaction with an object explicitly exposed in this way.

--- a/src/ngScenario/Describe.js
+++ b/src/ngScenario/Describe.js
@@ -94,7 +94,7 @@ angular.scenario.Describe.prototype.xdescribe = angular.noop;
  * Defines a test.
  *
  * @param {string} name Name of the test.
- * @param {function()} vody Body of the block.
+ * @param {function()} body Body of the block.
  */
 angular.scenario.Describe.prototype.it = function(name, body) {
   this.its.push({

--- a/src/ngScenario/Future.js
+++ b/src/ngScenario/Future.js
@@ -3,9 +3,9 @@
 /**
  * A future action in a spec.
  *
- * @param {string} name of the future action
- * @param {function()} future callback(error, result)
- * @param {function()} Optional. function that returns the file/line number.
+ * @param {string} name name of the future action
+ * @param {function()} behavior future callback(error, result)
+ * @param {function()} line Optional. function that returns the file/line number.
  */
 angular.scenario.Future = function(name, behavior, line) {
   this.name = name;

--- a/src/ngScenario/ObjectModel.js
+++ b/src/ngScenario/ObjectModel.js
@@ -170,7 +170,7 @@ angular.scenario.ObjectModel.prototype.getDefinitionPath = function(spec) {
 /**
  * Gets a spec by id.
  *
- * @param {string} The id of the spec to get the object for.
+ * @param {string} id The id of the spec to get the object for.
  * @return {Object} the Spec instance
  */
 angular.scenario.ObjectModel.prototype.getSpec = function(id) {
@@ -195,7 +195,7 @@ angular.scenario.ObjectModel.Spec = function(id, name, definitionNames) {
 /**
  * Adds a new step to the Spec.
  *
- * @param {string} step Name of the step (really name of the future)
+ * @param {string} name Name of the step (really name of the future)
  * @return {Object} the added step
  */
 angular.scenario.ObjectModel.Spec.prototype.addStep = function(name) {
@@ -229,7 +229,7 @@ angular.scenario.ObjectModel.Spec.prototype.setStatusFromStep = function(step) {
 /**
  * A single step inside a Spec.
  *
- * @param {string} step Name of the step
+ * @param {string} name Name of the step
  */
 angular.scenario.ObjectModel.Step = function(name) {
   this.name = name;

--- a/src/ngScenario/SpecRunner.js
+++ b/src/ngScenario/SpecRunner.js
@@ -18,7 +18,7 @@ angular.scenario.SpecRunner = function() {
  * based on the describe nesting.
  *
  * @param {Object} spec A spec object
- * @param {function()} specDone function that is called when the spec finshes. Function(error, index)
+ * @param {function()} specDone function that is called when the spec finishes. Function(error, index)
  */
 angular.scenario.SpecRunner.prototype.run = function(spec, specDone) {
   var self = this;


### PR DESCRIPTION
I fixed a lot of spelling errors as I was going through some documentation tonight. Also corrected a few JSDoc's that didn't have parameter specifications or had incorrect spec's.
