### PR TITLE
Fix input [number] example

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -120,9 +120,9 @@ var inputType = {
          <form name="myForm" ng-controller="Ctrl">
            Number: <input type="number" name="input" ng-model="value"
                           min="0" max="99" required>
-           <span class="error" ng-show="myForm.list.$error.required">
+           <span class="error" ng-show="myForm.input.$error.required">
              Required!</span>
-           <span class="error" ng-show="myForm.list.$error.number">
+           <span class="error" ng-show="myForm.input.$error.number">
              Not valid number!</span>
            <tt>value = {{value}}</tt><br/>
            <tt>myForm.input.$valid = {{myForm.input.$valid}}</tt><br/>


### PR DESCRIPTION
The input [number] error spans did not show on the example, as they were relying on an non-existing property (myForm.list.$error) vs the working property (myForm.$error)
