### PR TITLE
docs($ngmodel) demonstrate that $parent can be used for isolate scope directives

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -931,14 +931,14 @@ var VALID_CLASS = 'ng-valid',
  * Note that if you have a directive with an isolated scope, you cannot require `ngModel`
  * since the model value will be looked up on the isolated scope rather than the outer scope.
  * When the directive updates the model value, calling `ngModel.$setViewValue()` the property
- * on the outer scope will not be updated.
+ * on the outer scope will not be updated. However you can get around this by using $parent.
  *
- * Here is an example of this situation.  You'll notice that even though both 'input' and 'div'
- * seem to be attached to the same model, they are not kept in synch.
+ * Here is an example of this situation.  You'll notice that the first div is not updating the input. 
+ * However the second div can update the input properly.
  *
  * <example module="badIsolatedDirective">
     <file name="script.js">
-		angular.module('badIsolatedDirective', []).directive('bad', function() {
+		angular.module('badIsolatedDirective', []).directive('isolate', function() {
 		  return {
 		    require: 'ngModel',
 		    scope: { },
@@ -953,8 +953,9 @@ var VALID_CLASS = 'ng-valid',
 		});
     </file>
     <file name="index.html">
-	    <input ng-model="someModel">
-	    <div bad ng-model="someModel"></div>
+        <input ng-model="someModel"/>
+        <div isolate ng-model="someModel"></div>
+        <div isolate ng-model="$parent.someModel"></div>
     </file>
  * </example>
  *


### PR DESCRIPTION
demonstrate that $parent can be used for isolate scope directives
