### PR TITLE
Fix for date filter. Allow for negative millisecond values when passed as string.

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -260,7 +260,7 @@ var DATE_FORMATS = {
 };
 
 var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|Z))(.*)/,
-    NUMBER_STRING = /^\-?[1-9]\d*$/;
+    NUMBER_STRING = /^\-?\d+$/;
 
 /**
  * @ngdoc filter

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -260,7 +260,7 @@ var DATE_FORMATS = {
 };
 
 var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|Z))(.*)/,
-    NUMBER_STRING = /^\d+$/;
+    NUMBER_STRING = /^\-?[1-9]\d*$/;
 
 /**
  * @ngdoc filter

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -246,6 +246,11 @@ describe('filters', function() {
                       toEqual('September 03, 1');
     });
 
+    it('should accept negative numbers as strings', function() {
+      expect(date(earlyDate.getTime() + "")).
+                      toEqual('Sep 3, 1');
+    });
+
     it('should format timezones correctly (as per ISO_8601)', function() {
       //Note: TzDate's first argument is offset, _not_ timezone.
       var utc       = new angular.mock.TzDate( 0, '2010-09-03T12:05:08.000Z');


### PR DESCRIPTION
The regular expression for checking millisecond string values only accepts positive numbers.
