### PR TITLE
fix(httpBackend): IE undefined response in legacy standards mode

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -73,9 +73,10 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
 
           // responseText is the old-school way of retrieving response (supported by IE8 & 9)
           // response/responseType properties were introduced in XHR Level2 spec (supported by IE10)
+          // response will fallback to responseText for IE running in legacy document standards mode
           completeRequest(callback,
               status || xhr.status,
-              (xhr.responseType ? xhr.response : xhr.responseText),
+              (xhr.responseType ? xhr.response || xhr.responseText : xhr.responseText),
               responseHeaders);
         }
       };

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -76,7 +76,7 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
           // response will fallback to responseText for IE running in legacy document standards mode
           completeRequest(callback,
               status || xhr.status,
-              (xhr.responseType ? xhr.response || xhr.responseText : xhr.responseText),
+              (xhr.response || xhr.responseText),
               responseHeaders);
         }
       };


### PR DESCRIPTION
Fixes issue #4738. IE10 using IE8 document standards mode has
responseType but response in undefined, responseText has a value in this
scenario.
Solution is to try and fallback to responseText if reponse is empty.
