### PR TITLE
Removes px declaration from x,y coordinates in svg element

### DIFF
--- a/docs/img/angularjs-for-header-only.svg
+++ b/docs/img/angularjs-for-header-only.svg
@@ -5,7 +5,7 @@
 ]>
 <svg version="1.1"
 	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/"
-	 x="0px" y="0px" width="687px" height="176px" viewBox="0 0 687 176" overflow="visible" enable-background="new 0 0 687 176"
+	 x="0" y="0" width="687px" height="176px" viewBox="0 0 687 176" overflow="visible" enable-background="new 0 0 687 176"
 	 xml:space="preserve">
 <defs>
 </defs>


### PR DESCRIPTION
px is the default unit for x and y coordinates in svg elements.

http://www.w3.org/TR/SVG/coords.html#InitialCoordinateSystem
