### PR TITLE
fix for ngList: separator does not work - comma is used all the time

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1322,7 +1322,7 @@ var ngListDirective = function() {
       ctrl.$parsers.push(parse);
       ctrl.$formatters.push(function(value) {
         if (isArray(value)) {
-          return value.join(', ');
+          return value.join(separator);
         }
 
         return undefined;


### PR DESCRIPTION
ng-list="<separator>" does not work.
comma is hard-coded in formatters and is used all the time.
