### PR TITLE
feat(copy, equals): copy and equals can now handle cyclic structures.

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -694,45 +694,76 @@ function shallowCopy(src, dst) {
  * @param {*} o2 Object or value to compare.
  * @returns {boolean} True if arguments are equal.
  */
-function equals(o1, o2) {
-  if (o1 === o2) return true;
-  if (o1 === null || o2 === null) return false;
-  if (o1 !== o1 && o2 !== o2) return true; // NaN === NaN
-  var t1 = typeof o1, t2 = typeof o2, length, key, keySet;
-  if (t1 == t2) {
-    if (t1 == 'object') {
-      if (isArray(o1)) {
-        if ((length = o1.length) == o2.length) {
-          for(key=0; key<length; key++) {
-            if (!equals(o1[key], o2[key])) return false;
+
+var equals = function() {
+  function equals(stack1, stack2, o1, o2) {
+    if (o1 === o2) return true;
+    if (o1 === null || o2 === null) return false;
+    if (o1 !== o1 && o2 !== o2) return true; // NaN === NaN
+    var t1 = typeof o1, t2 = typeof o2, length, key, keySet;
+    if (t1 == t2) {
+      if (t1 == 'object') {
+        if (isArray(o1)) {
+          if ((length = o1.length) == o2.length) {
+            var idx1, idx2, equal;
+            for(key=0; key<length; key++) {
+              idx1 = stack1.lastIndexOf(o1[key]);
+              idx2 = stack2.lastIndexOf(o2[key]);
+              if (idx1 < 0 || idx1 != idx2) {
+                stack1.push(o1[key]);
+                stack2.push(o2[key]);
+
+                equal = equals(stack1, stack2, o1[key], o2[key]);
+
+                stack1.pop(); 
+                stack2.pop();              
+                if(!equal) return false;
+              }
+            }
+            return true;
           }
-          return true;
-        }
-      } else if (isDate(o1)) {
-        return isDate(o2) && o1.getTime() == o2.getTime();
-      } else if (isRegExp(o1) && isRegExp(o2)) {
-        return o1.toString() == o2.toString();
-      } else {
-        if (isScope(o1) || isScope(o2) || isWindow(o1) || isWindow(o2)) return false;
-        keySet = {};
-        for(key in o1) {
-          if (key.charAt(0) === '$' || isFunction(o1[key])) continue;
-          if (!equals(o1[key], o2[key])) return false;
-          keySet[key] = true;
-        }
-        for(key in o2) {
+        } else if (isDate(o1)) {
+          return isDate(o2) && o1.getTime() == o2.getTime();
+        } else if (isRegExp(o1) && isRegExp(o2)) {
+          return o1.toString() == o2.toString();
+        } else {
+          if (isScope(o1) || isScope(o2) || isWindow(o1) || isWindow(o2)) return false;
+          keySet = {};
+          var idx1, idx2, equal;
+          for(key in o1) {
+            if (key.charAt(0) === '$' || isFunction(o1[key])) continue;
+
+            idx1 = stack1.lastIndexOf(o1[key]);
+            idx2 = stack2.lastIndexOf(o2[key]);
+            if (idx1 < 0 || idx1 != idx2) {
+              stack1.push(o1[key]);
+              stack2.push(o2[key]);
+
+              equal = equals(stack1, stack2, o1[key], o2[key]);
+
+              stack1.pop();
+              stack2.pop();              
+              if (!equal) return false;
+            }
+
+            keySet[key] = true;
+          }
+          for(key in o2) {
           if (!keySet.hasOwnProperty(key) &&
               key.charAt(0) !== '$' &&
               o2[key] !== undefined &&
               !isFunction(o2[key])) return false;
+          }
+          return true;
         }
-        return true;
       }
     }
+    return false;
   }
-  return false;
-}
-
+  return function(o1, o2) {
+    return equals([], [], o1, o2);
+  };
+}();
 
 function concat(array1, array2, index) {
   return array1.concat(slice.call(array2, index));

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -24,6 +24,71 @@ describe('angular', function() {
       expect(copy([], arr)).toBe(arr);
     });
 
+    it("should copy a cyclic object", function () {
+      var src = {name: "value", level2:{level3:{}}};
+      src['self'] = src;
+      src['level2']['self'] = src;
+
+      var cpy = copy(src);
+      expect(cpy['name']).toEqual("value");
+      expect(cpy['self']).toEqual(cpy);
+
+      var dst = {};
+      copy(src, dst);
+      expect(dst['name']).toEqual("value");
+      expect(dst['self']).toEqual(dst);
+    });
+
+    it("should copy a cyclic array", function () {
+      var src = [0];
+      src.push(src);
+      src.push(2);
+
+      var cpy = copy(src);
+      expect(cpy[0]).toEqual(0);
+      expect(cpy[1]).toEqual(cpy);
+      expect(cpy[2]).toEqual(2);
+      expect(cpy[1][0]).toEqual(0);
+
+      var dst = [];
+      copy(src, dst);
+      expect(dst[0]).toEqual(0);
+      expect(dst[1]).toEqual(dst);
+      expect(dst[2]).toEqual(2);
+      expect(dst[1][0]).toEqual(0);
+    });
+
+    it("should copy complex cyclic objects", function () {
+      var obj = {name: "value", list:[], obj:{list:[]}};
+      obj['self'] = obj;
+
+      obj['obj']['self'] = obj;
+      obj['obj']['list'].push(obj);
+      obj['obj']['list'].push(obj['obj']['list'])
+
+      obj['list'].push(obj);
+      obj['list'].push(obj['list']);
+      obj['list'].push({list:obj['list'], self:obj});
+
+      var cpy = copy(obj);
+      expect(cpy['obj']['self']).toBe(cpy);
+      expect(cpy['obj']['list'][0]).toBe(cpy);
+      expect(cpy['obj']['list'][1]).toBe(cpy['obj']['list']);
+      expect(cpy['list'][0]).toBe(cpy);
+      expect(cpy['list'][1]).toBe(cpy['list']);
+      expect(cpy['list'][2]['list']).toBe(cpy['list']);
+      expect(cpy['list'][2]['self']).toBe(cpy);
+
+      cpy = copy(obj, {});
+      expect(cpy['obj']['self']).toBe(cpy);
+      expect(cpy['obj']['list'][0]).toBe(cpy);
+      expect(cpy['obj']['list'][1]).toBe(cpy['obj']['list']);
+      expect(cpy['list'][0]).toBe(cpy);
+      expect(cpy['list'][1]).toBe(cpy['list']);
+      expect(cpy['list'][2]['list']).toBe(cpy['list']);
+      expect(cpy['list'][2]['self']).toBe(cpy);
+    });
+
     it("should copy Date", function() {
       var date = new Date(123);
       expect(copy(date) instanceof Date).toBeTruthy();

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -269,6 +269,54 @@ describe('angular', function() {
       expect(equals(['misko'], ['misko', 'adam'])).toEqual(false);
     });
 
+    it("should handle cyclic objects", function () {
+      var obj = {name: "value"}
+      obj['self'] = obj;
+
+      var cpy = {name: "value"};
+      cpy['self'] = cpy;
+
+      expect(equals(obj, cpy)).toEqual(true);
+    });
+
+    it("should handle cyclic arrays", function () {
+      var obj = [0];
+      obj.push(obj);
+      obj.push(2);
+
+      var cpy = [0];
+      cpy.push(cpy);
+      cpy.push(2);
+
+      expect(equals(obj, cpy)).toEqual(true);
+    });
+
+    it("should handle complex cyclic objects", function () {
+      var obj = {name: "value", list:[], obj:{list:[]}};
+      obj['self'] = obj;
+
+      obj['obj']['self'] = obj;
+      obj['obj']['list'].push(obj);
+      obj['obj']['list'].push(obj['obj']['list'])
+
+      obj['list'].push(obj);
+      obj['list'].push(obj['list']);
+      obj['list'].push({list:obj['list'], self:obj});
+
+      var cpy = {name: "value", list:[], obj:{list:[]}};
+      cpy['self'] = cpy;
+
+      cpy['obj']['self'] = cpy;
+      cpy['obj']['list'].push(cpy);
+      cpy['obj']['list'].push(cpy['obj']['list'])
+
+      cpy['list'].push(cpy);
+      cpy['list'].push(cpy['list']);
+      cpy['list'].push({list:cpy['list'], self:cpy});
+
+      expect(equals(obj, cpy)).toEqual(true);
+    });
+
     it('should ignore undefined member variables during comparison', function() {
       var obj1 = {name: 'misko'},
           obj2 = {name: 'misko', undefinedvar: undefined};


### PR DESCRIPTION
- Copy can now accurately copy cyclic structures.
- Equals can now accurately assess equality of cyclic structures.
- This should enable watching of cyclic objects.

Eg: copy and equals should work as expected in the following:

```
var obj = {name: "value"};
obj['nested'] = {self: obj};

var cpy = copy(obj);
expect(equals(obj, copy)).toBe(true);
expect(obj['nested']['self']).toBe(obj);
```

However, this is NOT graph copy.
Eg.

```
var obj = {name: "value"};
nested = {level2: "level2"};
obj['nested1'] = nested;
obj['nested2'] = nested;
var cpy = copy(obj);
expect(equals(obj, copy).toBe(true);

//This will fail. Although they were the same
//in the original object, they are distinct copies now.
expect(cpy['nested1']).toBe(cpy['nested2']);
```
