### PR TITLE
fix(isElement): return boolean value rather than `truthy` value.

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -478,9 +478,9 @@ var trim = (function() {
  * @returns {boolean} True if `value` is a DOM element (or wrapped jQuery element).
  */
 function isElement(node) {
-  return node &&
+  return !!(node &&
     (node.nodeName  // we are a direct element
-    || (node.on && node.find));  // we have an on and find method part of jQuery API
+    || (node.on && node.find)));  // we have an on and find method part of jQuery API
 }
 
 /**

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1079,4 +1079,17 @@ describe('angular', function() {
     }
   });
 
+  describe('isElement', function() {
+    it('should return a boolean value', inject(function($compile, $document, $rootScope) {
+      var element = $compile('<p>Hello, world!</p>')($rootScope),
+          body = $document.find('body')[0],
+          expected = [false, false, false, false, false, false, false, true, true],
+          tests = [null, undefined, "string", 1001, {}, 0, false, body, element];
+      angular.forEach(tests, function(value, idx) {
+        var result = angular.isElement(value);
+        expect(typeof result).toEqual('boolean');
+        expect(result).toEqual(expected[idx]);
+      });
+    }));
+  });
 });


### PR DESCRIPTION
angular.isElement currently returns a truthy object/function, or false. This 
patch aims to correct this behaviour by casting the result of the isElement 
expression to a boolean value via double-negation.

Closes #4519
