### PR TITLE
fix(a): make anchors in SVGs work

### DIFF
--- a/src/ng/directive/a.js
+++ b/src/ng/directive/a.js
@@ -35,7 +35,10 @@ var htmlAnchorDirective = valueFn({
     return function(scope, element) {
       element.on('click', function(event){
         // if we have no href url, then don't navigate anywhere.
-        if (!element.attr('href')) {
+        if (!element.attr('href') &&
+            // Links in SVGs use the xlink namespace
+            (!element[0].getAttributeNS ||
+             !element[0].getAttributeNS('http://www.w3.org/1999/xlink', 'href'))) {
           event.preventDefault();
         }
       });

--- a/test/ng/directive/aSpec.js
+++ b/test/ng/directive/aSpec.js
@@ -49,6 +49,79 @@ describe('a', function() {
     expect(document.location.href).toEqual(orgLocation);
   });
 
+  // don't run next tests on IE<9, as SVG isn't supported
+  if (!(msie < 9)) {
+    it('should prevent default action to be executed when xlink namespaced href is empty', function() {
+      var orgLocation = document.location.href,
+          preventDefaultCalled = false,
+          event;
+
+      var svgNs = 'http://www.w3.org/2000/svg';
+      var svg = document.createElementNS(svgNs, 'svg');
+
+      var a = document.createElementNS(svgNs, 'a');
+      var xlinkNs = 'http://www.w3.org/1999/xlink';
+      a.setAttributeNS(xlinkNs,
+                       // Note prefix specified here. It's optional but when
+                       // added breaks before this fix.
+                       'xlink:href',
+                       '');
+      a.textContent = 'empty link';
+      svg.appendChild(a);
+
+      element = $compile(svg)($rootScope);
+
+      event = document.createEvent('MouseEvent');
+      event.initMouseEvent(
+        'click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+
+      event.preventDefaultOrg = event.preventDefault;
+      event.preventDefault = function() {
+        preventDefaultCalled = true;
+        if (this.preventDefaultOrg) this.preventDefaultOrg();
+      };
+
+      element.find('a')[0].dispatchEvent(event);
+
+      expect(preventDefaultCalled).toEqual(true);
+
+      expect(document.location.href).toEqual(orgLocation);
+    });
+
+    it('should not prevent default action to be executed when xlink namespaced href is not empty', function() {
+      var nonEmptyHash = '#nonempty',
+          preventDefaultCalled = false,
+          event;
+
+      var svgNs = 'http://www.w3.org/2000/svg';
+      var svg = document.createElementNS(svgNs, 'svg');
+
+      var a = document.createElementNS(svgNs, 'a');
+      var xlinkNs = 'http://www.w3.org/1999/xlink';
+      a.setAttributeNS(xlinkNs,
+                       // Note prefix specified here. It's optional but when
+                       // added breaks before this fix.
+                       'xlink:href',
+                       nonEmptyHash);
+      a.textContent = 'non-empty link';
+      svg.appendChild(a);
+
+      element = $compile(svg)($rootScope);
+
+      browserTrigger(element.find('a'), 'click');
+
+      // Firefox 23 needs some time to process the events
+      var nextTurn = false;
+      // let the browser process all events (and potentially reload the page)
+      setTimeout(function() { nextTurn = true;}, 100);
+
+      waitsFor(function() { return nextTurn; });
+
+      runs(function () {
+        expect(document.location.hash).toEqual(nonEmptyHash);
+      });
+    });
+  }
 
   it('should prevent IE for changing text content when setting attribute', function() {
     // see issue #1949


### PR DESCRIPTION
Previously, anchors in SVGs with any prefix namespace for the href attribute wouldn't work because jqLite uses getAttribute to retrieve the href attribute and is unaware of namespaces.

Add a check for the xlink namespaced `href` in case it exists.

Right now the tests are just checking IE version for SVG support. However, it probably should use SVG feature detection. Or alternatively, tests shouldn't even use the `svg` element and just apply the namespaces without regard to SVG support.

Example of this (remove `ng-app` and the example will work):
http://jsfiddle.net/sirhc/2WLZx/
