### PR TITLE
chore(dependencies): revert to marked@0.2.9 to fix CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "karma-sauce-launcher": "~0.1.1",
     "karma-script-launcher": "~0.1.0",
     "yaml-js": "~0.0.8",
-    "marked": "~0.2.9",
+    "marked": "0.2.9",
     "rewire": "1.1.3",
     "grunt-jasmine-node": "~0.1.0",
     "grunt-parallel": "~0.3.1",


### PR DESCRIPTION
marked v0.2.10 breaking test:docgen

Tests on travis have been failing the past few days, so I wanted to dig around for the cause.

To reproduce:

``` bash
rm -rf node_modules/marked
npm install marked@0.2.9
grunt test:docgen

(PASSES)

rm -rf node_modules/marked
npm install marked (now installs 0.2.10)
grunt test:docgen

(FAILS)
```

I think the simplest way to fix travis build would be to remove the `~` operator before the version number in package.json, but a more robust fix would involve migrating the code. Clearly there are some breaking changes introduced in v0.2.10
