### PR TITLE
fix(loader): rename window parameter

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -8,7 +8,7 @@
  * Interface for configuring angular {@link angular.module modules}.
  */
 
-function setupModuleLoader(window) {
+function setupModuleLoader(windowObj) {
 
   var $injectorMinErr = minErr('$injector');
 
@@ -16,7 +16,7 @@ function setupModuleLoader(window) {
     return obj[name] || (obj[name] = factory());
   }
 
-  return ensure(ensure(window, 'angular', Object), 'module', function() {
+  return ensure(ensure(windowObj, 'angular', Object), 'module', function() {
     /** @type {Object.<string, angular.Module>} */
     var modules = {};
 


### PR DESCRIPTION
fix(loader): rename window parameter

The parameter name of `window` causes problems with 
code coverage tools.

Closes #3449
