### PR TITLE
fix(ngScenario): disable animations during e2e tests

### DIFF
--- a/src/ngScenario/Application.js
+++ b/src/ngScenario/Application.js
@@ -70,15 +70,10 @@ angular.scenario.Application.prototype.navigateTo = function(url, loadFn, errorF
 
         if ($window.angular) {
           // Disable animations
-
-          // TODO(i): this doesn't disable javascript animations
-          //          we don't need that for our tests, but it should be done
           $window.angular.resumeBootstrap([['$provide', function($provide) {
-            $provide.decorator('$sniffer', function($delegate) {
-              $delegate.transitions = false;
-              $delegate.animations = false;
-              return $delegate;
-            });
+            return ['$animate', function($animate) {
+              $animate.enabled(false);
+            }];
           }]]);
         }
 


### PR DESCRIPTION
The current tutorial (step-12) fails its e2e tests as the animations are not completing before the
expectations are checked.  This fixes that and is generally the right thing to do for other e2e
test situations.
