### PR TITLE
docs(minerr): fill in error message descriptions

### DIFF
--- a/docs/content/error/httpBackend/noxhr.ngdoc
+++ b/docs/content/error/httpBackend/noxhr.ngdoc
@@ -2,3 +2,8 @@
 @name $httpBackend:noxhr
 @fullName Unsupported XHR
 @description
+
+This error occurs in browsers that do not support XmlHttpRequest. AngularJS
+supports Safari, Chrome, Firefox, Opera, IE8 and higher, and mobile browsers
+(Android, Chrome Mobile, iOS Safari). To avoid this error, use an officially
+supported browser.

--- a/docs/content/error/injector/cdep.ngdoc
+++ b/docs/content/error/injector/cdep.ngdoc
@@ -2,3 +2,25 @@
 @name $injector:cdep
 @fullName Circular Dependency
 @description
+
+This error occurs when the {@link api/angular.injector $injector} tries to get
+a service that depends on itself, either directly or indirectly. To fix this,
+construct your dependency chain such that there are no circular dependencies.
+
+For example:
+
+```
+angular.module('myApp', [])
+  .factory('myService', function (myService) {
+    // ...
+  })
+  .controller('MyCtrl', function ($scope, myService) {
+    // ...
+  });
+```
+
+When an instance of `MyCtrl` is created, the service `myService` will be created
+by the `$injector`. `myService` depends on itself, which causes the `$injector`
+to detect a circular dependency and throw the error.
+
+For more information, see the {@link guide/di Dependency Injection Guide}.

--- a/docs/content/error/injector/itkn.ngdoc
+++ b/docs/content/error/injector/itkn.ngdoc
@@ -2,3 +2,25 @@
 @name $injector:itkn
 @fullName Bad Injection Token
 @description
+
+This error occurs when using a bad token as a dependency injection annotation.
+Dependency injection annotation tokens should always be strings. Using any other
+type will cause this error to be thrown.
+
+Examples of code with bad injection tokens include:
+
+```
+var myCtrl = function ($scope, $http) { /* ... */ };
+myCtrl.$inject = ['$scope', 42];
+
+myAppModule.controller('MyCtrl', ['$scope', {}, function ($scope, $timeout) {
+  // ...
+}]);
+```
+
+The bad injection tokens are `42` in the first example and `{}` in the second.
+To avoid the error, always use string literals for dependency injection annotation
+tokens.
+
+For an explanation of what injection annotations are and how to use them, refer
+to the {@link guide/di Dependency Injection Guide}.

--- a/docs/content/error/injector/modulerr.ngdoc
+++ b/docs/content/error/injector/modulerr.ngdoc
@@ -2,3 +2,6 @@
 @name $injector:modulerr
 @fullName Module Error
 @description
+
+This error occurs when a module fails to load due to some exception. The error
+message above should provide additional context.

--- a/docs/content/error/injector/nomod.ngdoc
+++ b/docs/content/error/injector/nomod.ngdoc
@@ -2,3 +2,25 @@
 @name $injector:nomod
 @fullName Module Unavailable
 @description
+
+This error occurs when trying to "re-open" a module that has not yet been defined.
+
+To define a new module, call {@link api/angular.module angular.module} with a name
+and an array of dependent modules, like so:
+
+```
+// When defining a module with no module dependencies,
+// the requires array should be defined and empty.
+var myApp = angular.module('myApp', []);
+```
+
+To retrieve a reference to the same module for further configuration, call
+`angular.module` without the `requires` array.
+
+```
+var myApp = angular.module('myApp');
+```
+
+Calling `angular.module` without the `requires` array when the module has not yet
+been defined causes this error to be thrown. To fix it, define your module with
+a name and an empty array, as in the first example above.

--- a/docs/content/error/injector/pget.ngdoc
+++ b/docs/content/error/injector/pget.ngdoc
@@ -2,3 +2,25 @@
 @name $injector:pget
 @fullName Provider Missing $get
 @description
+
+This error occurs when attempting to register a provider that does not have a
+`$get` method. For example:
+
+```
+function BadProvider() {} // No $get method!
+angular.module("myApp", [])
+  .provider('bad', BadProvider);  // this throws the error
+```
+
+To fix the error, fill in the `$get` method on the provider like so:
+
+```
+function GoodProvider() {
+  this.$get = angular.noop;
+}
+angular.module("myApp", [])
+  .provider('good', GoodProvider);
+```
+
+For more information, refer to the {@link api/AUTO.$provide#provider
+$provide.provider} api doc.

--- a/docs/content/error/injector/unpr.ngdoc
+++ b/docs/content/error/injector/unpr.ngdoc
@@ -2,3 +2,25 @@
 @name $injector:unpr
 @fullName Unknown Provider
 @description
+
+This error results from the `$injector` being unable to resolve a required
+dependency. To fix this, make sure the dependency is defined and spelled
+correctly. For example:
+
+```
+angular.module('myApp', [])
+  .controller('myCtrl', ['myService', function (myService) {
+    // Do something with myService
+  }]);
+```
+
+This code will fail with `$injector:unpr` if `myService` is not defined. Making
+sure each dependency is defined will fix the problem.
+
+```
+angular.module('myApp', [])
+  .service('myService', function () { /* ... */ })
+  .controller('myCtrl', ['myService', function (myService) {
+    // Do something with myService
+  }]);
+```

