### PR TITLE
Docs generate anchors for headers

### DIFF
--- a/docs/content/cookbook/mvc.ngdoc
+++ b/docs/content/cookbook/mvc.ngdoc
@@ -125,4 +125,4 @@ board variable.
 * The view can call any controller function.
 * In this example, the `setUrl()` and `readUrl()` functions copy the game state to/from the URL's
 hash so the browser's back button will undo game steps. See deep-linking. This example calls {@link
-api/ng.$rootScope.Scope#$watch $watch()} to set up a listener that invokes `readUrl()` when needed.
+api/ng.$rootScope.Scope#methods_$watch $watch()} to set up a listener that invokes `readUrl()` when needed.

--- a/docs/content/error/compile/ctreq.ngdoc
+++ b/docs/content/error/compile/ctreq.ngdoc
@@ -3,7 +3,7 @@
 @fullName Missing Required Controller
 @description
 
-This error occurs when {@link api/ng.$compile template compiler} tries process the directive that specifies the `require` option in a {@link guide/directive#directivedefinitionobject directive definition},
+This error occurs when {@link api/ng.$compile template compiler} tries process the directive that specifies the `require` option in a {@link guide/directive#writing-directives_directive-definition-object directive definition},
 but the required directive controller is not present on the current DOM element (or its ancestor element, if `^` was specified).
 
 To resolve this error ensure that there is no typo in the required controller name and that the required directive controller is present on the current element.

--- a/docs/content/error/compile/iscp.ngdoc
+++ b/docs/content/error/compile/iscp.ngdoc
@@ -21,4 +21,4 @@ myModule.directive('directiveName', function factory() {
 });
 ```
 
-Please refer to the {@link guide/directive#directivedefinitionobject directive definition docs} to learn more about the api.
+Please refer to the {@link guide/directive#writing-directives_directive-definition-object directive definition docs} to learn more about the api.

--- a/docs/content/error/compile/nonassign.ngdoc
+++ b/docs/content/error/compile/nonassign.ngdoc
@@ -3,7 +3,7 @@
 @fullName Non-Assignable Expression
 @description
 
-This error occurs when a directive defines an isolate scope property that support two-way data-binding (using the `=` mode in the {@link guide/directive#directivedefinitionobject  directive definition}) but the directive is used with an expression that is not-assignable.
+This error occurs when a directive defines an isolate scope property that support two-way data-binding (using the `=` mode in the {@link guide/directive#writing-directives_directive-definition-object  directive definition}) but the directive is used with an expression that is not-assignable.
 
 In order for the two-way data-binding to work, it must be possible to write new values back into the path defined with the expression.
 

--- a/docs/content/error/injector/pget.ngdoc
+++ b/docs/content/error/injector/pget.ngdoc
@@ -22,5 +22,5 @@ angular.module("myApp", [])
   .provider('good', GoodProvider);
 ```
 
-For more information, refer to the {@link api/AUTO.$provide#provider
+For more information, refer to the {@link api/AUTO.$provide#methods_provider
 $provide.provider} api doc.

--- a/docs/content/error/jqLite/nosel.ngdoc
+++ b/docs/content/error/jqLite/nosel.ngdoc
@@ -3,7 +3,7 @@
 @fullName Unsupported Selector Lookup
 @description
 
-In order to keep Angular small, Angular implements only a subset of the selectors in {@link api/angular.element#angularsjqlite jqLite}.
+In order to keep Angular small, Angular implements only a subset of the selectors in {@link api/angular.element#description_angulars-jqlite jqLite}.
 This error occurs when a jqLite instance is invoked with a selector other than this subset.
 
 In order to resolve this error, rewrite your code to only use tag name selectors and manually traverse the DOM using the APIs provided by jqLite.

--- a/docs/content/error/sce/icontext.ngdoc
+++ b/docs/content/error/sce/icontext.ngdoc
@@ -3,6 +3,6 @@
 @fullName Invalid / Unknown SCE context
 @description
 
-The context enum passed to {@link api/ng.$sce#trustAs $sce.trustAs} was not recognized.
+The context enum passed to {@link api/ng.$sce#methods_trustAs $sce.trustAs} was not recognized.
 
 Please consult the list of {@link api/ng.$sce#contexts supported Strict Contextual Escaping (SCE) contexts}.

--- a/docs/content/error/sce/iequirks.ngdoc
+++ b/docs/content/error/sce/iequirks.ngdoc
@@ -3,7 +3,7 @@
 @fullName IE8 in quirks mode is unsupported
 @description
 
-This error occurs when you are using AngularJS with {@link api/ng.$sce#strictcontextualescaping Strict Contextual Escaping (SCE)} mode enabled (the default) on IE8 or lower in quirks mode.
+This error occurs when you are using AngularJS with {@link api/ng.$sce Strict Contextual Escaping (SCE)} mode enabled (the default) on IE8 or lower in quirks mode.
 
 In this mode, IE8 allows one to execute arbitrary javascript by the use of the `expression()` syntax and is not supported.
 Refer {@link http://blogs.msdn.com/b/ie/archive/2008/10/16/ending-expressions.aspx MSDN Blogs > IEBlog > Ending Expressions} to learn more about them.

--- a/docs/content/error/sce/imatcher.ngdoc
+++ b/docs/content/error/sce/imatcher.ngdoc
@@ -3,7 +3,7 @@
 @fullName Invalid matcher (only string patterns and RegExp instances are supported)
 @description
 
-Please see {@link api/ng.$sceDelegateProvider#resourceUrlWhitelist
+Please see {@link api/ng.$sceDelegateProvider#methods_resourceUrlWhitelist
 $sceDelegateProvider.resourceUrlWhitelist} and {@link
-api/ng.$sceDelegateProvider#resourceUrlBlacklist $sceDelegateProvider.resourceUrlBlacklist} for the
+api/ng.$sceDelegateProvider#methods_resourceUrlBlacklist $sceDelegateProvider.resourceUrlBlacklist} for the
 list of acceptable items.

--- a/docs/content/error/sce/insecurl.ngdoc
+++ b/docs/content/error/sce/insecurl.ngdoc
@@ -3,21 +3,21 @@
 @fullName Processing of a Resource from Untrusted Source Blocked
 @description
 
-AngularJS' {@link api/ng.$sce#strictcontextualescaping Strict Contextual Escaping (SCE)} mode (enabled by default) has blocked loading a resource from an insecure URL.
+AngularJS' {@link api/ng.$sce Strict Contextual Escaping (SCE)} mode (enabled by default) has blocked loading a resource from an insecure URL.
 
 Typically, this would occur if you're attempting to load an Angular template from an untrusted source.
 It's also possible that a custom directive threw this error for a similar reason.
 
-Angular only loads templates from trusted URLs (by calling {@link api/ng.$sce#getTrustedResourceUrl $sce.getTrustedResourceUrl} on the template URL).
+Angular only loads templates from trusted URLs (by calling {@link api/ng.$sce#methods_getTrustedResourceUrl $sce.getTrustedResourceUrl} on the template URL).
 
 By default, only URLs that belong to the same origin are trusted. These are urls with the same domain and protocol as the application document.
 
 The {@link api/ng.directive:ngInclude ngInclude} directive and {@link guide/directive directives} that specify a `templateUrl` require a trusted resource URL.
 
 To load templates from other domains and/or protocols, either adjust the {@link
-api/ng.$sceDelegateProvider#resourceUrlWhitelist whitelist}/ {@link
-api/ng.$sceDelegateProvider#resourceUrlBlacklist blacklist} or wrap the URL with a call to {@link
-api/ng.$sce#trustAsResourceUrl $sce.trustAsResourceUrl}.
+api/ng.$sceDelegateProvider#methods_resourceUrlWhitelist whitelist}/ {@link
+api/ng.$sceDelegateProvider#methods_resourceUrlBlacklist blacklist} or wrap the URL with a call to {@link
+api/ng.$sce#methods_trustAsResourceUrl $sce.trustAsResourceUrl}.
 
 **Note**: The browser's {@link
 https://code.google.com/p/browsersec/wiki/Part2#Same-origin_policy_for_XMLHttpRequest Same Origin

--- a/docs/content/error/sce/itype.ngdoc
+++ b/docs/content/error/sce/itype.ngdoc
@@ -3,6 +3,6 @@
 @fullName String Value is Required for SCE Trust Call
 @description
 
-{@link api/ng.$sce#trustAs $sce.trustAs} requires a string value.
+{@link api/ng.$sce#methods_trustAs $sce.trustAs} requires a string value.
 
-Read more about {@link api/ng.$sce#strictcontextualescaping Strict Contextual Escaping (SCE)} in AngularJS.
+Read more about {@link api/ng.$sce Strict Contextual Escaping (SCE)} in AngularJS.

--- a/docs/content/error/sce/iwcard.ngdoc
+++ b/docs/content/error/sce/iwcard.ngdoc
@@ -3,7 +3,7 @@
 @fullName The sequence *** is not a valid pattern wildcard
 @description
 
-The strings in {@link api/ng.$sceDelegateProvider#resourceUrlWhitelist
+The strings in {@link api/ng.$sceDelegateProvider#methods_resourceUrlWhitelist
 $sceDelegateProvider.resourceUrlWhitelist} and {@link
-api/ng.$sceDelegateProvider#resourceUrlBlacklist $sceDelegateProvider.resourceUrlBlacklist} may not
+api/ng.$sceDelegateProvider#methods_resourceUrlBlacklist $sceDelegateProvider.resourceUrlBlacklist} may not
 contain the undefined sequence `***`.  Only `*` and `**` wildcard patterns are defined.

--- a/docs/content/error/sce/unsafe.ngdoc
+++ b/docs/content/error/sce/unsafe.ngdoc
@@ -5,11 +5,11 @@
 
 The value provided for use in a specific context was not found to be safe/trusted for use.
 
-Angular's {@link api/ng.$sce#strictcontextualescaping Strict Contextual Escaping (SCE)} mode
+Angular's {@link api/ng.$sce Strict Contextual Escaping (SCE)} mode
 (enabled by default), requires bindings in certain
 contexts to result in a value that is trusted as safe for use in such a context.  (e.g. loading an
 Angular template from a URL requires that the URL is one considered safe for loading resources.)
 
 This helps prevent XSS and other security issues.  Read more at {@link
-api/ng.$sce#strictcontextualescaping Strict Contextual Escaping (SCE)}
+api/ng.$sce Strict Contextual Escaping (SCE)}
 

--- a/docs/content/guide/animations.ngdoc
+++ b/docs/content/guide/animations.ngdoc
@@ -253,13 +253,13 @@ The table below explains in detail which animation events are triggered
 
 | Directive                                                                           | Supported Animations                     |
 |-------------------------------------------------------------------------------------|------------------------------------------|
-| {@link api/ng.directive:ngRepeat#animations ngRepeat}                               | enter, leave, and move                   |
-| {@link api/ngRoute.directive:ngView#animations ngView}                              | enter and leave                          |
-| {@link api/ng.directive:ngInclude#animations ngInclude}                             | enter and leave                          |
-| {@link api/ng.directive:ngSwitch#animations ngSwitch}                               | enter and leave                          |
-| {@link api/ng.directive:ngIf#animations ngIf}                                       | enter and leave                          |
-| {@link api/ng.directive:ngShow#animations ngClass or &#123;&#123;class&#125;&#125;} | add and remove                           |
-| {@link api/ng.directive:ngShow#animations ngShow & ngHide}                          | add and remove (the ng-hide class value) |
+| {@link api/ng.directive:ngRepeat#usage_animations ngRepeat}                               | enter, leave, and move                   |
+| {@link api/ngRoute.directive:ngView#usage_animations ngView}                              | enter and leave                          |
+| {@link api/ng.directive:ngInclude#usage_animations ngInclude}                             | enter and leave                          |
+| {@link api/ng.directive:ngSwitch#usage_animations ngSwitch}                               | enter and leave                          |
+| {@link api/ng.directive:ngIf#usage_animations ngIf}                                       | enter and leave                          |
+| {@link api/ng.directive:ngShow#usage_animations ngClass or &#123;&#123;class&#125;&#125;} | add and remove                           |
+| {@link api/ng.directive:ngShow#usage_animations ngShow & ngHide}                          | add and remove (the ng-hide class value) |
 
 For a full breakdown of the steps involved during each animation event, refer to the {@link api/ngAnimate.$animate API docs}.
 

--- a/docs/content/guide/compiler.ngdoc
+++ b/docs/content/guide/compiler.ngdoc
@@ -7,7 +7,7 @@
 Angular's {@link api/ng.$compile HTML compiler} allows the developer to teach the
 browser new HTML syntax. The compiler allows you to attach behavior to any HTML element or attribute
 and even create new HTML elements or attributes with custom behavior. Angular calls these behavior
-extensions {@link api/ng.$compileProvider#directive directives}.
+extensions {@link api/ng.$compileProvider#methods_directive directives}.
 
 HTML has a lot of constructs for formatting the HTML for static documents in a declarative fashion.
 For example if something needs to be centered, there is no need to provide instructions to the
@@ -59,7 +59,7 @@ api/ng.directive:ngBind `ng-bind`} directive.
 </pre>
 
 A directive is just a function which executes when the compiler encounters it in the DOM. See {@link
-api/ng.$compileProvider#directive directive API} for in-depth documentation on how
+api/ng.$compileProvider#methods_directive directive API} for in-depth documentation on how
 to write directives.
 
 Here is a directive which makes any element draggable. Notice the `draggable` attribute on the

--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -75,26 +75,26 @@ directive which is handling the event. An explicit call to $apply is needed only
 implementing custom event callbacks, or when working with third-party library callbacks.
 
   1. Enter Angular execution context by calling {@link guide/scope scope}`.`{@link
-     api/ng.$rootScope.Scope#$apply $apply}`(stimulusFn)`. Where `stimulusFn` is
+     api/ng.$rootScope.Scope#methods_$apply $apply}`(stimulusFn)`. Where `stimulusFn` is
      the work you wish to do in Angular execution context.
   2. Angular executes the `stimulusFn()`, which typically modifies application state.
-  3. Angular enters the {@link api/ng.$rootScope.Scope#$digest $digest} loop. The
+  3. Angular enters the {@link api/ng.$rootScope.Scope#methods_$digest $digest} loop. The
      loop is made up of two smaller loops which process {@link
-     api/ng.$rootScope.Scope#$evalAsync $evalAsync} queue and the {@link
-     api/ng.$rootScope.Scope#$watch $watch} list. The {@link
-     api/ng.$rootScope.Scope#$digest $digest} loop keeps iterating until the model
-     stabilizes, which means that the {@link api/ng.$rootScope.Scope#$evalAsync
-     $evalAsync} queue is empty and the {@link api/ng.$rootScope.Scope#$watch
+     api/ng.$rootScope.Scope#methods_$evalAsync $evalAsync} queue and the {@link
+     api/ng.$rootScope.Scope#methods_$watch $watch} list. The {@link
+     api/ng.$rootScope.Scope#methods_$digest $digest} loop keeps iterating until the model
+     stabilizes, which means that the {@link api/ng.$rootScope.Scope#methods_$evalAsync
+     $evalAsync} queue is empty and the {@link api/ng.$rootScope.Scope#methods_$watch
      $watch} list does not detect any changes.
-  4. The {@link api/ng.$rootScope.Scope#$evalAsync $evalAsync} queue is used to
+  4. The {@link api/ng.$rootScope.Scope#methods_$evalAsync $evalAsync} queue is used to
      schedule work which needs to occur outside of current stack frame, but before the browser's
      view render. This is usually done with `setTimeout(0)`, but the `setTimeout(0)` approach
      suffers from slowness and may cause view flickering since the browser renders the view after
      each event.
-  5. The {@link api/ng.$rootScope.Scope#$watch $watch} list is a set of expressions
+  5. The {@link api/ng.$rootScope.Scope#methods_$watch $watch} list is a set of expressions
      which may have changed since last iteration. If a change is detected then the `$watch`
      function is called which typically updates the DOM with the new value.
-  6. Once the Angular {@link api/ng.$rootScope.Scope#$digest $digest} loop finishes
+  6. Once the Angular {@link api/ng.$rootScope.Scope#methods_$digest $digest} loop finishes
      the execution leaves the Angular and JavaScript context. This is followed by the browser
      re-rendering the DOM to reflect any changes.
 
@@ -107,17 +107,17 @@ user enters text into the text field.
         api/ng.directive:input input} {@link guide/directive
         directive} set up a `keydown` listener on the `<input>` control.
      2. the {@link api/ng.$interpolate &#123;&#123;name&#125;&#125; } interpolation
-        sets up a {@link api/ng.$rootScope.Scope#$watch $watch} to be notified of
+        sets up a {@link api/ng.$rootScope.Scope#methods_$watch $watch} to be notified of
         `name` changes.
   2. During the runtime phase:
      1. Pressing an '`X`' key causes the browser to emit a `keydown` event on the input control.
      2. The {@link api/ng.directive:input input} directive
         captures the change to the input's value and calls {@link
-        api/ng.$rootScope.Scope#$apply $apply}`("name = 'X';")` to update the
+        api/ng.$rootScope.Scope#methods_$apply $apply}`("name = 'X';")` to update the
         application model inside the Angular execution context.
      3. Angular applies the `name = 'X';` to the model.
-     4. The {@link api/ng.$rootScope.Scope#$digest $digest} loop begins
-     5. The {@link api/ng.$rootScope.Scope#$watch $watch} list detects a change
+     4. The {@link api/ng.$rootScope.Scope#methods_$digest $digest} loop begins
+     5. The {@link api/ng.$rootScope.Scope#methods_$watch $watch} list detects a change
         on the `name` property and notifies the {@link api/ng.$interpolate
         &#123;&#123;name&#125;&#125; } interpolation, which in turn updates the DOM.
      6. Angular exits the execution context, which in turn exits the `keydown` event and with it
@@ -253,7 +253,7 @@ rendering the view compared to most other templating systems.
     template sprinkled in.) The browser parses the HTML into the DOM, and the DOM becomes the input to
     the template engine known as the {@link api/ng.$compile compiler}. The compiler
     looks for {@link guide/directive directives} which in turn set up {@link
-    api/ng.$rootScope.Scope#$watch watches} on the model. The result is a
+    api/ng.$rootScope.Scope#methods_$watch watches} on the model. The result is a
     continuously updating view which does not need template model re-merging. Your model becomes
     the single source-of-truth for your view.
 
@@ -377,8 +377,8 @@ as a {@link api/AUTO.$provide provider}.
 
 
 But the real magic of the {@link api/AUTO.$injector injector} is that it can be
-used to {@link api/AUTO.$injector#invoke call} methods and {@link
-api/AUTO.$injector#instantiate instantiate} types. This subtle feature is what
+used to {@link api/AUTO.$injector#methods_invoke call} methods and {@link
+api/AUTO.$injector#methods_instantiate instantiate} types. This subtle feature is what
 allows the methods and types to ask for their dependencies instead of having to look for them.
 
 <pre>
@@ -406,7 +406,7 @@ allows the methods and types to ask for their dependencies instead of having to 
 
 Notice that the only thing you needed to write was the function, and list the dependencies in the
 function arguments. When angular calls the function, it will use the {@link
-api/AUTO.$injector#invoke call} which will automatically fill the function
+api/AUTO.$injector#methods_invoke call} which will automatically fill the function
 arguments.
 
 Examine the `ClockCtrl` below, and notice how it lists the dependencies in the constructor. When the

--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -58,8 +58,8 @@ The following demonstrates the various ways a Directive (ngBind in this case) ca
 During the compilation process the {@link api/ng.$compile compiler} matches text and
 attributes using the {@link api/ng.$interpolate $interpolate} service to see if they
 contain embedded expressions. These expressions are registered as {@link
-api/ng.$rootScope.Scope#$watch watches} which will be processed as part of the normal {@link
-api/ng.$rootScope.Scope#$digest digest} cycle. An example of interpolation is shown
+api/ng.$rootScope.Scope#methods_$watch watches} which will be processed as part of the normal {@link
+api/ng.$rootScope.Scope#methods_$digest digest} cycle. An example of interpolation is shown
 here:
 
 <pre>
@@ -112,7 +112,7 @@ Compilation of HTML happens in three phases:
   3. Link the template with a scope by calling the linking function returned from the previous step.
   This in turn will call the linking function of the individual directives allowing them to
   register any listeners on the elements and set up any {@link
-  api/ng.$rootScope.Scope#$watch watches} with the {@link
+  api/ng.$rootScope.Scope#methods_$watch watches} with the {@link
   api/ng.$rootScope.Scope scope}. The result is a live binding between the
   scope and the DOM (i.e., a change in the scope is reflected in the DOM).
 
@@ -294,7 +294,7 @@ Here's an example directive declared with a Directive Definition Object:
 
 In most cases you will not need such fine control, so the above can be simplified. You could still
 return a Directive Definition Object, but only set the 'link' function property of the Object
-and rely on the default values for other properties. 
+and rely on the default values for other properties.
 
 Therefore the above could be simplified as:
 
@@ -317,7 +317,7 @@ Therefore the above could be simplified as:
 The factory method is responsible for creating the directive. It is invoked only once, when the
 {@link api/ng.$compile compiler} matches the directive for the first time. You can
 perform any initialization work here. The method is invoked using the {@link
-api/AUTO.$injector#invoke $injector.invoke} which
+api/AUTO.$injector#methods_invoke $injector.invoke} which
 makes it injectable (subject to all of the rules of the injection annotation).
 
 ## Directive Definition Object
@@ -415,7 +415,7 @@ compiler}. The attributes are:
 
   * `template` - replace the current element with the contents of the given HTML. The replacement process
     migrates all of the attributes / classes from the old element to the new one. See the
-    {@link guide/directive#Components Creating Components} section below for more information.
+    {@link guide/directive#creating-components Creating Components} section below for more information.
 
     You can specify `template` as a string representing the template or as a function which takes
     two arguments `tElement` and `tAttrs` (described in the `compile` function api below) and
@@ -428,7 +428,7 @@ compiler}. The attributes are:
     You can specify `templateUrl` as a string representing the URL or as a function which takes two
     arguments `tElement` and `tAttrs` (described in the `compile` function api below) and returns
     a string value representing the url.  In either case, the template URL is passed through {@link
-    api/ng.$sce#getTrustedResourceUrl $sce.getTrustedResourceUrl}.
+    api/ng.$sce#methods_getTrustedResourceUrl $sce.getTrustedResourceUrl}.
 
   * `replace` - specify where the template should be inserted. Defaults to `false`.
 
@@ -471,7 +471,7 @@ compile function takes the following arguments:
 
   * `tAttrs` - template attributes - Normalized list of attributes declared on this element shared
     between all directive compile functions. See {@link
-    guide/directive#Attributes Attributes}.
+    guide/directive#writing-directives_attributes Attributes}.
 
   * `transclude` - A transclude linking function: `function(scope, cloneLinkingFn)`.
 
@@ -480,10 +480,10 @@ been cloned. For this reason it is not safe to do anything in the compile functi
 transformation that applies to all DOM clones. Specifically, DOM listener registration should be
 done in a linking function rather than in a compile function.
 
-A compile function can have a return value which can be either a function or an object. Returning a 
-(post-link) function is equivalent to registering the linking function via the 'link` property of 
-the config object when the compile function is empty. Returning an object with function(s) registered 
-via `pre` and `post` properties allows you to control when a linking function should be called during 
+A compile function can have a return value which can be either a function or an object. Returning a
+(post-link) function is equivalent to registering the linking function via the 'link` property of
+the config object when the compile function is empty. Returning an object with function(s) registered
+via `pre` and `post` properties allows you to control when a linking function should be called during
 the linking phase. See info about pre-linking and post-linking functions below.
 
 
@@ -498,7 +498,7 @@ executed after the template has been cloned. This is where most of the directive
 put.
 
   * `scope` - {@link api/ng.$rootScope.Scope Scope} - The scope to be used by the
-    directive for registering {@link api/ng.$rootScope.Scope#$watch watches}.
+    directive for registering {@link api/ng.$rootScope.Scope#methods_$watch watches}.
 
   * `iElement` - instance element - The element where the directive is to be used. It is safe to
     manipulate the children of the element only in `postLink` function since the children have
@@ -506,7 +506,7 @@ put.
 
   * `iAttrs` - instance attributes - Normalized list of attributes declared on this element shared
     between all directive linking functions. See {@link
-    guide/directive#Attributes Attributes}.
+    guide/directive#writing-directives_attributes Attributes}.
 
   * `controller` - a controller instance - A controller instance if at least one directive on the
     element defines a controller. The controller is shared among all the directives, which allows

--- a/docs/content/guide/expression.ngdoc
+++ b/docs/content/guide/expression.ngdoc
@@ -34,7 +34,7 @@ You can think of Angular expressions as JavaScript expressions with following di
 
 If, on the other hand, you do want to run arbitrary JavaScript code, you should make it a
 controller method and call the method. If you want to `eval()` an angular expression from
-JavaScript, use the {@link api/ng.$rootScope.Scope#$eval `$eval()`} method.
+JavaScript, use the {@link api/ng.$rootScope.Scope#methods_$eval `$eval()`} method.
 
 ## Example
 <doc:example>

--- a/docs/content/guide/forms.ngdoc
+++ b/docs/content/guide/forms.ngdoc
@@ -186,11 +186,11 @@ To get a hold of the controller the directive specifies a dependency as shown in
 The validation can occur in two places:
 
   * **Model to View update** -
-    Whenever the bound model changes, all functions in {@link api/ng.directive:ngModel.NgModelController#$formatters NgModelController#$formatters} array are pipe-lined, so that each of these functions has an opportunity to format the value and change validity state of the form control through {@link api/ng.directive:ngModel.NgModelController#$setValidity NgModelController#$setValidity}.
+    Whenever the bound model changes, all functions in {@link api/ng.directive:ngModel.NgModelController#properties_$formatters NgModelController#$formatters} array are pipe-lined, so that each of these functions has an opportunity to format the value and change validity state of the form control through {@link api/ng.directive:ngModel.NgModelController#methods_$setValidity NgModelController#$setValidity}.
 
   * **View to Model update** -
-    In a similar way, whenever a user interacts with a control it calls {@link api/ng.directive:ngModel.NgModelController#$setViewValue NgModelController#$setViewValue}.
-This in turn pipelines all functions in the {@link api/ng.directive:ngModel.NgModelController#$parsers NgModelController#$parsers} array, so that each of these functions has an opportunity to convert the value and change validity state of the form control through {@link api/ng.directive:ngModel.NgModelController#$setValidity NgModelController#$setValidity}.
+    In a similar way, whenever a user interacts with a control it calls {@link api/ng.directive:ngModel.NgModelController#methods_$setViewValue NgModelController#$setViewValue}.
+This in turn pipelines all functions in the {@link api/ng.directive:ngModel.NgModelController#properties_$parsers NgModelController#$parsers} array, so that each of these functions has an opportunity to convert the value and change validity state of the form control through {@link api/ng.directive:ngModel.NgModelController#methods_$setValidity NgModelController#$setValidity}.
 
 In the following example we create two directives.
 
@@ -278,7 +278,7 @@ However, if you need more flexibility, you can write your own form control as a 
 
 In order for custom control to work with `ngModel` and to achieve two-way data-binding it needs to:
 
-  - implement `$render` method, which is responsible for rendering the data after it passed the {@link   api/ng.directive:ngModel.NgModelController#$formatters NgModelController#$formatters},
+  - implement `$render` method, which is responsible for rendering the data after it passed the {@link   api/ng.directive:ngModel.NgModelController#properties_$formatters NgModelController#$formatters},
   - call `$setViewValue` method, whenever the user interacts with the control and model needs to be updated. This is usually done inside a DOM Event listener.
 
 See {@link guide/directive $compileProvider.directive} for more info.

--- a/docs/content/guide/scope.ngdoc
+++ b/docs/content/guide/scope.ngdoc
@@ -11,10 +11,10 @@ watch {@link guide/expression expressions} and propagate events.
 
 ## Scope characteristics
 
-  - Scopes provide APIs ({@link api/ng.$rootScope.Scope#$watch $watch}) to observe
+  - Scopes provide APIs ({@link api/ng.$rootScope.Scope#methods_$watch $watch}) to observe
     model mutations.
 
-  - Scopes provide APIs ({@link api/ng.$rootScope.Scope#$apply $apply}) to
+  - Scopes provide APIs ({@link api/ng.$rootScope.Scope#methods_$apply $apply}) to
     propagate any model changes through the system into the view from outside of the "Angular
     realm" (controllers, services, Angular event handlers).
 
@@ -28,8 +28,8 @@ watch {@link guide/expression expressions} and propagate events.
 ## Scope as Data-Model
 
 Scope is the glue between application controller and the view. During the template {@link compiler
-linking} phase the {@link api/ng.$compileProvider#directive directives} set up
-{@link api/ng.$rootScope.Scope#$watch `$watch`} expressions on the scope. The
+linking} phase the {@link api/ng.$compileProvider#methods_directive directives} set up
+{@link api/ng.$rootScope.Scope#methods_$watch `$watch`} expressions on the scope. The
 `$watch` allows the directives to be notified of property changes, which allows the directive to
 render the updated value to the DOM.
 
@@ -182,8 +182,8 @@ To examine the scope in the debugger:
 ## Scope Events Propagation
 
 Scopes can propagate events in similar fashion to DOM events. The event can be {@link
-api/ng.$rootScope.Scope#$broadcast broadcasted} to the scope children or {@link
-api/ng.$rootScope.Scope#$emit emitted} to scope parents.
+api/ng.$rootScope.Scope#methods_$broadcast broadcasted} to the scope children or {@link
+api/ng.$rootScope.Scope#methods_$emit emitted} to scope parents.
 
 <example>
   <file name="script.js">
@@ -225,14 +225,14 @@ more events.
 When the browser calls into JavaScript the code executes outside the Angular execution context,
 which means that Angular is unaware of model modifications. To properly process model
 modifications the execution has to enter the Angular execution context using the {@link
-api/ng.$rootScope.Scope#$apply `$apply`} method. Only model modifications which
+api/ng.$rootScope.Scope#methods_$apply `$apply`} method. Only model modifications which
 execute inside the `$apply` method will be properly accounted for by Angular. For example if a
 directive listens on DOM events, such as {@link
 api/ng.directive:ngClick `ng-click`} it must evaluate the
 expression inside the `$apply` method.
 
 After evaluating the expression, the `$apply` method performs a {@link
-api/ng.$rootScope.Scope#$digest `$digest`}. In the $digest phase the scope examines all
+api/ng.$rootScope.Scope#methods_$digest `$digest`}. In the $digest phase the scope examines all
 of the `$watch` expressions and compares them with the previous value. This dirty checking is done
 asynchronously. This means that assignment such as `$scope.username="angular"` will not
 immediately cause a `$watch` to be notified, instead the `$watch` notification is delayed until
@@ -250,20 +250,20 @@ the `$digest` phase. This delay is desirable, since it coalesces multiple model 
   2. **Watcher registration**
 
      During template linking directives register {@link
-     api/ng.$rootScope.Scope#$watch watches} on the scope. These watches will be
+     api/ng.$rootScope.Scope#methods_$watch watches} on the scope. These watches will be
      used to propagate model values to the DOM.
 
   3. **Model mutation**
 
      For mutations to be properly observed, you should make them only within the {@link
-     api/ng.$rootScope.Scope#$apply scope.$apply()}. (Angular APIs do this
+     api/ng.$rootScope.Scope#methods_$apply scope.$apply()}. (Angular APIs do this
      implicitly, so no extra `$apply` call is needed when doing synchronous work in controllers,
      or asynchronous work with {@link api/ng.$http $http} or {@link
      api/ng.$timeout $timeout} services.
 
   4. **Mutation observation**
 
-     At the end `$apply`, Angular performs a {@link api/ng.$rootScope.Scope#$digest
+     At the end `$apply`, Angular performs a {@link api/ng.$rootScope.Scope#methods_$digest
      $digest} cycle on the root scope, which then propagates throughout all child scopes. During
      the `$digest` cycle, all `$watch`ed expressions or functions are checked for model mutation
      and if a mutation is detected, the `$watch` listener is called.
@@ -271,7 +271,7 @@ the `$digest` phase. This delay is desirable, since it coalesces multiple model 
   5. **Scope destruction**
 
      When child scopes are no longer needed, it is the responsibility of the child scope creator
-     to destroy them via {@link api/ng.$rootScope.Scope#$destroy scope.$destroy()}
+     to destroy them via {@link api/ng.$rootScope.Scope#methods_$destroy scope.$destroy()}
      API. This will stop propagation of `$digest` calls into the child scope and allow for memory
      used by the child scope models to be reclaimed by the garbage collector.
 
@@ -279,27 +279,27 @@ the `$digest` phase. This delay is desirable, since it coalesces multiple model 
 ### Scopes and Directives
 
 During the compilation phase, the {@link compiler compiler} matches {@link
-api/ng.$compileProvider#directive directives} against the DOM template. The directives
+api/ng.$compileProvider#methods_directive directives} against the DOM template. The directives
 usually fall into one of two categories:
 
-  - Observing {@link api/ng.$compileProvider#directive directives}, such as
+  - Observing {@link api/ng.$compileProvider#methods_directive directives}, such as
     double-curly expressions `{{expression}}`, register listeners using the {@link
-    api/ng.$rootScope.Scope#$watch $watch()} method. This type of directive needs
+    api/ng.$rootScope.Scope#methods_$watch $watch()} method. This type of directive needs
     to be notified whenever the expression changes so that it can update the view.
 
   - Listener directives, such as {@link api/ng.directive:ngClick
     ng-click}, register a listener with the DOM. When the DOM listener fires, the directive
     executes the associated expression and updates the view using the {@link
-    api/ng.$rootScope.Scope#$apply $apply()} method.
+    api/ng.$rootScope.Scope#methods_$apply $apply()} method.
 
 When an external event (such as a user action, timer or XHR) is received, the associated {@link
 expression expression} must be applied to the scope through the {@link
-api/ng.$rootScope.Scope#$apply $apply()} method so that all listeners are updated
+api/ng.$rootScope.Scope#methods_$apply $apply()} method so that all listeners are updated
 correctly.
 
 ### Directives that Create Scopes
 
-In most cases, {@link api/ng.$compileProvider#directive directives} and scopes interact
+In most cases, {@link api/ng.$compileProvider#methods_directive directives} and scopes interact
 but do not create new instances of scope. However, some directives, such as {@link
 api/ng.directive:ngController ng-controller} and {@link
 api/ng.directive:ngRepeat ng-repeat}, create new child scopes
@@ -315,7 +315,7 @@ Scopes and controllers interact with each other in the following situations:
 
    - Controllers define methods (behavior) that can mutate the model (properties on the scope).
 
-   - Controllers may register {@link api/ng.$rootScope.Scope#$watch watches} on
+   - Controllers may register {@link api/ng.$rootScope.Scope#methods_$watch watches} on
      the model. These watches execute immediately after the controller behavior executes.
 
 See the {@link api/ng.directive:ngController ng-controller} for more

--- a/docs/content/tutorial/step_07.ngdoc
+++ b/docs/content/tutorial/step_07.ngdoc
@@ -107,7 +107,7 @@ module `phonecatControllers`. By listing these two modules as dependencies of `p
 can use the directives and services they provide.
 
 Thus using the `config` API we request the `$routeProvider` to be injected into our config function
-and use the {@link api/ngRoute.$routeProvider#when `$routeProvider.when`} API to define our routes.
+and use the {@link api/ngRoute.$routeProvider#methods_when `$routeProvider.when`} API to define our routes.
 
 Our application routes are defined as follows:
 

--- a/docs/spec/domSpec.js
+++ b/docs/spec/domSpec.js
@@ -1,10 +1,36 @@
 var DOM = require('../src/dom.js').DOM;
+var normalizeHeaderToId = require('../src/dom.js').normalizeHeaderToId;
 
 describe('dom', function() {
   var dom;
 
   beforeEach(function() {
     dom = new DOM();
+  });
+
+  describe('html', function() {
+    it('should add ids to all h tags', function() {
+      dom.html('<h1>Some Header</h1>');
+      expect(dom.toString()).toContain('<h1 id="some-header">Some Header</h1>');
+    });
+
+    it('should collect <a name> anchors too', function() {
+      dom.html('<h2>Xxx <a name="foo"></a> and bar <a name="bar"></a>');
+      expect(dom.anchors).toContain('foo');
+      expect(dom.anchors).toContain('bar');
+    })
+  });
+
+  it('should collect h tag ids', function() {
+    dom.h('Page Title', function() {
+      dom.html('<h1>Second</h1>xxx <h2>Third</h2>');
+      dom.h('Another Header', function() {});
+    });
+
+    expect(dom.anchors).toContain('page-title');
+    expect(dom.anchors).toContain('second');
+    expect(dom.anchors).toContain('second_third');
+    expect(dom.anchors).toContain('another-header');
   });
 
   describe('h', function() {
@@ -25,7 +51,7 @@ describe('dom', function() {
         this.html('<h1>sub-heading</h1>');
       });
       expect(dom.toString()).toContain('<h1 id="heading">heading</h1>');
-      expect(dom.toString()).toContain('<h2>sub-heading</h2>');
+      expect(dom.toString()).toContain('<h2 id="sub-heading">sub-heading</h2>');
     });
 
     it('should properly number nested headings', function() {
@@ -40,12 +66,45 @@ describe('dom', function() {
 
       expect(dom.toString()).toContain('<h1 id="heading">heading</h1>');
       expect(dom.toString()).toContain('<h2 id="heading2">heading2</h2>');
-      expect(dom.toString()).toContain('<h3>heading3</h3>');
+      expect(dom.toString()).toContain('<h3 id="heading2_heading3">heading3</h3>');
 
       expect(dom.toString()).toContain('<h1 id="other1">other1</h1>');
-      expect(dom.toString()).toContain('<h2>other2</h2>');
+      expect(dom.toString()).toContain('<h2 id="other2">other2</h2>');
     });
 
+
+    it('should add nested ids to all h tags', function() {
+      dom.h('Page Title', function() {
+        dom.h('Second', function() {
+          dom.html('some <h1>Third</h1>');
+        });
+      });
+
+      var resultingHtml = dom.toString();
+      expect(resultingHtml).toContain('<h1 id="page-title">Page Title</h1>');
+      expect(resultingHtml).toContain('<h2 id="second">Second</h2>');
+      expect(resultingHtml).toContain('<h3 id="second_third">Third</h3>');
+    });
+
+  });
+
+
+  describe('normalizeHeaderToId', function() {
+    it('should ignore content in the parenthesis', function() {
+      expect(normalizeHeaderToId('One (more)')).toBe('one');
+    });
+
+    it('should ignore html content', function() {
+      expect(normalizeHeaderToId('Section <a name="section"></a>')).toBe('section');
+    });
+
+    it('should ignore special characters', function() {
+      expect(normalizeHeaderToId('Section \'!?')).toBe('section');
+    });
+
+    it('should ignore html entities', function() {
+      expect(normalizeHeaderToId('angular&#39;s-jqlite')).toBe('angulars-jqlite');
+    });
   });
 
 });

--- a/docs/spec/ngdocSpec.js
+++ b/docs/spec/ngdocSpec.js
@@ -262,33 +262,37 @@ describe('ngdoc', function() {
       expect(docs[0].events).toEqual([eventA, eventB]);
       expect(docs[0].properties).toEqual([propA, propB]);
     });
+  });
 
 
+  describe('checkBrokenLinks', function() {
+    var docs;
 
-    describe('links checking', function() {
-      var docs;
-      beforeEach(function() {
-        spyOn(console, 'log');
-        docs = [new Doc({section: 'api', id: 'fake.id1', links: ['non-existing-link']}),
-                new Doc({section: 'api', id: 'fake.id2'}),
-                new Doc({section: 'api', id: 'fake.id3'})];
-      });
+    beforeEach(function() {
+      spyOn(console, 'log');
+      docs = [new Doc({section: 'api', id: 'fake.id1', anchors: ['one']}),
+              new Doc({section: 'api', id: 'fake.id2'}),
+              new Doc({section: 'api', id: 'fake.id3'})];
+    });
 
-      it('should log warning when any link doesn\'t exist', function() {
-        ngdoc.merge(docs);
-        expect(console.log).toHaveBeenCalled();
-        expect(console.log.argsForCall[0][0]).toContain('WARNING:');
-      });
+    it('should log warning when a linked page does not exist', function() {
+      docs.push(new Doc({section: 'api', id: 'with-broken.link', links: ['non-existing-link']}))
+      ngdoc.checkBrokenLinks(docs);
+      expect(console.log).toHaveBeenCalled();
+      var warningMsg = console.log.argsForCall[0][0]
+      expect(warningMsg).toContain('WARNING:');
+      expect(warningMsg).toContain('non-existing-link');
+      expect(warningMsg).toContain('api/with-broken.link');
+    });
 
-      it('should say which link doesn\'t exist', function() {
-        ngdoc.merge(docs);
-        expect(console.log.argsForCall[0][0]).toContain('non-existing-link');
-      });
-
-      it('should say where is the non-existing link', function() {
-        ngdoc.merge(docs);
-        expect(console.log.argsForCall[0][0]).toContain('api/fake.id1');
-      });
+    it('should log warning when a linked anchor does not exist', function() {
+      docs.push(new Doc({section: 'api', id: 'with-broken.link', links: ['api/fake.id1#non-existing']}))
+      ngdoc.checkBrokenLinks(docs);
+      expect(console.log).toHaveBeenCalled();
+      var warningMsg = console.log.argsForCall[0][0]
+      expect(warningMsg).toContain('WARNING:');
+      expect(warningMsg).toContain('non-existing');
+      expect(warningMsg).toContain('api/with-broken.link');
     });
   });
 
@@ -524,7 +528,7 @@ describe('ngdoc', function() {
         doc.ngdoc = 'filter';
         doc.parse();
         expect(doc.html()).toContain(
-            '<h3 id="Animations">Animations</h3>\n' +
+            '<h3 id="usage_animations">Animations</h3>\n' +
             '<div class="animations">' +
               '<ul>' +
                 '<li>enter - Add text</li>' +
@@ -541,7 +545,7 @@ describe('ngdoc', function() {
         var doc = new Doc('@ngdoc overview\n@name angular\n@description\n#heading\ntext');
         doc.parse();
         expect(doc.html()).toContain('text');
-        expect(doc.html()).toContain('<h2>heading</h2>');
+        expect(doc.html()).toContain('<h2 id="heading">heading</h2>');
         expect(doc.html()).not.toContain('Description');
       });
     });

--- a/docs/src/dom.js
+++ b/docs/src/dom.js
@@ -4,6 +4,7 @@
 
 exports.DOM = DOM;
 exports.htmlEscape = htmlEscape;
+exports.normalizeHeaderToId = normalizeHeaderToId;
 
 //////////////////////////////////////////////////////////
 
@@ -16,10 +17,36 @@ function htmlEscape(text){
           .replace(/\}\}/g, '<span>}}</span>');
 }
 
+function nonEmpty(header) {
+  return !!header;
+}
+
+function idFromCurrentHeaders(headers) {
+  if (headers.length === 1) return headers[0];
+  // Do not include the first level title, as that's the title of the page.
+  return headers.slice(1).filter(nonEmpty).join('_');
+}
+
+function normalizeHeaderToId(header) {
+  if (typeof header !== 'string') {
+    return '';
+  }
+
+  return header.toLowerCase()
+      .replace(/<.*>/g, '')         // html tags
+      .replace(/[\!\?\:\.\']/g, '') // special characters
+      .replace(/&#\d\d;/g, '')      // html entities
+      .replace(/\(.*\)/mg, '')      // stuff in parenthesis
+      .replace(/\s$/, '')           // trailing spaces
+      .replace(/\s+/g, '-');        // replace whitespaces with dashes
+}
+
 
 function DOM() {
   this.out = [];
   this.headingDepth = 0;
+  this.currentHeaders = [];
+  this.anchors = [];
 }
 
 var INLINE_TAGS = {
@@ -44,17 +71,28 @@ DOM.prototype = {
   },
 
   html: function(html) {
-    if (html) {
-      var headingDepth = this.headingDepth;
-      for ( var i = 10; i > 0; --i) {
-        html = html
-          .replace(new RegExp('<h' + i + '(.*?)>([\\s\\S]+)<\/h' + i +'>', 'gm'), function(_, attrs, content){
-            var tag = 'h' + (i + headingDepth);
-            return '<' + tag + attrs + '>' + content + '</' + tag + '>';
-          });
-      }
-      this.out.push(html);
-    }
+    if (!html) return;
+
+    var self = this;
+    // rewrite header levels, add ids and collect the ids
+    html = html.replace(/<h(\d)(.*?)>([\s\S]+?)<\/h\1>/gm, function(_, level, attrs, content) {
+      level = parseInt(level, 10) + self.headingDepth; // change header level based on the context
+
+      self.currentHeaders[level - 1] = normalizeHeaderToId(content);
+      self.currentHeaders.length = level;
+
+      var id = idFromCurrentHeaders(self.currentHeaders);
+      self.anchors.push(id);
+      return '<h' + level + attrs + ' id="' + id + '">' + content + '</h' + level + '>';
+    });
+
+    // collect anchors
+    html = html.replace(/<a name="(\w*)">/g, function(match, anchor) {
+      self.anchors.push(anchor);
+      return match;
+    });
+
+    this.out.push(html);
   },
 
   tag: function(name, attr, text) {
@@ -85,17 +123,18 @@ DOM.prototype = {
 
   h: function(heading, content, fn){
     if (content==undefined || (content instanceof Array && content.length == 0)) return;
+
     this.headingDepth++;
+    this.currentHeaders[this.headingDepth - 1] = normalizeHeaderToId(heading);
+    this.currentHeaders.length = this.headingDepth;
+
     var className = null,
         anchor = null;
     if (typeof heading == 'string') {
-      var id = heading.
-          replace(/\(.*\)/mg, '').
-          replace(/[^\d\w\$]/mg, '.').
-          replace(/-+/gm, '-').
-          replace(/-*$/gm, '');
+      var id = idFromCurrentHeaders(this.currentHeaders);
+      this.anchors.push(id);
       anchor = {'id': id};
-      var classNameValue = id.toLowerCase().replace(/[._]/mg, '-');
+      var classNameValue = this.currentHeaders[this.headingDepth - 1]
       if(classNameValue == 'hide') classNameValue = '';
       className = {'class': classNameValue};
     }

--- a/docs/src/gen-docs.js
+++ b/docs/src/gen-docs.js
@@ -55,6 +55,8 @@ writer.makeDir('build/docs/', true).then(function() {
     fileFutures.push(writer.output('partials/' + doc.section + '/' + id + '.html', doc.html()));
   });
 
+  ngdoc.checkBrokenLinks(docs);
+
   writeTheRest(fileFutures);
 
   return Q.deep(fileFutures);

--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -276,26 +276,26 @@ function annotate(fn) {
  * factories** are functions which, in turn, are created by a **service provider**.
  * The **service providers** are constructor functions. When instantiated they must contain a property
  * called `$get`, which holds the **service factory** function.
- * 
+ *
  * When you request a service, the {@link AUTO.$injector $injector} is responsible for finding the
  * correct **service provider**, instantiating it and then calling its `$get` **service factory**
  * function to get the instance of the **service**.
- * 
+ *
  * Often services have no configuration options and there is no need to add methods to the service
  * provider.  The provider will be no more than a constructor function with a `$get` property. For
  * these cases the {@link AUTO.$provide $provide} service has additional helper methods to register
  * services without specifying a provider.
  *
- * * {@link AUTO.$provide#provider provider(provider)} - registers a **service provider** with the
+ * * {@link AUTO.$provide#methods_provider provider(provider)} - registers a **service provider** with the
  *     {@link AUTO.$injector $injector}
- * * {@link AUTO.$provide#constant constant(obj)} - registers a value/object that can be accessed by
+ * * {@link AUTO.$provide#methods_constant constant(obj)} - registers a value/object that can be accessed by
  *     providers and services.
- * * {@link AUTO.$provide#value value(obj)} - registers a value/object that can only be accessed by
+ * * {@link AUTO.$provide#methods_value value(obj)} - registers a value/object that can only be accessed by
  *     services, not providers.
- * * {@link AUTO.$provide#factory factory(fn)} - registers a service **factory function**, `fn`, that
+ * * {@link AUTO.$provide#methods_factory factory(fn)} - registers a service **factory function**, `fn`, that
  *     will be wrapped in a **service provider** object, whose `$get` property will contain the given
  *     factory function.
- * * {@link AUTO.$provide#service service(class)} - registers a **constructor function**, `class` that
+ * * {@link AUTO.$provide#methods_service service(class)} - registers a **constructor function**, `class` that
  *     will be wrapped in a **service provider** object, whose `$get` property will instantiate a new
  *     object using the given constructor function.
  *
@@ -310,7 +310,7 @@ function annotate(fn) {
  *
  * Register a **provider function** with the {@link AUTO.$injector $injector}. Provider functions are
  * constructor functions, whose instances are responsible for "providing" a factory for a service.
- * 
+ *
  * Service provider names start with the name of the service they provide followed by `Provider`.
  * For example, the {@link ng.$log $log} service has a provider called {@link ng.$logProvider $logProvider}.
  *
@@ -334,7 +334,7 @@ function annotate(fn) {
  * @example
  *
  * The following example shows how to create a simple event tracking service and register it using
- * {@link AUTO.$provide#provider $provide.provider()}.
+ * {@link AUTO.$provide#methods_provider $provide.provider()}.
  *
  * <pre>
  *  // Define the eventTracker provider
@@ -414,7 +414,7 @@ function annotate(fn) {
  * @returns {Object} registered provider instance
  *
  * @example
- * Here is an example of registering a service 
+ * Here is an example of registering a service
  * <pre>
  *   $provide.factory('ping', ['$http', function($http) {
  *     return function ping() {
@@ -441,7 +441,7 @@ function annotate(fn) {
  * This is short for registering a service where its provider's `$get` property is the service
  * constructor function that will be used to instantiate the service instance.
  *
- * You should use {@link AUTO.$provide#service $provide.service(class)} if you define your service
+ * You should use {@link AUTO.$provide#methods_service $provide.service(class)} if you define your service
  * as a type/class. This is common when using {@link http://coffeescript.org CoffeeScript}.
  *
  * @param {string} name The name of the instance.
@@ -449,14 +449,14 @@ function annotate(fn) {
  * @returns {Object} registered provider instance
  *
  * @example
- * Here is an example of registering a service using {@link AUTO.$provide#service $provide.service(class)}
+ * Here is an example of registering a service using {@link AUTO.$provide#methods_service $provide.service(class)}
  * that is defined as a CoffeeScript class.
  * <pre>
  *   class Ping
  *     constructor: (@$http)->
  *     send: ()=>
  *       @$http.get('/ping')
- *  
+ *
  *   $provide.service('ping', ['$http', Ping])
  * </pre>
  * You would then inject and use this service like this:
@@ -481,7 +481,7 @@ function annotate(fn) {
  * Value services are similar to constant services, except that they cannot be injected into a module
  * configuration function (see {@link angular.Module#config}) but they can be overridden by an Angular
  * {@link AUTO.$provide#decorator decorator}.
- * 
+ *
  * @param {string} name The name of the instance.
  * @param {*} value The value.
  * @returns {Object} registered provider instance
@@ -490,9 +490,9 @@ function annotate(fn) {
  * Here are some examples of creating value services.
  * <pre>
  *   $provide.constant('ADMIN_USER', 'admin');
- *   
+ *
  *   $provide.constant('RoleLookup', { admin: 0, writer: 1, reader: 2 });
- *   
+ *
  *   $provide.constant('halfOf', function(value) {
  *     return value / 2;
  *   });
@@ -519,9 +519,9 @@ function annotate(fn) {
  * Here a some examples of creating constants:
  * <pre>
  *   $provide.constant('SHARD_HEIGHT', 306);
- *   
+ *
  *   $provide.constant('MY_COLOURS', ['red', 'blue', 'grey']);
- *   
+ *
  *   $provide.constant('double', function(value) {
  *     return value * 2;
  *   });

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -804,7 +804,7 @@ forEach({
 
   triggerHandler: function(element, eventName, eventData) {
     var eventFns = (JQLiteExpandoStore(element, 'events') || {})[eventName];
-    
+
     eventData = eventData || [];
 
     var event = [{

--- a/src/loader.js
+++ b/src/loader.js
@@ -66,7 +66,7 @@ function setupModuleLoader(window) {
      * @param {Array.<string>=} requires If specified then new module is being created. If unspecified then the
      *        the module is being retrieved for further configuration.
      * @param {Function} configFn Optional configuration function for the module. Same as
-     *        {@link angular.Module#config Module#config()}.
+     *        {@link angular.Module#methods_config Module#config()}.
      * @returns {module} new module with the {@link angular.Module} api.
      */
     return function module(name, requires, configFn) {
@@ -236,7 +236,7 @@ function setupModuleLoader(window) {
            * @param {Function} directiveFactory Factory function for creating new instance of
            * directives.
            * @description
-           * See {@link ng.$compileProvider#directive $compileProvider.directive()}.
+           * See {@link ng.$compileProvider#methods_directive $compileProvider.directive()}.
            */
           directive: invokeLater('$compileProvider', 'directive'),
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -28,7 +28,7 @@
  * can then be used to link {@link ng.$rootScope.Scope scope} and the template together.
  *
  * The compilation is a process of walking the DOM tree and trying to match DOM elements to
- * {@link ng.$compileProvider#directive directives}. For each match it
+ * {@link ng.$compileProvider#methods_directive directives}. For each match it
  * executes corresponding template function and collects the
  * instance functions into a single template function which is then returned.
  *

--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -8,7 +8,7 @@
  * controllers.
  *
  * This provider allows controller registration via the
- * {@link ng.$controllerProvider#register register} method.
+ * {@link ng.$controllerProvider#methods_register register} method.
  */
 function $ControllerProvider() {
   var controllers = {},

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -818,7 +818,7 @@ var VALID_CLASS = 'ng-valid',
        the control reads value from the DOM.  Each function is called, in turn, passing the value
        through to the next. Used to sanitize / convert the value as well as validation.
        For validation, the parsers should update the validity state using
-       {@link ng.directive:ngModel.NgModelController#$setValidity $setValidity()},
+       {@link ng.directive:ngModel.NgModelController#methods_$setValidity $setValidity()},
        and return `undefined` for invalid values.
 
  *
@@ -999,10 +999,10 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
    *
    * @description
    * This is called when we need to determine if the value of the input is empty.
-   * 
+   *
    * For instance, the required directive does this to work out if the input has data or not.
    * The default `$isEmpty` function checks whether the value is `undefined`, `''`, `null` or `NaN`.
-   * 
+   *
    * You can override this for input directives whose concept of being empty is different to the
    * default. The `checkboxInputType` directive does this because in its case a value of `false`
    * implies empty.

--- a/src/ng/directive/ngBind.js
+++ b/src/ng/directive/ngBind.js
@@ -13,8 +13,8 @@
  * Typically, you don't use `ngBind` directly, but instead you use the double curly markup like
  * `{{ expression }}` which is similar but less verbose.
  *
- * It is preferrable to use `ngBind` instead of `{{ expression }}` when a template is momentarily 
- * displayed by the browser in its raw state before Angular compiles it. Since `ngBind` is an 
+ * It is preferrable to use `ngBind` instead of `{{ expression }}` when a template is momentarily
+ * displayed by the browser in its raw state before Angular compiles it. Since `ngBind` is an
  * element attribute, it makes the bindings invisible to the user while the page is loading.
  *
  * An alternative solution to this problem would be using the
@@ -125,7 +125,7 @@ var ngBindTemplateDirective = ['$interpolate', function($interpolate) {
  * ngSanitize.$sanitize $sanitize} service.  To utilize this functionality, ensure that `$sanitize`
  * is available, for example, by including {@link ngSanitize} in your module's dependencies (not in
  * core Angular.)  You may also bypass sanitization for values you know are safe. To do so, bind to
- * an explicitly trusted value via {@link ng.$sce#trustAsHtml $sce.trustAsHtml}.  See the example
+ * an explicitly trusted value via {@link ng.$sce#methods_trustAsHtml $sce.trustAsHtml}.  See the example
  * under {@link ng.$sce#Example Strict Contextual Escaping (SCE)}.
  *
  * Note: If a `$sanitize` service is unavailable and the bound value isn't explicitly trusted, you

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -9,10 +9,10 @@
  * Fetches, compiles and includes an external HTML fragment.
  *
  * By default, the template URL is restricted to the same domain and protocol as the
- * application document. This is done by calling {@link ng.$sce#getTrustedResourceUrl
+ * application document. This is done by calling {@link ng.$sce#methods_getTrustedResourceUrl
  * $sce.getTrustedResourceUrl} on it. To load templates from other domains or protocols
- * you may either {@link ng.$sceDelegateProvider#resourceUrlWhitelist whitelist them} or
- * {@link ng.$sce#trustAsResourceUrl wrap them} as trusted values. Refer to Angular's {@link
+ * you may either {@link ng.$sceDelegateProvider#methods_resourceUrlWhitelist whitelist them} or
+ * {@link ng.$sce#methods_trustAsResourceUrl wrap them} as trusted values. Refer to Angular's {@link
  * ng.$sce Strict Contextual Escaping}.
  *
  * In addition, the browser's

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -263,12 +263,12 @@ function $HttpProvider() {
      *
      * Complete list of shortcut methods:
      *
-     * - {@link ng.$http#get $http.get}
-     * - {@link ng.$http#head $http.head}
-     * - {@link ng.$http#post $http.post}
-     * - {@link ng.$http#put $http.put}
-     * - {@link ng.$http#delete $http.delete}
-     * - {@link ng.$http#jsonp $http.jsonp}
+     * - {@link ng.$http#methods_get $http.get}
+     * - {@link ng.$http#methods_head $http.head}
+     * - {@link ng.$http#methods_post $http.post}
+     * - {@link ng.$http#methods_put $http.put}
+     * - {@link ng.$http#methods_delete $http.delete}
+     * - {@link ng.$http#methods_jsonp $http.jsonp}
      *
      *
      * # Setting HTTP Headers

--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -113,7 +113,7 @@ function $InterpolateProvider() {
      *    embedded expression in order to return an interpolation function. Strings with no
      *    embedded expression will return null for the interpolation function.
      * @param {string=} trustedContext when provided, the returned function passes the interpolated
-     *    result through {@link ng.$sce#getTrusted $sce.getTrusted(interpolatedResult,
+     *    result through {@link ng.$sce#methods_getTrusted $sce.getTrusted(interpolatedResult,
      *    trustedContext)} before returning it.  Refer to the {@link ng.$sce $sce} service that
      *    provides Strict Contextual Escaping for details.
      * @returns {function(context)} an interpolation function which is used to compute the interpolated

--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -21,7 +21,7 @@ function $IntervalProvider() {
       * number of iterations that have run.
       * To cancel an interval, call `$interval.cancel(promise)`.
       *
-      * In tests you can use {@link ngMock.$interval#flush `$interval.flush(millis)`} to
+      * In tests you can use {@link ngMock.$interval#methods_flush `$interval.flush(millis)`} to
       * move forward by `millis` milliseconds and trigger any functions scheduled to run in that
       * time.
       *
@@ -30,7 +30,7 @@ function $IntervalProvider() {
       * @param {number=} [count=0] Number of times to repeat. If not set, or 0, will repeat
       *   indefinitely.
       * @param {boolean=} [invokeApply=true] If set to `false` skips model dirty checking, otherwise
-      *   will invoke `fn` within the {@link ng.$rootScope.Scope#$apply $apply} block.
+      *   will invoke `fn` within the {@link ng.$rootScope.Scope#methods_$apply $apply} block.
       * @returns {promise} A promise which will be notified on each iteration.
       */
     function interval(fn, delay, count, invokeApply) {

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -85,7 +85,7 @@ function $RootScopeProvider(){
      * @description
      * A root scope can be retrieved using the {@link ng.$rootScope $rootScope} key from the
      * {@link AUTO.$injector $injector}. Child scopes are created using the
-     * {@link ng.$rootScope.Scope#$new $new()} method. (Most scopes are created automatically when
+     * {@link ng.$rootScope.Scope#methods_$new $new()} method. (Most scopes are created automatically when
      * compiled HTML template is executed.)
      *
      * Here is a simple scope snippet to show how you can interact with the scope.
@@ -466,9 +466,9 @@ function $RootScopeProvider(){
        *
        * Usually, you don't call `$digest()` directly in
        * {@link ng.directive:ngController controllers} or in
-       * {@link ng.$compileProvider#directive directives}.
+       * {@link ng.$compileProvider#methods_directive directives}.
        * Instead, you should call {@link ng.$rootScope.Scope#$apply $apply()} (typically from within a
-       * {@link ng.$compileProvider#directive directives}), which will force a `$digest()`.
+       * {@link ng.$compileProvider#methods_directive directives}), which will force a `$digest()`.
        *
        * If you want to be notified whenever `$digest()` is called,
        * you can register a `watchExpression` function with {@link ng.$rootScope.Scope#$watch $watch()}

--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -84,9 +84,9 @@ function adjustMatchers(matchers) {
  * can override it completely to change the behavior of `$sce`, the common case would
  * involve configuring the {@link ng.$sceDelegateProvider $sceDelegateProvider} instead by setting
  * your own whitelists and blacklists for trusting URLs used for loading AngularJS resources such as
- * templates.  Refer {@link ng.$sceDelegateProvider#resourceUrlWhitelist
+ * templates.  Refer {@link ng.$sceDelegateProvider#methods_resourceUrlWhitelist
  * $sceDelegateProvider.resourceUrlWhitelist} and {@link
- * ng.$sceDelegateProvider#resourceUrlBlacklist $sceDelegateProvider.resourceUrlBlacklist}
+ * ng.$sceDelegateProvider#methods_resourceUrlBlacklist $sceDelegateProvider.resourceUrlBlacklist}
  */
 
 /**
@@ -97,8 +97,8 @@ function adjustMatchers(matchers) {
  * The `$sceDelegateProvider` provider allows developers to configure the {@link ng.$sceDelegate
  * $sceDelegate} service.  This allows one to get/set the whitelists and blacklists used to ensure
  * that the URLs used for sourcing Angular templates are safe.  Refer {@link
- * ng.$sceDelegateProvider#resourceUrlWhitelist $sceDelegateProvider.resourceUrlWhitelist} and
- * {@link ng.$sceDelegateProvider#resourceUrlBlacklist $sceDelegateProvider.resourceUrlBlacklist}
+ * ng.$sceDelegateProvider#methods_resourceUrlWhitelist $sceDelegateProvider.resourceUrlWhitelist} and
+ * {@link ng.$sceDelegateProvider#methods_resourceUrlBlacklist $sceDelegateProvider.resourceUrlBlacklist}
  *
  * For the general details about this service in Angular, read the main page for {@link ng.$sce
  * Strict Contextual Escaping (SCE)}.
@@ -312,16 +312,16 @@ function $SceDelegateProvider() {
      * @methodOf ng.$sceDelegate
      *
      * @description
-     * If the passed parameter had been returned by a prior call to {@link ng.$sceDelegate#trustAs
+     * If the passed parameter had been returned by a prior call to {@link ng.$sceDelegate#methods_trustAs
      * `$sceDelegate.trustAs`}, returns the value that had been passed to {@link
-     * ng.$sceDelegate#trustAs `$sceDelegate.trustAs`}.
+     * ng.$sceDelegate#methods_trustAs `$sceDelegate.trustAs`}.
      *
      * If the passed parameter is not a value that had been returned by {@link
-     * ng.$sceDelegate#trustAs `$sceDelegate.trustAs`}, returns it as-is.
+     * ng.$sceDelegate#methods_trustAs `$sceDelegate.trustAs`}, returns it as-is.
      *
-     * @param {*} value The result of a prior {@link ng.$sceDelegate#trustAs `$sceDelegate.trustAs`}
+     * @param {*} value The result of a prior {@link ng.$sceDelegate#methods_trustAs `$sceDelegate.trustAs`}
      *      call or anything else.
-     * @returns {*} The value the was originally provided to {@link ng.$sceDelegate#trustAs
+     * @returns {*} The value the was originally provided to {@link ng.$sceDelegate#methods_trustAs
      *     `$sceDelegate.trustAs`} if `value` is the result of such a call.  Otherwise, returns `value`
      *     unchanged.
      */
@@ -339,14 +339,14 @@ function $SceDelegateProvider() {
      * @methodOf ng.$sceDelegate
      *
      * @description
-     * Takes the result of a {@link ng.$sceDelegate#trustAs `$sceDelegate.trustAs`} call and returns the
+     * Takes the result of a {@link ng.$sceDelegate#methods_trustAs `$sceDelegate.trustAs`} call and returns the
      * originally supplied value if the queried context type is a supertype of the created type.  If
      * this condition isn't satisfied, throws an exception.
      *
      * @param {string} type The kind of context in which this value is to be used.
-     * @param {*} maybeTrusted The result of a prior {@link ng.$sceDelegate#trustAs
+     * @param {*} maybeTrusted The result of a prior {@link ng.$sceDelegate#methods_trustAs
      * `$sceDelegate.trustAs`} call.
-     * @returns {*} The value the was originally provided to {@link ng.$sceDelegate#trustAs
+     * @returns {*} The value the was originally provided to {@link ng.$sceDelegate#methods_trustAs
      *     `$sceDelegate.trustAs`} if valid in this context.  Otherwise, throws an exception.
      */
     function getTrusted(type, maybeTrusted) {
@@ -448,20 +448,20 @@ function $SceDelegateProvider() {
  * allowing only the files in a specific directory to do this.  Ensuring that the internal API
  * exposed by that code doesn't markup arbitrary values as safe then becomes a more manageable task.
  *
- * In the case of AngularJS' SCE service, one uses {@link ng.$sce#trustAs $sce.trustAs} (and shorthand
- * methods such as {@link ng.$sce#trustAsHtml $sce.trustAsHtml}, etc.) to obtain values that will be
+ * In the case of AngularJS' SCE service, one uses {@link ng.$sce#methods_trustAs $sce.trustAs} (and shorthand
+ * methods such as {@link ng.$sce#methods_trustAsHtml $sce.trustAsHtml}, etc.) to obtain values that will be
  * accepted by SCE / privileged contexts.
  *
  *
  * ## How does it work?
  *
- * In privileged contexts, directives and code will bind to the result of {@link ng.$sce#getTrusted
+ * In privileged contexts, directives and code will bind to the result of {@link ng.$sce#methods_getTrusted
  * $sce.getTrusted(context, value)} rather than to the value directly.  Directives use {@link
- * ng.$sce#parse $sce.parseAs} rather than `$parse` to watch attribute bindings, which performs the
- * {@link ng.$sce#getTrusted $sce.getTrusted} behind the scenes on non-constant literals.
+ * ng.$sce#methods_parse $sce.parseAs} rather than `$parse` to watch attribute bindings, which performs the
+ * {@link ng.$sce#methods_getTrusted $sce.getTrusted} behind the scenes on non-constant literals.
  *
  * As an example, {@link ng.directive:ngBindHtml ngBindHtml} uses {@link
- * ng.$sce#parseAsHtml $sce.parseAsHtml(binding expression)}.  Here's the actual code (slightly
+ * ng.$sce#methods_parseAsHtml $sce.parseAsHtml(binding expression)}.  Here's the actual code (slightly
  * simplified):
  *
  * <pre class="prettyprint">
@@ -480,10 +480,10 @@ function $SceDelegateProvider() {
  * `templateUrl`'s specified by {@link guide/directive directives}.
  *
  * By default, Angular only loads templates from the same domain and protocol as the application
- * document.  This is done by calling {@link ng.$sce#getTrustedResourceUrl
+ * document.  This is done by calling {@link ng.$sce#methods_getTrustedResourceUrl
  * $sce.getTrustedResourceUrl} on the template URL.  To load templates from other domains and/or
- * protocols, you may either either {@link ng.$sceDelegateProvider#resourceUrlWhitelist whitelist
- * them} or {@link ng.$sce#trustAsResourceUrl wrap it} into a trusted value.
+ * protocols, you may either either {@link ng.$sceDelegateProvider#methods_resourceUrlWhitelist whitelist
+ * them} or {@link ng.$sce#methods_trustAsResourceUrl wrap it} into a trusted value.
  *
  * *Please note*:
  * The browser's
@@ -503,20 +503,21 @@ function $SceDelegateProvider() {
  * `<div ng-html-bind-unsafe="'<b>implicitly trusted</b>'"></div>`) just works.
  *
  * Additionally, `a[href]` and `img[src]` automatically sanitize their URLs and do not pass them
- * through {@link ng.$sce#getTrusted $sce.getTrusted}.  SCE doesn't play a role here.
+ * through {@link ng.$sce#methods_getTrusted $sce.getTrusted}.  SCE doesn't play a role here.
  *
  * The included {@link ng.$sceDelegate $sceDelegate} comes with sane defaults to allow you to load
  * templates in `ng-include` from your application's domain without having to even know about SCE.
  * It blocks loading templates from other domains or loading templates over http from an https
  * served document.  You can change these by setting your own custom {@link
- * ng.$sceDelegateProvider#resourceUrlWhitelist whitelists} and {@link
- * ng.$sceDelegateProvider#resourceUrlBlacklist blacklists} for matching such URLs.
+ * ng.$sceDelegateProvider#methods_resourceUrlWhitelist whitelists} and {@link
+ * ng.$sceDelegateProvider#methods_resourceUrlBlacklist blacklists} for matching such URLs.
  *
  * This significantly reduces the overhead.  It is far easier to pay the small overhead and have an
  * application that's secure and can be audited to verify that with much more ease than bolting
  * security onto an application later.
  *
- * ## What trusted context types are supported?<a name="contexts"></a>
+ * <a name="contexts"></a>
+ * ## What trusted context types are supported?
  *
  * | Context             | Notes          |
  * |---------------------|----------------|
@@ -526,7 +527,7 @@ function $SceDelegateProvider() {
  * | `$sce.RESOURCE_URL` | For URLs that are not only safe to follow as links, but whose contens are also safe to include in your application.  Examples include `ng-include`, `src` / `ngSrc` bindings for tags other than `IMG` (e.g. `IFRAME`, `OBJECT`, etc.)  <br><br>Note that `$sce.RESOURCE_URL` makes a stronger statement about the URL than `$sce.URL` does and therefore contexts requiring values trusted for `$sce.RESOURCE_URL` can be used anywhere that values trusted for `$sce.URL` are required. |
  * | `$sce.JS`           | For JavaScript that is safe to execute in your application's context.  Currently unused.  Feel free to use it in your own directives. |
  *
- * ## Format of items in {@link ng.$sceDelegateProvider#resourceUrlWhitelist resourceUrlWhitelist}/{@link ng.$sceDelegateProvider#resourceUrlBlacklist Blacklist} <a name="resourceUrlPatternItem"></a>
+ * ## Format of items in {@link ng.$sceDelegateProvider#methods_resourceUrlWhitelist resourceUrlWhitelist}/{@link ng.$sceDelegateProvider#methods_resourceUrlBlacklist Blacklist} <a name="resourceUrlPatternItem"></a>
  *
  *  Each element in these arrays must be one of the following:
  *
@@ -571,7 +572,7 @@ function $SceDelegateProvider() {
  *      Closure library's [goog.string.regExpEscape(s)](
  *      http://docs.closure-library.googlecode.com/git/closure_goog_string_string.js.source.html#line962).
  *
- * Refer {@link ng.$sceDelegateProvider#example $sceDelegateProvider} for an example.
+ * Refer {@link ng.$sceDelegateProvider $sceDelegateProvider} for an example.
  *
  * ## Show me an example using SCE.
  *
@@ -770,7 +771,7 @@ function $SceProvider() {
      * @description
      * Converts Angular {@link guide/expression expression} into a function.  This is like {@link
      * ng.$parse $parse} and is identical when the expression is a literal constant.  Otherwise, it
-     * wraps the expression in a call to {@link ng.$sce#getTrusted $sce.getTrusted(*type*,
+     * wraps the expression in a call to {@link ng.$sce#methods_getTrusted $sce.getTrusted(*type*,
      * *result*)}
      *
      * @param {string} type The kind of SCE context in which this result will be used.
@@ -799,7 +800,7 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Delegates to {@link ng.$sceDelegate#trustAs `$sceDelegate.trustAs`}.  As such, returns an object
+     * Delegates to {@link ng.$sceDelegate#methods_trustAs `$sceDelegate.trustAs`}.  As such, returns an object
      * that is trusted by angular for use in specified strict contextual escaping contexts (such as
      * ng-html-bind-unsafe, ng-include, any src attribute interpolation, any dom event binding
      * attribute interpolation such as for onclick,  etc.) that uses the provided value.  See *
@@ -818,13 +819,13 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Shorthand method.  `$sce.trustAsHtml(value)` → {@link ng.$sceDelegate#trustAs `$sceDelegate.trustAs($sce.HTML, value)`}
+     * Shorthand method.  `$sce.trustAsHtml(value)` → {@link ng.$sceDelegate#methods_trustAs `$sceDelegate.trustAs($sce.HTML, value)`}
      *
      * @param {*} value The value to trustAs.
-     * @returns {*} An object that can be passed to {@link ng.$sce#getTrustedHtml
+     * @returns {*} An object that can be passed to {@link ng.$sce#methods_getTrustedHtml
      *     $sce.getTrustedHtml(value)} to obtain the original value.  (privileged directives
      *     only accept expressions that are either literal constants or are the
-     *     return value of {@link ng.$sce#trustAs $sce.trustAs}.)
+     *     return value of {@link ng.$sce#methods_trustAs $sce.trustAs}.)
      */
 
     /**
@@ -833,13 +834,13 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Shorthand method.  `$sce.trustAsUrl(value)` → {@link ng.$sceDelegate#trustAs `$sceDelegate.trustAs($sce.URL, value)`}
+     * Shorthand method.  `$sce.trustAsUrl(value)` → {@link ng.$sceDelegate#methods_trustAs `$sceDelegate.trustAs($sce.URL, value)`}
      *
      * @param {*} value The value to trustAs.
-     * @returns {*} An object that can be passed to {@link ng.$sce#getTrustedUrl
+     * @returns {*} An object that can be passed to {@link ng.$sce#methods_getTrustedUrl
      *     $sce.getTrustedUrl(value)} to obtain the original value.  (privileged directives
      *     only accept expressions that are either literal constants or are the
-     *     return value of {@link ng.$sce#trustAs $sce.trustAs}.)
+     *     return value of {@link ng.$sce#methods_trustAs $sce.trustAs}.)
      */
 
     /**
@@ -848,13 +849,13 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Shorthand method.  `$sce.trustAsResourceUrl(value)` → {@link ng.$sceDelegate#trustAs `$sceDelegate.trustAs($sce.RESOURCE_URL, value)`}
+     * Shorthand method.  `$sce.trustAsResourceUrl(value)` → {@link ng.$sceDelegate#methods_trustAs `$sceDelegate.trustAs($sce.RESOURCE_URL, value)`}
      *
      * @param {*} value The value to trustAs.
-     * @returns {*} An object that can be passed to {@link ng.$sce#getTrustedResourceUrl
+     * @returns {*} An object that can be passed to {@link ng.$sce#methods_getTrustedResourceUrl
      *     $sce.getTrustedResourceUrl(value)} to obtain the original value.  (privileged directives
      *     only accept expressions that are either literal constants or are the return
-     *     value of {@link ng.$sce#trustAs $sce.trustAs}.)
+     *     value of {@link ng.$sce#methods_trustAs $sce.trustAs}.)
      */
 
     /**
@@ -863,13 +864,13 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Shorthand method.  `$sce.trustAsJs(value)` → {@link ng.$sceDelegate#trustAs `$sceDelegate.trustAs($sce.JS, value)`}
+     * Shorthand method.  `$sce.trustAsJs(value)` → {@link ng.$sceDelegate#methods_trustAs `$sceDelegate.trustAs($sce.JS, value)`}
      *
      * @param {*} value The value to trustAs.
-     * @returns {*} An object that can be passed to {@link ng.$sce#getTrustedJs
+     * @returns {*} An object that can be passed to {@link ng.$sce#methods_getTrustedJs
      *     $sce.getTrustedJs(value)} to obtain the original value.  (privileged directives
      *     only accept expressions that are either literal constants or are the
-     *     return value of {@link ng.$sce#trustAs $sce.trustAs}.)
+     *     return value of {@link ng.$sce#methods_trustAs $sce.trustAs}.)
      */
 
     /**
@@ -878,14 +879,14 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Delegates to {@link ng.$sceDelegate#getTrusted `$sceDelegate.getTrusted`}.  As such, takes
-     * the result of a {@link ng.$sce#trustAs `$sce.trustAs`}() call and returns the originally supplied
+     * Delegates to {@link ng.$sceDelegate#methods_getTrusted `$sceDelegate.getTrusted`}.  As such, takes
+     * the result of a {@link ng.$sce#methods_trustAs `$sce.trustAs`}() call and returns the originally supplied
      * value if the queried context type is a supertype of the created type.  If this condition
      * isn't satisfied, throws an exception.
      *
      * @param {string} type The kind of context in which this value is to be used.
-     * @param {*} maybeTrusted The result of a prior {@link ng.$sce#trustAs `$sce.trustAs`} call.
-     * @returns {*} The value the was originally provided to {@link ng.$sce#trustAs `$sce.trustAs`} if
+     * @param {*} maybeTrusted The result of a prior {@link ng.$sce#methods_trustAs `$sce.trustAs`} call.
+     * @returns {*} The value the was originally provided to {@link ng.$sce#methods_trustAs `$sce.trustAs`} if
      *     valid in this context.  Otherwise, throws an exception.
      */
 
@@ -895,7 +896,7 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Shorthand method.  `$sce.getTrustedHtml(value)` → {@link ng.$sceDelegate#getTrusted `$sceDelegate.getTrusted($sce.HTML, value)`}
+     * Shorthand method.  `$sce.getTrustedHtml(value)` → {@link ng.$sceDelegate#methods_getTrusted `$sceDelegate.getTrusted($sce.HTML, value)`}
      *
      * @param {*} value The value to pass to `$sce.getTrusted`.
      * @returns {*} The return value of `$sce.getTrusted($sce.HTML, value)`
@@ -907,7 +908,7 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Shorthand method.  `$sce.getTrustedCss(value)` → {@link ng.$sceDelegate#getTrusted `$sceDelegate.getTrusted($sce.CSS, value)`}
+     * Shorthand method.  `$sce.getTrustedCss(value)` → {@link ng.$sceDelegate#methods_getTrusted `$sceDelegate.getTrusted($sce.CSS, value)`}
      *
      * @param {*} value The value to pass to `$sce.getTrusted`.
      * @returns {*} The return value of `$sce.getTrusted($sce.CSS, value)`
@@ -919,7 +920,7 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Shorthand method.  `$sce.getTrustedUrl(value)` → {@link ng.$sceDelegate#getTrusted `$sceDelegate.getTrusted($sce.URL, value)`}
+     * Shorthand method.  `$sce.getTrustedUrl(value)` → {@link ng.$sceDelegate#methods_getTrusted `$sceDelegate.getTrusted($sce.URL, value)`}
      *
      * @param {*} value The value to pass to `$sce.getTrusted`.
      * @returns {*} The return value of `$sce.getTrusted($sce.URL, value)`
@@ -931,7 +932,7 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Shorthand method.  `$sce.getTrustedResourceUrl(value)` → {@link ng.$sceDelegate#getTrusted `$sceDelegate.getTrusted($sce.RESOURCE_URL, value)`}
+     * Shorthand method.  `$sce.getTrustedResourceUrl(value)` → {@link ng.$sceDelegate#methods_getTrusted `$sceDelegate.getTrusted($sce.RESOURCE_URL, value)`}
      *
      * @param {*} value The value to pass to `$sceDelegate.getTrusted`.
      * @returns {*} The return value of `$sce.getTrusted($sce.RESOURCE_URL, value)`
@@ -943,7 +944,7 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Shorthand method.  `$sce.getTrustedJs(value)` → {@link ng.$sceDelegate#getTrusted `$sceDelegate.getTrusted($sce.JS, value)`}
+     * Shorthand method.  `$sce.getTrustedJs(value)` → {@link ng.$sceDelegate#methods_getTrusted `$sceDelegate.getTrusted($sce.JS, value)`}
      *
      * @param {*} value The value to pass to `$sce.getTrusted`.
      * @returns {*} The return value of `$sce.getTrusted($sce.JS, value)`
@@ -955,7 +956,7 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Shorthand method.  `$sce.parseAsHtml(expression string)` → {@link ng.$sce#parse `$sce.parseAs($sce.HTML, value)`}
+     * Shorthand method.  `$sce.parseAsHtml(expression string)` → {@link ng.$sce#methods_parse `$sce.parseAs($sce.HTML, value)`}
      *
      * @param {string} expression String expression to compile.
      * @returns {function(context, locals)} a function which represents the compiled expression:
@@ -972,7 +973,7 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Shorthand method.  `$sce.parseAsCss(value)` → {@link ng.$sce#parse `$sce.parseAs($sce.CSS, value)`}
+     * Shorthand method.  `$sce.parseAsCss(value)` → {@link ng.$sce#methods_parse `$sce.parseAs($sce.CSS, value)`}
      *
      * @param {string} expression String expression to compile.
      * @returns {function(context, locals)} a function which represents the compiled expression:
@@ -989,7 +990,7 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Shorthand method.  `$sce.parseAsUrl(value)` → {@link ng.$sce#parse `$sce.parseAs($sce.URL, value)`}
+     * Shorthand method.  `$sce.parseAsUrl(value)` → {@link ng.$sce#methods_parse `$sce.parseAs($sce.URL, value)`}
      *
      * @param {string} expression String expression to compile.
      * @returns {function(context, locals)} a function which represents the compiled expression:
@@ -1006,7 +1007,7 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Shorthand method.  `$sce.parseAsResourceUrl(value)` → {@link ng.$sce#parse `$sce.parseAs($sce.RESOURCE_URL, value)`}
+     * Shorthand method.  `$sce.parseAsResourceUrl(value)` → {@link ng.$sce#methods_parse `$sce.parseAs($sce.RESOURCE_URL, value)`}
      *
      * @param {string} expression String expression to compile.
      * @returns {function(context, locals)} a function which represents the compiled expression:
@@ -1023,7 +1024,7 @@ function $SceProvider() {
      * @methodOf ng.$sce
      *
      * @description
-     * Shorthand method.  `$sce.parseAsJs(value)` → {@link ng.$sce#parse `$sce.parseAs($sce.JS, value)`}
+     * Shorthand method.  `$sce.parseAsJs(value)` → {@link ng.$sce#methods_parse `$sce.parseAs($sce.JS, value)`}
      *
      * @param {string} expression String expression to compile.
      * @returns {function(context, locals)} a function which represents the compiled expression:

--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -28,7 +28,7 @@ function $TimeoutProvider() {
       * @param {function()} fn A function, whose execution should be delayed.
       * @param {number=} [delay=0] Delay in milliseconds.
       * @param {boolean=} [invokeApply=true] If set to `false` skips model dirty checking, otherwise
-      *   will invoke `fn` within the {@link ng.$rootScope.Scope#$apply $apply} block.
+      *   will invoke `fn` within the {@link ng.$rootScope.Scope#methods_$apply $apply} block.
       * @returns {Promise} Promise that will be resolved when the timeout is reached. The value this
       *   promise will be resolved with is the return value of the `fn` function.
       * 

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -20,13 +20,13 @@
  *
  * | Directive                                                 | Supported Animations                               |
  * |---------------------------------------------------------- |----------------------------------------------------|
- * | {@link ng.directive:ngRepeat#animations ngRepeat}         | enter, leave and move                              |
- * | {@link ngRoute.directive:ngView#animations ngView}        | enter and leave                                    |
- * | {@link ng.directive:ngInclude#animations ngInclude}       | enter and leave                                    |
- * | {@link ng.directive:ngSwitch#animations ngSwitch}         | enter and leave                                    |
- * | {@link ng.directive:ngIf#animations ngIf}                 | enter and leave                                    |
- * | {@link ng.directive:ngClass#animations ngClass}           | add and remove                                     |
- * | {@link ng.directive:ngShow#animations ngShow & ngHide}    | add and remove (the ng-hide class value)           |
+ * | {@link ng.directive:ngRepeat#usage_animations ngRepeat}         | enter, leave and move                              |
+ * | {@link ngRoute.directive:ngView#usage_animations ngView}        | enter and leave                                    |
+ * | {@link ng.directive:ngInclude#usage_animations ngInclude}       | enter and leave                                    |
+ * | {@link ng.directive:ngSwitch#usage_animations ngSwitch}         | enter and leave                                    |
+ * | {@link ng.directive:ngIf#usage_animations ngIf}                 | enter and leave                                    |
+ * | {@link ng.directive:ngClass#usage_animations ngClass}           | add and remove                                     |
+ * | {@link ng.directive:ngShow#usage_animations ngShow & ngHide}    | add and remove (the ng-hide class value)           |
  *
  * You can find out more information about animations upon visiting each directive page.
  *
@@ -204,7 +204,7 @@ angular.module('ngAnimate', ['ng'])
     var rootAnimateState = {running:true};
     $provide.decorator('$animate', ['$delegate', '$injector', '$sniffer', '$rootElement', '$timeout', '$rootScope',
                             function($delegate,   $injector,   $sniffer,   $rootElement,   $timeout,   $rootScope) {
-        
+
       $rootElement.data(NG_ANIMATE_STATE, rootAnimateState);
 
       function lookup(name) {
@@ -657,7 +657,7 @@ angular.module('ngAnimate', ['ng'])
           animationReflowQueue = [];
           animationTimer = null;
           lookupCache = {};
-        }, 10, false); 
+        }, 10, false);
       }
 
       function getElementAnimationDetails(element, cacheKey, onlyCheckTransition) {

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -445,7 +445,7 @@ angular.mock.$LogProvider = function() {
  * @description
  * Mock implementation of the $interval service.
  *
- * Use {@link ngMock.$interval#flush `$interval.flush(millis)`} to
+ * Use {@link ngMock.$interval#methods_flush `$interval.flush(millis)`} to
  * move forward by `millis` milliseconds and trigger any functions scheduled to run in that
  * time.
  *
@@ -454,7 +454,7 @@ angular.mock.$LogProvider = function() {
  * @param {number=} [count=0] Number of times to repeat. If not set, or 0, will repeat
  *   indefinitely.
  * @param {boolean=} [invokeApply=true] If set to `false` skips model dirty checking, otherwise
- *   will invoke `fn` within the {@link ng.$rootScope.Scope#$apply $apply} block.
+ *   will invoke `fn` within the {@link ng.$rootScope.Scope#methods_$apply $apply} block.
  * @returns {promise} A promise which will be notified on each iteration.
  */
 angular.mock.$IntervalProvider = function() {
@@ -1951,7 +1951,7 @@ angular.mock.clearDataCache = function() {
    *
    * @param {...(string|Function|Object)} fns any number of modules which are represented as string
    *        aliases or as anonymous module initialization functions. The modules are used to
-   *        configure the injector. The 'ng' and 'ngMock' modules are automatically loaded. If an 
+   *        configure the injector. The 'ng' and 'ngMock' modules are automatically loaded. If an
    *        object literal is passed they will be register as values in the module, the key being
    *        the module name and the value being what is returned.
    */
@@ -1994,17 +1994,17 @@ angular.mock.clearDataCache = function() {
    * ## Resolving References (Underscore Wrapping)
    * Often, we would like to inject a reference once, in a `beforeEach()` block and reuse this
    * in multiple `it()` clauses. To be able to do this we must assign the reference to a variable
-   * that is declared in the scope of the `describe()` block. Since we would, most likely, want 
+   * that is declared in the scope of the `describe()` block. Since we would, most likely, want
    * the variable to have the same name of the reference we have a problem, since the parameter
    * to the `inject()` function would hide the outer variable.
    *
    * To help with this, the injected parameters can, optionally, be enclosed with underscores.
    * These are ignored by the injector when the reference name is resolved.
-   * 
+   *
    * For example, the parameter `_myService_` would be resolved as the reference `myService`.
    * Since it is available in the function body as _myService_, we can then assign it to a variable
    * defined in an outer scope.
-   * 
+   *
    * ```
    * // Defined out reference variable outside
    * var myService;
@@ -2012,15 +2012,15 @@ angular.mock.clearDataCache = function() {
    * // Wrap the parameter in underscores
    * beforeEach( inject( function(_myService_){
    *   myService = _myService_;
-   * })); 
+   * }));
    *
    * // Use myService in a series of tests.
    * it('makes use of myService', function() {
    *   myService.doStuff();
    * });
-   * 
+   *
    * ```
-   * 
+   *
    * See also {@link angular.mock.module angular.mock.module}
    *
    * ## Example
@@ -2060,7 +2060,7 @@ angular.mock.clearDataCache = function() {
    *   });
    *
    * </pre>
-   * 
+   *
    * @param {...Function} fns any number of functions which will be injected using the injector.
    */
   window.inject = angular.mock.inject = function() {

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -58,7 +58,7 @@ var $resourceMinErr = angular.$$minErr('$resource');
  *
  * @param {Object.<Object>=} actions Hash with declaration of custom action that should extend the
  *   default set of resource actions. The declaration should be created in the format of {@link
- *   ng.$http#Parameters $http.config}:
+ *   ng.$http#usage_parameters $http.config}:
  *
  *       {action1: {method:?, params:?, isArray:?, headers:?, ...},
  *        action2: {method:?, params:?, isArray:?, headers:?, ...},

--- a/src/ngRoute/routeParams.js
+++ b/src/ngRoute/routeParams.js
@@ -14,7 +14,7 @@ ngRouteModule.provider('$routeParams', $RouteParamsProvider);
  * Requires the {@link ngRoute `ngRoute`} module to be installed.
  *
  * The route parameters are a combination of {@link ng.$location `$location`}'s
- * {@link ng.$location#search `search()`} and {@link ng.$location#path `path()`}.
+ * {@link ng.$location#methods_search `search()`} and {@link ng.$location#methods_path `path()`}.
  * The `path` parameters are extracted when the {@link ngRoute.$route `$route`} path is matched.
  *
  * In case of parameter name collision, `path` params take precedence over `search` params.


### PR DESCRIPTION
Each header has now id (which [works as linkable anchor](http://stackoverflow.com/a/484781/531342)).
Nested headers have their ancestors in the id, but `h1` is ignored, because that's title of the page and so it's already contained in the url.

``` html
<h1>$http</h1>
<h2 id="description">Description</h2>
<h3 id="description_general-usage">General usage</h2>
<h2 id="methods">Methods</h2>
<h3 id="methods_post">post</h3>
<h4 id="methods_post_parameters">Parameters</h4>
```

It also reports broken links:

```
WARNING: guide/directive (defined in docs/content/guide/directive.ngdoc) points to a non existing anchor "guide/directive#attributes"!
```

It also collects anchors, so it is possible to use `<a name="xxx"></a>` in the markup and then link to it and it won't be reported as a broken link.
