### PR TITLE
fix(event.stopPropagation()): sibling event handlers should not be cancelled by event.stopPropagation()

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -864,12 +864,14 @@ function $RootScopeProvider(){
               continue;
             }
             try {
+              //allow all listeners attached to the current scope to run
               namedListeners[i].apply(null, listenerArgs);
-              if (stopPropagation) return event;
             } catch (e) {
               $exceptionHandler(e);
             }
           }
+          //if any listener on the current scope stops propagation, prevent bubbling
+          if (stopPropagation) return event;
           //traverse upwards
           scope = scope.$parent;
         } while (scope);

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1046,6 +1046,14 @@ describe('Scope', function() {
         expect(log).toEqual('2>1>0>');
       });
 
+      it('should allow all events on the same scope to run even if stopPropagation is called', function(){
+        child.$on('myEvent', logger);
+        grandChild.$on('myEvent', function(e) { e.stopPropagation(); });
+        grandChild.$on('myEvent', logger);
+        grandChild.$on('myEvent', logger);
+        grandChild.$emit('myEvent');
+        expect(log).toEqual('2>2>2>');
+      });
 
       it('should dispatch exceptions to the $exceptionHandler',
           inject(function($exceptionHandler) {


### PR DESCRIPTION
This fix addresses an issue where event.stopPropagation() prematurely ends execution of event listeners assigned to the same scope from which they are $emit-ted.

For example you assign 2 listeners to the same scope:
a)

scope.on('myEvent', function(evt) {
  evt.stopPropagation();
  //Do something
});
b) Somewhere else on the same scope, perhaps inside other directive or controller

scope.on('myEvent', function(evt) {
  //Do something else
});
Currently handler in 'a' will prevent handler 'b' from executing even though they are on the same exact scope, but this is not the intention of the stopPropagation() function. Intention is to prevent 'myEvent' from bubbling into $parent scope.

If we take jQuery or just plain DOM eventing model, we'll see that stopPropagation does NOT prevent multiple handlers that are attached to the same node from firing.
