### PR TITLE
fix(angular.js): wrong $httpBackend status code

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -109,7 +109,7 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
       jsonpDone = xhr = null;
 
       // fix status code for file protocol (it's always 0)
-      status = (protocol == 'file') ? (response ? 200 : 404) : status;
+      status = (protocol == 'file' && status === 0) ? (response ? 200 : 404) : status;
 
       // normalize IE bug (http://bugs.jquery.com/ticket/1450)
       status = status == 1223 ? 204 : status;

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -393,6 +393,16 @@ describe('$httpBackend', function() {
       expect(callback).toHaveBeenCalled();
       expect(callback.mostRecentCall.args[0]).toBe(404);
     });
+
+    it('should return backend status code', function () {
+      $backend = createHttpBackend($browser, MockXhr, null, null, null, 'file');
+
+      $backend('POST', 'http://rest_api/create_whatever', null, callback);
+      respond(201, '');
+
+      expect(callback).toHaveBeenCalled();
+      expect(callback.mostRecentCall.args[0]).toBe(201);
+    });
   });
 });
 


### PR DESCRIPTION
If I run html document as a file in browser (e.g. file:///index.html), then all ajax responses have a protocol "file" (and therefore response status code can be 200 or 404)

```
(protocol == 'file') ? (response ? 200 : 404)
```

locationProtocol has higher priority in completeRequest function.

It's critical in mobile hybrid applications which use angularjs (index.html run from local filesystem)
