### PR TITLE
fix($animate): ensure that a timeStamp is created if not provided by the browser event

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -787,15 +787,15 @@ angular.module('ngAnimate', ['ng'])
         function onAnimationProgress(event) {
           event.stopPropagation();
           var ev = event.originalEvent || event;
+          var timeStamp = ev.$manualTimeStamp || ev.timeStamp || Date.now();
           /* $manualTimeStamp is a mocked timeStamp value which is set
            * within browserTrigger(). This is only here so that tests can
-           * mock animations properly. Real events fallback to event.timeStamp.
-           * We're checking to see if the timestamp surpasses the expected delay,
-           * but we're using elapsedTime instead of the timestamp on the 2nd
+           * mock animations properly. Real events fallback to event.timeStamp,
+           * or, if they don't, then a timeStamp is automatically created for them.
+           * We're checking to see if the timeStamp surpasses the expected delay,
+           * but we're using elapsedTime instead of the timeStamp on the 2nd
            * pre-condition since animations sometimes close off early */
-          if((ev.$manualTimeStamp || ev.timeStamp) - startTime >= maxDelayTime &&
-              ev.elapsedTime >= maxDuration) {
-
+          if(Math.max(timeStamp - startTime, 0) >= maxDelayTime && ev.elapsedTime >= maxDuration) {
             done();
           }
         }


### PR DESCRIPTION
Firefox and (sometimes) Opera may not provide a timeStamp value in their event when passed
to the event handler. This may cause animations not to close properly. This fix will automatically
create a timeStamp value for the event in this situation when missing.

Broken example (use firefox):
http://plnkr.co/edit/jDbt7gJqxe0Y4G5hnogu?p=preview

Working example (use firefox)
http://plnkr.co/edit/06IKn2WWq0ttvhAdf2Iq?p=preview

Closes #3053
