### PR TITLE
chore(tools): Point to the NPM version of grunt-parallel && feature(ngMock) Allow for passing an object literal as shorthand to module 

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "marked": "~0.2.9",
     "rewire": "1.1.3",
     "grunt-contrib-jasmine-node": "~0.1.1",
-    "grunt-parallel": "git://github.com/vojtajina/grunt-parallel.git#streaming-per-task",
+    "grunt-parallel": "~0.3.1",
     "grunt-ddescribe-iit": "~0.0.1",
     "grunt-merge-conflict": "~0.0.1",
     "promises-aplus-tests": "~1.3.2",

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1851,9 +1851,11 @@ angular.mock.clearDataCache = function() {
    *
    * See {@link angular.mock.inject inject} for usage example
    *
-   * @param {...(string|Function)} fns any number of modules which are represented as string
+   * @param {...(string|Function|Object)} fns any number of modules which are represented as string
    *        aliases or as anonymous module initialization functions. The modules are used to
-   *        configure the injector. The 'ng' and 'ngMock' modules are automatically loaded.
+   *        configure the injector. The 'ng' and 'ngMock' modules are automatically loaded. If an 
+   *        object literal is passed they will be register as values in the module, the key being
+   *        the module name and the value being what is returned.
    */
   window.module = angular.mock.module = function() {
     var moduleFns = Array.prototype.slice.call(arguments, 0);
@@ -1865,7 +1867,15 @@ angular.mock.clearDataCache = function() {
       } else {
         var modules = currentSpec.$modules || (currentSpec.$modules = []);
         angular.forEach(moduleFns, function(module) {
-          modules.push(module);
+          if (angular.isObject(module) && !angular.isArray(module)) {
+            modules.push(function($provide) {
+              angular.forEach(module, function(value, key) {
+                $provide.value(key, value);
+              });
+            });
+          } else {
+            modules.push(module);
+          }
         });
       }
     }

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -520,6 +520,42 @@ describe('ngMock', function() {
     });
 
     describe('module', function() {
+
+      describe('object literal format', function() {
+        var mock = { log: 'module' };
+        
+        beforeEach(function() {
+          module({
+              'service': mock,
+              'other': { some: 'replacement'}
+            },
+            'ngResource',
+            function ($provide) { $provide.value('example', 'win'); }
+          );
+        });
+
+        it('should inject the mocked module', function() {
+          inject(function(service) {
+            expect(service).toEqual(mock);
+          });
+        });
+        
+        it('should support multiple key value pairs', function() {
+          inject(function(service, other) {
+            expect(other.some).toEqual('replacement');
+            expect(service).toEqual(mock);
+          });
+        });
+
+        it('should integrate with string and function', function() {
+          inject(function(service, $resource, example) {
+            expect(service).toEqual(mock);
+            expect($resource).toBeDefined();
+            expect(example).toEqual('win');
+          });
+        });
+      });
+
       describe('in DSL', function() {
         it('should load module', module(function() {
           log += 'module';


### PR DESCRIPTION
This commit allows shorthand for mocking services...

``` javascript
module({
  service: mock
});

inject(function(service) {
  // Receives mock
});
```
