### PR TITLE
docs($compile): Explain that post-link functions run in reverse order.

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -115,7 +115,8 @@
  * When there are multiple directives defined on a single DOM element, sometimes it
  * is necessary to specify the order in which the directives are applied. The `priority` is used
  * to sort the directives before their `compile` functions get called. Priority is defined as a
- * number. Directives with greater numerical `priority` are compiled first. The order of directives with
+ * number. Directives with greater numerical `priority` are compiled first. Pre-link functions are also
+ * run in priority order, but post-link functions are run in reverse order. The order of directives with
  * the same priority is undefined. The default priority is `0`.
  *
  * #### `terminal`


### PR DESCRIPTION
Update the $compile docs to mention the change introduced in #4266.
