### PR TITLE
Correcting example of isolated scope function binding

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -694,8 +694,8 @@ behavior to it.
       });
   </file>
   <file name="index.html">
-    <div ng-controller="Ctrl">
-      <my-dialog ng-hide="dialogIsHidden" on-close="dialogIsHidden = true">
+    <div ng-controller="Ctrl" ng-hide="dialogIsHidden">
+      <my-dialog on-close="hideDialog()">
         Check out the contents, {{name}}!
       </my-dialog>
     </div>


### PR DESCRIPTION
Moving the ng-hide to be in the scope outside the directive in stead of inside and calling the hideDialog function from the controller in stead of just switching the variable boolean value.
