### PR TITLE
fix(docs): remove statement about isolated scopes and ngModelController

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -847,11 +847,7 @@ var VALID_CLASS = 'ng-valid',
  * specifically does not contain any logic which deals with DOM rendering or listening to
  * DOM events. The `NgModelController` is meant to be extended by other directives where, the
  * directive provides DOM manipulation and the `NgModelController` provides the data-binding.
- * Note that you cannot use `NgModelController` in a directive with an isolated scope,
- * as, in that case, the `ng-model` value gets put into the isolated scope and does not get
- * propogated to the parent scope.
- *
- *
+ * 
  * This example shows how to use `NgModelController` with a custom control to achieve
  * data-binding. Notice how different directives (`contenteditable`, `ng-model`, and `required`)
  * collaborate together to achieve the desired result.


### PR DESCRIPTION
It's obviously possible to use ngModelController in a directive that uses an isolated scope, so this sentence seems to be outdated.

E.g. the bootstrap datepicker does that:

https://github.com/angular-ui/bootstrap/blob/master/src/datepicker/datepicker.js#L131
