### PR TITLE
fix($location): compatibility with SVG anchors

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -515,8 +515,8 @@ function $LocationProvider(){
     }
   };
 
-  this.$get = ['$rootScope', '$browser', '$sniffer', '$rootElement',
-      function( $rootScope,   $browser,   $sniffer,   $rootElement) {
+  this.$get = ['$rootScope', '$browser', '$sniffer', '$rootElement', '$window',
+      function( $rootScope,   $browser,   $sniffer,   $rootElement,   $window) {
     var $location,
         LocationMode,
         baseHref = $browser.baseHref(), // if base[href] is undefined, it defaults to ''
@@ -548,6 +548,13 @@ function $LocationProvider(){
       }
 
       var absHref = elm.prop('href');
+
+      // If this was an anchor element in an SVG, it'll need to be unpacked.
+      if ($window.SVGAnimatedString &&
+          absHref instanceof $window.SVGAnimatedString) {
+        absHref = absHref.animVal;
+      }
+
       var rewrittenUrl = $location.$$rewrite(absHref);
 
       if (absHref && !elm.attr('target') && rewrittenUrl && !event.isDefaultPrevented()) {

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1326,6 +1326,50 @@ describe('$location', function() {
       })
     );
 
+    // don't run next tests on IE<9, as SVG isn't supported
+    if (!(msie < 9)) {
+     it('should listen on click events on href and prevent browser default in hashbang mode in svg', function() {
+        module(function() {
+          return function($rootElement, $compile, $rootScope) {
+            // innerHTML isn't available in SVGs and jqLite doesn't handle namespaced elements
+            $rootElement.html('');
+
+            var svgNs = "http://www.w3.org/2000/svg";
+            var svg = document.createElementNS(svgNs, 'svg');
+            $rootElement[0].appendChild(svg);
+
+            var a = document.createElementNS(svgNs, 'a');
+            a.setAttributeNS('http://www.w3.org/1999/xlink', 'href', 'http://server/#/somePath');
+            a.textContent = 'link';
+            svg.appendChild(a);
+
+            $compile($rootElement)($rootScope);
+            jqLite(document.body).append($rootElement);
+          }
+        });
+
+        inject(function($location, $rootScope, $browser, $rootElement) {
+          var log = '',
+              link = $rootElement.find('a');
+
+
+          $rootScope.$on('$locationChangeStart', function(event) {
+            event.preventDefault();
+            log += '$locationChangeStart';
+          });
+          $rootScope.$on('$locationChangeSuccess', function() {
+            throw new Error('after cancellation in hashbang mode');
+          });
+
+          browserTrigger(link, 'click');
+
+          expect(log).toEqual('$locationChangeStart');
+          expect($browser.url()).toEqual('http://server/');
+
+          dealoc($rootElement);
+        });
+      });
+    }
 
    it('should listen on click events on href and prevent browser default in hashbang mode', function() {
       module(function() {


### PR DESCRIPTION
In SVGs, the `href` property of an anchor element is a `SVGAnimatedString`, so it needs to be unpacked.

Demonstration of this problem: http://jsfiddle.net/sirhc/MKQnM/

Fixes #1420 .
