### PR TITLE
Route continues to be processed even if providing a redirectTo

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -430,6 +430,7 @@ function $RouteProvider(){
               $location.url(next.redirectTo(next.pathParams, $location.path(), $location.search()))
                        .replace();
             }
+            return;//exit out and don't process current next value, wait for next location change from redirect
           }
         }
 

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -423,6 +423,7 @@ function $RouteProvider(){
         $route.current = next;
         if (next) {
           if (next.redirectTo) {
+            var url = $location.url();
             if (isString(next.redirectTo)) {
               $location.path(interpolate(next.redirectTo, next.params)).search(next.params)
                        .replace();
@@ -430,7 +431,9 @@ function $RouteProvider(){
               $location.url(next.redirectTo(next.pathParams, $location.path(), $location.search()))
                        .replace();
             }
-            return;//exit out and don't process current next value, wait for next location change from redirect
+            if (url !== $location.url()) {
+                return;//exit out and don't process current next value, wait for next location change from redirect
+            }
           }
         }
 

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -509,6 +509,28 @@ describe('ngView', function() {
     });
   });
 
+  it('should not instantiate controller of redirected route', function() {
+      var firstController = jasmine.createSpy('first controller spy');
+      var secondController = jasmine.createSpy('second controller spy');
+      module(function($routeProvider) {
+          $routeProvider.when('/redirect', {
+              template: 'redirect view',
+              redirectTo: '/redirected',
+              controller: firstController
+          });
+          $routeProvider.when('/redirected', {
+              template: 'redirected view',
+              controller: secondController
+          });
+      });
+      inject(function($route, $location, $rootScope) {
+          $location.path('/redirect');
+          $rootScope.$digest();
+          expect(firstController).not.toHaveBeenCalled();
+          expect(secondController).toHaveBeenCalled();
+      });
+  });
+
   describe('ngAnimate ', function() {
     var window, vendorPrefix;
     var body, element, $rootElement;


### PR DESCRIPTION
If a route defines a redirectTo value, the current route should stop processing the route and instead wait to process the route of the redirect. 

Currently, what is happening is that Angular detects a redirectTo value and updates $location, but then continues processing the route that was intended to be redirected. Templates are loaded, resolves are processed, ng-view then updates the view with a new template and instantiates the controller all for a route that should have been redirected.

A common use case for assigning a function to the redirectTo is to validation authentication, permission check, or some other logic to determine if the route should continue or redirect else where. In the end, this happens, but in between, unexpected results may occur by updating the view and instantiating controllers for logic that wasn't expected to be executed.

http://plnkr.co/edit/8QlA0ouuePH3p35Ntmjy?p=preview
