### PR TITLE
fix(minerr): escape double quotes in error displays

### DIFF
--- a/docs/src/ngdoc.js
+++ b/docs/src/ngdoc.js
@@ -456,7 +456,7 @@ Doc.prototype = {
         minerrMsg = lookupMinerrMsg(self);
         dom.tag('pre', {
           class:'minerr-errmsg',
-          'error-display': minerrMsg
+          'error-display': minerrMsg.replace(/"/g, '&quot;')
         }, minerrMsg);
       }
       if (self.ngdoc != 'overview') {


### PR DESCRIPTION
This fixes the quoting bug that we found this morning.
