### PR TITLE
chore(bower): add a .bowerrc file

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,4 @@
+{
+  "directory": "bower_components",
+  "json": "bower.json"
+}


### PR DESCRIPTION
Having a `.bowerrc` file somewhere in the local directory structure above angular leads to incorrect bower component installation.
