### PR TITLE
fix(ngRepeat): allow multiple spaces before `in`

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -217,7 +217,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
     compile: function(element, attr, linker) {
       return function($scope, $element, $attr){
         var expression = $attr.ngRepeat;
-        var match = expression.match(/^\s*(.+)\s+in\s+(.*?)\s*(\s+track\s+by\s+(.+)\s*)?$/),
+        var match = expression.match(/^\s*(.+?)\s+in\s+(.*?)\s*(\s+track\s+by\s+(.+)\s*)?$/),
           trackByExp, trackByExpGetter, trackByIdFn, trackByIdArrayFn, trackByIdObjFn, lhs, rhs, valueIdentifier, keyIdentifier,
           hashFnLocals = {$id: hashKey};
 

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -59,6 +59,19 @@ describe('ngRepeat', function() {
   });
 
 
+  it('should allow multiple spaces between the identifer and `in`', function() {
+    element = $compile(
+      '<ul>' +
+        '<li ng-repeat="item   in items">{{item.name}};</li>' +
+      '</ul>')(scope);
+
+    scope.items = [{name: 'misko'}, {name:'shyam'}];
+    scope.$digest();
+    expect(element.find('li').length).toEqual(2);
+    expect(element.text()).toEqual('misko;shyam;');
+  });
+
+
   it('should iterate over an array-like object', function() {
     element = $compile(
       '<ul>' +


### PR DESCRIPTION
Allow ng-repeat to have multiple spaces between the identifier and the `in` keyword
