### PR TITLE
chore(grunt): switch to the new //# sourceMappingURL pragma

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -134,9 +134,7 @@ module.exports = {
 
 
   sourceMap: function(mapFile, fileContents) {
-    // use the following once Chrome beta or stable supports the //# pragma
-    // var sourceMapLine = '//# sourceMappingURL=' + mapFile + '\n';
-    var sourceMapLine = '/*\n//@ sourceMappingURL=' + mapFile + '\n*/\n';
+    var sourceMapLine = '//# sourceMappingURL=' + mapFile + '\n';
     return fileContents + sourceMapLine;
   },
 


### PR DESCRIPTION
All browsers except from Chrome implemented both the old
"//@ sourceMappingURL" and the new "//# sourceMappingURL" pragmas
in the same version so the only reason to keep the old one was Chrome.
However, Chrome 29, i.e. current stable version already supports
the new pragma so there's no need to wait any longer.
