### PR TITLE
feat($rootScope): add possibility to disable temporarily a scope

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -129,6 +129,7 @@ function $RootScopeProvider(){
                      this.$$childHead = this.$$childTail = null;
       this['this'] = this.$root =  this;
       this.$$destroyed = false;
+      this.$$disabled = false;
       this.$$asyncQueue = [];
       this.$$postDigestQueue = [];
       this.$$listeners = {};
@@ -494,6 +495,35 @@ function $RootScopeProvider(){
 
       /**
        * @ngdoc function
+       * @name ng.$rootScope.Scope#$nextEnabledSibling
+       * @methodOf ng.$rootScope.Scope
+       * @function
+       *
+       * @description
+       * Gets next sibling which has the `$$disabled` flag equals to false. In another words, it
+       * return the next sibling which is not disabled.
+       *
+       */
+      $nextEnabledSibling: function() {
+          return this.$$nextSibling && (!this.$$nextSibling.$$disabled && this.$$nextSibling || this.$$nextSibling.$nextEnabledSibling());
+      },
+      /**
+       * @ngdoc function
+       * @name ng.$rootScope.Scope#$nextEnabledChild
+       * @methodOf ng.$rootScope.Scope
+       * @function
+       *
+       * @description
+       * Gets next child which has the `$$disabled` flag equals to false. In another words, it
+       * return the next child from the scope which is not disabled.
+       *
+       */
+      $nextEnabledChild: function() {
+          return this.$$childHead && (!this.$$childHead.$$disabled && this.$$childHead || this.$$childHead.$nextEnabledSibling());
+      },
+
+      /**
+       * @ngdoc function
        * @name ng.$rootScope.Scope#$digest
        * @methodOf ng.$rootScope.Scope
        * @function
@@ -602,8 +632,8 @@ function $RootScopeProvider(){
             // Insanity Warning: scope depth-first traversal
             // yes, this code is a bit crazy, but it works and we have tests to prove it!
             // this piece should be kept in sync with the traversal in $broadcast
-            if (!(next = (current.$$childHead || (current !== target && current.$$nextSibling)))) {
-              while(current !== target && !(next = current.$$nextSibling)) {
+            if (!(next = (current.$nextEnabledChild() || (current !== target && current.$nextEnabledSibling())))) {
+              while(current !== target && !(next = current.$nextEnabledSibling())) {
                 current = current.$parent;
               }
             }
@@ -998,9 +1028,9 @@ function $RootScopeProvider(){
 
           // Insanity Warning: scope depth-first traversal
           // yes, this code is a bit crazy, but it works and we have tests to prove it!
-          // this piece should be kept in sync with the traversal in $digest
-          if (!(next = (current.$$childHead || (current !== target && current.$$nextSibling)))) {
-            while(current !== target && !(next = current.$$nextSibling)) {
+          // this piece should be kept in sync with the traversal in $broadcast
+          if (!(next = (current.$nextEnabledChild() || (current !== target && current.$nextEnabledSibling())))) {
+            while(current !== target && !(next = current.$nextEnabledSibling())) {
               current = current.$parent;
             }
           }

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -89,6 +89,35 @@ describe('Scope', function() {
       expect(spy).wasCalledWith('misko', undefined, $rootScope);
     }));
 
+    it('should have all scopes initialized as enabled', inject(function($rootScope) {
+        var scope01 = $rootScope.$new(),
+            scope02 = $rootScope.$new(),
+            scope002 = scope02.$new(),
+            scope001 = scope02.$new(),
+            log = '';
+
+        expect($rootScope.$$disabled || scope01.$$disabled || scope02.$$disabled || scope002.$$disabled || scope001.$$disabled)
+            .toBe(false)
+    }));
+
+    it('should ignore scope marked as disabled', inject(function($rootScope) {
+        var scope01 = $rootScope.$new(),
+            scope02 = $rootScope.$new(),
+            scope002 = scope02.$new(),
+            log = '';
+
+        scope01.$watch('', function() { log += '1'; });
+        scope02.$watch('', function() { log += '2'; });
+        scope002.$watch('', function() { log += '02'; });
+
+        expect(scope02.$$disabled).toBe(false);
+        scope02.$$disabled = true;
+
+        $rootScope.$digest();
+
+        expect(log).toBe('1');
+    }));
+
 
     it('should watch and fire on expression change', inject(function($rootScope) {
       var spy = jasmine.createSpy();


### PR DESCRIPTION
I have a use case in mobile applications when I need to keep complex DOM nodes hidden. These should be shown fast (if the user swipes left for example), and because of that I cannot $destroy the scope or remove the DOM completely, or the user experiences a performance impact. So basically they are kept hidden, with watchers and $digests being triggered with no use. They don't need to be updated so frequently, only when they are shown.

So I created this solution, where it creates the possibility to disable the scope temporarily, making the $digest and $broadcast skip it and its children.

I know that the $digest cycle is quite fragile and should be extremely performant, so I sincerely didn't know how to change the behavior without adding the new functions. I've tried using an inline while loop, but the code got really ugly. Maybe a perfomance/logic guru can help making this better.
