### PR TITLE
docs(ngModel): $setViewValue does not check validity before updating model

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1042,8 +1042,8 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
    * For example {@link ng.directive:input input} or
    * {@link ng.directive:select select} directives call it.
    *
-   * It internally calls all `parsers` and if resulted value is valid, updates the model and
-   * calls all registered change listeners.
+   * It internally calls all `parsers`, updates the model and calls
+   * all registered change listeners.
    *
    * @param {string} value Value from the view.
    */


### PR DESCRIPTION
Removes an incorrect assertion in the docs for $setViewValue. It actually updates the model regardless of the control validity.
