### PR TITLE
fix(ngRepeat): ngRepeat and ngInclude should be allowed on the same element

### DIFF
--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -306,6 +306,26 @@ describe('ngInclude', function() {
   });
 
 
+  it('should allow ngInclude on the same element as ngRepeat', function() {
+    inject(function($compile, $rootScope, $templateCache) {
+      $templateCache.put('a.html', '<div>a</div>');
+      $templateCache.put('b.html', '<div>b</div>');
+      $templateCache.put('c.html', '<div>c</div>');
+      element = $compile(
+        '<div>' +
+          '<div ng-repeat="item in items" ng-include="item + \'.html\'">no!</div>' +
+        '</div>'
+      )($rootScope);
+
+      $rootScope.item = 'x';
+      $rootScope.items = [ 'a', 'b', 'c' ];
+      $rootScope.$digest();
+
+      expect(element.text()).toBe('abc');
+    });
+  });
+
+
   describe('autoscoll', function() {
     var autoScrollSpy;
 


### PR DESCRIPTION
Lowering the priority of ngRepeat from 1000 to 400 fixes the issue that popped up couple of times right after the 1.2.0rc1 release (#3584, #3581).
