### PR TITLE
feat(ngSwitch): Allow multiple case matches for one element

### DIFF
--- a/test/ng/directive/ngSwitchSpec.js
+++ b/test/ng/directive/ngSwitchSpec.js
@@ -66,6 +66,38 @@ describe('ngSwitch', function() {
   }));
 
 
+  it('should allow multiple switch-whens when using array notation', inject(function($rootScope, $compile) {
+    element = $compile(
+      '<ul ng-switch="select">' +
+        '<li ng-switch-when="1">first:{{name}}</li>' +
+        '<li ng-switch-when="[1,8-6]"> both:{{name}}</li>' +
+        '<li ng-switch-when="2"> second:{{name}}</li>' +
+        '<li ng-switch-when="true">true:{{name}}</li>' +
+      '</ul>')($rootScope);
+    $rootScope.select = 1;
+    $rootScope.name="pete";
+    $rootScope.$apply();
+    expect(element.text()).toEqual('first:pete both:pete');
+    $rootScope.select = 2;
+    $rootScope.$apply();
+    expect(element.text()).toEqual(' both:pete second:pete');
+  }));
+
+
+  it('should switch only once even if multiple whens matches the same element when using array notation', inject(function($rootScope, $compile) {
+    element = $compile(
+      '<ul ng-switch="select">' +
+        '<li ng-switch-when="1">first:{{name}}</li>' +
+        '<li ng-switch-when="[2,8-6]"> both:{{name}}</li>' +
+        '<li ng-switch-when="2"> second:{{name}}</li>' +
+        '<li ng-switch-when="true">true:{{name}}</li>' +
+      '</ul>')($rootScope);
+    $rootScope.name="pete";
+    $rootScope.select = 2;
+    $rootScope.$apply();
+    expect(element.text()).toEqual(' both:pete second:pete');
+  }));
+
   it('should switch on switch-when-default', inject(function($rootScope, $compile) {
     element = $compile(
       '<ng:switch on="select">' +


### PR DESCRIPTION
Now you can also use an array in `ng-switch-when`, which allows specifying multiple values for the same element. Values will be evaluated within the scope when using the array notation.

I.e. `ng-switch-when="[1, 3, 'hello', 5-3]"`

Each element will switch only once even if there are multiple matches in the same element.

**BREAKING CHANGE:** Previously `ng-switch-when` expressions that matched against square brackets strings won't work anymore. The fix is encapsulate the string into a one-element array.
I.e. before `ng-switch-when='[hi]'`, now `ng-switch-when="['[hi]']"`

Closes #3410
