### PR TITLE
feat(scenario): expose jQuery for usage outside of angular scenario

### DIFF
--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -10,6 +10,11 @@
 angular.scenario = angular.scenario || {};
 
 /**
+ * Expose jQuery (e.g. for custom dsl extensions).
+ */
+angular.scenario.jQuery = _jQuery;
+
+/**
  * Defines a new output format.
  *
  * @param {string} name the name of the new output format


### PR DESCRIPTION
We are using jQuery in some custom angular scenario dsl methods. Unfortunately the jQuery included in angular-scneario is not available for us, because via noConflict() the global reference is removed and only a local reference is kept. To remove the necessity to include a second jQuery in our test setup, this commit adds a angular.scenario.jQuery variable, making jQuery available for others.

I already signed the CLA. My full name is Andreas Marek.

Best regards
