### PR TITLE
More strict checking for isNumber() function and isObject() function

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -335,7 +335,7 @@ function isDefined(value){return typeof value != 'undefined';}
  * @param {*} value Reference to check.
  * @returns {boolean} True if `value` is an `Object` but not `null`.
  */
-function isObject(value){return value != null && typeof value == 'object';}
+function isObject(value){return value != null && typeof value == 'object' && !isArray(value);}
 
 
 /**
@@ -363,7 +363,7 @@ function isString(value){return typeof value == 'string';}
  * @param {*} value Reference to check.
  * @returns {boolean} True if `value` is a `Number`.
  */
-function isNumber(value){return typeof value == 'number';}
+function isNumber(value){return !isNaN(value) && typeof value == 'number';}
 
 
 /**


### PR DESCRIPTION
Simple typeof checking is not enough for isNumber and isObject functions. Because typeof NaN == "number" will give true and typeof  [] == "object" also will give true.

I think we need these checks because, the developers who is going to use angular.isObject and angular.isNumber functions will be expecting this.
