### PR TITLE
fix($location): re-assign location after BFCache back

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -148,6 +148,9 @@ function Browser(window, document, $log, $sniffer) {
    * @param {boolean=} replace Should new url replace current history record ?
    */
   self.url = function(url, replace) {
+    // Android Browser BFCache causes location reference to become stale.
+    if (location !== window.location) location = window.location;
+
     // setter
     if (url) {
       if (lastBrowserUrl == url) return;


### PR DESCRIPTION
In the Android browser, the BFCache maintains
the state of JavaScript applications even when
navigating to another app, so that going
forward and back, to and from an application
is very fast.

Unfortunately, this can have undesired side
effects. In this instance, the location
variable was holding a reference to a stale
window.location, and was throwing errors
when going back to an Angular app after
browsing to another site.

This fix makes sure that location.url()
includes a check to make sure that location
is referencing the current window.location.

Closes #4044
