### PR TITLE
add ngPoster directive for VIDEO tag. 

### DIFF
--- a/src/ng/directive/booleanAttrs.js
+++ b/src/ng/directive/booleanAttrs.js
@@ -110,6 +110,31 @@
 
 /**
  * @ngdoc directive
+ * @name ng.directive:ngPoster
+ * @restrict A
+ *
+ * @description
+ * Using Angular markup like `{{hash}}` in a `poster` attribute doesn't
+ * work right: The browser will fetch from the URL with the literal
+ * text `{{hash}}` until Angular replaces the expression inside
+ * `{{hash}}`. The `ngPoster` directive solves this problem.
+ *
+ * The buggy way to write it:
+ * <pre>
+ * <video poster="http://www.gravatar.com/avatar/{{hash}}"></video>
+ * </pre>
+ *
+ * The correct way to write it:
+ * <pre>
+ * <video ng-poster="http://www.gravatar.com/avatar/{{hash}}"></video>
+ * </pre>
+ *
+ * @element VIDEO
+ * @param {template} ngPoster any string which can contain `{{}}` markup.
+ */
+
+/**
+ * @ngdoc directive
  * @name ng.directive:ngSrcset
  * @restrict A
  *
@@ -325,8 +350,8 @@ forEach(BOOLEAN_ATTR, function(propName, attrName) {
 });
 
 
-// ng-src, ng-srcset, ng-href are interpolated
-forEach(['src', 'srcset', 'href'], function(attrName) {
+// ng-src, ng-srcset, ng-href, ng-poster are interpolated
+forEach(['src', 'srcset', 'href', 'poster'], function(attrName) {
   var normalized = directiveNormalize('ng-' + attrName);
   ngAttributeAliasDirectives[normalized] = function() {
     return {

--- a/test/ng/directive/booleanAttrsSpec.js
+++ b/test/ng/directive/booleanAttrsSpec.js
@@ -252,3 +252,22 @@ describe('ngHref', function() {
     expect(element.attr('href')).toEqual('http://server');
   }));
 });
+
+describe("ngPoster", function() {
+  var element;
+
+  afterEach(function() {
+    dealoc(element);
+  });
+
+  it("should interpolate the expression and bind the poster", inject(function($rootScope, $compile){
+    element = $compile('<video ng-poster="some/{{poster_img}}"></video>')($rootScope)
+    $rootScope.$digest();
+    expect(element.attr('poster')).toEqual('some/');
+
+    $rootScope.$apply(function() {
+      $rootScope.poster_img = 1;
+    });
+    expect(element.attr('poster')).toEqual('some/1');
+  }));
+});


### PR DESCRIPTION
A teeny tiny commit adding support for poster's video attribute (http://dev.w3.org/html5/spec-author-view/video.html#attr-video-poster).
`
<video ng-poster="{{super-poster-url}}"></video>
`

Thanks for this awesome front end framework :-)
