### PR TITLE
docs($compile) Updated the sentence fluency

### DIFF
--- a/docs/content/error/compile/multidir.ngdoc
+++ b/docs/content/error/compile/multidir.ngdoc
@@ -3,7 +3,7 @@
 @fullName Multiple Directive Resource Contention
 @description
 
-This error occurs when multiple directives are applied to the same DOM element, and processing them would result in an collisions or unsupported configuration.
+This error occurs when multiple directives are applied to the same DOM element, and processing them would result in a collision or an unsupported configuration.
 
 
 To resolve this issue remove one of the directives which is causing the collision.


### PR DESCRIPTION
In the error reference.
http://docs.angularjs.org/error/$compile:multidir?p0=drag&p1=resizeable&p2=isolated%20scope&p3=%3Cdiv%20drag%3D%22%22%20drag-left%3D%22element.left%22%20drag-top%3D%22element.top%22%20resizeable%3D%22%22%20resizeable-height%3D%22element.height%22%20resizeable-width%3D%22element.width%22%20ng-repeat%3D%22element%20in%20card.canvas.elements%22%20class%3D%22element%20ng-isolate-scope%20ng-scope%22%3E
