### PR TITLE
chore($compile): use minErr on "as instance" syntax

### DIFF
--- a/docs/content/error/compile/enscp.ngdoc
+++ b/docs/content/error/compile/enscp.ngdoc
@@ -1,0 +1,28 @@
+@ngdoc error
+@name $compile:enscp
+@fullName Can not export controller as no scope object is provided
+@description
+If the directive doesn't have a local scope or is not a valid object, you can not export
+the controller. Please specify the scope element the defining the directive, even if its
+empty.
+
+<pre>
+myModule.directive('directiveName', function factory() {
+  return {
+    ...
+    controllerAs: 'DirCtrl'; // ERROR: no local scope specified
+    ...
+  }
+});
+</pre>
+
+<pre>
+myModule.directive('directiveName', function factory() {
+  return {
+    ...
+    scope: {},
+    controllerAs: 'DirCtrl'; // OK: local scope is a valid object
+    ...
+  }
+});
+</pre>

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1036,8 +1036,8 @@ function $CompileProvider($provide) {
                 controllerInstance);
             if (directive.controllerAs) {
               if (typeof locals.$scope !== 'object') {
-                throw new Error('Can not export controller as "' + identifier + '". ' +
-                    'No scope object provided!');
+                throw $compileMinErr('enscp', "Can not export controller as '{0}' as no scope object is provided!'",
+                    identifier);
               }
 
               locals.$scope[directive.controllerAs] = controllerInstance;


### PR DESCRIPTION
This should take one of the `minall` task warnings away.
