### PR TITLE
i18n: Taking numberformatsymbolsext into account

### DIFF
--- a/i18n/src/closureSlurper.js
+++ b/i18n/src/closureSlurper.js
@@ -22,9 +22,12 @@ function readSymbols() {
     .then(function(content) {
       var currencySymbols = closureI18nExtractor.extractCurrencySymbols(content);
       return qfs.read(__dirname + '/../closure/numberSymbols.js', 'b').then(function(content) {
+        closureI18nExtractor.extractNumberSymbols(content, localeInfo, currencySymbols);
+        return qfs.read(__dirname + '/../closure/numberSymbolsExt.js', 'b').then(function(content) {
           closureI18nExtractor.extractNumberSymbols(content, localeInfo, currencySymbols);
         });
       });
+    });
 
   console.log("Processing datetime symbols ...");
   var datetimeStagePromise = qfs.read(__dirname + '/../closure/datetimeSymbols.js', 'b')

--- a/i18n/update-closure.sh
+++ b/i18n/update-closure.sh
@@ -11,4 +11,5 @@ curl http://closure-library.googlecode.com/svn/trunk/closure/goog/i18n/currency.
 curl http://closure-library.googlecode.com/svn/trunk/closure/goog/i18n/datetimesymbols.js > closure/datetimeSymbols.js
 curl http://closure-library.googlecode.com/svn/trunk/closure/goog/i18n/datetimesymbolsext.js > closure/datetimeSymbolsExt.js
 curl http://closure-library.googlecode.com/svn/trunk/closure/goog/i18n/numberformatsymbols.js > closure/numberSymbols.js
+curl http://closure-library.googlecode.com/svn/trunk/closure/goog/i18n/numberformatsymbolsext.js > closure/numberSymbolsExt.js
 curl http://closure-library.googlecode.com/svn/trunk/closure/goog/i18n/pluralrules.js > closure/pluralRules.js

--- a/src/ngLocale/angular-locale_af-na.js
+++ b/src/ngLocale/angular-locale_af-na.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "R",
+    "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [
@@ -86,9 +86,9 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "(\u00a4",
-        "negSuf": ")",
-        "posPre": "\u00a4",
+        "negPre": "\u00a4\u00a0-",
+        "negSuf": "",
+        "posPre": "\u00a4\u00a0",
         "posSuf": ""
       }
     ]

--- a/src/ngLocale/angular-locale_ar-ae.js
+++ b/src/ngLocale/angular-locale_ar-ae.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
+    "CURRENCY_SYM": "dh",
     "DECIMAL_SEP": "\u066b",
     "GROUP_SEP": "\u066c",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_ar-bh.js
+++ b/src/ngLocale/angular-locale_ar-bh.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
+    "CURRENCY_SYM": "din",
     "DECIMAL_SEP": "\u066b",
     "GROUP_SEP": "\u066c",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_ar-dz.js
