### PR TITLE
fix(ngInclude & ngView): Conditionally autoscroll after animation

### DIFF
--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -178,6 +178,11 @@ var ngIncludeDirective = ['$http', '$templateCache', '$anchorScroll', '$compile'
         };
 
         scope.$watch($sce.parseAsResourceUrl(srcExp), function ngIncludeWatchAction(src) {
+          var afterAnimation = function() {
+            if (isDefined(autoScrollExp) && (!autoScrollExp || scope.$eval(autoScrollExp))) {
+              $anchorScroll();
+            }
+          };
           var thisChangeId = ++changeCounter;
 
           if (src) {
@@ -192,13 +197,8 @@ var ngIncludeDirective = ['$http', '$templateCache', '$anchorScroll', '$compile'
                 currentElement = clone;
 
                 currentElement.html(response);
-                $animate.enter(currentElement, null, $element);
+                $animate.enter(currentElement, null, $element, afterAnimation);
                 $compile(currentElement.contents())(currentScope);
-
-                if (isDefined(autoScrollExp) && (!autoScrollExp || scope.$eval(autoScrollExp))) {
-                  $anchorScroll();
-                }
-
                 currentScope.$emit('$includeContentLoaded');
                 scope.$eval(onloadExp);
               });

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -562,7 +562,7 @@ angular.mock.$IntervalProvider = function() {
  */
 (function() {
   var R_ISO8061_STR = /^(\d{4})-?(\d\d)-?(\d\d)(?:T(\d\d)(?:\:?(\d\d)(?:\:?(\d\d)(?:\.(\d{3}))?)?)?(Z|([+-])(\d\d):?(\d\d)))?$/;
-  
+
   function jsonStringToDate(string) {
     var match;
     if (match = string.match(R_ISO8061_STR)) {
@@ -776,7 +776,12 @@ angular.mock.animate = angular.module('mock.animate', ['ng'])
         enabled : $delegate.enabled,
         flushNext : function(name) {
           var tick = animate.queue.shift();
-          expect(tick.method).toBe(name);
+
+          if (!tick) throw new Error('No animation to be flushed');
+          if(tick.method !== name) {
+            throw new Error('The next animation is not "' + name +
+              '", but is "' + tick.method + '"');
+          }
           tick.fn();
           return tick;
         }
@@ -1191,7 +1196,7 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
    * @returns {requestHandler} Returns an object with `respond` method that controls how a matched
    *   request is handled.
    *
-   *  - respond – 
+   *  - respond –
    *      `{function([status,] data[, headers])|function(function(method, url, data, headers)}`
    *    – The respond method takes a set of static data to be returned or a function that can return
    *    an array containing response status (number), response data (string) and response headers

--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -184,6 +184,7 @@ function ngViewFactory(   $route,   $anchorScroll,   $compile,   $controller,   
       return function(scope, $element, attr) {
         var currentScope,
             currentElement,
+            autoScrollExp = attr.autoscroll,
             onloadExp = attr.onload || '';
 
         scope.$on('$routeChangeSuccess', update);
@@ -208,7 +209,12 @@ function ngViewFactory(   $route,   $anchorScroll,   $compile,   $controller,   
             var newScope = scope.$new();
             linker(newScope, function(clone) {
               clone.html(template);
-              $animate.enter(clone, null, currentElement || $element);
+              $animate.enter(clone, null, currentElement || $element, function onNgViewEnter () {
+                if (angular.isDefined(autoScrollExp)
+                  && (!autoScrollExp || scope.$eval(autoScrollExp))) {
+                  $anchorScroll();
+                }
+              });
 
               cleanupLastView();
 
@@ -231,9 +237,6 @@ function ngViewFactory(   $route,   $anchorScroll,   $compile,   $controller,   
               link(currentScope);
               currentScope.$emit('$viewContentLoaded');
               currentScope.$eval(onloadExp);
-
-              // $anchorScroll might listen on event...
-              $anchorScroll();
             });
           } else {
             cleanupLastView();


### PR DESCRIPTION
We need to wait until animations have added the content to the document before
trying to autoscroll to anchors that may have been inserted.
