### PR TITLE
docs(angular.equals): fix an important error in the description

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -792,7 +792,7 @@ function shallowCopy(src, dst) {
  * Two objects or values are considered equivalent if at least one of the following is true:
  *
  * * Both objects or values pass `===` comparison.
- * * Both objects or values are of the same type and all of their properties pass `===` comparison.
+ * * Both objects or values are of the same type and all of their properties pass `angular.equals` comparison.
  * * Both values are NaN. (In JavaScript, NaN == NaN => false. But we consider two NaN as equal)
  * * Both values represent the same regular expression (In JavasScript,
  *   /abc/ == /abc/ => false. But we consider two regular expressions as equal when their textual


### PR DESCRIPTION
angular.equals calls itself recursively.
