### PR TITLE
typo in httpBackendSpec

### DIFF
--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -42,7 +42,7 @@ describe('$httpBackend', function() {
         return {};
       }),
       body: {
-        appendChild: jasmine.createSpy('body.appendChid').andCallFake(function(script) {
+        appendChild: jasmine.createSpy('body.appendChild').andCallFake(function(script) {
           fakeDocument.$$scripts.push(script);
         }),
         removeChild: jasmine.createSpy('body.removeChild').andCallFake(function(script) {


### PR DESCRIPTION
While browsing through the tests I found what appears to be a typo. The tests pass with and without this spy, so this is possibly something that is no longer used?
