### PR TITLE
fix($httpBackend): remove Content-Type header on DELETE requests

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -103,7 +103,7 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
         xhr.responseType = responseType;
       }
 
-      xhr.send(post || '');
+      xhr.send(post || null);
     }
 
     if (timeout > 0) {


### PR DESCRIPTION
Sending empty string with `XMLHttpRequest`'s `post` method causes browsers adding unneeded `Content-Type` request header on `DELETE` requests. Chrome adds `Content-Type:application/xml`, Firefox and IE adds `Content-Type text/plain`. Sending `null` insted of empty string fixes the problem.

More detail: https://github.com/angular/angular.js/issues/2149#issuecomment-22664501
