### PR TITLE
feat ngRepeat: add $even and $odd properties to iterator

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -17,6 +17,8 @@
  * | `$first`  | {@type boolean} | true if the repeated element is first in the iterator.                      |
  * | `$middle` | {@type boolean} | true if the repeated element is between the first and last in the iterator. |
  * | `$last`   | {@type boolean} | true if the repeated element is last in the iterator.                       |
+ * | `$even`   | {@type boolean} | true if the iterator position `$index` is even (otherwise false).           |
+ * | `$odd`    | {@type boolean} | true if the iterator position `$index` is odd (otherwise false).            |
  *
  * Additionally, you can also provide animations via the ngAnimate attribute to animate the **enter**,
  * **leave** and **move** effects.
@@ -345,6 +347,7 @@ var ngRepeatDirective = ['$parse', '$animator', function($parse, $animator) {
             childScope.$first = (index === 0);
             childScope.$last = (index === (arrayLength - 1));
             childScope.$middle = !(childScope.$first || childScope.$last);
+            childScope.$odd = !(childScope.$even = index%2==0);
 
             if (!block.startNode) {
               linker(childScope, function(clone) {

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -344,7 +344,6 @@ describe('ngRepeat', function() {
     expect(element.text()).toEqual('misko:0|shyam:1|frodo:2|');
   });
 
-
   it('should expose iterator offset as $index when iterating over objects', function() {
     element = $compile(
       '<ul>' +
@@ -386,6 +385,36 @@ describe('ngRepeat', function() {
   });
 
 
+  it('should expose iterator position as $even and $odd when iterating over arrays',
+      function() {
+    element = $compile(
+      '<ul>' +
+        '<li ng-repeat="item in items">{{item}}:{{$even}}-{{$odd}}|</li>' +
+      '</ul>')(scope);
+    scope.items = ['misko', 'shyam', 'doug'];
+    scope.$digest();
+    expect(element.text()).
+        toEqual('misko:true-false|shyam:false-true|doug:true-false|');
+
+    scope.items.push('frodo');
+    scope.$digest();
+    expect(element.text()).
+        toEqual('misko:true-false|' +
+                'shyam:false-true|' +
+                'doug:true-false|' +
+                'frodo:false-true|');
+
+    scope.items.pop();
+    scope.items.pop();
+    scope.$digest();
+    expect(element.text()).toEqual('misko:true-false|shyam:false-true|');
+
+    scope.items.pop();
+    scope.$digest();
+    expect(element.text()).toEqual('misko:true-false|');
+  });
+
+
   it('should expose iterator position as $first, $middle and $last when iterating over objects',
       function() {
     element = $compile(
@@ -411,6 +440,31 @@ describe('ngRepeat', function() {
   });
 
 
+  it('should expose iterator position as $even and $odd when iterating over objects',
+      function() {
+    element = $compile(
+      '<ul>' +
+        '<li ng-repeat="(key, val) in items">{{key}}:{{val}}:{{$even}}-{{$odd}}|</li>' +
+      '</ul>')(scope);
+    scope.items = {'misko':'m', 'shyam':'s', 'doug':'d', 'frodo':'f'};
+    scope.$digest();
+    expect(element.text()).
+        toEqual('doug:d:true-false|' +
+                'frodo:f:false-true|' +
+                'misko:m:true-false|' +
+                'shyam:s:false-true|');
+
+    delete scope.items.doug;
+    delete scope.items.frodo;
+    scope.$digest();
+    expect(element.text()).toEqual('misko:m:true-false|shyam:s:false-true|');
+
+    delete scope.items.shyam;
+    scope.$digest();
+    expect(element.text()).toEqual('misko:m:true-false|');
+  });
+
+
   it('should calculate $first, $middle and $last when we filter out properties from an obj', function() {
     element = $compile(
         '<ul>' +
@@ -423,6 +477,21 @@ describe('ngRepeat', function() {
         'frodo:f:false-true-false|' +
         'misko:m:false-true-false|' +
         'shyam:s:false-false-true|');
+  });
+
+
+  it('should calculate $even and $odd when we filter out properties from an obj', function() {
+    element = $compile(
+        '<ul>' +
+            '<li ng-repeat="(key, val) in items">{{key}}:{{val}}:{{$even}}-{{$odd}}|</li>' +
+            '</ul>')(scope);
+    scope.items = {'misko':'m', 'shyam':'s', 'doug':'d', 'frodo':'f', '$toBeFilteredOut': 'xxxx'};
+    scope.$digest();
+    expect(element.text()).
+        toEqual('doug:d:true-false|' +
+        'frodo:f:false-true|' +
+        'misko:m:true-false|' +
+        'shyam:s:false-true|');
   });
 
 


### PR DESCRIPTION
When iterating, odd/even status is often nice to to have readily available in a
highly readable way.
These properties are not coupled to using CSS classes in the way of ngClassEven
and ngClassOdd directives.
