### PR TITLE
fix($httpbackend): ie11 api changes for jsonp

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -135,7 +135,7 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
     script.type = 'text/javascript';
     script.src = url;
 
-    if (msie) {
+    if (msie && isDefined(script.onreadystatechange)) {
       script.onreadystatechange = function() {
         if (/loaded|complete/.test(script.readyState)) doneWrapper();
       };


### PR DESCRIPTION
IE11 changed their script api and no longer uses onreadystatechange. It
now follows other browsers with onload and onerror

Fixes #4523
