### PR TITLE
feat($injector): add dependencies method for getting providers and their dependencies

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -608,11 +608,45 @@ function createInjector(modulesToLoad) {
       return isObject(returnedValue) ? returnedValue : instance;
     }
 
+    function dependencies() {
+      var res = [],
+          suffixLength = providerSuffix.length,
+          _provider,
+          providerName;
+
+      for (providerName in providerCache) {
+        if (providerCache.hasOwnProperty(providerName)) {
+          _provider = providerCache[providerName];
+          switch (providerName) {
+            case "$provide":
+              continue;
+            case "$controllerProvider":
+              forEach(_provider.constructors(), function(item) {
+                res.push({
+                  name: item.name,
+                  requires: annotate(item.constructor)
+                });
+              });
+            default:
+              if (isFunction(_provider.$get) || isArray(_provider.$get)) {
+                res.push({
+                  name: providerName.substr(0, providerName.length - suffixLength),
+                  requires: annotate(_provider.$get)
+                });
+              }
+          }
+        }
+      }
+
+      return res;
+    }
+
     return {
       invoke: invoke,
       instantiate: instantiate,
       get: getService,
       annotate: annotate,
+      dependencies: dependencies,
       has: function(name) {
         return providerCache.hasOwnProperty(name + providerSuffix) || cache.hasOwnProperty(name);
       }

--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -32,6 +32,25 @@ function $ControllerProvider() {
     }
   };
 
+  /**
+   * @ngdoc function
+   * @name ng.$controllerProvider#constructors
+   * @methodOf ng.$controllerProvider
+   * @return {Array} constructors
+   */
+  this.constructors = function() {
+    var res = [],
+        name;
+    for (name in controllers) {
+      if (controllers.hasOwnProperty(name)) {
+        res.push({
+          name: name,
+          constructor: controllers[name]
+        });
+      }
+    }
+    return res;
+  };
 
   this.$get = ['$injector', '$window', function($injector, $window) {
 

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -225,6 +225,31 @@ describe('injector', function() {
     expect(log).toEqual('value;function;service;->value;function;service;');
   });
 
+  it('should make service and controller dependencies available', function() {
+    var injector = createInjector([function($provide) {
+      $provide.value('FooValue', 'FooValue');
+      $provide.factory('FooFactory', function(FooValue) {});
+      $provide.provider('FooService', function() {
+        this.$get = function (FooValue, FooFactory) {};
+      });
+    }]);
+    var found = 0;
+    forEach(injector.dependencies(), function (x) {
+      if (x.name === 'FooValue') {
+        expect(x.requires).toEqual([]);
+        found++;
+      }
+      if (x.name === 'FooFactory') {
+        expect(x.requires).toEqual(['FooValue']);
+        found++;
+      }
+      if (x.name === 'FooService') {
+        expect(x.requires).toEqual(['FooValue', 'FooFactory']);
+        found++;
+      }
+    });
+    expect(found).toEqual(3);
+  });
 
   describe('module', function() {
     it('should provide $injector even when no module is requested', function() {

--- a/test/ng/controllerSpec.js
+++ b/test/ng/controllerSpec.js
@@ -57,6 +57,20 @@ describe('$controller', function() {
       expect(scope.foo).toBe('bar');
       expect(ctrl instanceof FooCtrl).toBe(true);
     });
+
+    it('should make registered controller constructors accessible', function() {
+      var FooCtrl = function($scope) {},
+          found = false;
+      $controllerProvider.register('FooCtrl', FooCtrl);
+      forEach($controllerProvider.constructors(), function (x) {
+        if (x.name === 'FooCtrl') {
+          found = true;
+          expect(x.constructor).toEqual(FooCtrl);
+          return false;
+        }
+      });
+      expect(found).toBe(true);
+    });
   });
 
 


### PR DESCRIPTION
I'm using this method to generate a dependency graph with graphviz.
The code ~~isn't portable and has no tests or documentation~~ so I don't expect this to get merged.
However, I think it would be useful to add this type of functionality to angular.

example usage:

``` html
<html>
  <head>
    <script src="angular.js"></script>
    <script type="text/javascript">

      angular.module("App", []).run(function ($injector) {
        $injector.dependencies().forEach(function (item) {
          console.log(item.name, item.requires);
        });
      });

    </script>
  </head>
  <body ng-app="App"></body>
</html>
```
