### PR TITLE
feat(ngSanitize): linky does not sanitize when used in ngBindHtml directive

### DIFF
--- a/src/ngSanitize/directive/ngBindHtml.js
+++ b/src/ngSanitize/directive/ngBindHtml.js
@@ -18,7 +18,17 @@ angular.module('ngSanitize').directive('ngBindHtml', ['$sanitize', function($san
   return function(scope, element, attr) {
     element.addClass('ng-binding').data('$binding', attr.ngBindHtml);
     scope.$watch(attr.ngBindHtml, function ngBindHtmlWatchAction(value) {
-      value = $sanitize(value);
+      value = $sanitize(value, false);
+      element.html(value || '');
+    });
+  };
+}]);
+
+angular.module('ngSanitize').directive('ngBindHtmlLinky', ['$sanitize', function($sanitize) {
+  return function(scope, element, attr) {
+    element.addClass('ng-binding').data('$binding', attr.ngBindHtmlLinky);
+    scope.$watch(attr.ngBindHtmlLinky, function ngBindHtmlLinkyWatchAction(value) {
+      value = $sanitize(value, true);
       element.html(value || '');
     });
   };


### PR DESCRIPTION
Look at the top comment here: http://docs.angularjs.org/api/ngSanitize.filter:linky

... and here is a demo of the undesirable behavior: http://jsfiddle.net/5uSnj/

The purpose of this pull request is to hopefully push this issue further along and gain some attention.

The attached code creates a new directive which calls the htmlParser with a new argument to 'linkify' URLs that are not already wrapped in an &lt;a> tag.  I am not very experienced with AngularJS and JavaScript, so this is probably not The Best approach.  There must be some way to simply use the ngBindHtml directive with the linky filter for the desired behavior.

Thanks!
Brian
