### PR TITLE
feat(ngMock): allow the use of a predicate to match data

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1123,7 +1123,7 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
    *
    * @param {string} method HTTP method.
    * @param {string|RegExp} url HTTP url.
-   * @param {(string|RegExp)=} data HTTP request body.
+   * @param {(string|RegExp|function(Object))=} data HTTP request body.
    * @param {(Object|function(Object))=} headers HTTP headers or function that receives http header
    *   object and returns true if the headers match the current definition.
    * @returns {requestHandler} Returns an object with `respond` method that control how a matched
@@ -1199,7 +1199,7 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
    * Creates a new backend definition for POST requests. For more info see `when()`.
    *
    * @param {string|RegExp} url HTTP url.
-   * @param {(string|RegExp)=} data HTTP request body.
+   * @param {(string|RegExp|function(Object))=} data HTTP request body.
    * @param {(Object|function(Object))=} headers HTTP headers.
    * @returns {requestHandler} Returns an object with `respond` method that control how a matched
    * request is handled.
@@ -1213,7 +1213,7 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
    * Creates a new backend definition for PUT requests.  For more info see `when()`.
    *
    * @param {string|RegExp} url HTTP url.
-   * @param {(string|RegExp)=} data HTTP request body.
+   * @param {(string|RegExp|function(Object))=} data HTTP request body.
    * @param {(Object|function(Object))=} headers HTTP headers.
    * @returns {requestHandler} Returns an object with `respond` method that control how a matched
    * request is handled.
@@ -1311,7 +1311,7 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
    * Creates a new request expectation for POST requests. For more info see `expect()`.
    *
    * @param {string|RegExp} url HTTP url.
-   * @param {(string|RegExp)=} data HTTP request body.
+   * @param {(string|RegExp|function(Object))=} data HTTP request body.
    * @param {Object=} headers HTTP headers.
    * @returns {requestHandler} Returns an object with `respond` method that control how a matched
    *   request is handled.
@@ -1325,7 +1325,7 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
    * Creates a new request expectation for PUT requests. For more info see `expect()`.
    *
    * @param {string|RegExp} url HTTP url.
-   * @param {(string|RegExp)=} data HTTP request body.
+   * @param {(string|RegExp|function(Object))=} data HTTP request body.
    * @param {Object=} headers HTTP headers.
    * @returns {requestHandler} Returns an object with `respond` method that control how a matched
    *   request is handled.
@@ -1339,7 +1339,7 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
    * Creates a new request expectation for PATCH requests. For more info see `expect()`.
    *
    * @param {string|RegExp} url HTTP url.
-   * @param {(string|RegExp)=} data HTTP request body.
+   * @param {(string|RegExp|function(Object))=} data HTTP request body.
    * @param {Object=} headers HTTP headers.
    * @returns {requestHandler} Returns an object with `respond` method that control how a matched
    *   request is handled.
@@ -1492,6 +1492,7 @@ function MockHttpExpectation(method, url, data, headers) {
   this.matchData = function(d) {
     if (angular.isUndefined(data)) return true;
     if (data && angular.isFunction(data.test)) return data.test(d);
+    if (data && angular.isFunction(data)) return true && data(d);
     if (data && !angular.isString(data)) return angular.toJson(data) == d;
     return data == d;
   };
@@ -1714,7 +1715,7 @@ angular.module('ngMockE2E', ['ng']).config(function($provide) {
  *
  * @param {string} method HTTP method.
  * @param {string|RegExp} url HTTP url.
- * @param {(string|RegExp)=} data HTTP request body.
+ * @param {(string|RegExp|function(Object))=} data HTTP request body.
  * @param {(Object|function(Object))=} headers HTTP headers or function that receives http header
  *   object and returns true if the headers match the current definition.
  * @returns {requestHandler} Returns an object with `respond` and `passThrough` methods that
@@ -1776,7 +1777,7 @@ angular.module('ngMockE2E', ['ng']).config(function($provide) {
  * Creates a new backend definition for POST requests. For more info see `when()`.
  *
  * @param {string|RegExp} url HTTP url.
- * @param {(string|RegExp)=} data HTTP request body.
+ * @param {(string|RegExp|function(Object))=} data HTTP request body.
  * @param {(Object|function(Object))=} headers HTTP headers.
  * @returns {requestHandler} Returns an object with `respond` and `passThrough` methods that
  *   control how a matched request is handled.
@@ -1790,7 +1791,7 @@ angular.module('ngMockE2E', ['ng']).config(function($provide) {
  * Creates a new backend definition for PUT requests.  For more info see `when()`.
  *
  * @param {string|RegExp} url HTTP url.
- * @param {(string|RegExp)=} data HTTP request body.
+ * @param {(string|RegExp|function(Object))=} data HTTP request body.
  * @param {(Object|function(Object))=} headers HTTP headers.
  * @returns {requestHandler} Returns an object with `respond` and `passThrough` methods that
  *   control how a matched request is handled.
@@ -1804,7 +1805,7 @@ angular.module('ngMockE2E', ['ng']).config(function($provide) {
  * Creates a new backend definition for PATCH requests.  For more info see `when()`.
  *
  * @param {string|RegExp} url HTTP url.
- * @param {(string|RegExp)=} data HTTP request body.
+ * @param {(string|RegExp|function(Object))=} data HTTP request body.
  * @param {(Object|function(Object))=} headers HTTP headers.
  * @returns {requestHandler} Returns an object with `respond` and `passThrough` methods that
  *   control how a matched request is handled.

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1036,6 +1036,15 @@ describe('ngMock', function() {
         expect(exp.match('POST', '/url', '{"one"')).toBe(false);
       });
 
+      
+      it('should accept data as function', function() {
+        var exp = new MockHttpExpectation('POST', '/url', function(d) {
+          return d.indexOf('a') >= 0;
+        });
+
+        expect(exp.match('POST', '/url', 'bbabb')).toBe(true);
+        expect(exp.match('POST', '/url', 'bbbbb')).toBe(false);
+      });
 
       it('should ignore data only if undefined (not null or false)', function() {
         var exp = new MockHttpExpectation('POST', '/url', null);


### PR DESCRIPTION
When using $httpBackend, the data in definitions and expectations can only
be defined as a string (which must be matched exactly) or as a regexp.
Both are not very practical when it comes to matching JSON objects. This
commits adds the possibility to pass a predicate function, which should
return a truthy value if the data matches with the expectation and a falsy
value if it doesn't.
