### PR TITLE
fix($animate): skip unnecessary addClass/removeClass animations

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -541,6 +541,16 @@ angular.module('ngAnimate', ['ng'])
           (ngAnimateState.done || noop)();
         }
 
+        //There is no point in perform a class-based animation if the element already contains
+        //(on addClass) or doesn't contain (on removeClass) the className being animated.
+        //The reason why this is being called after the previous animations are cancelled
+        //is so that the CSS classes present on the element can be properly examined.
+        if((event == 'addClass'    && element.hasClass(className)) ||
+           (event == 'removeClass' && !element.hasClass(className))) {
+          onComplete && onComplete();
+          return;
+        }
+
         element.data(NG_ANIMATE_STATE, {
           running:true,
           structural:!isClassBased,


### PR DESCRIPTION
Skip addClass animations if the element already contains the class that is being
added to element. Also skip removeClass animations if the element does not contain
the class that is being removed.

Closes #4401
Closes #2332
