### PR TITLE
feat(jqLite): use querySelectorAll instead of getElementsByTagName in jqLite.find

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -790,7 +790,7 @@ forEach({
   },
 
   find: function(element, selector) {
-    return element.getElementsByTagName(selector);
+    return (element.querySelectorAll || element.getElementsByTagName).call(element, selector);
   },
 
   clone: JQLiteClone,

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1277,6 +1277,13 @@ describe('jqLite', function() {
       expect(innerDiv.length).toEqual(1);
       expect(innerDiv.html()).toEqual('text');
     });
+
+    it('should find child by an advanced selector', function() {
+      var root = jqLite('<div><div><span>a</span><span>b</span><span>c</span></div></div>');
+      var innerDiv = root.find('div > span:nth-child(2)');
+      expect(innerDiv.length).toEqual(1);
+      expect(innerDiv.html()).toEqual('b');
+    });
   });
 
 


### PR DESCRIPTION
Addresses #3586
