### PR TITLE
fix(sce) IE 7 standards mode not supported

### DIFF
--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -620,7 +620,7 @@ function $SceProvider() {
     // the "expression(javascript expression)" syntax which is insecure.
     if (enabled && msie) {
       var documentMode = $document[0].documentMode;
-      if (documentMode !== undefined && documentMode < 8) {
+      if (documentMode !== undefined && documentMode < 7) {
         throw $sceMinErr('iequirks',
           'Strict Contextual Escaping does not support Internet Explorer version < 9 in quirks ' +
           'mode.  You can fix this by adding the text <!doctype html> to the top of your HTML ' +

--- a/test/ng/sceSpecs.js
+++ b/test/ng/sceSpecs.js
@@ -60,6 +60,10 @@ describe('SCE', function() {
     it('should throw an exception when sce is enabled in quirks mode', function() {
       runTest(true, 5, true);
     });
+    
+    it('should NOT throw an exception when sce is enabled and in IE7 standards mode', function() {
+      runTest(true, 7, false);
+    });
 
     it('should NOT throw an exception when sce is enabled and in standards mode', function() {
       runTest(true, 8, false);
@@ -71,6 +75,10 @@ describe('SCE', function() {
 
     it('should NOT throw an exception when sce is disabled even when in quirks mode', function() {
       runTest(false, 5, false);
+    });
+    
+    it('should NOT throw an exception when sce is disabled and in IE7 standards mode', function() {
+      runTest(false, 7, false);
     });
 
     it('should NOT throw an exception when sce is disabled and in standards mode', function() {

--- a/test/ng/sceSpecs.js
+++ b/test/ng/sceSpecs.js
@@ -58,7 +58,7 @@ describe('SCE', function() {
     }
 
     it('should throw an exception when sce is enabled in quirks mode', function() {
-      runTest(true, 7, true);
+      runTest(true, 5, true);
     });
 
     it('should NOT throw an exception when sce is enabled and in standards mode', function() {
@@ -70,7 +70,7 @@ describe('SCE', function() {
     });
 
     it('should NOT throw an exception when sce is disabled even when in quirks mode', function() {
-      runTest(false, 7, false);
+      runTest(false, 5, false);
     });
 
     it('should NOT throw an exception when sce is disabled and in standards mode', function() {


### PR DESCRIPTION
Changed documentMode test from 8 to 7 to support IE 8 in IE 7 standards mode while still protecting against quirks mode. documentMode returns the following values: 5 - quirks mode, 7 - IE 7 standards mode, 8 - IE 8 standards mode.  Closes #3633. 
