### PR TITLE
encode uri: Matrix urls, semicolons fix 4065

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -307,6 +307,7 @@ angular.module('ngResource', ['ng']).
     function encodeUriSegment(val) {
       return encodeUriQuery(val, true).
         replace(/%26/gi, '&').
+        replace(/%3B/gi, ';').
         replace(/%3D/gi, '=').
         replace(/%2B/gi, '+');
     }

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -137,6 +137,18 @@ describe("resource", function() {
   });
 
 
+  it('should not encode ; in url params', function() {
+   //encodeURIComponent is too agressive and doesn't follow http://www.ietf.org/rfc/rfc3986.txt
+   //with regards to the character set (pchar) allowed in path segments
+   //so we need this test to make sure that we don't over-encode the params and break stuff like
+   //buzz api which uses @self
+
+   var R = $resource('/Path/:a/semicolon');
+   $httpBackend.expect('GET', '/Path/a=a;b=b;c=x/semicolon').respond('{}');
+   R.get({a: 'a=a;b=b;c=x'});
+  });
+
+
   it('should encode array params', function() {
     var R = $resource('/Path/:a');
     $httpBackend.expect('GET', '/Path/doh&foo?bar=baz1&bar=baz2').respond('{}');


### PR DESCRIPTION
Solved issue 4065, Support for Matrix URIs
https://github.com/angular/angular.js/issues/4065
- added ; to the list of replacements
- added a unit test
