### PR TITLE
feat($q): add shorthand for defining promise success or error handlers

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -91,6 +91,8 @@
  *   This method *returns a new promise* which is resolved or rejected via the return value of the
  *   `successCallback` or `errorCallback`.
  *
+ * - `catch(errorCallback)` – it is shorthand for `promise.then(null, errorCallback)`
+ *
  * - `always(callback)` – allows you to observe either the fulfillment or rejection of a promise,
  *   but to do so without modifying the final value. This is useful to release resources or do some
  *   clean-up that needs to be done whether the promise was rejected or resolved. See the [full
@@ -230,6 +232,9 @@ function qFactory(nextTick, exceptionHandler) {
 
 
       promise: {
+        "catch": function(callback) {
+          return this.then(null, callback);
+        },
         then: function(callback, errback, progressback) {
           var result = defer();
 
@@ -268,7 +273,6 @@ function qFactory(nextTick, exceptionHandler) {
           return result.promise;
         },
         always: function(callback) {
-          
           function makePromise(value, resolved) {
             var result = defer();
             if (resolved) {
@@ -278,14 +282,14 @@ function qFactory(nextTick, exceptionHandler) {
             }
             return result.promise;
           }
-          
+
           function handleCallback(value, isResolved) {
-            var callbackOutput = null;            
+            var callbackOutput = null;
             try {
               callbackOutput = (callback ||defaultCallback)();
             } catch(e) {
               return makePromise(e, false);
-            }            
+            }
             if (callbackOutput && callbackOutput.then) {
               return callbackOutput.then(function() {
                 return makePromise(value, isResolved);
@@ -296,7 +300,7 @@ function qFactory(nextTick, exceptionHandler) {
               return makePromise(value, isResolved);
             }
           }
-          
+
           return this.then(function(value) {
             return handleCallback(value, true);
           }, function(error) {

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -516,6 +516,10 @@ describe('q', function() {
         expect(typeof promise.then).toBe('function');
       });
 
+      it('should have a catch method', function() {
+        expect(typeof promise['catch']).toBe('function');
+      });
+
       it('should have a always method', function() {
         expect(typeof promise.always).toBe('function');
       });
@@ -879,6 +883,14 @@ describe('q', function() {
 
           });
 
+        });
+      });
+
+      describe('catch', function() {
+        it('should be a shorthand for defining promise error handlers', function() {
+          promise['catch'](error(1)).then(null, error(2))
+          syncReject(deferred, 'foo');
+          expect(logStr()).toBe('error1(foo)->reject(foo); error2(foo)->reject(foo)');
         });
       });
     });

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -16,6 +16,7 @@ trap "warn SIGHUP" SIGHUP
 export SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
 ./lib/sauce/sauce_connect_setup.sh
 npm install -g grunt-cli
+./node_modules/bower/bin/bower install
 grunt ci-checks package
 
 echo ">>> grunt exited with code: $?"


### PR DESCRIPTION
Now we can instead this

```
promise.then(null, errorHandler)
```

like this

```
promise.catch(errorhandler)
```

Closes #2048
