### PR TITLE
fix($anchorScroll): fix broken example code with correct controller name

### DIFF
--- a/src/ng/anchorScroll.js
+++ b/src/ng/anchorScroll.js
@@ -12,11 +12,11 @@
  *
  * It also watches the `$location.hash()` and scrolls whenever it changes to match any anchor.
  * This can be disabled by calling `$anchorScrollProvider.disableAutoScrolling()`.
- * 
+ *
  * @example
    <example>
      <file name="index.html">
-       <div ng-controller="MainCtrl">
+       <div ng-controller="ScrollCtrl">
          <a ng-click="gotoBottom()">Go to bottom</a>
          <a id="bottom"></a> You're at the bottom!
        </div>
@@ -27,7 +27,7 @@
            // set the location.hash to the id of
            // the element you wish to scroll to.
            $location.hash('bottom');
-           
+
            // call $anchorScroll()
            $anchorScroll();
          }


### PR DESCRIPTION
The demo does not work
http://docs.angularjs.org/api/ng.$anchorScroll
![screenshot 2013-10-09 13 03 40](https://f.cloud.github.com/assets/1016365/1301180/e97f04dc-311d-11e3-9114-bb2d13a4892c.png)

Rename "MainCtrl" ng-controller to correct controller name "ScrollCtrl"
