### PR TITLE
grunt-contrib-jasmine-node doesnt exist anymore and performance isArray

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-contrib-compress');
-  grunt.loadNpmTasks('grunt-contrib-jasmine-node');
+  grunt.loadNpmTasks('grunt-jasmine-node');
   grunt.loadNpmTasks('grunt-ddescribe-iit');
   grunt.loadNpmTasks('grunt-merge-conflict');
   grunt.loadNpmTasks('grunt-parallel');

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "yaml-js": "~0.0.8",
     "marked": "~0.2.9",
     "rewire": "1.1.3",
-    "grunt-contrib-jasmine-node": "~0.1.1",
+    "grunt-jasmine-node": "~0.1.0",
     "grunt-parallel": "~0.3.1",
     "grunt-ddescribe-iit": "~0.0.1",
     "grunt-merge-conflict": "~0.0.1",

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -393,14 +393,9 @@ function isDate(value){
  * @param {*} value Reference to check.
  * @returns {boolean} True if `value` is an `Array`.
  */
-var isArray = (function() {
-  if(Array.isArray) {
-    return Array.isArray;
-  }
-  return function(value) {
-    return toString.apply(value) == '[object Array]';
-  };
-})();
+var isArray = Array.isArray || function(value) {
+  return toString.apply(value) == '[object Array]';
+};
 
 
 /**

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -393,9 +393,14 @@ function isDate(value){
  * @param {*} value Reference to check.
  * @returns {boolean} True if `value` is an `Array`.
  */
-function isArray(value) {
-  return toString.apply(value) == '[object Array]';
-}
+var isArray = (function() {
+  if(Array.isArray) {
+    return Array.isArray;
+  }
+  return function(value) {
+    return toString.apply(value) == '[object Array]';
+  };
+})();
 
 
 /**


### PR DESCRIPTION
it looks like grunt-contrib-jasmine-node is renamed to grunt-jasmine-node, since it isnt being maintained by the grunt team. npm install will fail because of this.
https://npmjs.org/package/grunt-contrib-jasmine-node
https://npmjs.org/package/grunt-jasmine-node

I have also changed the isArray method by a faster one, see benchmarks at the jsperf site:
http://jsperf.com/array-isarray-vs-angular-isarray/2
