### PR TITLE
Fix for style attribute interpolation in templates for directives with replace: true

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1547,13 +1547,17 @@ function $CompileProvider($provide) {
         }
       });
 
+      if (src.hasOwnProperty('style')) { 
+        dst['style'] = $element.attr('style') + ';';
+      }
+
       // copy the new attributes on the old attrs object
       forEach(src, function(value, key) {
         if (key == 'class') {
           safeAddClass($element, value);
           dst['class'] = (dst['class'] ? dst['class'] + ' ' : '') + value;
         } else if (key == 'style') {
-          $element.attr('style', $element.attr('style') + ';' + value);
+          dst['style'] += value + ';';
           // `dst` will never contain hasOwnProperty as DOM parser won't let it.
           // You will get an "InvalidCharacterError: DOM Exception 5" error if you
           // have an attribute like "has-own-property" or "data-has-own-property", etc.

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1547,7 +1547,7 @@ function $CompileProvider($provide) {
         }
       });
 
-      if (src.hasOwnProperty('style')) { 
+      if (src.hasOwnProperty('style')) {
         dst['style'] = $element.attr('style') + ';';
       }
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -588,6 +588,24 @@ describe('$compile', function() {
           expect(element).toHaveClass('class_2');
         }));
 
+        it('should merge interpolated css style attr during replace',
+            function() {
+          module(function($interpolateProvider, $compileProvider) {
+            $compileProvider.directive('testReplaceWithStyleInterpolationDir', function() {
+              return {
+                replace: true,
+                template: '<div style="top: {{ topVal }}px"></div>'
+              };
+            });
+          });
+
+          inject(function($compile, $rootScope) {
+            element = $compile('<div test-replace-with-style-interpolation-dir />')($rootScope);
+            $rootScope.topVal = 1979;
+            $rootScope.$digest();
+            expect(element.css('top')).toBe('1979px');
+          });
+        });
 
         it('should merge interpolated css class', inject(function($compile, $rootScope) {
           element = $compile('<div class="one {{cls}} three" replace></div>')($rootScope);


### PR DESCRIPTION
We encountered a bug when attempting to interpolate values in the style attribute on the top level DOM node of directives that set replace: true. 

The problem appears to stem from templateMergeAttributes() in compile.js, where the style attribute is special cased, but its value is never copied to the `dst` object for use by the attrInterpolatePreLinkFn. Since attrInterpolatePreLinkFn gets an attrs object with no style property, $interpolate() throws an exception when it receives `undefined` as its text arg and attempts to dereference its `length` property. 

I've fixed this by doing the copy to the `dst` object in templateMergeAttributes(). 

Joe has written a unit test in test/ng/compileSpec.js for the issue, which fails for the previous commit and passes with my patch. 
