### PR TITLE
Prevent <code> elements from wrapping to the next line

### DIFF
--- a/docs/src/templates/css/docs.css
+++ b/docs/src/templates/css/docs.css
@@ -111,6 +111,7 @@
   padding: 0;
   font-size: inherit;
   font-family: monospace;
+  white-space: nowrap;
 }
 
 .content h2,


### PR DESCRIPTION
Prevent code wrapping to the next line like here:
![code_nowrap](https://f.cloud.github.com/assets/259753/1190611/a802c1d8-2439-11e3-95aa-083d83776dc9.png)
