### PR TITLE
docs(tutorial): fixed link URL being displayed twice

### DIFF
--- a/docs/content/tutorial/step_00.ngdoc
+++ b/docs/content/tutorial/step_00.ngdoc
@@ -58,8 +58,7 @@ directory.</li>
             <ol>
               <li>In a <i>separate</i> terminal tab or window, run <code>node
 scripts\web-server.js</code> to start the web server.</li>
-              <li>Open a browser window for the app and navigate to <a
-href="http://localhost:8000/app/index.html">http://localhost:8000/app/index.html</a></li>
+              <li>Open a browser window for the app and navigate to <code>http://localhost:8000/app/index.html</code></li>
             </ol>
           </li>
           <li><b>For other http servers:</b>


### PR DESCRIPTION
- removed inline HTML, as it was diplaying the URL twice
