### PR TITLE
docs(guide/expression): fixing ng-repeater duplicate key error

### DIFF
--- a/docs/content/guide/expression.ngdoc
+++ b/docs/content/guide/expression.ngdoc
@@ -70,7 +70,7 @@ You can try evaluating different expressions here:
    <input type='text' ng-model="expr" size="80"/>
    <button ng-click="addExp(expr)">Evaluate</button>
    <ul>
-    <li ng-repeat="expr in exprs">
+    <li ng-repeat="expr in exprs track by $index">
       [ <a href="" ng-click="removeExp($index)">X</a> ]
       <tt>{{expr}}</tt> => <span ng-bind="$parent.$eval(expr)"></span>
      </li>


### PR DESCRIPTION
Issue occurs when the same expression is added twice or more. After that no new expressions can be added.

This can be resolved by adding: "track by $index" to ng-repeater. This way items are keyed by their position. For reference see:
http://docs.angularjs.org/error/ngRepeat:dupes
