### PR TITLE
fix($scope): $evalAsync executes on the right scope

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -498,7 +498,7 @@ function $RootScopeProvider(){
             dirty, ttl = TTL,
             next, current, target = this,
             watchLog = [],
-            logIdx, logMsg;
+            logIdx, logMsg, asyncElement;
 
         beginPhase('$digest');
 
@@ -508,7 +508,8 @@ function $RootScopeProvider(){
 
           while(asyncQueue.length) {
             try {
-              current.$eval(asyncQueue.shift());
+              asyncElement = asyncQueue.shift();
+              asyncElement.scope.$eval(asyncElement.expression);
             } catch (e) {
               $exceptionHandler(e);
             }
@@ -680,7 +681,7 @@ function $RootScopeProvider(){
        *
        */
       $evalAsync: function(expr) {
-        this.$$asyncQueue.push(expr);
+        this.$$asyncQueue.push({scope: this, expression: expr});
       },
 
       /**

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -692,6 +692,17 @@ describe('Scope', function() {
       expect($rootScope.log).toBe('12');
     }));
 
+    it('should run async expressions in their proper context', inject(function ($rootScope) {
+      var child = $rootScope.$new();
+      $rootScope.ctx = 'root context';
+      $rootScope.log = '';
+      child.ctx = 'child context';
+      child.log = '';
+      child.$evalAsync('log=ctx');
+      $rootScope.$digest();
+      expect($rootScope.log).toBe('');
+      expect(child.log).toBe('child context');
+    }));
 
     it('should operate only with a single queue across all child and isolate scopes', inject(function($rootScope) {
       var childScope = $rootScope.$new();
@@ -703,7 +714,10 @@ describe('Scope', function() {
 
       expect(childScope.$$asyncQueue).toBe($rootScope.$$asyncQueue);
       expect(isolateScope.$$asyncQueue).toBe($rootScope.$$asyncQueue);
-      expect($rootScope.$$asyncQueue).toEqual(['rootExpression', 'childExpression', 'isolateExpression']);
+      expect($rootScope.$$asyncQueue).toEqual([
+        {scope: $rootScope, expression: 'rootExpression'},
+        {scope: childScope, expression: 'childExpression'},
+        {scope: isolateScope, expression: 'isolateExpression'}]);
     }));
   });
 


### PR DESCRIPTION
Executes `$evalAsync` on the scope that the call was made.

Closes: #3548
