### PR TITLE
fix($resource): don't use $parse for @dotted.member

### DIFF
--- a/docs/content/error/resource/badmember.ngdoc
+++ b/docs/content/error/resource/badmember.ngdoc
@@ -1,0 +1,27 @@
+@ngdoc error
+@name $resource:badmember
+@fullName Syntax error in param value using @member lookup
+@description
+
+Occurs when there is a syntax error when attempting to extract a param
+value from the data object.
+
+Here's an example of valid syntax for `params` or `paramsDefault`:
+
+````javascript
+{
+  bar: '@foo.bar'
+}
+````
+
+The part following the `@`, `foo.bar` in this case, should be a simple
+dotted member lookup using only ASCII identifiers.  This error occurs
+when there is an error in that expression.  The following are all syntax
+errors
+
+ | Value   | Error          |
+ |---------|----------------|
+ | `@`     | Empty expression following `@`. |
+ | `@1.a`  | `1` is an invalid javascript identifier. |
+ | `@.a`   | Leading `.` is invalid. |
+ | `@a[1]` | Only dotted lookups are supported (no index operator) |


### PR DESCRIPTION
params and paramDefaults support looking up the parameter value from the
data object.  The syntax for that is `@nested.property.name`.
Currently, $resource uses $parse to do this.  This is too liberal
(you can use values like `@a=b` or `@a | filter` and have it work -
which doesn't really make sense).  It also puts up a dependency on
$parse which is has restrictions to secure expressions used in
templates.  The value here, though a string, is specified in Javascript
code and shouldn't have those restrictions.
