### PR TITLE
chore(grunt): reduce JVM heap size hint on win

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -172,7 +172,7 @@ module.exports = {
     shell.exec(
         'java ' +
             this.java32flags() + ' ' +
-            '-Xmx2g ' +
+            '-Xmx512m ' +
             '-cp bower_components/closure-compiler/compiler.jar' + classPathSep +
             'bower_components/ng-closure-runner/ngcompiler.jar ' +
             'org.angularjs.closurerunner.NgClosureRunner ' +


### PR DESCRIPTION
The current grunt scripts set the maximum JVM heap space to 2GB. While this is only a maximum, and not an initial, it is preventing the JVM from even initializing on a number of people's machines. The build still runs successfully for me locally using only 512MB for this setting. See issue #4595 for reported instances.

Closes #4595
