### PR TITLE
docs($resource): remove extra "to" from $resource docs

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -89,7 +89,7 @@ var $resourceMinErr = angular.$$minErr('$resource');
  *     caching.
  *   - **`timeout`** – `{number|Promise}` – timeout in milliseconds, or {@link ng.$q promise} that
  *     should abort the request when resolved.
- *   - **`withCredentials`** - `{boolean}` - whether to to set the `withCredentials` flag on the
+ *   - **`withCredentials`** - `{boolean}` - whether to set the `withCredentials` flag on the
  *     XHR object. See {@link https://developer.mozilla.org/en/http_access_control#section_5
  *     requests with credentials} for more information.
  *   - **`responseType`** - `{string}` - see {@link


### PR DESCRIPTION
Tiny change to fix wording in the $resource docs.
