### PR TITLE
Update documentation to allow for minifcation-safe usage of directives

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -172,7 +172,7 @@ function $CompileProvider($provide) {
    *
    * @param {string} name Name of the directive in camel-case. (ie <code>ngBind</code> which will match as
    *                <code>ng-bind</code>).
-   * @param {function} directiveFactory An injectable directive factory function. See {@link guide/directive} for more
+   * @param {function|Array} directiveFactory An injectable directive factory function. See {@link guide/directive} for more
    *                info.
    * @returns {ng.$compileProvider} Self for chaining.
    */


### PR DESCRIPTION
To avoid "Argument type Array is not assignable to parameter type function" validation error  when using the minifcation-safe array style 

(eg .directive('myDirective', ['$http','$timeout','$compile', function($http,$timeout $compile).... )
