### PR TITLE
fix($rootScope): make $digest loop works correctly with $sce trusted values

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -71,8 +71,8 @@ function $RootScopeProvider(){
     return TTL;
   };
 
-  this.$get = ['$injector', '$exceptionHandler', '$parse', '$browser',
-      function( $injector,   $exceptionHandler,   $parse,   $browser) {
+  this.$get = ['$injector', '$exceptionHandler', '$parse', '$browser', '$sce',
+      function( $injector,   $exceptionHandler,   $parse,   $browser,   $sce) {
 
     /**
      * @ngdoc function
@@ -529,7 +529,7 @@ function $RootScopeProvider(){
                   watch = watchers[length];
                   // Most common watches are on primitives, in which case we can short
                   // circuit it with === operator, only when === fails do we use .equals
-                  if (watch && (value = watch.get(current)) !== (last = watch.last) &&
+                  if (watch && (value = $sce.valueOf(watch.get(current))) !== (last = watch.last) &&
                       !(watch.eq
                           ? equals(value, last)
                           : (typeof value == 'number' && typeof last == 'number'

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -314,6 +314,24 @@ describe('Scope', function() {
     }));
 
 
+    it('should handle $sce trusted values', inject(function($rootScope, $sce) {
+      $rootScope.$sce = $sce;
+      $rootScope.$watch('$sce.trustAsHtml("<html></html>")', function() {});
+      expect(function() {
+        $rootScope.$digest();
+      }).not.toThrow();
+    }));
+
+
+    it('should handle $sce trusted values in deep compare', inject(function($rootScope, $sce) {
+      $rootScope.$sce = $sce;
+      $rootScope.$watch('$sce.trustAsHtml("<html></html>")', function() {}, true);
+      expect(function() {
+        $rootScope.$digest();
+      }).not.toThrow();
+    }));
+
+
     it('should return a function that allows listeners to be unregistered', inject(
         function($rootScope) {
       var listener = jasmine.createSpy('watch listener'),


### PR DESCRIPTION
When using `$watch(..., ..., false)` to watch a `$sce` trusted value that is constructed dynamically, $digest comparison fails to recognize that while the trusted value instance may be different, the value being wrapped is the same. This results in the "10 $digest() iterations reached. Aborting!" error. A common use case is using a filter to transform HTML and wrap the result with `$sce.trustAsHtml()`. This plunker demonstrates the issue: http://plnkr.co/edit/Q04wTEgMwr7HnSsG0xVs?p=preview.

This fix modifies $digest comparison loop to use `$sce.valueOf()` to unwrap values. To save one unwrap operation per comparison, instead of invoking that method to unwrap both the current value and last values, the method is only invoked for the current value and just let the unwrapped value stored in last value.
