### PR TITLE
fix(ngList):Make ngList work with input of type email, url

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -516,6 +516,14 @@ function map(obj, iterator, context) {
   return results;
 }
 
+function every(array, fun) {
+  for (var i = 0; i < array.length; i++) {
+    if (i in array && !fun.call(array, array[i], i, Object(array))) {
+        return false;
+    }
+  }
+  return true;
+}
 
 /**
  * @description

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -4,6 +4,8 @@ var URL_REGEXP = /^(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\
 var EMAIL_REGEXP = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}$/;
 var NUMBER_REGEXP = /^\s*(\-|\+)?(\d+|(\d*(\.\d*)))\s*$/;
 
+
+
 var inputType = {
 
   /**
@@ -581,9 +583,14 @@ function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 
 function urlInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   textInputType(scope, element, attr, ctrl, $sniffer, $browser);
-
+  var testedValid;
   var urlValidator = function(value) {
-    if (ctrl.$isEmpty(value) || URL_REGEXP.test(value)) {
+    if (isArray(value)) {
+      testedValid = every(value, function(val){return URL_REGEXP.test(val)})
+    } else {
+      testedValid = URL_REGEXP.test(value)
+    }
+    if (ctrl.$isEmpty(value) || testedValid) {
       ctrl.$setValidity('url', true);
       return value;
     } else {
@@ -600,7 +607,13 @@ function emailInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   textInputType(scope, element, attr, ctrl, $sniffer, $browser);
 
   var emailValidator = function(value) {
-    if (ctrl.$isEmpty(value) || EMAIL_REGEXP.test(value)) {
+    var testedValid;
+    if (isArray(value)) {
+      testedValid = every(value, function(val){return EMAIL_REGEXP.test(val)})
+    } else {
+      testedValid = EMAIL_REGEXP.test(value)
+    }
+    if (ctrl.$isEmpty(value) || testedValid) {
       ctrl.$setValidity('email', true);
       return value;
     } else {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -726,50 +726,138 @@ describe('input', function() {
   });
 
   describe('email', function() {
+    describe('should validate e-mail', function(){
+      it('when used simply', function() {
+        compileInput('<input type="email" ng-model="email" name="alias" />');
+        var widget = scope.form.alias;
 
-    it('should validate e-mail', function() {
-      compileInput('<input type="email" ng-model="email" name="alias" />');
+        changeInputValueTo('vojta@google.com');
+        expect(scope.email).toBe('vojta@google.com');
+        expect(inputElm).toBeValid();
+        expect(widget.$error.email).toBe(false);
 
-      var widget = scope.form.alias;
-      changeInputValueTo('vojta@google.com');
+        changeInputValueTo('invalid@');
+        expect(scope.email).toBeUndefined();
+        expect(inputElm).toBeInvalid();
+        expect(widget.$error.email).toBeTruthy();
+      });
+      it('when used with ngList (default separator)', function() {
+        compileInput('<input ng-list type="email" ng-model="email" name="alias" />');
+        var widget = scope.form.alias;
 
-      expect(scope.email).toBe('vojta@google.com');
-      expect(inputElm).toBeValid();
-      expect(widget.$error.email).toBe(false);
+        changeInputValueTo('vojta@google.com');
+        expect(scope.email).toEqual(['vojta@google.com']);
+        expect(inputElm).toBeValid();
+        expect(widget.$error.email).toBe(false);
 
-      changeInputValueTo('invalid@');
-      expect(scope.email).toBeUndefined();
-      expect(inputElm).toBeInvalid();
-      expect(widget.$error.email).toBeTruthy();
+        changeInputValueTo('vojta@google.com, igor.minar@gmail.com');
+        expect(scope.email).toEqual(['vojta@google.com', 'igor.minar@gmail.com']);
+        expect(inputElm).toBeValid();
+        expect(widget.$error.email).toBe(false);
+
+        changeInputValueTo('invalid@');
+        expect(scope.email).toBeUndefined();
+        expect(inputElm).toBeInvalid();
+        expect(widget.$error.email).toBeTruthy();
+      });
+      it('when used with ngList (custom separator)', function() {
+        compileInput('<input ng-list=";" type="email" ng-model="email" name="alias" />');
+
+        var widget = scope.form.alias;
+        changeInputValueTo('vojta@google.com');
+        expect(scope.email).toEqual(['vojta@google.com']);
+        expect(inputElm).toBeValid();
+        expect(widget.$error.email).toBe(false);
+
+        changeInputValueTo('vojta@google.com;igor.minar@gmail.com');
+        expect(scope.email).toEqual(['vojta@google.com', 'igor.minar@gmail.com']);
+        expect(inputElm).toBeValid();
+        expect(widget.$error.email).toBe(false);
+
+        changeInputValueTo('vojta@google.com, dorosh@google.com');
+        expect(scope.email).toBeUndefined();
+        expect(inputElm).toBeInvalid();
+        expect(widget.$error.email).toBeTruthy();
+
+
+        changeInputValueTo('invalid@');
+        expect(scope.email).toBeUndefined();
+        expect(inputElm).toBeInvalid();
+        expect(widget.$error.email).toBeTruthy();
+      });
     });
 
 
-    describe('EMAIL_REGEXP', function() {
-
+    describe('EMAIL_REGEXP', function(){
       it('should validate email', function() {
         expect(EMAIL_REGEXP.test('a@b.com')).toBe(true);
         expect(EMAIL_REGEXP.test('a@b.museum')).toBe(true);
         expect(EMAIL_REGEXP.test('a@B.c')).toBe(false);
       });
     });
+
   });
 
 
   describe('url', function() {
+    describe('should validate url', function(){
+      it('when used simply', function() {
+        compileInput('<input type="url" ng-model="url" name="alias" />');
+        var widget = scope.form.alias;
 
-    it('should validate url', function() {
-      compileInput('<input type="url" ng-model="url" name="alias" />');
-      var widget = scope.form.alias;
+        changeInputValueTo('http://www.something.com');
+        expect(scope.url).toBe('http://www.something.com');
+        expect(inputElm).toBeValid();
+        expect(widget.$error.url).toBe(false);
 
-      changeInputValueTo('http://www.something.com');
-      expect(scope.url).toBe('http://www.something.com');
-      expect(inputElm).toBeValid();
-      expect(widget.$error.url).toBe(false);
+        changeInputValueTo('invalid.com');
+        expect(scope.url).toBeUndefined();
+        expect(inputElm).toBeInvalid();
+        expect(widget.$error.url).toBeTruthy();
+      });
+      it('when used with ngList (default separator)', function() {
+        compileInput('<input ng-list type="url" ng-model="url" name="alias" />');
 
-      changeInputValueTo('invalid.com');
-      expect(scope.url).toBeUndefined();
-      expect(inputElm).toBeInvalid();
-      expect(widget.$error.url).toBeTruthy();
+        var widget = scope.form.alias;
+        changeInputValueTo('http://www.something.com');
+        expect(scope.url).toEqual(['http://www.something.com']);
+        expect(inputElm).toBeValid();
+        expect(widget.$error.url).toBe(false);
+
+        changeInputValueTo('http://www.something.com, http://www.somethingelse.com');
+        expect(scope.url).toEqual(['http://www.something.com', 'http://www.somethingelse.com']);
+        expect(inputElm).toBeValid();
+        expect(widget.$error.url).toBe(false);
+
+        changeInputValueTo('http:');
+        expect(scope.url).toBeUndefined();
+        expect(inputElm).toBeInvalid();
+        expect(widget.$error.url).toBeTruthy();
+      });
+      it('when used with ngList (custom separator)', function() {
+        compileInput('<input ng-list=";" type="url" ng-model="url" name="alias" />');
+
+        var widget = scope.form.alias;
+        changeInputValueTo('http://www.something.com');
+        expect(scope.url).toEqual(['http://www.something.com']);
+        expect(inputElm).toBeValid();
+        expect(widget.$error.url).toBe(false);
+
+        changeInputValueTo('http://www.something.com;http://www.somethingelse.com');
+        expect(scope.url).toEqual(['http://www.something.com', 'http://www.somethingelse.com']);
+        expect(inputElm).toBeValid();
+        expect(widget.$error.url).toBe(false);
+
+        changeInputValueTo('http://www.something.com, http://www.somethingelse.com');
+        expect(scope.url).toBeUndefined();
+        expect(inputElm).toBeInvalid();
+        expect(widget.$error.url).toBeTruthy();
+
+        changeInputValueTo('http:');
+        expect(scope.url).toBeUndefined();
+        expect(inputElm).toBeInvalid();
+        expect(widget.$error.url).toBeTruthy();
+      });
     });
 
 


### PR DESCRIPTION
Validity for inputs are checked for single value using static regexp, which won't work with ngList directive on the input, since it's getting us an array of attributes.

Just like [https://github.com/angular/angular.js/pull/4295], but introducing `every` helper function, just as I mentioned at my last comment there.
