### PR TITLE
fix(ngAnimate): fix regression with animations on translate properties

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -203,7 +203,7 @@ angular.module('ngAnimate', ['ng'])
     var rootAnimateState = {running:true};
     $provide.decorator('$animate', ['$delegate', '$injector', '$sniffer', '$rootElement', '$timeout', '$rootScope',
                             function($delegate,   $injector,   $sniffer,   $rootElement,   $timeout,   $rootScope) {
-        
+
       $rootElement.data(NG_ANIMATE_STATE, rootAnimateState);
 
       function lookup(name) {
@@ -618,9 +618,12 @@ angular.module('ngAnimate', ['ng'])
           var node = element[0];
 
           //temporarily disable the transition so that the enter styles
-          //don't animate twice (this is here to avoid a bug in Chrome/FF).
-          node.style[w3cTransitionProp + propertyKey] = 'none';
-          node.style[vendorTransitionProp + propertyKey] = 'none';
+          //that are not translations don't animate twice
+          //(this is here to avoid a bug in Chrome/FF).
+          if (propertyKey.indexOf('translate') === -1) {
+            node.style[w3cTransitionProp + propertyKey] = 'none';
+            node.style[vendorTransitionProp + propertyKey] = 'none';
+          }
 
           var activeClassName = '';
           forEach(className.split(' '), function(klass, i) {


### PR DESCRIPTION
1.2.0rc1 induced a fix that prevented animations from running twice, but this had the unintended consequence of causing animations on translate, translateX, and translateY to sometimes not run. This fix checks for those cases and only applies the work-around when appropriate.

My only issue is that I'm not sure how to (or if we even can) test this.

Closes #3933
