### PR TITLE
Fix animation progress event handling in browsers / devices tests.

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -659,7 +659,8 @@ angular.module('ngAnimate', ['ng'])
         }
 
         function onAnimationProgress(event) {
-          event.originalEvent.elapsedTime >= totalTime && done();
+          var e = event.originalEvent || event;
+          e.elapsedTime >= totalTime && done();
         }
 
         function parseMaxTime(str) {


### PR DESCRIPTION
Calling `event.elapsedTime` is correct in every browser and device I've tested on, `event.originalEvent.elapsedTime` seems only to be required for passing unit tests.
