### PR TITLE
feat($location): add support for state and title in pushState

### DIFF
--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -567,7 +567,7 @@ describe('$location', function() {
       $rootScope.$apply();
 
       expect($browserUrl).toHaveBeenCalledOnce();
-      expect($browserUrl.mostRecentCall.args).toEqual(['http://new.com/a/b#!/n/url', true]);
+      expect($browserUrl.mostRecentCall.args).toEqual(['http://new.com/a/b#!/n/url', true, null, undefined]);
       expect($location.$$replace).toBe(false);
     }));
 

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -865,7 +865,7 @@ describe('$route', function() {
 
         expect($location.path()).toEqual('/bar/id3');
         expect($browserUrl.mostRecentCall.args)
-            .toEqual(['http://server/#/bar/id3?extra=eId', true]);
+            .toEqual(['http://server/#/bar/id3?extra=eId', true, null, undefined]);
       });
     });
   });


### PR DESCRIPTION
Adds $location pushState & replaceState methods acting as proxies to history
pushState & replaceState methods. This allows using pushState to change state
and title as well as URL. Note that these methods are not compatible with
browsers not supporting the HTML5 History API, namely IE<10.

This builds on work from https://github.com/angular/angular.js/pull/1675. I applied changes based on developers' remarks, I added a few tests and fixed a couple of issues regarding the older pull request.

As for the fallback story - there isn't any easy fallback for browsers not supporting the HTML5 History API. It's possible to use a shim like https://github.com/browserstate/history.js which declares the `History` objects normalizing some stuff or to adjust it to just polyfill the `history` `pushState` and `replaceState` methods as well as the `state` property, though it would require quite significant amount of code.

I'll repeat what I wrote in a comment in the older pull request thread: would it be possible to add this feature while making note IE9 and older are not supported with this methods? I personally work more & more on projects dumping IE8 and older completely and IE9 already has way lower market share than IE8 and it's going quickly down as most IE9 users are auto-updated to IE10.

This should work for Google projects as well because Google policy is to fully support only the current and previous versions of each browser and once IE11 goes out in a few months, this means dumping IE9 which makes pushState available in all supported browsers.

I'm commited to make this patch go inside Angular, our team needs it a lot. If you have any remarks/need more tests/etc., I'll apply the needed changes.
