### PR TITLE
docs (tutorial) update step 11: angular.module in app.js section

### DIFF
--- a/docs/content/tutorial/step_11.ngdoc
+++ b/docs/content/tutorial/step_11.ngdoc
@@ -62,7 +62,7 @@ api/ng.$http $http} service.
 __`app/js/app.js`.__
 <pre>
 ...
-angular.module('phonecatApp', ['phonecatFilters', 'phonecatServices']).
+angular.module('phonecatApp', ['ngRoute','phonecatControllers','phonecatFilters', 'phonecatServices']).
 ...
 </pre>
 


### PR DESCRIPTION
Added in 'ngRoute' and 'phonecatControllers', which is missing in the text of the tutorial but is in the source for app.js
