### PR TITLE
fix($compile): work around issue in jQuery 1.10.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "AngularJS",
   "devDependencies": {
-    "jquery": "git://github.com/components/jquery.git#v1.8.3",
+    "jquery": "1.10.2",
     "lunr.js": "0.4.0",
     "google-code-prettify": "1.0.0",
     "components-font-awesome": "3.1.0",


### PR DESCRIPTION
jQuery 1.10.2 does not attach data to comment nodes, which previously broke `$compile`.
This changes how elements with "transclude element" and a controller are compiled to
avoid the issue.

Closes #3764
