### PR TITLE
docs(input): fix "usage as element" attribute names

### DIFF
--- a/docs/src/ngdoc.js
+++ b/docs/src/ngdoc.js
@@ -796,7 +796,7 @@ Doc.prototype = {
           dom.text(prefix);
           dom.text(param.optional ? '[' : '');
           var parts = param.name.split('|');
-          dom.text(parts[skipSelf ? 0 : 1] || parts[0]);
+          dom.text(dashCase(parts[skipSelf ? 0 : 1] || parts[0]));
         }
         if (BOOLEAN_ATTR[param.name]) {
           dom.text(param.optional ? ']' : '');

--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -206,7 +206,7 @@ function FormController(element, attrs) {
  * does not allow nesting of form elements. It is useful to nest forms, for example if the validity of a
  * sub-group of controls needs to be determined.
  *
- * @param {string=} name|ngForm Name of the form. If specified, the form controller will be published into
+ * @param {string=} ngForm|name Name of the form. If specified, the form controller will be published into
  *                       related scope, under this name.
  *
  */


### PR DESCRIPTION
Docs for input, select, and textarea were incorrectly using camelCase for attribute names.

Also fixes ngForm parameters that were causing the usage docs to be incorrect.
