### PR TITLE
fix(ng-if): make ng-if evaluate things using javascript logic

### DIFF
--- a/src/ng/directive/ngIf.js
+++ b/src/ng/directive/ngIf.js
@@ -85,9 +85,9 @@ var ngIfDirective = ['$animate', function($animate) {
     $$tlb: true,
     link: function ($scope, $element, $attr, ctrl, $transclude) {
         var block, childScope, previousElements;
-        $scope.$watch($attr.ngIf, function ngIfWatchAction(value) {
+        $scope.$watch('!!(' + $attr.ngIf + ')', function ngIfWatchAction(value) {
 
-          if (toBoolean(value)) {
+          if (value) {
             if (!childScope) {
               $transclude(function (clone, newScope) {
                 childScope = newScope;

--- a/src/ng/directive/ngShowHide.js
+++ b/src/ng/directive/ngShowHide.js
@@ -162,8 +162,8 @@
  */
 var ngShowDirective = ['$animate', function($animate) {
   return function(scope, element, attr) {
-    scope.$watch(attr.ngShow, function ngShowWatchAction(value){
-      $animate[toBoolean(value) ? 'removeClass' : 'addClass'](element, 'ng-hide');
+    scope.$watch('!!(' + attr.ngShow + ')', function ngShowWatchAction(value){
+      $animate[value ? 'removeClass' : 'addClass'](element, 'ng-hide');
     });
   };
 }];
@@ -318,8 +318,8 @@ var ngShowDirective = ['$animate', function($animate) {
  */
 var ngHideDirective = ['$animate', function($animate) {
   return function(scope, element, attr) {
-    scope.$watch(attr.ngHide, function ngHideWatchAction(value){
-      $animate[toBoolean(value) ? 'addClass' : 'removeClass'](element, 'ng-hide');
+    scope.$watch('!!(' + attr.ngHide + ')', function ngHideWatchAction(value){
+      $animate[value ? 'addClass' : 'removeClass'](element, 'ng-hide');
     });
   };
 }];

--- a/test/BinderSpec.js
+++ b/test/BinderSpec.js
@@ -245,7 +245,7 @@ describe('Binder', function() {
 
     assertHidden(element);
 
-    $rootScope.hidden = 'false';
+    $rootScope.hidden = false;
     $rootScope.$apply();
 
     assertVisible(element);
@@ -264,7 +264,7 @@ describe('Binder', function() {
 
     assertVisible(element);
 
-    $rootScope.show = 'false';
+    $rootScope.show = false;
     $rootScope.$apply();
 
     assertHidden(element);

--- a/test/ng/directive/ngIfSpec.js
+++ b/test/ng/directive/ngIfSpec.js
@@ -136,6 +136,18 @@ describe('ngIf', function () {
     expect(element.text()).toBe('before;after;');
   });
 
+  it('should evaluate using javascript `truthy`/`falsy` logic', function () {
+    var cases = ['[]', 'f', [], [''], 'false', {}, function() {}, function(f) {}, 0, false, null, undefined, '', NaN];
+    element.append($compile(
+        '<div ng-if="value">Lucas</div>'
+    )($scope));
+    angular.forEach(cases, function(value) {
+      $scope.value = value;
+      $scope.$apply();
+      expect(element.text()).toBe(value ? 'Lucas' : '');
+    });
+  });
+
   it('should restore the element to its compiled state', function() {
     $scope.value = true;
     makeIf('value');

--- a/test/ng/directive/ngShowHideSpec.js
+++ b/test/ng/directive/ngShowHideSpec.js
@@ -38,6 +38,18 @@ describe('ngShow / ngHide', function() {
       $rootScope.$digest();
       expect(element).toBeShown();
     }));
+
+
+    it('should follow javascript `truthy`/`falsy` logic', inject(function($rootScope, $compile) {
+      var cases = ['[]', 'f', [], [''], 'false', {}, function() {}, function(f) {}, 0, false, null, undefined, '', NaN];
+      element = jqLite('<div ng-show="exp"></div>');
+      element = $compile(element)($rootScope);
+      angular.forEach(cases, function(value) {
+        $rootScope.exp = value;
+        $rootScope.$digest();
+        expect(element)[value ? 'toBeShown' : 'toBeHidden']();
+      });
+    }));
   });
 
   describe('ngHide', function() {
@@ -48,6 +60,18 @@ describe('ngShow / ngHide', function() {
       $rootScope.exp = true;
       $rootScope.$digest();
       expect(element).toBeHidden();
+    }));
+
+
+    it('should follow javascript `truthy`/`falsy` logic', inject(function($rootScope, $compile) {
+      var cases = ['[]', 'f', [], [''], 'false', {}, function() {}, function(f) {}, 0, false, null, undefined, '', NaN];
+      element = jqLite('<div ng-hide="exp"></div>');
+      element = $compile(element)($rootScope);
+      angular.forEach(cases, function(value) {
+        $rootScope.exp = value;
+        $rootScope.$digest();
+        expect(element)[value ? 'toBeHidden' : 'toBeShown']();
+      });
     }));
   });
 });


### PR DESCRIPTION
Make ng-if evaluate things using javascript logic
Do not reevaluate everything contained within an ng-if when there
is a change of the value of the ng-if, but the truthy of falsy value
does not change

Fixes #3969

BREAKING CHANGE: The expressions
- `<div ng-if="[]">X</div>`
- `<div ng-if="'f'">X</div>`
- `<div ng-if="'[]'">X</div>`

used to be evaluated to `false`
