### PR TITLE
feat($rootScope): support registration of listener for multiple events

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -802,19 +802,29 @@ function $RootScopeProvider(){
        *   - `preventDefault` - `{function}`: calling `preventDefault` sets `defaultPrevented` flag to true.
        *   - `defaultPrevented` - `{boolean}`: true if `preventDefault` was called.
        *
-       * @param {string} name Event name to listen on.
+       * @param {string|array} names Event names to listen on, specified as either a space-separated string, or
+			 *                             an array of strings.
        * @param {function(event, args...)} listener Function to call when the event is emitted.
        * @returns {function()} Returns a deregistration function for this listener.
        */
-      $on: function(name, listener) {
-        var namedListeners = this.$$listeners[name];
-        if (!namedListeners) {
-          this.$$listeners[name] = namedListeners = [];
-        }
-        namedListeners.push(listener);
-
+      $on: function(names, listener) {
+				var $$listeners = this.$$listeners;
+				if (isString(names)) {
+					names = names.split(/\s+/);
+				}
+				for(var i=0; i<names.length; ++i) {
+					var name = names[i],
+	            namedListeners = $$listeners[name];
+	        if (!namedListeners) {
+	          this.$$listeners[name] = namedListeners = [];
+	        }
+	        namedListeners.push(listener);
+				}
         return function() {
-          namedListeners[indexOf(namedListeners, listener)] = null;
+					for(var i=0; i<names.length; ++i) {
+						var namedListeners = $$listeners[names[i]];
+          	namedListeners[indexOf(namedListeners, listener)] = null;
+					}
         };
       },
 

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1002,6 +1002,32 @@ describe('Scope', function() {
       }));
 
 
+      it('should add listener for both $emit and $broadcast events for each name', inject(function($rootScope) {
+        var log = '',
+            child = $rootScope.$new();
+
+        function eventFn() {
+          log += 'X';
+        }
+
+				// Space separated notation
+        child.$on('abc xyz', eventFn);
+        expect(log).toEqual('');
+
+        child.$emit('abc');
+				child.$broadcast('xyz');
+        expect(log).toEqual('XX');
+
+				// Array notation
+				log = '';
+				child.$on(['xxx', 'yyy'], eventFn);
+				expect(log).toEqual('');
+        child.$emit('xxx');
+				child.$broadcast('yyy');
+        expect(log).toEqual('XX');
+      }));
+
+
       it('should return a function that deregisters the listener', inject(function($rootScope) {
         var log = '',
             child = $rootScope.$new(),
@@ -1023,6 +1049,44 @@ describe('Scope', function() {
         listenerRemove();
         child.$emit('abc');
         child.$broadcast('abc');
+        expect(log).toEqual('');
+      }));
+
+
+      it('should return a function that deregisters the listeners', inject(function($rootScope) {
+        var log = '',
+            child = $rootScope.$new(),
+            listenersRemove,
+						arrayRemove;
+
+        function eventFn() {
+          log += 'X';
+        }
+
+        listenersRemove = child.$on('abc xyz', eventFn);
+				arrayRemove = child.$on(['xxx', 'yyy'], eventFn);
+
+        expect(log).toEqual('');
+        expect(listenersRemove).toBeDefined();
+
+        child.$emit('abc');
+        child.$broadcast('xyz');
+        expect(log).toEqual('XX');
+
+        log = '';
+        listenersRemove();
+        child.$emit('abc');
+        child.$broadcast('xyz');
+        expect(log).toEqual('');
+
+        child.$emit('xxx');
+        child.$broadcast('yyy');
+        expect(log).toEqual('XX');
+
+        log = '';
+        arrayRemove();
+        child.$emit('xxx');
+        child.$broadcast('yyy');
         expect(log).toEqual('');
       }));
     });


### PR DESCRIPTION
Adds support for registering multiple events within a single call, either as a
string containing space-separated event names, or else as an array of strings.
The same listener is registered for each name.

Closes #4432
