### PR TITLE
The Git URL for cloning erros out

### DIFF
--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -66,7 +66,7 @@ and follow the instructions for setting up your computer.
          <a href="http://git-scm.com/download">the Git site</a>.</p></li>
       <li><p>Clone the angular-phonecat repository located at
       <a href="https://github.com/angular/angular-phonecat">Github</a> by running the following command:</p>
-      <pre>git clone git://github.com/angular/angular-phonecat.git</pre>
+      <pre>git clone git@github.com:angular/angular-phonecat.git</pre>
       <p>This command creates the <code>angular-phonecat</code> directory in your current
 directory.</p></li>
       <li><p>Change your current directory to <code>angular-phonecat</code>:</p>


### PR DESCRIPTION
Current path to github gives the following error on Mac (10.8.5) with git 1.7.9.6 (Apple Git-31.1)

```
$ git clone git://github.com/angular/angular-phonecat.git
Cloning into 'angular-phonecat'...
fatal: unable to connect to github.com:
github.com[0: 192.30.252.129]: errno=Connection refused
```
