### PR TITLE
feat(currencyFilter): add numbers after dot count parameter

### DIFF
--- a/i18n/src/converter.js
+++ b/i18n/src/converter.js
@@ -21,6 +21,7 @@ function convertNumberData(dataObj, currencySymbols) {
 
   if (currencySymbols[dataObj.DEF_CURRENCY_CODE]) {
     numberFormats.CURRENCY_SYM = currencySymbols[dataObj.DEF_CURRENCY_CODE][1];
+    numberFormats.DEFAULT_PRECISION = (currencySymbols[dataObj.DEF_CURRENCY_CODE][0] === 0) ? 0 : 2;
   } else {
     if (dataObj.DEF_CURRENCY_CODE == 'MTL') {
       numberFormats.CURRENCY_SYM = '₤'; //for some reason this is missing in closure
@@ -29,6 +30,7 @@ function convertNumberData(dataObj, currencySymbols) {
       var code = numberFormats.CURRENCY_SYM = dataObj.DEF_CURRENCY_CODE;
       console.log(code +' has no currency symbol in closure, used ' + code + ' instead!');
     }
+    numberFormats.DEFAULT_PRECISION = 2;
   }
   return numberFormats;
 }

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -11,6 +11,7 @@
  *
  * @param {number} amount Input to filter.
  * @param {string=} symbol Currency symbol or identifier to be displayed.
+ * @param {number=} number of digits after dot after rounding.
  * @returns {string} Formatted number.
  *
  *
@@ -44,9 +45,11 @@
 currencyFilter.$inject = ['$locale'];
 function currencyFilter($locale) {
   var formats = $locale.NUMBER_FORMATS;
-  return function(amount, currencySymbol){
+  return function(amount, currencySymbol, meanNumbers){
+    meanNumbers = isNumber(meanNumbers) ? meanNumbers : formats.DEFAULT_PRECISION;
+    meanNumbers = meanNumbers || 2;
     if (isUndefined(currencySymbol)) currencySymbol = formats.CURRENCY_SYM;
-    return formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP, 2).
+    return formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP, meanNumbers).
                 replace(/\u00A4/g, currencySymbol);
   };
 }

