### PR TITLE
feat(locale): Add zipCode Regex to locale

### DIFF
--- a/src/ngLocale/angular-locale_de-de.js
+++ b/src/ngLocale/angular-locale_de-de.js
@@ -94,6 +94,7 @@ $provide.value("$locale", {
     ]
   },
   "id": "de-de",
-  "pluralCat": function (n) {  if (n == 1) {   return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function (n) {  if (n == 1) {   return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;},
+  "zipCode" : "^[0-9]{5}$"
 });
 }]);


### PR DESCRIPTION
Heyho,

in my current Project I need Regex validation for zipCodes.
I think this problem is generic for many developers.

So maybe we should add this to the locale definitions?
I added a example for the de-de locale.

Let's discuss this :)
