### PR TITLE
fix($injector): allow a constructor function to return a function

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -759,7 +759,7 @@ function createInjector(modulesToLoad) {
       instance = new Constructor();
       returnedValue = invoke(Type, instance, locals);
 
-      return isObject(returnedValue) ? returnedValue : instance;
+      return isObject(returnedValue) || isFunction(returnedValue) ? returnedValue : instance;
     }
 
     return {

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -788,6 +788,16 @@ describe('injector', function() {
     });
 
 
+    it('should allow constructor to return a function', function() {
+      var fn = function() {};
+      var Class = function() {
+        return fn;
+      };
+
+      expect($injector.instantiate(Class)).toBe(fn);
+    });
+
+
     it('should handle constructor exception', function() {
       expect(function() {
         $injector.instantiate(function() { throw 'MyError'; });


### PR DESCRIPTION
This change makes `$injector.instantiate` (and thus `$provide.service`) to behave the same as native
`new` operator.
