### PR TITLE
docs(guide/e2e-testing): add note about Protractor replacement

### DIFF
--- a/docs/content/guide/dev_guide.e2e-testing.ngdoc
+++ b/docs/content/guide/dev_guide.e2e-testing.ngdoc
@@ -3,6 +3,10 @@
 @name Developer Guide: E2E Testing
 @description
 
+**If you're starting a new Angular project, you may want to look into
+using {@link https://github.com/angular/protractor Protractor}, as it is going to
+replace the currrent method of E2E Testing in the near future.**
+
 As applications grow in size and complexity, it becomes unrealistic to rely on manual testing to
 verify the correctness of new features, catch bugs and notice regressions.
 


### PR DESCRIPTION
Added a note to warn people starting new projects about Protractor replacing the current way of doing E2E testing.
