### PR TITLE
fix($compile): ng-attr to support dash separated attribute names

### DIFF
--- a/docs/content/guide/dev_guide.services.$location.ngdoc
+++ b/docs/content/guide/dev_guide.services.$location.ngdoc
@@ -322,6 +322,14 @@ reload to the original link.
 - Links starting with '/' that lead to a different base path when base is defined<br>
   Example: `<a href="/not-my-base/link">link</a>`
 
+When running Angular in the root of a domain, along side perhaps a normal application in the same
+directory, the "otherwise" route handler will try to handle all the URLs, including ones that map
+to static files.
+
+To prevent this, you can set your base href for the app to `<base href=".">` and then prefix links
+to URLs that should be handled with `.`. Now, links to locations, which are not to be routed by Angular,
+are not prefixed with `.` and will not be intercepted by the `otherwise` rule in your `$routeProvider`.
+
 
 ### Server side
 

--- a/docs/content/guide/dev_guide.services.$location.ngdoc
+++ b/docs/content/guide/dev_guide.services.$location.ngdoc
@@ -330,6 +330,14 @@ To prevent this, you can set your base href for the app to `<base href=".">` and
 to URLs that should be handled with `.`. Now, links to locations, which are not to be routed by Angular,
 are not prefixed with `.` and will not be intercepted by the `otherwise` rule in your `$routeProvider`.
 
+When running Angular in the root of a domain, along side perhaps a normal application in the same
+directory, the "otherwise" route handler will try to handle all the URLs, including ones that map
+to static files.
+
+To prevent this, you can set your base href for the app to `<base href=".">` and then prefix links
+to URLs that should be handled with `.`. Now, links to locations, which are not to be routed by Angular,
+are not prefixed with `.` and will not be intercepted by the `otherwise` rule in your `$routeProvider`.
+
 
 ### Server side
 

--- a/docs/content/misc/faq.ngdoc
+++ b/docs/content/misc/faq.ngdoc
@@ -113,11 +113,12 @@ make our schwag will be happy to do a custom run for you, based on our existing 
 they'll waive the setup costs, and you can order any quantity you need.
 
 **Stickers**
