### PR TITLE
chore(bower): upgrade bower to 1.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "AngularJS",
+  "directory": "components",
   "devDependencies": {
     "jquery": "git://github.com/components/jquery.git#v1.8.3",
     "lunr.js": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "codename": "spooky-giraffe",
   "devDependencies": {
     "grunt": "0.4.0",
-    "bower": "0.9.2",
+    "bower": "1.0.0",
     "grunt-contrib-clean": "0.4.0",
     "grunt-contrib-compress": "0.4.1",
     "grunt-contrib-connect": "0.1.2",


### PR DESCRIPTION
We explicitly set the Bower install directory to components/ for
compatibility with our existing code base. Recent Bower prefers
bower_components/.
