### PR TITLE
feat(ngParse): support bitwise shift operators

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -88,7 +88,10 @@ var OPERATORS = {
     '&':function(self, locals, a,b){return a(self, locals)&b(self, locals);},
 //    '|':function(self, locals, a,b){return a|b;},
     '|':function(self, locals, a,b){return b(self, locals)(self, locals, a(self, locals));},
-    '!':function(self, locals, a){return !a(self, locals);}
+    '!':function(self, locals, a){return !a(self, locals);},
+    '<<':function(self, locals, a,b){return a(self, locals)<<b(self, locals);},
+    '>>':function(self, locals, a,b){return a(self, locals)>>b(self, locals);},
+    '>>>':function(self, locals, a,b){return a(self, locals)>>>b(self, locals);}
 };
 var ESCAPE = {"n":"\n", "f":"\f", "r":"\r", "t":"\t", "v":"\v", "'":"'", '"':'"'};
 
@@ -645,10 +648,19 @@ Parser.prototype = {
   },
 
   relational: function() {
-    var left = this.additive();
+    var left = this.bitwiseShift();
     var token;
     if ((token = this.expect('<', '>', '<=', '>='))) {
       left = this.binaryFn(left, token.fn, this.relational());
+    }
+    return left;
+  },
+
+  bitwiseShift: function() {
+    var left = this.additive();
+    var token;
+    while ((token = this.expect('<<','>>','>>>'))) {
+      left = this.binaryFn(left, token.fn, this.additive());
     }
     return left;
   },

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -210,6 +210,7 @@ describe('parser', function() {
         expect(scope.$eval("0--1+1.5")).toEqual(0- -1 + 1.5);
         expect(scope.$eval("-0--1++2*-3/-4")).toEqual(-0- -1+ +2*-3/-4);
         expect(scope.$eval("1/2*3")).toEqual(1/2*3);
+        expect(scope.$eval("-2+10<<2*7>>6")).toEqual(-2 + 10 << 2 * 7 >> 6);
       });
 
       it('should parse comparison', function() {
@@ -390,6 +391,12 @@ describe('parser', function() {
         scope.subTotal =  100;
         expect(scope.$eval("taxRate / 100 * subTotal")).toEqual(8);
         expect(scope.$eval("subTotal * taxRate / 100")).toEqual(8);
+      });
+
+      it('should evaluate bitwise shifts', function() {
+        expect(scope.$eval('2<<8')).toEqual(512);
+        expect(scope.$eval('480>>5')).toEqual(15);
+        expect(scope.$eval('-1>>>127')).toEqual(-1>>>127);
       });
 
       it('should evaluate array', function() {


### PR DESCRIPTION
Fixes #3834.

Provides support for the signed left-shift '<<' operator, signed right-shift
'>>' operator, and unsigned right-shift '>>>' operator. The order of
operations should be sound, according to 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence

I'm not sure if unsigned right-shift '>>>' is particularly useful for many
applications which would need to $evaluate the expression from a string, so
it may be removed.

There are a couple added, however these might be improved with review.
