### PR TITLE
fix(docs): fix diagram in tutorial/step_03

### DIFF
--- a/docs/content/tutorial/step_03.ngdoc
+++ b/docs/content/tutorial/step_03.ngdoc
@@ -69,7 +69,7 @@ available as a filter input in the list repeater (`phone in phones | filter:`__`
 changes to the data model cause the repeater's input to change, the repeater efficiently updates
 the DOM to reflect the current state of the model.
 
-      <img  class="diagram" src="img/tutorial/tutorial_03.png">
+<img  class="diagram" src="img/tutorial/tutorial_03.png">
 
 * Use of the `filter` filter: The {@link api/ng.filter:filter filter} function uses the
 `query` value to create a new array that contains only those records that match the `query`.


### PR DESCRIPTION
Removes whitespace before image tag as it caused it to be interpreted as a code block.
