### PR TITLE
feat(): added scope as an optional argument to $timeout()

### DIFF
--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -32,10 +32,11 @@ function $TimeoutProvider() {
       * @returns {Promise} Promise that will be resolved when the timeout is reached. The value this
       *   promise will be resolved with is the return value of the `fn` function.
       */
-    function timeout(fn, delay, invokeApply) {
+    function timeout(fn, delay, invokeApply, scope) {
       var deferred = $q.defer(),
           promise = deferred.promise,
           skipApply = (isDefined(invokeApply) && !invokeApply),
+          scope = scope || $rootScope,
           timeoutId, cleanup;
 
       timeoutId = $browser.defer(function() {
@@ -46,7 +47,7 @@ function $TimeoutProvider() {
           $exceptionHandler(e);
         }
 
-        if (!skipApply) $rootScope.$apply();
+        if (!skipApply) scope.$apply();
       }, delay);
 
       cleanup = function() {

--- a/test/ng/timeoutSpec.js
+++ b/test/ng/timeoutSpec.js
@@ -48,6 +48,22 @@ describe('$timeout', function() {
   }));
 
 
+  it('should call a specific scope if passed as an argument', inject(function($timeout, $rootScope) {
+    var scope = $rootScope.$new();
+    scope.$apply = function(){};
+    var applySpy = spyOn(scope, '$apply').andCallThrough();
+    var rootScopeApplySpy = spyOn($rootScope, '$apply').andCallThrough();
+
+    $timeout(function() {}, 12, true, scope);
+    expect(applySpy).not.toHaveBeenCalled();
+    expect(rootScopeApplySpy).not.toHaveBeenCalled();
+
+    $timeout.flush();
+    expect(applySpy).toHaveBeenCalled();
+    expect(rootScopeApplySpy).not.toHaveBeenCalled();
+  }));
+
+
   it('should allow you to specify the delay time', inject(function($timeout, $browser) {
     var defer = spyOn($browser, 'defer');
     $timeout(noop, 123);


### PR DESCRIPTION
This isn't a complete request yet, but I'm curious to see if there's any interest.

It would be nice if $timeout could be passed a scope to run $apply() on, rather than always using $rootScope. I think this would help performance in larger apps(?). Of course, this is doable by hand in your own code, but this makes it more convenient / less verbose.

``` javascript
app.controller('SomeCtrl',function($scope,$timeout){
  ...
  $timeout( doSomething, 1000, true, $scope );
  ...
});
```

I think it could also be the 3rd argument, rather than the 4th. `true` could mean use $rootScope, `false` would mean don't call $apply, and and passing a scope would call $apply on that scope.

``` javascript
$timeout( doSomething, 1000, $scope );
```

Thoughts?
