### PR TITLE
docs: update angular.copy for corner cases

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -598,7 +598,8 @@ function isLeafNode (node) {
  * * If no destination is supplied, a copy of the object or array is created.
  * * If a destination is provided, all of its elements (for array) or properties (for objects)
  *   are deleted and then all elements/properties from the source are copied to it.
- * * If  `source` is not an object or array, `source` is returned.
+ * * If `source` is not an object or array (inc. `null` and `undefined`), `source` is returned.
+ * * If `source` is identical to 'destination' an exception will be thrown. 
  *
  * Note: this function is used to augment the Object type in Angular expressions. See
  * {@link ng.$filter} for more information about Angular arrays.


### PR DESCRIPTION
The behaviour when null or undefined was passed was not clear.
The exception thrown when source == destination was not documented.
