### PR TITLE
feat($rootScope): implement non-propagating event dispatcher

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -959,6 +959,26 @@ function $RootScopeProvider(){
        */
       $broadcast: function(name, args) {
         return scopeDispatch(this, name, arguments, scopePropagateDepthFirst);
+      },
+
+
+      /**
+       * @ngdoc function
+       * @name ng.$rootScope.Scope#$dispatch
+       * @methodOf ng.$rootScope.Scope
+       * @function
+       *
+       * @description
+       * Dispatches an event `name` to each listener on the current scope, without propagating to
+       * parents or children. This strategy would typically be used in directives which need to
+       * communicate with surrounding scopes without worrying about propagation.
+       *
+       * @param {string} name Event name to broadcast.
+       * @param {...*} args Optional set of arguments which will be passed onto the event listeners.
+       * @return {Object} Event object, see {@link ng.$rootScope.Scope#$on}
+       */
+      $dispatch: function(name, args) {
+        return scopeDispatch(this, name, arguments, false);
       }
     };
 

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1313,6 +1313,56 @@ describe('Scope', function() {
         }));
       });
     });
+
+
+    describe('$dispatch', function() {
+      it('should not propagate', inject(function($rootScope) {
+        var child = $rootScope.$new(), child2 = child.$new(),
+            spy = jasmine.createSpy('eventListener');
+        $rootScope.$on('abc', spy);
+        child2.$on('abc', spy);
+        child.$dispatch('abc');
+        expect(spy).not.toHaveBeenCalled();
+      }));
+
+      it('should trigger all listeners', inject(function($rootScope) {
+        var spy = jasmine.createSpy('eventListener1'), spy2 = jasmine.createSpy('eventListener2');
+        $rootScope.$on('abc', spy);
+        $rootScope.$on('abc', spy2);
+        $rootScope.$dispatch('abc');
+        expect(spy).toHaveBeenCalled();
+        expect(spy2).toHaveBeenCalled();
+      }));
+
+
+      describe('listener', function() {
+        it('should receive event object', inject(function($rootScope) {
+          var scope = $rootScope, event;
+
+          scope.$on('fooEvent', function(e) {
+            event = e;
+          });
+          scope.$dispatch('fooEvent');
+
+          expect(event.name).toBe('fooEvent');
+          expect(event.targetScope).toBe(scope);
+          expect(event.currentScope).toBe(scope);
+        }));
+
+
+        it('should support passing messages as varargs', inject(function($rootScope) {
+          var scope = $rootScope, args;
+
+          scope.$on('fooEvent', function() {
+            args = arguments;
+          });
+          scope.$dispatch('fooEvent', 'do', 're', 'me', 'fa');
+
+          expect(args.length).toBe(5);
+          expect(sliceArgs(args, 1)).toEqual(['do', 're', 'me', 'fa']);
+        }));
+      });
+    });
   });
 
   describe("doc examples", function() {


### PR DESCRIPTION
$dispatch provides a mechanism to dispatch events to a single scope without worrying about having to terminate propagation. This is useful for many directives which need to communicate with an immediately adjacent scope, but do not wish to propagate the events beyond that point.

This patch also (experimentally) combines the event dispatch logic from $broadcast and $emit into a shared routine, so that $dispatch can easily share the same code. Unfortunately the shared code is not super clean, which is
sort of a downside.

This is really just an experiment, however a strategy like $dispatch would be useful in a lot of cases, so I'm interested to see what people think of it.

The good news is that, in combination with the "shared logic" patch, `$dispatch()` is a one-liner.
