### PR TITLE
feat(ngMobile): Emit 'swipeleft' and 'swiperight' events

### DIFF
--- a/src/ngMobile/directive/ngSwipe.js
+++ b/src/ngMobile/directive/ngSwipe.js
@@ -54,7 +54,7 @@
     </doc:example>
  */
 
-function makeSwipeDirective(directiveName, direction) {
+function makeSwipeDirective(directiveName, direction, eventName) {
   ngMobile.directive(directiveName, ['$parse', '$swipe', function($parse, $swipe) {
     // The maximum vertical delta for a swipe should be less than 75px.
     var MAX_VERTICAL_DISTANCE = 75;
@@ -98,6 +98,7 @@ function makeSwipeDirective(directiveName, direction) {
         'end': function(coords) {
           if (validSwipe(coords)) {
             scope.$apply(function() {
+              element.triggerHandler(eventName);
               swipeHandler(scope);
             });
           }
@@ -108,6 +109,6 @@ function makeSwipeDirective(directiveName, direction) {
 }
 
 // Left is negative X-coordinate, right is positive.
-makeSwipeDirective('ngSwipeLeft', -1);
-makeSwipeDirective('ngSwipeRight', 1);
+makeSwipeDirective('ngSwipeLeft', -1, 'swipeleft');
+makeSwipeDirective('ngSwipeRight', 1, 'swiperight');
 

--- a/test/ngMobile/directive/ngSwipeSpec.js
+++ b/test/ngMobile/directive/ngSwipeSpec.js
@@ -102,6 +102,38 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
 
       expect($rootScope.swiped).toBeUndefined();
     }));
+
+    it('should emit "swipeleft" events for left swipes', inject(function($rootScope, $compile, $rootElement) {
+      element = $compile('<div ng-swipe-left="swiped = true"></div>')($rootScope);
+      $rootElement.append(element);
+      $rootScope.$digest();
+
+      expect($rootScope.swiped).toBeUndefined();
+      var eventFired = false;
+      element.on('swipeleft', function() {
+        eventFired = true;
+      });
+
+      browserTrigger(element, startEvent, [], 100, 20);
+      browserTrigger(element, endEvent, [], 20, 20);
+      expect(eventFired).toEqual(true);
+    }));
+
+    it('should emit "swiperight" events for right swipes', inject(function($rootScope, $compile, $rootElement) {
+      element = $compile('<div ng-swipe-right="swiped = true"></div>')($rootScope);
+      $rootElement.append(element);
+      $rootScope.$digest();
+
+      expect($rootScope.swiped).toBeUndefined();
+      var eventFired = false;
+      element.on('swiperight', function() {
+        eventFired = true;
+      });
+
+      browserTrigger(element, startEvent, [], 20, 20);
+      browserTrigger(element, endEvent, [], 100, 20);
+      expect(eventFired).toEqual(true);
+    }));
   });
 }
 


### PR DESCRIPTION
Similar to ngMobile clicks, these events were not capturable by other
directives. Now they emit 'swipeleft' and 'swiperight' events that can
be follow with element.on('swipeleft', ...).

Fixes #3130.
