### PR TITLE
feat(compile): replace of type `attributes`

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -430,8 +430,11 @@ compiler}. The attributes are:
     a string value representing the url.  In either case, the template URL is passed through {@link
     api/ng.$sce#getTrustedResourceUrl $sce.getTrustedResourceUrl}.
 
-  * `replace` - if set to `true` then the template will replace the current element, rather than
-    append the template to the element.
+  * `replace` - use the template to replace part of the current element.
+
+    * `true` - the template will replace the current element entirely.
+    * `'attributes'` - the template top level attributes will be merged with the current element. The
+      element content remains untouched. Anything at the template but the attributes are ignored.
 
   * `transclude` - compile the content of the element and make it available to the directive.
     Typically used with {@link api/ng.directive:ngTransclude

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -596,8 +596,9 @@ function $CompileProvider($provide) {
      *        the function returns.
      * @param attrs The shared attrs object which is used to populate the normalized attributes.
      * @param {number=} maxPriority Max directive priority.
+     * @param ignoreElementDirective if the element directive should not be collected
      */
-    function collectDirectives(node, directives, attrs, maxPriority, ignoreDirective) {
+    function collectDirectives(node, directives, attrs, maxPriority, ignoreDirective, ignoreElementDirective) {
       var nodeType = node.nodeType,
           attrsMap = attrs.$attr,
           match,
@@ -606,8 +607,10 @@ function $CompileProvider($provide) {
       switch(nodeType) {
         case 1: /* Element */
           // use the node name: <directive>
-          addDirective(directives,
-              directiveNormalize(nodeName_(node).toLowerCase()), 'E', maxPriority, ignoreDirective);
+          if (!ignoreElementDirective) {
+            addDirective(directives,
+                directiveNormalize(nodeName_(node).toLowerCase()), 'E', maxPriority, ignoreDirective);
+          }
 
           // iterate over the attributes
           for (var attr, name, nName, ngAttrName, value, nAttrs = node.attributes,
@@ -810,8 +813,10 @@ function $CompileProvider($provide) {
         }
 
         if (directive.template) {
-          assertNoDuplicate('template', templateDirective, directive, $compileNode);
-          templateDirective = directive;
+          if (directive.replace !== 'attributes') {
+            assertNoDuplicate('template', templateDirective, directive, $compileNode);
+            templateDirective = directive;
+          }
 
           directiveValue = (isFunction(directive.template))
               ? directive.template($compileNode, templateAttrs)
@@ -830,7 +835,9 @@ function $CompileProvider($provide) {
               throw $compileMinErr('tplrt', "Template for directive '{0}' must have exactly one root element. {1}", directiveName, '');
             }
 
-            replaceWith(jqCollection, $compileNode, compileNode);
+            if (directive.replace !== 'attributes') {
+              replaceWith(jqCollection, $compileNode, compileNode);
+            }
 
             var newTemplateAttrs = {$attr: {}};
 
@@ -843,7 +850,10 @@ function $CompileProvider($provide) {
                 collectDirectives(
                     compileNode,
                     directives.splice(i + 1, directives.length - (i + 1)),
-                    newTemplateAttrs
+                    newTemplateAttrs,
+                    undefined,
+                    undefined,
+                    directive.replace === 'attributes'
                 )
             );
             mergeTemplateAttributes(templateAttrs, newTemplateAttrs);
@@ -855,10 +865,12 @@ function $CompileProvider($provide) {
         }
 
         if (directive.templateUrl) {
-          assertNoDuplicate('template', templateDirective, directive, $compileNode);
-          templateDirective = directive;
+          if (directive.replace !== 'attributes') {
+            assertNoDuplicate('template', templateDirective, directive, $compileNode);
+            templateDirective = directive;
+          }
 
-          if (directive.replace) {
+          if (directive.replace !== 'attributes') {
             replaceDirective = directive;
           }
           nodeLinkFn = compileTemplateUrl(directives.splice(i, directives.length - i),
@@ -1158,7 +1170,9 @@ function $CompileProvider($provide) {
               ? origAsyncDirective.templateUrl($compileNode, tAttrs)
               : origAsyncDirective.templateUrl;
 
-      $compileNode.html('');
+      if (origAsyncDirective.replace !== 'attributes') {
+        $compileNode.html('');
+      }
 
       $http.get($sce.getTrustedResourceUrl(templateUrl), {cache: $templateCache}).
         success(function(content) {
@@ -1176,8 +1190,10 @@ function $CompileProvider($provide) {
             }
 
             tempTemplateAttrs = {$attr: {}};
-            replaceWith($rootElement, $compileNode, compileNode);
-            collectDirectives(compileNode, directives, tempTemplateAttrs);
+            if (origAsyncDirective.replace !== 'attributes') {
+              replaceWith($rootElement, $compileNode, compileNode);
+            }
+            collectDirectives(compileNode, directives, tempTemplateAttrs, undefined, undefined, origAsyncDirective.replace === 'attributes');
             mergeTemplateAttributes(tAttrs, tempTemplateAttrs);
           } else {
             compileNode = beforeTemplateCompileNode;


### PR DESCRIPTION
Found myself needing to create a form of _alias_ of a collection of attributes/directives to be applied to an element. Currently there is no way to cleanly create this alias, so make the compiler understand the value `'attribute'` for the property `replace` that, when present at a directive will:
- Take the attributes from the template and apply them to the element
- Keep the content of the element unmodified
- Ignore anything that is not an attribute at the template
