### PR TITLE
feat($compile): support tel: links

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -153,7 +153,7 @@ function $CompileProvider($provide) {
       Suffix = 'Directive',
       COMMENT_DIRECTIVE_REGEXP = /^\s*directive\:\s*([\d\w\-_]+)\s+(.*)$/,
       CLASS_DIRECTIVE_REGEXP = /(([\d\w\-_]+)(?:\:([^;]+))?;?)/,
-      aHrefSanitizationWhitelist = /^\s*(https?|ftp|mailto|file):/,
+      aHrefSanitizationWhitelist = /^\s*(https?|ftp|mailto|tel|file):/,
       imgSrcSanitizationWhitelist = /^\s*(https?|ftp|file):|data:image\//;
 
   // Ref: http://developers.whatwg.org/webappapis.html#event-handler-idl-attributes

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3126,6 +3126,10 @@ describe('$compile', function() {
       $rootScope.$apply();
       expect(element.attr('href')).toBe('mailto:foo@bar.com');
 
+      $rootScope.testUrl = "tel:5558675309";
+      $rootScope.$apply();
+      expect(element.attr('href')).toBe('tel:5558675309');
+
       $rootScope.testUrl = "file:///foo/bar.html";
       $rootScope.$apply();
       expect(element.attr('href')).toBe('file:///foo/bar.html');


### PR DESCRIPTION
Allow tel: links so that click-to-call works in mobile browsers
