### PR TITLE
Fix for getElementByTagName invoked on Text node.

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -809,7 +809,11 @@ forEach({
   },
 
   find: function(element, selector) {
-    return element.getElementsByTagName(selector);
+    if (element.nodeType==3) {
+      return [];
+    } else {
+      return element.getElementsByTagName(selector);
+    }
   },
 
   clone: jqLiteClone,


### PR DESCRIPTION
This is a fixed for the problem with the find method when it tries to invoke getElementsByTagName on a TextNode causing the following error:
<code>TypeError: Object #<Text> has no method 'getElementsByTagName'</code>

Bug report:
https://github.com/angular/angular.js/issues/4120
