### PR TITLE
Added "replace" filter

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -37,6 +37,7 @@ angularFiles = {
     'src/ng/filter/filters.js',
     'src/ng/filter/limitTo.js',
     'src/ng/filter/orderBy.js',
+    'src/ng/filter/replace.js',
 
     'src/ng/directive/directives.js',
     'src/ng/directive/a.js',

--- a/src/ng/filter.js
+++ b/src/ng/filter.js
@@ -100,4 +100,5 @@ function $FilterProvider($provide) {
   register('number', numberFilter);
   register('orderBy', orderByFilter);
   register('uppercase', uppercaseFilter);
+  register('replace', replaceFilter);
 }

--- a/src/ng/filter/replace.js
+++ b/src/ng/filter/replace.js
@@ -1,0 +1,46 @@
+'use strict';
+
+/**
+ * @ngdoc filter
+ * @name ng.filter:replace
+ * @function
+ *
+ * @description
+ * Allows you to replace substrings in an expression with other expressions.
+ *
+ * This is useful when you have strings from a translation dictionary that require
+ * substrings to be replaced with expressions
+ *
+ * @param {object} A JavaScript object with key value pairs that represent from string keys and to values (expressions)
+ * @returns {string} String with all from's replaced by their to's
+ *
+ *
+ * @example:
+ <doc:example>
+ <doc:source>
+ <pre>{{ 'Hello %userName%' | replace:{'%userName%': user.userName} }}</pre>
+ </doc:source>
+ </doc:example>
+ *
+ */
+function replaceFilter(){
+  return function(input, replacements){
+
+    // Handle invalid replacements
+    if (!angular.isObject(replacements)) {
+      return input;
+    }
+
+    // Perform replacements
+    angular.forEach(replacements, function (to, from) {
+      if (to) {
+
+        // Convert to regular expression for global replacement
+        var regex = new RegExp(from, "g");
+        input = input.replace(regex, to);
+      }
+    });
+
+    return input;
+  };
+}

--- a/test/ng/filter/replaceSpec.js
+++ b/test/ng/filter/replaceSpec.js
@@ -1,0 +1,23 @@
+'use strict';
+
+ddescribe('replace filter', function() {
+
+  var filter;
+
+  beforeEach(inject(function($filter){
+    filter = $filter;
+  }));
+
+  it('should return input when no replacements passed', function() {
+      expect(filter('replace')('test')).toEqual('test');
+  });
+
+  it('should replace from with to', function() {
+    expect(filter('replace')('hello %user%', {'%user%': 'someName'})).toEqual('hello someName');
+  });
+
+  it('should accept multiple replacements', function() {
+    expect(filter('replace')('%hello% %user%', {'%hello%': 'hello', '%user%': 'someName'})).toEqual('hello someName');
+  });
+
+});


### PR DESCRIPTION
This PR adds a "replace" filter to replace substrings inside a string:

```
{{ 'Hello %name%' | replace:{'%name%': 'AngularJS'} }} // Will display "Hello AngularJS"
```

The filter accepts a plain JavaScript object as the only parameter with one or more key value pairs and also supports expressions as values like this:

```
{{ 'Hello %firstName% %lastName%' | replace:{'%firstName%': user.firstName, '%lastName%',  user.lastName} }} 
```

This is very handy for websites that need to support different languages and need to replace substrings in translations.

Replacements are also updated on-the-fly when the value expression(s) are changed thanks to the 2-way binding of AngularJS.

This PR also includes the unit tests for the filter.
