### PR TITLE
fix(ngInput): When 'name' attribute is a property name, '$name' should be evaluated to the property value

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -971,7 +971,12 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
   this.$dirty = false;
   this.$valid = true;
   this.$invalid = false;
-  this.$name = $attr.name;
+  try {
+    var attrName = $scope.$eval($attr.name);
+    this.$name = isUndefined(attrName) ? $attr.name : attrName;
+  } catch (e) {
+    this.$name = $attr.name;
+  }
 
   var ngModelGet = $parse($attr.ngModel),
       ngModelSet = ngModelGet.assign;

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -27,12 +27,12 @@ describe('NgModelController', function() {
   });
 
 
-  it('should fail on non-assignable model binding', inject(function($controller) {
+  it('should fail on non-assignable model binding', inject(function($controller, $rootScope) {
     var exception;
 
     try {
       $controller(NgModelController, {
-        $scope: null,
+        $scope: $rootScope,
         $element: jqLite('<input ng-model="1+2">'),
         $attrs: {
           ngModel: '1+2'
@@ -61,6 +61,15 @@ describe('NgModelController', function() {
 
     expect(ctrl.$name).toBe('testAlias');
   });
+
+  it('should use the property value when name is a property name', inject(function($controller, $rootScope) {
+    var scope = $rootScope.$new();
+    scope.testAlias = 'myAlias';
+    var controller = $controller(NgModelController, {
+      $scope: scope, $element: element.find('input'), $attrs: {name: 'testAlias', ngModel: 'value'}
+    });
+    expect(controller.$name).toBe(scope.testAlias);
+  }));
 
 
   describe('setValidity', function() {


### PR DESCRIPTION
Not exactly sure if this is a bug fix or a feature enhancement. For simple cases such as the following, it works:

``` html
<form name="myForm">
    User name: <input type="text" name="userName" ng-model="user.name" required>
    <span class="error" ng-show="myForm.userName.$error.required">Required!</span>
</form>
```

But if the `<input>` is dynamically generated and the `name` is a scope property, it run into issue:

``` html
<form name="myForm">
    <div ng-repeat="field in formFields">
        <span>{{field.label}}</span>
        <input type="text" name="{{field.name}}" required>
        <span class="error" ng-show="myForm[field.name].$error.required">Required!</span>
    </div>
</form>
```
