### PR TITLE
docs(directive/script): escape `</script>`

### DIFF
--- a/docs/src/example.js
+++ b/docs/src/example.js
@@ -126,7 +126,7 @@ exports.Example.prototype.toHtmlTabs = function() {
           '<pre class="prettyprint linenums" ng-set-text="' + source.id + '"' + wrap + '></pre>\n' +
           (isCss
              ? ('<style type="text/css" id="' + source.id + '">' + source.content + '</style>\n')
-             : ('<script type="text/ng-template" id="' + source.id + '">' + source.content + '</script>\n') ) +
+             : ('<script type="text/ng-template" id="' + source.id + '">' + source.content + '&lt;/script>\n') ) +
         '</div>\n');
     });
   }


### PR DESCRIPTION
Fixes missing </script> tag here:
http://docs.angularjs.org/api/ng.directive:script

Closes https://github.com/angular/angular.js/issues/2820
