### PR TITLE
chore(package.json): update npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "bower": "~1.2.2",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-compress": "~0.5.2",
-    "grunt-contrib-connect": "~0.3.0",
+    "grunt-contrib-connect": "~0.5.0",
     "grunt-contrib-copy": "~0.4.1",
     "jasmine-node": "~1.11.0",
     "q": "~0.9.2",
     "q-fs": "~0.1.36",
     "qq": "~0.3.5",
-    "shelljs": "~0.1.4",
+    "shelljs": "~0.2.6",
     "karma": "~0.11",
     "karma-jasmine": "~0.1.0",
     "karma-chrome-launcher": "~0.1.0",
@@ -35,9 +35,9 @@
     "grunt-ddescribe-iit": "~0.0.1",
     "grunt-merge-conflict": "~0.0.1",
     "promises-aplus-tests": "~1.3.2",
-    "grunt-shell": "~0.3.1",
+    "grunt-shell": "~0.4.0",
     "semver": "~2.1.0",
-    "lodash": "~1.3.1"
+    "lodash": "~2.1.0"
   },
   "licenses": [
     {


### PR DESCRIPTION
Some of node dependencies have much newer versions; one of them is Lo-Dash
that has recently released the 2.0.0 version bringing in new useful methods.
