### PR TITLE
Fix a typo in index.ngdoc

### DIFF
--- a/docs/content/guide/index.ngdoc
+++ b/docs/content/guide/index.ngdoc
@@ -88,7 +88,7 @@ In Angular applications, you move the job of filling page templates with data fr
 
 * **Workflow:** [Yeoman.io](https://github.com/yeoman/generator-angular) and [Angular Yeoman Tutorial](http://www.sitepoint.com/kickstart-your-angularjs-development-with-yeoman-grunt-and-bower/)
 
-## Complimentary Libraries
+## Complementary Libraries
 
 This is a short list of libraries with specific support and documentation for working with Angular.  You can find a full list of all known Angular external libraries at [ngmodules.org](http://ngmodules.org/).
 


### PR DESCRIPTION
The index page of the guide lists _complimentary_ resources where _complementary_ resources are intended.
