### PR TITLE
fix(parse): handle promises returned from parsed function calls

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -689,9 +689,21 @@ function parser(text, json, $filter, csp){
       }
       var fnPtr = fn(scope, locals, context) || noop;
       // IE stupidity!
-      return fnPtr.apply
+      var v = fnPtr.apply
           ? fnPtr.apply(context, args)
           : fnPtr(args[0], args[1], args[2], args[3], args[4]);
+
+      // Check for promise
+      if (v && v.then) {
+        var p = v;
+        if (!('$$v' in v)) {
+          p.$$v = undefined;
+          p.then(function(val) { p.$$v = val; });
+        }
+        v = v.$$v;
+      }
+
+      return v;
     };
   }
 

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -846,6 +846,18 @@ describe('parser', function() {
             expect(scope.$eval('greeting')).toBe(undefined);
           });
 
+          it('should evaluate a function call returning a promise and eventually get its return value', function() {
+            scope.greetingFn = function() { return promise; };
+            expect(scope.$eval('greetingFn()')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('greetingFn()')).toBe(undefined);
+
+            deferred.resolve('hello!');
+            expect(scope.$eval('greetingFn()')).toBe(undefined);
+            scope.$digest();
+            expect(scope.$eval('greetingFn()')).toBe('hello!');
+          });
 
           describe('assignment into promises', function() {
             // This behavior is analogous to assignments to non-promise values


### PR DESCRIPTION
When a parsed function call returns a promise, the evaluated value
is the resolved value of the promise rather than the promise object.

Closes #3503
