### PR TITLE
docs($compile) fix doc comment being displayed as code segment

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -97,8 +97,8 @@
  * (a DOM element/tree) to a scope. Where:
  *
  *  * `scope` - A {@link ng.$rootScope.Scope Scope} to bind to.
- *  * `cloneAttachFn` - If `cloneAttachFn` is provided, then the link function will clone the
- *               `template` and call the `cloneAttachFn` function allowing the caller to attach the
+ *  * `cloneAttachFn` - If `cloneAttachFn` is provided, then the link function will clone the `template` and
+ *               call the `cloneAttachFn` function allowing the caller to attach the
  *               cloned elements to the DOM document at the appropriate place. The `cloneAttachFn` is
  *               called as: <br> `cloneAttachFn(clonedElement, scope)` where:
  *


### PR DESCRIPTION
Look at the returns section on this page : http://docs.angularjs.org/api/ng.$compile
