### PR TITLE
feat(angular): expose msie property 

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -855,6 +855,16 @@ function startingTag(element) {
 
 }
 
+/**
+ * @name angular.msieVersion
+ * @function
+ * 
+ * @description Returns version of IE or NaN if not IE
+ * @returns {int} or NaN
+ */
+function msieVersion() {
+	return msie;
+}
 
 /////////////////////////////////////////////////
 

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -44,6 +44,7 @@ function publishExternalAPI(angular){
     'isNumber': isNumber,
     'isElement': isElement,
     'isArray': isArray,
+    'msieVersion' : msieVersion,
     '$$minErr': minErr,
     'version': version,
     'isDate': isDate,


### PR DESCRIPTION
Added msieVersion() to allow public access to the IE version, so there isn't a need for repeated code to determine the IE version when it is fundamentally built into Angular.
