### PR TITLE
feat(matchers): add future-awareness to matcher parameters

### DIFF
--- a/src/ngScenario/Runner.js
+++ b/src/ngScenario/Runner.js
@@ -199,6 +199,20 @@ angular.scenario.Runner.prototype.run = function(application) {
         });
 
         // Make these methods work on the current chain
+        scope.resolveFuture = function(future) {
+          if(future instanceof angular.scenario.Future) {
+            if(! future.fulfilled) {
+              future.execute(function(error) {
+                if(error) {
+                  this.emit('StepFailure', this.spec, future, error);
+                }
+              });
+            }
+            future = future.value;
+          }
+          return future;
+        };
+
         scope.addFuture = function() {
           Array.prototype.push.call(arguments, line);
           return angular.scenario.SpecRunner.

--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -83,6 +83,7 @@ angular.scenario.matcher = angular.scenario.matcher || function(name, fn) {
       function(done) {
         var error;
         self.actual = self.future.value;
+        expected = self.resolveFuture(expected);
         if ((self.inverse && fn.call(self, expected)) ||
             (!self.inverse && !fn.call(self, expected))) {
           error = 'expected ' + angular.toJson(expected) +

--- a/test/ngScenario/dslSpec.js
+++ b/test/ngScenario/dslSpec.js
@@ -28,6 +28,21 @@ describe("angular.scenario.dsl", function() {
     $root.futures = [];
     $root.futureLog = [];
     $root.$window = $window;
+
+    $root.resolveFuture = function(future) {
+      if(future instanceof angular.scenario.Future) {
+        if(! future.fulfilled) {
+          future.execute(function(error) {
+            if(error) {
+              this.emit('StepFailure', this.spec, future, error);
+            }
+          });
+        }
+        future = future.value;
+      }
+      return future;
+    };
+
     $root.addFuture = function(name, fn) {
       this.futures.push(name);
       fn.call(this, function(error, result) {

--- a/test/ngScenario/matchersSpec.js
+++ b/test/ngScenario/matchersSpec.js
@@ -27,6 +27,19 @@ describe('angular.scenario.matchers', function () {
         matchers.error = error;
       });
     };
+    matchers.resolveFuture = function(future) {
+      if(future instanceof angular.scenario.Future) {
+        if(! future.fulfilled) {
+          future.execute(function(error) {
+            if(error) {
+              this.emit('StepFailure', this.spec, future, error);
+            }
+          });
+        }
+        future = future.value;
+      }
+      return future;
+    };
     angular.extend(matchers, angular.scenario.matcher);
   });
 


### PR DESCRIPTION
Added the ability to pass futures as the argument to matchers.  This allows you to do things like this: 

```
expect(element('.bar').width()).toEqual(element('.nav').width())
```

I've found it to be extremely useful in my own tests.  If you want this let me know and i'll add some unit tests for the functionality.
