### PR TITLE
add ability for "default Model" to resource

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -390,7 +390,12 @@ angular.module('ngResource', ['ng']).
     };
 
 
-    function ResourceFactory(url, paramDefaults, actions) {
+    function ResourceFactory(url, paramDefaults, model, actions) {
+      if( !actions){
+            actions  = model;
+            model = undefined;
+      }
+        
       var route = new Route(url);
 
       actions = extend({}, DEFAULT_ACTIONS, actions);
@@ -410,7 +415,8 @@ angular.module('ngResource', ['ng']).
       }
 
       function Resource(value){
-        copy(value || {}, this);
+        var m = extend( copy(model),value ) ;
+        copy(m || {}, this);
       }
 
       forEach(actions, function(action, name) {
@@ -530,7 +536,7 @@ angular.module('ngResource', ['ng']).
       });
 
       Resource.bind = function(additionalParamDefaults){
-        return ResourceFactory(url, extend({}, paramDefaults, additionalParamDefaults), actions);
+        return ResourceFactory(url, extend({}, paramDefaults, additionalParamDefaults), model, actions);
       };
 
       return Resource;


### PR DESCRIPTION
add ability for "default Model"  on $resource so you can do nice think like that: 

``` javascript
.factory('User',function($resource){
        var model = {
                contacts:[],
                logos:[]
        };
        var User = $resource('user/:id/:action',{id:'@_id'},model,{
            get: { method:'GET',   params:{action:''} },
            remove:{ method:'GET', params:{action:'remove'} },
            save:{ method:'POST',  params:{action:'' } },
            list:{ method:'GET',  params:{action:'list'},isArray:true) }
        });

        return User;

});

function ctrl($scope,User){
  $scope.user = new User()
}

/*
$scope.user = {
      contacts:[],
      logos:[]
      $get:function,
      $remove:function
      $save:function,
      $list:function
 }
*/
```

so your controller not throw exception when you try to add something to array that not exsist
