### PR TITLE
docs($http): Add missing brace

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -415,6 +415,7 @@ function $HttpProvider() {
      *       'response': function(response) {
      *          // same as above
      *       }
+     *    }
      *   });
      * </pre>
      *


### PR DESCRIPTION
A brace is missing in the register example of an interceptor as a service.