+++ b/src/ngLocale/angular-locale_ar-dz.js
@@ -63,9 +63,9 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
-    "DECIMAL_SEP": "\u066b",
-    "GROUP_SEP": "\u066c",
+    "CURRENCY_SYM": "din",
+    "DECIMAL_SEP": ",",
+    "GROUP_SEP": ".",
     "PATTERNS": [
       {
         "gSize": 0,

--- a/src/ngLocale/angular-locale_ar-iq.js
+++ b/src/ngLocale/angular-locale_ar-iq.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
+    "CURRENCY_SYM": "din",
     "DECIMAL_SEP": "\u066b",
     "GROUP_SEP": "\u066c",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_ar-jo.js
+++ b/src/ngLocale/angular-locale_ar-jo.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
+    "CURRENCY_SYM": "din",
     "DECIMAL_SEP": "\u066b",
     "GROUP_SEP": "\u066c",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_ar-kw.js
+++ b/src/ngLocale/angular-locale_ar-kw.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
+    "CURRENCY_SYM": "din",
     "DECIMAL_SEP": "\u066b",
     "GROUP_SEP": "\u066c",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_ar-lb.js
+++ b/src/ngLocale/angular-locale_ar-lb.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
+    "CURRENCY_SYM": "L\u00a3",
     "DECIMAL_SEP": "\u066b",
     "GROUP_SEP": "\u066c",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_ar-ly.js
+++ b/src/ngLocale/angular-locale_ar-ly.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
+    "CURRENCY_SYM": "din",
     "DECIMAL_SEP": "\u066b",
     "GROUP_SEP": "\u066c",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_ar-ma.js
+++ b/src/ngLocale/angular-locale_ar-ma.js
@@ -63,9 +63,9 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
-    "DECIMAL_SEP": "\u066b",
-    "GROUP_SEP": "\u066c",
+    "CURRENCY_SYM": "dh",
+    "DECIMAL_SEP": ",",
+    "GROUP_SEP": ".",
     "PATTERNS": [
       {
         "gSize": 0,

--- a/src/ngLocale/angular-locale_ar-om.js
+++ b/src/ngLocale/angular-locale_ar-om.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
+    "CURRENCY_SYM": "Rial",
     "DECIMAL_SEP": "\u066b",
     "GROUP_SEP": "\u066c",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_ar-qa.js
+++ b/src/ngLocale/angular-locale_ar-qa.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
+    "CURRENCY_SYM": "Rial",
     "DECIMAL_SEP": "\u066b",
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
@@ -86,9 +86,9 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "\u00a4\u00a0",
-        "negSuf": "-",
-        "posPre": "\u00a4\u00a0",
+        "negPre": "\u00a4-",
+        "negSuf": "",
+        "posPre": "\u00a4",
         "posSuf": ""
       }
     ]

--- a/src/ngLocale/angular-locale_ar-sa.js
+++ b/src/ngLocale/angular-locale_ar-sa.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
+    "CURRENCY_SYM": "Rial",
     "DECIMAL_SEP": "\u066b",
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
@@ -86,9 +86,9 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "\u00a4\u00a0",
-        "negSuf": "-",
-        "posPre": "\u00a4\u00a0",
+        "negPre": "\u00a4-",
+        "negSuf": "",
+        "posPre": "\u00a4",
         "posSuf": ""
       }
     ]

--- a/src/ngLocale/angular-locale_ar-sd.js
+++ b/src/ngLocale/angular-locale_ar-sd.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
+    "CURRENCY_SYM": "SDG",
     "DECIMAL_SEP": "\u066b",
     "GROUP_SEP": "\u066c",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_ar-sy.js
+++ b/src/ngLocale/angular-locale_ar-sy.js
@@ -86,9 +86,9 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "\u00a4\u00a0",
-        "negSuf": "-",
-        "posPre": "\u00a4\u00a0",
+        "negPre": "\u00a4-",
+        "negSuf": "",
+        "posPre": "\u00a4",
         "posSuf": ""
       }
     ]

--- a/src/ngLocale/angular-locale_ar-tn.js
+++ b/src/ngLocale/angular-locale_ar-tn.js
@@ -63,9 +63,9 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
-    "DECIMAL_SEP": "\u066b",
-    "GROUP_SEP": "\u066c",
+    "CURRENCY_SYM": "din",
+    "DECIMAL_SEP": ",",
+    "GROUP_SEP": ".",
     "PATTERNS": [
       {
         "gSize": 0,
@@ -86,9 +86,9 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "\u00a4\u00a0",
-        "negSuf": "-",
-        "posPre": "\u00a4\u00a0",
+        "negPre": "\u00a4-",
+        "negSuf": "",
+        "posPre": "\u00a4",
         "posSuf": ""
       }
     ]

--- a/src/ngLocale/angular-locale_ar-ye.js
+++ b/src/ngLocale/angular-locale_ar-ye.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a3",
+    "CURRENCY_SYM": "Rial",
     "DECIMAL_SEP": "\u066b",
     "GROUP_SEP": "\u066c",
     "PATTERNS": [
@@ -86,9 +86,9 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "\u00a4\u00a0",
-        "negSuf": "-",
-        "posPre": "\u00a4\u00a0",
+        "negPre": "\u00a4-",
+        "negSuf": "",
+        "posPre": "\u00a4",
         "posSuf": ""
       }
     ]

--- a/src/ngLocale/angular-locale_bn-in.js
+++ b/src/ngLocale/angular-locale_bn-in.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u09f3",
+    "CURRENCY_SYM": "\u20b9",
     "DECIMAL_SEP": ".",
     "GROUP_SEP": ",",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_de-li.js
+++ b/src/ngLocale/angular-locale_de-li.js
@@ -63,9 +63,9 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
-    "DECIMAL_SEP": ",",
-    "GROUP_SEP": ".",
+    "CURRENCY_SYM": "CHF",
+    "DECIMAL_SEP": ".",
+    "GROUP_SEP": "'",
     "PATTERNS": [
       {
         "gSize": 3,
@@ -86,10 +86,10 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "-",
-        "negSuf": "\u00a0\u00a4",
-        "posPre": "",
-        "posSuf": "\u00a0\u00a4"
+        "negPre": "\u00a4\u00a0-",
+        "negSuf": "",
+        "posPre": "\u00a4\u00a0",
+        "posSuf": ""
       }
     ]
   },

