### PR TITLE
feature(ngEnabled): define ngEnabled directive as negation of ngDisabled

### DIFF
--- a/test/ng/directive/booleanAttrsSpec.js
+++ b/test/ng/directive/booleanAttrsSpec.js
@@ -30,6 +30,16 @@ describe('boolean attr directives', function() {
     expect(element.attr('disabled')).toBeTruthy();
   }));
 
+  it('should bind disabled to the negation of ng-enabled', inject(function($rootScope, $compile) {
+    element = $compile('<button ng-enabled="isEnabled">Button</button>')($rootScope);
+    $rootScope.isEnabled = false;
+    $rootScope.$digest();
+    expect(element.attr('disabled')).toBeTruthy();
+    $rootScope.isEnabled = true;
+    $rootScope.$digest();
+    expect(element.attr('disabled')).toBeFalsy();
+  }));
+
 
   it('should bind checked', inject(function($rootScope, $compile) {
     element = $compile('<input type="checkbox" ng-checked="isChecked" />')($rootScope)

--- a/test/ngTouch/directive/ngClickSpec.js
+++ b/test/ngTouch/directive/ngClickSpec.js
@@ -466,6 +466,42 @@ describe('ngClick (touch)', function() {
 
       expect($rootScope.event).toBeDefined();
     }));
+    it('should trigger click if ngEnabled is true', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-click="event = $event" ng-enabled="enabled"></div>')($rootScope);
+      $rootScope.enabled = true;
+      $rootScope.$digest();
+
+      browserTrigger(element, 'touchstart',{
+        keys: [],
+        x: 10,
+        y: 10
+      });
+      browserTrigger(element, 'touchend',{
+        keys: [],
+        x: 10,
+        y: 10
+      });
+
+      expect($rootScope.event).toBeDefined();
+    }));
+    it('should not trigger click if ngEnabled is false', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-click="event = $event" ng-enabled="enabled"></div>')($rootScope);
+      $rootScope.enabled = false;
+      $rootScope.$digest();
+
+      browserTrigger(element, 'touchstart',{
+        keys: [],
+        x: 10,
+        y: 10
+      });
+      browserTrigger(element, 'touchend',{
+        keys: [],
+        x: 10,
+        y: 10
+      });
+
+      expect($rootScope.event).toBeUndefined();
+    }));
     it('should not trigger click if regular disabled is true', inject(function($rootScope, $compile) {
       element = $compile('<div ng-click="event = $event" disabled="true"></div>')($rootScope);
 


### PR DESCRIPTION
Provide a negated form of the `ngDisabled` directive as `ngEnabled` in
the same vein as the `ngHide`/`ngShow` pair. Allow for slightly clearer
templates by avoiding double negatives, as in:

```
<input ng-disabled='!(predicate1 && predicate2)'/>
<input ng-enabled='predicate1 && predicate2'/>
```

Closes #1252
