### PR TITLE
fix(jqLite): throw when jqLite#off called with 4 args

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -193,8 +193,8 @@ function JQLiteDealoc(element){
   }
 }
 
-function JQLiteOff(element, type, fn) {
-  if ( arguments.length > 4 ) throw jqLiteMinErr('off_args', 'jqLite#off() does not support the `selector` parameter');
+function JQLiteOff(element, type, fn, other1) {
+  if (isDefined(other1)) throw jqLiteMinErr('off_args', 'jqLite#off() does not support the `selector` parameter');
 
   var events = JQLiteExpandoStore(element, 'events'),
       handle = JQLiteExpandoStore(element, 'handle');

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -901,7 +901,7 @@ describe('jqLite', function() {
   });
 
 
-  describe('unbind', function() {
+  describe('off', function() {
     it('should do nothing when no listener was registered with bound', function() {
       var aElem = jqLite(a);
 
@@ -1051,6 +1051,17 @@ describe('jqLite', function() {
       expect(masterSpy).not.toHaveBeenCalled();
       expect(extraSpy).toHaveBeenCalledOnce();
     });
+
+    // Only run this test for jqLite and not normal jQuery
+    if ( _jqLiteMode ) {
+      it('should throw an error if a selector is passed', function () {
+        var aElem = jqLite(a);
+        aElem.on('click', noop);
+        expect(function () {
+          aElem.off('click', noop, '.test');
+        }).toThrowMatching(/\[jqLite:off_args\]/);
+      });
+    }
   });
 
 


### PR DESCRIPTION
This fixes the bug identified in my [comment](https://github.com/angular/angular.js/commit/f1b94b4b599ab701bc75b55bbbbb73c5ef329a93#commitcomment-3800998) from yesterday.
