### PR TITLE
fix(ngTouch): ngClick directive does not use correct event with jQuery

### DIFF
--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -110,6 +110,15 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     return false; // No allowable region; bust it.
   }
 
+  function getTouches(event) {
+    event = event.originalEvent || event;
+    return event.changedTouches && event.changedTouches.length
+      ? event.changedTouches
+      : event.touches && event.touches.length
+        ? event.touches
+        : [event];
+  }
+
   // Global click handler that prevents the click if it's in a bustable zone and preventGhostClick
   // was called recently.
   function onClick(event) {
@@ -117,7 +126,7 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
       return; // Too old.
     }
 
-    var touches = event.touches && event.touches.length ? event.touches : [event];
+    var touches = getTouches(event);
     var x = touches[0].clientX;
     var y = touches[0].clientY;
     // Work around desktop Webkit quirk where clicking a label will fire two clicks (on the label
@@ -146,7 +155,7 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
   // Global touchstart handler that creates an allowable region for a click event.
   // This allowable region can be removed by preventGhostClick if we want to bust it.
   function onTouchStart(event) {
-    var touches = event.touches && event.touches.length ? event.touches : [event];
+    var touches = getTouches(event);
     var x = touches[0].clientX;
     var y = touches[0].clientY;
     touchCoordinates.push(x, y);
@@ -202,10 +211,9 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
 
       startTime = Date.now();
 
-      var touches = event.touches && event.touches.length ? event.touches : [event];
-      var e = touches[0].originalEvent || touches[0];
-      touchStartX = e.clientX;
-      touchStartY = e.clientY;
+      var touches = getTouches(event);
+      touchStartX = touches[0].clientX;
+      touchStartY = touches[0].clientY;
     });
 
     element.on('touchmove', function(event) {
@@ -219,11 +227,9 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     element.on('touchend', function(event) {
       var diff = Date.now() - startTime;
 
-      var touches = (event.changedTouches && event.changedTouches.length) ? event.changedTouches :
-          ((event.touches && event.touches.length) ? event.touches : [event]);
-      var e = touches[0].originalEvent || touches[0];
-      var x = e.clientX;
-      var y = e.clientY;
+      var touches = getTouches(event);
+      var x = touches[0].clientX;
+      var y = touches[0].clientY;
       var dist = Math.sqrt( Math.pow(x - touchStartX, 2) + Math.pow(y - touchStartY, 2) );
 
       if (tapping && diff < TAP_DURATION && dist < MOVE_TOLERANCE) {

--- a/src/ngTouch/swipe.js
+++ b/src/ngTouch/swipe.js
@@ -23,12 +23,17 @@ ngTouch.factory('$swipe', [function() {
   // The total distance in any direction before we make the call on swipe vs. scroll.
   var MOVE_BUFFER_RADIUS = 10;
 
+  function getTouches(event) {
+    event = event.originalEvent || event;
+    return event.changedTouches && event.changedTouches.length
+      ? event.changedTouches
+      : event.touches && event.touches.length
+        ? event.touches
+        : [event];
+  }
+
   function getCoordinates(event) {
-    var touches = event.touches && event.touches.length ? event.touches : [event];
-    var e = (event.changedTouches && event.changedTouches[0]) ||
-        (event.originalEvent && event.originalEvent.changedTouches &&
-            event.originalEvent.changedTouches[0]) ||
-        touches[0].originalEvent || touches[0];
+    var e = getTouches(event)[0];
 
     return {
       x: e.clientX,


### PR DESCRIPTION
The ngClick directive is not using the correct touch object when jQuery is loaded.  This caused the coordinates to get mapped to undefined instead of the actual x and y coordinates. This logic was happening in multiple places so I extracted it into a function to help with simplicity.
