### PR TITLE
Added optional support for Zepto in addition to jQuery

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -84,6 +84,7 @@ module.exports = function(grunt) {
     test: {
       jqlite: 'karma-jqlite.conf.js',
       jquery: 'karma-jquery.conf.js',
+      zepto: 'karma-zepto.conf.js',
       docs: 'karma-docs.conf.js',
       modules: 'karma-modules.conf.js',
       //NOTE run grunt test:e2e instead and it will start a webserver for you
@@ -237,7 +238,7 @@ module.exports = function(grunt) {
 
 
   //alias tasks
-  grunt.registerTask('test:unit', ['test:jqlite', 'test:jquery', 'test:modules']);
+  grunt.registerTask('test:unit', ['test:jqlite', 'test:jquery', 'test:zepto', 'test:modules']);
   grunt.registerTask('test:docgen', ['jasmine-node']);
   grunt.registerTask('minify', ['shell:bower','clean', 'build', 'minall']);
   grunt.registerTask('test:e2e', ['connect:testserver', 'test:end2end']);

--- a/angularFiles.js
+++ b/angularFiles.js
@@ -116,8 +116,10 @@ angularFiles = {
   ],
 
   'karma': [
+    'components/zepto/zepto.js',
     'components/jquery/jquery.js',
     'test/jquery_remove.js',
+    'test/zepto_remove.js',
     '@angularSrc',
     'src/publishExternalApis.js',
     '@angularSrcModules',
@@ -128,6 +130,7 @@ angularFiles = {
   ],
 
   'karmaExclude': [
+    'test/zepto_alias.js',
     'test/jquery_alias.js',
     'src/angular-bootstrap.js',
     'src/ngScenario/angular-bootstrap.js'
@@ -154,7 +157,9 @@ angularFiles = {
 
   'karmaJquery': [
     'components/jquery/jquery.js',
+    'components/zepto/zepto.js',
     'test/jquery_alias.js',
+    'test/zepto_remove.js',
     '@angularSrc',
     'src/publishExternalApis.js',
     '@angularSrcModules',
@@ -168,7 +173,30 @@ angularFiles = {
   'karmaJqueryExclude': [
     'src/angular-bootstrap.js',
     'src/ngScenario/angular-bootstrap.js',
-    'test/jquery_remove.js'
+    'test/jquery_remove.js',
+    'test/zepto_alias.js'
+  ],
+
+  'karmaZepto': [
+    'components/jquery/jquery.js',
+    'components/zepto/zepto.js',
+    'test/zepto_alias.js',
+    'test/jquery_remove.js',
+    '@angularSrc',
+    'src/publishExternalApis.js',
+    '@angularSrcModules',
+    '@angularScenario',
+    '@angularTest',
+    'example/personalLog/*.js',
+
+    'example/personalLog/test/*.js'
+  ],
+
+  'karmaZeptoExclude': [
+    'src/angular-bootstrap.js',
+    'src/ngScenario/angular-bootstrap.js',
+    'test/zepto_remove.js',
+    'test/jquery_alias.js'
   ]
 };
 

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "AngularJS",
   "devDependencies": {
     "jquery": "git://github.com/components/jquery.git#v1.8.3",
+    "zepto": "git://github.com/components/zepto#1.0.0",
     "lunr.js": "0.4.0",
     "google-code-prettify": "1.0.0",
     "components-font-awesome": "3.1.0",

--- a/karma-zepto.conf.js
+++ b/karma-zepto.conf.js
@@ -1,0 +1,18 @@
+var angularFiles = require('./angularFiles');
+var sharedConfig = require('./karma-shared.conf');
+
+module.exports = function(config) {
+  sharedConfig(config);
+
+  config.set({
+    files: angularFiles.mergeFilesFor('karmaZepto'),
+    exclude: angularFiles.mergeFilesFor('karmaZeptoExclude'),
+
+    junitReporter: {
+      outputFile: 'test_out/zepto.xml',
+      suite: 'Zepto'
+    }
+  });
+
+  config.sauceLabs.testName = 'AngularJS: Zepto';
+};

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -59,8 +59,9 @@ if ('i' !== 'I'.toLowerCase()) {
 
 var /** holds major version number for IE or NaN for real browsers */
     msie              = int((/msie (\d+)/.exec(lowercase(navigator.userAgent)) || [])[1]),
-    jqLite,           // delay binding since jQuery could be loaded after us.
+    jqLite,           // delay binding since jQuery or Zepto could be loaded after us.
     jQuery,           // delay binding
+    Zepto,            // delay binding
     slice             = [].slice,
     push              = [].push,
     toString          = Object.prototype.toString,
@@ -1089,12 +1090,14 @@ function snake_case(name, separator){
 }
 
 function bindJQuery() {
-  // bind to jQuery if present;
+  // bind to jQuery or Zepto if present;
   jQuery = window.jQuery;
-  // reset to jQuery or default to us.
-  if (jQuery) {
-    jqLite = jQuery;
-    extend(jQuery.fn, {
+  Zepto = window.Zepto;
+  // reset to jQuery or Zepto or default to us.
+  if (jQuery || Zepto || false) {
+    var binder = jQuery || Zepto;
+    jqLite = binder;
+    extend(binder.fn, {
       scope: JQLitePrototype.scope,
       controller: JQLitePrototype.controller,
       injector: JQLitePrototype.injector,

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -123,10 +123,11 @@ function camelCase(name) {
 /////////////////////////////////////////////
 
 function JQLitePatchJQueryRemove(name, dispatchThis, filterElems, getterIfNoArguments) {
-  var originalJqFn = jQuery.fn[name];
+  var binder = jQuery || Zepto,
+    originalJqFn = binder.fn[name];
   originalJqFn = originalJqFn.$original || originalJqFn;
   removePatch.$original = originalJqFn;
-  jQuery.fn[name] = removePatch;
+  binder.fn[name] = removePatch;
 
   function removePatch(param) {
     var list = filterElems && param ? [this.filter(param)] : [this],
@@ -147,7 +148,7 @@ function JQLitePatchJQueryRemove(name, dispatchThis, filterElems, getterIfNoArgu
           for(childIndex = 0, childLength = (children = element.children()).length;
               childIndex < childLength;
               childIndex++) {
-            list.push(jQuery(children[childIndex]));
+            list.push(binder(children[childIndex]));
           }
         }
       }

--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -233,23 +233,24 @@ function callerFile(offset) {
  *
  * To work around this we instead use our own handler that fires a real event.
  */
-(function(fn){
-  var parentTrigger = fn.trigger;
-  fn.trigger = function(type) {
-    if (/(click|change|keydown|blur|input|mousedown|mouseup)/.test(type)) {
-      var processDefaults = [];
-      this.each(function(index, node) {
-        processDefaults.push(browserTrigger(node, type));
-      });
+if (angular.isDefined(_jQuery)) {
+  (function(fn){
+    var parentTrigger = fn.trigger;
+    fn.trigger = function(type) {
+      if (/(click|change|keydown|blur|input|mousedown|mouseup)/.test(type)) {
+        var processDefaults = [];
+        this.each(function(index, node) {
+          processDefaults.push(browserTrigger(node, type));
+        });
 
-      // this is not compatible with jQuery - we return an array of returned values,
-      // so that scenario runner know whether JS code has preventDefault() of the event or not...
-      return processDefaults;
-    }
-    return parentTrigger.apply(this, arguments);
-  };
-})(_jQuery.fn);
-
+        // this is not compatible with jQuery - we return an array of returned values,
+        // so that scenario runner know whether JS code has preventDefault() of the event or not...
+        return processDefaults;
+      }
+      return parentTrigger.apply(this, arguments);
+    };
+  })(_jQuery.fn);
+}
 /**
  * Finds all bindings with the substring match of name and returns an
  * array of their values.

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -40,8 +40,8 @@ describe('jqLite', function() {
   });
 
 
-  it('should be jqLite when jqLiteMode is on, otherwise jQuery', function() {
-    expect(jqLite).toBe(_jqLiteMode ? JQLite : _jQuery);
+  it('should be jqLite when jqLiteMode is on, otherwise jQuery or Zepto', function() {
+    expect(jqLite).toBe(_jqLiteMode ? JQLite : (angular.isDefined(_jQuery)) ? _jQuery : _Zepto);
   });
 
 

--- a/test/testabilityPatch.js
+++ b/test/testabilityPatch.js
@@ -22,6 +22,10 @@ beforeEach(function() {
       jQuery = _jQuery;
     }
 
+    if (!_jqLiteMode && _Zepto !== Zepto) {
+      Zepto = _Zepto;
+    }
+
     // This resets global id counter;
     uid = ['0', '0', '0'];
 

--- a/test/zepto_alias.js
+++ b/test/zepto_alias.js
@@ -1,0 +1,4 @@
+'use strict';
+
+var _Zepto = Zepto,
+    _jqLiteMode = false;

--- a/test/zepto_remove.js
+++ b/test/zepto_remove.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var _jQuery = jQuery.noConflict(true),
-    _jqLiteMode;
+var _Zepto = Zepto,
+  _jqLiteMode;
+
+Zepto = false;
 
 _jqLiteMode === false ? _jqLiteMode = false : _jqLiteMode = true;


### PR DESCRIPTION
This PR addresses [issue #3340](https://github.com/angular/angular.js/issues/3340), adding support for Zepto as well as jQuery.

This modification will opt for jQuery over Zepto whenever both are present.

Note:  This also requires a modification to karma-ng-scenario, which I will submit a PR for to pair with this PR.

Warning:  There may be tests/code that I did not write that should be written to account for the differences between jQuery, Zepto, and Angular, so it is possible that this is not complete - all of the current tests pass though, which otherwise break badly.

The documentation would need to be rewritten to note this feature as well.
