### PR TITLE
Add clarification on defining a controller in both the $routeProvider an...

### DIFF
--- a/src/ng/directive/ngController.js
+++ b/src/ng/directive/ngController.js
@@ -16,7 +16,8 @@
  * * Controller — The `ngController` directive specifies a Controller class; the class contains business
  *   logic behind the application to decorate the scope with functions and values
  *
- * Note that an alternative way to define controllers is via the {@link ngRoute.$route $route} service.
+ * Note that an alternative way to define controllers is via the {@link ngRoute.$route $route} service, however, do not
+ * define controllers there if you have already defined them via ng-controller.
  *
  * @element ANY
  * @scope


### PR DESCRIPTION
...d ng-controller

A common mistake for beginners is to define a controller in both the $routeProvider and also in the html document under the ng-controller directive. This clarification hopes to prevent developers from doing this in the future.