--- a/src/ngLocale/angular-locale_af-na.js
+++ b/src/ngLocale/angular-locale_af-na.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "R",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_af-za.js
+++ b/src/ngLocale/angular-locale_af-za.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "R",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_af.js
+++ b/src/ngLocale/angular-locale_af.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "R",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_am-et.js
+++ b/src/ngLocale/angular-locale_am-et.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Birr",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_am.js
+++ b/src/ngLocale/angular-locale_am.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Birr",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-001.js
+++ b/src/ngLocale/angular-locale_ar-001.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-ae.js
+++ b/src/ngLocale/angular-locale_ar-ae.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-bh.js
+++ b/src/ngLocale/angular-locale_ar-bh.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-dz.js
+++ b/src/ngLocale/angular-locale_ar-dz.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-eg.js
+++ b/src/ngLocale/angular-locale_ar-eg.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-iq.js
+++ b/src/ngLocale/angular-locale_ar-iq.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-jo.js
+++ b/src/ngLocale/angular-locale_ar-jo.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-kw.js
+++ b/src/ngLocale/angular-locale_ar-kw.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-lb.js
+++ b/src/ngLocale/angular-locale_ar-lb.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-ly.js
+++ b/src/ngLocale/angular-locale_ar-ly.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-ma.js
+++ b/src/ngLocale/angular-locale_ar-ma.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-om.js
+++ b/src/ngLocale/angular-locale_ar-om.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-qa.js
+++ b/src/ngLocale/angular-locale_ar-qa.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-sa.js
+++ b/src/ngLocale/angular-locale_ar-sa.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-sd.js
+++ b/src/ngLocale/angular-locale_ar-sd.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-sy.js
+++ b/src/ngLocale/angular-locale_ar-sy.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-tn.js
+++ b/src/ngLocale/angular-locale_ar-tn.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar-ye.js
+++ b/src/ngLocale/angular-locale_ar-ye.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ar.js
+++ b/src/ngLocale/angular-locale_ar.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_bg-bg.js
+++ b/src/ngLocale/angular-locale_bg-bg.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "lev",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_bg.js
+++ b/src/ngLocale/angular-locale_bg.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "lev",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_bn-bd.js
+++ b/src/ngLocale/angular-locale_bn-bd.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u09f3",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_bn-in.js
+++ b/src/ngLocale/angular-locale_bn-in.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u09f3",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_bn.js
+++ b/src/ngLocale/angular-locale_bn.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u09f3",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ca-ad.js
+++ b/src/ngLocale/angular-locale_ca-ad.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ca-es.js
+++ b/src/ngLocale/angular-locale_ca-es.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ca.js
+++ b/src/ngLocale/angular-locale_ca.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_cs-cz.js
+++ b/src/ngLocale/angular-locale_cs-cz.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "K\u010d",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_cs.js
+++ b/src/ngLocale/angular-locale_cs.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "K\u010d",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_da-dk.js
+++ b/src/ngLocale/angular-locale_da-dk.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "kr",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_da.js
+++ b/src/ngLocale/angular-locale_da.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "kr",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_de-at.js
+++ b/src/ngLocale/angular-locale_de-at.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_de-be.js
+++ b/src/ngLocale/angular-locale_de-be.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_de-ch.js
+++ b/src/ngLocale/angular-locale_de-ch.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "CHF",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "'",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_de-de.js
+++ b/src/ngLocale/angular-locale_de-de.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_de-li.js
+++ b/src/ngLocale/angular-locale_de-li.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_de-lu.js
+++ b/src/ngLocale/angular-locale_de-lu.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_de.js
+++ b/src/ngLocale/angular-locale_de.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_el-cy.js
+++ b/src/ngLocale/angular-locale_el-cy.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_el-gr.js
+++ b/src/ngLocale/angular-locale_el-gr.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_el.js
+++ b/src/ngLocale/angular-locale_el.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-as.js
+++ b/src/ngLocale/angular-locale_en-as.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-au.js
+++ b/src/ngLocale/angular-locale_en-au.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-bb.js
+++ b/src/ngLocale/angular-locale_en-bb.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-be.js
+++ b/src/ngLocale/angular-locale_en-be.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-bm.js
+++ b/src/ngLocale/angular-locale_en-bm.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-bw.js
+++ b/src/ngLocale/angular-locale_en-bw.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-bz.js
+++ b/src/ngLocale/angular-locale_en-bz.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-ca.js
+++ b/src/ngLocale/angular-locale_en-ca.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-dsrt-us.js
+++ b/src/ngLocale/angular-locale_en-dsrt-us.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-dsrt.js
+++ b/src/ngLocale/angular-locale_en-dsrt.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-fm.js
+++ b/src/ngLocale/angular-locale_en-fm.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-gb.js
+++ b/src/ngLocale/angular-locale_en-gb.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a3",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-gu.js
+++ b/src/ngLocale/angular-locale_en-gu.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-gy.js
+++ b/src/ngLocale/angular-locale_en-gy.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-hk.js
+++ b/src/ngLocale/angular-locale_en-hk.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-ie.js
+++ b/src/ngLocale/angular-locale_en-ie.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-in.js
+++ b/src/ngLocale/angular-locale_en-in.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-iso.js
+++ b/src/ngLocale/angular-locale_en-iso.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-jm.js
+++ b/src/ngLocale/angular-locale_en-jm.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-mh.js
+++ b/src/ngLocale/angular-locale_en-mh.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-mp.js
+++ b/src/ngLocale/angular-locale_en-mp.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-mt.js
+++ b/src/ngLocale/angular-locale_en-mt.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-mu.js
+++ b/src/ngLocale/angular-locale_en-mu.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-na.js
+++ b/src/ngLocale/angular-locale_en-na.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-nz.js
+++ b/src/ngLocale/angular-locale_en-nz.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-ph.js
+++ b/src/ngLocale/angular-locale_en-ph.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-pk.js
+++ b/src/ngLocale/angular-locale_en-pk.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-pr.js
+++ b/src/ngLocale/angular-locale_en-pr.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-pw.js
+++ b/src/ngLocale/angular-locale_en-pw.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-sg.js
+++ b/src/ngLocale/angular-locale_en-sg.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-tc.js
+++ b/src/ngLocale/angular-locale_en-tc.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-tt.js
+++ b/src/ngLocale/angular-locale_en-tt.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-um.js
+++ b/src/ngLocale/angular-locale_en-um.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-us.js
+++ b/src/ngLocale/angular-locale_en-us.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-vg.js
+++ b/src/ngLocale/angular-locale_en-vg.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-vi.js
+++ b/src/ngLocale/angular-locale_en-vi.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-za.js
+++ b/src/ngLocale/angular-locale_en-za.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "R",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en-zw.js
+++ b/src/ngLocale/angular-locale_en-zw.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_en.js
+++ b/src/ngLocale/angular-locale_en.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-419.js
+++ b/src/ngLocale/angular-locale_es-419.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-ar.js
+++ b/src/ngLocale/angular-locale_es-ar.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-bo.js
+++ b/src/ngLocale/angular-locale_es-bo.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-cl.js
+++ b/src/ngLocale/angular-locale_es-cl.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-co.js
+++ b/src/ngLocale/angular-locale_es-co.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-cr.js
+++ b/src/ngLocale/angular-locale_es-cr.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-do.js
+++ b/src/ngLocale/angular-locale_es-do.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-ea.js
+++ b/src/ngLocale/angular-locale_es-ea.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-ec.js
+++ b/src/ngLocale/angular-locale_es-ec.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-es.js
+++ b/src/ngLocale/angular-locale_es-es.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-gq.js
+++ b/src/ngLocale/angular-locale_es-gq.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-gt.js
+++ b/src/ngLocale/angular-locale_es-gt.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-hn.js
+++ b/src/ngLocale/angular-locale_es-hn.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-ic.js
+++ b/src/ngLocale/angular-locale_es-ic.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-mx.js
+++ b/src/ngLocale/angular-locale_es-mx.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-ni.js
+++ b/src/ngLocale/angular-locale_es-ni.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-pa.js
+++ b/src/ngLocale/angular-locale_es-pa.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-pe.js
+++ b/src/ngLocale/angular-locale_es-pe.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-pr.js
+++ b/src/ngLocale/angular-locale_es-pr.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-py.js
+++ b/src/ngLocale/angular-locale_es-py.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-sv.js
+++ b/src/ngLocale/angular-locale_es-sv.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-us.js
+++ b/src/ngLocale/angular-locale_es-us.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-uy.js
+++ b/src/ngLocale/angular-locale_es-uy.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es-ve.js
+++ b/src/ngLocale/angular-locale_es-ve.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_es.js
+++ b/src/ngLocale/angular-locale_es.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_et-ee.js
+++ b/src/ngLocale/angular-locale_et-ee.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_et.js
+++ b/src/ngLocale/angular-locale_et.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_eu-es.js
+++ b/src/ngLocale/angular-locale_eu-es.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_eu.js
+++ b/src/ngLocale/angular-locale_eu.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fa-af.js
+++ b/src/ngLocale/angular-locale_fa-af.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Rial",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fa-ir.js
+++ b/src/ngLocale/angular-locale_fa-ir.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Rial",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fa.js
+++ b/src/ngLocale/angular-locale_fa.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Rial",
     "DECIMAL_SEP": "\u066b",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fi-fi.js
