### PR TITLE
fix(loader): don't rely on functions defined in Angular.js

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -66,6 +66,7 @@ angularFiles = {
   ],
 
   'angularLoader': [
+    'src/minErr.js',
     'src/loader.js'
   ],
 

--- a/src/loader.js
+++ b/src/loader.js
@@ -10,13 +10,14 @@
 
 function setupModuleLoader(window) {
 
-  var $injectorMinErr = minErr('$injector');
-
   function ensure(obj, name, factory) {
     return obj[name] || (obj[name] = factory());
   }
 
-  return ensure(ensure(window, 'angular', Object), 'module', function() {
+  var angular = ensure(window, 'angular', Object);
+  angular.$$minErr = angular.$$minErr || minErr;
+
+  return ensure(angular, 'module', function() {
     /** @type {Object.<string, angular.Module>} */
     var modules = {};
 
@@ -71,6 +72,14 @@ function setupModuleLoader(window) {
      * @returns {module} new module with the {@link angular.Module} api.
      */
     return function module(name, requires, configFn) {
+      var $injectorMinErr = minErr('$injector');
+      var ngMinErr = minErr('ng');
+      var assertNotHasOwnProperty = function(name, context) {
+        if (name === 'hasOwnProperty') {
+          throw ngMinErr('badname', "hasOwnProperty is not a valid {0} name", context);
+        }
+      };
+      
       assertNotHasOwnProperty(name, 'module');
       if (requires && modules.hasOwnProperty(name)) {
         modules[name] = null;
@@ -294,3 +303,5 @@ function setupModuleLoader(window) {
   });
 
 }
+
+setupModuleLoader(window);

--- a/src/loader.prefix
+++ b/src/loader.prefix
@@ -4,4 +4,4 @@
  * License: MIT
  */
 'use strict';
-(
+(function(window) {

--- a/src/loader.suffix
+++ b/src/loader.suffix
@@ -1,4 +1,4 @@
-)(window);
+})(window);
 
 /**
  * Closure compiler type information


### PR DESCRIPTION
The loader had not been tested since minErr had been implemented so was breaking the phonecat tutorial application.  Moreover I had added a call to `assertNotHasOwnProperty`, not understanding that loader does not get access to Angular.js functions.

The loader now has its own copies of minErr (via AngularFiles.js) and `assertNotHasOwnProperty`.
