### PR TITLE
docs(guide/compiler): fixed a typo

### DIFF
--- a/docs/content/guide/compiler.ngdoc
+++ b/docs/content/guide/compiler.ngdoc
@@ -285,7 +285,7 @@ on the cloned `<li>`.
 
 
 
-### Understanding How Scopes Work with Transclused Directives
+### Understanding How Scopes Work with Transcluded Directives
 
 One of the most common use cases for directives is to create reusable components.
 


### PR DESCRIPTION
from 'Transclused' to 'Transcluded'