+++ b/src/ngLocale/angular-locale_fi-fi.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fi.js
+++ b/src/ngLocale/angular-locale_fi.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fil-ph.js
+++ b/src/ngLocale/angular-locale_fil-ph.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b1",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fil.js
+++ b/src/ngLocale/angular-locale_fil.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b1",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-be.js
+++ b/src/ngLocale/angular-locale_fr-be.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-bf.js
+++ b/src/ngLocale/angular-locale_fr-bf.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-bi.js
+++ b/src/ngLocale/angular-locale_fr-bi.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-bj.js
+++ b/src/ngLocale/angular-locale_fr-bj.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-bl.js
+++ b/src/ngLocale/angular-locale_fr-bl.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-ca.js
+++ b/src/ngLocale/angular-locale_fr-ca.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-cd.js
+++ b/src/ngLocale/angular-locale_fr-cd.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-cf.js
+++ b/src/ngLocale/angular-locale_fr-cf.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-cg.js
+++ b/src/ngLocale/angular-locale_fr-cg.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-ch.js
+++ b/src/ngLocale/angular-locale_fr-ch.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-ci.js
+++ b/src/ngLocale/angular-locale_fr-ci.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-cm.js
+++ b/src/ngLocale/angular-locale_fr-cm.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-dj.js
+++ b/src/ngLocale/angular-locale_fr-dj.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-fr.js
+++ b/src/ngLocale/angular-locale_fr-fr.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-ga.js
+++ b/src/ngLocale/angular-locale_fr-ga.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-gf.js
+++ b/src/ngLocale/angular-locale_fr-gf.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-gn.js
+++ b/src/ngLocale/angular-locale_fr-gn.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-gq.js
+++ b/src/ngLocale/angular-locale_fr-gq.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-km.js
+++ b/src/ngLocale/angular-locale_fr-km.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-lu.js
+++ b/src/ngLocale/angular-locale_fr-lu.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-mc.js
+++ b/src/ngLocale/angular-locale_fr-mc.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-mf.js
+++ b/src/ngLocale/angular-locale_fr-mf.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-mg.js
+++ b/src/ngLocale/angular-locale_fr-mg.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-ml.js
+++ b/src/ngLocale/angular-locale_fr-ml.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-mq.js
+++ b/src/ngLocale/angular-locale_fr-mq.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-ne.js
+++ b/src/ngLocale/angular-locale_fr-ne.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-re.js
+++ b/src/ngLocale/angular-locale_fr-re.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr-rw.js
+++ b/src/ngLocale/angular-locale_fr-rw.js
@@ -94,7 +94,7 @@ $provide.value("$locale", {
       }
     ]
   },
