### PR TITLE
fix(docs): fix diagram in tutorial/step_04

### DIFF
--- a/docs/content/tutorial/step_04.ngdoc
+++ b/docs/content/tutorial/step_04.ngdoc
@@ -45,7 +45,7 @@ We made the following changes to the `index.html` template:
 * First, we added a `<select>` html element named `orderProp`, so that our users can pick from the
 two provided sorting options.
 
-      <img  class="diagram" src="img/tutorial/tutorial_04.png">
+<img  class="diagram" src="img/tutorial/tutorial_04.png">
 
 * We then chained the `filter` filter with {@link api/ng.filter:orderBy `orderBy`}
 filter to further process the input into the repeater. `orderBy` is a filter that takes an input


### PR DESCRIPTION
Removes whitespace before image tag as it caused it to be interpreted as a code block.
