### PR TITLE
test($browser): correct false positive in ApplicationSpec.js

### DIFF
--- a/test/ngScenario/ApplicationSpec.js
+++ b/test/ngScenario/ApplicationSpec.js
@@ -29,7 +29,7 @@ describe('angular.scenario.Application', function() {
       return {x:counter++, document:{x:counter++}};
     };
     app.navigateTo('http://www.google.com/');
-    app.executeAction(function($document, $window) {
+    app.executeAction(function($window, $document) {
       testWindow = $window;
       testDocument = $document;
     });


### PR DESCRIPTION
Previously, the check that Application should return a new $window and
$document had the arguments reversed in the first call to navigateTo;
thus, the subsequent check of inequality of $window and $document in the
next navigateTo call would always pass.

This corrects the argument order, which makes this test not succeptible
to false positives.
