### PR TITLE
fix(location): pathUrl is not containing the actual app path

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -94,7 +94,7 @@ function LocationHtml5Url(appBase, basePrefix) {
   this.$$parse = function(url) {
     var parsed = {}
     matchUrl(url, parsed);
-    var pathUrl = beginsWith(appBaseNoFile, url);
+    var pathUrl = beginsWith(serverBase(url), url);
     if (!isString(pathUrl)) {
       throw $locationMinErr('nopp', 'Invalid url "{0}", missing path prefix "{1}".', url, appBaseNoFile);
     }


### PR DESCRIPTION
If you refresh the browser with a valid path, the original version redirected you to the "otherwise" routing path. The original code only received the last part of an URI. (for example: http://server:port/admin/users/1 -> path would be /1, and not /admin/users/1) The routing worked if you started from the base path, but not always worked when you started with something different. I assume, that the pathUrl should be the part after the serverBase.
I compared the code with 1.0.7, but that version did not contain these new methods, and had a different approach. (One, that worked...)

html5Mode(true), Chrome 28
