### PR TITLE
fix(input): determine input[type=number] validity with ValidityState

### DIFF
--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -651,6 +651,17 @@ describe('input', function() {
     });
 
 
+    it('should invalidate non-numeric values', function() {
+      compileInput('<input type="number" ng-model="age" />');
+
+      scope.$apply(function() {
+        scope.age = 'gerbils';
+      });
+      scope.$digest();
+      expect(inputElm).toBeInvalid();
+    });
+
+
     describe('min', function() {
 
       it('should validate', function() {


### PR DESCRIPTION
Fixes #2144

**What happens**:

``` html
<form name="form">
  <input type="number" ng-model="value" name="value" />
  Number is valid: {{form.value.$valid}}
</form>
```
- **Chromium** / **Safari** / **Opera**
  1. Non-numeric evaluates to empty string
  2. Empty-string is considered valid unless `require` flag is set
  3. False positive: invalid number reported as valid
- **Firefox** / **Internet Explorer**
  1. Non-numeric string entered, string is not transformed by native code
  2. Regex tests string for validity
  3. Regex test fails, invalid number reported as invalid

**This patch should**:
1. Listen to input's `ValidityState` on browsers which implement `ValidityState`
2. Allow the differentiation between "invalid" empty strings and "valid" empty strings
3. Not need `require` flag to validate number inputs correctly.
4. Provide (kind of gross) framework for adding `ValidityState` support to other InputTypes
