### PR TITLE
Added missing seed app link to menu in docs

### DIFF
--- a/docs/src/templates/index.html
+++ b/docs/src/templates/index.html
@@ -137,6 +137,7 @@
                 <li><a href="http://www.youtube.com/user/angularjs">Watch</a></li>
                 <li><a href="tutorial">Tutorial</a></li>
                 <li><a href="http://builtwith.angularjs.org/">Case Studies</a></li>
+                <li><a href="https://github.com/angular/angular-seed">Seed App project template</a></li>
                 <li><a href="misc/faq">FAQ</a></li>
               </ul>
             </li>


### PR DESCRIPTION
On angularjs.org, under learn there is a link to the seed app. This link was missing from the menu on docs.angularjs.org.
