### PR TITLE
docs($rootScope): fix comment of Scope.$evalAsync

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -673,7 +673,9 @@ function $RootScopeProvider(){
        * @function
        *
        * @description
-       * Executes the expression on the current scope at a later point in time.
+       * Executes the expression at a later point in time.
+       * The expression will be executed on a scope whose {@link ng.$rootScope.Scope#$digest $digest cycle} is the next to run.
+       * This scope might or might not be the same as the current scope.
        *
        * The `$evalAsync` makes no guarantees as to when the `expression` will be executed, only that:
        *
@@ -690,7 +692,7 @@ function $RootScopeProvider(){
        * @param {(string|function())=} expression An angular expression to be executed.
        *
        *    - `string`: execute using the rules as defined in {@link guide/expression expression}.
-       *    - `function(scope)`: execute the function with the current `scope` parameter.
+       *    - `function(scope)`: execute the function with the `scope` whose {@link ng.$rootScope.Scope#$digest $digest cycle} is being run.
        *
        */
       $evalAsync: function(expr) {


### PR DESCRIPTION
The current comment of Scope.$evalAsync contains two errors. First, it states that the expression will be executed on the current scope. In fact, the expression will be executed on whichever scope whose digest loop will run next. Second, it states that the function passed in this method will be invoked with the current scope being the first argument. However, the scope passed in is the scope whose digest loop is being run. The fix states the actual behaviors and warns users that the current scope might not be used for evaluation.
