### PR TITLE
fix($q): promises should still resolve outside of the $digest/$apply phase

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -161,13 +161,28 @@
  */
 function $QProvider() {
 
-  this.$get = ['$rootScope', '$exceptionHandler', function($rootScope, $exceptionHandler) {
-    return qFactory(function(callback) {
-      $rootScope.$evalAsync(callback);
+  this.$get = ['$rootScope', '$exceptionHandler','$browser', function($rootScope, $exceptionHandler,$browser) {
+    return qFactory(function (callback) {
+        if($rootScope.$$phase){
+            $rootScope.$evalAsync(callback);
+        }
+        else {
+            var timeoutId = $browser.defer(function(){
+                timeoutId = false;
+                $rootScope.$apply();
+            });
+            $rootScope.$evalAsync(function(){
+                if(timeoutId){
+                    //$digest was called before
+                    $browser.defer.cancel(timeoutId);
+                    timeoutId = null;
+                }
+                $rootScope.$eval(callback);
+            });
+        }
     }, $exceptionHandler);
   }];
 }
-
 
 /**
  * Constructs a promise manager.

--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -2,10 +2,13 @@
 
 
 function $TimeoutProvider() {
-  this.$get = ['$rootScope', '$browser', '$q', '$exceptionHandler',
-       function($rootScope,   $browser,   $q,   $exceptionHandler) {
+  this.$get = ['$rootScope', '$browser', '$exceptionHandler',
+       function($rootScope,   $browser,    $exceptionHandler) {
     var deferreds = {};
 
+     var $q = qFactory(function(callback){
+         $rootScope.$evalAsync(callback);
+     },$exceptionHandler);
 
      /**
       * @ngdoc function


### PR DESCRIPTION
A number of issues have been raised (see #2431) because the current promise implementation has the unexpected behavior of not forwarding execution to the `onResolve` or `onReject` callbacks until the next $digest cycle, nor does it schedule a new cycle.

The currently recommended solution is to wrap all callbacks with $apply, but that is unnecessarily cumbersome (the user will almost always wants $apply called). It becomes increasingly problematic when dealing with longer promise chains, or using third party libraries that expect conventional promises as input.

Closes #2431
