### PR TITLE
fix(ngResource): Remove request body from $delete

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -466,7 +466,7 @@ angular.module('ngResource', ['ng']).
             }
           });
 
-          httpConfig.data = data;
+          if (hasBody) httpConfig.data = data;
           route.setUrlParams(httpConfig, extend({}, extractParams(data, action.params || {}), params), action.url);
 
           var promise = $http(httpConfig).then(function(response) {


### PR DESCRIPTION
Prevent the  obj.$delete instance method from sending the resource as the request body.  This commit uses the existing hasBody boolean to only set httpConfig.data for methods which should have a request body.

Closes #4280
