### PR TITLE
fix syntax error in angular.mock documentation

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1958,7 +1958,7 @@ angular.mock.clearDataCache = function() {
    *       inject(function(version) {
    *         expect(version).toEqual('overridden');
    *       });
-   *     ));
+   *     });
    *   });
    *
    * </pre>


### PR DESCRIPTION
![screen shot 2013-09-27 at 3 40 51 pm](https://f.cloud.github.com/assets/909156/1228878/c48a3f68-27ac-11e3-9191-24459efbf943.png)
Fixing documentation for the angular.mock.inject api as seen on http://docs.angularjs.org/api/angular.mock.inject
Line 30 in the attached screenshot should contain a bracket to properly end the function.