--- a/src/ngLocale/angular-locale_el-cy.js
+++ b/src/ngLocale/angular-locale_el-cy.js
@@ -86,10 +86,10 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "-",
-        "negSuf": "\u00a0\u00a4",
-        "posPre": "",
-        "posSuf": "\u00a0\u00a4"
+        "negPre": "\u00a4-",
+        "negSuf": "",
+        "posPre": "\u00a4",
+        "posSuf": ""
       }
     ]
   },

--- a/src/ngLocale/angular-locale_en-be.js
+++ b/src/ngLocale/angular-locale_en-be.js
@@ -63,9 +63,9 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "$",
-    "DECIMAL_SEP": ".",
-    "GROUP_SEP": ",",
+    "CURRENCY_SYM": "\u20ac",
+    "DECIMAL_SEP": ",",
+    "GROUP_SEP": ".",
     "PATTERNS": [
       {
         "gSize": 3,
@@ -86,10 +86,10 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "(\u00a4",
-        "negSuf": ")",
-        "posPre": "\u00a4",
-        "posSuf": ""
+        "negPre": "-",
+        "negSuf": "\u00a0\u00a4",
+        "posPre": "",
+        "posSuf": "\u00a0\u00a4"
       }
     ]
   },

--- a/src/ngLocale/angular-locale_en-bw.js
+++ b/src/ngLocale/angular-locale_en-bw.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "$",
+    "CURRENCY_SYM": "P",
     "DECIMAL_SEP": ".",
     "GROUP_SEP": ",",
     "PATTERNS": [
@@ -86,8 +86,8 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "(\u00a4",
-        "negSuf": ")",
+        "negPre": "\u00a4-",
+        "negSuf": "",
         "posPre": "\u00a4",
         "posSuf": ""
       }

--- a/src/ngLocale/angular-locale_en-bz.js
+++ b/src/ngLocale/angular-locale_en-bz.js
@@ -86,8 +86,8 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "(\u00a4",
-        "negSuf": ")",
+        "negPre": "\u00a4-",
+        "negSuf": "",
         "posPre": "\u00a4",
         "posSuf": ""
       }

--- a/src/ngLocale/angular-locale_en-dsrt.js
+++ b/src/ngLocale/angular-locale_en-dsrt.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "$",
+    "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ".",
     "GROUP_SEP": ",",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_en-jm.js
+++ b/src/ngLocale/angular-locale_en-jm.js
@@ -86,8 +86,8 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "(\u00a4",
-        "negSuf": ")",
+        "negPre": "\u00a4-",
+        "negSuf": "",
         "posPre": "\u00a4",
         "posSuf": ""
       }

--- a/src/ngLocale/angular-locale_en-mt.js
+++ b/src/ngLocale/angular-locale_en-mt.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "$",
+    "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ".",
     "GROUP_SEP": ",",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_en-mu.js
+++ b/src/ngLocale/angular-locale_en-mu.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "$",
+    "CURRENCY_SYM": "MURs",
     "DECIMAL_SEP": ".",
     "GROUP_SEP": ",",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_en-na.js
+++ b/src/ngLocale/angular-locale_en-na.js
@@ -86,8 +86,8 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "(\u00a4",
-        "negSuf": ")",
+        "negPre": "\u00a4-",
+        "negSuf": "",
         "posPre": "\u00a4",
         "posSuf": ""
       }

--- a/src/ngLocale/angular-locale_en-ph.js
+++ b/src/ngLocale/angular-locale_en-ph.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "$",
+    "CURRENCY_SYM": "\u20b1",
     "DECIMAL_SEP": ".",
     "GROUP_SEP": ",",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_en-pk.js
