### PR TITLE
fix(ngMocks): $logProvider#debugEnabled should work the same within tests

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -316,7 +316,7 @@ angular.mock.$LogProvider = function() {
   }
 
   this.debugEnabled = function(flag) {
-	  if (isDefined(flag)) {
+	  if (angular.isDefined(flag)) {
 		  debug = flag;
 		  return this;
 	  } else {


### PR DESCRIPTION
angular.mocks.$LogProvider $logProvider.debugEnabled(false) is crashing
with undefined when run inside karma/jasmine test runner

The following crashes when run inside Karma/Jasmine test suite

``` javascript
angular.module('foo', [])
  .config(['$logProvider', function ($logProvider) {
    $logProvider.debugEnabled(false);
  }]);
```

Closes #3612
