### PR TITLE
Allow directive's bi-directional isolate scope to do deep equality check

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -942,13 +942,14 @@ function $CompileProvider($provide) {
         $element = attrs.$$element;
 
         if (newIsolateScopeDirective) {
-          var LOCAL_REGEXP = /^\s*([@=&])(\??)\s*(\w*)\s*$/;
+          var LOCAL_REGEXP = /^\s*([@=&])(\??)(\*?)\s*(\w*)\s*$/;
 
           var parentScope = scope.$parent || scope;
 
           forEach(newIsolateScopeDirective.scope, function(definition, scopeName) {
             var match = definition.match(LOCAL_REGEXP) || [],
-                attrName = match[3] || scopeName,
+                attrName = match[4] || scopeName,
+                eq = (match[3] == '*'),
                 optional = (match[2] == '?'),
                 mode = match[1], // @, =, or &
                 lastValue,
@@ -995,6 +996,11 @@ function $CompileProvider($provide) {
                       parentSet(parentScope, parentValue = lastValue = scope[scopeName]);
                     }
                   }
+
+                  if (eq) {
+                    this.eq = true;
+                  }
+
                   return parentValue;
                 });
                 break;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2004,6 +2004,8 @@ describe('$compile', function() {
             optref: '=?',
             optrefAlias: '=? optref',
             optreference: '=?',
+            eqref: '=*',
+            eqrefAlias: '=* eqref',
             expr: '&',
             exprAlias: '&expr'
           },
@@ -2166,6 +2168,30 @@ describe('$compile', function() {
       }));
     });
 
+    describe('equality object reference', function() {
+      it('should update local reference to array when origin changes without $digest errors', inject(function() {
+        $rootScope.list = [{
+          name: 'Mark',
+          value: 45
+        }, {
+          name: 'Misko',
+          value: 52
+        }];
+        $rootScope.query = "";
+        $rootScope.$apply();
+
+        compile('<div><span my-component eqref="list | filter:query">');
+
+        expect(componentScope.eqref).toEqual($rootScope.list);
+        expect(componentScope.eqrefAlias).toEqual(componentScope.eqref);
+
+        $rootScope.query = "Ma";
+        $rootScope.$apply();
+
+        expect(componentScope.eqref).toEqual([$rootScope.list[0]]);
+        expect(componentScope.eqrefAlias).toEqual([$rootScope.list[0]]);
+      }));
+    });
 
     describe('executable expression', function() {
       it('should allow expression execution with locals', inject(function() {


### PR DESCRIPTION
### Background

Consider the following directive:

``` js
myApp.directive('listUsers', function() {
  return {
    restrict: 'E',
    template: "<ul><li ng-repeat='user in users'>{{user.name}} - {{user.age}}</li></ul>",
    scope: {
      users: '='
    }
  };
});
```

It sets up bi-directional binding to the parent scope's `users` property that it receives via an attribute. In this particular situation, it expects an array of user objects and lists user names and their respective ages.

We could use this directive like so.

``` html
<div ng-init="users = [{name: 'Mark', value: 42}, {name: 'Misko', value: 55}]">
  <list-users users="users"></list-users>
</div>
```

Everything works just fine. At least until we decide to use a filter.

``` html
<div ng-init="users = [{name: 'Mark', value: 42}, {name: 'Misko', value: 55}]">
  <input type="text" ng-model="query">
  <list-users users="users | filter:query"></list-users>
</div>
```

If you look in the browser console, you will see something along the lines of: `10 $digest() iterations reached. Aborting!`

The problem is that `filter`, along with many other functions that mutate arrays, return a copy and not the original array. During the $digest [comparison step](https://github.com/angular/angular.js/blob/master/src/ng/rootScope.js#L527-L530), the array value is deemed as changed (since a new reference is returned even though the actual elements in the array have not changed) and the watchers are called again and again.
### Proposition

Allow optional "deep" equality checks on bi-directional scope values to avoid unnecessary digests.

This pull request introduces an optional argument, `*`, that can be passed to a directive's scope definition. When passed, a deep [equality](https://github.com/angular/angular.js/blob/master/src/Angular.js#L682) check will be forced when determining if watcher value has changed.

Now, the example above will work properly with just a minor tweak to the directive's scope definition:

``` js
myApp.directive('listUsers', function() {
  return {
    ...
    scope: {
      users: '=*'
    }
  };
});
```
