### PR TITLE
Fixed: format multilevel json to querystring correctly

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "lunr.js": "0.4.0",
     "google-code-prettify": "1.0.0",
     "components-font-awesome": "3.1.0",
-    "bootstrap": "2.0.2",
+    "bootstrap": "https://raw.github.com/twbs/bootstrap/v2.0.2/docs/assets/bootstrap.zip",
     "closure-compiler": "https://closure-compiler.googlecode.com/files/compiler-20130603.zip",
-    "ng-closure-runner": "https://github.com/angular/ng-closure-runner/archive/v0.2.2.zip"
+    "ng-closure-runner": "https://raw.github.com/angular/ng-closure-runner/v0.2.2/assets/ng-closure-runner.zip"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "lunr.js": "0.4.0",
     "google-code-prettify": "1.0.0",
     "components-font-awesome": "3.1.0",
-    "bootstrap": "https://raw.github.com/twbs/bootstrap/v2.0.2/docs/assets/bootstrap.zip",
+    "bootstrap": "2.0.2",
     "closure-compiler": "https://closure-compiler.googlecode.com/files/compiler-20130603.zip",
-    "ng-closure-runner": "https://raw.github.com/angular/ng-closure-runner/v0.2.2/assets/ng-closure-runner.zip"
+    "ng-closure-runner": "https://github.com/angular/ng-closure-runner/archive/v0.2.2.zip"
   }
 }

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -963,22 +963,38 @@ function $HttpProvider() {
       }
     }
 
+		function is(type, obj) {
+		    var clas = Object.prototype.toString.call(obj).slice(8, -1);
+		    return obj !== undefined && obj !== null && clas === type;
+		}
+		
+		function toQueryString(params, parts, pk) {
+      forEachSorted(params, function(value, key) {
+	      if (value == null || value == undefined) return;
+				if (pk) key = pk+'['+key+']'
+	      if (is('Array',value)) {
+		      forEach(value, function(v,i) {
+						if(is('Object', v)){
+							key = key+'['+i+']'
+			      	toQueryString(v, parts, key)
+						} else {
+				      parts.push(encodeUriQuery(key) + '=' +
+				                 encodeUriQuery(v));
+						}
+		      });
+					return;
+	      } else if (is('Object',value)) {
+					return toQueryString(value, parts, key)
+	      }
+	      parts.push(encodeUriQuery(key) + '=' +
+	                 encodeUriQuery(value));
+      });
+		}
 
     function buildUrl(url, params) {
           if (!params) return url;
           var parts = [];
-          forEachSorted(params, function(value, key) {
-            if (value == null || value == undefined) return;
-            if (!isArray(value)) value = [value];
-
-            forEach(value, function(v) {
-              if (isObject(v)) {
-                v = toJson(v);
-              }
-              parts.push(encodeUriQuery(key) + '=' +
-                         encodeUriQuery(v));
-            });
-          });
+					toQueryString(params, parts)
           return url + ((url.indexOf('?') == -1) ? '?' : '&') + parts.join('&');
         }
 

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -971,11 +971,11 @@ function $HttpProvider() {
 		function toQueryString(params, parts, pk) {
       forEachSorted(params, function(value, key) {
 	      if (value == null || value == undefined) return;
-				if (pk) key = pk+'['+key+']'
+				if (pk) key = pk+'['+key+']';
 	      if (is('Array',value)) {
 		      forEach(value, function(v,i) {
 						if(is('Object', v)){
-							key = key+'['+i+']'
+							key = key+'['+i+']';
 			      	toQueryString(v, parts, key)
 						} else {
 				      parts.push(encodeUriQuery(key) + '=' +
@@ -994,7 +994,7 @@ function $HttpProvider() {
     function buildUrl(url, params) {
           if (!params) return url;
           var parts = [];
-					toQueryString(params, parts)
+					toQueryString(params, parts);
           return url + ((url.indexOf('?') == -1) ? '?' : '&') + parts.join('&');
         }
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -432,7 +432,7 @@ describe('$http', function() {
 
 
       it('should jsonify objects in params map', inject(function($httpBackend, $http) {
-        $httpBackend.expect('GET', '/url?a=1&b=%7B%22c%22:3%7D').respond('');
+        $httpBackend.expect('GET', '/url?a=1&b%5Bc%5D=3').respond('');
         $http({url: '/url', params: {a:1, b:{c:3}}, method: 'GET'});
       }));
 


### PR DESCRIPTION
Consider follow json convert to http query string

``` json
{
    "$or": [
        {
            "username": {
                "$regex": "admin"
            },
            "name": {
                "$regex": "admin"
            }
        }
    ], 
    "limit": 10, 
    "page": 1, 
    "status": {
        "$ne": "removed"
    }
}

```

TO Query String

```
GET /users?status%5B$ne%5D=removed&$or%5B0%5D%5Busername%5D%5B$regex%5D=ad&$or%5B1%5D%5Bname%5D%5B$regex%5D=admin
```

So, we can query mongo directly from angular.js
