### PR TITLE
feat($parseProvider): add the `additionalIsIdent` configuration method

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -224,7 +224,8 @@ Lexer.prototype = {
   isIdent: function(ch) {
     return ('a' <= ch && ch <= 'z' ||
             'A' <= ch && ch <= 'Z' ||
-            '_' === ch || ch === '$');
+            '_' === ch || ch === '$' ||
+            this.options.additionalIsIdent(ch));
   },
 
   isExpOperator: function(ch) {
@@ -1120,7 +1121,8 @@ function $ParseProvider() {
   var $parseOptions = {
     csp: false,
     unwrapPromises: false,
-    logPromiseWarnings: true
+    logPromiseWarnings: true,
+    additionalIsIdent: noop
   };
 
 
@@ -1203,6 +1205,55 @@ function $ParseProvider() {
       return this;
     } else {
       return $parseOptions.logPromiseWarnings;
+    }
+  };
+
+
+  /**
+   * @ngdoc method
+   * @name ng.$parseProvider#additionalIsIdent
+   * @methodOf ng.$parseProvider
+   * @description
+   *
+   * Allows extending of the set of character allowed in identifiers used in Angular expressions. The
+   * `fn` function will be passed a character as argument and is expected to return `true` or `false`,
+   * based on whether that character is allowed or not. It is useful when you want to have non-English
+   * Unicode letters in your identifiers.
+   *
+   * Since this function will be called with every characters outside of `/[a-zA-Z_$]/`, it’s a good
+   * idea to keep it simple and fast. When the character set you want to add is relativelly small, a
+   * string and `indexOf()` (as in the example below) is preferable to a regexp and `test()`. On the
+   * subject of performance, it is good to take advantage of how variable scope works in JS and
+   * define the character set — whether a large string or large regexp — *outside* of `fn` itself (as
+   * in the example below), so that we don’t have to create it on every function call.
+   *
+   * @param {function=} fn The function that the the caracter will be passed to, to decide whether it’s
+   *                       allowed or not. The default is set to `noop` function which returns falsy.
+   *
+   * @returns {function|self} Returns the current setting when used as getter and self if used as
+   *                         setter.
+   *
+   * @example
+   * Let’s say that you’re developing an app for some business that has a domain language
+   * that is just hard to translate to English, and you want to try to use natural terminology, in
+   * Romanian. This snippet will allow you to use Romanian charactes:
+   *
+   * <pre>
+   *   app.config(function($parseProvider) {
+   *     var romanianCharacters = 'şŞţŢîÎăĂâÂ';
+   *
+   *     $parseProvider.additionalIsIdent(function(ch) {
+   *       return romanianCharacters.indexOf(ch) > -1;
+   *     });
+   *   });
+   * </pre>
+   */
+  this.additionalIsIdent = function(fn) {
+    if (isFunction(fn)) {
+      $parseOptions.additionalIsIdent = fn;
+      return this;
+    } else {
+      return $parseOptions.additionalIsIdent;
     }
   };
 


### PR DESCRIPTION
Allows extending of the set of character allowed in identifiers used in Angular expressions.

Closes #2174 #3847 
