### PR TITLE
fix(ngTouch): add $event to ng-swipe

### DIFF
--- a/src/ngTouch/directive/ngSwipe.js
+++ b/src/ngTouch/directive/ngSwipe.js
@@ -92,18 +92,18 @@ function makeSwipeDirective(directiveName, direction, eventName) {
       }
 
       $swipe.bind(element, {
-        'start': function(coords) {
+        'start': function(coords, event) {
           startCoords = coords;
           valid = true;
         },
-        'cancel': function() {
+        'cancel': function(event) {
           valid = false;
         },
-        'end': function(coords) {
+        'end': function(coords, event) {
           if (validSwipe(coords)) {
             scope.$apply(function() {
               element.triggerHandler(eventName);
-              swipeHandler(scope);
+              swipeHandler(scope, {$event: event});
             });
           }
         }

--- a/src/ngTouch/swipe.js
+++ b/src/ngTouch/swipe.js
@@ -83,12 +83,12 @@ ngTouch.factory('$swipe', [function() {
         totalX = 0;
         totalY = 0;
         lastPos = startCoords;
-        eventHandlers['start'] && eventHandlers['start'](startCoords);
+        eventHandlers['start'] && eventHandlers['start'](startCoords, event);
       });
 
       element.on('touchcancel', function(event) {
         active = false;
-        eventHandlers['cancel'] && eventHandlers['cancel']();
+        eventHandlers['cancel'] && eventHandlers['cancel'](event);
       });
 
       element.on('touchmove mousemove', function(event) {
@@ -116,20 +116,19 @@ ngTouch.factory('$swipe', [function() {
         if (totalY > totalX) {
           // Allow native scrolling to take over.
           active = false;
-          eventHandlers['cancel'] && eventHandlers['cancel']();
+          eventHandlers['cancel'] && eventHandlers['cancel'](event);
           return;
         } else {
           // Prevent the browser from scrolling.
           event.preventDefault();
-
-          eventHandlers['move'] && eventHandlers['move'](coords);
+          eventHandlers['move'] && eventHandlers['move'](coords, event);
         }
       });
 
       element.on('touchend mouseup', function(event) {
         if (!active) return;
         active = false;
-        eventHandlers['end'] && eventHandlers['end'](getCoordinates(event));
+        eventHandlers['end'] && eventHandlers['end'](getCoordinates(event), event);
       });
     }
   };

--- a/test/ngTouch/directive/ngSwipeSpec.js
+++ b/test/ngTouch/directive/ngSwipeSpec.js
@@ -66,6 +66,23 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBe(true);
     }));
 
+    it('should pass event object', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-swipe-left="event = $event"></div>')($rootScope);
+      $rootScope.$digest();
+
+      browserTrigger(element, startEvent, {
+        keys : [],
+        x : 100,
+        y : 20
+      });
+      browserTrigger(element, endEvent,{
+        keys: [],
+        x: 20,
+        y: 20
+      });
+      expect($rootScope.event).toBeDefined();
+    }));
+
     it('should not swipe if you move too far vertically', inject(function($rootScope, $compile, $rootElement) {
       element = $compile('<div ng-swipe-left="swiped = true"></div>')($rootScope);
       $rootElement.append(element);


### PR DESCRIPTION
Existing documentation implies that an Event object should be available
as $event on swipe directives, which previously was only working for
ng-click.

Closes #4071
