### PR TITLE
feat($rootScope): add $applyFn method for wrapping functions in $apply block

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -647,11 +647,9 @@ function checkboxInputType(scope, element, attr, ctrl) {
   if (!isString(trueValue)) trueValue = true;
   if (!isString(falseValue)) falseValue = false;
 
-  element.on('click', function() {
-    scope.$apply(function() {
-      ctrl.$setViewValue(element[0].checked);
-    });
-  });
+  element.on('click', scope.$applyFn(function() {
+    ctrl.$setViewValue(element[0].checked);
+  }));
 
   ctrl.$render = function() {
     element[0].checked = ctrl.$viewValue;
@@ -884,9 +882,7 @@ var VALID_CLASS = 'ng-valid',
               };
 
               // Listen for change events to enable binding
-              element.on('blur keyup change', function() {
-                scope.$apply(read);
-              });
+              element.on('blur keyup change', scope.$applyFn(read));
               read(); // initialize
 
               // Write data to the model

--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -43,11 +43,9 @@ forEach(
     ngEventDirectives[directiveName] = ['$parse', function($parse) {
       return function(scope, element, attr) {
         var fn = $parse(attr[directiveName]);
-        element.on(lowercase(name), function(event) {
-          scope.$apply(function() {
-            fn(scope, {$event:event});
-          });
-        });
+        element.on(lowercase(name), scope.$applyFn(function(event) {
+          fn(scope, {$event: event});
+        }));
       };
     }];
   }

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -257,12 +257,10 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
           }
         };
 
-        selectElement.on('change', function() {
-          scope.$apply(function() {
-            if (unknownOption.parent()) unknownOption.remove();
-            ngModelCtrl.$setViewValue(selectElement.val());
-          });
-        });
+        selectElement.on('change', scope.$applyFn(function() {
+          if (unknownOption.parent()) unknownOption.remove();
+          ngModelCtrl.$setViewValue(selectElement.val());
+        }));
       }
 
       function Multiple(scope, selectElement, ctrl) {
@@ -283,17 +281,15 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
           }
         });
 
