### PR TITLE
feat($parse): Custom private field tagging

### DIFF
--- a/docs/content/error/parse/iresre.ngdoc
+++ b/docs/content/error/parse/iresre.ngdoc
@@ -1,0 +1,19 @@
+@ngdoc error
+@name $parse:iresre
+@fullName Invalid matching pattern for tagging private fields
+@description
+
+Occurs when a non-regexp expression is assigned as the
+matching pattern used to tag private fields.
+
+Example that will throw this error:
+
+```
+$parseProvider.restrictFieldsMatching('priv');
+```
+
+If you want to tag private fields with a 'priv' preffix
+you should do this instead:
+```
+$parseProvider.restrictFieldsMatching(/priv/);
+```

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -3,6 +3,7 @@
 var $parseMinErr = minErr('$parse');
 var promiseWarningCache = {};
 var promiseWarning;
+var restrictFieldsMatching = /^_|_$/;
 
 // Sandboxing Angular Expressions
 // ------------------------------
@@ -47,7 +48,7 @@ function ensureSafeMemberName(name, fullExpression, allowConstructor) {
         'Referencing "constructor" field in Angular expressions is disallowed! Expression: {0}',
         fullExpression);
   }
-  if (name.charAt(0) === '_' || name.charAt(name.length-1) === '_') {
+  if (restrictFieldsMatching && (name.match(restrictFieldsMatching))) {
     throw $parseMinErr('isecprv',
         'Referencing private fields in Angular expressions is disallowed! Expression: {0}',
         fullExpression);
@@ -1204,6 +1205,36 @@ function $ParseProvider() {
     } else {
       return $parseOptions.logPromiseWarnings;
     }
+  };
+
+
+  /**
+   * @ngdoc method
+   * @name ng.$parseProvider#restrictFieldsMatching
+   * @methodOf ng.$parseProvider
+   * @description
+   *
+   * Allows using a custom regular expression for tagging private fields. You
+   * can turn off private fields by passing `null` as a parameter.
+   *
+   * The default is set to `/$_|_^/` which means every fields that begins or ends with an
+   * underscore.
+   *
+   * @param {RegExp=} value New value.
+   * @returns {RegExp} Returns the current setting
+   */
+  this.restrictFieldsMatching = function(value) {
+    if (isDefined(value)) {
+      if ((value === null) || (value instanceof RegExp)) {
+        restrictFieldsMatching = value;
+      }
+      else {
+        throw $parseMinErr('iresre',
+            'Invalid expression for matching private fields! Expression: {0}',
+            value);
+      }
+    }
+    return restrictFieldsMatching;
   };
 
 


### PR DESCRIPTION
Commit 3d6a89e introduced the concept of private field that can not be evaluated on an Angular expression for security reasons.

This PR allows changing the pattern that matches a field as private. It also allows disabling the private field access restriction.

Some examples:

``` js
myModule.config(function($parseProvider) {
  // disable private fields restriction
  $parseProvider.restrictFieldsMatching(null);
});
```

``` js
myModule.config(function($parseProvider) {
  // Now private fields will be those beginning with 'priv'
  $parseProvider.restrictFieldsMatching(/^priv/);
});
```

Custom private fields allow backwards compatibility with AngularJS <1.2 projects that use underscores in scope fields (i.e. data retrieved from a MongoDB instance) while still enjoying the new private field security policy.

Closes #4509
