### PR TITLE
fix(compile): fix directives with controller, templateUrl and compile properties

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -782,13 +782,6 @@ function $CompileProvider($provide) {
 
         directiveName = directive.name;
 
-        if (directiveValue = directive.controller) {
-          controllerDirectives = controllerDirectives || {};
-          assertNoDuplicate("'" + directiveName + "' controller",
-              controllerDirectives[directiveName], directive, $compileNode);
-          controllerDirectives[directiveName] = directive;
-        }
-
         if (directiveValue = directive.transclude) {
           assertNoDuplicate('transclusion', transcludeDirective, directive, $compileNode);
           transcludeDirective = directive;
@@ -875,6 +868,13 @@ function $CompileProvider($provide) {
           } catch (e) {
             $exceptionHandler(e, startingTag($compileNode));
           }
+        }
+
+        if (!directive.templateUrl && directive.controller) {
+          controllerDirectives = controllerDirectives || {};
+          assertNoDuplicate("'" + directiveName + "' controller",
+              controllerDirectives[directiveName], directive, $compileNode);
+          controllerDirectives[directiveName] = directive;
         }
 
         if (directive.terminal) {
@@ -1157,7 +1157,7 @@ function $CompileProvider($provide) {
           origAsyncDirective = directives.shift(),
           // The fact that we have to copy and patch the directive seems wrong!
           derivedSyncDirective = extend({}, origAsyncDirective, {
-            controller: null, templateUrl: null, transclude: null, scope: null, replace: null
+            templateUrl: null, transclude: null, scope: null, replace: null
           }),
           templateUrl = (isFunction(origAsyncDirective.templateUrl))
               ? origAsyncDirective.templateUrl($compileNode, tAttrs)

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2502,6 +2502,68 @@ describe('$compile', function() {
         expect(element.text()).toBe('parentTemplateText;childTemplateText;childContentText;babyTemplateText;')
       });
     });
+
+    it('should allow controller usage in directives with templateUrl', function () {
+      module(function () {
+        var Ctrl = function (log) {
+          log('instance');
+        };
+
+        directive('myDirective', function () {
+          return {
+            scope: true,
+            templateUrl: 'hello.html',
+            controller: Ctrl,
+            compile: function () {
+              return {
+                pre: function (scope, template, attr, ctrl) {},
+                post: function () {}
+              };
+            }
+          };
+        });
+      });
+
+      inject(function ($templateCache, $compile, $rootScope, log) {
+        $templateCache.put('hello.html', '<p>Hello</p>');
+
+        element = $compile('<div my-directive></div>')($rootScope);
+        $rootScope.$apply();
+
+        expect(log).toEqual('instance');
+        expect(element.text()).toBe('Hello');
+      });
+    });
+
+    it('should allow controller usage in directives with a template', function () {
+      module(function () {
+        var Ctrl = function (log) {
+          log('instance');
+        };
+
+        directive('myDirective', function () {
+          return {
+            scope: true,
+            template: '<p>Hello</p>',
+            controller: Ctrl,
+            compile: function () {
+              return {
+                pre: function (scope, template, attr, ctrl) {},
+                post: function () {}
+              };
+            }
+          };
+        });
+      });
+
+      inject(function ($templateCache, $compile, $rootScope, log) {
+        element = $compile('<div my-directive></div>')($rootScope);
+        $rootScope.$apply();
+
+        expect(log).toEqual('instance');
+        expect(element.text()).toBe('Hello');
+      });
+    });
   });
 
 


### PR DESCRIPTION
This PR addresses the following JSBin: http://jsbin.com/azomeh/9/edit

Directives combining templateUrl and a controller were not getting compiled correctly. The second call to `applyDirectivesToNode` was being made with the `controller` property of the directive set to `null` which made it impossible for the compiler to find the controller constructor function.
