### PR TITLE
chore(angular.toJson): use charAt instead of regexp

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -781,7 +781,7 @@ function bind(self, fn) {
 function toJsonReplacer(key, value) {
   var val = value;
 
-  if (/^\$+/.test(key)) {
+  if (typeof key === 'string' && key.charAt(0) === '$') {
     val = undefined;
   } else if (isWindow(value)) {
     val = '$WINDOW';


### PR DESCRIPTION
Regular Expressions is an expensive operation and this case can be simplified. Here's a comparison: http://jsperf.com/check-first-char
Using charAt is better than using brackets, explanation of this can be found here http://stackoverflow.com/questions/5943726/string-charatx-or-stringx/5943760#5943760
