### PR TITLE
chore(ngdocs): update the config block within the $routeProvider example to be more explicit.

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -220,7 +220,7 @@ function $RouteProvider(){
        </file>
 
        <file name="script.js">
-         angular.module('ngView', ['ngRoute'], function($routeProvider, $locationProvider) {
+         angular.module('ngView', ['ngRoute']).config(function($routeProvider, $locationProvider) {
            $routeProvider.when('/Book/:bookId', {
              templateUrl: 'book.html',
              controller: BookCntl,


### PR DESCRIPTION
The implicit `config` block here tripped up a few users in the angular IRC channel, and I'm of the opinion that using the explicit `.config` API is more desirable in practice and in the examples :)
