### PR TITLE
feat(ngRepeat): use block separator comments

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -327,8 +327,21 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
           for (key in lastBlockMap) {
             if (lastBlockMap.hasOwnProperty(key)) {
               block = lastBlockMap[key];
-              $animate.leave(block.elements);
-              forEach(block.elements, function(element) { element[NG_REMOVED] = true});
+
+              var elementsToRemove = [];
+              var elementToRemove = block.startNode;
+              elementsToRemove.push(elementToRemove);
+
+              if (block.startNode !== block.endNode) {
+                do {
+                  elementToRemove = elementToRemove.nextSibling;
+                  if (!elementToRemove) break;
+                  elementsToRemove.push(elementToRemove);
+                } while (elementToRemove !== block.endNode);
+              }
+
+              $animate.leave(angular.element(elementsToRemove));
+              forEach(elementsToRemove, function(element) { element[NG_REMOVED] = true; });
               block.scope.$destroy();
             }
           }
@@ -338,6 +351,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
             key = (collection === collectionKeys) ? index : collectionKeys[index];
             value = collection[key];
             block = nextBlockOrder[index];
+            if (nextBlockOrder[index - 1]) previousNode = nextBlockOrder[index - 1].endNode;
 
             if (block.startNode) {
               // if we have already seen this object, then we need to reuse the
@@ -371,10 +385,11 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
 
             if (!block.startNode) {
               linker(childScope, function(clone) {
+                clone[clone.length++] = document.createComment(' end ngRepeat: ' + expression + ' ');
                 $animate.enter(clone, null, jqLite(previousNode));
                 previousNode = clone;
                 block.scope = childScope;
-                block.startNode = clone[0];
+                block.startNode = previousNode && previousNode.endNode ? previousNode.endNode : clone[0];
                 block.elements = clone;
                 block.endNode = clone[clone.length - 1];
                 nextBlockMap[block.id] = block;

--- a/test/BinderSpec.js
+++ b/test/BinderSpec.js
@@ -96,7 +96,9 @@ describe('Binder', function() {
         '<ul>' +
           '<!-- ngRepeat: item in model.items -->' +
           '<li ng-bind="item.a" ng-repeat="item in model.items">A</li>' +
+          '<!-- end ngRepeat: item in model.items -->' +
           '<li ng-bind="item.a" ng-repeat="item in model.items">B</li>' +
+          '<!-- end ngRepeat: item in model.items -->' +
         '</ul>');
 
     items.unshift({a: 'C'});
@@ -105,8 +107,11 @@ describe('Binder', function() {
         '<ul>' +
           '<!-- ngRepeat: item in model.items -->' +
           '<li ng-bind="item.a" ng-repeat="item in model.items">C</li>' +
+          '<!-- end ngRepeat: item in model.items -->' +
           '<li ng-bind="item.a" ng-repeat="item in model.items">A</li>' +
+          '<!-- end ngRepeat: item in model.items -->' +
           '<li ng-bind="item.a" ng-repeat="item in model.items">B</li>' +
+          '<!-- end ngRepeat: item in model.items -->' +
         '</ul>');
 
     items.shift();
@@ -115,7 +120,9 @@ describe('Binder', function() {
         '<ul>' +
           '<!-- ngRepeat: item in model.items -->' +
           '<li ng-bind="item.a" ng-repeat="item in model.items">A</li>' +
+          '<!-- end ngRepeat: item in model.items -->' +
           '<li ng-bind="item.a" ng-repeat="item in model.items">B</li>' +
+          '<!-- end ngRepeat: item in model.items -->' +
         '</ul>');
 
     items.shift();
@@ -134,6 +141,7 @@ describe('Binder', function() {
         '<ul>' +
           '<!-- ngRepeat: item in model.items -->' +
           '<li ng-repeat="item in model.items"><span ng-bind="item.a">A</span></li>' +
+          '<!-- end ngRepeat: item in model.items -->' +
         '</ul>');
   }));
 
@@ -148,15 +156,15 @@ describe('Binder', function() {
     $rootScope.items = items;
 
     $rootScope.$apply();
-    expect(element[0].childNodes.length - 1).toEqual(0);
+    expect(element[0].childNodes.length).toEqual(1);
 
     items.name = 'misko';
     $rootScope.$apply();
-    expect(element[0].childNodes.length - 1).toEqual(1);
+    expect(element[0].childNodes.length).toEqual(3);
 
     delete items.name;
     $rootScope.$apply();
-    expect(element[0].childNodes.length - 1).toEqual(0);
+    expect(element[0].childNodes.length).toEqual(1);
   }));
 
   it('IfTextBindingThrowsErrorDecorateTheSpan', function() {
@@ -223,13 +231,19 @@ describe('Binder', function() {
           '<div name="a" ng-repeat="m in model">'+
             '<!-- ngRepeat: i in m.item -->' +
             '<ul name="a1" ng-repeat="i in m.item"></ul>'+
+            '<!-- end ngRepeat: i in m.item -->' +
             '<ul name="a2" ng-repeat="i in m.item"></ul>'+
+            '<!-- end ngRepeat: i in m.item -->' +
           '</div>'+
+          '<!-- end ngRepeat: m in model -->' +
           '<div name="b" ng-repeat="m in model">'+
             '<!-- ngRepeat: i in m.item -->' +
             '<ul name="b1" ng-repeat="i in m.item"></ul>'+
+            '<!-- end ngRepeat: i in m.item -->' +
             '<ul name="b2" ng-repeat="i in m.item"></ul>'+
+            '<!-- end ngRepeat: i in m.item -->' +
           '</div>' +
+          '<!-- end ngRepeat: m in model -->' +
         '</div>');
   }));
 
@@ -306,15 +320,18 @@ describe('Binder', function() {
         '<div ng-repeat="i in [0,1]" ng-class-even="\'e\'" ng-class-odd="\'o\'"></div>' +
       '</div>')($rootScope);
     $rootScope.$apply();
+
     var d1 = jqLite(element[0].childNodes[1]);
-    var d2 = jqLite(element[0].childNodes[2]);
+    var d2 = jqLite(element[0].childNodes[3]);
     expect(d1.hasClass('o')).toBeTruthy();
     expect(d2.hasClass('e')).toBeTruthy();
     expect(sortedHtml(element)).toBe(
        '<div>' +
         '<!-- ngRepeat: i in [0,1] -->' +
         '<div class="o" ng-class-even="\'e\'" ng-class-odd="\'o\'" ng-repeat="i in [0,1]"></div>' +
+        '<!-- end ngRepeat: i in [0,1] -->' +
         '<div class="e" ng-class-even="\'e\'" ng-class-odd="\'o\'" ng-repeat="i in [0,1]"></div>' +
+        '<!-- end ngRepeat: i in [0,1] -->' +
         '</div>');
   }));
 
@@ -420,7 +437,9 @@ describe('Binder', function() {
         '<ul>' +
           '<!-- ngRepeat: (k,v) in {a:0,b:1} -->' +
           '<li ng-bind=\"k + v\" ng-repeat="(k,v) in {a:0,b:1}">a0</li>' +
+          '<!-- end ngRepeat: (k,v) in {a:0,b:1} -->' +
           '<li ng-bind=\"k + v\" ng-repeat="(k,v) in {a:0,b:1}">b1</li>' +
+          '<!-- end ngRepeat: (k,v) in {a:0,b:1} -->' +
         '</ul>');
   }));
 

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -166,7 +166,7 @@ describe('ngClass', function() {
     element = $compile('<ul><li ng-repeat="i in [0,1]" class="existing" ng-class-odd="\'odd\'" ng-class-even="\'even\'"></li><ul>')($rootScope);
     $rootScope.$digest();
     var e1 = jqLite(element[0].childNodes[1]);
-    var e2 = jqLite(element[0].childNodes[2]);
+    var e2 = jqLite(element[0].childNodes[3]);
     expect(e1.hasClass('existing')).toBeTruthy();
     expect(e1.hasClass('odd')).toBeTruthy();
     expect(e2.hasClass('existing')).toBeTruthy();
@@ -181,7 +181,7 @@ describe('ngClass', function() {
       '<ul>')($rootScope);
     $rootScope.$apply();
     var e1 = jqLite(element[0].childNodes[1]);
-    var e2 = jqLite(element[0].childNodes[2]);
+    var e2 = jqLite(element[0].childNodes[3]);
 
     expect(e1.hasClass('plainClass')).toBeTruthy();
     expect(e1.hasClass('odd')).toBeTruthy();
@@ -199,7 +199,7 @@ describe('ngClass', function() {
       '<ul>')($rootScope);
     $rootScope.$apply();
     var e1 = jqLite(element[0].childNodes[1]);
-    var e2 = jqLite(element[0].childNodes[2]);
+    var e2 = jqLite(element[0].childNodes[3]);
 
     expect(e1.hasClass('A')).toBeTruthy();
     expect(e1.hasClass('B')).toBeTruthy();
@@ -273,7 +273,7 @@ describe('ngClass', function() {
     $rootScope.$digest();
 
     var e1 = jqLite(element[0].childNodes[1]);
-    var e2 = jqLite(element[0].childNodes[2]);
+    var e2 = jqLite(element[0].childNodes[3]);
 
     expect(e1.hasClass('odd')).toBeTruthy();
     expect(e1.hasClass('even')).toBeFalsy();
@@ -295,7 +295,7 @@ describe('ngClass', function() {
     $rootScope.$digest();
 
     var e1 = jqLite(element[0].childNodes[1]);
-    var e2 = jqLite(element[0].childNodes[2]);
+    var e2 = jqLite(element[0].childNodes[3]);
 
     expect(e1.hasClass('odd')).toBeTruthy();
     expect(e1.hasClass('even')).toBeFalsy();


### PR DESCRIPTION
This change allows the use of ngRepeat in combination with directives that use transclusion and directives that replace its original elements or add more elements to ngRepeat blocks.
