### PR TITLE
Allow directive's require to be passed an object instead of an array

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1338,6 +1338,11 @@ function $CompileProvider($provide) {
             value.push(getControllers(require, $element));
           });
         }
+         else if (isObject(require)) {
+            value = {};
+            forEach(require, function(requireVal, requireKey) {
+                value[requireKey] = getControllers(requireVal, $element);
+            });
         return value;
       }
 


### PR DESCRIPTION
so instead of ['^country', '^state'], you can now use:
require : { countryCtrl: '^country', stateCtrl: '^state'}

and then in the link function:
//much better syntax than relying on array locations
 link    : function (scope, element, attrs, ctrls) {
                ctrls.countryCtrl.makeAnnouncement('from city');
                ctrls.stateCtrl.makeLaw('Jump higher!');
            }
