### PR TITLE
fix(ngMobile): Emit click event for touchy clicks

### DIFF
--- a/src/ngMobile/directive/ngClick.js
+++ b/src/ngMobile/directive/ngClick.js
@@ -233,9 +233,7 @@ ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
         }
 
         if (!angular.isDefined(attr.disabled) || attr.disabled === false) {
-          scope.$apply(function() {
-            clickHandler(scope, {$event: event});
-          });
+          element.triggerHandler('click', event);
         }
       }
 
@@ -246,9 +244,12 @@ ngMobile.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     // something else nearby.
     element.onclick = function(event) { };
 
-    // Fallback click handler.
-    // Busted clicks don't get this far, and adding this handler allows ng-tap to be used on
-    // desktop as well, to allow more portable sites.
+    // Actual click handler.
+    // There are three different kinds of clicks, only two of which reach this point.
+    // - On desktop browsers without touch events, their clicks will always come here.
+    // - On mobile browsers, the simulated "fast" click will call this.
+    // - But the browser's follow-up slow click will be "busted" before it reaches this handler.
+    // Therefore it's safe to use this directive on both mobile and desktop.
     element.on('click', function(event) {
       scope.$apply(function() {
         clickHandler(scope, {$event: event});

--- a/test/ngMobile/directive/ngClickSpec.js
+++ b/test/ngMobile/directive/ngClickSpec.js
@@ -358,4 +358,20 @@ describe('ngClick (mobile)', function() {
   });
 
 
+  describe('the normal click event', function() {
+    it('should be capturable by other handlers', inject(function($rootScope, $compile) {
+      var called = false;
+
+      element = $compile('<div ng-click="event = $event" ></div>')($rootScope);
+
+      element.on('click', function() {
+        called = true;
+      });
+
+      browserTrigger(element, 'touchstart', [], 10, 10);
+      browserTrigger(element, 'touchend', [], 10, 10);
+
+      expect(called).toEqual(true);
+    }));
+  });
 });


### PR DESCRIPTION
Previously, no handlers for the click event would be called for the
fast, touch-based ngMobile clicks, only for desktop browser clicks. Now
the event will fire properly for all clicks.
