### PR TITLE
fix(docs-bootstrap): Removed injector from bootstrapped docs samples.

### DIFF
--- a/docs/components/angular-bootstrap/bootstrap-prettify.js
+++ b/docs/components/angular-bootstrap/bootstrap-prettify.js
@@ -241,6 +241,7 @@ directive.ngEmbedApp = ['$templateCache', '$browser', '$rootScope', '$location',
         embedRootScope.$destroy();
       });
 
+      element.data('$injector', null);
       angular.bootstrap(element, modules);
     }
   };

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -330,7 +330,7 @@ function JQLiteInheritedData(element, name, value) {
   }
 
   while (element.length) {
-    if (value = element.data(name)) return value;
+    if ((value = element.data(name)) !== undefined) return value;
     element = element.parent();
   }
 }

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -126,6 +126,20 @@ describe('jqLite', function() {
         dealoc(doc);
       }
     );
+
+    it('should return null values', function () {
+      var ul = jqLite('<ul><li><p><b>deep deep</b><p></li></ul>'),
+          li = ul.find('li'),
+          b = li.find('b');
+
+      ul.data('foo', 'bar');
+      li.data('foo', null);
+      expect(b.inheritedData('foo')).toBe(null);
+      expect(li.inheritedData('foo')).toBe(null);
+      expect(ul.inheritedData('foo')).toBe('bar');
+
+      dealoc(ul);
+    });
   });
 
 

--- a/test/testabilityPatch.js
+++ b/test/testabilityPatch.js
@@ -56,7 +56,7 @@ afterEach(function() {
   forEachSorted(cache, function(expando, key){
     angular.forEach(expando.data, function(value, key){
       count ++;
-      if (value.$element) {
+      if (value && value.$element) {
         dump('LEAK', key, value.$id, sortedHtml(value.$element));
       } else {
         dump('LEAK', key, angular.toJson(value));


### PR DESCRIPTION
This is necessary to make e2e tests pass for implementing #3411. At present, the docs are violating the rule being enforced by double-bootstrap prevention.

There's still some work to be done before merging:
- [x] Write unit tests
- [x] Implement feature
- [x] Pass all new and existing tests on CI
