### PR TITLE
jsonp httpBackend callback fix if no data sent from the server throws an error ie9 failed

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -40,6 +40,7 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
     if (lowercase(method) == 'jsonp') {
       var callbackId = '_' + (callbacks.counter++).toString(36);
       callbacks[callbackId] = function(data) {
+		data = data || [];
         callbacks[callbackId].data = data;
       };
 

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -263,7 +263,7 @@ describe('$httpBackend', function() {
     it('should set the data to [] if no data is passed to the callback', function() {
 	  callback.andCallFake(function(status, response) {
 		  expect(status).toBe(200);
-		  expect(response).toBe([]);
+		  expect(response).toEqual([]);
 	  });
 
 	  $backend('JSONP', 'http://example.org/path?cb=JSON_CALLBACK', null, callback);

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -260,6 +260,29 @@ describe('$httpBackend', function() {
       expect(callback).toHaveBeenCalledOnce();
     });
 
+    it('should set the data to [] if no data is passed to the callback', function() {
+	  callback.andCallFake(function(status, response) {
+		  expect(status).toBe(200);
+		  expect(response).toBe([]);
+	  });
+
+	  $backend('JSONP', 'http://example.org/path?cb=JSON_CALLBACK', null, callback);
+
+	  var script = fakeDocument.$$scripts.shift(),
+		  url = script.src.match(SCRIPT_URL);
+
+	  expect(url[1]).toBe('http://example.org/path');
+	  callbacks[url[2]](undefined);
+
+	  if (script.onreadystatechange) {
+		  script.readyState = 'complete';
+		  script.onreadystatechange();
+	  } else {
+		  script.onload()
+	  }
+
+	  expect(callback).toHaveBeenCalledOnce();
+    });
 
     it('should clean up the callback and remove the script', function() {
       $backend('JSONP', 'http://example.org/path?cb=JSON_CALLBACK', null, callback);

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -260,6 +260,29 @@ describe('$httpBackend', function() {
       expect(callback).toHaveBeenCalledOnce();
     });
 
+    it('should set the data to [] if no data is passed to the callback', function() {
+	  callback.andCallFake(function(status, response) {
+		  expect(status).toBe(200);
+		  expect(response).toEqual([]);
+	  });
+
+	  $backend('JSONP', 'http://example.org/path?cb=JSON_CALLBACK', null, callback);
+
+	  var script = fakeDocument.$$scripts.shift(),
+		  url = script.src.match(SCRIPT_URL);
+
+	  expect(url[1]).toBe('http://example.org/path');
+	  callbacks[url[2]](undefined);
+
+	  if (script.onreadystatechange) {
+		  script.readyState = 'complete';
+		  script.onreadystatechange();
+	  } else {
+		  script.onload()
+	  }
+
+	  expect(callback).toHaveBeenCalledOnce();
+    });
 
     it('should clean up the callback and remove the script', function() {
       $backend('JSONP', 'http://example.org/path?cb=JSON_CALLBACK', null, callback);


### PR DESCRIPTION
added a default for data passed to the callback if the call of httpBackend is of type jsonp and there is null or undefined or empty string from the server to set the data to empty array - [], to avoid an error being thrown inside angular js - fixed broken test
