### PR TITLE
fix(filter): filter on false properties

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -183,7 +183,7 @@ function filterFilter() {
             })();
           } else {
             (function() {
-              if (!expression[key]) return;
+              if (typeof(expression[key]) == 'undefined') { return; }
               var path = key;
               predicates.push(function(value) {
                 return search(getter(value,path), expression[path]);

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -60,6 +60,17 @@ describe('Filter: filter', function() {
     expect(filter(items, {first:'misko', last:'hevery'})[0]).toEqual(items[0]);
   });
 
+  it('should support boolean properties', function() {
+    var items = [{name: 'tom', current: true},
+	             {name: 'demi', current: false},
+	             {name: 'sofia'}];
+
+    expect(filter(items, {current:true}).length).toBe(1);
+    expect(filter(items, {current:true})[0].name).toBe('tom');
+    expect(filter(items, {current:false}).length).toBe(1);
+    expect(filter(items, {current:false})[0].name).toBe('demi');
+  });
+
   it('should support negation operator', function() {
     var items = ['misko', 'adam'];
 


### PR DESCRIPTION
Code was evaluating !expression[key] while attempting to
see if the key was present, but this was evaluating to true for
false values as well as missing keys.

Closes #2797. 
