### PR TITLE
fix($compile): merge attributes safely to avoid upsetting IE8

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -383,7 +383,10 @@ function $CompileProvider($provide) {
           if (writeAttr !== false) {
             if (value === null || value === undefined) {
               this.$$element.removeAttr(attrName);
-            } else {
+            } else if (value !== this.$$element.attr(attrName)) {
+              // Set new value only if it is not already there, avoiding
+              // issues with IE, where certain attributes cannot be set
+              // on in-document elements, e.g. 'type' on <input>
               this.$$element.attr(attrName, value);
             }
           }
@@ -1130,8 +1133,9 @@ function $CompileProvider($provide) {
       // reapply the old attributes to the new element
       forEach(dst, function(value, key) {
         if (key.charAt(0) != '$') {
-          if (src[key]) {
-            value += (key === 'style' ? ';' : ' ') + src[key];
+          var srcVal = src[key];
+          if (srcVal && srcVal !== value) {
+            value += (key === 'style' ? ';' : ' ') + srcVal;
           }
           dst.$set(key, value, true, srcAttr[key]);
         }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -489,6 +489,14 @@ describe('$compile', function() {
               expect(element).toBe(attr.$$element);
             }
           }));
+          directive('replaceWithArbitraryAttribute', valueFn({
+            replace: true,
+            template: '<div data-foo="bar">With data-foo</div>',
+            compile: function(element, attr) {
+              attr.$set('compiled', 'COMPILED');
+              expect(element).toBe(attr.$$element);
+            }
+          }));
         }));
 
 
@@ -536,6 +544,14 @@ describe('$compile', function() {
           expect(div.css('height')).toBe('20px');
           expect(div.attr('replace')).toEqual('');
           expect(div.attr('high-log')).toEqual('');
+        }));
+
+        it('should preserve identical attributes when merging', inject(function($compile, $rootScope) {
+          element = $compile(
+            '<div><div replace-with-arbitrary-attribute data-foo="bar"/><div>')
+            ($rootScope);
+          var div = element.find('div');
+          expect(div.attr('data-foo')).toBe('bar');
         }));
 
         it('should prevent multiple templates per element', inject(function($compile) {


### PR DESCRIPTION
Merging an `<input>` with an `<input>` in IE8 will automatically break because the "type" attribute may not be set automatically on in-document elements. This change makes Angular replace only unchanged attributes. Additionally, source and target attributes are only merged by concatenation if their values differ, to avoid unexpected results such as 'type="text text"'.

Closes #4029

CLA has been submitted electronically.

(Note that a further logical related change might be to only merge attribute values by concatenation in the case of "style" or "class":   see https://github.com/purcell/angular.js/commit/f919241a79f5c73dfcfb6511d0aa8b42e7f578e0, which is omitted from this pull request.)
