### PR TITLE
fix: sanitizer should not accept <!--> as a valid comment

### DIFF
--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -221,9 +221,10 @@ function htmlParser( html, handler ) {
 
       // Comment
       if ( html.indexOf("<!--") === 0 ) {
-        index = html.indexOf("-->");
+        // comments containing -- are not allowed unless they terminate the comment
+        index = html.indexOf("--",4);
 
-        if ( index >= 0 ) {
+        if ( index >= 0 && html.lastIndexOf("-->",index) === index) {
           if (handler.comment) handler.comment( html.substring( 4, index ) );
           html = html.substring( index + 3 );
           chars = false;

--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -15,7 +15,7 @@ describe('HTML', function() {
   describe('htmlParser', function() {
     if (angular.isUndefined(window.htmlParser)) return;
 
-    var handler, start, text;
+    var handler, start, text, comment;
     beforeEach(function() {
       handler = {
           start: function(tag, attrs, unary){
@@ -35,8 +35,40 @@ describe('HTML', function() {
           },
           end:function(tag) {
             expect(tag).toEqual(start.tag);
+          },
+          comment:function(comment_) {
+            comment = comment_;
           }
       };
+    });
+
+    it('should parse comments', function() {
+      htmlParser('<!--FOOBAR-->', handler);
+      expect(comment).toEqual('FOOBAR');
+    });
+
+    it('should throw an exception for invalid comments', function() {
+      var caught=false;
+      try {
+        htmlParser('<!-->', handler);
+      }
+      catch (ex) {
+        caught = true;
+        // expected an exception due to a bad parse
+      }
+      expect(caught).toBe(true);
+    });
+
+    it('double-dashes are not allowed in a comment', function() {
+      var caught=false;
+      try {
+        htmlParser('<!-- -- -->', handler);
+      }
+      catch (ex) {
+        caught = true;
+        // expected an exception due to a bad parse
+      }
+      expect(caught).toBe(true);
     });
 
     it('should parse basic format', function() {


### PR DESCRIPTION
According to http://validator.w3.org/ , <!--> is not a valid comment
and neither is any comment containing the -- substring.

I came across this possible issue while browsing the code for something unrelated. This makes the parser stricter, but I'm not sure that that's really desired. At any rate, I also added a unit test for comment parsing, as that was missing.
