### PR TITLE
feat($parse): support trailing commas in object & array literals

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -785,6 +785,10 @@ Parser.prototype = {
     var allConstant = true;
     if (this.peekToken().text !== ']') {
       do {
+        if (this.peek(']')) {
+          // Support trailing commas per ES5.1.
+          break;
+        }
         var elementFn = this.expression();
         elementFns.push(elementFn);
         if (!elementFn.constant) {
@@ -811,6 +815,10 @@ Parser.prototype = {
     var allConstant = true;
     if (this.peekToken().text !== '}') {
       do {
+        if (this.peek('}')) {
+          // Support trailing commas per ES5.1.
+          break;
+        }
         var token = this.expect(),
         key = token.string || token.text;
         this.consume(':');

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -460,6 +460,8 @@ describe('parser', function() {
           expect(scope.$eval("[1, 2]").length).toEqual(2);
           expect(scope.$eval("[1, 2]")[0]).toEqual(1);
           expect(scope.$eval("[1, 2]")[1]).toEqual(2);
+          expect(scope.$eval("[1, 2,]")[1]).toEqual(2);
+          expect(scope.$eval("[1, 2,]").length).toEqual(2);
         });
 
         it('should evaluate array access', function() {
@@ -474,6 +476,9 @@ describe('parser', function() {
           expect(toJson(scope.$eval("{a:'b'}"))).toEqual('{"a":"b"}');
           expect(toJson(scope.$eval("{'a':'b'}"))).toEqual('{"a":"b"}');
           expect(toJson(scope.$eval("{\"a\":'b'}"))).toEqual('{"a":"b"}');
+          expect(toJson(scope.$eval("{a:'b',}"))).toEqual('{"a":"b"}');
+          expect(toJson(scope.$eval("{'a':'b',}"))).toEqual('{"a":"b"}');
+          expect(toJson(scope.$eval("{\"a\":'b',}"))).toEqual('{"a":"b"}');
         });
 
         it('should evaluate object access', function() {


### PR DESCRIPTION
Per ECMAScript 5.1 specification trailing commas are allowed in object and
array literals. All modern browsers as well as IE>8 support this syntax.
This commit adds support for such syntax to Angular expressions.

I'm creating a new pull request as @btford asked me to re-open #3685 with an explanation
and I don't have privileges to re-open prs.

Main use case of trailing commas are when using multi-line notation for objects/arrays. When you have sth like:

``` javascript
{
    par1: "val1",
    par3: "val3",
    par2: "val2",
}
```

it's much easier to move lines 2. and 3. around without causing errors. Such reordering is cumberscome when trailing commas are ommited. I agree readability is a little reduced when using a single-line form, but for multi-line ones it's IMO a godsend.

Currently there are no good tools to minify Angular expressions so this might be less used form now but once such a tool is created, for longer objects/arrays such notation would help.
