### PR TITLE
fix(docs): wrap error message text inside box

### DIFF
--- a/docs/src/templates/css/docs.css
+++ b/docs/src/templates/css/docs.css
@@ -502,5 +502,4 @@ pre ol li {
   top: 10px;
   font-size: 16px;
   word-break: normal;
-  word-wrap: normal;
 }


### PR DESCRIPTION
This fix makes the word wrapping in error message displays more sane.

Example before:

![example1](https://f.cloud.github.com/assets/1271410/978208/a03882c6-06b6-11e3-8f43-150da76894bd.png)

Example after:

![example2](https://f.cloud.github.com/assets/1271410/978210/a5ec691c-06b6-11e3-956f-eb6e78f338fe.png)

Ignore the blue link text. It's there from something else I'm currently playing around with and won't show up when you apply the change.
