### PR TITLE
Improved parameter documentation for several boolean attribute directives

### DIFF
--- a/src/ng/directive/booleanAttrs.js
+++ b/src/ng/directive/booleanAttrs.js
@@ -195,6 +195,7 @@
       </doc:scenario>
     </doc:example>
  *
+ * @element INPUT
  * @param {expression} ngChecked If the {@link guide/expression expression} is truthy, 
  *     then special attribute "checked" will be set on the element
  */
@@ -225,6 +226,7 @@
       </doc:scenario>
     </doc:example>
  *
+ * @element INPUT
  * @param {expression} ngReadonly If the {@link guide/expression expression} is truthy, 
  *     then special attribute "readonly" will be set on the element
  */

--- a/src/ng/directive/booleanAttrs.js
+++ b/src/ng/directive/booleanAttrs.js
@@ -165,7 +165,8 @@
     </doc:example>
  *
  * @element INPUT
- * @param {expression} ngDisabled Angular expression that will be evaluated.
+ * @param {expression} ngDisabled If the {@link guide/expression expression} is truthy, 
+ *     then special attribute "disabled" will be set on the element
  */
 
 
@@ -194,8 +195,8 @@
       </doc:scenario>
     </doc:example>
  *
- * @element INPUT
- * @param {expression} ngChecked Angular expression that will be evaluated.
+ * @param {expression} ngChecked If the {@link guide/expression expression} is truthy, 
+ *     then special attribute "checked" will be set on the element
  */
 
 
@@ -224,8 +225,8 @@
       </doc:scenario>
     </doc:example>
  *
- * @element INPUT
- * @param {string} expression Angular expression that will be evaluated.
+ * @param {expression} ngReadonly If the {@link guide/expression expression} is truthy, 
+ *     then special attribute "readonly" will be set on the element
  */
 
 
@@ -258,7 +259,8 @@
     </doc:example>
  *
  * @element OPTION
- * @param {string} expression Angular expression that will be evaluated.
+ * @param {expression} ngSelected If the {@link guide/expression expression} is truthy, 
+ *     then special attribute "selected" will be set on the element
  */
 
 /**
@@ -290,7 +292,8 @@
      </doc:example>
  *
  * @element DETAILS
- * @param {string} expression Angular expression that will be evaluated.
+ * @param {expression} ngOpen If the {@link guide/expression expression} is truthy, 
+ *     then special attribute "open" will be set on the element
  */
 
 var ngAttributeAliasDirectives = {};


### PR DESCRIPTION
Improved parameter definitions for boolean attribute directives ngDisabled, ngChecked, ngReadonly, ngSelected, and ngOpen.

Fixes [Issue 3726](https://github.com/angular/angular.js/issues/3726)
