### PR TITLE
docs(guide/animations): markup fix

### DIFF
--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -19,9 +19,9 @@ ngRouteModule.directive('ngView', ngViewFactory);
  * @animations
  * enter - animation is used to bring new content into the browser.
  * leave - animation is used to animate existing content away.
- *
- * The enter and leave animation occur concurrently.
- *
+ 
+  The enter and leave animation occur concurrently.
+ 
  * @scope
  * @priority 400
  * @example


### PR DESCRIPTION
The asterisks make every line a list item even when it meant to be a description paragraph as in this case.
