### PR TITLE
fix: replace x.indexOf(y)==0 with x.lastIndexOf(y,0)===0

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -645,7 +645,7 @@ function shallowCopy(src, dst) {
   dst = dst || {};
 
   for(var key in src) {
-    if (src.hasOwnProperty(key) && key.substr(0, 2) !== '$$') {
+    if (src.hasOwnProperty(key) && key.lastIndexOf('$$',0) !== 0) {
       dst[key] = src[key];
     }
   }

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -55,7 +55,7 @@ function composeProtocolHostPort(protocol, host, port) {
  * @returns {string} returns text from whole after begin or otherwise if it does not begin with expected string.
  */
 function beginsWith(begin, whole, otherwise) {
-  return whole.indexOf(begin) == 0 ? whole.substr(begin.length) : otherwise;
+  return whole.lastIndexOf(begin,0) === 0 ? whole.substr(begin.length) : otherwise;
 }
 
 

--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -220,7 +220,7 @@ function htmlParser( html, handler ) {
     if ( !stack.last() || !specialElements[ stack.last() ] ) {
 
       // Comment
-      if ( html.indexOf("<!--") === 0 ) {
+      if ( html.lastIndexOf("<!--",0) === 0 ) {
         index = html.indexOf("-->");
 
         if ( index >= 0 ) {

--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -271,7 +271,7 @@ _jQuery.fn.bindings = function(windowJquery, bindExp) {
       if (actualExp) {
         actualExp = actualExp.replace(/\s/g, '');
         if (actualExp == bindExp) return true;
-        if (actualExp.indexOf(bindExp) == 0) {
+        if (actualExp.lastIndexOf(bindExp,0) === 0) {
           return actualExp.charAt(bindExp.length) == '|';
         }
       }


### PR DESCRIPTION
Replace the pattern x.indexOf(y)===0 with x.lastIndexOf(y,0) since that
does not have to check the entire string x for that substring.
This fix was triggered when found a test like this x.substr(0,2)=='$$'.

I ran all the unit tests and e2e tests, but did not add any new tests. I was thinking of creating an angular.startsWith function and can do so if desired, but ultimately the number of such prefix tests is rather small so that I decided against it.

I found this little nugget at stack-overflow:  http://stackoverflow.com/questions/646628/javascript-startswith
