### PR TITLE
BUG REPRO: ie8 bug when module() inside it() throws and exception (thrown during in...

### DIFF
--- a/test/ng/sceSpecs.js
+++ b/test/ng/sceSpecs.js
@@ -2,6 +2,11 @@
 
 describe('SCE', function() {
 
+  iit('CKCK: IE8 TypeError', function() {
+    module(function() { throw "CKCK: foo"; });
+    expect(function() { inject(angular.nop); }).toThrow('CKCK: foo');
+  });
+
   describe('when disabled', function() {
     beforeEach(function() {
       module(function($sceProvider) {


### PR DESCRIPTION
ie8 bug when module() inside it() throws and exception (thrown during inject() call)

This is a bug where my exception object is getting lost.  Here's the
result from a Karma trace:

```
Running "autotest:jqlite" (autotest) task
INFO [karma]: Karma v0.11.0 server started at http://localhost:9876/
WARN [web-server]: 404: /favicon.ico
INFO [IE 8.0.0 (Windows XP)]: Connected on socket hfE_1IJ4LeFwf6RJcVOe
INFO [watcher]: Changed file "/Users/chirayu/work/angular.js/test/ng/sceSpecs.js".
INFO [karma]: Delaying execution, these browsers are not ready: IE 8.0.0 (Windows XP)
IE 8.0.0 (Windows XP) SCE CKCK: IE8 TypeError FAILED
        Expected function to throw CKCK: foo , but it threw Object doesn't support this property or method
IE 8.0.0 (Windows XP): Executed 1 of 2225 (1 FAILED) (skipped 2224) ERROR (7.738 secs / 0.031 secs)
```

I don't see the real exception but get a TypeError.  There is only one
stack frame between when the exception object is the one I want and the
one where it's been replaced by TypeError.  No code executes between
those two frames afaik from looking at the IE8 debugger.

In the inject() call:

```
  if (!injector) {
    injector = currentSpec.$injector = angular.injector(modules);
  }
```

the exception is thrown in "injector = currentSpec.$injector = angular.injector(modules);"

making injector undefined.  The caller frame is the anonymous function
in the expect() line:

```
expect(function() { inject(angular.nop); }).toThrow('CKCK: foo');
```

When control reaches that frame through, the exception object is no
longer "CKCK: foo" but a TypeError.  :(
