### PR TITLE
Fixes controller name bug when using $routeProvider

### DIFF
--- a/docs/content/tutorial/step_07.ngdoc
+++ b/docs/content/tutorial/step_07.ngdoc
@@ -72,8 +72,8 @@ __`app/js/app.js`:__
 angular.module('phonecat', []).
   config(['$routeProvider', function($routeProvider) {
   $routeProvider.
-      when('/phones', {templateUrl: 'partials/phone-list.html',   controller: PhoneListCtrl}).
-      when('/phones/:phoneId', {templateUrl: 'partials/phone-detail.html', controller: PhoneDetailCtrl}).
+      when('/phones', {templateUrl: 'partials/phone-list.html',   controller: 'PhoneListCtrl'}).
+      when('/phones/:phoneId', {templateUrl: 'partials/phone-detail.html', controller: 'PhoneDetailCtrl'}).
       otherwise({redirectTo: '/phones'});
 }]);
 </pre>


### PR DESCRIPTION
The controller name was previously not declared as a string and users have reported a "[controller] is not defined from [moduleName]" error. This corrects the documentation into a working example.
