### PR TITLE
Make $urlUtils public and add a resolve callback

### DIFF
--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -126,7 +126,7 @@ function publishExternalAPI(angular){
         $templateCache: $TemplateCacheProvider,
         $timeout: $TimeoutProvider,
         $window: $WindowProvider,
-        $$urlUtils: $$UrlUtilsProvider
+        $urlUtils: $UrlUtilsProvider
       });
     }
   ]);

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -274,9 +274,9 @@ function $CompileProvider($provide) {
 
   this.$get = [
             '$injector', '$interpolate', '$exceptionHandler', '$http', '$templateCache', '$parse',
-            '$controller', '$rootScope', '$document', '$$urlUtils',
+            '$controller', '$rootScope', '$document', '$urlUtils',
     function($injector,   $interpolate,   $exceptionHandler,   $http,   $templateCache,   $parse,
-             $controller,   $rootScope,   $document,   $$urlUtils) {
+             $controller,   $rootScope,   $document,   $urlUtils) {
 
     var Attributes = function(element, attr) {
       this.$$element = element;
@@ -324,9 +324,9 @@ function $CompileProvider($provide) {
         // sanitize a[href] and img[src] values
         if ((nodeName === 'A' && key === 'href') ||
             (nodeName === 'IMG' && key === 'src')) {
-          // NOTE: $$urlUtils.resolve() doesn't support IE < 8 so we don't sanitize for that case.
+          // NOTE: $urlUtils.resolve() doesn't support IE < 8 so we don't sanitize for that case.
           if (!msie || msie >= 8 ) {
-            normalizedVal = $$urlUtils.resolve(value);
+            normalizedVal = $urlUtils.resolve(value);
             if (normalizedVal !== '') {
               if ((key === 'href' && !normalizedVal.match(aHrefSanitizationWhitelist)) ||
                   (key === 'src' && !normalizedVal.match(imgSrcSanitizationWhitelist))) {

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -131,8 +131,8 @@ function $HttpProvider() {
    */
   var responseInterceptorFactories = this.responseInterceptors = [];
 
-  this.$get = ['$httpBackend', '$browser', '$cacheFactory', '$rootScope', '$q', '$injector', '$$urlUtils',
-      function($httpBackend, $browser, $cacheFactory, $rootScope, $q, $injector, $$urlUtils) {
+  this.$get = ['$httpBackend', '$browser', '$cacheFactory', '$rootScope', '$q', '$injector', '$urlUtils',
+      function($httpBackend, $browser, $cacheFactory, $rootScope, $q, $injector, $urlUtils) {
 
     var defaultCache = $cacheFactory('$http');
 
@@ -620,7 +620,7 @@ function $HttpProvider() {
       config.headers = headers;
       config.method = uppercase(config.method);
 
-      var xsrfValue = $$urlUtils.isSameOrigin(config.url)
+      var xsrfValue = $urlUtils.isSameOrigin(config.url)
           ? $browser.cookies()[config.xsrfCookieName || defaults.xsrfCookieName]
           : undefined;
       if (xsrfValue) {

--- a/src/ng/urlUtils.js
+++ b/src/ng/urlUtils.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function $$UrlUtilsProvider() {
+function $UrlUtilsProvider() {
   this.$get = ['$window', '$document', function($window, $document) {
     var urlParsingNode = $document[0].createElement("a"),
         originUrl = resolve($window.location.href, true);
@@ -8,8 +8,6 @@ function $$UrlUtilsProvider() {
     /**
      * @description
      * Normalizes and optionally parses a URL.
-     *
-     * NOTE:  This is a private service.  The API is subject to change unpredictably in any commit.
      *
      * Implementation Notes for non-IE browsers
      * ----------------------------------------
@@ -45,8 +43,11 @@ function $$UrlUtilsProvider() {
      *   http://james.padolsey.com/javascript/parsing-urls-with-the-dom/
      *
      * @param {string} url The URL to be parsed.
-     * @param {boolean=} parse When true, returns an object for the parsed URL.  Otherwise, returns
-     *   a single string that is the normalized URL.
+     * @param {boolean|function} parse When true, returns an object for the parsed URL.
+     *   When a function, calls that function with a modifiable object for the parsed URL, the
+     *   function may modify the object and its normalized URL will be recomputed, then the
+     *   modified object for the URL is returned.
+     *   Otherwise, returns a single string that is the normalized URL.
      * @returns {object|string} When parse is true, returns the normalized URL as a string.
      * Otherwise, returns an object with the following members.
      *
@@ -55,13 +56,9 @@ function $$UrlUtilsProvider() {
      *   | href          | A normalized version of the provided URL if it was not an absolute URL |
      *   | protocol      | The protocol including the trailing colon                              |
      *   | host          | The host and port (if the port is non-default) of the normalizedUrl    |
-     *
-     * These fields from the UrlUtils interface are currently not needed and hence not returned.
-     *
-     *   | member name   | Description    |
-     *   |===============|================|
      *   | hostname      | The host without the port of the normalizedUrl                         |
      *   | pathname      | The path following the host in the normalizedUrl                       |
+     *   | port          | The port (if the port is non-default)                                  |
      *   | hash          | The URL hash if present                                                |
      *   | search        | The query string                                                       |
      *
@@ -79,17 +76,21 @@ function $$UrlUtilsProvider() {
       if (!parse) {
         return urlParsingNode.href;
       }
+
+      if (isFunction(parse)) {
+        parse(urlParsingNode);
+      }
+
       // urlParsingNode provides the UrlUtils interface - http://url.spec.whatwg.org/#urlutils
       return {
         href: urlParsingNode.href,
         protocol: urlParsingNode.protocol,
-        host: urlParsingNode.host
-        // Currently unused and hence commented out.
-        // hostname: urlParsingNode.hostname,
-        // port: urlParsingNode.port,
-        // pathname: urlParsingNode.pathname,
-        // hash: urlParsingNode.hash,
-        // search: urlParsingNode.search
+        host: urlParsingNode.host,
+        hostname: urlParsingNode.hostname,
+        port: urlParsingNode.port,
+        pathname: urlParsingNode.pathname,
+        hash: urlParsingNode.hash,
+        search: urlParsingNode.search
       };
     }
 

--- a/test/ng/urlUtilsSpec.js
+++ b/test/ng/urlUtilsSpec.js
@@ -1,31 +1,39 @@
 'use strict';
 
-describe('$$urlUtils', function() {
+describe('$urlUtils', function() {
   describe('parse', function() {
-    it('should normalize a relative url', inject(function($$urlUtils) {
-      expect($$urlUtils.resolve("foo")).toMatch(/^https?:\/\/[^/]+\/foo$/);
+    it('should normalize a relative url', inject(function($urlUtils) {
+      expect($urlUtils.resolve("foo")).toMatch(/^https?:\/\/[^/]+\/foo$/);
     }));
 
-    it('should parse relative URL into component pieces', inject(function($$urlUtils) {
-      var parsed = $$urlUtils.resolve("foo", true);
+    it('should parse relative URL into component pieces', inject(function($urlUtils) {
+      var parsed = $urlUtils.resolve("foo", true);
       expect(parsed.href).toMatch(/https?:\/\//);
       expect(parsed.protocol).toMatch(/^https?:/);
       expect(parsed.host).not.toBe("");
     }));
+
+    it('should parse relative URL into component pieces and modify the protocol', inject(function($urlUtils) {
+      var parsed = $urlUtils.resolve("foo", function(urlUtils) {
+        urlUtils.protocol = urlUtils.protocol === 'https:' ? 'wss:' : 'ws:';
+      });
+      expect(parsed.href).toMatch(/wss?:\/\//);
+      expect(parsed.protocol).toMatch(/^wss?:/);
+    }));
   });
 
   describe('isSameOrigin', function() {
-    it('should support various combinations of urls', inject(function($$urlUtils, $document) {
-      expect($$urlUtils.isSameOrigin('path')).toBe(true);
-      var origin = $$urlUtils.resolve($document[0].location.href, true);
-      expect($$urlUtils.isSameOrigin('//' + origin.host + '/path')).toBe(true);
+    it('should support various combinations of urls', inject(function($urlUtils, $document) {
+      expect($urlUtils.isSameOrigin('path')).toBe(true);
+      var origin = $urlUtils.resolve($document[0].location.href, true);
+      expect($urlUtils.isSameOrigin('//' + origin.host + '/path')).toBe(true);
       // Different domain.
-      expect($$urlUtils.isSameOrigin('http://example.com/path')).toBe(false);
+      expect($urlUtils.isSameOrigin('http://example.com/path')).toBe(false);
       // Auto fill protocol.
-      expect($$urlUtils.isSameOrigin('//example.com/path')).toBe(false);
+      expect($urlUtils.isSameOrigin('//example.com/path')).toBe(false);
       // Should not match when the ports are different.
       // This assumes that the test is *not* running on port 22 (very unlikely).
-      expect($$urlUtils.isSameOrigin('//' + origin.hostname + ':22/path')).toBe(false);
+      expect($urlUtils.isSameOrigin('//' + origin.hostname + ':22/path')).toBe(false);
     }));
   });
 });


### PR DESCRIPTION
The resolve callback allows the application code to modify the
resolved url before it is normailzed by urlParsingNode.href for example:

var parsed = $urlUtils.resolve("foo", function(urlUtils) {
  urlUtils.protocol =
    urlUtils.protocol === 'https:' ? 'wss:' : 'ws:';
});
parsed.href // wss://localhost/foo

The resolved url object now includes the aditional properties hostname,
port, pathname, hash and search.
