### PR TITLE
fix($compile): fix missing error handling when new-scope directive is applied before isolated-scope directive

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -794,18 +794,19 @@ function $CompileProvider($provide) {
         }
 
         if (directiveValue = directive.scope) {
-          newScopeDirective = newScopeDirective || directive;
-
           // skip the check for directives with async templates, we'll check the derived sync directive when
           // the template arrives
           if (!directive.templateUrl) {
-            assertNoDuplicate('new/isolated scope', newIsolateScopeDirective, directive, $compileNode);
             if (isObject(directiveValue)) {
+              assertNoDuplicate('new/isolated scope', newIsolateScopeDirective || newScopeDirective, directive, $compileNode);
               safeAddClass($compileNode, 'ng-isolate-scope');
               newIsolateScopeDirective = directive;
+            } else {
+              assertNoDuplicate('new/isolated scope', newIsolateScopeDirective, directive, $compileNode);  
             }
             safeAddClass($compileNode, 'ng-scope');
           }
+          newScopeDirective = newScopeDirective || directive;
         }
 
         directiveName = directive.name;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1539,6 +1539,25 @@ describe('$compile', function() {
           })
         );
 
+        it('should not allow more than one isolate scope creation per element regardless of directive priority', function() {
+          module(function($compileProvider) {
+            $compileProvider.directive('highPriorityScope', function() {
+              return {
+                restrict: 'C',
+                priority: 1,
+                scope: true,
+                link: function() {}
+              }
+            });
+          }); 
+          inject(function($compile) {
+            expect(function(){
+              $compile('<div class="iscope-a; high-priority-scope"></div>');
+            }).toThrowMinErr('$compile', 'multidir', 'Multiple directives [highPriorityScope, iscopeA] asking for new/isolated scope on: ' +
+                    '<div class="iscope-a; high-priority-scope ng-scope">');
+          });
+        });
+
 
         it('should create new scope even at the root of the template', inject(
           function($rootScope, $compile, log) {


### PR DESCRIPTION
Given `dirA`, which requests new scope, and `dirB`, which requests new & isolated scope. If `dirA` is applied _after_ `dirB`, `$compile` reports an error ('Multiple directives [dirB, dirA] asking for new/isolated scope'), which is expected. However, if `dirA` is applied _before_ `dirB`, e.g. because `dirA` has higher priority, then no error is thrown and `dirA` shares the isolated scope created for `dirB`. This is inconsistent and can break `dirA`, which might need to access to parent scope's members. This fix addresses this situation by throwing error regardless of order of directive application.

Closes #4402