-  "id": "fr-gp",
+  "id": "fr-rw",
   "pluralCat": function (n) {  if (n >= 0 && n <= 2 && n != 2) {   return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-sn.js
+++ b/src/ngLocale/angular-locale_fr-sn.js
@@ -94,7 +94,7 @@ $provide.value("$locale", {
       }
     ]
   },
-  "id": "fr-gp",
+  "id": "fr-sn",
   "pluralCat": function (n) {  if (n >= 0 && n <= 2 && n != 2) {   return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-td.js
+++ b/src/ngLocale/angular-locale_fr-td.js
@@ -94,7 +94,7 @@ $provide.value("$locale", {
       }
     ]
   },
-  "id": "fr-gp",
+  "id": "fr-td",
   "pluralCat": function (n) {  if (n >= 0 && n <= 2 && n != 2) {   return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-yt.js
+++ b/src/ngLocale/angular-locale_fr-yt.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_fr.js
+++ b/src/ngLocale/angular-locale_fr.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_gl-es.js
+++ b/src/ngLocale/angular-locale_gl-es.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_gl.js
+++ b/src/ngLocale/angular-locale_gl.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_gsw-ch.js
+++ b/src/ngLocale/angular-locale_gsw-ch.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "CHF",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u2019",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_gsw.js
+++ b/src/ngLocale/angular-locale_gsw.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "CHF",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u2019",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_gu-in.js
+++ b/src/ngLocale/angular-locale_gu-in.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_gu.js
+++ b/src/ngLocale/angular-locale_gu.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_he-il.js
+++ b/src/ngLocale/angular-locale_he-il.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20aa",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_he.js
+++ b/src/ngLocale/angular-locale_he.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20aa",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_hi-in.js
+++ b/src/ngLocale/angular-locale_hi-in.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_hi.js
+++ b/src/ngLocale/angular-locale_hi.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_hr-hr.js
+++ b/src/ngLocale/angular-locale_hr-hr.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "kn",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_hr.js
+++ b/src/ngLocale/angular-locale_hr.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "kn",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_hu-hu.js
+++ b/src/ngLocale/angular-locale_hu-hu.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Ft",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_hu.js
+++ b/src/ngLocale/angular-locale_hu.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Ft",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_id-id.js
+++ b/src/ngLocale/angular-locale_id-id.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Rp",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_id.js
+++ b/src/ngLocale/angular-locale_id.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Rp",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_in.js
+++ b/src/ngLocale/angular-locale_in.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Rp",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_is-is.js
+++ b/src/ngLocale/angular-locale_is-is.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "kr",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_is.js
+++ b/src/ngLocale/angular-locale_is.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "kr",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_it-it.js
+++ b/src/ngLocale/angular-locale_it-it.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_it-sm.js
+++ b/src/ngLocale/angular-locale_it-sm.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_it.js
+++ b/src/ngLocale/angular-locale_it.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_iw.js
+++ b/src/ngLocale/angular-locale_iw.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20aa",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ja-jp.js
+++ b/src/ngLocale/angular-locale_ja-jp.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a5",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ja.js
+++ b/src/ngLocale/angular-locale_ja.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a5",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_kn-in.js
+++ b/src/ngLocale/angular-locale_kn-in.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_kn.js
+++ b/src/ngLocale/angular-locale_kn.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ko-kr.js
+++ b/src/ngLocale/angular-locale_ko-kr.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20a9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ko.js
+++ b/src/ngLocale/angular-locale_ko.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20a9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ln-cd.js
+++ b/src/ngLocale/angular-locale_ln-cd.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "FrCD",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ln.js
+++ b/src/ngLocale/angular-locale_ln.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "FrCD",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_lt-lt.js
+++ b/src/ngLocale/angular-locale_lt-lt.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Lt",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_lt.js
+++ b/src/ngLocale/angular-locale_lt.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Lt",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_lv-lv.js
+++ b/src/ngLocale/angular-locale_lv-lv.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Ls",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_lv.js
+++ b/src/ngLocale/angular-locale_lv.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Ls",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ml-in.js
+++ b/src/ngLocale/angular-locale_ml-in.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ml.js
+++ b/src/ngLocale/angular-locale_ml.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_mr-in.js
+++ b/src/ngLocale/angular-locale_mr-in.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_mr.js
+++ b/src/ngLocale/angular-locale_mr.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ms-my.js
+++ b/src/ngLocale/angular-locale_ms-my.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "RM",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ms.js
+++ b/src/ngLocale/angular-locale_ms.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "RM",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_mt-mt.js
+++ b/src/ngLocale/angular-locale_mt-mt.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_mt.js
+++ b/src/ngLocale/angular-locale_mt.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_nl-cw.js
+++ b/src/ngLocale/angular-locale_nl-cw.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_nl-nl.js
+++ b/src/ngLocale/angular-locale_nl-nl.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_nl-sx.js
+++ b/src/ngLocale/angular-locale_nl-sx.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_nl.js
+++ b/src/ngLocale/angular-locale_nl.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_no.js
+++ b/src/ngLocale/angular-locale_no.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "kr",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_or-in.js
+++ b/src/ngLocale/angular-locale_or-in.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_or.js
+++ b/src/ngLocale/angular-locale_or.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_pl-pl.js
+++ b/src/ngLocale/angular-locale_pl-pl.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "z\u0142",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_pl.js
+++ b/src/ngLocale/angular-locale_pl.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "z\u0142",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_pt-br.js
+++ b/src/ngLocale/angular-locale_pt-br.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "R$",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_pt-pt.js
+++ b/src/ngLocale/angular-locale_pt-pt.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_pt.js
+++ b/src/ngLocale/angular-locale_pt.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "R$",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ro-ro.js
+++ b/src/ngLocale/angular-locale_ro-ro.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "RON",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ro.js
+++ b/src/ngLocale/angular-locale_ro.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "RON",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ru-ru.js
+++ b/src/ngLocale/angular-locale_ru-ru.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u0440\u0443\u0431.",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ru.js
+++ b/src/ngLocale/angular-locale_ru.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u0440\u0443\u0431.",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_sk-sk.js
+++ b/src/ngLocale/angular-locale_sk-sk.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_sk.js
+++ b/src/ngLocale/angular-locale_sk.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_sl-si.js
+++ b/src/ngLocale/angular-locale_sl-si.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_sl.js
+++ b/src/ngLocale/angular-locale_sl.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_sq-al.js
+++ b/src/ngLocale/angular-locale_sq-al.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Lek",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_sq.js
+++ b/src/ngLocale/angular-locale_sq.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Lek",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_sr-cyrl-rs.js
+++ b/src/ngLocale/angular-locale_sr-cyrl-rs.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "din",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_sr-latn-rs.js
+++ b/src/ngLocale/angular-locale_sr-latn-rs.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "din",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_sr.js
+++ b/src/ngLocale/angular-locale_sr.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "din",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_sv-se.js
+++ b/src/ngLocale/angular-locale_sv-se.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "kr",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_sv.js
+++ b/src/ngLocale/angular-locale_sv.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "kr",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_sw-tz.js
+++ b/src/ngLocale/angular-locale_sw-tz.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "TSh",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_sw.js
+++ b/src/ngLocale/angular-locale_sw.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "TSh",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ta-in.js
+++ b/src/ngLocale/angular-locale_ta-in.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ta.js
+++ b/src/ngLocale/angular-locale_ta.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_te-in.js
+++ b/src/ngLocale/angular-locale_te-in.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_te.js
+++ b/src/ngLocale/angular-locale_te.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_th-th.js
+++ b/src/ngLocale/angular-locale_th-th.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u0e3f",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_th.js
+++ b/src/ngLocale/angular-locale_th.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u0e3f",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_tl.js
+++ b/src/ngLocale/angular-locale_tl.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b1",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_tr-tr.js
+++ b/src/ngLocale/angular-locale_tr-tr.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "TL",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_tr.js
+++ b/src/ngLocale/angular-locale_tr.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "TL",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_uk-ua.js
+++ b/src/ngLocale/angular-locale_uk-ua.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b4",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_uk.js
+++ b/src/ngLocale/angular-locale_uk.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20b4",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ur-pk.js
+++ b/src/ngLocale/angular-locale_ur-pk.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Rs",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_ur.js
+++ b/src/ngLocale/angular-locale_ur.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "Rs",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_vi-vn.js
+++ b/src/ngLocale/angular-locale_vi-vn.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ab",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_vi.js
+++ b/src/ngLocale/angular-locale_vi.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ab",
     "DECIMAL_SEP": ",",
+    "DEFAULT_PRECISION": 0,
     "GROUP_SEP": ".",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_zh-cn.js
+++ b/src/ngLocale/angular-locale_zh-cn.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a5",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_zh-hans-cn.js
+++ b/src/ngLocale/angular-locale_zh-hans-cn.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a5",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_zh-hk.js
+++ b/src/ngLocale/angular-locale_zh-hk.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_zh-tw.js
+++ b/src/ngLocale/angular-locale_zh-tw.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "NT$",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_zh.js
+++ b/src/ngLocale/angular-locale_zh.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u00a5",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_zu-za.js
+++ b/src/ngLocale/angular-locale_zu-za.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "R",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/src/ngLocale/angular-locale_zu.js
+++ b/src/ngLocale/angular-locale_zu.js
@@ -65,6 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "R",
     "DECIMAL_SEP": ".",
+    "DEFAULT_PRECISION": 2,
     "GROUP_SEP": ",",
     "PATTERNS": [
       {

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -95,6 +95,7 @@ describe('filters', function() {
       expect(currency(0)).toEqual('$0.00');
       expect(currency(-999)).toEqual('($999.00)');
       expect(currency(1234.5678, "USD$")).toEqual('USD$1,234.57');
+      expect(currency(1234.5678, "rub", 3)).toEqual('rub1,234.568');
     });
 
 


### PR DESCRIPTION
So we can format currency numbers like this:
expect(currency(1234.5678, "USD$")).toEqual('USD$1,234.57')
expect(currency(1234.5678, "rub", 3)).toEqual('rub1,234.568')
expect(currency(1234.5678, "rub", 0)).toEqual('rub1,234')
The last case is usual for Rubles for example.

There is also a target to remove hardcoded values from source.
