### PR TITLE
feat($compile): support multi-elements in all declaration styles

### DIFF
--- a/src/ng/directive/ngIf.js
+++ b/src/ng/directive/ngIf.js
@@ -82,7 +82,7 @@ var ngIfDirective = ['$animate', function($animate) {
     transclude: 'element',
     priority: 1000,
     terminal: true,
-    restrict: 'A',
+    restrict: 'AM',
     compile: function (element, attr, transclude) {
       return function ($scope, $element, $attr) {
         var childElement, childScope;

--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -214,6 +214,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
     transclude: 'element',
     priority: 1000,
     terminal: true,
+    restrict: 'AM',
     compile: function(element, attr, linker) {
       return function($scope, $element, $attr){
         var expression = $attr.ngRepeat;

--- a/src/ng/directive/ngShowHide.js
+++ b/src/ng/directive/ngShowHide.js
@@ -144,11 +144,14 @@
   </example>
  */
 var ngShowDirective = ['$animate', function($animate) {
-  return function(scope, element, attr) {
-    scope.$watch(attr.ngShow, function ngShowWatchAction(value){
-      $animate[toBoolean(value) ? 'removeClass' : 'addClass'](element, 'ng-hide');
-    });
-  };
+  return {
+    restrict: 'AM',
+    link: function(scope, element, attr) {
+      scope.$watch(attr.ngShow, function ngShowWatchAction(value){
+        $animate[toBoolean(value) ? 'removeClass' : 'addClass'](element, 'ng-hide');
+      });
+    }
+  }
 }];
 
 
@@ -296,9 +299,12 @@ var ngShowDirective = ['$animate', function($animate) {
   </example>
  */
 var ngHideDirective = ['$animate', function($animate) {
-  return function(scope, element, attr) {
-    scope.$watch(attr.ngHide, function ngHideWatchAction(value){
-      $animate[toBoolean(value) ? 'addClass' : 'removeClass'](element, 'ng-hide');
-    });
-  };
+  return {
+    restrict: 'AM',
+    link: function(scope, element, attr) {
+      scope.$watch(attr.ngHide, function ngHideWatchAction(value){
+        $animate[toBoolean(value) ? 'addClass' : 'removeClass'](element, 'ng-hide');
+      });
+    }
+  }
 }];

--- a/test/ng/directive/ngIfSpec.js
+++ b/test/ng/directive/ngIfSpec.js
@@ -73,6 +73,38 @@ describe('ngIf', function () {
     expect(element.children()[0].className).toContain('my-class');
   });
 
+  it('should work with multi-nodes declared as attributes', function () {
+    $scope.value = false;
+    element.append($compile(
+      '<div ng-if-start="value"></div>' +
+        '<div></div>' +
+        '<div></div>' +
+        '<div ng-if-end></div>'
+    )($scope));
+    $scope.$apply();
+    expect(element.children().length).toBe(0);
+    $scope.$apply('value = true');
+    expect(element.children().length).toBe(4);
+    $scope.$apply('value = false');
+    expect(element.children().length).toBe(0);
+  });
+
+  it('should work with multi-nodes declared as comments', function () {
+    $scope.value = false;
+    element.append($compile(
+      '<!-- directive: ng-if-start value -->' +
+        '<div></div>' +
+        '<div></div>' +
+        '<!-- ng-if-end -->'
+    )($scope));
+    $scope.$apply();
+    expect(element.children().length).toBe(0);
+    $scope.$apply('value = true');
+    expect(element.children().length).toBe(2);
+    $scope.$apply('value = false');
+    expect(element.children().length).toBe(0);
+  });
+
 });
 
 describe('ngIf animations', function () {

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -843,25 +843,48 @@ describe('ngRepeat', function() {
     });
   });
 
-  it('should grow multi-node repeater', inject(function($compile, $rootScope) {
-    $rootScope.show = false;
-    $rootScope.books = [
-      {title:'T1', description: 'D1'},
-      {title:'T2', description: 'D2'}
-    ];
-    element = $compile(
+  describe('should grow multi-node repeater', function () {
+    it('when declared as attributes', inject(function($compile, $rootScope) {
+      $rootScope.show = false;
+      $rootScope.books = [
+        {title:'T1', description: 'D1'},
+        {title:'T2', description: 'D2'}
+      ];
+      element = $compile(
         '<div>' +
-            '<dt ng-repeat-start="book in books">{{book.title}}:</dt>' +
-            '<dd ng-repeat-end>{{book.description}};</dd>' +
-        '</div>')($rootScope);
+          '<dt ng-repeat-start="book in books">{{book.title}}:</dt>' +
+          '<dd ng-repeat-end>{{book.description}};</dd>' +
 
-    $rootScope.$digest();
-    expect(element.text()).toEqual('T1:D1;T2:D2;');
-    $rootScope.books.push({title:'T3', description: 'D3'});
-    $rootScope.$digest();
-    expect(element.text()).toEqual('T1:D1;T2:D2;T3:D3;');
-  }));
+          '</div>')($rootScope);
 
+      $rootScope.$digest();
+      expect(element.text()).toEqual('T1:D1;T2:D2;');
+      $rootScope.books.push({title:'T3', description: 'D3'});
+      $rootScope.$digest();
+      expect(element.text()).toEqual('T1:D1;T2:D2;T3:D3;');
+    }));
+
+    it('when declared as comments', inject(function($compile, $rootScope) {
+      $rootScope.show = false;
+      $rootScope.books = [
+        {title:'T1', description: 'D1'},
+        {title:'T2', description: 'D2'}
+      ];
+      element = $compile(
+        '<div>' +
+          '<!-- directive: ng-repeat-start book in books -->' +
+          '<dt>{{book.title}}:</dt>' +
+          '<dd>{{book.description}};</dd>' +
+          '<!-- ng-repeat-end -->' +
+          '</div>')($rootScope);
+
+      $rootScope.$digest();
+      expect(element.text()).toEqual('T1:D1;T2:D2;');
+      $rootScope.books.push({title:'T3', description: 'D3'});
+      $rootScope.$digest();
+      expect(element.text()).toEqual('T1:D1;T2:D2;T3:D3;');
+    }));
+  });
 
 });
 

--- a/test/ng/directive/ngShowHideSpec.js
+++ b/test/ng/directive/ngShowHideSpec.js
@@ -3,7 +3,6 @@
 describe('ngShow / ngHide', function() {
   var element;
 
-
   afterEach(function() {
     dealoc(element);
   });
@@ -28,6 +27,22 @@ describe('ngShow / ngHide', function() {
       $rootScope.$digest();
       expect(element).toBeShown();
     }));
+
+    it('should work with multi-nodes declared as attributes', multiNodeTests(
+      'ngShow',
+      '<div ng-show-start="exp"></div>' +
+        '<div></div>' +
+        '<div></div>' +
+        '<div ng-show-end></div>'
+    ));
+
+    it('should work with multi-nodes declared as comment', multiNodeTests(
+      'ngShow',
+      '<!-- directive: ng-show-start exp -->' +
+        '<div></div>' +
+        '<div></div>' +
+        '<!-- ng-show-end -->'
+    ));
   });
 
   describe('ngHide', function() {
@@ -39,7 +54,39 @@ describe('ngShow / ngHide', function() {
       $rootScope.$digest();
       expect(element).toBeHidden();
     }));
+
+    it('should work with multi-nodes declared as attributes', multiNodeTests(
+      'ngHide',
+      '<div ng-hide-start="exp"></div>' +
+        '<div></div>' +
+        '<div></div>' +
+        '<div ng-hide-end></div>'
+    ));
+
+    it('should work with multi-nodes declared as comment', multiNodeTests(
+      'ngHide',
+      '<!-- directive: ng-hide-start exp -->' +
+        '<div></div>' +
+        '<div></div>' +
+        '<!-- ng-hide-end -->'
+    ));
   });
+
+  function multiNodeTests(directive, html) {
+    return inject(function($rootScope, $compile) {
+      element = jqLite('<div></div>').html(html);
+      element = $compile(element)($rootScope);
+      $rootScope.$digest();
+      forEach(element.children(), function (element) {
+        expect(element)[directive == 'ngShow' ? 'toBeHidden' : 'toBeShown']();
+      });
+      $rootScope.exp = true;
+      $rootScope.$digest();
+      forEach(element.children(), function (element) {
+        expect(element)[directive == 'ngShow' ? 'toBeShown' : 'toBeHidden']();
+      });
+    })
+  }
 });
 
 describe('ngShow / ngHide animations', function() {


### PR DESCRIPTION
I've built on the work of #2783 to make multi-elements possible in all
directive decralation styles.

Basically #2783 was limited to directives declared via attributes.
With this commit, appending X-start and X-end would work
in Comments, Attributes, ClassNames and ElementNames

``` html
<table>
  <!-- directive: ng-repeat-start item in list -->
    <tr>If ngRepeat's 'restrict' get changed to include 'M'</tr>
    <tr>I get repeated</tr>
  <!-- ng-repeat-end -->

  <!-- the 'directive:' part for X-end is optional -->
</table>
```

**I will be adding tests for the compileSpec very soon, just wanted to know if it looks good for you guys.**

After I write the tests, I also want to add `restrict: 'CMA'` for the following directives:
- ng-repeat
- ng-show/ng-hide
- ng-if
