### PR TITLE
Replaced ng\\:view with ng\:view (Error in the CSS selector!)

### DIFF
--- a/docs/content/guide/ie.ngdoc
+++ b/docs/content/guide/ie.ngdoc
@@ -164,7 +164,7 @@ To make CSS selectors work with custom elements, the custom element name must be
         </script>
       <![endif]-->
       <style>
-        ng\\:view {
+        ng\:view {
           display: block;
           border: 1px solid red;
         }


### PR DESCRIPTION
Replaced ng\:view {
    With ng:view {

http://docs.angularjs.org/guide/ie#long-version_css-styling-of-custom-tag-names
