### PR TITLE
fix: grunt-contrib-jasmine-node non-existant

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-contrib-compress');
-  grunt.loadNpmTasks('grunt-contrib-jasmine-node');
+  grunt.loadNpmTasks('grunt-contrib-jasmine');
   grunt.loadNpmTasks('grunt-ddescribe-iit');
   grunt.loadNpmTasks('grunt-merge-conflict');
   grunt.loadNpmTasks('grunt-parallel');
@@ -193,7 +193,7 @@ module.exports = function(grunt) {
       process: ['build/docs/*.html', 'build/docs/.htaccess']
     },
 
-    "jasmine-node": {
+    "jasmine": {
       run: { spec: 'docs/spec' }
     },
 
@@ -256,7 +256,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test:docs', 'Run the doc-page tests with Karma', ['package', 'tests:docs']);
   grunt.registerTask('test:unit', 'Run unit, jQuery and Karma module tests with Karma', ['tests:jqlite', 'tests:jquery', 'tests:modules']);
   grunt.registerTask('test:e2e', 'Run the end to end tests with Karma and keep a test server running in the background', ['connect:testserver', 'tests:end2end']);
-  grunt.registerTask('test:docgen', ['jasmine-node']);
+  grunt.registerTask('test:docgen', ['jasmine']);
   grunt.registerTask('test:promises-aplus',['build:promises-aplus-adapter','shell:promises-aplus-tests']);
 
   grunt.registerTask('minify', ['bower','clean', 'build', 'minall']);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "yaml-js": "~0.0.8",
     "marked": "~0.2.9",
     "rewire": "1.1.3",
-    "grunt-contrib-jasmine-node": "~0.1.1",
+    "grunt-contrib-jasmine": "0.5.2",
     "grunt-parallel": "~0.3.1",
     "grunt-ddescribe-iit": "~0.0.1",
     "grunt-merge-conflict": "~0.0.1",


### PR DESCRIPTION
rename package grunt-contrib-jasmine-node to grunt-contrib-jasmine, as the former does not exist

Closes #4626
