### PR TITLE
feat($injector): ability to load new modules after bootstrapping

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -599,8 +599,11 @@ function createInjector(modulesToLoad) {
             return instanceInjector.invoke(provider.$get, provider);
           }));
 
+  instanceInjector.loadNewModules = function(mods) {
+      forEach(loadModules(mods), function(fn) { instanceInjector.invoke(fn || noop); });
+  };
 
-  forEach(loadModules(modulesToLoad), function(fn) { instanceInjector.invoke(fn || noop); });
+  instanceInjector.loadNewModules(modulesToLoad);
 
   return instanceInjector;
 

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -86,6 +86,29 @@ describe('injector', function() {
   it('should create a new $injector for the run phase', inject(function($injector) {
     expect($injector).not.toBe(providerInjector);
   }));
+ 
+
+  describe('loadNewModules', function() {
+    it('should be defined on $injector', function() {
+      var injector = createInjector([]);
+      expect(injector.loadNewModules).toBeDefined();
+    });
+
+    it('should allow new modules to be added after injector creation and their runBlocks executed', function() {
+      var log = '';
+      angular.module('0', [], function(){ log += '0'; }).run(function() { log += '1'; });
+      var injector = createInjector(['0']);
+      log += '2';
+      angular.module('a', [], function(){ log += 'a'; }).run(function() { log += 'A'; });
+      angular.module('b', ['a'], function(){ log += 'b'; }).run(function() { log += 'B'; });
+      injector.loadNewModules([
+          'b',
+          valueFn(function() { log += 'C'; }),
+          [valueFn(function() { log += 'D'; })]
+      ]);
+      expect(log).toEqual('012abABCD');
+    });
+  });
 
 
   describe('invoke', function() {


### PR DESCRIPTION
Added new method to $injector called loadNewModules.
Added corresponding unit tests for new method.

$injector.loadNewModules can be called any time after bootstrap so that any new angular modules defined after bootstrap can still function correctly.  Please see https://groups.google.com/d/msg/angular/w0ZEBz02l8s/YK3H0eMmlxcJ for a detailed justification and explanation of this simple but powerful change.
