### PR TITLE
Fixed a lil typo

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -67,7 +67,7 @@
  *
  * ### Events
  * - `$destroy` - AngularJS intercepts all jqLite/jQuery's DOM destruction apis and fires this event
- *    on all DOM nodes being removed.  This can be used to clean up and 3rd party bindings to the DOM
+ *    on all DOM nodes being removed.  This can be used to clean up any 3rd party bindings to the DOM
  *    element before it is removed.
  * ### Methods
  * - `controller(name)` - retrieves the controller of the current element or its parent. By default


### PR DESCRIPTION
Here was the previous sentence:

"This can be used to clean up and 3rd party bindings to the DOM element before it is removed."

Changed "and" to "any"
