### PR TITLE
chore: upgrade grunt packages to match master

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/angular/angular.js.git"
   },
   "devDependencies": {
-    "grunt": "0.4.0",
-    "grunt-contrib-clean": "0.4.0",
-    "grunt-contrib-compress": "0.4.1",
-    "grunt-contrib-connect": "0.1.2",
-    "grunt-contrib-copy": "0.4.1",
-    "grunt-parallel": "~0.2.0",
+    "grunt": "~0.4.1",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-compress": "~0.5.2",
+    "grunt-contrib-connect": "~0.3.0",
+    "grunt-contrib-copy": "~0.4.1",
+    "grunt-parallel": "git://github.com/vojtajina/grunt-parallel.git#streaming-per-task",
     "grunt-ddescribe-iit": "~0.0.1",
     "grunt-merge-conflict": "~0.0.1",
     "jasmine-node": "1.2.3",


### PR DESCRIPTION
Seems to fix Jenkins build.

Broken: http://ci.angularjs.org/job/angular.js-angular-v1.0.x/lastBuild/console

Fixed: http://ci.angularjs.org/job/angular.js-brian/34/console
