### PR TITLE
fix(bower): update bower usage and resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ performance/temp*.html
 angular.js.tmproj
 /node_modules/
 /components/
+/bower_components/
 angular.xcodeproj
 .idea
 .agignore

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,7 +106,9 @@ module.exports = function(grunt) {
       bower: {
         command: 'node ./node_modules/bower/bin/bower install',
         options: {
-            stdout: false
+            stdout: true,
+            stderr: true,
+            failOnError: true
         }
       }
     },
@@ -116,7 +118,7 @@ module.exports = function(grunt) {
       scenario: {
         dest: 'build/angular-scenario.js',
         src: [
-          'components/jquery/jquery.js',
+          'bower_components/jquery/jquery.js',
           util.wrap([files['angularSrc'], files['angularScenario']], 'ngScenario/angular')
         ],
         styles: {

--- a/angularFiles.js
+++ b/angularFiles.js
@@ -117,7 +117,7 @@ angularFiles = {
   ],
 
   'karma': [
-    'components/jquery/jquery.js',
+    'bower_components/jquery/jquery.js',
     'test/jquery_remove.js',
     '@angularSrc',
     'src/publishExternalApis.js',
@@ -154,7 +154,7 @@ angularFiles = {
   ],
 
   'karmaJquery': [
-    'components/jquery/jquery.js',
+    'bower_components/jquery/jquery.js',
     'test/jquery_alias.js',
     '@angularSrc',
     'src/publishExternalApis.js',

--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,11 @@
 {
   "name": "AngularJS",
-  "directory": "components",
   "devDependencies": {
     "jquery": "git://github.com/components/jquery.git#v1.8.3",
     "lunr.js": "0.4.0",
     "google-code-prettify": "1.0.0",
     "components-font-awesome": "3.1.0",
-    "bootstrap": "https://raw.github.com/twitter/bootstrap/v2.0.2/docs/assets/bootstrap.zip",
+    "bootstrap": "https://raw.github.com/twbs/bootstrap/v2.0.2/docs/assets/bootstrap.zip",
     "closure-compiler": "https://closure-compiler.googlecode.com/files/compiler-20130603.zip",
     "ng-closure-runner": "https://raw.github.com/angular/ng-closure-runner/v0.2.1/assets/ng-closure-runner.zip"
   }

--- a/docs/src/gen-docs.js
+++ b/docs/src/gen-docs.js
@@ -79,16 +79,16 @@ function writeTheRest(writesFuture) {
 
   var manifest = 'manifest="/build/docs/appcache.manifest"';
 
-  writesFuture.push(writer.copyDir('components/components-font-awesome/css', 'components/font-awesome/css'));
-  writesFuture.push(writer.copyDir('components/components-font-awesome/font', 'components/font-awesome/font'));
-  writesFuture.push(writer.copyDir('components/bootstrap', 'components/bootstrap'));
+  writesFuture.push(writer.copyDir('bower_components/components-font-awesome/css', 'components/font-awesome/css'));
+  writesFuture.push(writer.copyDir('bower_components/components-font-awesome/font', 'components/font-awesome/font'));
+  writesFuture.push(writer.copyDir('bower_components/bootstrap', 'components/bootstrap'));
 
   writesFuture.push(writer.copy('node_modules/marked/lib/marked.js', 'components/marked.js'));
-  writesFuture.push(writer.copy('components/lunr.js/lunr.js', 'components/lunr.js'));
-  writesFuture.push(writer.copy('components/lunr.js/lunr.min.js', 'components/lunr.min.js'));
-  writesFuture.push(writer.copy('components/jquery/jquery.js', 'components/jquery.js'));
-  writesFuture.push(writer.copy('components/jquery/jquery.min.js', 'components/jquery.min.js'));
-  writesFuture.push(writer.copy('components/google-code-prettify/src/prettify.js', 'components/google-code-prettify.js'));
+  writesFuture.push(writer.copy('bower_components/lunr.js/lunr.js', 'components/lunr.js'));
+  writesFuture.push(writer.copy('bower_components/lunr.js/lunr.min.js', 'components/lunr.min.js'));
+  writesFuture.push(writer.copy('bower_components/jquery/jquery.js', 'components/jquery.js'));
+  writesFuture.push(writer.copy('bower_components/jquery/jquery.min.js', 'components/jquery.min.js'));
+  writesFuture.push(writer.copy('bower_components/google-code-prettify/src/prettify.js', 'components/google-code-prettify.js'));
   writesFuture.push(writer.copy('docs/components/angular-bootstrap/bootstrap.js', 'components/angular-bootstrap.js'));
   writesFuture.push(writer.copy('docs/components/angular-bootstrap/bootstrap-prettify.js', 'components/angular-bootstrap-prettify.js'));
 

--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -146,10 +146,8 @@ module.exports = {
         'java ' +
             this.java32flags() + ' ' +
             '-Xmx2g ' +
-            '-cp components/closure-compiler/compiler.jar' + classPathSep +
-            'components/ng-closure-runner/ngcompiler.jar ' +
-            // '-classpath ./components/closure-compiler/compiler.jar' + classPathSep +
-            // './components/ng-closure-runner/ngcompiler.jar ' +
+            '-cp bower_components/closure-compiler/compiler.jar' + classPathSep +
+            'bower_components/ng-closure-runner/ngcompiler.jar ' +
             'org.angularjs.closurerunner.NgClosureRunner ' +
             '--compilation_level SIMPLE_OPTIMIZATIONS ' +
             '--language_in ECMASCRIPT5_STRICT ' +


### PR DESCRIPTION
Changes:
- Fix our old code to use `bower_components/` as the install dir
- Fix the Bootstrap asset to use github.com/twbs/bootstrap (it moved)
- Fail the build on Bower failure. Bower should not fail silently.
