### PR TITLE
Update Angular.js

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -786,7 +786,8 @@ function sliceArgs(args, startIndex) {
  * @description
  * Returns a function which calls function `fn` bound to `self` (`self` becomes the `this` for
  * `fn`). You can supply optional `args` that are prebound to the function. This feature is also
- * known as [function currying](http://en.wikipedia.org/wiki/Currying).
+ * known as [partial application](http://en.wikipedia.org/wiki/Partial_application), as distinguished
+ * from [function currying](http://en.wikipedia.org/wiki/Currying).
  *
  * @param {Object} self Context which `fn` should be evaluated in.
  * @param {function()} fn Function to be bound.


### PR DESCRIPTION
the bind function reflects the definition of "partial application", which reduces a function's arity rather than transforming a function with n args into a chain of n functions, each having a single arg.

curry :
f(x,y,z) -> f(x)(y)(z)

partial application :
f(x,y,z) -> f(x)(y,z)
