### PR TITLE
Hierarchical log level support

### DIFF
--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -26,8 +26,8 @@
  <input type="text" ng-model="message"/>
  <button ng-click="$log.debug(message)">debug</button>
  <button ng-click="$log.log(message)">log</button>
- <button ng-click="$log.info(message)">info</button>
  <button ng-click="$log.warn(message)">warn</button>
+ <button ng-click="$log.info(message)">info</button>
  <button ng-click="$log.error(message)">error</button>
  </div>
  </file>
@@ -40,7 +40,7 @@
  * @description
  * Use the `$logProvider` to configure how the application logs messages
  */
-function $LogProvider() {
+function $LogProvider(){
     var levels = {
             off: Number.MAX_VALUE,
             error: 5,
@@ -73,7 +73,7 @@ function $LogProvider() {
      * @param {string=} flag enable or disable debug level messages
      * @returns {*} current value if used as getter or itself (chaining) if used as setter
      */
-    this.debugEnabled = function (flag) {
+    this.debugEnabled = function(flag) {
         if (isDefined(flag)) {
             if (flag) {
                 this.setLogLevel('debug');
@@ -97,9 +97,9 @@ function $LogProvider() {
      */
     this.setLogLevel = function (level) {
         this.level = levels[level];
-    }
+    };
 
-    this.$get = ['$window', function ($window) {
+    this.$get = ['$window', function($window){
         return {
             /**
              * @ngdoc method
@@ -174,9 +174,9 @@ function $LogProvider() {
                 logFn = console[type] || console.log || noop;
 
             if (logFn.apply) {
-                return function () {
+                return function() {
                     var args = [];
-                    forEach(arguments, function (arg) {
+                    forEach(arguments, function(arg) {
                         args.push(formatError(arg));
                     });
                     return logFn.apply(console, args);
@@ -185,11 +185,9 @@ function $LogProvider() {
 
             // we are IE which either doesn't have window.console => this is noop and we do nothing,
             // or we are IE where console.log doesn't have apply so we log at least first 2 args
-            return function (arg1, arg2) {
+            return function(arg1, arg2) {
                 logFn(arg1, arg2);
             }
         }
-    }
-    ]
-    ;
+    }];
 }

--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -12,25 +12,26 @@
  * The main purpose of this service is to simplify debugging and troubleshooting.
  *
  * @example
-   <example>
-     <file name="script.js">
-       function LogCtrl($scope, $log) {
+ <example>
+ <file name="script.js">
+ function LogCtrl($scope, $log) {
          $scope.$log = $log;
          $scope.message = 'Hello World!';
        }
-     </file>
-     <file name="index.html">
-       <div ng-controller="LogCtrl">
-         <p>Reload this page with open console, enter text and hit the log button...</p>
-         Message:
-         <input type="text" ng-model="message"/>
-         <button ng-click="$log.log(message)">log</button>
-         <button ng-click="$log.warn(message)">warn</button>
-         <button ng-click="$log.info(message)">info</button>
-         <button ng-click="$log.error(message)">error</button>
-       </div>
-     </file>
-   </example>
+ </file>
+ <file name="index.html">
+ <div ng-controller="LogCtrl">
+ <p>Reload this page with open console, enter text and hit the log button...</p>
+ Message:
+ <input type="text" ng-model="message"/>
+ <button ng-click="$log.debug(message)">debug</button>
+ <button ng-click="$log.log(message)">log</button>
+ <button ng-click="$log.info(message)">info</button>
+ <button ng-click="$log.warn(message)">warn</button>
+ <button ng-click="$log.error(message)">error</button>
+ </div>
+ </file>
+ </example>
  */
 
 /**
@@ -39,120 +40,156 @@
  * @description
  * Use the `$logProvider` to configure how the application logs messages
  */
-function $LogProvider(){
-  var debug = true,
-      self = this;
-  
-  /**
-   * @ngdoc property
-   * @name ng.$logProvider#debugEnabled
-   * @methodOf ng.$logProvider
-   * @description
-   * @param {string=} flag enable or disable debug level messages
-   * @returns {*} current value if used as getter or itself (chaining) if used as setter
-   */
-  this.debugEnabled = function(flag) {
-	  if (isDefined(flag)) {
-		  debug = flag;
-		  return this;
-	  } else {
-		  return debug;
-	  }
-  };
-  
-  this.$get = ['$window', function($window){
-    return {
-      /**
-       * @ngdoc method
-       * @name ng.$log#log
-       * @methodOf ng.$log
-       *
-       * @description
-       * Write a log message
-       */
-      log: consoleLog('log'),
+function $LogProvider() {
+    var levels = {
+            off: Number.MAX_VALUE,
+            error: 5,
+            warn: 4,
+            info: 3,
+            log: 2,
+            debug: 1,
+            all: Number.MIN_VALUE
+        },
+        self = this;
 
-      /**
-       * @ngdoc method
-       * @name ng.$log#info
-       * @methodOf ng.$log
-       *
-       * @description
-       * Write an information message
-       */
-      info: consoleLog('info'),
+    /**
+     * @ngdoc property
+     * @name ng.$logProvider#level
+     * @description
+     * A hierarchical level controlling what is logged to the console.
+     * Possible values (in order of priority):
+     *      'off', 'error', 'warn', 'info', 'log', 'debug', 'all'
+     *
+     *  For example, a level of info results in error, warn, and info messages being logged.
+     */
+    this.level = levels.debug;
 
-      /**
-       * @ngdoc method
-       * @name ng.$log#warn
-       * @methodOf ng.$log
-       *
-       * @description
-       * Write a warning message
-       */
-      warn: consoleLog('warn'),
-
-      /**
-       * @ngdoc method
-       * @name ng.$log#error
-       * @methodOf ng.$log
-       *
-       * @description
-       * Write an error message
-       */
-      error: consoleLog('error'),
-      
-      /**
-       * @ngdoc method
-       * @name ng.$log#debug
-       * @methodOf ng.$log
-       * 
-       * @description
-       * Write a debug message
-       */
-      debug: (function () {
-    	var fn = consoleLog('debug');
-    	
-    	return function() {
-    		if (debug) {
-    			fn.apply(self, arguments);
-    		}
-    	}
-      }())
+    /**
+     * @ngdoc property
+     * @name ng.$logProvider#debugEnabled
+     * @methodOf ng.$logProvider
+     * @deprecated use the ng.$logProvider#setLogLevel method instead.
+     * @description
+     * @param {string=} flag enable or disable debug level messages
+     * @returns {*} current value if used as getter or itself (chaining) if used as setter
+     */
+    this.debugEnabled = function (flag) {
+        if (isDefined(flag)) {
+            if (flag) {
+                this.setLogLevel('debug');
+            } else {
+                this.setLogLevel('log');
+            }
+            return this;
+        } else {
+            return (this.level <= levels.debug);
+        }
     };
 
-    function formatError(arg) {
-      if (arg instanceof Error) {
-        if (arg.stack) {
-          arg = (arg.message && arg.stack.indexOf(arg.message) === -1)
-              ? 'Error: ' + arg.message + '\n' + arg.stack
-              : arg.stack;
-        } else if (arg.sourceURL) {
-          arg = arg.message + '\n' + arg.sourceURL + ':' + arg.line;
-        }
-      }
-      return arg;
+    /**
+     * @ngdoc method
+     * @name ng.$logProvider#setLogLevel
+     * @methodOf ng.$logProvider
+     * @description
+     * Sets the ng.$logProvider#level property.
+     * @param {string=} Possible values (in order of priority):
+     *      'off', 'error', 'warn', 'info', 'log', 'debug', 'all'
+     */
+    this.setLogLevel = function (level) {
+        this.level = levels[level];
     }
 
-    function consoleLog(type) {
-      var console = $window.console || {},
-          logFn = console[type] || console.log || noop;
+    this.$get = ['$window', function ($window) {
+        return {
+            /**
+             * @ngdoc method
+             * @name ng.$log#log
+             * @methodOf ng.$log
+             *
+             * @description
+             * Write a log message
+             */
+            log: meetsLevel('log') ? consoleLog('log') : noop,
 
-      if (logFn.apply) {
-        return function() {
-          var args = [];
-          forEach(arguments, function(arg) {
-            args.push(formatError(arg));
-          });
-          return logFn.apply(console, args);
+            /**
+             * @ngdoc method
+             * @name ng.$log#info
+             * @methodOf ng.$log
+             *
+             * @description
+             * Write an information message
+             */
+            info: meetsLevel('info') ? consoleLog('info') : noop,
+
+            /**
+             * @ngdoc method
+             * @name ng.$log#warn
+             * @methodOf ng.$log
+             *
+             * @description
+             * Write a warning message
+             */
+            warn: meetsLevel('warn') ? consoleLog('warn') : noop,
+
+            /**
+             * @ngdoc method
+             * @name ng.$log#error
+             * @methodOf ng.$log
+             *
+             * @description
+             * Write an error message
+             */
+            error: meetsLevel('error') ? consoleLog('error') : noop,
+
+            /**
+             * @ngdoc method
+             * @name ng.$log#debug
+             * @methodOf ng.$log
+             *
+             * @description
+             * Write a debug message
+             */
+            debug: meetsLevel('debug') ? consoleLog('debug') : noop
         };
-      }
 
-      // we are IE which either doesn't have window.console => this is noop and we do nothing,
-      // or we are IE where console.log doesn't have apply so we log at least first 2 args
-      return function(arg1, arg2) {
-        logFn(arg1, arg2);
-      }
+        function meetsLevel(level) {
+            return (self.level <= levels[level]);
+        }
+
+        function formatError(arg) {
+            if (arg instanceof Error) {
+                if (arg.stack) {
+                    arg = (arg.message && arg.stack.indexOf(arg.message) === -1)
+                        ? 'Error: ' + arg.message + '\n' + arg.stack
+                        : arg.stack;
+                } else if (arg.sourceURL) {
+                    arg = arg.message + '\n' + arg.sourceURL + ':' + arg.line;
+                }
+            }
+            return arg;
+        }
+
+        function consoleLog(type) {
+            var console = $window.console || {},
+                logFn = console[type] || console.log || noop;
+
+            if (logFn.apply) {
+                return function () {
+                    var args = [];
+                    forEach(arguments, function (arg) {
+                        args.push(formatError(arg));
+                    });
+                    return logFn.apply(console, args);
+                };
+            }
+
+            // we are IE which either doesn't have window.console => this is noop and we do nothing,
+            // or we are IE where console.log doesn't have apply so we log at least first 2 args
+            return function (arg1, arg2) {
+                logFn(arg1, arg2);
+            }
+        }
     }
-  }];
+    ]
+    ;
 }

--- a/test/ng/logSpec.js
+++ b/test/ng/logSpec.js
@@ -1,27 +1,24 @@
 'use strict';
 
-describe('$log', function () {
+function initService(debugEnabled) {
+    return module(function($logProvider){
+        $logProvider.debugEnabled(debugEnabled);
+    });
+}
+
+describe('$log', function() {
     var $window, logger, log, warn, info, error, debug;
 
 
-    beforeEach(module(function ($provide) {
+
+    beforeEach(module(function($provide){
         $window = {navigator: {}, document: {}};
         logger = '';
-        log = function () {
-            logger += 'log;';
-        };
-        warn = function () {
-            logger += 'warn;';
-        };
-        info = function () {
-            logger += 'info;';
-        };
-        error = function () {
-            logger += 'error;';
-        };
-        debug = function () {
-            logger += 'debug;';
-        };
+        log = function() { logger+= 'log;'; };
+        warn = function() { logger+= 'warn;'; };
+        info = function() { logger+= 'info;'; };
+        error = function() { logger+= 'error;'; };
+        debug = function() { logger+= 'debug;'; };
 
         $provide.provider('$log', $LogProvider);
         $provide.value('$exceptionHandler', angular.mock.rethrow);
@@ -29,16 +26,14 @@ describe('$log', function () {
     }));
 
     it('should use console if present', inject(
-        function () {
-            $window.console = {
-                log: log,
+        function(){
+            $window.console = {log: log,
                 warn: warn,
                 info: info,
                 error: error,
-                debug: debug
-            };
+                debug: debug};
         },
-        function ($log) {
+        function($log) {
             $log.log();
             $log.warn();
             $log.info();
@@ -50,10 +45,10 @@ describe('$log', function () {
 
 
     it('should use console.log() if other not present', inject(
-        function () {
+        function(){
             $window.console = {log: log};
         },
-        function ($log) {
+        function($log) {
             $log.log();
             $log.warn();
             $log.info();
@@ -65,7 +60,7 @@ describe('$log', function () {
 
 
     it('should use noop if no console', inject(
-        function ($log) {
+        function($log) {
             $log.log();
             $log.warn();
             $log.info();
@@ -76,7 +71,7 @@ describe('$log', function () {
 
 
     it("should work in IE where console.error doesn't have apply method", inject(
-        function () {
+        function() {
             log.apply = log.call =
                 warn.apply = warn.call =
                     info.apply = info.call =
@@ -89,7 +84,7 @@ describe('$log', function () {
                 error: error,
                 debug: debug};
         },
-        function ($log) {
+        function($log) {
             $log.log.apply($log);
             $log.warn.apply($log);
             $log.info.apply($log);
@@ -101,19 +96,17 @@ describe('$log', function () {
 
     describe("$log.debug", function () {
 
-        beforeEach(module(function ($logProvider) {
-            $logProvider.debugEnabled(false);
-        }));
+        beforeEach(initService(false));
 
         it("should skip debugging output if disabled", inject(
-            function () {
+            function(){
                 $window.console = {log: log,
                     warn: warn,
                     info: info,
                     error: error,
                     debug: debug};
             },
-            function ($log) {
+            function($log) {
                 $log.log();
                 $log.warn();
                 $log.info();
@@ -125,36 +118,36 @@ describe('$log', function () {
 
     });
 
-    describe('$log.error', function () {
+    describe('$log.error', function() {
         var e, $log, errorArgs;
 
-        beforeEach(function () {
+        beforeEach(function() {
             e = new Error('');
             e.message = undefined;
             e.sourceURL = undefined;
             e.line = undefined;
             e.stack = undefined;
 
-            $log = new $LogProvider().$get[1]({console: {error: function () {
+            $log = new $LogProvider().$get[1]({console:{error:function() {
                 errorArgs = [].slice.call(arguments, 0);
             }}});
         });
 
 
-        it('should pass error if does not have trace', function () {
+        it('should pass error if does not have trace', function() {
             $log.error('abc', e);
             expect(errorArgs).toEqual(['abc', e]);
         });
 
 
-        it('should print stack', function () {
+        it('should print stack', function() {
             e.stack = 'stack';
             $log.error('abc', e);
             expect(errorArgs).toEqual(['abc', 'stack']);
         });
 
 
-        it('should print line', function () {
+        it('should print line', function() {
             e.message = 'message';
             e.sourceURL = 'sourceURL';
             e.line = '123';
@@ -164,12 +157,9 @@ describe('$log', function () {
     });
 
     describe('$log with level set to "off"', function () {
-
         beforeEach(module(function ($logProvider) {
             $logProvider.setLogLevel('off');
         }));
-
-        //off, error, warn, info, log, debug, all
 
         it('should not log anything if level is "off"', inject(
             function () {

--- a/test/ng/logSpec.js
+++ b/test/ng/logSpec.js
@@ -1,158 +1,356 @@
 'use strict';
 
-function initService(debugEnabled) {
-    return module(function($logProvider){
-      $logProvider.debugEnabled(debugEnabled);
-    });
-  }
-
-describe('$log', function() {
-  var $window, logger, log, warn, info, error, debug;
+describe('$log', function () {
+    var $window, logger, log, warn, info, error, debug;
 
 
+    beforeEach(module(function ($provide) {
+        $window = {navigator: {}, document: {}};
+        logger = '';
+        log = function () {
+            logger += 'log;';
+        };
+        warn = function () {
+            logger += 'warn;';
+        };
+        info = function () {
+            logger += 'info;';
+        };
+        error = function () {
+            logger += 'error;';
+        };
+        debug = function () {
+            logger += 'debug;';
+        };
 
-  beforeEach(module(function($provide){
-    $window = {navigator: {}, document: {}};
-    logger = '';
-    log = function() { logger+= 'log;'; };
-    warn = function() { logger+= 'warn;'; };
-    info = function() { logger+= 'info;'; };
-    error = function() { logger+= 'error;'; };
-    debug = function() { logger+= 'debug;'; };
+        $provide.provider('$log', $LogProvider);
+        $provide.value('$exceptionHandler', angular.mock.rethrow);
+        $provide.value('$window', $window);
+    }));
 
-    $provide.provider('$log', $LogProvider);
-    $provide.value('$exceptionHandler', angular.mock.rethrow);
-    $provide.value('$window', $window);
-  }));
-
-  it('should use console if present', inject(
-    function(){
-      $window.console = {log: log,
-                         warn: warn,
-                         info: info,
-                         error: error,
-                         debug: debug};
-    },
-    function($log) {
-      $log.log();
-      $log.warn();
-      $log.info();
-      $log.error();
-      $log.debug();
-      expect(logger).toEqual('log;warn;info;error;debug;');
-    }
-  ));
-
-
-  it('should use console.log() if other not present', inject(
-    function(){
-      $window.console = {log: log};
-    },
-    function($log) {
-      $log.log();
-      $log.warn();
-      $log.info();
-      $log.error();
-      $log.debug();
-      expect(logger).toEqual('log;log;log;log;log;');
-    }
-  ));
+    it('should use console if present', inject(
+        function () {
+            $window.console = {
+                log: log,
+                warn: warn,
+                info: info,
+                error: error,
+                debug: debug
+            };
+        },
+        function ($log) {
+            $log.log();
+            $log.warn();
+            $log.info();
+            $log.error();
+            $log.debug();
+            expect(logger).toEqual('log;warn;info;error;debug;');
+        }
+    ));
 
 
-  it('should use noop if no console', inject(
-    function($log) {
-      $log.log();
-      $log.warn();
-      $log.info();
-      $log.error();
-      $log.debug();
-    }
-  ));
+    it('should use console.log() if other not present', inject(
+        function () {
+            $window.console = {log: log};
+        },
+        function ($log) {
+            $log.log();
+            $log.warn();
+            $log.info();
+            $log.error();
+            $log.debug();
+            expect(logger).toEqual('log;log;log;log;log;');
+        }
+    ));
 
 
-  it("should work in IE where console.error doesn't have apply method", inject(
-      function() {
-        log.apply = log.call =
-            warn.apply = warn.call =
-            info.apply = info.call =
-            error.apply = error.call =
-            debug.apply = debug.call = null;
+    it('should use noop if no console', inject(
+        function ($log) {
+            $log.log();
+            $log.warn();
+            $log.info();
+            $log.error();
+            $log.debug();
+        }
+    ));
 
-        $window.console = {log: log,
-                           warn: warn,
-                           info: info,
-                           error: error,
-                           debug: debug};
-      },
-      function($log) {
-        $log.log.apply($log);
-        $log.warn.apply($log);
-        $log.info.apply($log);
-        $log.error.apply($log);
-        $log.debug.apply($log);
-        expect(logger).toEqual('log;warn;info;error;debug;');
-      })
-  );
 
-  describe("$log.debug", function () {
-	 
-	  beforeEach(initService(false));
-	  
-	  it("should skip debugging output if disabled", inject(
-	    function(){
-	      $window.console = {log: log,
-	                         warn: warn,
-	                         info: info,
-	                         error: error,
-	                         debug: debug};
-	    }, 
-	    function($log) {
-	      $log.log();
-	      $log.warn();
-	      $log.info();
-	      $log.error();
-	      $log.debug();
-	      expect(logger).toEqual('log;warn;info;error;');
-	    }
-  ));
-	  
-  });
+    it("should work in IE where console.error doesn't have apply method", inject(
+        function () {
+            log.apply = log.call =
+                warn.apply = warn.call =
+                    info.apply = info.call =
+                        error.apply = error.call =
+                            debug.apply = debug.call = null;
 
-  describe('$log.error', function() {
-    var e, $log, errorArgs;
+            $window.console = {log: log,
+                warn: warn,
+                info: info,
+                error: error,
+                debug: debug};
+        },
+        function ($log) {
+            $log.log.apply($log);
+            $log.warn.apply($log);
+            $log.info.apply($log);
+            $log.error.apply($log);
+            $log.debug.apply($log);
+            expect(logger).toEqual('log;warn;info;error;debug;');
+        })
+    );
 
-    beforeEach(function() {
-      e = new Error('');
-      e.message = undefined;
-      e.sourceURL = undefined;
-      e.line = undefined;
-      e.stack = undefined;
+    describe("$log.debug", function () {
 
-      $log = new $LogProvider().$get[1]({console:{error:function() {
-        errorArgs = [].slice.call(arguments, 0);
-      }}});
+        beforeEach(module(function ($logProvider) {
+            $logProvider.debugEnabled(false);
+        }));
+
+        it("should skip debugging output if disabled", inject(
+            function () {
+                $window.console = {log: log,
+                    warn: warn,
+                    info: info,
+                    error: error,
+                    debug: debug};
+            },
+            function ($log) {
+                $log.log();
+                $log.warn();
+                $log.info();
+                $log.error();
+                $log.debug();
+                expect(logger).toEqual('log;warn;info;error;');
+            }
+        ));
+
     });
 
+    describe('$log.error', function () {
+        var e, $log, errorArgs;
 
-    it('should pass error if does not have trace', function() {
-      $log.error('abc', e);
-      expect(errorArgs).toEqual(['abc', e]);
+        beforeEach(function () {
+            e = new Error('');
+            e.message = undefined;
+            e.sourceURL = undefined;
+            e.line = undefined;
+            e.stack = undefined;
+
+            $log = new $LogProvider().$get[1]({console: {error: function () {
+                errorArgs = [].slice.call(arguments, 0);
+            }}});
+        });
+
+
+        it('should pass error if does not have trace', function () {
+            $log.error('abc', e);
+            expect(errorArgs).toEqual(['abc', e]);
+        });
+
+
+        it('should print stack', function () {
+            e.stack = 'stack';
+            $log.error('abc', e);
+            expect(errorArgs).toEqual(['abc', 'stack']);
+        });
+
+
+        it('should print line', function () {
+            e.message = 'message';
+            e.sourceURL = 'sourceURL';
+            e.line = '123';
+            $log.error('abc', e);
+            expect(errorArgs).toEqual(['abc', 'message\nsourceURL:123']);
+        });
     });
 
+    describe('$log with level set to "off"', function () {
 
-    it('should print stack', function() {
-      e.stack = 'stack';
-      $log.error('abc', e);
-      expect(errorArgs).toEqual(['abc', 'stack']);
+        beforeEach(module(function ($logProvider) {
+            $logProvider.setLogLevel('off');
+        }));
+
+        //off, error, warn, info, log, debug, all
+
+        it('should not log anything if level is "off"', inject(
+            function () {
+                $window.console = {
+                    error: error,
+                    warn: warn,
+                    info: info,
+                    log: log,
+                    debug: debug
+                };
+            },
+            function ($log) {
+                $log.error();
+                $log.warn();
+                $log.info();
+                $log.log();
+                $log.debug();
+                expect(logger).toEqual('');
+            }
+        ));
     });
 
+    describe('$log with level set to "error"', function () {
 
-    it('should print line', function() {
-      e.message = 'message';
-      e.sourceURL = 'sourceURL';
-      e.line = '123';
-      $log.error('abc', e);
-      expect(errorArgs).toEqual(['abc', 'message\nsourceURL:123']);
+        beforeEach(module(function ($logProvider) {
+            $logProvider.setLogLevel('error');
+        }));
+
+        it('should only log error when level is "error"', inject(
+            function () {
+                $window.console = {
+                    error: error,
+                    warn: warn,
+                    info: info,
+                    log: log,
+                    debug: debug
+                };
+            },
+            function ($log) {
+                $log.error();
+                $log.warn();
+                $log.info();
+                $log.log();
+                $log.debug();
+                expect(logger).toEqual('error;');
+            }
+        ));
     });
-  });
+
+    describe('$log with level set to "warn"', function () {
+
+        beforeEach(module(function ($logProvider) {
+            $logProvider.setLogLevel('warn');
+        }));
+
+        it('should log error and warn when level is "warn"', inject(
+            function () {
+                $window.console = {
+                    error: error,
+                    warn: warn,
+                    info: info,
+                    log: log,
+                    debug: debug
+                };
+            },
+            function ($log) {
+                $log.error();
+                $log.warn();
+                $log.info();
+                $log.log();
+                $log.debug();
+                expect(logger).toEqual('error;warn;');
+            }
+        ));
+    });
+
+    describe('$log with level set to "info"', function () {
+
+        beforeEach(module(function ($logProvider) {
+            $logProvider.setLogLevel('info');
+        }));
+
+        it('should log error and warn when level is "info"', inject(
+            function () {
+                $window.console = {
+                    error: error,
+                    warn: warn,
+                    info: info,
+                    log: log,
+                    debug: debug
+                };
+            },
+            function ($log) {
+                $log.error();
+                $log.warn();
+                $log.info();
+                $log.log();
+                $log.debug();
+                expect(logger).toEqual('error;warn;info;');
+            }
+        ));
+    });
+
+    describe('$log with level set to "log"', function () {
+
+        beforeEach(module(function ($logProvider) {
+            $logProvider.setLogLevel('log');
+        }));
+
+        it('should log error and warn when level is "log"', inject(
+            function () {
+                $window.console = {
+                    error: error,
+                    warn: warn,
+                    info: info,
+                    log: log,
+                    debug: debug
+                };
+            },
+            function ($log) {
+                $log.error();
+                $log.warn();
+                $log.info();
+                $log.log();
+                $log.debug();
+                expect(logger).toEqual('error;warn;info;log;');
+            }
+        ));
+    });
+
+    describe('$log.level "debug"', function () {
+
+        beforeEach(module(function ($logProvider) {
+            $logProvider.setLogLevel('debug');
+        }));
+
+        it('should log error and warn when level is "debug"', inject(
+            function () {
+                $window.console = {
+                    error: error,
+                    warn: warn,
+                    info: info,
+                    log: log,
+                    debug: debug
+                };
+            },
+            function ($log) {
+                $log.error();
+                $log.warn();
+                $log.info();
+                $log.log();
+                $log.debug();
+                expect(logger).toEqual('error;warn;info;log;debug;');
+            }
+        ));
+    });
+
+    describe('$log.level "all"', function () {
+
+        beforeEach(module(function ($logProvider) {
+            $logProvider.setLogLevel('all');
+        }));
+
+        it('should log error and warn when level is "all"', inject(
+            function () {
+                $window.console = {
+                    error: error,
+                    warn: warn,
+                    info: info,
+                    log: log,
+                    debug: debug
+                };
+            },
+            function ($log) {
+                $log.error();
+                $log.warn();
+                $log.info();
+                $log.log();
+                $log.debug();
+                expect(logger).toEqual('error;warn;info;log;debug;');
+            }
+        ));
+    });
 });


### PR DESCRIPTION
Enhances the existing "debugEnabled" support in $log by providing the ability to configure a log level via $logProvider.  The log level works on a hierarchy system where the priority is:
           'off', 'error', 'warn', 'info', 'log', 'debug', 'all'

For example, when setting the log level to 'info', error, warn, and info messages are logged to the console (following the existing logic for checking if the console exists/etc).  For backwards compatibility, the existing debugEnabled logic was left in (marked deprecated) and simply delegated to the appropriate log level.

Test cases can be found in test/ng/logSpec.js including (again, legacy debug test cases were left in).
