### PR TITLE
chore(select): fix migrate warning for jQuery.fn.attr('selected')

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -533,7 +533,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
                   // rather then the element.
                   (element = optionTemplate.clone())
                       .val(option.id)
-                      .attr('selected', option.selected)
+                      .prop('selected', option.selected)
                       .text(option.label);
                 }
 


### PR DESCRIPTION
Full listing of jQuery migrate warning can be found here - [https://github.com/jquery/jquery-migrate/blob/master/warnings.md](https://github.com/jquery/jquery-migrate/blob/master/warnings.md)

Closes #4107
