### PR TITLE
feat(filter): allow map of filters to be registered in $FilterProvider

### DIFF
--- a/src/ng/filter.js
+++ b/src/ng/filter.js
@@ -79,7 +79,13 @@ function $FilterProvider($provide) {
   var suffix = 'Filter';
 
   function register(name, factory) {
-    return $provide.factory(name + suffix, factory);
+    if(isObject(name)) {
+      forEach(name, function(filter, key) {
+        register(key, filter);
+      });
+    } else {
+      return $provide.factory(name + suffix, factory);
+    }
   }
   this.register = register;
 

--- a/test/ng/filterSpec.js
+++ b/test/ng/filterSpec.js
@@ -1,0 +1,53 @@
+'use strict';
+
+describe('$filter', function() {
+  var $filterProvider, $filter;
+
+  beforeEach(module(function(_$filterProvider_) {
+    $filterProvider = _$filterProvider_;
+  }));
+
+  beforeEach(inject(function(_$filter_) {
+    $filter = _$filter_;
+  }));
+
+  describe('provider', function() {
+    it('should allow registration of filters', function() {
+      var FooFilter = function() {
+        return function() {
+          return 'foo';
+        }
+      };
+
+      $filterProvider.register('foo', FooFilter);
+
+      var fooFilter = $filter('foo');
+      expect(fooFilter()).toBe('foo');
+    });
+
+    it('should allow registration of a map of filters', function() {
+      var FooFilter = function() {
+        return function() {
+          return 'foo';
+        }
+      };
+
+      var BarFilter = function() {
+        return function() {
+          return 'bar';
+        }
+      };
+
+      $filterProvider.register({
+        'foo': FooFilter,
+        'bar': BarFilter
+      });
+
+      var fooFilter = $filter('foo');
+      expect(fooFilter()).toBe('foo');
+
+      var barFilter = $filter('bar');
+      expect(barFilter()).toBe('bar');
+    });
+  });
+});


### PR DESCRIPTION
This feature adds similar functionality to what `$ControllerProvider.register` and `$CompileProvider.directive` currently provide by allowing a map of filter name/factories to be passed as the sole argument to `$FilterProvider.register` to register all of the specified filters.

Closes #4036
