### PR TITLE
feat($rootScope): optionally limit depth of $watch recursion

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -805,12 +805,14 @@ function shallowCopy(src, dst) {
  *
  * @param {*} o1 Object or value to compare.
  * @param {*} o2 Object or value to compare.
+ * @param {number=-1} limit Depth limit of nested properties to compare.
  * @returns {boolean} True if arguments are equal.
  */
-function equals(o1, o2) {
+function equals(o1, o2, limit) {
   if (o1 === o2) return true;
   if (o1 === null || o2 === null) return false;
   if (o1 !== o1 && o2 !== o2) return true; // NaN === NaN
+  if (typeof limit !== 'number') limit = -1; // By default, recurse infinitely
   var t1 = typeof o1, t2 = typeof o2, length, key, keySet;
   if (t1 == t2) {
     if (t1 == 'object') {
@@ -818,7 +820,7 @@ function equals(o1, o2) {
         if (!isArray(o2)) return false;
         if ((length = o1.length) == o2.length) {
           for(key=0; key<length; key++) {
-            if (!equals(o1[key], o2[key])) return false;
+            if (limit && !equals(o1[key], o2[key], limit-1)) return false;
           }
           return true;
         }
@@ -831,7 +833,7 @@ function equals(o1, o2) {
         keySet = {};
         for(key in o1) {
           if (key.charAt(0) === '$' || isFunction(o1[key])) continue;
-          if (!equals(o1[key], o2[key])) return false;
+          if (limit && !equals(o1[key], o2[key], limit-1)) return false;
           keySet[key] = true;
         }
         for(key in o2) {

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -311,9 +311,11 @@ function $RootScopeProvider(){
        *      parameters.
        *
        * @param {boolean=} objectEquality Compare object for equality rather than for reference.
+       * @param {number=} depthLimit Maximum depth of nested properties to compare when
+       *   objectEquality is true.
        * @returns {function()} Returns a deregistration function for this listener.
        */
-      $watch: function(watchExp, listener, objectEquality) {
+      $watch: function(watchExp, listener, objectEquality, depthLimit) {
         var scope = this,
             get = compileToFn(watchExp, 'watch'),
             array = scope.$$watchers,
@@ -322,7 +324,8 @@ function $RootScopeProvider(){
               last: initWatchVal,
               get: get,
               exp: watchExp,
-              eq: !!objectEquality
+              eq: !!objectEquality,
+              limit: depthLimit
             };
 
         // in the case user pass string, we need to compile it, do we really need this ?
@@ -577,7 +580,7 @@ function $RootScopeProvider(){
                   // circuit it with === operator, only when === fails do we use .equals
                   if (watch && (value = watch.get(current)) !== (last = watch.last) &&
                       !(watch.eq
-                          ? equals(value, last)
+                          ? equals(value, last, watch.limit)
                           : (typeof value == 'number' && typeof last == 'number'
                              && isNaN(value) && isNaN(last)))) {
                     dirty = true;

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -284,6 +284,25 @@ describe('Scope', function() {
     }));
 
 
+    it('should limit equality test recursion for nested objects', inject(function($rootScope) {
+      var log = '';
+      $rootScope.a = { b: { c: 64 } };
+      $rootScope.b = { b: { c: 128 } };
+      $rootScope.$watch('a', function(value) {
+        log += 'a!';
+      }, true, 1);
+      $rootScope.$watch('b', function(value) {
+        log += 'b!';
+      }, true, 2);
+      $rootScope.$digest();
+      log = '';
+      $rootScope.a.b.d = 256;
+      $rootScope.b.b.d = 256;
+      $rootScope.$digest();
+      expect(log).toEqual("b!");
+    }));
+
+
     it('should watch functions', function() {
       module(provideLog);
       inject(function($rootScope, log) {


### PR DESCRIPTION
New parameter to `angular.equals` limits depth of recursion (default is infinite recursion).

$watch allows a new parameter to limit the depth of equals() when  objectEquality is true. Only effects simple objects or array-like objects.

While creating many $watches is not a totally performant feature, this is useful in the case of many nested directives which look at nested properties of the same object, and only really need to care about a single "level" of nested properties, or perhaps several levels.
