### PR TITLE
Fixed typo in 'Attributes' docs

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1457,7 +1457,7 @@ function directiveNormalize(name) {
  * @description
  *
  * A shared object between directive compile / linking functions which contains normalized DOM element
- * attributes. The the values reflect current binding state `{{ }}`. The normalization is needed
+ * attributes. The values reflect current binding state `{{ }}`. The normalization is needed
  * since all of these are treated as equivalent in Angular:
  *
  *          <span ng:bind="a" ng-bind="a" data-ng-bind="a" x-ng-bind="a">


### PR DESCRIPTION
'Attributes' docs, main Description, contain the following typo: 'The the'.
