### PR TITLE
fix(directive/select/ngOptions): ignore properties which start with $ or $$ when iterating over an object for ng-options

### DIFF
--- a/docs/content/tutorial/step_03.ngdoc
+++ b/docs/content/tutorial/step_03.ngdoc
@@ -69,7 +69,7 @@ available as a filter input in the list repeater (`phone in phones | filter:`__`
 changes to the data model cause the repeater's input to change, the repeater efficiently updates
 the DOM to reflect the current state of the model.
 
-      <img  class="diagram" src="img/tutorial/tutorial_03.png">
+<img  class="diagram" src="img/tutorial/tutorial_03.png">
 
 * Use of the `filter` filter: The {@link api/ng.filter:filter filter} function uses the
 `query` value to create a new array that contains only those records that match the `query`.

--- a/docs/content/tutorial/step_04.ngdoc
+++ b/docs/content/tutorial/step_04.ngdoc
@@ -45,7 +45,7 @@ We made the following changes to the `index.html` template:
 * First, we added a `<select>` html element named `orderProp`, so that our users can pick from the
 two provided sorting options.
 
-      <img  class="diagram" src="img/tutorial/tutorial_04.png">
+<img class="diagram" src="img/tutorial/tutorial_04.png">
 
 * We then chained the `filter` filter with {@link api/ng.filter:orderBy `orderBy`}
 filter to further process the input into the repeater. `orderBy` is a filter that takes an input

--- a/docs/content/tutorial/step_09.ngdoc
+++ b/docs/content/tutorial/step_09.ngdoc
@@ -94,7 +94,6 @@ describe('filter', function() {
 
   beforeEach(module('phonecatFilters'));
 
-
   describe('checkmark', function() {
 
     it('should convert boolean values to unicode checkmark or cross',
@@ -106,8 +105,12 @@ describe('filter', function() {
 });
 </pre>
 
-Note that you need to configure our test injector with the `phonecatFilters` module before any of
-our filter tests execute.
+We must call `beforeEach(module('phonecatFilters'))` before any of
+our filter tests execute. This call loads our `phonecatFilters` module into the injector
+for this test run.
+
+Note that we call the helper function, `inject(function(checkmarkFilter) { ... })`, to get
+access to the filter that we want to test.  See {@link api/angular.mock.inject angular.mock.inject()}.
 
 You should now see the following output in the Karma tab:
 

--- a/src/ng/directive/booleanAttrs.js
+++ b/src/ng/directive/booleanAttrs.js
@@ -165,7 +165,8 @@
     </doc:example>
  *
  * @element INPUT
- * @param {expression} ngDisabled Angular expression that will be evaluated.
+ * @param {expression} ngDisabled If the {@link guide/expression expression} is truthy, 
+ *     then special attribute "disabled" will be set on the element
  */
 
 
@@ -195,7 +196,8 @@
     </doc:example>
  *
  * @element INPUT
- * @param {expression} ngChecked Angular expression that will be evaluated.
+ * @param {expression} ngChecked If the {@link guide/expression expression} is truthy, 
+ *     then special attribute "checked" will be set on the element
  */
 
 
@@ -225,7 +227,8 @@
     </doc:example>
  *
  * @element INPUT
- * @param {string} expression Angular expression that will be evaluated.
+ * @param {expression} ngReadonly If the {@link guide/expression expression} is truthy, 
+ *     then special attribute "readonly" will be set on the element
  */
 
 
@@ -258,7 +261,8 @@
     </doc:example>
  *
  * @element OPTION
- * @param {string} expression Angular expression that will be evaluated.
+ * @param {expression} ngSelected If the {@link guide/expression expression} is truthy, 
+ *     then special attribute "selected" will be set on the element
  */
 
 /**
@@ -290,7 +294,8 @@
      </doc:example>
  *
  * @element DETAILS
- * @param {string} expression Angular expression that will be evaluated.
+ * @param {expression} ngOpen If the {@link guide/expression expression} is truthy, 
+ *     then special attribute "open" will be set on the element
  */
 
 var ngAttributeAliasDirectives = {};

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -429,6 +429,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
 
           // We now build up the list of options we need (we merge later)
           for (index = 0; length = keys.length, index < length; index++) {
+               if (keyName && keys[index].charAt(0) === '$') continue;
                locals[valueName] = values[keyName ? locals[keyName]=keys[index]:index];
                optionGroupName = groupByFn(scope, locals) || '';
             if (!(optionGroup = optionGroups[optionGroupName])) {

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -429,9 +429,16 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
 
           // We now build up the list of options we need (we merge later)
           for (index = 0; length = keys.length, index < length; index++) {
-               if (keyName && keys[index].charAt(0) === '$') continue;
-               locals[valueName] = values[keyName ? locals[keyName]=keys[index]:index];
-               optionGroupName = groupByFn(scope, locals) || '';
+            if (keyName) {
+              if (keys[index].charAt(0) === '$') continue;
+              var key = keys[index];
+              locals[keyName] = key;
+              locals[valueName] = values[key];
+            } else {
+              locals[valueName] = values[index];
+            }
+
+            optionGroupName = groupByFn(scope, locals) || '';
             if (!(optionGroup = optionGroups[optionGroupName])) {
               optionGroup = optionGroups[optionGroupName] = [];
               optionGroupNames.push(optionGroupName);

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -692,6 +692,21 @@ describe('select', function() {
       expect(jqLite(element.find('option')[0]).text()).toEqual('blank');
     });
 
+    it('should ignore $ and $$ properties', function() {
+      createSelect({
+        'ng-options': 'key as value for (key, value) in object',
+        'ng-model': 'selected'
+      });
+
+      scope.$apply(function() {
+        scope.object = {'regularProperty': 'visible', '$$private': 'invisible', '$property': 'invisible'};
+        scope.selected = 'regularProperty';
+      });
+
+      var options = element.find('option');
+      expect(options.length).toEqual(1);
+      expect(sortedHtml(options[0])).toEqual('<option value="regularProperty">visible</option>');
+    });
 
     describe('binding', function() {
 


### PR DESCRIPTION
When using `<select ng-options ...` with an object, the directive renders properties of the object even if they begin with `$` or `$$`. This means that when using `$resource` to `query()` a REST service for example, the directive renders the private `$then` and `$resolved` properties of the response object as `<option>`s. The `ng-repeat` directive includes a check to make sure it doesn't render properties beginning with `$` or `$$`, and this PR adds a similar check for `ng-options`.
