### PR TITLE
toJsonReplacer() patch  to support Badgerfish Json format

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -809,7 +809,7 @@ function bind(self, fn) {
 function toJsonReplacer(key, value) {
   var val = value;
 
-  if (typeof key === 'string' && key.charAt(0) === '$') {
+  if (typeof key === 'string' && key.length > 1 && key.charAt(0) === '$') {
     val = undefined;
   } else if (isWindow(value)) {
     val = '$WINDOW';


### PR DESCRIPTION
Hello,

some strange backends, like ours, may accept only Badgerfish Json format which expects text leave nodes to be sent with a single '$' key, ref: http://badgerfish.ning.com.
I have seen toJsonReplacer() has been changed from rc2 to rc3 in a way which makes it ease to get it working (by adding the key length as qualification), this is a patch that introduces the change:
--- angular.js 2013-10-18 07:06:34.000000000 +0000
+++ angular.js.patched 2013-10-18 07:03:29.000000000 +0000
@@ -888,7 +888,7 @@
function toJsonReplacer(key, value) {
var val = value;

if (typeof key === 'string' && key.charAt(0) === '$') {
if (typeof key === 'string' && key.length > 1 && key.charAt(0) === '$') { val = undefined; } else if (isWindow(value)) { val = '$WINDOW';
Would it be possible to make it in the stable path?
Many thanks in any case!

Best regards
Roman
