### PR TITLE
docs(ngModel): provide link for best practices.

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1129,6 +1129,10 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
  * current scope. If the property doesn't already exist on this scope, it will be created
  * implicitly and added to the scope.
  *
+ * For best practices on using `ngModel`, see:
+ *
+ *  - {@link https://github.com/angular/angular.js/wiki/Understanding-Scopes}
+ *
  * For basic examples, how to use `ngModel`, see:
  *
  *  - {@link ng.directive:input input}


### PR DESCRIPTION
The documentation for ngModel suggests the total opposite of the best practices outlined here: https://github.com/angular/angular.js/wiki/Understanding-Scopes

I added a link to the best practices in the docs.
