### PR TITLE
fix(isArrayLike): correctly handle string primitives

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -90,9 +90,12 @@ function isArrayLike(obj) {
     return true;
   }
 
-  return isArray(obj) || !isFunction(obj) && (
-    length === 0 || typeof length === "number" && length > 0 && (length - 1) in obj
-  );
+  if (typeof obj !== 'object') {
+    return typeof obj === 'string';
+  }
+
+  return isArray(obj) || length === 0 ||
+         typeof length === "number" && length > 0 && (length - 1) in obj;
 }
 
 /**

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -461,6 +461,13 @@ describe('angular', function() {
       expect(log).toEqual(['0:a', '1:b', '2:c']);
     });
 
+    it('should handle string values like arrays', function() {
+      var log = [];
+
+      forEach('bar', function(value, key) { log.push(key + ':' + value)});
+      expect(log).toEqual(['0:b', '1:a', '2:r']);
+    });
+
 
     it('should handle objects with length property as objects', function() {
       var obj = {


### PR DESCRIPTION
Fix for #3713:

> The `isArrayLike` test in 1.0 worked properly with any string values, returning `true` (since they can be indexed just like `String` objects and work with functions like `Array.prototype.forEach`). The new test in 1.2 (introduced by #3356) raises a `TypeError`, because the `in` operator cannot be used on a non-object.

Since there are no tests for the private `isArrayLike`, I'm including a test for `angular.forEach`, its main caller.
