### PR TITLE
Fix wording in 'Understanding the Controller Component' doc

### DIFF
--- a/docs/content/guide/dev_guide.mvc.understanding_controller.ngdoc
+++ b/docs/content/guide/dev_guide.mvc.understanding_controller.ngdoc
@@ -75,10 +75,9 @@ you have to perform your own manual DOM manipulation, encapsulate the presentati
 {@link guide/directive directives}.
 - Input formatting — Use {@link forms angular form controls} instead.
 - Output filtering — Use {@link dev_guide.templates.filters angular filters} instead.
-- To run stateless or stateful code shared across controllers — Use {@link dev_guide.services angular
+- Stateless or stateful code sharing across controllers — Use {@link dev_guide.services angular
 services} instead.
-- To instantiate or manage the life-cycle of other components (for example, to create service
-instances).
+- Managing the life-cycle of other components (for example, to create service instances).
 
 
 # Associating Controllers with Angular Scope Objects


### PR DESCRIPTION
Fixes the wording so that it goes from:

'Do not use controllers for to run stateless or stateful code shared across controllers'

to:

'Do not use controllers for stateless or stateful code sharing across controllers'
