### PR TITLE
Added ability for $controller to fetch controller constructor function when expression evaluates to string in scope

### DIFF
--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -58,15 +58,24 @@ function $ControllerProvider() {
      * BC version}.
      */
     return function(expression, locals) {
-      var instance, match, constructor, identifier;
+      var instance, match, constructor, identifier, constructorObject;
 
       if(isString(expression)) {
         match = expression.match(CNTRL_REG),
         constructor = match[1],
         identifier = match[3];
-        expression = controllers.hasOwnProperty(constructor)
-            ? controllers[constructor]
-            : getter(locals.$scope, constructor, true) || getter($window, constructor, true);
+        if(controllers.hasOwnProperty(constructor)) {
+          expression = controllers[constructor];
+        }
+        else {
+          constructorObject = getter(locals.$scope, constructor, true);
+          if(isString(constructorObject)) {
+            expression = controllers[constructorObject] || getter($window, constructorObject, true);
+          }
+          else {
+            expression = constructorObject || getter($window, constructor, true);
+          }
+        }
 
         assertArgFn(expression, constructor, true);
       }

--- a/src/ng/directive/ngController.js
+++ b/src/ng/directive/ngController.js
@@ -21,7 +21,7 @@
  * @scope
  * @param {expression} ngController Name of a globally accessible constructor function or an
  *     {@link guide/expression expression} that on the current scope evaluates to a
- *     constructor function. The controller instance can further be published into the scope
+ *     constructor function or a string that references the constructor function. The controller instance can further be published into the scope
  *     by adding `as localName` the controller name attribute.
  *
  * @example

--- a/test/ng/controllerSpec.js
+++ b/test/ng/controllerSpec.js
@@ -90,6 +90,31 @@ describe('$controller', function() {
   });
 
 
+  it('should instantiate controller referenced in scope', function() {
+    var FooCtrl = function($scope) {};
+    $controllerProvider.register('FooCtrl', FooCtrl);
+    var scope = {
+      foo: 'FooCtrl'
+    };
+
+    var ctrl = $controller('foo', {$scope: scope});
+    expect(ctrl instanceof FooCtrl).toBe(true);
+  });
+
+
+  it('should instantiate controller defined on window and referenced in scope', inject(function($window) {
+    var scope = {
+      foo: 'a.Foo'
+    };
+    var Foo = function() {};
+    $window.a = {Foo: Foo};
+
+    var foo = $controller('foo', {$scope: scope});
+    expect(foo).toBeDefined();
+    expect(foo instanceof Foo).toBe(true);
+  }));
+
+
   it('should instantiate controller defined on window', inject(function($window) {
     var scope = {};
     var Foo = function() {};

--- a/test/ng/directive/ngControllerSpec.js
+++ b/test/ng/directive/ngControllerSpec.js
@@ -1,9 +1,10 @@
 'use strict';
 
 describe('ngController', function() {
-  var element;
+  var element, $controllerProvider;
 
-  beforeEach(module(function($controllerProvider) {
+  beforeEach(module(function(_$controllerProvider_) {
+    $controllerProvider = _$controllerProvider_;
     $controllerProvider.register('PublicModule', function() {
       this.mark = 'works';
     });
@@ -84,5 +85,18 @@ describe('ngController', function() {
     element = $compile('<div ng-controller="Greeter">{{name}}</div>')($rootScope);
     $rootScope.$digest();
     expect(element.text()).toBe('Vojta');
+  }));
+
+
+  it('should instantiate a controller reference defined on scope', inject(function($compile, $rootScope) {
+    var Ctrl = function($scope) { $scope.name = 'Wes'; };
+    $controllerProvider.register('Ctrl', Ctrl);
+    $rootScope.foo = {
+      bar: 'Ctrl'
+    };
+
+    element = $compile('<div ng-controller="foo.bar">{{name}}</div>')($rootScope);
+    $rootScope.$digest();
+    expect(element.text()).toBe('Wes');
   }));
 });


### PR DESCRIPTION
This PR adds support for the `$controller` service to evaluate an expression in scope and fetch the appropriate controller constructor function if the evaluated expression is a string.

This addresses [#3375](https://github.com/angular/angular.js/issues/3375).

Example usage:

```
<div ng-controller="ExampleCtrl">
  <div ng-controller="currentRoute.controller">
    {{text}}
  </div>
</div>

function ExampleCtrl($scope) {
  $scope.currentRoute = {
    controller: 'FooCtrl'
  };
}

function FooCtrl($scope) {
  $scope.text = 'Hello World!';
}
```
