### PR TITLE
Improve limitTo filter handling of non-integer limit values

### DIFF
--- a/src/ng/filter/limitTo.js
+++ b/src/ng/filter/limitTo.js
@@ -64,24 +64,10 @@
    </doc:example>
  */
 function limitToFilter() {
-  return function(input, limit) {
-    if (!isArray(input) && !isString(input)) return input;
-
+  return function (input, limit) {
     limit = int(limit);
-    var start, end;
+    if (!isArray(input) && !isString(input) || isNaN(limit)) return input;
 
-    if (isNaN(limit)) {
-      start = end = 0;
-    }
-    else if (limit >= 0) {
-      start = 0;
-      end = limit;
-    }
-    else {
-      start = limit;
-      end = undefined;
-    }
-
-    return input.slice(start, end);
+    return limit >=0 ? input.slice(0, limit) : input.slice(limit);
   }
 }

--- a/src/ng/filter/limitTo.js
+++ b/src/ng/filter/limitTo.js
@@ -63,42 +63,25 @@
      </doc:scenario>
    </doc:example>
  */
-function limitToFilter(){
+function limitToFilter() {
   return function(input, limit) {
     if (!isArray(input) && !isString(input)) return input;
-    
+
     limit = int(limit);
+    var start, end;
 
-    if (isString(input)) {
-      //NaN check on limit
-      if (limit) {
-        return limit >= 0 ? input.slice(0, limit) : input.slice(limit, input.length);
-      } else {
-        return "";
-      }
+    if (isNaN(limit)) {
+      start = end = 0;
+    }
+    else if (limit >= 0) {
+      start = 0;
+      end = limit;
+    }
+    else {
+      start = limit;
+      end = undefined;
     }
 
-    var out = [],
-      i, n;
-
-    // if abs(limit) exceeds maximum length, trim it
-    if (limit > input.length)
-      limit = input.length;
-    else if (limit < -input.length)
-      limit = -input.length;
-
-    if (limit > 0) {
-      i = 0;
-      n = limit;
-    } else {
-      i = input.length + limit;
-      n = input.length;
-    }
-
-    for (; i<n; i++) {
-      out.push(input[i]);
-    }
-
-    return out;
+    return input.slice(start, end);
   }
 }

--- a/test/ng/filter/limitToSpec.js
+++ b/test/ng/filter/limitToSpec.js
@@ -7,7 +7,7 @@ describe('Filter: limitTo', function() {
 
   beforeEach(inject(function($filter) {
     items = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
-    str = "tuvwxyz";
+    str = 'tuvwxyz';
     limitTo = $filter('limitTo');
   }));
 
@@ -15,33 +15,31 @@ describe('Filter: limitTo', function() {
   it('should return the first X items when X is positive', function() {
     expect(limitTo(items, 3)).toEqual(['a', 'b', 'c']);
     expect(limitTo(items, '3')).toEqual(['a', 'b', 'c']);
-    expect(limitTo(str, 3)).toEqual("tuv");
-    expect(limitTo(str, '3')).toEqual("tuv");
+    expect(limitTo(str, 3)).toEqual('tuv');
+    expect(limitTo(str, '3')).toEqual('tuv');
   });
 
 
   it('should return the last X items when X is negative', function() {
     expect(limitTo(items, -3)).toEqual(['f', 'g', 'h']);
     expect(limitTo(items, '-3')).toEqual(['f', 'g', 'h']);
-    expect(limitTo(str, -3)).toEqual("xyz");
-    expect(limitTo(str, '-3')).toEqual("xyz");
+    expect(limitTo(str, -3)).toEqual('xyz');
+    expect(limitTo(str, '-3')).toEqual('xyz');
   });
 
 
-  it('should return an empty array when X cannot be parsed', function() {
-    expect(limitTo(items, 'bogus')).toEqual([]);
-    expect(limitTo(items, 'null')).toEqual([]);
-    expect(limitTo(items, 'undefined')).toEqual([]);
-    expect(limitTo(items, null)).toEqual([]);
-    expect(limitTo(items, undefined)).toEqual([]);
+  it('should return no items when X is 0', function () {
+    expect(limitTo(items, 0)).toEqual([]);
+    expect(limitTo(str, 0)).toEqual('');
   });
 
-  it('should return an empty string when X cannot be parsed', function() {
-    expect(limitTo(str, 'bogus')).toEqual("");
-    expect(limitTo(str, 'null')).toEqual("");
-    expect(limitTo(str, 'undefined')).toEqual("");
-    expect(limitTo(str, null)).toEqual("");
-    expect(limitTo(str, undefined)).toEqual("");
+
+  it('should return the entire input when X cannot be parsed', function() {
+    expect(limitTo(items, 'bogus')).toEqual(items);
+    expect(limitTo(items, 'null')).toEqual(items);
+    expect(limitTo(items, 'undefined')).toEqual(items);
+    expect(limitTo(items, null)).toEqual(items);
+    expect(limitTo(items, undefined)).toEqual(items);
   });
 
 
@@ -61,6 +59,7 @@ describe('Filter: limitTo', function() {
 
     expect(limitTo(items, 9)).not.toBe(items);
   });
+
 
   it('should return the entire string if X exceeds input length', function() {
     expect(limitTo(str, 9)).toEqual(str);


### PR DESCRIPTION
Improve handling of non-integer limit values in limitTo filter, and simplify implementation. 

See https://github.com/angular/angular.js/issues/3560
