### PR TITLE
fix(ngLocale): Turkish shortDate fix

### DIFF
--- a/src/ngLocale/angular-locale_tr-tr.js
+++ b/src/ngLocale/angular-locale_tr-tr.js
@@ -58,7 +58,7 @@ $provide.value("$locale", {
     "mediumDate": "d MMM y",
     "mediumTime": "HH:mm:ss",
     "short": "dd MM yyyy HH:mm",
-    "shortDate": "dd MM yyyy",
+    "shortDate": "dd.MM.yyyy",
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {

--- a/src/ngLocale/angular-locale_tr.js
+++ b/src/ngLocale/angular-locale_tr.js
@@ -58,7 +58,7 @@ $provide.value("$locale", {
     "mediumDate": "d MMM y",
     "mediumTime": "HH:mm:ss",
     "short": "dd MM yyyy HH:mm",
-    "shortDate": "dd MM yyyy",
+    "shortDate": "dd.MM.yyyy",
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {


### PR DESCRIPTION
The Turkish shortDate format was wrong, [it should be](http://en.wikipedia.org/wiki/Date_and_time_notation_in_Turkey) `dd.MM.yyyy`. I don't know why the Google closure [has it separated with spaces](https://code.google.com/p/closure-library/source/browse/closure/goog/i18n/datetimesymbolsext.js#17471).
