### PR TITLE
Fixed issue in generated docs with MD headers not being generated

### DIFF
--- a/docs/src/ngdoc.js
+++ b/docs/src/ngdoc.js
@@ -372,7 +372,7 @@ Doc.prototype = {
           return explainModuleInstallation(module);
         });
     });
-    text = parts.join('');
+    text = parts.join('' + '\n');
 
     function prepareClassName(text) {
       return text.toLowerCase().replace(/[_\W]+/g, '-');


### PR DESCRIPTION
For [example](http://docs.angularjs.org/guide/concepts#runtime). Note the unprocessed '# Runtime' heading followed by a bunch of unformatted text. There are other examples on the same page ('Model', eg). Adding a newline character to the end of the generated example html text appears to fix the problem.
