### PR TITLE
Fixing mexican spanish locale

### DIFF
--- a/src/ngLocale/angular-locale_es-mx.js
+++ b/src/ngLocale/angular-locale_es-mx.js
@@ -1,5 +1,5 @@
 angular.module("ngLocale", [], ["$provide", function($provide) {
-var PLURAL_CATEGORY = {ZERO: "zero", ONE: "one", TWO: "two", FEW: "few", MANY: "many", OTHER: "other"};
+var PLURAL_CATEGORY = {ZERO: "cero", ONE: "uno", TWO: "dos", FEW: "pocos", MANY: "muchos", OTHER: "otros"};
 $provide.value("$locale", {
   "DATETIME_FORMATS": {
     "AMPMS": [
@@ -62,9 +62,9 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
-    "DECIMAL_SEP": ",",
-    "GROUP_SEP": ".",
+    "CURRENCY_SYM": "$",
+    "DECIMAL_SEP": ".",
+    "GROUP_SEP": ",",
     "PATTERNS": [
       {
         "gSize": 3,


### PR DESCRIPTION
Just updating some words and the money symbol, we also use the "dollar", dot as separator for cents and comma as a group separator
