### PR TITLE
fix(ngInclude): fix regression when ngInclude is present on an element with interpolated attributes

### DIFF
--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -153,6 +153,7 @@ var ngIncludeDirective = ['$http', '$templateCache', '$anchorScroll', '$compile'
                   function($http,   $templateCache,   $anchorScroll,   $compile,   $animate,   $sce) {
   return {
     restrict: 'ECA',
+    priority: 500,
     terminal: true,
     transclude: 'element',
     compile: function(element, attr, transclusion) {

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -281,6 +281,32 @@ describe('ngInclude', function() {
   }));
 
 
+  it('should work when placed on an anchor link', inject(function($compile, $rootScope, $httpBackend) {
+    // regression #3793
+
+    element = $compile('<div><a ng-href="#/{{hrefUrl}}" ng:include="includeUrl"></a></div>')($rootScope);
+    $httpBackend.expect('GET', 'url1').respond('template text 1');
+    $rootScope.hrefUrl = 'fooUrl1';
+    $rootScope.includeUrl = 'url1';
+    $rootScope.$digest();
+    $httpBackend.flush();
+    expect(element.text()).toBe('template text 1');
+    expect(element.find('a').attr('href')).toBe('#/fooUrl1');
+
+    $httpBackend.expect('GET', 'url2').respond('template text 2');
+    $rootScope.includeUrl = 'url2';
+    $rootScope.$digest();
+    $httpBackend.flush();
+    expect(element.text()).toBe('template text 2');
+    expect(element.find('a').attr('href')).toBe('#/fooUrl1');
+
+    $rootScope.hrefUrl = 'fooUrl2';
+    $rootScope.$digest();
+    expect(element.text()).toBe('template text 2');
+    expect(element.find('a').attr('href')).toBe('#/fooUrl2');
+  }));
+
+
   describe('autoscoll', function() {
     var autoScrollSpy;
 


### PR DESCRIPTION
Not sure what the right priority should be. `100` was too low, `1000` would have put this as the same priority as `ngRepeat`, `500` made the tests happy.

I also added a regression test.

Closes #3793
