### PR TITLE
fix(ngScenario): click() and dblclick() no longer follow "void" hrefs

### DIFF
--- a/src/ngScenario/dsl.js
+++ b/src/ngScenario/dsl.js
@@ -344,6 +344,16 @@ angular.scenario.dsl('element', function() {
   ];
   var chain = {};
 
+  var hrefIsJavascriptCall = function(href) {
+    href = href.toLowerCase();
+    href.replace(/\s+/g, ' ');
+    if (href.substring(0, 11) == "javascript:") {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
   chain.count = function() {
     return this.addFutureAction("element '" + this.label + "' count", function($window, $document, done) {
       try {
@@ -360,7 +370,7 @@ angular.scenario.dsl('element', function() {
       var href = elements.attr('href');
       var eventProcessDefault = elements.trigger('click')[0];
 
-      if (href && elements[0].nodeName.toUpperCase() === 'A' && eventProcessDefault) {
+      if (href && !hrefIsJavascriptCall(href) && elements[0].nodeName.toUpperCase() === 'A' && eventProcessDefault) {
         this.application.navigateTo(href, function() {
           done();
         }, done);
@@ -376,7 +386,7 @@ angular.scenario.dsl('element', function() {
       var href = elements.attr('href');
       var eventProcessDefault = elements.trigger('dblclick')[0];
 
-      if (href && elements[0].nodeName.toUpperCase() === 'A' && eventProcessDefault) {
+      if (href && !hrefIsJavascriptCall(href) && elements[0].nodeName.toUpperCase() === 'A' && eventProcessDefault) {
         this.application.navigateTo(href, function() {
           done();
         }, done);

--- a/test/ngScenario/dslSpec.js
+++ b/test/ngScenario/dslSpec.js
@@ -315,6 +315,19 @@ describe("angular.scenario.dsl", function() {
         dealoc(elm);
       });
 
+      it('should not navigate if click was on anchor whose href starts with "javascript:"', function() {
+        $window.location = '#foo';
+        doc.append('<a id="first" href="javascript:void(0)" onclick=""></a>');
+        $root.dsl.element('first').click();
+        expect($window.location).toEqual('#foo');
+        doc.append('<a id="second" href="javascript:void(0);" onclick=""></a>');
+        $root.dsl.element('second').click();
+        expect($window.location).toEqual('#foo');
+        doc.append('<a id="third" href=" JavaScript: void(0) ;" onclick=""></a>');
+        $root.dsl.element('third').click();
+        expect($window.location).toEqual('#foo');
+      });
+
       it('should execute dblclick', function() {
         var clicked;
         // Hash is important, otherwise we actually
@@ -345,6 +358,19 @@ describe("angular.scenario.dsl", function() {
         $root.dsl.element('a').dblclick();
         expect($window.location).toBe(initLocation);
         dealoc(elm);
+      });
+
+      it('should not navigate if dblclick was on anchor whose href starts with "javascript:"', function() {
+        $window.location = '#foo';
+        doc.append('<a id="first" href="javascript:void(0)" onclick=""></a>');
+        $root.dsl.element('first').dblclick();
+        expect($window.location).toEqual('#foo');
+        doc.append('<a id="second" href="javascript:void(0);" onclick=""></a>');
+        $root.dsl.element('second').dblclick();
+        expect($window.location).toEqual('#foo');
+        doc.append('<a id="third" href=" JavaScript: void(0) ;" onclick=""></a>');
+        $root.dsl.element('third').dblclick();
+        expect($window.location).toEqual('#foo');
       });
 
       it('should execute mouseover', function() {


### PR DESCRIPTION
Add check for anchors where the href starts with "javascript:void(0)" and do
not navigate to such "locations"

Closes #4038
