### PR TITLE
fix(jqLite): clone wrapNode in jqlite/wrap

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -882,7 +882,7 @@ forEach({
   },
 
   wrap: function(element, wrapNode) {
-    wrapNode = jqLite(wrapNode)[0];
+    wrapNode = jqLite(wrapNode).eq(0).clone()[0];
     var parent = element.parentNode;
     if (parent) {
       parent.replaceChild(wrapNode, element);

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1542,6 +1542,15 @@ describe('jqLite', function() {
       text.wrap("<span>");
       expect(text.parent().text()).toEqual('A<a>B</a>C');
     });
+    it('should clone elements to be wrapped around target', function () {
+      var root = jqLite('<div class="sigil"></div>');
+      var span = jqLite('<span>A</span>');
+      jqLite(document.body).append(root);
+
+      span.wrap(root);
+      expect(root.text()).toBe('');
+      expect(span.parent().hasClass('sigil')).toBeTruthy();
+    });
   });
 
 


### PR DESCRIPTION
Change jqLite's implementation of wrap() to clone the wrapNode before
wrapping the target element in it.

Match jQuery's wrap() behavior and prevent accidentally attaching
target element to the DOM as a side effect.

Closes #3860
