### PR TITLE
(1) Clarified directive e2e test result and (2) template referencing exa...

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -27,28 +27,28 @@ attribute only.)
   <!-- directive: my-dir exp -->
 </pre>
 
-Directives can be invoked in many different ways, but are equivalent in the end result as shown in
-the following example.
+The following demonstrates the various ways a Directive (ngBind in this case) can be referenced from within a template.
 
 <doc:example>
   <doc:source >
    <script>
      function Ctrl1($scope) {
-       $scope.name = 'angular';
+       $scope.name = 'Max Karl Ernst Ludwig Planck (April 23, 1858 – October 4, 1947)';
      }
    </script>
    <div ng-controller="Ctrl1">
      Hello <input ng-model='name'> <hr/>
+     &lt;span ng-bind="name"&gt; <span ng-bind="name"></span> <br/>
      &lt;span ng:bind="name"&gt; <span ng:bind="name"></span> <br/>
      &lt;span ng_bind="name"&gt; <span ng_bind="name"></span> <br/>
-     &lt;span ng-bind="name"&gt; <span ng-bind="name"></span> <br/>
      &lt;span data-ng-bind="name"&gt; <span data-ng-bind="name"></span> <br/>
      &lt;span x-ng-bind="name"&gt; <span x-ng-bind="name"></span> <br/>
    </div>
   </doc:source>
   <doc:scenario>
     it('should show off bindings', function() {
-      expect(element('div[ng-controller="Ctrl1"] span[ng-bind]').text()).toBe('angular');
+      expect(element('div[ng-controller="Ctrl1"] span[ng-bind]').text())
+        .toBe('Max Karl Ernst Ludwig Planck (April 23, 1858 – October 4, 1947)');
     });
   </doc:scenario>
 </doc:example>


### PR DESCRIPTION
...mples

In the first case, the use of 'angular' as sample text is confusing to the newbie (of which I am) in that they are force to confirm that the text 'angular' is not a keyword or otherwise referring to a system component. It is useful to ensure that sample text are obviously sample text.

In the second case, the introduction to the list of ways of referring to directives from the template was in obvious need to repair. I have also moved the most common example to the top of the list in companionship with the use close by of ng-model.
