### PR TITLE
chore(ngMock): Encapsulated ngMock in module wrapper

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -146,8 +146,7 @@ module.exports = function(grunt) {
       },
       mocks: {
         dest: 'build/angular-mocks.js',
-        src: ['src/ngMock/angular-mocks.js'],
-        strict: false
+        src: util.wrap(['src/ngMock/angular-mocks.js'], 'module')
       },
       sanitize: {
         dest: 'build/angular-sanitize.js',

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1,10 +1,4 @@
-/**
- * @license AngularJS v"NG_VERSION_FULL"
- * (c) 2010-2012 Google, Inc. http://angularjs.org
- * License: MIT
- *
- * TODO(vojta): wrap whole file into closure during build
- */
+'use strict';
 
 /**
  * @ngdoc overview


### PR DESCRIPTION
(I know this issue is very old, but maybe this will help spark discussion on the subject of Testing.)

Fixes issue #533 - encapsulate angular-mocks.js into closure (vojtajina)
- Leaving mocks out of 'min' grunt task because it probably doesn't belong in most production implementations of angularjs i.e. for testing purposes. Well, probably the same for the unminified version. This might spark further talk.