-Contact Tom Witting (or anyone in sales) via email at tom@stickergiant.com, and tell him you want to order some AngularJS
+For orders of 250 stickers or more within Canada or the United States, contact Tom Witting (or anyone in sales) via email at tom@stickergiant.com, and tell him you want to order some AngularJS
 stickers just like the ones in job #42711. You'll have to give them your own info for billing and shipping.
 
 As long as the design stays exactly the same, {@link http://www.stickergiant.com StickerGiant} will give you a reorder discount.
 
+For a smaller order, or for other countries, we suggest downloading the logo artwork and making your own.
 
 ## Common Pitfalls
 

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -114,6 +114,16 @@ function camelCase(name) {
     replace(MOZ_HACK_REGEXP, 'Moz$1');
 }
 
+/**
+ * Converts camelCase and snake_case to dash-case.
+ * @param name Name to normalize
+ */
+function dashCase(name) {
+  return camelCase(name).
+    replace(/(\w)([A-Z])/g, '$1-$2').
+    toLowerCase();
+}
+
 /////////////////////////////////////////////
 // jQuery mutation patch
 //

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -663,7 +663,7 @@ function $CompileProvider($provide) {
               // support ngAttr attribute binding
               ngAttrName = directiveNormalize(name);
               if (NG_ATTR_BINDING.test(ngAttrName)) {
-                name = ngAttrName.substr(6).toLowerCase();
+                name = dashCase(ngAttrName.substr(6));
               }
               if ((index = ngAttrName.lastIndexOf('Start')) != -1 && index == ngAttrName.length - 5) {
                 attrStartName = name;

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -595,6 +595,38 @@ function $CompileProvider($provide) {
       }
     }
 
+    /**
+     * @ngdoc directive
+     * @name ng.directive:ngAttr
+     * @restrict A
+     *
+     * @description
+     * If an attribute with a binding is prefixed with ngAttr prefix
+     * (denormalized prefix: 'ng-attr-', 'ng:attr-') then during the
+     * compilation the prefix will be removed and the binding will be
+     * applied to an unprefixed attribute. This allows binding to
+     * attributes that would otherwise be eagerly processed by
+     * browsers in their uncompiled form (e.g. img[src] or svg's
+     * circle[cx] attributes).
+     *
+     * For example, considering template:
+     * <pre>
+     * <svg>
+     *   <circle ng-attr-cx="{{cx}}"></circle>
+     * </svg>
+     * </pre>
+     *
+     * and model cx set to 5, will result in rendering this dom:
+     * <pre>
+     * <svg>
+     *   <circle cx="5"></circle>
+     * </svg>
+     * </pre>
+     *
+     * If you were to bind {{cx}} directly to the cx attribute, you'd
+     * get the following error: Error: Invalid value for attribute
+     * cx="{{cx}}". With ng-attr-cx you can work around this problem.
+     */
 
     /**
      * Looks for directives on the given node and adds them to the directive collection which is

--- a/src/ng/directive/ngShowHide.js
+++ b/src/ng/directive/ngShowHide.js
@@ -6,7 +6,7 @@
  *
  * @description
  * The `ngShow` directive shows and hides the given HTML element conditionally based on the expression
- * provided to the ngShow attribute. The show and hide mechanism is a achieved by removing and adding
+ * provided to the ngShow attribute. The show and hide mechanism is achieved by removing and adding
  * the `ng-hide` CSS class onto the element. The `.ng-hide` CSS class is a predefined CSS class present
  * in AngularJS which sets the display style to none (using an !important flag).
  *

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -11,7 +11,7 @@ var $resourceMinErr = angular.$$minErr('$resource');
  *
  * `ngResource` is the name of the optional Angular module that adds support for interacting with
  * [RESTful](http://en.wikipedia.org/wiki/Representational_State_Transfer) server-side data sources.
- * `ngReource` provides the {@link ngResource.$resource `$resource`} serivce.
+ * `ngResource` provides the {@link ngResource.$resource `$resource`} service.
  *
  * {@installModule resource}
  *

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1352,6 +1352,31 @@ describe('jqLite', function() {
      expect(camelCase('-moz-foo-bar')).toBe('MozFooBar');
      expect(camelCase('-webkit-foo-bar')).toBe('webkitFooBar');
      expect(camelCase('-webkit-foo-bar')).toBe('webkitFooBar');
-   })
+   });
   });
+
+
+  describe('dashCase', function() {
+
+   it('should leave non-dashed strings alone', function() {
+     expect(dashCase('foo')).toBe('foo');
+     expect(dashCase('')).toBe('');
+   });
+
+   it('should preserve dashed strings', function() {
+     expect(dashCase('foo-bar')).toBe('foo-bar');
+     expect(dashCase('foo-bar-baz')).toBe('foo-bar-baz');
+   });
+
+   it('should covert camelCase strings to dash-case', function() {
+     expect(dashCase('fooBar')).toBe('foo-bar');
+     expect(dashCase('fooBarBaz')).toBe('foo-bar-baz');
+   });
+
+   it('should covert mixed separators to dash-case', function() {
+     expect(dashCase('foo:bar_baz')).toBe('foo-bar-baz');
+   });
+
+  });
+
 });

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3278,6 +3278,35 @@ describe('$compile', function() {
       expect(element.attr('test3')).toBe('Misko');
       expect(element.attr('test4')).toBe('Misko');
     }));
+
+    describe('when an attribute has a dash-separated name', function () {
+
+      it('should work with different prefixes', inject(function($compile, $rootScope) {
+        $rootScope.name = "JamieMason";
+        element = $compile('<span ng:attr:dash-test="{{name}}" ng-Attr-dash-test2="{{name}}" ng_Attr_dash-test3="{{name}}"></span>')($rootScope);
+        expect(element.attr('dash-test')).toBeUndefined();
+        expect(element.attr('dash-test2')).toBeUndefined();
+        expect(element.attr('dash-test3')).toBeUndefined();
+        $rootScope.$digest();
+        expect(element.attr('dash-test')).toBe('JamieMason');
+        expect(element.attr('dash-test2')).toBe('JamieMason');
+        expect(element.attr('dash-test3')).toBe('JamieMason');
+      }));
+
+      it('should work if they are prefixed with x- or data-', inject(function($compile, $rootScope) {
+        $rootScope.name = "JamieMason";
+        element = $compile('<span data-ng-attr-dash-test2="{{name}}" x-ng-attr-dash-test3="{{name}}" data-ng:attr-dash-test4="{{name}}"></span>')($rootScope);
+        expect(element.attr('dash-test2')).toBeUndefined();
+        expect(element.attr('dash-test3')).toBeUndefined();
+        expect(element.attr('dash-test4')).toBeUndefined();
+        $rootScope.$digest();
+        expect(element.attr('dash-test2')).toBe('JamieMason');
+        expect(element.attr('dash-test3')).toBe('JamieMason');
+        expect(element.attr('dash-test4')).toBe('JamieMason');
+      }));
+
+    });
+
   });
 
 


### PR DESCRIPTION
When compiling:

``` html
<div ng-attr-data-src="value"></div>
```

Currently Angular will output:

``` html
<div datasrc="value"></div>
```

This pull request and tests propose that Angular should output:

``` html
<div data-src="value"></div>
```

Please note that ahead of making my amends, there were 3 failing tests elsewhere in master, as per my comment on the mailing list at https://groups.google.com/d/msg/angular/54olurwDWJw/_b-6_G-hl74J.

Thank you.

Note: this is a new submission of #3798, fao: @petebacondarwin
