### PR TITLE
fix(input): make ngList honor custom separators

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1314,8 +1314,7 @@ var requiredDirective = function() {
  * can be a fixed string (by default a comma) or a regular expression.
  *
  * @element input
- * @param {string=} ngList optional delimiter that should be used to split the value. If
- *   specified in form `/something/` then the value will be converted into a regular expression.
+ * @param {string=} ngList optional delimiter that should be used to split the value.
  *
  * @example
     <doc:example>
@@ -1357,8 +1356,7 @@ var ngListDirective = function() {
   return {
     require: 'ngModel',
     link: function(scope, element, attr, ctrl) {
-      var match = /\/(.*)\//.exec(attr.ngList),
-          separator = match && new RegExp(match[1]) || attr.ngList || ',';
+      var separator = attr.ngList || ', ';
 
       var parse = function(viewValue) {
         // If the viewValue is invalid (say required but empty) it will be `undefined`
@@ -1367,7 +1365,7 @@ var ngListDirective = function() {
         var list = [];
 
         if (viewValue) {
-          forEach(viewValue.split(separator), function(value) {
+          forEach(viewValue.split(trim(separator)), function(value) {
             if (value) list.push(trim(value));
           });
         }
@@ -1378,7 +1376,7 @@ var ngListDirective = function() {
       ctrl.$parsers.push(parse);
       ctrl.$formatters.push(function(value) {
         if (isArray(value)) {
-          return value.join(', ');
+          return value.join(separator);
         }
 
         return undefined;

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -970,7 +970,7 @@ describe('input', function() {
     it("should not clobber text if model changes due to itself", function() {
       // When the user types 'a,b' the 'a,' stage parses to ['a'] but if the
       // $parseModel function runs it will change to 'a', in essence preventing
-      // the user from ever typying ','.
+      // the user from ever typing ','.
       compileInput('<input type="text" ng-model="list" ng-list />');
 
       changeInputValueTo('a ');
@@ -1012,6 +1012,11 @@ describe('input', function() {
     it('should allow custom separator', function() {
       compileInput('<input type="text" ng-model="list" ng-list=":" />');
 
+      scope.$apply(function() {
+        scope.list = ['x', 'y', 'z'];
+      });
+      expect(inputElm.val()).toBe('x:y:z');
+
       changeInputValueTo('a,a');
       expect(scope.list).toEqual(['a,a']);
 
@@ -1019,15 +1024,11 @@ describe('input', function() {
       expect(scope.list).toEqual(['a', 'b']);
     });
 
+    it('should ignore separator whitespace when splitting', function() {
+      compileInput('<input type="text" ng-model="list" ng-list="  |  " />');
 
-    it('should allow regexp as a separator', function() {
-      compileInput('<input type="text" ng-model="list" ng-list="/:|,/" />');
-
-      changeInputValueTo('a,b');
+      changeInputValueTo('a|b');
       expect(scope.list).toEqual(['a', 'b']);
-
-      changeInputValueTo('a,b: c');
-      expect(scope.list).toEqual(['a', 'b', 'c']);
     });
   });
 


### PR DESCRIPTION
Remove support for regexp separators, and correctly use custom separator when formatting values into the control.

Follows @IgorMinar's suggestions from #2561, as suggested by @petebacondarwin in #4008.

The existing "should allow custom separator" test was incomplete, since it did not check that the custom separator was used to format the values in the control.

Notes:
1. The behaviour is still not perfect, because when using a custom separator containing whitespace, e.g. `" | "`, the spaces should be rendered into the control. Even with my changes, this is not the case, because the `attr.ngList` value has already been trimmed prior to being passed to the directive. I have omitted the failing test for this case. How would we handle this?
2. The whitespace behaviour should arguably be affected by the value of `ng-trim` where present: I'd suggest that when it is present, the values between the separators should not be trimmed.
