### PR TITLE
chore(docs/docModuleComponents): allow browser to scroll to anchors

### DIFF
--- a/docs/src/templates/js/docs.js
+++ b/docs/src/templates/js/docs.js
@@ -207,7 +207,7 @@ docsApp.directive.sourceEdit = function(getEmbeddedTemplate) {
   }
 };
 
-docsApp.directive.docModuleComponents = ['sections', function(sections) {
+docsApp.directive.docModuleComponents = ['sections', '$anchorScroll', '$timeout', function(sections, $anchorScroll, $timeout) {
   return {
     template: '  <div class="component-breakdown">' +
               '    <h2>Module Components</h2>' +
@@ -246,9 +246,14 @@ docsApp.directive.docModuleComponents = ['sections', function(sections) {
         }
       });
       $scope.components = components;
-    }]
+    }],
+    link: function() {
+      // This directive creates new HTML that contains anchors. We need to give the browser the
+      // opportunity to scroll to them after they have been rendered.
+      $timeout($anchorScroll);
+    }
   };
-}]
+}];
 
 docsApp.directive.docTutorialNav = function(templateMerge) {
   var pages = [


### PR DESCRIPTION
This directive, in the documentation application, creates new HTML that contains anchors.
If we link to one of these anchors we need to give the browser the opportunity to scroll
to them after they have been rendered.
An example of such an anchor would be http://docs.angularjs.org/api/ng#directive
