### PR TITLE
Make triggerHandler work like in jQuery

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -817,15 +817,16 @@ forEach({
   triggerHandler: function(element, eventName, eventData) {
     var eventFns = (jqLiteExpandoStore(element, 'events') || {})[eventName];
 
-    eventData = eventData || [];
-
-    var event = [{
+    var ev = {
+      type: eventName,
+      target: element,
+      currentTarget: element,
       preventDefault: noop,
       stopPropagation: noop
-    }];
+    };
 
     forEach(eventFns, function(fn) {
-      fn.apply(element, event.concat(eventData));
+      fn.call(element, ev, eventData);
     });
   }
 }, function(fn, name){


### PR DESCRIPTION
Make triggerHandler work like jQuery, so that first argument is an event and second argument is a data. Also it is passing data as is, so if I call in one place angular.element(document.body).triggerHandler('is-active', false); then I can expect that in other place I will get false instead of empty array. Hope that makes sense.
