### PR TITLE
Encoding of arrays in GET params.

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -966,16 +966,17 @@ function $HttpProvider() {
 
     function buildUrl(url, params) {
           if (!params) return url;
-          var parts = [];
+          var parts = [], valueIsArray;
           forEachSorted(params, function(value, key) {
             if (value == null || value == undefined) return;
-            if (!isArray(value)) value = [value];
+            valueIsArray = isArray(value);
+            if (!valueIsArray) value = [value];
 
             forEach(value, function(v) {
               if (isObject(v)) {
                 v = toJson(v);
               }
-              parts.push(encodeUriQuery(key) + '=' +
+              parts.push(encodeUriQuery(key) + (valueIsArray ? '[]=' : '=') +
                          encodeUriQuery(v));
             });
           });

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -438,8 +438,14 @@ describe('$http', function() {
 
 
       it('should expand arrays in params map', inject(function($httpBackend, $http) {
-          $httpBackend.expect('GET', '/url?a=1&a=2&a=3').respond('');
+          $httpBackend.expect('GET', '/url?a[]=1&a[]=2&a[]=3').respond('');
           $http({url: '/url', params: {a: [1,2,3]}, method: 'GET'});
+      }));
+
+
+      it('should expand short arrays in params map', inject(function($httpBackend, $http) {
+          $httpBackend.expect('GET', '/url?a[]=1').respond('');
+          $http({url: '/url', params: {a: [1]}, method: 'GET'});
       }));
 
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -139,7 +139,7 @@ describe("resource", function() {
 
   it('should encode array params', function() {
     var R = $resource('/Path/:a');
-    $httpBackend.expect('GET', '/Path/doh&foo?bar=baz1&bar=baz2').respond('{}');
+    $httpBackend.expect('GET', '/Path/doh&foo?bar[]=baz1&bar[]=baz2').respond('{}');
     R.get({a: 'doh&foo', bar: ['baz1', 'baz2']});
   });
 


### PR DESCRIPTION
**fix($http) change buildUrl to allow for better array support**

Arrays of length one would be sent a key-value pair (`{a:[1]}` -> `a=1`). On the server side an additional check would be required. Not all third party APIs have a check/autofix for this. Adding in `[]=` when value is an array fixes this issue (`{a:[1]}` -> `a[]=1`).
