### PR TITLE
Add the word "safely" to clarify

### DIFF
--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -6,7 +6,7 @@
  * @requires $window
  *
  * @description
- * Simple service for logging. Default implementation writes the message
+ * Simple service for logging. Default implementation safely writes the message
  * into the browser's console (if present).
  * 
  * The main purpose of this service is to simplify debugging and troubleshooting.


### PR DESCRIPTION
I was reading the doc and had to read the code to be sure it was safe.  Spelling it out seems easier.
