### PR TITLE
fix(package.json): add a repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.2.0-snapshot",
   "cdnVersion": "1.2.0rc1",
   "codename": "barehand-atomspliting",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular.js.git"
+  },
   "devDependencies": {
     "grunt": "0.4.0",
     "bower": "1.2.0",


### PR DESCRIPTION
The `npm install` command complains about the missing repository field.
