### PR TITLE
fix($compile): allow interpolations for non-event handlers attrs

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -159,7 +159,7 @@ function $CompileProvider($provide) {
   // Ref: http://developers.whatwg.org/webappapis.html#event-handler-idl-attributes
   // The assumption is that future DOM event attribute names will begin with
   // 'on' and be composed of only English letters.
-  var EVENT_HANDLER_ATTR_REGEXP = /^(on[a-z]*|formaction)$/;
+  var EVENT_HANDLER_ATTR_REGEXP = /^(on[a-z]+|formaction)$/;
 
   /**
    * @ngdoc function

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3198,6 +3198,18 @@ describe('$compile', function() {
       $rootScope.$apply();
       expect(element.attr('on-click')).toEqual('javascript:doSomething()');
     }));
+
+    it('should pass through arbitrary values on "on" and "data-on" attributes', inject(function($compile, $rootScope) {
+      element = $compile('<button data-on="{{dataOnVar}}"></script>')($rootScope);
+      $rootScope.dataOnVar = 'data-on text';
+      $rootScope.$apply();
+      expect(element.attr('data-on')).toEqual('data-on text');
+      
+      element = $compile('<button on="{{onVar}}"></script>')($rootScope);
+      $rootScope.onVar = 'on text';
+      $rootScope.$apply();
+      expect(element.attr('on')).toEqual('on text');
+    }));
   });
 
   describe('iframe[src]', function() {


### PR DESCRIPTION
Fix wrong behaviour that didn't allow 'data-on' and 'on' element attributes
to be interpolated by $compile. The regex now accepts any string beginning
with 'on' and with at least one more English letter.
