### PR TITLE
feat(ngParse): support trailing commas in object & array literals

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -713,6 +713,10 @@ function parser(text, json, $filter, csp){
     var allConstant = true;
     if (peekToken().text != ']') {
       do {
+        if (peek(']')) {
+          // Support trailing commas per ES5.1.
+          break;
+        }
         var elementFn = expression();
         elementFns.push(elementFn);
         if (!elementFn.constant) {
@@ -738,6 +742,10 @@ function parser(text, json, $filter, csp){
     var allConstant = true;
     if (peekToken().text != '}') {
       do {
+        if (peek('}')) {
+          // Support trailing commas per ES5.1.
+          break;
+        }
         var token = expect(),
         key = token.string || token.text;
         consume(":");
@@ -751,7 +759,7 @@ function parser(text, json, $filter, csp){
     consume('}');
     return extend(function(self, locals){
       var object = {};
-      for ( var i = 0; i < keyValues.length; i++) {
+      for (var i = 0; i < keyValues.length; i++) {
         var keyValue = keyValues[i];
         object[keyValue.key] = keyValue.value(self, locals);
       }

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -388,6 +388,8 @@ describe('parser', function() {
         expect(scope.$eval("[1, 2]").length).toEqual(2);
         expect(scope.$eval("[1, 2]")[0]).toEqual(1);
         expect(scope.$eval("[1, 2]")[1]).toEqual(2);
+        expect(scope.$eval("[1, 2,]")[1]).toEqual(2);
+        expect(scope.$eval("[1, 2,]").length).toEqual(2);
       });
 
       it('should evaluate array access', function() {
@@ -402,6 +404,9 @@ describe('parser', function() {
         expect(toJson(scope.$eval("{a:'b'}"))).toEqual('{"a":"b"}');
         expect(toJson(scope.$eval("{'a':'b'}"))).toEqual('{"a":"b"}');
         expect(toJson(scope.$eval("{\"a\":'b'}"))).toEqual('{"a":"b"}');
+        expect(toJson(scope.$eval("{a:'b',}"))).toEqual('{"a":"b"}');
+        expect(toJson(scope.$eval("{'a':'b',}"))).toEqual('{"a":"b"}');
+        expect(toJson(scope.$eval("{\"a\":'b',}"))).toEqual('{"a":"b"}');
       });
 
       it('should evaluate object access', function() {


### PR DESCRIPTION
Per ECMAScript 5.1 specification trailing commas are allowed in object and
array literals. All modern browsers as well as IE>8 support this syntax.
This commit adds support for such syntax to Angular expressions.
