### PR TITLE
fix(ngdoc.js): update default directive @restrict to 'A' + add appropriate docs for ng.directives

### DIFF
--- a/docs/src/ngdoc.js
+++ b/docs/src/ngdoc.js
@@ -714,7 +714,7 @@ Doc.prototype = {
   html_usage_directive: function(dom){
     var self = this;
     dom.h('Usage', function() {
-      var restrict = self.restrict || 'AC';
+      var restrict = self.restrict || 'A';
 
       if (restrict.match(/E/)) {
         dom.html('<p>');

--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -302,7 +302,7 @@ var formDirectiveFactory = function(isNgForm) {
   return ['$timeout', function($timeout) {
     var formDirective = {
       name: 'form',
-      restrict: 'E',
+      restrict: isNgForm ? 'EAC' : 'E',
       controller: FormController,
       compile: function() {
         return {
@@ -351,7 +351,7 @@ var formDirectiveFactory = function(isNgForm) {
       }
     };
 
-    return isNgForm ? extend(copy(formDirective), {restrict: 'EAC'}) : formDirective;
+    return formDirective;
   }];
 };
 

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1165,7 +1165,6 @@ var ngModelDirective = function() {
 /**
  * @ngdoc directive
  * @name ng.directive:ngChange
- * @restrict E
  *
  * @description
  * Evaluate given expression when user changes the input.
@@ -1174,6 +1173,8 @@ var ngModelDirective = function() {
  * Note, this directive requires `ngModel` to be present.
  *
  * @element input
+ * @param {expression} ngChange {@link guide/expression Expression} to evaluate upon change
+ * in input value.
  *
  * @example
  * <doc:example>

--- a/src/ng/directive/ngBind.js
+++ b/src/ng/directive/ngBind.js
@@ -3,6 +3,7 @@
 /**
  * @ngdoc directive
  * @name ng.directive:ngBind
+ * @restrict AC
  *
  * @description
  * The `ngBind` attribute tells Angular to replace the text content of the specified HTML element

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -72,6 +72,7 @@ function classDirective(name, selector) {
 /**
  * @ngdoc directive
  * @name ng.directive:ngClass
+ * @restrict AC
  *
  * @description
  * The `ngClass` allows you to set CSS classes on HTML an element, dynamically, by databinding
@@ -210,6 +211,7 @@ var ngClassDirective = classDirective('', true);
 /**
  * @ngdoc directive
  * @name ng.directive:ngClassOdd
+ * @restrict AC
  *
  * @description
  * The `ngClassOdd` and `ngClassEven` directives work exactly as
@@ -257,6 +259,7 @@ var ngClassOddDirective = classDirective('Odd', 0);
 /**
  * @ngdoc directive
  * @name ng.directive:ngClassEven
+ * @restrict AC
  *
  * @description
  * The `ngClassOdd` and `ngClassEven` directives work exactly as

--- a/src/ng/directive/ngCloak.js
+++ b/src/ng/directive/ngCloak.js
@@ -3,6 +3,7 @@
 /**
  * @ngdoc directive
  * @name ng.directive:ngCloak
+ * @restrict AC
  *
  * @description
  * The `ngCloak` directive is used to prevent the Angular html template from being briefly

--- a/src/ng/directive/ngInit.js
+++ b/src/ng/directive/ngInit.js
@@ -3,6 +3,7 @@
 /**
  * @ngdoc directive
  * @name ng.directive:ngInit
+ * @restrict AC
  *
  * @description
  * The `ngInit` directive specifies initialization tasks to be executed

--- a/src/ng/directive/ngNonBindable.js
+++ b/src/ng/directive/ngNonBindable.js
@@ -3,6 +3,7 @@
 /**
  * @ngdoc directive
  * @name ng.directive:ngNonBindable
+ * @restrict AC
  * @priority 1000
  *
  * @description

--- a/src/ng/directive/ngStyle.js
+++ b/src/ng/directive/ngStyle.js
@@ -3,6 +3,7 @@
 /**
  * @ngdoc directive
  * @name ng.directive:ngStyle
+ * @restrict AC
  *
  * @description
  * The `ngStyle` directive allows you to set CSS style on an HTML element conditionally.

--- a/src/ng/directive/ngTransclude.js
+++ b/src/ng/directive/ngTransclude.js
@@ -3,6 +3,7 @@
 /**
  * @ngdoc directive
  * @name ng.directive:ngTransclude
+ * @restrict AC
  *
  * @description
  * Directive that marks the insertion point for the transcluded DOM of the nearest parent directive that uses transclusion.

--- a/src/ng/directive/script.js
+++ b/src/ng/directive/script.js
@@ -3,12 +3,12 @@
 /**
  * @ngdoc directive
  * @name ng.directive:script
+ * @restrict E
  *
  * @description
  * Load content of a script tag, with type `text/ng-template`, into `$templateCache`, so that the
  * template can be used by `ngInclude`, `ngView` or directive templates.
  *
- * @restrict E
  * @param {'text/ng-template'} type must be set to `'text/ng-template'`
  *
  * @example


### PR DESCRIPTION
The default restrict of a directive has been changed from `AC` to `A` awhile ago (and the guides have been updated to reflect that). 
But `ngdocs.js` still has it's default restrict set to `AC`

This generated a lot of wrong documentation, like [ngShow](http://code.angularjs.org/1.2.0rc1/docs/api/ng.directive:ngShow#Usage), where it's stated that it can be used as `AC`, when it's actually just `A` ([plunk](http://plnkr.co/edit/jRRqNuO1ikoTae0pv6kt?p=preview)).

---

This PR fixes the restrict in `ngdocs.js`. It also adds the correct `@restrict` to directives that need it.

Since I was fixing the usage of directives, I also fixed the `ngChange` usage, and simplified the `restrict` declaration of `form/ngForm`, all separated in their respective commits.

I've signed the CLA as Rodric Haddad
