### PR TITLE
clear() method added to remove all routes from $route service

### DIFF
--- a/src/ng/route.js
+++ b/src/ng/route.js
@@ -110,6 +110,20 @@ function $RouteProvider(){
     return this;
   };
 
+  /**
+   * @ngdoc method
+   * @name ng.$routeProvider#clear
+   * @methodOf ng.$routeProvider
+   *
+   * @returns {Object} self
+   *
+   * @description
+   * Clears all route definitions already added to `$route` service.
+   */
+  this.clear = function () {
+    routes = {};
+    return this;
+  };
 
   this.$get = ['$rootScope', '$location', '$routeParams', '$q', '$injector', '$http', '$templateCache',
       function( $rootScope,   $location,   $routeParams,   $q,   $injector,   $http,   $templateCache) {


### PR DESCRIPTION
`clear()` method removes all routes already added to `$route` service.
This is useful, especially, when we need to remove all routes registered
in another module on which the app module depends
