### PR TITLE
refactor(parse): set values on highest possible parent

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -779,6 +779,9 @@ function setter(obj, path, setValue, fullExp) {
     }
   }
   key = ensureSafeMemberName(element.shift(), fullExp);
+  while (i == 0 && isScope(obj) && obj !== obj.$root && (key in obj) && !obj.hasOwnProperty(key)) {
+    obj = obj.$parent;
+  }
   obj[key] = setValue;
   return setValue;
 }

--- a/test/ng/directive/ngIfSpec.js
+++ b/test/ng/directive/ngIfSpec.js
@@ -39,7 +39,7 @@ describe('ngIf', function () {
   it('should create a new scope', function () {
     $scope.$apply('value = true');
     element.append($compile(
-      '<div ng-if="value"><span ng-init="value=false"></span></div>'
+      '<div ng-if="value"><span ng-init="this.value=false"></span></div>'
     )($scope));
     $scope.$apply();
     expect(element.children('div').length).toBe(1);

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1044,6 +1044,60 @@ describe('parser', function() {
           fn.assign(scope, 123);
           expect(scope).toEqual({a:123});
         }));
+        describe('assignable with scopes', function() {
+          it('should assign to the same scope when there is a dot notation', inject(function($rootScope, $parse) {
+            var fn = $parse('a.b'),
+              parentScope = $rootScope.$new(),
+              childScope = parentScope.$new();
+            fn.assign(childScope, 123);
+            expect(parentScope.a).toBe(undefined);
+            expect(childScope.a.b).toBe(123);
+          }));
+          it('should assign to the parent scope when the parent has the definition and there is a dot notation', inject(function($rootScope, $parse) {
+            var fn = $parse('a.b'),
+              parentScope = $rootScope.$new(),
+              childScope = parentScope.$new();
+            parentScope.a = {};
+            fn.assign(childScope, 123);
+            expect(parentScope.a.b).toBe(123);
+            expect(childScope.a.b).toBe(123);
+          }));
+          it('should assign to the same scope when there is no dot notation and the property is not present on the parent', inject(function($rootScope, $parse) {
+            var fn = $parse('a'),
+              parentScope = $rootScope.$new(),
+              childScope = parentScope.$new();
+            fn.assign(childScope, 'lucas');
+            expect(parentScope.a).toBe(undefined);
+            expect(childScope.a).toBe('lucas');
+          }));
+          it('should assign to the scope that has a definition when there is no dot notation', inject(function($rootScope, $parse) {
+            var fn = $parse('a'),
+              parentScope = $rootScope.$new(),
+              childScope = parentScope.$new();
+            parentScope.a = '';
+            fn.assign(childScope, 'lucas');
+            expect(parentScope.a).toBe('lucas');
+            expect(childScope.a).toBe('lucas');
+          }));
+          it('should be able to use `this` to force the current scope', inject(function($rootScope, $parse) {
+            var fn = $parse('this.a'),
+              parentScope = $rootScope.$new(),
+              childScope = parentScope.$new();
+            parentScope.a = '';
+            fn.assign(childScope, 'lucas');
+            expect(parentScope.a).toBe('');
+            expect(childScope.a).toBe('lucas');
+          }));
+          it('should not cross isolated scopes', inject(function($rootScope, $parse) {
+            var fn = $parse('a'),
+              parentScope = $rootScope.$new(),
+              childScope = parentScope.$new(true);
+            parentScope.a = '';
+            fn.assign(childScope, 'lucas');
+            expect(parentScope.a).toBe('');
+            expect(childScope.a).toBe('lucas');
+          }));
+        });
       });
 
 


### PR DESCRIPTION
This is one of those PRs that I am torn about, but after seeing a lot of developers have so many WTF moments, I thought it was about time to change this

When assigning a value on a scope, the expression is visible but not defined at the current scope then assign the value on the highest possible scope that would make the expression visible on the child scope. If the value is not defined at any scope, then the value is defined at the child scope

BREAKING CHANGE: assign of values is done at the scope that has the expression definition when there is no dot notation

To force that a property is set on the current scope, prepend the expression with `this.` like the example below:

Before:
  <input ng-model="foo">
  <input ng-model="bar.baz">
  <div ng-if="something">
    <input ng-model="foo">  <!-- for some reason I want to change the value of `foo` just at this child scope -->
    <input ng-model="bar.baz">
  </div>

After
  <input ng-model="foo">
  <input ng-model="bar.baz">
  <div ng-if="something">
    <input ng-model="this.foo">  <!-- force that we use the current scope using `this` -->
    <input ng-model="bar.baz"> <!-- this still works as before as it uses the dot notation -->
  </div>
