### PR TITLE
Update step_02.ngdoc

### DIFF
--- a/docs/content/tutorial/step_02.ngdoc
+++ b/docs/content/tutorial/step_02.ngdoc
@@ -158,6 +158,10 @@ is the same test using `$controller`:
 __`test/unit/controllersSpec.js`:__
 <pre>
 describe('PhoneCat controllers', function() {
+  beforeEach(function () {
+    // Load the controller's module
+    module('phonecatApp');
+  });
 
   describe('PhoneListCtrl', function(){
 


### PR DESCRIPTION
fix(test): add beforeEach to load module

The non-global controller test throws an error because the test does not know about the module and so can not find the controller.  This change tells the test about the module so the test can find the controller.
