### PR TITLE
Added missing semicolon

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -129,7 +129,7 @@ function filterFilter() {
       default:
         comperator = function(obj, text) {
           text = (''+text).toLowerCase();
-          return (''+obj).toLowerCase().indexOf(text) > -1
+          return (''+obj).toLowerCase().indexOf(text) > -1;
         };
     }
     var search = function(obj, text){


### PR DESCRIPTION
I was curious as to how Angular was searching for a substring in its array filter, when I came across a missing semicolon.
