### PR TITLE
Fix filter demo concepts.ngdoc

### DIFF
--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -327,6 +327,9 @@ they are used in conjunction with the locale to format the data in locale specif
 They follow the spirit of UNIX filters and use similar syntax `|` (pipe).
 
 <example>
+  <file name="script.js">
+    angular.module('App', [])
+  </file>
   <file name="index.html">
     <div ng-init="list = ['Chrome', 'Safari', 'Firefox', 'IE'] ">
       Number formatting: {{ 1234567890 | number }} <br>


### PR DESCRIPTION
The code generating the plunkr from <example> tags is broken when no top level module is defined. I fixed this for the filters demo, but a better fix would update the code generator.
