### PR TITLE
docs(guide/scope): correct CSS rules in Scope Hierarchies example

### DIFF
--- a/docs/content/guide/scope.ngdoc
+++ b/docs/content/guide/scope.ngdoc
@@ -140,8 +140,7 @@ a diagram depicting the scope boundaries.
     }
   </file>
   <file name="style.css">
-    .show-scope .doc-example-live.ng-scope,
-    .show-scope .doc-example-live .ng-scope  {
+    .ng-scope  {
       border: 1px solid red;
       margin: 3px;
     }


### PR DESCRIPTION
Remove extra selectors .show-scope and .doc-example-live.

These classes do not appear using the provided code; the example will not work.

Fiddle example of change: http://jsfiddle.net/72KP4/
