### PR TITLE
docs(contribute): justify note about elevation on win

### DIFF
--- a/docs/content/misc/contribute.ngdoc
+++ b/docs/content/misc/contribute.ngdoc
@@ -81,8 +81,8 @@ grunt package
 
 
 <div class="alert alert-warning">
-**Note:** If you're using Windows you must run your command line with administrative privileges (right click, run as
-Administrator).
+**Note:** If you're using Windows, you must use an elevated command prompt (right click, run as
+Administrator). This is because `grunt package` creates some symbolic links.
 </div>
 
 The build output can be located under the `build` directory. It consists of the following files and


### PR DESCRIPTION
This message needs a justification. Without one, it's like asking somebody
on *nix to run everything under sudo 'just because'.
