### PR TITLE
Issue #4680

### DIFF
--- a/src/ng/urlUtils.js
+++ b/src/ng/urlUtils.js
@@ -81,8 +81,8 @@ function urlResolve(url) {
     hash: urlParsingNode.hash ? urlParsingNode.hash.replace(/^#/, '') : '',
     hostname: urlParsingNode.hostname,
     port: urlParsingNode.port,
-    pathname: (urlParsingNode.protocol.indexOf('file')===0 && urlParsingNode.pathname.indexOf('\:')===2)?
-      urlParsingNode.pathname.substring(3) : urlParsingNode.pathname.charAt(0) === '/' ? 
+    pathname: (urlParsingNode.protocol.indexOf('file')===0 && urlParsingNode.pathname.indexOf(':')===2)?
+      urlParsingNode.pathname.substring(3) : urlParsingNode.pathname.charAt(0) === '/' ?
         urlParsingNode.pathname : '/' + urlParsingNode.pathname
   };
 }

--- a/src/ng/urlUtils.js
+++ b/src/ng/urlUtils.js
@@ -81,8 +81,8 @@ function urlResolve(url) {
     hash: urlParsingNode.hash ? urlParsingNode.hash.replace(/^#/, '') : '',
     hostname: urlParsingNode.hostname,
     port: urlParsingNode.port,
-    pathname: (urlParsingNode.protocol.indexOf('file')===0 && urlParsingNode.pathname.indexOf(':')===2)?
-      urlParsingNode.pathname.substring(3) : urlParsingNode.pathname.charAt(0) === '/' ?
+    pathname: (urlParsingNode.protocol.indexOf('file')===0 && urlParsingNode.pathname.indexOf('\:')===2)?
+      urlParsingNode.pathname.substring(3) : urlParsingNode.pathname.charAt(0) === '/' ? 
         urlParsingNode.pathname : '/' + urlParsingNode.pathname
   };
 }

--- a/src/ng/urlUtils.js
+++ b/src/ng/urlUtils.js
@@ -81,9 +81,9 @@ function urlResolve(url) {
     hash: urlParsingNode.hash ? urlParsingNode.hash.replace(/^#/, '') : '',
     hostname: urlParsingNode.hostname,
     port: urlParsingNode.port,
-    pathname: (urlParsingNode.protocol.indexOf('file')===0 && urlParsingNode.pathname.indexOf('\:')===2)?
-      urlParsingNode.pathname.substring(3) : urlParsingNode.pathname.charAt(0) === '/' ? 
-        urlParsingNode.pathname : '/' + urlParsingNode.pathname
+    pathname: (urlParsingNode.protocol.indexOf('file')===0 && urlParsingNode.pathname.indexOf(':')===2)?
+      urlParsingNode.pathname.substring(3) : (urlParsingNode.pathname.charAt(0) === '/' ?
+        urlParsingNode.pathname : '/' + urlParsingNode.pathname)
   };
 }
 

--- a/src/ng/urlUtils.js
+++ b/src/ng/urlUtils.js
@@ -81,7 +81,8 @@ function urlResolve(url) {
     hash: urlParsingNode.hash ? urlParsingNode.hash.replace(/^#/, '') : '',
     hostname: urlParsingNode.hostname,
     port: urlParsingNode.port,
-    pathname: urlParsingNode.pathname && urlParsingNode.pathname.charAt(0) === '/' ?
+    pathname: (urlParsingNode.protocol.indexOf('file')===0 && urlParsingNode.pathname.indexOf('\:')===2)?
+      urlParsingNode.pathname.substring(3) : urlParsingNode.pathname.charAt(0) === '/' ? 
         urlParsingNode.pathname : '/' + urlParsingNode.pathname
   };
 }


### PR DESCRIPTION
fix(location,route): Breaks with file:// protocol in Chrome

FF and IE implementations considere the drive letter as "host" and remove it from pathname
CHROME implementation let it as part of the pathname
We should remove the drive letter from the pathname to let routing work.

Closes #4680 
