### PR TITLE
fix(input): `false` is no longer an empty value by default

### DIFF
--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -998,6 +998,16 @@ describe('input', function() {
       expect(scope.list).toEqual([]);
     });
 
+    it('should be invalid if required and empty', function() {
+      compileInput('<input type="text" ng-list ng-model="list" required>');
+      changeInputValueTo('');
+      expect(scope.list).toBeUndefined();
+      expect(inputElm).toBeInvalid();
+      changeInputValueTo('a,b');
+      expect(scope.list).toEqual(['a','b']);
+      expect(inputElm).toBeValid();
+    });
+
 
     it('should allow custom separator', function() {
       compileInput('<input type="text" ng-model="list" ng-list=":" />');
@@ -1090,10 +1100,29 @@ describe('input', function() {
 
 
     it('should set $invalid when model undefined', function() {
-      compileInput('<input type="text" ng-model="notDefiend" required />');
+      compileInput('<input type="text" ng-model="notDefined" required />');
       scope.$digest();
       expect(inputElm).toBeInvalid();
-    })
+    });
+
+
+    it('should allow `false` as a valid value when the input type is not "checkbox"', function() {
+      compileInput('<input type="radio" ng-value="true" ng-model="answer" required />' +
+        '<input type="radio" ng-value="false" ng-model="answer" required />');
+
+      scope.$apply();
+      expect(inputElm).toBeInvalid();
+
+      scope.$apply(function() {
+        scope.answer = true;
+      });
+      expect(inputElm).toBeValid();
+
+      scope.$apply(function() {
+        scope.answer = false;
+      });
+      expect(inputElm).toBeValid();
+    });
   });
 
 

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1213,6 +1213,31 @@ describe('select', function() {
         });
         expect(element).toBeValid();
       });
+
+
+      it('should allow falsy values as values', function() {
+        createSelect({
+          'ng-model': 'value',
+          'ng-options': 'item.value as item.name for item in values',
+          'ng-required': 'required'
+        }, true);
+
+        scope.$apply(function() {
+          scope.values = [{name: 'True', value: true}, {name: 'False', value: false}];
+          scope.required = false;
+        });
+
+        element.val('1');
+        browserTrigger(element, 'change');
+        expect(element).toBeValid();
+        expect(scope.value).toBe(false);
+
+        scope.$apply(function() {
+          scope.required = true;
+        });
+        expect(element).toBeValid();
+        expect(scope.value).toBe(false);
+      });
     });
   });
 


### PR DESCRIPTION
This builds upon and improves @lgalfaso's PR https://github.com/angular/angular.js/pull/3658, without resorting to hard-coding fixes across directives.

`checkboxInputType` and `ngList` directives need to have special logic for whether
they are empty or not.  Previously this had been hard coded into their
own directives or the `ngRequired` directive.  This made it difficult to handle
these special cases.

This change factors out the question of whether an input is empty into a method
`$isEmpty` on the `ngModelController`.  The `ngRequired` directive now uses this
method when testing for validity and directives, such as `checkbox` or `ngList`
can override it to apply logic specific to their needs.

Closes #3490, #3658, #2594
