### PR TITLE
Moving the creation of a DOM element into the correct scope to prevent detached DOM tree

### DIFF
--- a/src/ng/urlUtils.js
+++ b/src/ng/urlUtils.js
@@ -6,7 +6,6 @@
 // doesn't know about mocked locations and resolves URLs to the real document - which is
 // exactly the behavior needed here.  There is little value is mocking these out for this
 // service.
-var urlParsingNode = document.createElement("a");
 var originUrl = urlResolve(window.location.href, true);
 
 /**
@@ -62,6 +61,7 @@ var originUrl = urlResolve(window.location.href, true);
  *
  */
 function urlResolve(url) {
+  var urlParsingNode = document.createElement("a");
   var href = url;
   if (msie) {
     // Normalize before parse.  Refer Implementation Notes on why this is


### PR DESCRIPTION
There is a creation of an : a : tag inside the urlUtils however it is created in the outer scope of the only function that uses it which seems to cause that a tag to show up as a detached DOM tree.  I have move the creation of that DOM element into the function that uses it in order to prevent the detached DOM tree from happening.
