### PR TITLE
fix(ngView) : add the new element after the previous element

### DIFF
--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -203,12 +203,14 @@ var ngViewDirective = ['$route', '$anchorScroll', '$compile', '$controller', '$a
               template = locals && locals.$template;
 
           if (template) {
+            var previousElement = currentElement && currentElement.parentNode || anchor;
             cleanupLastView();
 
             currentScope = scope.$new();
             currentElement = element.clone();
             currentElement.html(template);
-            $animate.enter(currentElement, null, anchor);
+            $animate.enter(currentElement, null, previousElement);
+            previousElement = null;
 
             var link = $compile(currentElement, false, NG_VIEW_PRIORITY - 1),
                 current = $route.current;


### PR DESCRIPTION
when using enter leave animations without absolute positioning it makes more sense to keep the "leaving" view about the "entering" view. so that the "leaving" view can transition out without being pushed down by the "entering" view
