### PR TITLE
style(): only instantiate lex/parse once

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1034,14 +1034,15 @@ function $ParseProvider() {
   var cache = {};
   this.$get = ['$filter', '$sniffer', function($filter, $sniffer) {
     return function(exp) {
+      var lexer = new Lexer($sniffer.csp);
+      var parser = new Parser(lexer, $filter, $sniffer.csp);
+
       switch (typeof exp) {
         case 'string':
           if (cache.hasOwnProperty(exp)) {
             return cache[exp];
           }
 
-          var lexer = new Lexer($sniffer.csp);
-          var parser = new Parser(lexer, $filter, $sniffer.csp);
           return cache[exp] = parser.parse(exp, false);
 
         case 'function':


### PR DESCRIPTION
There is no need to instantiate a new lexer and parser for every call to $parse.

[In fact, since these objects are really singletons in Angular, the optimisation of moving stuff into prototypes for these objects, could have been done less verbosely by putting the shared data and methods into closure]
