### PR TITLE
fix($timeout): clean deferreds immediately after callback exec/cancel

### DIFF
--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -45,17 +45,15 @@ function $TimeoutProvider() {
           deferred.reject(e);
           $exceptionHandler(e);
         }
+        finally {
+          delete deferreds[promise.$$timeoutId];
+        }
 
         if (!skipApply) $rootScope.$apply();
       }, delay);
 
-      cleanup = function() {
-        delete deferreds[promise.$$timeoutId];
-      };
-
       promise.$$timeoutId = timeoutId;
       deferreds[timeoutId] = deferred;
-      promise.then(cleanup, cleanup);
 
       return promise;
     }
@@ -77,6 +75,7 @@ function $TimeoutProvider() {
     timeout.cancel = function(promise) {
       if (promise && promise.$$timeoutId in deferreds) {
         deferreds[promise.$$timeoutId].reject('canceled');
+        delete deferreds[promise.$$timeoutId];
         return $browser.defer.cancel(promise.$$timeoutId);
       }
       return false;

--- a/test/ng/timeoutSpec.js
+++ b/test/ng/timeoutSpec.js
@@ -68,6 +68,27 @@ describe('$timeout', function() {
   }));
 
 
+  it('should forget references to deferreds when callback called even if skipApply is true',
+      inject(function($timeout, $browser) {
+    // $browser.defer.cancel is only called on cancel if the deferred object is still referenced
+    var cancelSpy = spyOn($browser.defer, 'cancel').andCallThrough();
+
+    var promise1 = $timeout(function() {}, 0, false);
+    var promise2 = $timeout(function() {}, 100, false);
+    expect(cancelSpy).not.toHaveBeenCalled();
+
+    $timeout.flushNext(0);
+
+    // Promise1 deferred object should already be removed from the list and not cancellable
+    $timeout.cancel(promise1);
+    expect(cancelSpy).not.toHaveBeenCalled();
+
+    // Promise2 deferred object should not have been called and should be cancellable
+    $timeout.cancel(promise2);
+    expect(cancelSpy).toHaveBeenCalled();
+  }));
+
+
   describe('exception handling', function() {
 
     beforeEach(module(function($exceptionHandlerProvider) {
@@ -105,6 +126,20 @@ describe('$timeout', function() {
       $timeout.flush();
 
       expect(log).toEqual('error: Some Error');
+    }));
+
+
+    it('should forget references to relevant deferred even when exception is thrown',
+        inject(function($timeout, $browser) {
+      // $browser.defer.cancel is only called on cancel if the deferred object is still referenced
+      var cancelSpy = spyOn($browser.defer, 'cancel').andCallThrough();
+
+      var promise = $timeout(function() { throw "Test Error"; }, 0, false);
+      $timeout.flush();
+
+      expect(cancelSpy).not.toHaveBeenCalled();
+      $timeout.cancel(promise);
+      expect(cancelSpy).not.toHaveBeenCalled();
     }));
   });
 
@@ -146,6 +181,22 @@ describe('$timeout', function() {
 
     it('should not throw a runtime exception when given an undefined promise', inject(function($timeout) {
       expect($timeout.cancel()).toBe(false);
+    }));
+
+
+    it('should forget references to relevant deferred', inject(function($timeout, $browser) {
+      // $browser.defer.cancel is only called on cancel if the deferred object is still referenced
+      var cancelSpy = spyOn($browser.defer, 'cancel').andCallThrough();
+
+      var promise = $timeout(function() {}, 0, false);
+
+      expect(cancelSpy).not.toHaveBeenCalled();
+      $timeout.cancel(promise);
+      expect(cancelSpy).toHaveBeenCalledOnce();
+
+      // Promise deferred object should already be removed from the list and not cancellable again
+      $timeout.cancel(promise);
+      expect(cancelSpy).toHaveBeenCalledOnce();
     }));
   });
 });


### PR DESCRIPTION
Make sure $timeout callbacks are forgotten about immediately after
execution or cancellation.

Previously when passing invokeApply=false, the cleanup used $q and so
would be pending until the next $digest was triggered. This does not
make a large functional difference, but can be very visible when
looking at memory consumption of an app or debugging around the
$$asyncQueue - these callbacks can have a big retaining tree.

---

Motivation

In the app that I am working on, we have some quite memory hungry pages. I noticed that on navigating away from them to lighter pages, the memory they consumed would not be released until something was clicked or happened to cause a $digest.

After some digging it turns out that the form controller in the page is releasing event handlers inside a $timeout with applyInvoke=false. The callback is happening without trouble and releases the event handlers, but it is not itself released until the next digest cycle, and contains most of the page in its closure.

It is not clear from the $timeout documentation that internal cleanup should be dependant on the invokeApply parameter. I would only expect callbacks I'd added myself to the returned promise to be dependant on a digest as this is part of using $q. I don't think the changes in this pull request should be observable without debugging tools so shouldn't affect current code.
