### PR TITLE
docs($http): added return to interceptors success callback

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -412,6 +412,7 @@ function $HttpProvider() {
      *     return function(promise) {
      *       return promise.then(function(response) {
      *         // do something on success
+     *         return response;
      *       }, function(response) {
      *         // do something on error
      *         if (canRecover(response)) {


### PR DESCRIPTION
Http interceptor example was missing a required promise return
