### PR TITLE
Fix infinite digest loop triggered by changing $location.path()

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -125,7 +125,8 @@ function Browser(window, document, $log, $sniffer) {
 
   var lastBrowserUrl = location.href,
       baseElement = document.find('base'),
-      replacedUrl = null;
+      replacedUrl = null,
+      ignoreHashChange = false;
 
   /**
    * @name ng.$browser#url
@@ -160,6 +161,8 @@ function Browser(window, document, $log, $sniffer) {
           baseElement.attr('href', baseElement.attr('href'));
         }
       } else {
+        // Flag to ignore hashchange events occasionally generated in Android 2.2, 2.3
+        ignoreHashChange = true;
         if (replace) {
           location.replace(url);
           replacedUrl = url;
@@ -167,6 +170,7 @@ function Browser(window, document, $log, $sniffer) {
           location.href = url;
           replacedUrl = null;
         }
+        ignoreHashChange = false;
       }
       return self;
     // getter
@@ -182,7 +186,7 @@ function Browser(window, document, $log, $sniffer) {
       urlChangeInit = false;
 
   function fireUrlChange() {
-    if (lastBrowserUrl == self.url()) return;
+    if (lastBrowserUrl == self.url() || ignoreHashChange) return;
 
     lastBrowserUrl = self.url();
     forEach(urlChangeListeners, function(listener) {


### PR DESCRIPTION
_Web apps that use the $route module will typically not work on Android 2.x without this fix._

On Android 2.x, using `$location.path()` to change the url occasionally triggers an infinite digest iterations exception for no good reason. 

The problem is caused by a faulty assumption in `$browser.onUrlChange()`. The assumption is that the `hashchange` event will fire only as a result of non-Angular actions, e.g. a human editing the browser's url. Unfortunately in Android 2.2 and 2.3, this event occasionally fires when Angular's own `$browser.url()` changes the url.

The knock-on effect is a race condition between $location's two monitoring loops: 
- One uses `$browser.onUrlChange()` to get notified about non-Angular url changes and synchs `$location`'s inner data.
- The other, `$locationWatch()`, watches for changes in `$location.absUrl()` and synchs them to `$browser`. 

They end up reversing each other's changes in a vicious cycle until Angular cuts them off. Meanwhile the browser gets stuck and goes nowhere.

Closes #3814 
