### PR TITLE
ngRepeat: insert end comment only after last element, not after each iterated item

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -379,7 +379,9 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
 
             if (!block.startNode) {
               linker(childScope, function(clone) {
-                clone[clone.length++] = document.createComment(' end ngRepeat: ' + expression + ' ');
+                  if(childScope.$last) {
+                    clone[clone.length++] = document.createComment(' end ngRepeat: ' + expression + ' ');
+                  }
                 $animate.enter(clone, null, jqLite(previousNode));
                 previousNode = clone;
                 block.scope = childScope;

--- a/test/BinderSpec.js
+++ b/test/BinderSpec.js
@@ -96,7 +96,6 @@ describe('Binder', function() {
         '<ul>' +
           '<!-- ngRepeat: item in model.items -->' +
           '<li ng-bind="item.a" ng-repeat="item in model.items">A</li>' +
-          '<!-- end ngRepeat: item in model.items -->' +
           '<li ng-bind="item.a" ng-repeat="item in model.items">B</li>' +
           '<!-- end ngRepeat: item in model.items -->' +
         '</ul>');
@@ -107,9 +106,7 @@ describe('Binder', function() {
         '<ul>' +
           '<!-- ngRepeat: item in model.items -->' +
           '<li ng-bind="item.a" ng-repeat="item in model.items">C</li>' +
-          '<!-- end ngRepeat: item in model.items -->' +
           '<li ng-bind="item.a" ng-repeat="item in model.items">A</li>' +
-          '<!-- end ngRepeat: item in model.items -->' +
           '<li ng-bind="item.a" ng-repeat="item in model.items">B</li>' +
           '<!-- end ngRepeat: item in model.items -->' +
         '</ul>');
@@ -120,7 +117,6 @@ describe('Binder', function() {
         '<ul>' +
           '<!-- ngRepeat: item in model.items -->' +
           '<li ng-bind="item.a" ng-repeat="item in model.items">A</li>' +
-          '<!-- end ngRepeat: item in model.items -->' +
           '<li ng-bind="item.a" ng-repeat="item in model.items">B</li>' +
           '<!-- end ngRepeat: item in model.items -->' +
         '</ul>');
@@ -231,15 +227,12 @@ describe('Binder', function() {
           '<div name="a" ng-repeat="m in model">'+
             '<!-- ngRepeat: i in m.item -->' +
             '<ul name="a1" ng-repeat="i in m.item"></ul>'+
-            '<!-- end ngRepeat: i in m.item -->' +
             '<ul name="a2" ng-repeat="i in m.item"></ul>'+
             '<!-- end ngRepeat: i in m.item -->' +
           '</div>'+
-          '<!-- end ngRepeat: m in model -->' +
           '<div name="b" ng-repeat="m in model">'+
             '<!-- ngRepeat: i in m.item -->' +
             '<ul name="b1" ng-repeat="i in m.item"></ul>'+
-            '<!-- end ngRepeat: i in m.item -->' +
             '<ul name="b2" ng-repeat="i in m.item"></ul>'+
             '<!-- end ngRepeat: i in m.item -->' +
           '</div>' +
@@ -322,14 +315,13 @@ describe('Binder', function() {
     $rootScope.$apply();
 
     var d1 = jqLite(element[0].childNodes[1]);
-    var d2 = jqLite(element[0].childNodes[3]);
+    var d2 = jqLite(element[0].childNodes[2]);
     expect(d1.hasClass('o')).toBeTruthy();
     expect(d2.hasClass('e')).toBeTruthy();
     expect(sortedHtml(element)).toBe(
        '<div>' +
         '<!-- ngRepeat: i in [0,1] -->' +
         '<div class="o" ng-class-even="\'e\'" ng-class-odd="\'o\'" ng-repeat="i in [0,1]"></div>' +
-        '<!-- end ngRepeat: i in [0,1] -->' +
         '<div class="e" ng-class-even="\'e\'" ng-class-odd="\'o\'" ng-repeat="i in [0,1]"></div>' +
         '<!-- end ngRepeat: i in [0,1] -->' +
         '</div>');
@@ -437,7 +429,6 @@ describe('Binder', function() {
         '<ul>' +
           '<!-- ngRepeat: (k,v) in {a:0,b:1} -->' +
           '<li ng-bind=\"k + v\" ng-repeat="(k,v) in {a:0,b:1}">a0</li>' +
-          '<!-- end ngRepeat: (k,v) in {a:0,b:1} -->' +
           '<li ng-bind=\"k + v\" ng-repeat="(k,v) in {a:0,b:1}">b1</li>' +
           '<!-- end ngRepeat: (k,v) in {a:0,b:1} -->' +
         '</ul>');

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -166,7 +166,7 @@ describe('ngClass', function() {
     element = $compile('<ul><li ng-repeat="i in [0,1]" class="existing" ng-class-odd="\'odd\'" ng-class-even="\'even\'"></li><ul>')($rootScope);
     $rootScope.$digest();
     var e1 = jqLite(element[0].childNodes[1]);
-    var e2 = jqLite(element[0].childNodes[3]);
+    var e2 = jqLite(element[0].childNodes[2]);
     expect(e1.hasClass('existing')).toBeTruthy();
     expect(e1.hasClass('odd')).toBeTruthy();
     expect(e2.hasClass('existing')).toBeTruthy();
@@ -181,7 +181,7 @@ describe('ngClass', function() {
       '<ul>')($rootScope);
     $rootScope.$apply();
     var e1 = jqLite(element[0].childNodes[1]);
-    var e2 = jqLite(element[0].childNodes[3]);
+    var e2 = jqLite(element[0].childNodes[2]);
 
     expect(e1.hasClass('plainClass')).toBeTruthy();
     expect(e1.hasClass('odd')).toBeTruthy();
@@ -199,7 +199,7 @@ describe('ngClass', function() {
       '<ul>')($rootScope);
     $rootScope.$apply();
     var e1 = jqLite(element[0].childNodes[1]);
-    var e2 = jqLite(element[0].childNodes[3]);
+    var e2 = jqLite(element[0].childNodes[2]);
 
     expect(e1.hasClass('A')).toBeTruthy();
     expect(e1.hasClass('B')).toBeTruthy();
@@ -273,7 +273,7 @@ describe('ngClass', function() {
     $rootScope.$digest();
 
     var e1 = jqLite(element[0].childNodes[1]);
-    var e2 = jqLite(element[0].childNodes[3]);
+    var e2 = jqLite(element[0].childNodes[2]);
 
     expect(e1.hasClass('odd')).toBeTruthy();
     expect(e1.hasClass('even')).toBeFalsy();

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -750,14 +750,12 @@ describe('ngRepeat', function() {
   });
 
 
-  it('should add separator comments after each item', inject(function ($compile, $rootScope) {
+  it('should add separator comment after end of block', inject(function ($compile, $rootScope) {
     var check = function () {
       var children = element.find('div');
       expect(children.length).toBe(3);
 
       // Note: COMMENT_NODE === 8
-      expect(children[0].nextSibling.nodeType).toBe(8);
-      expect(children[1].nextSibling.nodeType).toBe(8);
       expect(children[2].nextSibling.nodeType).toBe(8);
       expect(children[2].nextSibling.nodeValue).toBe(' end ngRepeat: val in values ');
     }
@@ -1027,6 +1025,34 @@ describe('ngRepeat', function() {
       $rootScope.books.push({title:'T3', description: 'D3'});
       $rootScope.$digest();
       expect(element.text()).toEqual('T1:D1;T2:D2;T3:D3;');
+    }));
+
+
+    it('should properly react to list change', inject(function ($compile, $rootScope) {
+      $rootScope.values = [1, 2, 3];
+      $rootScope.showMe = true;
+
+      element = $compile(
+        '<div>' +
+          '<div ng-repeat-start="val in values">val:{{val}};</div>' +
+          '<div ng-repeat-end>val-end:{{val}};</div>' +
+        '</div>'
+      )($rootScope);
+
+      $rootScope.$digest();
+      expect(element.find('div').length).toBe(6);
+
+      $rootScope.values.shift();
+      $rootScope.values.push(4);
+
+      $rootScope.$digest();
+      console.log(element.html());
+      console.log($rootScope.values);
+      expect(element.find('div').length).toBe(6);
+      expect(element.text()).not.toContain('val:1;');
+      expect(element.text()).not.toContain('val-end:1;');
+      expect(element.text()).toContain('val:4;');
+      expect(element.text()).toContain('val-end:4;');
     }));
 
 

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -621,7 +621,6 @@ describe('ngRepeat', function() {
           '<div>' +
             '<!-- ngRepeat: i in items -->' +
             '<div ng-repeat="i in items" rr="">1|</div>' +
-            '<!-- end ngRepeat: i in items -->' +
             '<div ng-repeat="i in items" rr="">2|</div>' +
             '<!-- end ngRepeat: i in items -->' +
           '</div>'
@@ -653,7 +652,6 @@ describe('ngRepeat', function() {
           '<div>' +
               '<!-- ngRepeat: i in items -->' +
               '<div ng-repeat="i in items" rr="">1|</div>' +
-              '<!-- end ngRepeat: i in items -->' +
               '<div ng-repeat="i in items" rr="">2|</div>' +
               '<!-- end ngRepeat: i in items -->' +
               '</div>'
@@ -759,9 +757,7 @@ describe('ngRepeat', function() {
 
       // Note: COMMENT_NODE === 8
       expect(children[0].nextSibling.nodeType).toBe(8);
-      expect(children[0].nextSibling.nodeValue).toBe(' end ngRepeat: val in values ');
       expect(children[1].nextSibling.nodeType).toBe(8);
-      expect(children[1].nextSibling.nodeValue).toBe(' end ngRepeat: val in values ');
       expect(children[2].nextSibling.nodeType).toBe(8);
       expect(children[2].nextSibling.nodeValue).toBe(' end ngRepeat: val in values ');
     }


### PR DESCRIPTION
This caused a subtle bug in angular-sortable directive: when moving elements
between lists, previousNode was a comment, which doesn't have the .parentNode
attribute so the $animate.enter function tried to call insertBefore of a null.

Moreover, it looks bad that 'end ngRepeat' comment appears after every iterated
node, it should be just at the end of the repeat block.
