### PR TITLE
If the underlying model is a date, !== will not work for comparison

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1130,7 +1130,24 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
       value = fn(value);
     });
 
-    if (this.$modelValue !== value) {
+    // patch by ttsiodras: Javascript can't compare Dates!
+    // Look at this in your node:
+    //
+    //    $ node
+    //    var a = new Date(0);
+    //    var b = new Date(0);
+    //    a !== b
+    //    (prints true)
+    //
+    // Which means that we need to do special handling when the model is a Date (cast to number via '+')
+    // otherwise ngChange will trigger all the time, even when we just enter an input and leave...
+    var comparisonResult = this.$modelValue !== value;
+    var toClass = {}.toString;
+    if (toClass.call(this.$modelValue) == '[object Date]' || toClass.call(value) == '[object Date]')
+        comparisonResult = +this.$modelValue !== +value;
+
+    //if (this.$modelValue !== value) {
+    if (comparisonResult) {
       this.$modelValue = value;
       ngModelSet($scope, value);
       forEach(this.$viewChangeListeners, function(listener) {


### PR DESCRIPTION
While using a custom directive that uses a Date for the underlying model, I found out that when $setViewValue is called, Angular decides on whether to call the ngChange listeners via a simple comparison:

```
if (this.$modelValue !== value)
```

Unfortunately, this doesn't work if the model is a Date - javascript doesn't properly compare two identical Date objects:

```
$ node
var a = new Date(0);
var b = new Date(0);
a !== b
(prints true)
```

So I had to add the following patch that checks whether the model is a Date or not - and if it is, it uses the "proper" way to compare Dates in javascript, namely... casting via "+".

I hope this gets accepted - I wasted quite some time tracking this, no need for anyone else to pay the same price...
