### PR TITLE
docs(ngModel): validators should return undefined for invalid values.

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -817,6 +817,10 @@ var VALID_CLASS = 'ng-valid',
  * @property {Array.<Function>} $parsers Array of functions to execute, as a pipeline, whenever
        the control reads value from the DOM.  Each function is called, in turn, passing the value
        through to the next. Used to sanitize / convert the value as well as validation.
+       For validation, the parsers should update the validity state using
+       {@link ng.directive:ngModel.NgModelController#$setValidity $setValidity()},
+       and return `undefined` for invalid values.
+
  *
  * @property {Array.<Function>} $formatters Array of functions to execute, as a pipeline, whenever
        the model value changes. Each function is called, in turn, passing the value through to the
@@ -1042,10 +1046,8 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
    * For example {@link ng.directive:input input} or
    * {@link ng.directive:select select} directives call it.
    *
-   * It internally calls all `parsers` (including validators) and updates the `$modelValue` and the actual model path.
+   * It internally calls all `$parsers` (including validators) and updates the `$modelValue` and the actual model path.
    * Lastly it calls all registered change listeners.
-   *
-   * If validators determine the value is invalid, the `$modelValue` and the model path will be set to `undefined`.
    *
    * @param {string} value Value from the view.
    */


### PR DESCRIPTION
Per comments in https://github.com/angular/angular.js/pull/3498, clarifies that validators are responsible for returning `undefined` for invalid values.
