### PR TITLE
fix(ngAnimate): fix cancelChildAnimations throwing exception

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -583,7 +583,13 @@ angular.module('ngAnimate', ['ng'])
       }
 
       function cancelChildAnimations(element) {
-        angular.forEach(element[0].querySelectorAll('.' + NG_ANIMATE_CLASS_NAME), function(element) {
+        var ELEMENT_NODE = 1;
+        var node = element[0];
+        if(node.nodeType != ELEMENT_NODE) {
+          return;
+        }
+
+        angular.forEach(node.querySelectorAll('.' + NG_ANIMATE_CLASS_NAME), function(element) {
           element = angular.element(element);
           var data = element.data(NG_ANIMATE_STATE);
           if(data) {


### PR DESCRIPTION
fix ngAnimate throwing exception in cancelChildAnimations on deletion of
element (ngAnimate's leave decorator) of repeated element when using
ng-include on this element.

Closes #4548
