### PR TITLE
feat(ngMock): allow $timeout::flush to take a delay parameter

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1486,10 +1486,12 @@ angular.mock.$TimeoutDecorator = function($delegate, $browser) {
    * @methodOf ngMock.$timeout
    * @description
    *
+   * @param {number=} number of milliseconds to flush.
+   *
    * Flushes the queue of pending tasks.
    */
-  $delegate.flush = function() {
-    $browser.defer.flush();
+  $delegate.flush = function(delay) {
+    $browser.defer.flush(delay);
   };
 
   /**

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -336,6 +336,21 @@ describe('ngMock', function() {
       expect(logger).toEqual(['t1', 't3', 't2']);
     }));
 
+    it('should expose flush method that will flush the pending queue of tasks up to the given time', inject(
+        function($timeout) {
+      var logger = [],
+          logFn = function(msg) { return function() { logger.push(msg) }};
+
+      $timeout(logFn('t1'));
+      $timeout(logFn('t2'), 200);
+      $timeout(logFn('t3'));
+      expect(logger).toEqual([]);
+
+      $timeout.flush(100);
+      expect(logger).toEqual(['t1', 't3']);
+      $timeout.flush(100);
+      expect(logger).toEqual(['t1', 't3', 't2']);
+    }));
 
     it('should throw an exception when not flushed', inject(function($timeout){
       $timeout(noop);


### PR DESCRIPTION
Allow $timeout::flush at ngMock to take a `delay` parameter that defines the time in millis that should be flushed
