### PR TITLE
Add ordinal suffix option to date filter.

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -218,6 +218,13 @@ function dateStrGetter(name, shortForm) {
   };
 }
 
+function dateOrdinalGetter(date) {
+  var date = date.getDate();
+
+  // http://stackoverflow.com/a/6003581/1226469
+  return (date > 3 && date < 21 ? 'th' : {1: 'st', 2: 'nd', 3: 'rd'}[date % 10] || 'th');
+}
+
 function timeZoneGetter(date) {
   var zone = -1 * date.getTimezoneOffset();
   var paddedZone = (zone >= 0) ? "+" : "";
@@ -256,10 +263,11 @@ var DATE_FORMATS = {
   EEEE: dateStrGetter('Day'),
    EEE: dateStrGetter('Day', true),
      a: ampmGetter,
+     S: dateOrdinalGetter,
      Z: timeZoneGetter
 };
 
-var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|Z))(.*)/,
+var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaSZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|S|Z))(.*)/,
     NUMBER_STRING = /^\d+$/;
 
 /**
@@ -293,6 +301,7 @@ var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+
  *   * `'s'`: Second in minute (0-59)
  *   * `'.sss' or ',sss'`: Millisecond in second, padded (000-999)
  *   * `'a'`: am/pm marker
+ *   * `'S'`: 2 character English suffix for the day of the month (st, nd, rd, th)
  *   * `'Z'`: 4 digit (+sign) representation of the timezone offset (-1200-+1200)
  *
  *   `format` string can also be one of the following predefined

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -242,8 +242,35 @@ describe('filters', function() {
       expect(date(noon, "EEEE, MMMM dd, yyyy")).
                       toEqual('Friday, September 03, 2010');
 
-      expect(date(earlyDate, "MMMM dd, y")).
-                      toEqual('September 03, 1');
+      expect(date(earlyDate, "MMMM ddS, y")).
+                      toEqual('September 03rd, 1');
+    });
+
+    it('should get ordinal suffixes right', function() {
+      var first = new angular.mock.TzDate(+5, '1986-09-01T12:05:08.001Z'),
+          second = new angular.mock.TzDate(+5, '1986-09-02T12:05:08.001Z'),
+          third = new angular.mock.TzDate(+5, '1986-09-03T12:05:08.001Z'),
+          fourth = new angular.mock.TzDate(+5, '1986-09-04T12:05:08.001Z'),
+          twenty_second = new angular.mock.TzDate(+5, '1986-09-22T12:05:08.001Z'),
+          thirtyth = new angular.mock.TzDate(+5, '1986-09-30T12:05:08.001Z');
+
+      expect(date(first, "EEEE MMMM ddS yyyy")).
+                       toEqual('Monday September 01st 1986');
+
+      expect(date(second, "MMMM - ddS")).
+                       toEqual('September - 02nd');
+
+      expect(date(third, "EEE, MMM, ddS, yyyy")).
+                       toEqual('Wed, Sep, 03rd, 1986');
+
+      expect(date(fourth, "ddS yyyy")).
+                       toEqual('04th 1986');
+
+      expect(date(twenty_second, "ddS yyyy")).
+                       toEqual('22nd 1986');
+
+      expect(date(thirtyth, "EEEE, MMMM ddS")).
+                       toEqual('Tuesday, September 30th');
     });
 
     it('should format timezones correctly (as per ISO_8601)', function() {


### PR DESCRIPTION
I added the S character option for ordinal date suffixes, which let's you do things like `September the 3rd` or `December the 15th`. (It seems like [quite a few other people wanted it](http://docs.angularjs.org/api/ng.filter:date#comment-708492975) too.)

Cheers, Dave.
