### PR TITLE
fix(ngdocs): remove duplicate header ids

### DIFF
--- a/docs/spec/domSpec.js
+++ b/docs/spec/domSpec.js
@@ -14,8 +14,8 @@ describe('dom', function() {
       expect(dom.toString()).toContain('<h1 id="some-header">Some Header</h1>');
     });
 
-    it('should not add ids to h tags that have ids', function() {
-      dom.html('<h1 id="some-header">Some Header</h1>');
+    it('should override existing h tag ids', function() {
+      dom.html('<h1 id="header">Some Header</h1>');
       expect(dom.toString()).toContain('<h1 id="some-header">Some Header</h1>');
     });
 

--- a/docs/spec/domSpec.js
+++ b/docs/spec/domSpec.js
@@ -9,8 +9,13 @@ describe('dom', function() {
   });
 
   describe('html', function() {
-    it('should add ids to all h tags', function() {
+    it('should add ids to h tags', function() {
       dom.html('<h1>Some Header</h1>');
+      expect(dom.toString()).toContain('<h1 id="some-header">Some Header</h1>');
+    });
+
+    it('should not add ids to h tags that have ids', function() {
+      dom.html('<h1 id="some-header">Some Header</h1>');
       expect(dom.toString()).toContain('<h1 id="some-header">Some Header</h1>');
     });
 

--- a/docs/src/dom.js
+++ b/docs/src/dom.js
@@ -81,15 +81,10 @@ DOM.prototype = {
       self.currentHeaders[level - 1] = normalizeHeaderToId(content);
       self.currentHeaders.length = level;
 
-      var id, idAttr = /\sid=["'](.+?)["']/.exec(attrs);
-      if (idAttr === null) {
-        id = idFromCurrentHeaders(self.currentHeaders);
-        attrs += ' id="' + id + '"';
-      } else {
-        id = idAttr[1];
-      }
+      var id = idFromCurrentHeaders(self.currentHeaders);
       self.anchors.push(id);
-      return '<h' + level + attrs + '>' + content + '</h' + level + '>';
+      attrs = attrs.replace(/\sid=["'].+?["']/, '');
+      return '<h' + level + attrs + ' id="' + id + '">' + content + '</h' + level + '>';
     });
 
     // collect anchors

--- a/docs/src/dom.js
+++ b/docs/src/dom.js
@@ -81,9 +81,15 @@ DOM.prototype = {
       self.currentHeaders[level - 1] = normalizeHeaderToId(content);
       self.currentHeaders.length = level;
 
-      var id = idFromCurrentHeaders(self.currentHeaders);
+      var id, idAttr = /\sid=["'](.+?)["']/.exec(attrs);
+      if (idAttr === null) {
+        id = idFromCurrentHeaders(self.currentHeaders);
+        attrs += ' id="' + id + '"';
+      } else {
+        id = idAttr[1];
+      }
       self.anchors.push(id);
-      return '<h' + level + attrs + ' id="' + id + '">' + content + '</h' + level + '>';
+      return '<h' + level + attrs + '>' + content + '</h' + level + '>';
     });
 
     // collect anchors


### PR DESCRIPTION
Headers with ids are being given additional id attributes.
That's causing the test "ngdoc usage overview should supress description heading" to fail while building the documentation.
This prevents additional id attributes from being added to a header that already has an id.
