### PR TITLE
feat(jQuery): upgrade to jQuery to 2.0 [WIP]

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1160,6 +1160,7 @@ function bindJQuery() {
     JQLitePatchJQueryRemove('remove', true, true, false);
     JQLitePatchJQueryRemove('empty', false, false, false);
     JQLitePatchJQueryRemove('html', false, false, true);
+    JQLitePatchJQueryRemove('replaceWith', true, false, false);
   } else {
     jqLite = JQLite;
   }

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1370,6 +1370,7 @@ function $CompileProvider($provide) {
       var firstElementToRemove = elementsToRemove[0],
           removeCount = elementsToRemove.length,
           parent = firstElementToRemove.parentNode,
+          scope = jQuery(firstElementToRemove).data('$scope'),
           i, ii;
 
       if ($rootElement) {
@@ -1402,6 +1403,10 @@ function $CompileProvider($provide) {
         jqLite(element).remove(); // must do this way to clean up expando
         fragment.appendChild(element);
         delete elementsToRemove[k];
+      }
+
+      if (scope) {
+        jQuery(newNode).data('$scope', scope);
       }
 
       elementsToRemove[0] = newNode;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3256,7 +3256,7 @@ describe('$compile', function() {
       $rootScope.dataOnVar = 'data-on text';
       $rootScope.$apply();
       expect(element.attr('data-on')).toEqual('data-on text');
-      
+
       element = $compile('<button on="{{onVar}}"></script>')($rootScope);
       $rootScope.onVar = 'on text';
       $rootScope.$apply();


### PR DESCRIPTION
jQuery 2.0 removes `jQuery.cache` which prevents the angular-mocks logic to clean up after each test (to remove element data). There are two tests that fail because of this change. One way to fix this might be monkey-patching `jQuery#data` with a proxy which would keep track of all elements and data that need to be cleaned.