+++ b/src/ngLocale/angular-locale_en-pk.js
@@ -63,12 +63,12 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "$",
+    "CURRENCY_SYM": "Rs",
     "DECIMAL_SEP": ".",
     "GROUP_SEP": ",",
     "PATTERNS": [
       {
-        "gSize": 3,
+        "gSize": 2,
         "lgSize": 3,
         "macFrac": 0,
         "maxFrac": 3,
@@ -80,15 +80,15 @@ $provide.value("$locale", {
         "posSuf": ""
       },
       {
-        "gSize": 3,
+        "gSize": 2,
         "lgSize": 3,
         "macFrac": 0,
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "(\u00a4",
-        "negSuf": ")",
-        "posPre": "\u00a4",
+        "negPre": "\u00a4\u00a0-",
+        "negSuf": "",
+        "posPre": "\u00a4\u00a0",
         "posSuf": ""
       }
     ]

--- a/src/ngLocale/angular-locale_en-tt.js
+++ b/src/ngLocale/angular-locale_en-tt.js
@@ -86,8 +86,8 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "(\u00a4",
-        "negSuf": ")",
+        "negPre": "\u00a4-",
+        "negSuf": "",
         "posPre": "\u00a4",
         "posSuf": ""
       }

--- a/src/ngLocale/angular-locale_en-zw.js
+++ b/src/ngLocale/angular-locale_en-zw.js
@@ -86,8 +86,8 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "(\u00a4",
-        "negSuf": ")",
+        "negPre": "\u00a4-",
+        "negSuf": "",
         "posPre": "\u00a4",
         "posSuf": ""
       }

--- a/src/ngLocale/angular-locale_es-ar.js
+++ b/src/ngLocale/angular-locale_es-ar.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_es-bo.js
+++ b/src/ngLocale/angular-locale_es-bo.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "Bs",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_es-cl.js
+++ b/src/ngLocale/angular-locale_es-cl.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "H:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [
@@ -86,10 +86,10 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "-",
-        "negSuf": "\u00a0\u00a4",
-        "posPre": "",
-        "posSuf": "\u00a0\u00a4"
+        "negPre": "\u00a4-",
+        "negSuf": "",
+        "posPre": "\u00a4",
+        "posSuf": ""
       }
     ]
   },

--- a/src/ngLocale/angular-locale_es-co.js
+++ b/src/ngLocale/angular-locale_es-co.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "H:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_es-cr.js
+++ b/src/ngLocale/angular-locale_es-cr.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "\u20a1",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_es-do.js
+++ b/src/ngLocale/angular-locale_es-do.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_es-ec.js
+++ b/src/ngLocale/angular-locale_es-ec.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "H:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [
@@ -86,10 +86,10 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "-",
-        "negSuf": "\u00a0\u00a4",
-        "posPre": "",
-        "posSuf": "\u00a0\u00a4"
+        "negPre": "\u00a4-",
+        "negSuf": "",
+        "posPre": "\u00a4",
+        "posSuf": ""
       }
     ]
   },

--- a/src/ngLocale/angular-locale_es-gq.js
+++ b/src/ngLocale/angular-locale_es-gq.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "FCFA",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [
@@ -86,10 +86,10 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "-",
-        "negSuf": "\u00a0\u00a4",
-        "posPre": "",
-        "posSuf": "\u00a0\u00a4"
+        "negPre": "\u00a4-",
+        "negSuf": "",
+        "posPre": "\u00a4",
+        "posSuf": ""
       }
     ]
   },

--- a/src/ngLocale/angular-locale_es-gt.js
+++ b/src/ngLocale/angular-locale_es-gt.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "Q",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_es-hn.js
+++ b/src/ngLocale/angular-locale_es-hn.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "L",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_es-mx.js
+++ b/src/ngLocale/angular-locale_es-mx.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_es-ni.js
+++ b/src/ngLocale/angular-locale_es-ni.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "C$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_es-pa.js
+++ b/src/ngLocale/angular-locale_es-pa.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "B/.",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_es-pe.js
+++ b/src/ngLocale/angular-locale_es-pe.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "S/.",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_es-pr.js
+++ b/src/ngLocale/angular-locale_es-pr.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_es-py.js
+++ b/src/ngLocale/angular-locale_es-py.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "Gs",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [
@@ -86,10 +86,10 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "-",
-        "negSuf": "\u00a0\u00a4",
-        "posPre": "",
-        "posSuf": "\u00a0\u00a4"
+        "negPre": "\u00a4\u00a0-",
+        "negSuf": "",
+        "posPre": "\u00a4\u00a0",
+        "posSuf": ""
       }
     ]
   },

--- a/src/ngLocale/angular-locale_es-sv.js
+++ b/src/ngLocale/angular-locale_es-sv.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_es-us.js
+++ b/src/ngLocale/angular-locale_es-us.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_es-uy.js
+++ b/src/ngLocale/angular-locale_es-uy.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [
@@ -86,10 +86,10 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "-",
-        "negSuf": "\u00a0\u00a4",
-        "posPre": "",
-        "posSuf": "\u00a0\u00a4"
+        "negPre": "(\u00a4\u00a0",
+        "negSuf": ")",
+        "posPre": "\u00a4\u00a0",
+        "posSuf": ""
       }
     ]
   },

