### PR TITLE
indicate that $routeProvider requires ng-view

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -26,6 +26,7 @@ var ngRouteModule = angular.module('ngRoute', ['ng']).
  * Used for configuring routes. See {@link ngRoute.$route $route} for an example.
  *
  * Requires the {@link ngRoute `ngRoute`} module to be installed.
+ * Requires an ng-view element in the HTML
  */
 function $RouteProvider(){
   var routes = {};


### PR DESCRIPTION
I struggled with the $routeProvider thinking that it worked like Backbone routes and could be used in isolation, but it looks like it will silently fail if you don't put an `<ng-view>` element in the HTML. 

I think the best solution would be to raise an error instead of silently failing if there isn't an ng-view element.
