### PR TITLE
Don't copy server response to resource value if they are already the same object

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -488,7 +488,7 @@ angular.module('ngResource', ['ng']).
                   value.push(new Resource(item));
                 });
               } else {
-                copy(data, value);
+                if(data !== value) copy(data, value);
                 value.$promise = promise;
               }
             }

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -430,7 +430,7 @@ describe("resource", function() {
     expect(idBefore).toEqual(cc.id);
   });
 
-  it('should not mutate the resource object if response.data is the resource object', function() {
+  it('should not throw if response.data is the resource object', function() {
     var data = {id:{key:123}, number:'9876'};
     $httpBackend.expect('GET', '/CreditCard/123').respond(data);
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -430,6 +430,21 @@ describe("resource", function() {
     expect(idBefore).toEqual(cc.id);
   });
 
+  it('should not mutate the resource object if response.data is the resource object', function() {
+    var data = {id:{key:123}, number:'9876'};
+    $httpBackend.expect('GET', '/CreditCard/123').respond(data);
+
+    var cc = CreditCard.get({id:123});
+    $httpBackend.flush();
+    expect(cc instanceof CreditCard).toBe(true);
+
+    $httpBackend.expect('POST', '/CreditCard/123', angular.toJson(data)).respond(cc);
+
+    expect(function() {
+        cc.$save();
+        $httpBackend.flush();
+    }).not.toThrow();
+  });
 
   it('should bind default parameters', function() {
     $httpBackend.expect('GET', '/CreditCard/123.visa?minimum=0.05').respond({id: 123});


### PR DESCRIPTION
## EXPLANATION

An $http response interceptor may be used to compare the value sent **to** the server--available via `response.config.data`--to the value returned **from** the server--available via `response.data`--BEFORE logic inside `$resource` copies `response.data` to the resource instance value.   The logic of this response interceptor _MAY_, in some cases (see use case below), set the value of `response.data` to `response.config.data` which, when using `$resource` also happens to be a resource instance value.

This very simple pull request simply skips `$resource`'s attempt to copy the `response.data` to the resource value _if_ the two already reference the same object.   Without this change, the `copy()` function will throw when called from within the resource.
## USE CASE

The use case leading to this pull request is as follows.  In an application implementing auto-save, `$resource` is used to periodically persist in-progress changes (identified using `FormController.$dirty`) to the server.  While that save request is outstanding, the user may continue to make changes.   Because `$resource`'s default logic will discard any changes made between the time the save request was issued and it returns using `copy(data, value);`, a response interceptor has been implemented with custom application logic to merge three states of the object being saved:
1. at the time request was issued
2. the object's current state (possibly modified by the user since request was issued) 
3. the object state returned from the server (wherein the server may have made changes e.g. optimistic concurrency, etc.)

The application's custom merge logic, to avoid firing unnecessary watches or losing the user's changes, merges states (1) and (3) onto the existing object which is `response.config.data` and then sets `response.data` to `response.config.data`.   This currently causes `$resource` to throw and requires the very minor customization in this pull request.   I'd _LOVE_ to NOT have a customized copy of `ngResource` in my app.
