### PR TITLE
fix($animate): prevent leaving animate classes after animation is done

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -728,7 +728,7 @@ angular.module('ngAnimate', ['ng'])
       function animate(element, className, done) {
 
         var cacheKey = getCacheKey(element);
-        if(getElementAnimationDetails(element, cacheKey, true).transitionDuration > 0) {
+        if(getElementAnimationDetails(element, cacheKey + ' ' + className, true).transitionDuration > 0) {
 
           done();
           return;


### PR DESCRIPTION
In some cases ngAnimate transitional classes (like *-remove & *-remove-active) were left after animation was over. Change introduced in this commit prevent such situations.

Closes #4490
