### PR TITLE
fix($parse): make promise unwrapping opt-in

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -761,16 +761,6 @@ Parser.prototype = {
             ? fnPtr.apply(context, args)
             : fnPtr(args[0], args[1], args[2], args[3], args[4]);
 
-      // Check for promise
-      if (v && v.then && parser.options.unwrapPromises) {
-        var p = v;
-        if (!('$$v' in v)) {
-          p.$$v = undefined;
-          p.then(function(val) { p.$$v = val; });
-        }
-        v = v.$$v;
-      }
-
       return ensureSafeObject(v, parser.text);
     };
   },

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1129,18 +1129,6 @@ describe('parser', function() {
             expect(scope.$eval('greeting')).toBe(undefined);
           });
 
-          it('should evaluate a function call returning a promise and eventually get its return value', function() {
-            scope.greetingFn = function() { return promise; };
-            expect(scope.$eval('greetingFn()')).toBe(undefined);
-
-            scope.$digest();
-            expect(scope.$eval('greetingFn()')).toBe(undefined);
-
-            deferred.resolve('hello!');
-            expect(scope.$eval('greetingFn()')).toBe(undefined);
-            scope.$digest();
-            expect(scope.$eval('greetingFn()')).toBe('hello!');
-          });
 
           describe('assignment into promises', function() {
             // This behavior is analogous to assignments to non-promise values

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1,12 +1,20 @@
 'use strict';
 
 describe('parser', function() {
+
+  beforeEach(function() {
+    // clear caches
+    getterFnCache = {};
+    promiseWarningCache = {};
+  });
+
+
   describe('lexer', function() {
     var lex;
 
     beforeEach(function () {
       lex = function () {
-        var lexer = new Lexer();
+        var lexer = new Lexer({csp: false, unwrapPromises: false});
         return lexer.lex.apply(lexer, arguments);
       };
     });
@@ -198,7 +206,6 @@ describe('parser', function() {
       beforeEach(inject(function ($rootScope, $sniffer) {
         scope = $rootScope;
         $sniffer.csp = cspEnabled;
-        getterFnCache = {}; // clear cache
       }));
 
 
@@ -854,263 +861,6 @@ describe('parser', function() {
       });
 
 
-      describe('promises', function() {
-        var deferred, promise, q;
-
-        beforeEach(inject(function($q) {
-          q = $q;
-          deferred = q.defer();
-          promise = deferred.promise;
-        }));
-
-        describe('{{promise}}', function() {
-          it('should evaluated resolved promise and get its value', function() {
-            deferred.resolve('hello!');
-            scope.greeting = promise;
-            expect(scope.$eval('greeting')).toBe(undefined);
-            scope.$digest();
-            expect(scope.$eval('greeting')).toBe('hello!');
-          });
-
-
-          it('should evaluated rejected promise and ignore the rejection reason', function() {
-            deferred.reject('sorry');
-            scope.greeting = promise;
-            expect(scope.$eval('gretting')).toBe(undefined);
-            scope.$digest();
-            expect(scope.$eval('greeting')).toBe(undefined);
-          });
-
-
-          it('should evaluate a promise and eventualy get its value', function() {
-            scope.greeting = promise;
-            expect(scope.$eval('greeting')).toBe(undefined);
-
-            scope.$digest();
-            expect(scope.$eval('greeting')).toBe(undefined);
-
-            deferred.resolve('hello!');
-            expect(scope.$eval('greeting')).toBe(undefined);
-            scope.$digest();
-            expect(scope.$eval('greeting')).toBe('hello!');
-          });
-
-
-          it('should evaluate a promise and eventualy ignore its rejection', function() {
-            scope.greeting = promise;
-            expect(scope.$eval('greeting')).toBe(undefined);
-
-            scope.$digest();
-            expect(scope.$eval('greeting')).toBe(undefined);
-
-            deferred.reject('sorry');
-            expect(scope.$eval('greeting')).toBe(undefined);
-            scope.$digest();
-            expect(scope.$eval('greeting')).toBe(undefined);
-          });
-
-          it('should evaluate a function call returning a promise and eventually get its return value', function() {
-            scope.greetingFn = function() { return promise; };
-            expect(scope.$eval('greetingFn()')).toBe(undefined);
-
-            scope.$digest();
-            expect(scope.$eval('greetingFn()')).toBe(undefined);
-
-            deferred.resolve('hello!');
-            expect(scope.$eval('greetingFn()')).toBe(undefined);
-            scope.$digest();
-            expect(scope.$eval('greetingFn()')).toBe('hello!');
-          });
-
-          describe('assignment into promises', function() {
-            // This behavior is analogous to assignments to non-promise values
-            // that are lazily set on the scope.
-            it('should evaluate a resolved object promise and set its value', inject(function($parse) {
-              scope.person = promise;
-              deferred.resolve({'name': 'Bill Gates'});
-
-              var getter = $parse('person.name');
-              expect(getter(scope)).toBe(undefined);
-
-              scope.$digest();
-              expect(getter(scope)).toBe('Bill Gates');
-              getter.assign(scope, 'Warren Buffet');
-              expect(getter(scope)).toBe('Warren Buffet');
-            }));
-
-
-            it('should evaluate a resolved primitive type promise and set its value', inject(function($parse) {
-              scope.greeting = promise;
-              deferred.resolve('Salut!');
-
-              var getter = $parse('greeting');
-              expect(getter(scope)).toBe(undefined);
-
-              scope.$digest();
-              expect(getter(scope)).toBe('Salut!');
-
-              getter.assign(scope, 'Bonjour');
-              expect(getter(scope)).toBe('Bonjour');
-            }));
-
-
-            it('should evaluate an unresolved promise and set and remember its value', inject(function($parse) {
-              scope.person = promise;
-
-              var getter = $parse('person.name');
-              expect(getter(scope)).toBe(undefined);
-
-              scope.$digest();
-              expect(getter(scope)).toBe(undefined);
-
-              getter.assign(scope, 'Bonjour');
-              scope.$digest();
-
-              expect(getter(scope)).toBe('Bonjour');
-
-              var c1Getter = $parse('person.A.B.C1');
-              scope.$digest();
-              expect(c1Getter(scope)).toBe(undefined);
-              c1Getter.assign(scope, 'c1_value');
-              scope.$digest();
-              expect(c1Getter(scope)).toBe('c1_value');
-
-              // Set another property on the person.A.B
-              var c2Getter = $parse('person.A.B.C2');
-              scope.$digest();
-              expect(c2Getter(scope)).toBe(undefined);
-              c2Getter.assign(scope, 'c2_value');
-              scope.$digest();
-              expect(c2Getter(scope)).toBe('c2_value');
-
-              // c1 should be unchanged.
-              expect($parse('person.A')(scope)).toEqual(
-                  {B: {C1: 'c1_value', C2: 'c2_value'}});
-            }));
-
-
-            it('should evaluate a resolved promise and overwrite the previous set value in the absense of the getter',
-               inject(function($parse) {
-              scope.person = promise;
-              var c1Getter = $parse('person.A.B.C1');
-              c1Getter.assign(scope, 'c1_value');
-              // resolving the promise should update the tree.
-              deferred.resolve({A: {B: {C1: 'resolved_c1'}}});
-              scope.$digest();
-              expect(c1Getter(scope)).toEqual('resolved_c1');
-            }));
-          });
-        });
-
-        describe('dereferencing', function() {
-          it('should evaluate and dereference properties leading to and from a promise', function() {
-            scope.obj = {greeting: promise};
-            expect(scope.$eval('obj.greeting')).toBe(undefined);
-            expect(scope.$eval('obj.greeting.polite')).toBe(undefined);
-
-            scope.$digest();
-            expect(scope.$eval('obj.greeting')).toBe(undefined);
-            expect(scope.$eval('obj.greeting.polite')).toBe(undefined);
-
-            deferred.resolve({polite: 'Good morning!'});
-            scope.$digest();
-            expect(scope.$eval('obj.greeting')).toEqual({polite: 'Good morning!'});
-            expect(scope.$eval('obj.greeting.polite')).toBe('Good morning!');
-          });
-
-          it('should evaluate and dereference properties leading to and from a promise via bracket ' +
-              'notation', function() {
-            scope.obj = {greeting: promise};
-            expect(scope.$eval('obj["greeting"]')).toBe(undefined);
-            expect(scope.$eval('obj["greeting"]["polite"]')).toBe(undefined);
-
-            scope.$digest();
-            expect(scope.$eval('obj["greeting"]')).toBe(undefined);
-            expect(scope.$eval('obj["greeting"]["polite"]')).toBe(undefined);
-
-            deferred.resolve({polite: 'Good morning!'});
-            scope.$digest();
-            expect(scope.$eval('obj["greeting"]')).toEqual({polite: 'Good morning!'});
-            expect(scope.$eval('obj["greeting"]["polite"]')).toBe('Good morning!');
-          });
-
-
-          it('should evaluate and dereference array references leading to and from a promise',
-              function() {
-            scope.greetings = [promise];
-            expect(scope.$eval('greetings[0]')).toBe(undefined);
-            expect(scope.$eval('greetings[0][0]')).toBe(undefined);
-
-            scope.$digest();
-            expect(scope.$eval('greetings[0]')).toBe(undefined);
-            expect(scope.$eval('greetings[0][0]')).toBe(undefined);
-
-            deferred.resolve(['Hi!', 'Cau!']);
-            scope.$digest();
-            expect(scope.$eval('greetings[0]')).toEqual(['Hi!', 'Cau!']);
-            expect(scope.$eval('greetings[0][0]')).toBe('Hi!');
-          });
-
-
-          it('should evaluate and dereference promises used as function arguments', function() {
-            scope.greet = function(name) { return 'Hi ' + name + '!'; };
-            scope.name = promise;
-            expect(scope.$eval('greet(name)')).toBe('Hi undefined!');
-
-            scope.$digest();
-            expect(scope.$eval('greet(name)')).toBe('Hi undefined!');
-
-            deferred.resolve('Veronica');
-            expect(scope.$eval('greet(name)')).toBe('Hi undefined!');
-
-            scope.$digest();
-            expect(scope.$eval('greet(name)')).toBe('Hi Veronica!');
-          });
-
-
-          it('should evaluate and dereference promises used as array indexes', function() {
-            scope.childIndex = promise;
-            scope.kids = ['Adam', 'Veronica', 'Elisa'];
-            expect(scope.$eval('kids[childIndex]')).toBe(undefined);
-
-            scope.$digest();
-            expect(scope.$eval('kids[childIndex]')).toBe(undefined);
-
-            deferred.resolve(1);
-            expect(scope.$eval('kids[childIndex]')).toBe(undefined);
-
-            scope.$digest();
-            expect(scope.$eval('kids[childIndex]')).toBe('Veronica');
-          });
-
-
-          it('should evaluate and dereference promises used as keys in bracket notation', function() {
-            scope.childKey = promise;
-            scope.kids = {'a': 'Adam', 'v': 'Veronica', 'e': 'Elisa'};
-
-            expect(scope.$eval('kids[childKey]')).toBe(undefined);
-
-            scope.$digest();
-            expect(scope.$eval('kids[childKey]')).toBe(undefined);
-
-            deferred.resolve('v');
-            expect(scope.$eval('kids[childKey]')).toBe(undefined);
-
-            scope.$digest();
-            expect(scope.$eval('kids[childKey]')).toBe('Veronica');
-          });
-
-
-          it('should not mess with the promise if it was not directly evaluated', function() {
-            scope.obj = {greeting: promise, username: 'hi'};
-            var obj = scope.$eval('obj');
-            expect(obj.username).toEqual('hi');
-            expect(typeof obj.greeting.then).toBe('function');
-          });
-        });
-      });
-
-
       describe('assignable', function() {
         it('should expose assignment function', inject(function($parse) {
           var fn = $parse('a');
@@ -1201,6 +951,383 @@ describe('parser', function() {
           expect($parse('foo(1, 2, 3)').constant).toBe(false);
           expect($parse('"name" + id').constant).toBe(false);
         }));
+      });
+    });
+  });
+
+
+  describe('promises', function() {
+
+    var deferred, promise, q;
+
+    describe('unwrapPromises setting', function () {
+
+      beforeEach(inject(function($rootScope, $q) {
+        scope = $rootScope;
+
+        $rootScope.$apply(function() {
+          deferred = $q.defer();
+          deferred.resolve('Bobo');
+          promise = deferred.promise;
+        });
+      }));
+
+      it('should not unwrap promises by default', inject(function ($parse) {
+        scope.person = promise;
+        scope.things = {person: promise};
+        scope.getPerson = function () { return promise; };
+
+        var getter = $parse('person');
+        var propGetter = $parse('things.person');
+        var fnGetter = $parse('getPerson()');
+
+        expect(getter(scope)).toBe(promise);
+        expect(propGetter(scope)).toBe(promise);
+        expect(fnGetter(scope)).toBe(promise);
+      }));
+    });
+
+
+    forEach([true, false], function(cspEnabled) {
+
+      describe('promise logging (csp:' + cspEnabled + ')', function() {
+
+        var $log;
+        var PROMISE_WARNING_REGEXP = /\[\$parse\] Promise found in the expression `[^`]+`. Automatic unwrapping of promises in Angular expressions is deprecated\./;
+
+        beforeEach(module(function($parseProvider) {
+          $parseProvider.unwrapPromises(true);
+        }));
+
+        beforeEach(inject(function($rootScope, $q, _$log_) {
+          scope = $rootScope;
+
+          $rootScope.$apply(function() {
+            deferred = $q.defer();
+            deferred.resolve('Bobo');
+            promise = deferred.promise;
+          });
+
+          $log = _$log_;
+        }));
+
+        it('should log warnings by default', function() {
+          scope.person = promise;
+          scope.$eval('person');
+          expect($log.warn.logs.pop()).toEqual(['[$parse] Promise found in the expression `person`. ' +
+              'Automatic unwrapping of promises in Angular expressions is deprecated.']);
+        });
+
+
+        it('should log warnings for deep promises', function() {
+          scope.car = {wheel: {disc: promise}};
+          scope.$eval('car.wheel.disc.pad');
+          expect($log.warn.logs.pop()).toMatch(PROMISE_WARNING_REGEXP);
+        });
+
+
+        it('should log warnings for setters', function() {
+          scope.person = promise;
+          scope.$eval('person.name = "Bubu"');
+          expect($log.warn.logs.pop()).toMatch(PROMISE_WARNING_REGEXP);
+        });
+
+
+        it('should log only a single warning for each expression', function() {
+          scope.person1 = promise;
+          scope.person2 = promise;
+
+          scope.$eval('person1');
+          scope.$eval('person1');
+          expect($log.warn.logs.pop()).toMatch(/`person1`/);
+          expect($log.warn.logs).toEqual([]);
+
+          scope.$eval('person1');
+          scope.$eval('person2');
+          scope.$eval('person1');
+          scope.$eval('person2');
+          expect($log.warn.logs.pop()).toMatch(/`person2`/);
+          expect($log.warn.logs).toEqual([]);
+        });
+
+
+        it('should log warning for complex expressions', function() {
+          scope.person1 = promise;
+          scope.person2 = promise;
+
+          scope.$eval('person1 + person2');
+          expect($log.warn.logs.pop()).toMatch(/`person1 \+ person2`/);
+          expect($log.warn.logs).toEqual([]);
+        });
+      });
+    });
+
+
+    forEach([true, false], function(cspEnabled) {
+
+      describe('csp ' + cspEnabled, function() {
+
+        beforeEach(module(function($parseProvider) {
+          $parseProvider.unwrapPromises(true);
+          $parseProvider.logPromiseWarnings(false);
+        }));
+
+
+        beforeEach(inject(function($rootScope, $sniffer, $q) {
+          scope = $rootScope;
+          $sniffer.csp = cspEnabled;
+
+          q = $q;
+          deferred = q.defer();
+          promise = deferred.promise;
+        }));
+
+
+        describe('{{promise}}', function() {
+          it('should evaluated resolved promise and get its value', function() {
+            deferred.resolve('hello!');
+            scope.greeting = promise;
+            expect(scope.$eval('greeting')).toBe(undefined);
+            scope.$digest();
+            expect(scope.$eval('greeting')).toBe('hello!');
+          });
+
+
+          it('should evaluated rejected promise and ignore the rejection reason', function() {
+            deferred.reject('sorry');
+            scope.greeting = promise;
+            expect(scope.$eval('greeting')).toBe(undefined);
+            scope.$digest();
+            expect(scope.$eval('greeting')).toBe(undefined);
+          });
+
+
+          it('should evaluate a promise and eventualy get its value', function() {
+            scope.greeting = promise;
+            expect(scope.$eval('greeting')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('greeting')).toBe(undefined);
+
+            deferred.resolve('hello!');
+            expect(scope.$eval('greeting')).toBe(undefined);
+            scope.$digest();
+            expect(scope.$eval('greeting')).toBe('hello!');
+          });
+
+
+          it('should evaluate a promise and eventualy ignore its rejection', function() {
+            scope.greeting = promise;
+            expect(scope.$eval('greeting')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('greeting')).toBe(undefined);
+
+            deferred.reject('sorry');
+            expect(scope.$eval('greeting')).toBe(undefined);
+            scope.$digest();
+            expect(scope.$eval('greeting')).toBe(undefined);
+          });
+
+          it('should evaluate a function call returning a promise and eventually get its return value', function() {
+            scope.greetingFn = function() { return promise; };
+            expect(scope.$eval('greetingFn()')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('greetingFn()')).toBe(undefined);
+
+            deferred.resolve('hello!');
+            expect(scope.$eval('greetingFn()')).toBe(undefined);
+            scope.$digest();
+            expect(scope.$eval('greetingFn()')).toBe('hello!');
+          });
+
+          describe('assignment into promises', function() {
+            // This behavior is analogous to assignments to non-promise values
+            // that are lazily set on the scope.
+            it('should evaluate a resolved object promise and set its value', inject(function($parse) {
+              scope.person = promise;
+              deferred.resolve({'name': 'Bill Gates'});
+
+              var getter = $parse('person.name', { unwrapPromises: true });
+              expect(getter(scope)).toBe(undefined);
+
+              scope.$digest();
+              expect(getter(scope)).toBe('Bill Gates');
+              getter.assign(scope, 'Warren Buffet');
+              expect(getter(scope)).toBe('Warren Buffet');
+            }));
+
+
+            it('should evaluate a resolved primitive type promise and set its value', inject(function($parse) {
+              scope.greeting = promise;
+              deferred.resolve('Salut!');
+
+              var getter = $parse('greeting', { unwrapPromises: true });
+              expect(getter(scope)).toBe(undefined);
+
+              scope.$digest();
+              expect(getter(scope)).toBe('Salut!');
+
+              getter.assign(scope, 'Bonjour');
+              expect(getter(scope)).toBe('Bonjour');
+            }));
+
+
+            it('should evaluate an unresolved promise and set and remember its value', inject(function($parse) {
+              scope.person = promise;
+
+              var getter = $parse('person.name', { unwrapPromises: true });
+              expect(getter(scope)).toBe(undefined);
+
+              scope.$digest();
+              expect(getter(scope)).toBe(undefined);
+
+              getter.assign(scope, 'Bonjour');
+              scope.$digest();
+
+              expect(getter(scope)).toBe('Bonjour');
+
+              var c1Getter = $parse('person.A.B.C1', { unwrapPromises: true });
+              scope.$digest();
+              expect(c1Getter(scope)).toBe(undefined);
+              c1Getter.assign(scope, 'c1_value');
+              scope.$digest();
+              expect(c1Getter(scope)).toBe('c1_value');
+
+              // Set another property on the person.A.B
+              var c2Getter = $parse('person.A.B.C2', { unwrapPromises: true });
+              scope.$digest();
+              expect(c2Getter(scope)).toBe(undefined);
+              c2Getter.assign(scope, 'c2_value');
+              scope.$digest();
+              expect(c2Getter(scope)).toBe('c2_value');
+
+              // c1 should be unchanged.
+              expect($parse('person.A', { unwrapPromises: true })(scope)).toEqual(
+                  {B: {C1: 'c1_value', C2: 'c2_value'}});
+            }));
+
+
+            it('should evaluate a resolved promise and overwrite the previous set value in the absense of the getter',
+                inject(function($parse) {
+              scope.person = promise;
+              var c1Getter = $parse('person.A.B.C1', { unwrapPromises: true });
+              c1Getter.assign(scope, 'c1_value');
+              // resolving the promise should update the tree.
+              deferred.resolve({A: {B: {C1: 'resolved_c1'}}});
+              scope.$digest();
+              expect(c1Getter(scope)).toEqual('resolved_c1');
+            }));
+          });
+        });
+
+        describe('dereferencing', function() {
+          it('should evaluate and dereference properties leading to and from a promise', function() {
+            scope.obj = {greeting: promise};
+            expect(scope.$eval('obj.greeting')).toBe(undefined);
+            expect(scope.$eval('obj.greeting.polite')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('obj.greeting')).toBe(undefined);
+            expect(scope.$eval('obj.greeting.polite')).toBe(undefined);
+
+            deferred.resolve({polite: 'Good morning!'});
+            scope.$digest();
+            expect(scope.$eval('obj.greeting')).toEqual({polite: 'Good morning!'});
+            expect(scope.$eval('obj.greeting.polite')).toBe('Good morning!');
+          });
+
+          it('should evaluate and dereference properties leading to and from a promise via bracket ' +
+              'notation', function() {
+            scope.obj = {greeting: promise};
+            expect(scope.$eval('obj["greeting"]')).toBe(undefined);
+            expect(scope.$eval('obj["greeting"]["polite"]')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('obj["greeting"]')).toBe(undefined);
+            expect(scope.$eval('obj["greeting"]["polite"]')).toBe(undefined);
+
+            deferred.resolve({polite: 'Good morning!'});
+            scope.$digest();
+            expect(scope.$eval('obj["greeting"]')).toEqual({polite: 'Good morning!'});
+            expect(scope.$eval('obj["greeting"]["polite"]')).toBe('Good morning!');
+          });
+
+
+          it('should evaluate and dereference array references leading to and from a promise',
+              function() {
+                scope.greetings = [promise];
+                expect(scope.$eval('greetings[0]')).toBe(undefined);
+                expect(scope.$eval('greetings[0][0]')).toBe(undefined);
+
+                scope.$digest();
+                expect(scope.$eval('greetings[0]')).toBe(undefined);
+                expect(scope.$eval('greetings[0][0]')).toBe(undefined);
+
+                deferred.resolve(['Hi!', 'Cau!']);
+                scope.$digest();
+                expect(scope.$eval('greetings[0]')).toEqual(['Hi!', 'Cau!']);
+                expect(scope.$eval('greetings[0][0]')).toBe('Hi!');
+              });
+
+
+          it('should evaluate and dereference promises used as function arguments', function() {
+            scope.greet = function(name) { return 'Hi ' + name + '!'; };
+            scope.name = promise;
+            expect(scope.$eval('greet(name)')).toBe('Hi undefined!');
+
+            scope.$digest();
+            expect(scope.$eval('greet(name)')).toBe('Hi undefined!');
+
+            deferred.resolve('Veronica');
+            expect(scope.$eval('greet(name)')).toBe('Hi undefined!');
+
+            scope.$digest();
+            expect(scope.$eval('greet(name)')).toBe('Hi Veronica!');
+          });
+
+
+          it('should evaluate and dereference promises used as array indexes', function() {
+            scope.childIndex = promise;
+            scope.kids = ['Adam', 'Veronica', 'Elisa'];
+            expect(scope.$eval('kids[childIndex]')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('kids[childIndex]')).toBe(undefined);
+
+            deferred.resolve(1);
+            expect(scope.$eval('kids[childIndex]')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('kids[childIndex]')).toBe('Veronica');
+          });
+
+
+          it('should evaluate and dereference promises used as keys in bracket notation', function() {
+            scope.childKey = promise;
+            scope.kids = {'a': 'Adam', 'v': 'Veronica', 'e': 'Elisa'};
+
+            expect(scope.$eval('kids[childKey]')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('kids[childKey]')).toBe(undefined);
+
+            deferred.resolve('v');
+            expect(scope.$eval('kids[childKey]')).toBe(undefined);
+
+            scope.$digest();
+            expect(scope.$eval('kids[childKey]')).toBe('Veronica');
+          });
+
+
+          it('should not mess with the promise if it was not directly evaluated', function() {
+            scope.obj = {greeting: promise, username: 'hi'};
+            var obj = scope.$eval('obj');
+            expect(obj.username).toEqual('hi');
+            expect(typeof obj.greeting.then).toBe('function');
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
Previously promises found anywhere in the expression during expression
evaluation would evaluate to undefined while unresolved and to the
fulfillment value if fulfilled.

This is a feature that didn't prove to be wildly useful or popular,
primarily because of the dichotomy between data access in templates
(accessed as raw values) and controller code (accessed as promises).

In most code we ended up resolving promises manually in controllers
anyway and thus unifying the model access there.

Other downsides of automatic promise unwrapping:
- when building components it's often desirable to receive the
  raw promises
- adds complexity and slows down expression evaluation
- makes expression code pre-generation unattractive due to the
  amount of code that needs to be generated
- makes IDE auto-completion and tool support hard
- adds too much magic

Closes #4158
Closes #4270
