### PR TITLE
docs($injector): Reword `fn` param docs and link to DI information

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -147,7 +147,7 @@ function annotate(fn) {
  * @description
  * Invoke the method and supply the method arguments from the `$injector`.
  *
- * @param {!function} fn The function to invoke. The function arguments come form the function annotation.
+ * @param {!function} fn The function to invoke. Function parameters are injected according to the {@link http://docs.angularjs.org/guide/di $inject Annotation} rules.
  * @param {Object=} self The `this` for the invoked method.
  * @param {Object=} locals Optional object. If preset then any argument names are read from this object first, before
  *   the `$injector` is consulted.


### PR DESCRIPTION
The documentation for $injector.invoke is currently very unclear, and contains a typographic error.

I'd like to link to the more detailed DI docs instead of simply stating "function annotation" as though that means something out of context.

---

**note**: I'm not sure if I need to specify this link as an external link or not. If it's possible, please let me know so I can correct this.
