### PR TITLE
Fix for issue 3616 "View source" link on docs is broken

### DIFF
--- a/docs/spec/sourceLinkSpec.js
+++ b/docs/spec/sourceLinkSpec.js
@@ -18,6 +18,10 @@ describe('Docs Links', function() {
       expect(doc.html()).
         toContain('<a href="http://github.com/angular/angular.js/edit/master/test.js" class="improve-docs btn btn-primary"><i class="icon-edit"> </i> Improve this doc</a>');
     });
+    
+    it("should have a defined gruntUtil cdnVersion", function () {  
+      expect(gruntUtil.getVersion().cdnVersion).toBeDefined();
+    }); 
 
     it('should have an "view source" button', function() {
       expect(doc.html()).

--- a/docs/spec/sourceLinkSpec.js
+++ b/docs/spec/sourceLinkSpec.js
@@ -19,13 +19,13 @@ describe('Docs Links', function() {
         toContain('<a href="http://github.com/angular/angular.js/edit/master/test.js" class="improve-docs btn btn-primary"><i class="icon-edit"> </i> Improve this doc</a>');
     });
     
-    it("should have a defined gruntUtil cdnVersion", function () {  
-      expect(gruntUtil.getVersion().cdnVersion).toBeDefined();
+    it("should have a defined gruntUtil.getVersion().cdn property", function () {  
+      expect(gruntUtil.getVersion().cdn).toBeDefined();
     }); 
 
     it('should have an "view source" button', function() {
       expect(doc.html()).
-        toContain('<a href="http://github.com/angular/angular.js/tree/v' + gruntUtil.getVersion().cdnVersion + '/test.js#L42" class="view-source btn btn-action"><i class="icon-zoom-in"> </i> View source</a>');
+        toContain('<a href="http://github.com/angular/angular.js/tree/v' + gruntUtil.getVersion().cdn + '/test.js#L42" class="view-source btn btn-action"><i class="icon-zoom-in"> </i> View source</a>');
     });
 
   });

--- a/docs/spec/sourceLinkSpec.js
+++ b/docs/spec/sourceLinkSpec.js
@@ -21,7 +21,7 @@ describe('Docs Links', function() {
 
     it('should have an "view source" button', function() {
       expect(doc.html()).
-        toContain('<a href="http://github.com/angular/angular.js/tree/v' + gruntUtil.getVersion().number + '/test.js#L42" class="view-source btn btn-action"><i class="icon-zoom-in"> </i> View source</a>');
+        toContain('<a href="http://github.com/angular/angular.js/tree/v' + gruntUtil.getVersion().cdnVersion + '/test.js#L42" class="view-source btn btn-action"><i class="icon-zoom-in"> </i> View source</a>');
     });
 
   });

--- a/docs/src/ngdoc.js
+++ b/docs/src/ngdoc.js
@@ -437,7 +437,7 @@ Doc.prototype = {
     if (this.section === 'api') {
       dom.tag('a', {
           href: 'http://github.com/angular/angular.js/tree/v' +
-            gruntUtil.getVersion().cdnVersion + '/' + self.file + '#L' + self.line,
+            gruntUtil.getVersion().cdn + '/' + self.file + '#L' + self.line,
           class: 'view-source btn btn-action' }, function(dom) {
         dom.tag('i', {class:'icon-zoom-in'}, ' ');
         dom.text(' View source');

--- a/docs/src/ngdoc.js
+++ b/docs/src/ngdoc.js
@@ -437,7 +437,7 @@ Doc.prototype = {
     if (this.section === 'api') {
       dom.tag('a', {
           href: 'http://github.com/angular/angular.js/tree/v' +
-            gruntUtil.getVersion().number + '/' + self.file + '#L' + self.line,
+            gruntUtil.getVersion().cdnVersion + '/' + self.file + '#L' + self.line,
           class: 'view-source btn btn-action' }, function(dom) {
         dom.tag('i', {class:'icon-zoom-in'}, ' ');
         dom.text(' View source');


### PR DESCRIPTION
This solves Issue https://github.com/angular/angular.js/issues/3616

"View source" link on docs is broken because it references undefined property gruntUtil.getVersion().number.

I've changed two references to instead use gruntUtil.getVersion().cdnVersion, which presently contains an appropriate string (a git tag) for linking to documentation.

(If this is not an acceptable version property to reference, perhaps there is a better one? Or, as a temporary fix perhaps we should just link to the "master" code source instead of the grunt version tagged source file.)
