### PR TITLE
fix(mock): Added a way to preserve initally-bound events

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -111,6 +111,7 @@ angularFiles = {
     'test/ngResource/*.js',
     'test/ngRoute/**/*.js',
     'test/ngSanitize/**/*.js',
+    'test/documentEvent.js',
     'test/ngMock/*.js',
     'test/ngTouch/**/*.js'
   ],

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1790,10 +1790,15 @@ angular.mock.clearDataCache = function() {
 
   for(key in cache) {
     if (cache.hasOwnProperty(key)) {
-      var handle = cache[key].handle;
+      if (angular.mock.initialKeys && angular.mock.initialKeys.indexOf(key) > -1) {
+        delete cache[key];
+      }
+      else {
+        var handle = cache[key].handle;
 
-      handle && angular.element(handle.elem).off();
-      delete cache[key];
+        handle && angular.element(handle.elem).off();
+        delete cache[key];
+      }
     }
   }
 };
@@ -1805,6 +1810,11 @@ angular.mock.clearDataCache = function() {
   var currentSpec = null;
 
   beforeEach(function() {
+    if (!angular.mock.initialKeys) {
+      angular.element.cache.foo = 'bar';
+      angular.mock.initialKeys = Object.keys(angular.element.cache);
+      angular.mock.clearDataCache();
+    }
     currentSpec = this;
   });
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1785,20 +1785,35 @@ angular.mock.e2e.$httpBackendDecorator = ['$rootScope', '$delegate', '$browser',
 
 
 angular.mock.clearDataCache = function() {
-  var key,
+  var elementInfo, initElementInfo,
+      elementKey,
+      eventName,
       cache = angular.element.cache;
 
-  for(key in cache) {
-    if (cache.hasOwnProperty(key)) {
-      if (angular.mock.initialKeys && angular.mock.initialKeys.indexOf(key) > -1) {
-        delete cache[key];
-      }
-      else {
-        var handle = cache[key].handle;
+  for(elementKey in cache) {
+    if (!cache.hasOwnProperty(elementKey)) continue;
 
-        handle && angular.element(handle.elem).off();
-        delete cache[key];
+    elementInfo = cache[elementKey];
+    initElementInfo = angular.mock.initialElementCache[elementKey];
+
+    if (initElementInfo) {
+      for (eventName in elementInfo.events) {
+        if (!elementInfo.hasOwnProperty(eventName)) continue;
+        if (!initElementInfo.events || !initElementInfo.events[eventName]) {
+          angular.element(elementInfo.handle.elem).off(eventName);
+        } else {
+          angular.forEach(elementInfo.events[eventName], function(listener) {
+            if (angular.indexOf(initElementInfo.events[eventName], listener) == -1) {
+              angular.element(elementInfo.handle.elem).off(eventName, listener);
+            }
+          });
+        }
       }
+
+      cache[elementKey] = initElementInfo;
+    } else {
+      angular.element(elementInfo.handle && elementInfo.handle.elem).off();
+      delete cache[elementKey];
     }
   }
 };
@@ -1810,9 +1825,8 @@ angular.mock.clearDataCache = function() {
   var currentSpec = null;
 
   beforeEach(function() {
-    if (!angular.mock.initialKeys) {
-      angular.element.cache.foo = 'bar';
-      angular.mock.initialKeys = Object.keys(angular.element.cache);
+    if (!angular.mock.initialElementCache) {
+      angular.mock.initialElementCache = angular.copy(angular.element.cache);
       angular.mock.clearDataCache();
     }
     currentSpec = this;

--- a/test/documentEvent.js
+++ b/test/documentEvent.js
@@ -1,0 +1,4 @@
+document.hasBeenSpecialClicked = 0;
+jqLite(document).on('specialclick', function () {
+  document.hasBeenSpecialClicked++;
+});

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -472,6 +472,12 @@ describe('ngMock', function() {
       }
     }
 
+    it('should respond to an event registered before tests started', function () {
+      expect(document.hasBeenSpecialClicked).toBe(0);
+      browserTrigger(angular.element(document), 'specialclick');
+      expect(document.hasBeenSpecialClicked).toBe(1);
+    });
+
     it('should remove data', function() {
       expect(angular.element.cache).toEqual({});
       var div = angular.element('<div></div>');


### PR DESCRIPTION
Some third-party libraries, such as bootstrap, rely on
events that were initially added to the document in order
to function properly. Since angularMock automatically
clears data and events after each test, testing angular
components built with these third-party libraries becomes
impossible.

The solution is to preserve events that were added before
the first test, and let the angularMocks continue to do
its automatic cleanup for everything that is added thereafter.

Fixes #3916
