### PR TITLE
docs(bootstrap): Note that ngScenario requires ngApp

### DIFF
--- a/docs/content/guide/dev_guide.e2e-testing.ngdoc
+++ b/docs/content/guide/dev_guide.e2e-testing.ngdoc
@@ -302,3 +302,7 @@ element('.btn-danger').click();
     element('table tbody a');
     element('.btn-danger').click();
 </pre>
+
+# Caveats
+
+ngScenario does not work with apps that manually bootstrap using angular.bootstrap. You must use the ng-app directive.

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1036,6 +1036,9 @@ function angularInit(element, bootstrap) {
  *
  * See: {@link guide/bootstrap Bootstrap}
  *
+ * Note that ngScenario-based end-to-end tests cannot use this function to bootstrap manually.
+ * They must use {@link api/ng.directive:ngApp ngApp}.
+ *
  * @param {Element} element DOM element which is the root of angular application.
  * @param {Array<String|Function>=} modules an array of module declarations. See: {@link angular.module modules}
  * @returns {AUTO.$injector} Returns the newly created injector for this app.


### PR DESCRIPTION
ngScenario expects an ngApp directive to be used, and doesn't work for
manually bootstrapped apps. The failure mode is to hang on navigation.

Trying to make this wont-fix bug less obscure by documenting it.
Eventually Protractor will replace ngScenario and fix this.
