### PR TITLE
fix($routeProvider): when redirectTo exist should return

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -470,10 +470,11 @@ function $RouteProvider(){
             if (isString(next.redirectTo)) {
               $location.path(interpolate(next.redirectTo, next.params)).search(next.params)
                        .replace();
-            } else {
+            } else if (isFunction(next.redirectTo)) {
               $location.url(next.redirectTo(next.pathParams, $location.path(), $location.search()))
                        .replace();
             }
+            return;
           }
         }
 

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -824,6 +824,28 @@ describe('$route', function() {
             .toEqual(['http://server/#/bar/id3?extra=eId', true]);
       });
     });
+
+    it('should return immediately when redirectTo exist', function() {
+      module(function($routeProvider) {
+        $routeProvider.when('/bar/:id', {templateUrl: 'bar.html'});
+        $routeProvider.when('/foo/:id/:extra', {
+          redirectTo: '/bar/:id',
+          resolve: { notBeCalled: function() {} }
+        });
+      });
+      inject(function($browser, $route, $location, $rootScope) {
+        var $browserUrl = spyOnlyCallsWithArgs($browser, 'url').andCallThrough();
+        var route = $route.routes['/foo/:id/:extra'];
+
+        spyOn(route.resolve, 'notBeCalled');
+
+        $location.path('/foo/id3/eId');
+        $rootScope.$digest();
+
+        expect($location.path()).toEqual('/bar/id3');
+        expect(route.resolve.notBeCalled).not.toHaveBeenCalled()
+      })
+    })
   });
 
 


### PR DESCRIPTION
After check redirectTo exist, we should return to prevent below code load unnecessarity requests.
