### PR TITLE
feat($rootScope): add a useful error message when circular reference cau...

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -594,6 +594,12 @@ function $RootScopeProvider(){
                     }
                   }
                 } catch (e) {
+                  // catch maximum call stack errors
+                  if (e.name === 'RangeError') {
+                    var message = e.message + ' - Could be circular reference ';
+                    message = message + 'in $watch('+watch.exp+')';
+                    e = new RangeError(message);
+                  }
                   $exceptionHandler(e);
                 }
               }


### PR DESCRIPTION
...ses error in $watch

When there is a circular reference in the expression passed to $watch, a maximum
call stack error is thrown that does not have a useful stack trace.  A quick Google
search suggests that many angular users have struggled with this issue.  Rewrite the
error message, giving a hint about where the error is coming from.
