### PR TITLE
fix(jqLite): allow inputs to have a name of "className"

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -279,18 +279,18 @@ function JQLiteData(element, key, value) {
 }
 
 function JQLiteHasClass(element, selector) {
-  return ((" " + element.className + " ").replace(/[\n\t]/g, " ").
+  return ((" " + (element.getAttribute('class') || "") + " ").replace(/[\n\t]/g, " ").
       indexOf( " " + selector + " " ) > -1);
 }
 
 function JQLiteRemoveClass(element, cssClasses) {
   if (cssClasses) {
     forEach(cssClasses.split(' '), function(cssClass) {
-      element.className = trim(
-          (" " + element.className + " ")
+      jqLite(element).attr('class', trim(
+          (" " + (element.getAttribute('class') || "") + " ")
           .replace(/[\n\t]/g, " ")
           .replace(" " + trim(cssClass) + " ", " ")
-      );
+      ));
     });
   }
 }
@@ -299,7 +299,8 @@ function JQLiteAddClass(element, cssClasses) {
   if (cssClasses) {
     forEach(cssClasses.split(' '), function(cssClass) {
       if (!JQLiteHasClass(element, cssClass)) {
-        element.className = trim(element.className + ' ' + trim(cssClass));
+        jqLite(element).attr('class',
+            trim((element.getAttribute('class') || "") + ' ' + trim(cssClass)));
       }
     });
   }

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -479,6 +479,15 @@ describe('jqLite', function() {
 
   describe('class', function() {
 
+    it('should allow an input to have a name of "className" without affecting class selection on parent form', function() {
+      var element = jqLite('<form class="a"><input name="className"></form>');
+      element.addClass('b');
+      expect(element.attr('class')).toEqual('a b');
+
+      element.removeClass('b');
+      expect(element.attr('class')).toEqual('a');
+    });
+
     describe('hasClass', function() {
       it('should check class', function() {
         var selector = jqLite([a, b]);


### PR DESCRIPTION
Fixes #3773
# Summary

We can't merge this until #jquery/jquery/1346 is merged.

Additionally there are many other properties (and possibly elements) with similar name collision in the dom that this doesn't change doesn't fix. Something to keep in mind before we go off and complicate the code to fix this one particular issue.
