### PR TITLE
fix(sce) IE 7 standards mode not supported

### DIFF
--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -620,7 +620,7 @@ function $SceProvider() {
     // the "expression(javascript expression)" syntax which is insecure.
     if (enabled && msie) {
       var documentMode = $document[0].documentMode;
-      if (documentMode !== undefined && documentMode < 8) {
+      if (documentMode !== undefined && documentMode < 7) {
         throw $sceMinErr('iequirks',
           'Strict Contextual Escaping does not support Internet Explorer version < 9 in quirks ' +
           'mode.  You can fix this by adding the text <!doctype html> to the top of your HTML ' +


### PR DESCRIPTION
Changed documentMode test from 8 to 7 to support IE 8 in IE 7 standards mode while still protecting against quirks mode.  documentMode returns the following values: 5 - quirks mode, 7 - IE 7 standards mode, 8 - IE 8 standards mode.  See Issue #3633
