### PR TITLE
docs(docs.js): change deps array join to fix jsfiddle/plunkr examples

### DIFF
--- a/docs/src/templates/js/docs.js
+++ b/docs/src/templates/js/docs.js
@@ -375,7 +375,8 @@ docsApp.serviceFactory.prepareDefaultAppModule = function() {
     var moduleName = 'App';
     return {
       module : moduleName,
-      script : "angular.module('" + moduleName + "', ['" + deps.join("','") + "']);\n\n"
+      script : "angular.module('" + moduleName + "', [" + 
+          (deps.length ? "'" + deps.join("','") + "'" : "") + "]);\n\n"
     };
   };
 };


### PR DESCRIPTION
Change return value of docsApp.serviceFactory.prepareDefaultAppModule to include empty array `[]` instead of array containing one empty string element `['']`, for situations when the deps array is empty.

This will benefit plunkr/jsfiddle examples which lack animation or other dependencies, such as [ngChecked](http://docs.angularjs.org/api/ng.directive:ngChecked).

Current script.js sent to plunkr/jsfiddle when no deps exist: 

``` javascript
angular.module('App', ['']);
```

New script.js sent to plunkr/jsfiddle when no deps exist:

``` javascript
angular.module('App', []);
```
