### PR TITLE
chore(bower): update to latest ng-closure-runner

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "components-font-awesome": "3.1.0",
     "bootstrap": "https://raw.github.com/twitter/bootstrap/v2.0.2/docs/assets/bootstrap.zip",
     "closure-compiler": "https://closure-compiler.googlecode.com/files/compiler-20130603.zip",
-    "ng-closure-runner": "https://raw.github.com/angular/ng-closure-runner/v0.2.0/assets/ng-closure-runner.zip"
+    "ng-closure-runner": "https://raw.github.com/angular/ng-closure-runner/v0.2.1/assets/ng-closure-runner.zip"
   }
 }


### PR DESCRIPTION
This version does correct URL encoding of string parameters in the
production minErr asset code.
