### PR TITLE
feat(directives): Implements the "notIsolated" variant of directives with a child scope.

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1409,7 +1409,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           var LOCAL_REGEXP = /^\s*([@=&])(\??)\s*(\w*)\s*$/;
           var $linkNode = jqLite(linkNode);
 
-          isolateScope = scope.$new(true);
+          isolateScope = scope.$new(!!!newIsolateScopeDirective.notIsolated);
 
           if (templateDirective && (templateDirective === newIsolateScopeDirective.$$originalDirective)) {
             $linkNode.data('$isolateScope', isolateScope) ;


### PR DESCRIPTION
When declaring a directive definition object with a truthy notIsolated field, then whatever scope attributes the directive declares won't be bound to an isolated child scope, but a normal child scope. This is a necessary feature if Angular is to support directives that transclude their contents into the trascluded content of other transcluding directives, each of which may have bound directive scope attributes. Without this change, for a say high level directive with bound scope attributes whose template includes another say low level directive that transcludes its content, and the high level directive transcludes its content into the transcluded content of the low level directive in its template, then there's no way for the high level directive's transcluded content to have access to its desired scope as its scope will be a child of the isolate scope of the high level directive that transcludes into the transcluded content of the low level directive, which may or may not have isolate or notIsolated scope attributes. With this change, developers will be able to more richly develop hierarchies of transcluding directives that use other transcluding directives in their templates. It's a new feature that should be used sparingly as the transcluded contents of such a high level directive that doesn't isolate its scope will be able to modify values on that directive's scope, which frankly flies in the face of the philosophy behind directives as small, highly encapsulated pieces of markup and behavior. However, when you think of directives as an encapsulation tool that can scale to any extent of encapsulation, a feature such as this in the face of transclusion becomes quite necessary. Regardless, it's certainly one avenue of making Angular easily capable of truly high level encapsulation for the primary authors to take under consideration.
