### PR TITLE
fix(required): `false` is a valid model value for required <select>

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1228,14 +1228,15 @@ var requiredDirective = function() {
       attr.required = true; // force truthy in case we are on non input element
 
       var validator = function(value) {
-        if (attr.required && (isEmpty(value) || value === false)) {
+        if (attr.required && (isEmpty(value) || !acceptFalse && value === false)) {
           ctrl.$setValidity('required', false);
           return;
         } else {
           ctrl.$setValidity('required', true);
           return value;
         }
-      };
+      },
+        acceptFalse = nodeName_(elm).toLowerCase() !== 'input' || attr.type !== 'checkbox';
 
       ctrl.$formatters.push(validator);
       ctrl.$parsers.unshift(validator);

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1093,7 +1093,25 @@ describe('input', function() {
       compileInput('<input type="text" ng-model="notDefiend" required />');
       scope.$digest();
       expect(inputElm).toBeInvalid();
-    })
+    });
+
+    it('should allow `false` as a valid value when the input type is not "checkbox"', function() {
+      compileInput('<input type="radio" ng-value="true" ng-model="answer" required />' +
+        '<input type="radio" ng-value="false" ng-model="answer" required />');
+
+      scope.$apply();
+      expect(inputElm).toBeInvalid();
+
+      scope.$apply(function() {
+        scope.answer = true;
+      });
+      expect(inputElm).toBeValid();
+
+      scope.$apply(function() {
+        scope.answer = false;
+      });
+      expect(inputElm).toBeValid();
+    });
   });
 
 

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1198,6 +1198,30 @@ describe('select', function() {
         });
         expect(element).toBeValid();
       });
+
+      it('should allow falsy values as values', function() {
+        createSelect({
+          'ng-model': 'value',
+          'ng-options': 'item.value as item.name for item in values',
+          'ng-required': 'required'
+        }, true);
+
+        scope.$apply(function() {
+          scope.values = [{name: 'True', value: true}, {name: 'False', value: false}];
+          scope.required = false;
+        });
+
+        element.val('1');
+        browserTrigger(element, 'change');
+        expect(element).toBeValid();
+        expect(scope.value).toBe(false);
+
+        scope.$apply(function() {
+          scope.required = true;
+        });
+        expect(element).toBeValid();
+        expect(scope.value).toBe(false);
+      });
     });
   });
 


### PR DESCRIPTION
Make the `required` directive accept the model value `false` when it is not an <input> element. 

Closes #3490
