### PR TITLE
fix($compile): don't use new with minErr

### DIFF
--- a/docs/content/error/compile/selmulti.ngdoc
+++ b/docs/content/error/compile/selmulti.ngdoc
@@ -1,0 +1,4 @@
+@ngdoc error
+@name $compile:selmulti
+@fullName Binding to Multiple Attribute
+@description

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1220,7 +1220,7 @@ function $CompileProvider($provide) {
 
 
       if (name === "multiple" && nodeName_(node) === "SELECT") {
-        throw new $compileMinErr("selmulti", "Binding to the multiple attribute is not supported. Element: {0}",
+        throw $compileMinErr("selmulti", "Binding to the multiple attribute is not supported. Element: {0}",
             startingTag(node));
       }
 


### PR DESCRIPTION
Someone wrote `throw new $compileMinErr(...)` when it should have been
`throw $compileMinErr(...)`. This caused a build warning.
