### PR TITLE
fix(ngMock): add missing angular. prefix to isDefined calls in $interval

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -467,9 +467,9 @@ angular.mock.$IntervalProvider = function() {
     var $interval = function(fn, delay, count, invokeApply) {
       var deferred = $q.defer(),
           promise = deferred.promise,
-          count = (isDefined(count)) ? count : 0,
+          count = (angular.isDefined(count)) ? count : 0,
           iteration = 0,
-          skipApply = (isDefined(invokeApply) && !invokeApply);
+          skipApply = (angular.isDefined(invokeApply) && !invokeApply);
 
       promise.then(null, null, fn);
 


### PR DESCRIPTION
The newly introduced `$interval` mock service for ngMock calls `isDefined`
in the global namespace which fails when used within unit tests.

This change adds the missing `angular.` prefix to such `isDefined` calls.

Closes #4334
