### PR TITLE
docs($provide): Fix minor typo in $provide.factory documentation

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -405,7 +405,7 @@ function annotate(fn) {
  * Register a **service factory**, which will be called to return the service instance.
  * This is short for registering a service where its provider consists of only a `$get` property,
  * which is the given service factory function.
- * You should use {@link AUTO.$provide#factory $provide.factor(getFn)} if you do not need to configure
+ * You should use {@link AUTO.$provide#factory $provide.factory(getFn)} if you do not need to configure
  * your service in a provider.
  *
  * @param {string} name The name of the instance.


### PR DESCRIPTION
The docs for $provide.service have factory linked as factor. The link is correct, but the text is wrong.
