### PR TITLE
feat(input): interpolates form input name attrs for ngModel

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1657,8 +1657,8 @@ var VALID_CLASS = 'ng-valid',
  *
  *
  */
-var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$parse', '$animate', '$timeout', '$rootScope', '$q',
-    function($scope, $exceptionHandler, $attr, $element, $parse, $animate, $timeout, $rootScope, $q) {
+var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$parse', '$animate', '$timeout', '$rootScope', '$q', '$interpolate',
+    function($scope, $exceptionHandler, $attr, $element, $parse, $animate, $timeout, $rootScope, $q, $interpolate) {
   this.$viewValue = Number.NaN;
   this.$modelValue = Number.NaN;
   this.$validators = {};
@@ -1675,7 +1675,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
   this.$error = {}; // keep invalid keys here
   this.$$success = {}; // keep valid keys here
   this.$pending = undefined; // keep pending keys here
-  this.$name = $attr.name;
+  this.$name = $interpolate($attr.name || '', false)($scope);
 
 
   var parsedNgModel = $parse($attr.ngModel),
@@ -2386,6 +2386,12 @@ var ngModelDirective = function() {
 
         // notify others, especially parent forms
         formCtrl.$addControl(modelCtrl);
+
+        attr.$observe('name', function(newValue) {
+          if (modelCtrl.$name !== newValue) {
+            formCtrl.$$renameControl(modelCtrl, newValue);
+          }
+        });
 
         scope.$on('$destroy', function() {
           formCtrl.$removeControl(modelCtrl);

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -782,6 +782,57 @@ describe('form', function() {
     });
   });
 
+
+  it('should rename nested form controls when interpolated name changes', function() {
+    scope.idA = 'A';
+    scope.idB = 'X';
+
+    doc = $compile(
+      '<form name="form">' +
+        '<div ng-form="nested{{idA}}">' +
+          '<div ng-form name="nested{{idB}}"' +
+          '</div>' +
+        '</div>' +
+      '</form'
+    )(scope);
+
+    scope.$digest();
+    var formA = scope.form.nestedA;
+    expect(formA).toBeDefined();
+    expect(formA.$name).toBe('nestedA');
+
+    var formX = formA.nestedX;
+    expect(formX).toBeDefined();
+    expect(formX.$name).toBe('nestedX');
+
+    scope.idA = 'B';
+    scope.idB = 'Y';
+    scope.$digest();
+
+    expect(scope.form.nestedA).toBeUndefined();
+    expect(scope.form.nestedB).toBe(formA);
+    expect(formA.nestedX).toBeUndefined();
+    expect(formA.nestedY).toBe(formX);
+  });
+
+
+  it('should rename forms with no parent when interpolated name changes', function() {
+    var element = $compile('<form name="name{{nameID}}"></form>')(scope);
+    var element2 = $compile('<div ng-form="name{{nameID}}"></div>')(scope);
+    scope.nameID = "A";
+    scope.$digest();
+    var form = element.controller('form');
+    var form2 = element2.controller('form');
+    expect(form.$name).toBe('nameA');
+    expect(form2.$name).toBe('nameA');
+
+    scope.nameID = "B";
+    scope.$digest();
+    expect(form.$name).toBe('nameB');
+    expect(form2.$name).toBe('nameB');
+  });
+
+
   describe('$setSubmitted', function() {
     beforeEach(function() {
       doc = $compile(

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1289,6 +1289,42 @@ describe('input', function() {
     }
   }));
 
+
+  it('should interpolate input names', function() {
+    scope.nameID = '47';
+    compileInput('<input type="text" ng-model="name" name="name{{nameID}}" />');
+    expect(scope.form.name47.$pristine).toBeTruthy();
+    changeInputValueTo('caitp');
+    expect(scope.form.name47.$dirty).toBeTruthy();
+  });
+
+
+  it('should rename form controls in form when interpolated name changes', function() {
+    scope.nameID = "A";
+    compileInput('<input type="text" ng-model="name" name="name{{nameID}}" />');
+    expect(scope.form.nameA.$name).toBe('nameA');
+    var oldModel = scope.form.nameA;
+    scope.nameID = "B";
+    scope.$digest();
+    expect(scope.form.nameA).toBeUndefined();
+    expect(scope.form.nameB).toBe(oldModel);
+    expect(scope.form.nameB.$name).toBe('nameB');
+  });
+
+
+  it('should rename form controls in null form when interpolated name changes', function() {
+    var element = $compile('<input type="text" ng-model="name" name="name{{nameID}}" />')(scope);
+    scope.nameID = "A";
+    scope.$digest();
+    var model = element.controller('ngModel');
+    expect(model.$name).toBe('nameA');
+
+    scope.nameID = "B";
+    scope.$digest();
+    expect(model.$name).toBe('nameB');
+  });
+
+
   describe('"change" event', function() {
     function assertBrowserSupportsChangeEvent(inputEventSupported) {
       // Force browser to report a lack of an 'input' event

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -148,6 +148,33 @@ describe('select', function() {
     });
 
 
+    it('should interpolate select names', function() {
+      scope.robots = ['c3p0', 'r2d2'];
+      scope.name = 'r2d2';
+      scope.nameID = 47;
+      compile('<select ng-model="name" name="name{{nameID}}">' +
+                '<option ng-repeat="r in robots">{{r}}</option>' +
+              '</select>');
+      expect(scope.form.name47.$pristine).toBeTruthy();
+      browserTrigger(element.find('option').eq(0));
+      expect(scope.form.name47.$dirty).toBeTruthy();
+      expect(scope.name).toBe('c3p0');
+    });
+
+
+    it('should rename select controls in form when interpolated name changes', function() {
+      scope.nameID = "A";
+      compile('<select ng-model="name" name="name{{nameID}}"></select>');
+      expect(scope.form.nameA.$name).toBe('nameA');
+      var oldModel = scope.form.nameA;
+      scope.nameID = "B";
+      scope.$digest();
+      expect(scope.form.nameA).toBeUndefined();
+      expect(scope.form.nameB).toBe(oldModel);
+      expect(scope.form.nameB.$name).toBe('nameB');
+    });
+
+
     describe('empty option', function() {
 
       it('should select the empty option when model is undefined', function() {


### PR DESCRIPTION
@frankhuster / @niargh has brought up an issue with using the `$index` of a repeated element for the name attribute of a form input.

I don't know how common of a use-case it is, but it seems not especially harmful to do a one-time interpolation in post-link.

It shouldn't be a breaking change unless people are using interpolation markers in their names.
