### PR TITLE
Update directive.ngdoc

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -404,10 +404,6 @@ compiler}. The attributes are:
   * `controllerAs` - Controller alias at the directive scope. An alias for the controller so it
     can be referenced at the directive template. The directive needs to define a scope for this
     configuration to be used. Useful in the case when directive is used as component.
-  
-  * `require` - Require another controller be passed into current directive linking function. The
-    `require` takes a name of the directive controller to pass in. If no such controller can be
-    found an error is raised. The name can be prefixed with:
 
   * `restrict` - String of subset of `EACM` which restricts the directive to a specific directive
     declaration style. If omitted, the default (attributes only) is used.


### PR DESCRIPTION
removed redundant (and truncated) 'require' attribute description.
