### PR TITLE
feat($parse): toggle evaluation of private fields via $parseProvider.allowPrivateFields()

### DIFF
--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -192,10 +192,11 @@ describe('parser', function() {
     });
   });
 
-  var $filterProvider, scope;
+  var $filterProvider, $parseProvider, scope;
 
-  beforeEach(module(['$filterProvider', function (filterProvider) {
+  beforeEach(module(['$filterProvider', '$parseProvider', function (filterProvider, parseProvider) {
     $filterProvider = filterProvider;
+    $parseProvider = parseProvider;
   }]));
 
 
@@ -640,6 +641,23 @@ describe('parser', function() {
               testExpression('a["b"]["NAME"]');      testExpression('a["b"]["NAME"] = 1');
             });
           });
+
+          it('should allow access to private members if allowPrivateFields is true', function() {
+            scope._name = 'foo';
+            expect(function() {
+              scope.$eval('_name');
+            }).toThrowMinErr(
+                        '$parse', 'isecprv', 'Referencing private fields in Angular expressions is disallowed! ' +
+                        'Expression: _name');
+            $parseProvider.allowPrivateFields(true);
+            expect($parseProvider.allowPrivateFields()).toBe(true);
+            expect(function() {
+              scope.$eval('_name');
+            }).not.toThrow();
+            $parseProvider.allowPrivateFields(false);
+            expect($parseProvider.allowPrivateFields()).toBe(false);
+          });
+
         });
 
         describe('Function constructor', function() {


### PR DESCRIPTION
Disallowing evaluation of private fields in Angular expressions should be toggleable through a `config()` block.  Usage is shown in ngdoc comments.

It's worth noting that this behavior defaults to FALSE.  

That is to say, if you want pre-Angular-1.2 behavior, you must do:

``` javascript
myModule.config(function($parseProvider) {
  $parseProvider.allowPrivateFields(true);
});
```

Please let me know if the unit tests are insufficient; they do not consider multiple "formats" of private variables as the tests do in 3d6a89e8888b14ae5cb5640464e12b7811853c7e, but the main intent here was to show that the toggle works.
