### PR TITLE
fix(input) re-validate input[type=number] element when min/max changes

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -542,6 +542,13 @@ function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
     return ctrl.$isEmpty(value) ? '' : '' + value;
   });
 
+  var refreshView = function() {
+    var value = element.val();
+    if (value == ctrl.$viewValue) {
+      ctrl.$setViewValue(value);
+    }
+  };
+
   if (attr.min) {
     var minValidator = function(value) {
       var min = parseFloat(attr.min);
@@ -554,6 +561,7 @@ function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
       }
     };
 
+    attr.$observe('min', refreshView);
     ctrl.$parsers.push(minValidator);
     ctrl.$formatters.push(minValidator);
   }
@@ -570,6 +578,7 @@ function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
       }
     };
 
+    attr.$observe('max', refreshView);
     ctrl.$parsers.push(maxValidator);
     ctrl.$formatters.push(maxValidator);
   }

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -735,19 +735,22 @@ describe('input', function() {
         expect(scope.form.alias.$error.min).toBeFalsy();
       });
 
-      it('should validate even if min value changes on-the-fly', function(done) {
+      it('should validate even if min value changes on-the-fly', function() {
         scope.min = 10;
         compileInput('<input type="number" ng-model="value" name="alias" min="{{min}}" />');
         scope.$digest();
 
         changeInputValueTo('5');
         expect(inputElm).toBeInvalid();
+        expect(scope.value).toBeFalsy();
+        expect(scope.form.alias.$error.min).toBeTruthy();
 
         scope.min = 0;
-        scope.$digest(function () {
-          expect(inputElm).toBeValid();
-          done();
-        });
+        scope.$digest();
+
+        expect(inputElm).toBeValid();
+        expect(scope.value).toBe(5);
+        expect(scope.form.alias.$error.min).toBeFalsy();
       });
     });
 
@@ -769,19 +772,22 @@ describe('input', function() {
         expect(scope.form.alias.$error.max).toBeFalsy();
       });
 
-      it('should validate even if max value changes on-the-fly', function(done) {
+      it('should validate even if max value changes on-the-fly', function() {
         scope.max = 10;
         compileInput('<input type="number" ng-model="value" name="alias" max="{{max}}" />');
         scope.$digest();
 
         changeInputValueTo('5');
         expect(inputElm).toBeValid();
+        expect(scope.value).toBe(5);
+        expect(scope.form.alias.$error.max).toBeFalsy();
 
         scope.max = 0;
-        scope.$digest(function () {
-          expect(inputElm).toBeInvalid();
-          done();
-        });
+        scope.$digest();
+
+        expect(inputElm).toBeInvalid();
+        expect(scope.value).toBeFalsy();
+        expect(scope.form.alias.$error.max).toBeTruthy();
       });
     });
 


### PR DESCRIPTION
There is a bug when you change min/max attr but models' value stays the same.
