### PR TITLE
feat($controller): support controller resolution via $provide

### DIFF
--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -43,7 +43,8 @@ function $ControllerProvider() {
      *    controller constructor function. Otherwise it's considered to be a string which is used
      *    to retrieve the controller constructor using the following steps:
      *
-     *    * check if a controller with given name is registered via `$controllerProvider`
+     *    * check if a controller of the given name is registered with `$controllerProvider`
+     *    * check if a provider of the given name is registered with `$provide`.
      *    * check if evaluating the string on the current scope returns a constructor
      *    * check `window[constructor]` on the global `window` object
      *
@@ -67,6 +68,10 @@ function $ControllerProvider() {
         expression = controllers.hasOwnProperty(constructor)
             ? controllers[constructor]
             : getter(locals.$scope, constructor, true) || getter($window, constructor, true);
+
+        if (!expression && $injector.has(constructor)) {
+          expression = $injector.get(constructor);
+        }
 
         assertArgFn(expression, constructor, true);
       }

--- a/test/ng/controllerSpec.js
+++ b/test/ng/controllerSpec.js
@@ -1,9 +1,10 @@
 'use strict';
 
 describe('$controller', function() {
-  var $controllerProvider, $controller;
+  var $provide, $controllerProvider, $controller;
 
-  beforeEach(module(function(_$controllerProvider_) {
+  beforeEach(module(function(_$provide_, _$controllerProvider_) {
+    $provide = _$provide_;
     $controllerProvider = _$controllerProvider_;
   }));
 
@@ -100,6 +101,25 @@ describe('$controller', function() {
     expect(foo).toBeDefined();
     expect(foo instanceof Foo).toBe(true);
   }));
+
+
+  it('should resolve named controllers using $injector', function() {
+    var FooCtrl,
+        scope = {},
+        ctrl;
+
+    $provide.factory("Ctrl", function() {
+      return FooCtrl = function($scope, name) {
+        $scope.name = name;
+      };
+    });
+
+    ctrl = $controller("Ctrl as c", {$scope: scope, name: "foo"});
+    expect(ctrl).toBeDefined();
+    expect(ctrl instanceof FooCtrl).toBe(true);
+    expect(scope.c).toBe(ctrl);
+    expect(scope.name).toBe("foo");
+  });
 
 
   describe('ctrl as syntax', function() {


### PR DESCRIPTION
The patch extends the resolution strategy used by $controller to also search for controllers registered via $provide.

Using $provide gives developers more flexibility in how controllers are configured and created (it also seems more internally consistent to use Angular's own  dependency resolution framework for controller resolution.)

Includes updated ngdoc for $ng.$controller – I'm happy to add an update for the guide too, just LMK.
