### PR TITLE
docs($animator): fix doc signature for enabled()

### DIFF
--- a/src/ng/animator.js
+++ b/src/ng/animator.js
@@ -427,7 +427,7 @@ var $AnimatorProvider = function() {
      * @methodOf ng.$animator
      * @function
      *
-     * @param {Boolean=} If provided then set the animation on or off.
+     * @param {Boolean=} value If provided then set the animation on or off.
      * @return {Boolean} Current animation state.
      *
      * @description


### PR DESCRIPTION
The `enabled()` method shows up incorrectly in the docs, i.e.:

| Param | Type | Details |
| --- | --- | --- |
| If | Boolean | provided then set the animation on or off. |

...because the `@param` declaration doesn't have the parameter name.
