### PR TITLE
fix($parse): allow for new lines in expr when promise unwrapping is on

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1017,7 +1017,10 @@ function getterFn(path, options, fullExp) {
                       : '((k&&k.hasOwnProperty("' + key + '"))?k:s)') + '["' + key + '"]' + ';\n' +
               (options.unwrapPromises
                 ? 'if (s && s.then) {\n' +
-                  ' pw("' + fullExp.replace(/\"/g, '\\"') + '");\n' +
+                  ' pw("' +
+                  fullExp.replace(/\"/g, '\\"').replace(/[\r\n]/g, function (lineEnding) {
+                    return lineEnding === '\n' ? '\\n' : '\\r';
+                  }) + '");\n' +
                   ' if (!("$$v" in s)) {\n' +
                     ' p=s;\n' +
                     ' p.$$v = undefined;\n' +

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -138,7 +138,7 @@ describe('parser', function() {
     });
 
     it('should tokenize function invocation', function() {
-      var tokens = lex("a()")
+      var tokens = lex("a()");
       expect(map(tokens, function(t) { return t.text;})).toEqual(['a', '(', ')']);
     });
 
@@ -199,15 +199,19 @@ describe('parser', function() {
   }]));
 
 
-  forEach([true, false], function(cspEnabled) {
+  forEach([[true, true],[!0, !1],[!1, !0],[false, false]], function(options /* [csp, unwrapPromises] */) {
+    var cspEnabled = options[0], unwrapPromisesEnabled = options[1];
 
-    describe('csp ' + cspEnabled, function() {
+    describe('csp ' + cspEnabled + ", unwrapPromises " + unwrapPromisesEnabled, function() {
+
+      beforeEach(module(function ($parseProvider) {
+        $parseProvider.unwrapPromises(unwrapPromisesEnabled);
+      }));
 
       beforeEach(inject(function ($rootScope, $sniffer) {
         scope = $rootScope;
         $sniffer.csp = cspEnabled;
       }));
-
 
       it('should parse expressions', function() {
         expect(scope.$eval("-1")).toEqual(-1);
@@ -590,6 +594,12 @@ describe('parser', function() {
         expect(scope.$eval('bool.toString()')).toBe('false');
       });
 
+      it('should evaluate expressions with line terminators', function() {
+        scope.a = "a";
+        scope.b = {c: "bc"};
+        expect(scope.$eval('a + \n b.c + \r "\td" + \t \r\n\r "\r\n\n"')).toEqual("abc\td\r\n\n");
+      });
+
       describe('sandboxing', function() {
         describe('Function constructor', function() {
           it('should NOT allow access to Function constructor in getter', function() {
@@ -768,7 +778,7 @@ describe('parser', function() {
           // User defined value assigned to constructor.
           scope.foo.constructor = function constructor() {
             return "custom constructor";
-          }
+          };
           // Dot operator should still block it.
           expect(function() {
             scope.$eval('foo.constructor()', scope)


### PR DESCRIPTION
Previously, when unwrapping promises was set to `true`, (via `$parseProvider.unwrapPromises(true);`)
an error would occur if a parsed expression had a new line in it.

This was because when generating the `evaledFnGetter` [code](https://github.com/angular/angular.js/blob/d434eabec3955f8d56c859c93befe711bfa1de27/src/ng/parse.js#L1020),
a new line in an parsed expression would create a new line in a JS string in that code, which is illegal. 

That is:

``` js
pw("A+
B")
```

Plunk with 1.2.0-rc.3: http://plnkr.co/edit/QHJHkQOViLYQYNveMnVL?p=preview
Plunk with this PR: http://plnkr.co/edit/sI1e4vCSw4HBZnjitojG?p=preview
