### PR TITLE
fix(ngMobile): prevent ngClick when item disabled

### DIFF
--- a/src/ngMobile/directive/ngClick.js
+++ b/src/ngMobile/directive/ngClick.js
@@ -232,10 +232,11 @@ ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
           tapElement.blur();
         }
 
-        scope.$apply(function() {
-          // TODO(braden): This is sending the touchend, not a tap or click. Is that kosher?
-          clickHandler(scope, {$event: event});
-        });
+        if (!angular.isDefined(attr.disabled) || attr.disabled === false) {
+          scope.$apply(function() {
+            clickHandler(scope, {$event: event});
+          });
+        }
       }
 
       resetState();

--- a/test/ngMobile/directive/ngClickSpec.js
+++ b/test/ngMobile/directive/ngClickSpec.js
@@ -310,4 +310,52 @@ describe('ngClick (mobile)', function() {
   });
 
 
+  describe('disabled state', function() {
+    it('should not trigger click if ngDisabled is true', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-click="event = $event" ng-disabled="disabled"></div>')($rootScope);
+      $rootScope.disabled = true;
+      $rootScope.$digest();
+
+      browserTrigger(element, 'touchstart', [], 10, 10);
+      browserTrigger(element, 'touchend', [], 10, 10);
+
+      expect($rootScope.event).toBeUndefined();
+    }));
+    it('should trigger click if ngDisabled is false', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-click="event = $event" ng-disabled="disabled"></div>')($rootScope);
+      $rootScope.disabled = false;
+      $rootScope.$digest();
+
+      browserTrigger(element, 'touchstart', [], 10, 10);
+      browserTrigger(element, 'touchend', [], 10, 10);
+
+      expect($rootScope.event).toBeDefined();
+    }));
+    it('should not trigger click if regular disabled is true', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-click="event = $event" disabled="true"></div>')($rootScope);
+
+      browserTrigger(element, 'touchstart', [], 10, 10);
+      browserTrigger(element, 'touchend', [], 10, 10);
+
+      expect($rootScope.event).toBeUndefined();
+    }));
+    it('should not trigger click if regular disabled is present', inject(function($rootScope, $compile) {
+      element = $compile('<button ng-click="event = $event" disabled ></button>')($rootScope);
+
+      browserTrigger(element, 'touchstart', [], 10, 10);
+      browserTrigger(element, 'touchend', [], 10, 10);
+
+      expect($rootScope.event).toBeUndefined();
+    }));
+    it('should trigger click if regular disabled is not present', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-click="event = $event" ></div>')($rootScope);
+
+      browserTrigger(element, 'touchstart', [], 10, 10);
+      browserTrigger(element, 'touchend', [], 10, 10);
+
+      expect($rootScope.event).toBeDefined();
+    }));
+  });
+
+
 });


### PR DESCRIPTION
- the ngClick attribute was always triggered, regardless the ngDisabled/disabled attributes
  - we now check the DOM disabled status before triggering the original click event
  - deals with #3124 #3132 /cc @shepheb
  - also adds `ngClick` event, replacing PR #3219, which fixes #3218.
