### PR TITLE
chore(Grunt): upgrade ng-closure-runner to 0.2.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "components-font-awesome": "3.1.0",
     "bootstrap": "https://raw.github.com/twbs/bootstrap/v2.0.2/docs/assets/bootstrap.zip",
     "closure-compiler": "https://closure-compiler.googlecode.com/files/compiler-20130603.zip",
-    "ng-closure-runner": "https://raw.github.com/angular/ng-closure-runner/v0.2.1/assets/ng-closure-runner.zip"
+    "ng-closure-runner": "https://raw.github.com/angular/ng-closure-runner/v0.2.2/assets/ng-closure-runner.zip"
   }
 }


### PR DESCRIPTION
This is not pressing for tomorrow, but let's get it in by the end of the week. I refactored the compiler somewhat ahead of implementing typed MinErr, so this is a new version I released today.

Since the change is so small, I'm actually okay if we ignore this for now, but if it doesn't break anything then why not.
