### PR TITLE
docs(compile/tplrt): convert html characters to entities

### DIFF
--- a/docs/content/error/compile/tplrt.ngdoc
+++ b/docs/content/error/compile/tplrt.ngdoc
@@ -6,9 +6,10 @@
 When a directive is declared with `template` (or `templateUrl`) and `replace` mode on, the template
 must have exactly one root element. That is, the text of the template property or the content
 referenced by the templateUrl must be contained within a single html element.
-For example, '<p>blah <em>blah</em> blah</p>' instead of simply 'blah <em>blah</em> blah'.
-Otherwise, the replacement operation would result in a single element (the directive) being replaced
-with multiple elements or nodes, which is unsupported and not commonly needed in practice.
+For example, '&lt;p&gt;blah &lt;em&gt;blah&lt;/em&gt; blah&lt;/p&gt;' instead of simply 
+'blah &lt;em&gt;blah&lt;/em&gt; blah'. Otherwise, the replacement operation would result in a 
+single element (the directive) being replaced with multiple elements or nodes, which is unsupported
+and not commonly needed in practice.
 
 
 For example a directive with definition:


### PR DESCRIPTION
HTML elements were getting parsed by as html elements
