### PR TITLE
fix(jqLite): forgive unregistration of a non-registered handler

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -212,7 +212,7 @@ function JQLiteOff(element, type, fn) {
         removeEventListenerFn(element, type, events[type]);
         delete events[type];
       } else {
-        arrayRemove(events[type], fn);
+        arrayRemove(events[type] || [], fn);
       }
     });
   }

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -890,6 +890,12 @@ describe('jqLite', function() {
       aElem.off('click', function() {});
     });
 
+    it('should do nothing when a specific listener was not registered', function () {
+      var aElem = jqLite(a);
+      aElem.on('click', function() {});
+
+      aElem.off('mouseenter', function() {});
+    });
 
     it('should deregister all listeners', function() {
       var aElem = jqLite(a),


### PR DESCRIPTION
I've bumped into a subtle bug when unregisering handlers with jqLite. If you try to unregister a non-existing handler by specifing both its type and a function jqLite's `off` will fail if there was already a different handler was registered. See the test for more details.

With jQuery this situation is handled correctly, that it, unregistration has no effect.

I was hesitating a bit between fixing it in jqLite or fixing directly the `indexOf` / `arrayRemove` (in Angular.js). In any case the test illustrates my real problem, can amend the fix if needed.
