### PR TITLE
feat($q): add Promise.progress shorthand for notifyCallbacks

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -103,6 +103,8 @@
  *
  * - `catch(errorCallback)` – shorthand for `promise.then(null, errorCallback)`
  *
+ * - `progress(notifyCallback)` – shorthand for `promise.then(null, null, notifyCallback)`
+ *
  * - `finally(callback)` – allows you to observe either the fulfillment or rejection of a promise,
  *   but to do so without modifying the final value. This is useful to release resources or do some
  *   clean-up that needs to be done whether the promise was rejected or resolved. See the [full
@@ -286,6 +288,10 @@ function qFactory(nextTick, exceptionHandler) {
 
         "catch": function(callback) {
           return this.then(null, callback);
+        },
+
+        progress: function(callback) {
+          return this.then(null, null, callback);
         },
 
         "finally": function(callback) {

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -524,6 +524,10 @@ describe('q', function() {
         expect(typeof promise['finally']).toBe('function');
       });
 
+      it('should have a progress method', function () {
+        expect(typeof promise.progress).toBe('function');
+      });
+
 
       describe('then', function() {
         it('should allow registration of a success callback without an errback or progressback ' +
@@ -922,6 +926,15 @@ describe('q', function() {
           syncReject(deferred, 'foo');
           expect(logStr()).toBe('error1(foo)->reject(foo); error2(foo)->reject(foo)');
         });
+      });
+
+      describe('progress', function () {
+        it('should be a shorthand for defining promise progress handlers', function() {
+          promise.progress(progress(1)).then(null, null, progress(2));
+          deferred.notify('foo');
+          mockNextTick.flush();
+          expect(logStr()).toBe('progress1(foo)->foo; progress2(foo)->foo');
+        })
       });
     });
   });


### PR DESCRIPTION
Shorthand method for $q promises that allows attaching a progress
callback. Provides the same type of convenience as the existing
catch shorthand method, and matches functionality existing in the Q
library.

This should resolve the only remaining concern addressed in #1998

Closes #1998
