### PR TITLE
Clarification re angular.mock.module

### DIFF
--- a/docs/content/guide/dev_guide.services.testing_services.ngdoc
+++ b/docs/content/guide/dev_guide.services.testing_services.ngdoc
@@ -12,11 +12,11 @@ var mock, notify;
 beforeEach(function() {
   mock = {alert: jasmine.createSpy()};
 
-  module(function($provide) {
+  angular.mock.module(function($provide) {
     $provide.value('$window', mock);
   });
 
-  inject(function($injector) {
+  angular.mock.inject(function($injector) {
     notify = $injector.get('notify');
   });
 });


### PR DESCRIPTION
Make it explicit that it is calling the `angular.mock.module()` and not the `angular.module()` function. Same for `angular.mock.inject()`. This was not clear when I read the page.

It would be great if somebody could add a better explanation or a few comments to this page. I found it very hard to understand. I'd do it myself but I still don't really understand this code example ;)
