### PR TITLE
fix(ngAnimate): make sure that the class value passed into addClass/removeClass is the base class string value

### DIFF
--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1520,4 +1520,36 @@ describe("ngAnimate", function() {
     });
   });
 
+  it("should provide the correct CSS class to the addClass and removeClass callbacks within a JS animation", function() {
+    module(function($animateProvider) {
+      $animateProvider.register('.classify', function($timeout) {
+        return {
+          removeClass : function(element, className, done) {
+            element.data('classify','remove-' + className);
+            done();
+          },
+          addClass : function(element, className, done) {
+            element.data('classify','add-' + className);
+            done();
+          }
+        }
+      });
+    })
+    inject(function($compile, $rootScope, $animate, $timeout) {
+      var element = html($compile('<div class="classify"></div>')($rootScope));
+
+      $animate.addClass(element, 'super');
+      expect(element.data('classify')).toBe('add-super');
+      $timeout.flush();
+
+      $animate.removeClass(element, 'super');
+      expect(element.data('classify')).toBe('remove-super');
+      $timeout.flush();
+
+      $animate.addClass(element, 'superguy');
+      expect(element.data('classify')).toBe('add-superguy');
+      $timeout.flush();
+    });
+  });
+
 });


### PR DESCRIPTION
When the animation `addClass` or `removeClass` callback functions were called, they were passing in `CLASS-add` and `CLASS-remove` into the functions. This is incorrect, it should just be `CLASS`.

To make the fix, some of the code inside of `animate.js` had to be changed around to avoid redundant code. `animation()` was changed `$animateProvider.register` within the animate.js file.