--- a/src/ngLocale/angular-locale_es-ve.js
+++ b/src/ngLocale/angular-locale_es-ve.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "Bs",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [
@@ -86,10 +86,10 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "-",
-        "negSuf": "\u00a0\u00a4",
-        "posPre": "",
-        "posSuf": "\u00a0\u00a4"
+        "negPre": "\u00a4-",
+        "negSuf": "",
+        "posPre": "\u00a4",
+        "posSuf": ""
       }
     ]
   },

--- a/src/ngLocale/angular-locale_fa-af.js
+++ b/src/ngLocale/angular-locale_fa-af.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "H:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "Rial",
+    "CURRENCY_SYM": "Af.",
     "DECIMAL_SEP": "\u066b",
     "GROUP_SEP": "\u066c",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-be.js
+++ b/src/ngLocale/angular-locale_fr-be.js
@@ -65,7 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
-    "GROUP_SEP": "\u00a0",
+    "GROUP_SEP": ".",
     "PATTERNS": [
       {
         "gSize": 3,

--- a/src/ngLocale/angular-locale_fr-bf.js
+++ b/src/ngLocale/angular-locale_fr-bf.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "CFA",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-bi.js
+++ b/src/ngLocale/angular-locale_fr-bi.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "FBu",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-bj.js
+++ b/src/ngLocale/angular-locale_fr-bj.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "CFA",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-cd.js
+++ b/src/ngLocale/angular-locale_fr-cd.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "FrCD",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-cf.js
+++ b/src/ngLocale/angular-locale_fr-cf.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "FCFA",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-cg.js
+++ b/src/ngLocale/angular-locale_fr-cg.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "FCFA",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-ch.js
+++ b/src/ngLocale/angular-locale_fr-ch.js
@@ -63,9 +63,9 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
-    "DECIMAL_SEP": ",",
-    "GROUP_SEP": "\u00a0",
+    "CURRENCY_SYM": "CHF",
+    "DECIMAL_SEP": ".",
+    "GROUP_SEP": "'",
     "PATTERNS": [
       {
         "gSize": 3,
@@ -86,10 +86,10 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "(",
-        "negSuf": "\u00a0\u00a4)",
-        "posPre": "",
-        "posSuf": "\u00a0\u00a4"
+        "negPre": "\u00a4-",
+        "negSuf": "",
+        "posPre": "\u00a4\u00a0",
+        "posSuf": ""
       }
     ]
   },

--- a/src/ngLocale/angular-locale_fr-ci.js
+++ b/src/ngLocale/angular-locale_fr-ci.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "CFA",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-cm.js
+++ b/src/ngLocale/angular-locale_fr-cm.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "FCFA",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-dj.js
+++ b/src/ngLocale/angular-locale_fr-dj.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "Fdj",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-ga.js
+++ b/src/ngLocale/angular-locale_fr-ga.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "FCFA",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-gn.js
+++ b/src/ngLocale/angular-locale_fr-gn.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "FG",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-gq.js
+++ b/src/ngLocale/angular-locale_fr-gq.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "FCFA",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-km.js
+++ b/src/ngLocale/angular-locale_fr-km.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "CF",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-lu.js
+++ b/src/ngLocale/angular-locale_fr-lu.js
@@ -65,7 +65,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
-    "GROUP_SEP": "\u00a0",
+    "GROUP_SEP": ".",
     "PATTERNS": [
       {
         "gSize": 3,

--- a/src/ngLocale/angular-locale_fr-mg.js
+++ b/src/ngLocale/angular-locale_fr-mg.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "Ar",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-ml.js
+++ b/src/ngLocale/angular-locale_fr-ml.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "CFA",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_fr-ne.js
+++ b/src/ngLocale/angular-locale_fr-ne.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "CFA",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [


### PR DESCRIPTION
There are some errors in certain locale files, I noticed most latin american currencies were wrong. The problem is that closure library keeps a separate file numberformatsymbolsext.js for some languages.

This change uses this file too to generate the correct currency chars.

The locale generation process now downloads number format symbols from
this url too

http://closure-library.googlecode.com/svn/trunk/closure/goog/i18n/numberformatsymbolsext.js

Most locales should now be correct
