### PR TITLE
fix($location): $locationChangeStart/preventDefault bug

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -572,7 +572,7 @@ function $LocationProvider(){
     $browser.onUrlChange(function(newUrl) {
       if ($location.absUrl() != newUrl) {
         if ($rootScope.$broadcast('$locationChangeStart', newUrl, $location.absUrl()).defaultPrevented) {
-          $browser.url($location.absUrl());
+          $browser.url($location.absUrl(), true);
           return;
         }
         $rootScope.$evalAsync(function() {


### PR DESCRIPTION
When a $locationChangeStart that results from a url change is canceled, it should reset the browser url with a replaceState rather than a pushState.
