### PR TITLE
Maybe a usefull new configuration parameter encoding for ng-resource modul

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -470,7 +470,7 @@ angular.module('ngResource', ['ng']).
           });
 
           httpConfig.data = data;
-          var encoding = action.encoding ? action.encoding : true
+          var encoding = action.encoding || true;
           route.setUrlParams(httpConfig, extend({}, extractParams(data, action.params || {}), params), action.url, encoding);
 
           var promise = $http(httpConfig).then(function(response) {

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -470,7 +470,7 @@ angular.module('ngResource', ['ng']).
           });
 
           httpConfig.data = data;
-          var encoding = action.encoding ? action.encoding : false
+          var encoding = action.encoding ? action.encoding : true
           route.setUrlParams(httpConfig, extend({}, extractParams(data, action.params || {}), params), action.url, encoding);
 
           var promise = $http(httpConfig).then(function(response) {

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -358,9 +358,9 @@ angular.module('ngResource', ['ng']).
           if (angular.isDefined(val) && val !== null) {
             if(encoding) {
             	encodedVal = encodeUriSegment(val);
-		    } else {
-		    	encodedVal = val;
-		    }
+	    } else {
+	    	encodedVal = val;
+	    }
             url = url.replace(new RegExp(":" + urlParam + "(\\W|$)", "g"), encodedVal + "$1");
           } else {
             url = url.replace(new RegExp("(\/?):" + urlParam + "(\\W|$)", "g"), function(match,

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -470,7 +470,7 @@ angular.module('ngResource', ['ng']).
           });
 
           httpConfig.data = data;
-          var encoding = action.encoding || true;
+          var encoding = (action.encoding == null)? true : action.encoding;
           route.setUrlParams(httpConfig, extend({}, extractParams(data, action.params || {}), params), action.url, encoding);
 
           var promise = $http(httpConfig).then(function(response) {

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -338,7 +338,7 @@ angular.module('ngResource', ['ng']).
     }
 
     Route.prototype = {
-      setUrlParams: function(config, params, actionUrl) {
+      setUrlParams: function(config, params, actionUrl, encoding) {
         var self = this,
             url = actionUrl || self.template,
             val,
@@ -356,7 +356,11 @@ angular.module('ngResource', ['ng']).
         forEach(self.urlParams, function(_, urlParam){
           val = params.hasOwnProperty(urlParam) ? params[urlParam] : self.defaults[urlParam];
           if (angular.isDefined(val) && val !== null) {
-            encodedVal = encodeUriSegment(val);
+            if(encoding) {
+            	encodedVal = encodeUriSegment(val);
+		    } else {
+		    	encodedVal = val;
+		    }
             url = url.replace(new RegExp(":" + urlParam + "(\\W|$)", "g"), encodedVal + "$1");
           } else {
             url = url.replace(new RegExp("(\/?):" + urlParam + "(\\W|$)", "g"), function(match,
@@ -466,7 +470,8 @@ angular.module('ngResource', ['ng']).
           });
 
           httpConfig.data = data;
-          route.setUrlParams(httpConfig, extend({}, extractParams(data, action.params || {}), params), action.url);
+          var encoding = action.encoding ? action.encoding : false
+          route.setUrlParams(httpConfig, extend({}, extractParams(data, action.params || {}), params), action.url, encoding);
 
           var promise = $http(httpConfig).then(function(response) {
             var data = response.data,

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -130,13 +130,23 @@ describe("resource", function() {
 		});
 
     $httpBackend.expect('GET', '/Path/foo#1').respond('{}');
-    $httpBackend.expect('GET', '/Path/doh!@foo?bar=baz#1').respond('{}');
     $httpBackend.expect('GET', '/Path/http://localhost:8080').respond('{}');
 
     R.get({a: 'foo#1'});
-    R.get({a: 'doh!@foo', bar: 'baz#1'});
     R.get({a: 'http://localhost:8080'});
   });
+  
+  it('should still encode query params that are delegated to http', function() {
+    var R = $resource('/Path/:a', {}, {
+		  get : {method:'GET', params:{}, encoding:false}
+		});
+
+    $httpBackend.expect('GET', '/Path/doh!@foo?bar=baz%231').respond('{}');
+
+    R.get({a: 'doh!@foo', bar: 'baz#1'});
+  });
+  
+ 
 
   it('should not encode @ in url params', function() {
    //encodeURIComponent is too agressive and doesn't follow http://www.ietf.org/rfc/rfc3986.txt

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -123,7 +123,20 @@ describe("resource", function() {
     R.get({a: 'foo#1'});
     R.get({a: 'doh!@foo', bar: 'baz#1'});
   });
+  
+  it('should not encode url params if url encoding is disabled', function() {
+    var R = $resource('/Path/:a', {}, {
+		  get : {method:'GET', params:{}, encoding:false}
+		});
 
+    $httpBackend.expect('GET', '/Path/foo#1').respond('{}');
+    $httpBackend.expect('GET', '/Path/doh!@foo?bar=baz#1').respond('{}');
+    $httpBackend.expect('GET', '/Path/http://localhost:8080').respond('{}');
+
+    R.get({a: 'foo#1'});
+    R.get({a: 'doh!@foo', bar: 'baz#1'});
+    R.get({a: 'http://localhost:8080'});
+  });
 
   it('should not encode @ in url params', function() {
    //encodeURIComponent is too agressive and doesn't follow http://www.ietf.org/rfc/rfc3986.txt


### PR DESCRIPTION
Some Time ago i patched the angularjs resource module with a feature that i needed for the development.
Now i found the time to commit this simple feature.

I needed a way to specify if for a certian rest call the provided parameters should be url encoded or not.
Here is a simple resource definition.

$provide.factory('Proxy', function($resource){
            var resource = $resource('/proxy/:url' , {}, {
                get : {method:'GET', params:{}, isArray:false, encoding:false}
            });
            return resource;
        });

The param :url contains you get it a full url like http://www.google.de. So that parameter should not be url encoded and to adchive this i introduce the encoding parameter like encoding:false.

So maybe you have an advice for me to solve this with no needed of that patch ... .
I am very interressting in feedback for that and i would take the chance and thanks for the great wonderful
work done from you and the gerat piece of software called angularjs.

have a nice day keep working
