### PR TITLE
refactor($interpolate): optimize watched $interpolate functions performance

### DIFF
--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -236,7 +236,7 @@ function $InterpolateProvider() {
                   text, err.toString());
                 $exceptionHandler(newErr);
               }
-            }
+            };
           }
 
           function listenerOf(index) {

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -315,7 +315,7 @@ function $RootScopeProvider(){
        * @returns {function()} Returns a deregistration function for this listener.
        */
       $watch: function(watchExp, listener, objectEquality) {
-        if (isFunction(watchExp.$$beWatched)) {
+        if (watchExp.$$beWatched) {
           return watchExp.$$beWatched(this, listener, objectEquality, watchExp);
         }
         var scope = this,

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -315,6 +315,9 @@ function $RootScopeProvider(){
        * @returns {function()} Returns a deregistration function for this listener.
        */
       $watch: function(watchExp, listener, objectEquality) {
+        if (isFunction(watchExp.$$beWatched)) {
+          return watchExp.$$beWatched(this, listener, objectEquality, watchExp);
+        }
         var scope = this,
             get = compileToFn(watchExp, 'watch'),
             array = scope.$$watchers,

--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -2,13 +2,12 @@
 
 describe('$interpolate', function() {
 
-  it('should return a function when there are no bindings and textOnly is undefined',
+  it('should return a function when there are no bindings and mustHaveExpression is undefined',
       inject(function($interpolate) {
     expect(typeof $interpolate('some text')).toBe('function');
   }));
 
-
-  it('should return undefined when there are no bindings and textOnly is set to true',
+  it('should return null when there are no bindings and mustHaveExpression is set to true',
       inject(function($interpolate) {
     expect($interpolate('some text', true)).toBeNull();
   }));
@@ -318,6 +317,40 @@ describe('$interpolate', function() {
       });
       expect(nbCalls).toBe(4);
     }));
-  })
 
+    it('should call the listener only once per whole text change', inject(function ($rootScope, $interpolate) {
+      var nbCalls = 0, value;
+      $rootScope.$watch($interpolate("{{a}}-{{b}}"), function (_value){
+        nbCalls++;
+        value = _value;
+      });
+
+      $rootScope.$apply();
+      expect(nbCalls).toBe(1);
+      expect(value).toBe('-');
+
+      $rootScope.$apply('a=1;b=1');
+      expect(nbCalls).toBe(2);
+      expect(value).toBe('1-1');
+
+      // one changes
+      $rootScope.$apply('a=2');
+      expect(nbCalls).toBe(3);
+      expect(value).toBe('2-1');
+
+      $rootScope.$apply('b=2');
+      expect(nbCalls).toBe(4);
+      expect(value).toBe('2-2');
+
+      // both change
+      $rootScope.$apply('a=3;b=3');
+      expect(nbCalls).toBe(5);
+      expect(value).toBe('3-3');
+
+      // nothing changes
+      $rootScope.$apply();
+      expect(nbCalls).toBe(5);
+      expect(value).toBe('3-3');
+    }));
+  });
 });

--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -276,80 +276,76 @@ describe('$interpolate', function() {
   describe('custom $$beWatched', function () {
     it('should call the listener correctly when values change during digest',
         inject(function ($rootScope, $interpolate) {
-      var nbCalls = 0, value;
+      var count = 0, value;
       $rootScope.$watch($interpolate('{{a}}-{{b}}'), function (_value) {
-        value = _value;
-        switch(++nbCalls) {
+        switch(++count) {
           case 1:
           case 2:
-            $rootScope.b++;
+            $rootScope.a++;
             break;
           case 3:
           case 4:
-            $rootScope.a++;
+            $rootScope.b++;
+            break;
+          case 5:
+            value = _value;
             break;
         }
       });
-      $rootScope.$apply(function () {
-        $rootScope.a = $rootScope.b = 0;
-      });
+      $rootScope.$apply("a=0;b=0");
       expect(value).toBe("2-2");
-      expect(nbCalls).toBe(5);
+      expect(count).toBe(5);
     }));
 
     it('should call the listener correctly when the interpolation is watched multiple times',
         inject(function ($rootScope, $interpolate) {
-      var interpolateFn = $interpolate('{{a}}-{{b}}'), nbCalls = 0;
+      var interpolateFn = $interpolate('{{a}}-{{b}}'), count = 0;
       $rootScope.$watch(interpolateFn, function(){
-        nbCalls++;
+        count++;
       });
       $rootScope.$watch(interpolateFn, function(){
-        nbCalls++;
+        count++;
       });
 
-      $rootScope.$apply(function () {
-        $rootScope.a = $rootScope.b = 0;
-      });
-      expect(nbCalls).toBe(2);
+      $rootScope.$apply("a=0;b=0");
+      expect(count).toBe(2);
 
-      $rootScope.$apply(function () {
-        $rootScope.a = $rootScope.b = 1;
-      });
-      expect(nbCalls).toBe(4);
+      $rootScope.$apply("a=1;b=1");
+      expect(count).toBe(4);
     }));
 
     it('should call the listener only once per whole text change', inject(function ($rootScope, $interpolate) {
-      var nbCalls = 0, value;
+      var count = 0, value;
       $rootScope.$watch($interpolate("{{a}}-{{b}}"), function (_value){
-        nbCalls++;
+        count++;
         value = _value;
       });
 
       $rootScope.$apply();
-      expect(nbCalls).toBe(1);
+      expect(count).toBe(1);
       expect(value).toBe('-');
 
       $rootScope.$apply('a=1;b=1');
-      expect(nbCalls).toBe(2);
+      expect(count).toBe(2);
       expect(value).toBe('1-1');
 
       // one changes
       $rootScope.$apply('a=2');
-      expect(nbCalls).toBe(3);
+      expect(count).toBe(3);
       expect(value).toBe('2-1');
 
       $rootScope.$apply('b=2');
-      expect(nbCalls).toBe(4);
+      expect(count).toBe(4);
       expect(value).toBe('2-2');
 
       // both change
       $rootScope.$apply('a=3;b=3');
-      expect(nbCalls).toBe(5);
+      expect(count).toBe(5);
       expect(value).toBe('3-3');
 
       // nothing changes
       $rootScope.$apply();
-      expect(nbCalls).toBe(5);
+      expect(count).toBe(5);
       expect(value).toBe('3-3');
     }));
   });


### PR DESCRIPTION
This PR improves the performance of watched $interpolate functions: http://jsperf.com/ng-interpolation-optimization/8

This is the related Google groups thread, I explain my PR there: https://groups.google.com/forum/#!msg/angular-dev/QmcwYVkfsbo/8Y_pMsal0kYJ

If any changes are unclear, point them out and I'd be happy to elaborate on them :)

Signed the CLA as Rodric Haddad