-        selectElement.on('change', function() {
-          scope.$apply(function() {
-            var array = [];
-            forEach(selectElement.find('option'), function(option) {
-              if (option.selected) {
-                array.push(option.value);
-              }
-            });
-            ctrl.$setViewValue(array);
+        selectElement.on('change', scope.$applyFn(function() {
+          var array = [];
+          forEach(selectElement.find('option'), function(option) {
+            if (option.selected) {
+              array.push(option.value);
+            }
           });
-        });
+          ctrl.$setViewValue(array);
+        }));
       }
 
       function Options(scope, selectElement, ctrl) {
@@ -334,62 +330,60 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
         // clear contents, we'll add what's needed based on the model
         selectElement.html('');
 
-        selectElement.on('change', function() {
-          scope.$apply(function() {
-            var optionGroup,
-                collection = valuesFn(scope) || [],
-                locals = {},
-                key, value, optionElement, index, groupIndex, length, groupLength;
+        selectElement.on('change', scope.$applyFn(function() {
+          var optionGroup,
+              collection = valuesFn(scope) || [],
+              locals = {},
+              key, value, optionElement, index, groupIndex, length, groupLength;
 
-            if (multiple) {
-              value = [];
-              for (groupIndex = 0, groupLength = optionGroupsCache.length;
-                   groupIndex < groupLength;
-                   groupIndex++) {
-                // list of options for that group. (first item has the parent)
-                optionGroup = optionGroupsCache[groupIndex];
+          if (multiple) {
+            value = [];
+            for (groupIndex = 0, groupLength = optionGroupsCache.length;
+                 groupIndex < groupLength;
+                 groupIndex++) {
+              // list of options for that group. (first item has the parent)
+              optionGroup = optionGroupsCache[groupIndex];
 
-                for(index = 1, length = optionGroup.length; index < length; index++) {
-                  if ((optionElement = optionGroup[index].element)[0].selected) {
-                    key = optionElement.val();
-                    if (keyName) locals[keyName] = key;
-                    if (trackFn) {
-                      for (var trackIndex = 0; trackIndex < collection.length; trackIndex++) {
-                        locals[valueName] = collection[trackIndex];
-                        if (trackFn(scope, locals) == key) break;
-                      }
-                    } else {
-                      locals[valueName] = collection[key];
-                    }
-                    value.push(valueFn(scope, locals));
-                  }
-                }
-              }
-            } else {
-              key = selectElement.val();
-              if (key == '?') {
-                value = undefined;
-              } else if (key == ''){
-                value = null;
-              } else {
-                if (trackFn) {
-                  for (var trackIndex = 0; trackIndex < collection.length; trackIndex++) {
-                    locals[valueName] = collection[trackIndex];
-                    if (trackFn(scope, locals) == key) {
-                      value = valueFn(scope, locals);
-                      break;
-                    }
-                  }
-                } else {
-                  locals[valueName] = collection[key];
+              for(index = 1, length = optionGroup.length; index < length; index++) {
+                if ((optionElement = optionGroup[index].element)[0].selected) {
+                  key = optionElement.val();
                   if (keyName) locals[keyName] = key;
-                  value = valueFn(scope, locals);
+                  if (trackFn) {
+                    for (var trackIndex = 0; trackIndex < collection.length; trackIndex++) {
+                      locals[valueName] = collection[trackIndex];
+                      if (trackFn(scope, locals) == key) break;
+                    }
+                  } else {
+                    locals[valueName] = collection[key];
+                  }
+                  value.push(valueFn(scope, locals));
                 }
               }
             }
-            ctrl.$setViewValue(value);
-          });
-        });
+          } else {
+            key = selectElement.val();
+            if (key == '?') {
+              value = undefined;
+            } else if (key == ''){
+              value = null;
+            } else {
+              if (trackFn) {
+                for (var trackIndex = 0; trackIndex < collection.length; trackIndex++) {
+                  locals[valueName] = collection[trackIndex];
+                  if (trackFn(scope, locals) == key) {
+                    value = valueFn(scope, locals);
+                    break;
+                  }
+                }
+              } else {
+                locals[valueName] = collection[key];
+                if (keyName) locals[keyName] = key;
+                value = valueFn(scope, locals);
+              }
+            }
+          }
+          ctrl.$setViewValue(value);
+        }));
 
         ctrl.$render = render;
 

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -22,17 +22,15 @@
  *   function asyncGreet(name) {
  *     var deferred = $q.defer();
  *
- *     setTimeout(function() {
- *       // since this fn executes async in a future turn of the event loop, we need to wrap
- *       // our code into an $apply call so that the model changes are properly observed.
- *       scope.$apply(function() {
- *         if (okToGreet(name)) {
- *           deferred.resolve('Hello, ' + name + '!');
- *         } else {
- *           deferred.reject('Greeting ' + name + ' is not allowed.');
- *         }
- *       });
- *     }, 1000);
+ *     // since this fn executes async in a future turn of the event loop, we need to wrap
+ *     // our code with $applyFn so that the model changes are properly observed.
+ *     setTimeout(scope.$applyFn(function() {
+ *       if (okToGreet(name)) {
+ *         deferred.resolve('Hello, ' + name + '!');
+ *       } else {
+ *         deferred.reject('Greeting ' + name + ' is not allowed.');
+ *       }
+ *     }), 1000);
  *
  *     return deferred.promise;
  *   }

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -722,7 +722,7 @@ function $RootScopeProvider(){
        *    was executed using the {@link ng.$rootScope.Scope#$digest $digest()} method.
        *
        *
-       * @param {(string|function())=} exp An angular expression to be executed.
+       * @param {(string|function())=} expr An angular expression to be executed.
        *
        *    - `string`: execute using the rules as defined in {@link guide/expression expression}.
        *    - `function(scope)`: execute the function with current `scope` parameter.
@@ -744,6 +744,49 @@ function $RootScopeProvider(){
             throw e;
           }
         }
+      },
+
+      /**
+       * @ngdoc function
+       * @name ng.$rootScope.Scope#$applyFn
+       * @methodOf ng.$rootScope.Scope
+       * @function
+       *
+       * @description
+       * Similar to {@link ng.$rootScope.Scope#$apply $apply()}, but returns a wrapper function.
+       * This is useful in cases where a function is required as a parameter/callback outside of the
+       * angular framework. If `expr` is a function, it is bound to `scope` (`scope` becomes the
+       * `this` for the function) and any arguments will be passed along from the wrapper function.
+       *
+       * # Example
+       * <pre>
+           element.bind('click', scope.$applyFn(function(event) {
+             var scope = this;
+             scope.target = event.target;
+           }));
+       * </pre>
+       *
+       * @param {(string|function())=} expr An angular expression to be executed.
+       *
+       *    - `string`: execute using the rules as defined in {@link guide/expression expression}.
+       *    - `function()`: execute the function bound to the current `scope`.
+       *
+       * @returns {function()} Function that is wrapped with {@link ng.$rootScope.Scope#$apply $apply()}.
+       */
+      $applyFn: function(expr) {
+        var scope = this;
+        return (isFunction(expr) && !(expr instanceof RegExp))
+          ? function() {
+              var args = arguments;
+              return scope.$apply(function() {
+                return args.length
+                  ? expr.apply(scope, args)
+                  : expr.call(scope);
+              });
+            }
+          : function() {
+              return scope.$apply(expr);
+            };
       },
 
       /**

--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -253,11 +253,9 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     // - On mobile browsers, the simulated "fast" click will call this.
     // - But the browser's follow-up slow click will be "busted" before it reaches this handler.
     // Therefore it's safe to use this directive on both mobile and desktop.
-    element.on('click', function(event) {
-      scope.$apply(function() {
-        clickHandler(scope, {$event: event});
-      });
-    });
+    element.on('click', scope.$applyFn(function(event) {
+      clickHandler(scope, {$event: event});
+    }));
 
     element.on('mousedown', function(event) {
       element.addClass(ACTIVE_CLASS_NAME);

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -380,6 +380,14 @@ describe('input', function() {
   });
 
 
+  it('should perform an $apply on input change', function() {
+    compileInput('<input type="text" ng-model="name" name="alias" ng-change="change()" />');
+    var applySpy = spyOn(scope, '$apply').andCallThrough();
+
+    changeInputValueTo('adam');
+    expect(applySpy).toHaveBeenCalled();
+  });
+
   it('should update the model on "blur" event', function() {
     compileInput('<input type="text" ng-model="name" name="alias" ng-change="change()" />');
 

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -109,6 +109,20 @@ describe('select', function() {
     });
 
 
+    it('should perform an $apply on change', function() {
+      compile(
+        '<select name="select" ng-model="selection" required ng-change="change()">' +
+          '<option value=""></option>' +
+          '<option value="c">C</option>' +
+        '</select>');
+      var applySpy = spyOn(scope, '$apply').andCallThrough();
+
+      element[0].value = 'c';
+      browserTrigger(element, 'change');
+      expect(applySpy).toHaveBeenCalled();
+    });
+
+
     it('should not be invalid if no require', function() {
       compile(
         '<select name="select" ng-model="selection">' +
@@ -453,6 +467,19 @@ describe('select', function() {
       browserTrigger(element, 'change');
       expect(element).toBeValid();
       expect(element).toBeDirty();
+    });
+
+    it('should perform an $apply on change', function() {
+      compile(
+        '<select name="select" ng-model="selection" multiple required>' +
+          '<option>A</option>' +
+          '<option>B</option>' +
+        '</select>');
+      var applySpy = spyOn(scope, '$apply').andCallThrough();
+
+      element[0].value = 'B';
+      browserTrigger(element, 'change');
+      expect(applySpy).toHaveBeenCalled();
     });
   });
 

--- a/test/ngTouch/directive/ngClickSpec.js
+++ b/test/ngTouch/directive/ngClickSpec.js
@@ -343,7 +343,7 @@ describe('ngClick (touch)', function() {
       expect($rootScope.event).toBeUndefined();
     }));
     it('should not trigger click if regular disabled is present', inject(function($rootScope, $compile) {
-      element = $compile('<button ng-click="event = $event" disabled ></button>')($rootScope);
+      element = $compile('<button ng-click="event = $event" disabled></button>')($rootScope);
 
       browserTrigger(element, 'touchstart', [], 10, 10);
       browserTrigger(element, 'touchend', [], 10, 10);
@@ -351,7 +351,7 @@ describe('ngClick (touch)', function() {
       expect($rootScope.event).toBeUndefined();
     }));
     it('should trigger click if regular disabled is not present', inject(function($rootScope, $compile) {
-      element = $compile('<div ng-click="event = $event" ></div>')($rootScope);
+      element = $compile('<div ng-click="event = $event"></div>')($rootScope);
 
       browserTrigger(element, 'touchstart', [], 10, 10);
       browserTrigger(element, 'touchend', [], 10, 10);
@@ -365,7 +365,7 @@ describe('ngClick (touch)', function() {
     it('should be capturable by other handlers', inject(function($rootScope, $compile) {
       var called = false;
 
-      element = $compile('<div ng-click="event = $event" ></div>')($rootScope);
+      element = $compile('<div ng-click="event = $event"></div>')($rootScope);
 
       element.on('click', function() {
         called = true;
@@ -375,6 +375,15 @@ describe('ngClick (touch)', function() {
       browserTrigger(element, 'touchend', [], 10, 10);
 
       expect(called).toEqual(true);
+    }));
+
+    it('should perform an $apply', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-click="event = $event"></div>')($rootScope);
+      var applySpy = spyOn($rootScope, '$apply').andCallThrough();
+
+      browserTrigger(element, 'touchstart', [], 10, 10);
+      browserTrigger(element, 'touchend', [], 10, 10);
+      expect(applySpy).toHaveBeenCalled();
     }));
   });
 });

--- a/test/ngTouch/directive/ngSwipeSpec.js
+++ b/test/ngTouch/directive/ngSwipeSpec.js
@@ -134,6 +134,15 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       browserTrigger(element, endEvent, [], 100, 20);
       expect(eventFired).toEqual(true);
     }));
+
+    it('should perform an $apply', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-swipe-left="swiped = true"></div>')($rootScope);
+      var applySpy = spyOn($rootScope, '$apply').andCallThrough();
+
+      browserTrigger(element, startEvent, [], 100, 20);
+      browserTrigger(element, endEvent, [], 20, 20);
+      expect(applySpy).toHaveBeenCalled();
+    }));
   });
 }
 


### PR DESCRIPTION
This PR scratches an itch I've had for a while where I need to wrap a function with scope.$apply but don't want it to execute immediately.

Something like this:

``` javascript
element.bind('click', function(event) {
  return scope.$apply(function() {
    // do something
  });
});
```

gets simplified to:

``` javascript
element.bind('click', scope.$bind(null, function(event) {
  // do something
}));
```

Even better, if I'm working with a class I can go from this:

``` javascript
var self = this;
element.bind('click', function(event) {
  return scope.$apply(function() {
    return self.someMethod(event);
  });
});
```

to something like this:

``` javascript
element.bind('click', scope.$bind(this, this.someMethod));
```

In addition to adding the new method, I've gone through the existing code and found places that would benefit from using it. I also added tests where removing the existing $apply didn't produce an error. That way I could be sure the new method is doing what it should.

Please let me know what you all think. I have everything split into separate commits to make review easier. Obviously I'd merge and add a nice commit message if accepted.
