### PR TITLE
feat(scenario): add element methods hasClass(), addClass(), removeClass()

### DIFF
--- a/docs/content/guide/dev_guide.e2e-testing.ngdoc
+++ b/docs/content/guide/dev_guide.e2e-testing.ngdoc
@@ -151,6 +151,9 @@ Executes the function `fn(selectedElements, done)`, where selectedElements are t
 match the given jQuery `selector` and `done` is a function that is called at the end of the `fn`
 function.  The `label` is used for test output.
 
+## element(selector, label).{hasClass | addClass | removeClass}(className)
+Checks/adds/removes class on the element matching the given jQuery `selector`. The `label` is used for test output.
+
 ## element(selector, label).{method}()
 Returns the result of calling `method` on the element matching the given jQuery `selector`, where
 `method` can be any of the following jQuery methods: `val`, `text`, `html`, `height`,

--- a/src/ngScenario/dsl.js
+++ b/src/ngScenario/dsl.js
@@ -421,6 +421,29 @@ angular.scenario.dsl('element', function() {
     });
   };
 
+  chain.hasClass = function(value) {
+    return this.addFutureAction("element has class '" + value + "'", function($window, $document, done) {
+      var elements = $document.elements();
+      done(null, elements.hasClass(value));
+    });
+  };
+
+  chain.addClass = function(value) {
+    return this.addFutureAction("element add class '" + value + "'", function($window, $document, done) {
+      var elements = $document.elements();
+      elements.addClass(value);
+      done();
+    });
+  };
+
+  chain.removeClass = function(value) {
+    return this.addFutureAction("element remove class '" + value + "'", function($window, $document, done) {
+      var elements = $document.elements();
+      elements.removeClass(value);
+      done();
+    });
+  };
+
   angular.forEach(KEY_VALUE_METHODS, function(methodName) {
     chain[methodName] = function(name, value) {
       var args = arguments,

--- a/test/ngScenario/dslSpec.js
+++ b/test/ngScenario/dslSpec.js
@@ -454,6 +454,31 @@ describe("angular.scenario.dsl", function() {
         expect(doc.find('#test').prop('className')).toEqual('bam');
       });
 
+      it('should return hasClass correctly', function() {
+        doc.append('<div id="test" class="foo bar"></div>');
+        var chain = $root.dsl.element('#test');
+        chain.hasClass('foo');
+        expect($root.futureResult).toBeTruthy();
+        chain.hasClass('baz');
+        expect($root.futureResult).toBeFalsy();
+      });
+
+      it('should add class', function() {
+        doc.append('<div id="test" class="foo bar"></div>');
+        var chain = $root.dsl.element('#test');
+        chain.addClass('baz');
+        chain.hasClass('baz');
+        expect($root.futureResult).toBeTruthy();
+      });
+
+      it('should remove class', function() {
+        doc.append('<div id="test" class="foo bar"></div>');
+        var chain = $root.dsl.element('#test');
+        chain.removeClass('bar');
+        chain.hasClass('bar');
+        expect($root.futureResult).toBeFalsy();
+      });
+
       it('should get css', function() {
         doc.append('<div id="test" style="height: 30px"></div>');
         $root.dsl.element('#test').css('height');


### PR DESCRIPTION
Add jQuery like class manipulation methods to element dsl for e2e testing.
These methods simplify e2e scenarios. For example, when testing `:hover`
pseudo-class you can add own `.hover` class and check that app respond correctly.
