### PR TITLE
Don't send empty String in place of no body

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -103,7 +103,7 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
         xhr.responseType = responseType;
       }
 
-      xhr.send(post || '');
+      xhr.send(post || null);
     }
 
     if (timeout > 0) {

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -68,6 +68,12 @@ describe('$httpBackend', function() {
     expect(xhr.$$async).toBe(true);
   });
 
+  it('should pass null to send if no body is set', function() {
+    $backend('GET', '/some-url', null, noop);
+    xhr = MockXhr.$$lastInstance;
+
+    expect(xhr.$$data).toBe(null);
+  });
 
   it('should normalize IE\'s 1223 status code into 204', function() {
     callback.andCallFake(function(status) {


### PR DESCRIPTION
XMLHttpRequest.send spec defines different semantics for an empty string as compared to null, any string, whether empty or not, should be sent with a Content-Type of text/plain, whereas null should have no Content-Type header set.  Since the user hasn't passed in content to send, the latter should be used.

See http://www.w3.org/TR/XMLHttpRequest/#the-send()-method

Combined with this bug in WebKit based browsers:

https://code.google.com/p/chromium/issues/detail?id=172802

This means when no body is supplied, the `Content-Type` ends up being application/xml, which for an empty String, means the body is invalid according to the content type.  This causes issues for web servers that automatically parse the body according to the declared content type, such as this issue in Play framework:

https://github.com/playframework/playframework/issues/1676
