### PR TITLE
feat(ngSanitize): export $htmlParser

### DIFF
--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -132,11 +132,13 @@ var ngSanitizeMinErr = angular.$$minErr('ngSanitize');
      </doc:scenario>
    </doc:example>
  */
-var $sanitize = function(html) {
-  var buf = [];
-    htmlParser(html, htmlSanitizeWriter(buf));
+var $sanitizeFactory = ['$htmlParser', function($htmlParser) {
+  return function $sanitize(html) {
+    var buf = [];
+    $htmlParser(html, htmlSanitizeWriter(buf));
     return buf.join('');
-};
+  };
+}];
 
 
 // Regular Expressions for parsing tags and attributes
@@ -198,8 +200,12 @@ function makeMap(str) {
 
 
 /**
+ * @ngdoc service
+ * @name ngSanitize.$htmlParser
+ * @function
+ *
  * @example
- * htmlParser(htmlString, {
+ * $htmlParser(htmlString, {
  *     start: function(tag, attrs, unary) {},
  *     end: function(tag) {},
  *     chars: function(text) {},
@@ -209,7 +215,7 @@ function makeMap(str) {
  * @param {string} html string
  * @param {object} handler
  */
-function htmlParser( html, handler ) {
+function $htmlParser( html, handler ) {
   var index, chars, match, stack = [], last = html;
   stack.last = function() { return stack[ stack.length - 1 ]; };
 
@@ -416,4 +422,6 @@ function htmlSanitizeWriter(buf){
 
 
 // define ngSanitize module and register $sanitize service
-angular.module('ngSanitize', []).value('$sanitize', $sanitize);
+angular.module('ngSanitize', []).
+  factory('$sanitize', $sanitizeFactory).
+  value('$htmlParser', $htmlParser);

--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -2,19 +2,18 @@
 
 describe('HTML', function() {
 
-  var expectHTML;
+  var expectHTML, $htmlParser;
 
   beforeEach(module('ngSanitize'));
 
-  beforeEach(inject(function($sanitize) {
+  beforeEach(inject(function($sanitize, _$htmlParser_) {
     expectHTML = function(html){
       return expect($sanitize(html));
     };
+    $htmlParser = _$htmlParser_;
   }));
 
-  describe('htmlParser', function() {
-    if (angular.isUndefined(window.htmlParser)) return;
-
+  describe('$htmlParser', function() {
     var handler, start, text;
     beforeEach(function() {
       handler = {
@@ -40,31 +39,31 @@ describe('HTML', function() {
     });
 
     it('should parse basic format', function() {
-      htmlParser('<tag attr="value">text</tag>', handler);
+      $htmlParser('<tag attr="value">text</tag>', handler);
       expect(start).toEqual({tag:'tag', attrs:{attr:'value'}, unary:false});
       expect(text).toEqual('text');
     });
 
     it('should parse newlines in tags', function() {
-      htmlParser('<\ntag\n attr="value"\n>text<\n/\ntag\n>', handler);
+      $htmlParser('<\ntag\n attr="value"\n>text<\n/\ntag\n>', handler);
       expect(start).toEqual({tag:'tag', attrs:{attr:'value'}, unary:false});
       expect(text).toEqual('text');
     });
 
     it('should parse newlines in attributes', function() {
-      htmlParser('<tag attr="\nvalue\n">text</tag>', handler);
+      $htmlParser('<tag attr="\nvalue\n">text</tag>', handler);
       expect(start).toEqual({tag:'tag', attrs:{attr:'value'}, unary:false});
       expect(text).toEqual('text');
     });
 
     it('should parse namespace', function() {
-      htmlParser('<ns:t-a-g ns:a-t-t-r="\nvalue\n">text</ns:t-a-g>', handler);
+      $htmlParser('<ns:t-a-g ns:a-t-t-r="\nvalue\n">text</ns:t-a-g>', handler);
       expect(start).toEqual({tag:'ns:t-a-g', attrs:{'ns:a-t-t-r':'value'}, unary:false});
       expect(text).toEqual('text');
     });
 
     it('should parse empty value attribute of node', function() {
-      htmlParser('<OPTION selected value="">abc</OPTION>', handler);
+      $htmlParser('<OPTION selected value="">abc</OPTION>', handler);
       expect(start).toEqual({tag:'option', attrs:{selected:'', value:''}, unary:false});
       expect(text).toEqual('abc');
     });


### PR DESCRIPTION
htmlParser was previously private to ngSanitize. Export it as a service
so others can use it if needed.

Closes #3346
