### PR TITLE
docs(ngSwitch): rectify the description

### DIFF
--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -6,18 +6,8 @@
  * @restrict EA
  *
  * @description
- * The ngSwitch directive is used to conditionally swap DOM structure on your template based on a scope expression.
- * Elements within ngSwitch but without ngSwitchWhen or ngSwitchDefault directives will be preserved at the location
- * as specified in the template.
- *
- * The directive itself works similar to ngInclude, however, instead of downloading template code (or loading it
- * from the template cache), ngSwitch simply choses one of the nested elements and makes it visible based on which element
- * matches the value obtained from the evaluated expression. In other words, you define a container element
- * (where you place the directive), place an expression on the **on="..." attribute**
- * (or the **ng-switch="..." attribute**), define any inner elements inside of the directive and place
- * a when attribute per element. The when attribute is used to inform ngSwitch which element to display when the on
- * expression is evaluated. If a matching expression is not found via a when attribute then an element with the default
- * attribute is displayed.
+ * The `ngSwitch` directive is similar with {@link ngIf `ngIf`} directive in that it inserts
+ * or removes elements based on the condition.
  *
  * @animations
  * enter - happens after the ngSwitch contents change and the matched child element is placed inside the container


### PR DESCRIPTION
The previous one was incorrectly stating that “ngSwitch simply choses one of the nested elements and makes it visible”, which is not accurate: it actually removes or inserts the elements.
