### PR TITLE
feat($rootScope): allow $evalAsync to queue operations to be run after digest

### DIFF
--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -755,6 +755,26 @@ describe('Scope', function() {
       expect(isolateScope.$$internalAsyncQueue).toBe($rootScope.$$internalAsyncQueue);
       expect($rootScope.$$internalAsyncQueue).toEqual(['rootExpression', 'childExpression', 'isolateExpression']);
     }));
+
+    it('should include $evalAsync(fn, false) callbacks added during $apply() in the queue dispatched after the DOM is updated', function () {
+      inject(function ($compile, $rootScope) {
+        var element = $compile(
+          '<div><div ng-repeat="item in items">{{item}}</div></div>')($rootScope);
+
+        var executed = false;
+        $rootScope.items = [ 'a;', 'b;' ];
+        $rootScope.$apply(function () {
+          $rootScope.$evalAsync(function () {
+            executed = true;
+            expect(element.text()).toBe('a;b;');
+          }, false);
+        });
+
+        expect(executed).toBe(true);
+
+        dealoc(element);
+      });
+    });
   });
 
 

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -672,6 +672,56 @@ describe('Scope', function() {
       expect(log).toEqual('parent.async;child.async;parent.$digest;child.$digest;');
     }));
 
+    it('should not run another digest for an $evalAsync call when it is external', inject(function($rootScope) {
+      var internalWatchCount = 0;
+      var externalWatchCount = 0;
+
+      $rootScope.internalCount = 0;
+      $rootScope.externalCount = 0;
+
+      $rootScope.$evalAsync(function(scope) {
+        $rootScope.internalCount++;
+      });
+
+      $rootScope.$evalAsync(function(scope) {
+        $rootScope.externalCount++;
+      }, false);
+
+      $rootScope.$watch('internalCount', function(value) {
+        internalWatchCount = value;
+      });
+      $rootScope.$watch('externalCount', function(value) {
+        externalWatchCount = value;
+      });
+
+      $rootScope.$digest();
+
+      expect(internalWatchCount).toEqual(1);
+      expect(externalWatchCount).toEqual(0);
+    }));
+
+    it('should run an external evalAsync call on all child scopes when a parent scope is digested', inject(function($rootScope) {
+      var parent = $rootScope.$new(),
+          child = parent.$new(),
+          count = 0;
+
+      $rootScope.$evalAsync(function() {
+        count++;
+      }, false);
+
+      parent.$evalAsync(function() {
+        count++;
+      }, false);
+
+      child.$evalAsync(function() {
+        count++;
+      }, false);
+
+      expect(count).toBe(0);
+      $rootScope.$digest();
+      expect(count).toBe(3);
+    }));
+
     it('should cause a $digest rerun', inject(function($rootScope) {
       $rootScope.log = '';
       $rootScope.value = 0;
@@ -701,9 +751,9 @@ describe('Scope', function() {
       childScope.$evalAsync('childExpression');
       isolateScope.$evalAsync('isolateExpression');
 
-      expect(childScope.$$asyncQueue).toBe($rootScope.$$asyncQueue);
-      expect(isolateScope.$$asyncQueue).toBe($rootScope.$$asyncQueue);
-      expect($rootScope.$$asyncQueue).toEqual(['rootExpression', 'childExpression', 'isolateExpression']);
+      expect(childScope.$$internalAsyncQueue).toBe($rootScope.$$internalAsyncQueue);
+      expect(isolateScope.$$internalAsyncQueue).toBe($rootScope.$$internalAsyncQueue);
+      expect($rootScope.$$internalAsyncQueue).toEqual(['rootExpression', 'childExpression', 'isolateExpression']);
     }));
   });
 


### PR DESCRIPTION
This makes it possible to have callback functions for the digest loop.

The usefulness of this feature can be found when one need to safely measure or check the contents of elements after the DOM is updated.
