### PR TITLE
Fix the docsIsoFnBindExample

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -687,7 +687,8 @@ behavior to it.
           restrict: 'E',
           transclude: true,
           scope: {
-            'close': '&onClose'
+            close: '&onClose',
+            dialogIsHidden: '=dialogIsHidden'
           },
           templateUrl: 'my-dialog-close.html'
         };
@@ -695,7 +696,7 @@ behavior to it.
   </file>
   <file name="index.html">
     <div ng-controller="Ctrl">
-      <my-dialog ng-hide="dialogIsHidden" on-close="dialogIsHidden = true">
+      <my-dialog ng-hide="dialogIsHidden" dialog-is-hidden="dialogIsHidden" on-close="hideDialog()">
         Check out the contents, {{name}}!
       </my-dialog>
     </div>


### PR DESCRIPTION
OK so for me the docsIsoFnBindExample in the directives guide does nothing. That's also the point where I got lost a bit in the documentation. I think it's because transclusion and isolated scopes need to be explained a bit better still. Anyway, the non-working example didn't help my attempts at understanding.

I've fixed the example so it works, but I have little sense if this fix is in line with what you're trying to say in this section.

Here's the plnkr I used to test: http://plnkr.co/edit/EQFTn0?p=preview

@btford, your input is appreciated.