--- a/docs/content/error/interpolate/interr.ngdoc
+++ b/docs/content/error/interpolate/interr.ngdoc
@@ -2,3 +2,6 @@
 @name $interpolate:interr
 @fullName Interpolation Error
 @description
+
+This error occurs when interpolation fails due to some exception. The error
+message above should provide additional context.

--- a/docs/content/error/interpolate/noconcat.ngdoc
+++ b/docs/content/error/interpolate/noconcat.ngdoc
@@ -2,3 +2,11 @@
 @name $interpolate:noconcat
 @fullName Multiple Expressions
 @description
+
+This error occurs when performing an interpolation that concatenates multiple
+expressions when a trusted value is required. Concatenating expressions makes
+it hard to reason about whether some combination of concatenated values are
+unsafe to use and could easily lead to XSS.
+
+For more information about how AngularJS helps keep your app secure, refer to
+the {@link api/ng.$sce $sce} API doc.

--- a/docs/content/error/jqLite/off_args.ngdoc
+++ b/docs/content/error/jqLite/off_args.ngdoc
@@ -2,3 +2,6 @@
 @name jqLite:off_args
 @fullName Invalid jqLite#off() parameter
 @description
+
+This error occurs when trying to pass too many arguments to `jqLite#off`. Note
+that `jqLite#off` does not support namespaces or selectors like jQuery.

--- a/docs/content/error/jqLite/on_args.ngdoc
+++ b/docs/content/error/jqLite/on_args.ngdoc
@@ -2,3 +2,7 @@
 @name jqLite:on_args
 @fullName Invalid jqLite#on() Parameters
 @description
+
+This error occurs when trying to pass too many arguments to `jqLite#on`. Note
+that `jqLite#on` does not support the `selector` or `eventData` parameters as
+jQuery does.

--- a/docs/content/error/ng/areq.ngdoc
+++ b/docs/content/error/ng/areq.ngdoc
@@ -2,3 +2,7 @@
 @name ng:areq
 @fullName Bad Argument
 @description
+
+AngularJS often asserts that certain values will be present and truthy using a
+helper function. If the assertion fails, this error is thrown. To fix this problem,
+make sure that the value the assertion expects is defined and truthy.

--- a/docs/content/error/ng/cpi.ngdoc
+++ b/docs/content/error/ng/cpi.ngdoc
@@ -2,3 +2,9 @@
 @name ng:cpi
 @fullName Bad Copy
 @description
+
+This error occurs when attempting to copy an object to itself. Calling {@link
+api/angular.copy angular.copy} with a `destination` object deletes
+all of the elements or properties on `destination` before copying to it. Copying
+an object to itself is not supported. Make sure to check your calls to
+`angular.copy` and avoid copying objects or arrays to themselves.

--- a/docs/content/error/ng/cpws.ngdoc
+++ b/docs/content/error/ng/cpws.ngdoc
@@ -2,3 +2,9 @@
 @name ng:cpws
 @fullName Copying Window or Scope
 @description
+
+Copying Window or Scope instances is not supported because of cyclical and self
+references. Avoid copying windows and scopes, as well as any other cyclical or
+self-referential structures. Note that trying to deep copy an object containing
+cyclical references that is neither a window nor a scope will cause infinite
+recursion and a stack overflow.

--- a/docs/content/error/ngModel/noass.ngdoc
+++ b/docs/content/error/ngModel/noass.ngdoc
@@ -1,4 +1,0 @@
-@ngdoc error
-@name ngModel:noass
-@fullName Non-Assignable Expression
-@description

--- a/docs/content/error/ngModel/notassign.ngdoc
+++ b/docs/content/error/ngModel/notassign.ngdoc
@@ -1,0 +1,26 @@
+@ngdoc error
+@name ngModel:notassign
+@fullName Non-Assignable Expression
+@description
+
+This error occurs when setting the value of an `ng-model` attribute to a
+non-assignable expression. Examples of assignable expressions include:
+
+```
+namedVariable
+myObj.someProperty
+indexedArray[0]
+```
+
+Examples of non-assignable expressions include:
+
+```
+foo + bar
+42
+'oops'
+myFunc()
+```
+
+Always make sure that the expression value of an `ng-model` attribute can be
+assigned to. For more information, see the {@link api/ng.directive:ngModel ngModel
+API doc}.

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -940,7 +940,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
       ngModelSet = ngModelGet.assign;
 
   if (!ngModelSet) {
-    throw minErr('ngModel')('noass', "Expression '{0}' is non-assignable. Element: {1}",
+    throw minErr('ngModel')('notassign', "Expression '{0}' is non-assignable. Element: {1}",
         $attr.ngModel, startingTag($element));
   }
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -43,7 +43,7 @@ describe('NgModelController', function() {
     }
 
     expect(exception.message).
-        toMatch(/^\[ngModel:noass\] Expression '1\+2' is non\-assignable\. Element: <input( value="")? ng-model="1\+2">$/);
+        toMatch(/^\[ngModel:notassign\] Expression '1\+2' is non\-assignable\. Element: <input( value="")? ng-model="1\+2">$/);
   }));
 
 


### PR DESCRIPTION
Errors I've documented so far:
- `$injector:cdep`
- `$injector:itkn`
- `$injector:modulerr`
- `$injector:nomod`
- `$injector:pget`
- `$injector:unpr`
- `ng:areq`
- `ng:cpi`
- `ng:cpws`
- `ngModel:noass`

This is an incomplete list and should be considered a WIP until the team has gone through the error doc spreadsheet.
