### PR TITLE
fix(routeProvider): route matcher should fill parameters or fail

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -170,7 +170,9 @@ function $RouteProvider(){
           + (optional ? '' : slash)
           + '(?:'
           + (optional ? slash : '')
-          + (star && '(.+)?' || '([^/]+)?') + ')'
+          + (star && '(.+?)' || '([^/]+)')
+          + (optional || '')
+          + ')'
           + (optional || '');
       })
       .replace(/([\/$\*])/g, '\\$1');

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -331,6 +331,50 @@ describe('$route', function() {
   });
 
 
+  it('should skip routes with incomplete params', function() {
+    module(function($routeProvider) {
+      $routeProvider
+        .otherwise({template: 'other'})
+        .when('/pages/:page/:comment*', {template: 'comment'})
+        .when('/pages/:page', {template: 'page'})
+        .when('/pages', {template: 'index'})
+        .when('/foo/', {template: 'foo'})
+        .when('/foo/:bar', {template: 'bar'})
+        .when('/foo/:bar*/:baz', {template: 'baz'});
+    });
+
+    inject(function($route, $location, $rootScope) {
+      $location.url('/pages/');
+      $rootScope.$digest();
+      expect($route.current.template).toBe('index');
+
+      $location.url('/pages/page/');
+      $rootScope.$digest();
+      expect($route.current.template).toBe('page');
+
+      $location.url('/pages/page/1/');
+      $rootScope.$digest();
+      expect($route.current.template).toBe('comment');
+
+      $location.url('/foo/');
+      $rootScope.$digest();
+      expect($route.current.template).toBe('foo');
+
+      $location.url('/foo/bar/');
+      $rootScope.$digest();
+      expect($route.current.template).toBe('bar');
+
+      $location.url('/foo/bar/baz/');
+      $rootScope.$digest();
+      expect($route.current.template).toBe('baz');
+
+      $location.url('/something/');
+      $rootScope.$digest();
+      expect($route.current.template).toBe('other');
+    });
+  });
+
+
   describe('otherwise', function() {
 
     it('should handle unknown routes with "otherwise" route definition', function() {


### PR DESCRIPTION
Currently, a `$routeProvider` configured like so:

```
$routeProvider
  .when('/pages/:page/*comment', {template: 'comment'})
  .when('/pages/:page', {template: 'page'})
  .when('/pages', {template: 'index'});
```

Would never reach any of the 'page' or 'index' routes unless they are defined in reverse order. Given that ordering of route matching is not guaranteed to be the same as the definition of `when`s, a fix could be the one in this PR.

With this PR, a route containing parameters **must** be able to give a value to all parameters to match.

:bangbang: This creates _breaking change_ where locations like `/page/` will **not** match the route `/page/:id`.
