### PR TITLE
Store support object function in variable

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -414,13 +414,14 @@ function createInjector(modulesToLoad) {
       providerSuffix = 'Provider',
       path = [],
       loadedModules = new HashMap(),
+      so = supportObject;
       providerCache = {
         $provide: {
-            provider: supportObject(provider),
-            factory: supportObject(factory),
-            service: supportObject(service),
-            value: supportObject(value),
-            constant: supportObject(constant),
+            provider: so(provider),
+            factory: so(factory),
+            service: so(service),
+            value: so(value),
+            constant: so(constant),
             decorator: decorator
           }
       },

--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -414,7 +414,7 @@ function createInjector(modulesToLoad) {
       providerSuffix = 'Provider',
       path = [],
       loadedModules = new HashMap(),
-      so = supportObject;
+      so = supportObject,
       providerCache = {
         $provide: {
             provider: so(provider),


### PR DESCRIPTION
Storing the supportObject function in a variable so only that references needs to be changed if the function is swapped out.
