### PR TITLE
Return the same data to success as to $promise.then

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -496,7 +496,7 @@ angular.module('ngResource', ['ng']).
 
             response = (responseInterceptor)(response);
 
-            (success||noop)(response);
+            (success||noop)(response, response.headers);
 
             return response;
           }, function(response) {

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -492,9 +492,11 @@ angular.module('ngResource', ['ng']).
 
             value.$resolved = true;
 
-            (success||noop)(value, response.headers);
-
             response.resource = value;
+
+            response = (responseInterceptor)(response);
+
+            (success||noop)(response);
 
             return response;
           }, function(response) {


### PR DESCRIPTION
Feel free to reject if I've misunderstood this, but I was expecting my `success()` callback to receive the same arguments as passed to `$promise.then()`. Currently the response interceptor gets bypassed when using the `success()` approach.
