### PR TITLE
chore(bower): write grunt task for running bower

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,5 @@ env:
     - SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987
     - SAUCE_CONNECT_READY_FILE=/tmp/sauce-connect-ready
 
-before_script:
-  - export SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
-  - ./lib/sauce/sauce_connect_setup.sh
-  - npm install -g grunt-cli
-  - grunt ci-checks package
-  - ./lib/sauce/sauce_connect_block.sh
-
 script:
-  - grunt parallel:travis --reporters dots --browsers SL_Chrome
+  - ./travis_build.sh

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jasmine-node');
   grunt.loadNpmTasks('grunt-ddescribe-iit');
   grunt.loadNpmTasks('grunt-merge-conflict');
-  grunt.loadNpmTasks('grunt-shell');
   grunt.loadNpmTasks('grunt-parallel');
   grunt.loadTasks('lib/grunt');
 
@@ -100,18 +99,6 @@ module.exports = function(grunt) {
 
 
     clean: {build: ['build']},
-
-
-    shell: {
-      bower: {
-        command: 'node ./node_modules/bower/bin/bower install',
-        options: {
-            stdout: true,
-            stderr: true,
-            failOnError: true
-        }
-      }
-    },
 
 
     build: {
@@ -245,10 +232,10 @@ module.exports = function(grunt) {
   //alias tasks
   grunt.registerTask('test:unit', ['test:jqlite', 'test:jquery', 'test:modules']);
   grunt.registerTask('test:docgen', ['jasmine-node']);
-  grunt.registerTask('minify', ['shell:bower','clean', 'build', 'minall']);
+  grunt.registerTask('minify', ['bower','clean', 'build', 'minall']);
   grunt.registerTask('test:e2e', ['connect:testserver', 'test:end2end']);
   grunt.registerTask('webserver', ['connect:devserver']);
-  grunt.registerTask('package', ['shell:bower','clean', 'buildall', 'minall', 'collect-errors', 'docs', 'copy', 'write', 'compress']);
+  grunt.registerTask('package', ['bower','clean', 'buildall', 'minall', 'collect-errors', 'docs', 'copy', 'write', 'compress']);
   grunt.registerTask('ci-checks', ['ddescribe-iit', 'merge-conflict']);
   grunt.registerTask('default', ['package']);
 };

--- a/lib/grunt/plugins.js
+++ b/lib/grunt/plugins.js
@@ -1,3 +1,4 @@
+var bower = require('bower');
 var util = require('./utils.js');
 var spawn = require('child_process').spawn;
 
@@ -62,5 +63,16 @@ module.exports = function(grunt) {
 
   grunt.registerTask('collect-errors', 'Combine stripped error files', function () {
     util.collectErrors();
+  });
+
+  grunt.registerTask('bower', 'Install Bower packages.', function () {
+    var done = this.async();
+
+    bower.commands.install()
+      .on('log', function (result) {
+        grunt.log.ok('bower: ' + result.id + ' ' + result.data.endpoint.name);
+      })
+      .on('error', grunt.fail.warn.bind(grunt.fail))
+      .on('end', done);
   });
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "grunt-contrib-compress": "0.4.1",
     "grunt-contrib-connect": "0.1.2",
     "grunt-contrib-copy": "0.4.1",
-    "grunt-shell": "~0.2.2",
     "jasmine-node": "1.2.3",
     "q": "~0.9.2",
     "q-fs": "0.1.36",

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -xe
+
+warn() {
+  tput setaf 1
+  echo "[ERROR] Received $1"
+  tput sgr0
+  exit 1
+}
+
+trap "warn SIGINT" SIGINT
+trap "warn SIGTERM" SIGTERM
+trap "warn SIGHUP" SIGHUP
+
+export SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
+./lib/sauce/sauce_connect_setup.sh
+npm install -g grunt-cli
+grunt ci-checks package
+./lib/sauce/sauce_connect_block.sh
+grunt parallel:travis --reporters dots --browsers SL_Chrome


### PR DESCRIPTION
This PR changes the build to run `bower install` inside our own Grunt task instead of `grunt-shell`. This removes the dependency on `grunt-shell`.
