### PR TITLE
Add a $setDirty() method to NgModelController

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1069,6 +1069,26 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
 
   /**
    * @ngdoc function
+   * @name ng.directive:ngModel.NgModelController#$setPristine
+   * @methodOf ng.directive:ngModel.NgModelController
+   *
+   * @description
+   * Sets the control to dirty state.
+   *
+   * This method can be called to remove the 'ng-pristine' class and set the control to a dirty
+   * state (ng-dirty class).
+   */
+  this.$setDirty = function () {
+    if (this.$pristine) {
+      this.$dirty = true;
+      this.$pristine = false;
+      $element.removeClass(PRISTINE_CLASS).addClass(DIRTY_CLASS);
+      parentForm.$setDirty();
+    }
+  };
+
+  /**
+   * @ngdoc function
    * @name ng.directive:ngModel.NgModelController#$setViewValue
    * @methodOf ng.directive:ngModel.NgModelController
    *
@@ -1088,12 +1108,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
     this.$viewValue = value;
 
     // change to dirty
-    if (this.$pristine) {
-      this.$dirty = true;
-      this.$pristine = false;
-      $element.removeClass(PRISTINE_CLASS).addClass(DIRTY_CLASS);
-      parentForm.$setDirty();
-    }
+    this.$setDirty();
 
     forEach(this.$parsers, function(fn) {
       value = fn(value);


### PR DESCRIPTION
As it was done for FormController.$setPristine, I would like to propose to add the $setDirty() method on NgModelController.

There is one concrete case where this is useful: Suppose you have a form with different inputs, some being required/minlength/pattern-based/... If the user clicks the Submit button, he won't see which inputs are actually invalid.

See example:
http://jsfiddle.net/lastnico/P6gh5/

Note that the CSS is designed on purpose to only mark .ng-dirty.ng-invalid inputs as red, just to not scare the user immediately with tons of red things while he did not even click anything.

By having a way to do a $setDirty() programmatically on each NgModelController, we will give the user a feedback on what's wrong (An even better solution would be to have a FormController.$setDirty() function that would notify deeper elements instead of going up in its hierarchy (as it currently does)).
