### PR TITLE
Fix Argentina Spanish currency

### DIFF
--- a/src/ngLocale/angular-locale_es-ar.js
+++ b/src/ngLocale/angular-locale_es-ar.js
@@ -62,7 +62,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [
@@ -85,10 +85,10 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "-",
-        "negSuf": "\u00a0\u00a4",
-        "posPre": "",
-        "posSuf": "\u00a0\u00a4"
+        "negPre": "- \u00a4",
+        "negSuf": "",
+        "posPre": "\u00a4",
+        "posSuf": ""
       }
     ]
   },


### PR DESCRIPTION
Argentina doesnt use the euro and currency labels are not post-fixed. 
http://en.wikipedia.org/wiki/Argentine_peso
