### PR TITLE
feat(sce): trust resourceUrls where url is in a $cache

### DIFF
--- a/test/ng/sceSpecs.js
+++ b/test/ng/sceSpecs.js
@@ -302,6 +302,40 @@ describe('SCE', function() {
           /[^[]*\[\$sce:imatcher\] Matchers may only be "self", string patterns or RegExp objects/.source));
     });
 
+    it('should accept $templateCache-stored resourceUrls when passed `true`', inject(function($templateCache, $sce, $rootScope) {
+      $rootScope.template = 'test.tpl';
+      $templateCache.put('test.tpl', '<div>This is trusted because I put it here myself.</div>');
+      expect($sce.getTrustedResourceUrl('test.tpl', true)).toEqual('test.tpl');
+      expect($sce.parseAsResourceUrl("template", true)($rootScope)).toEqual('test.tpl');
+    }));
+
+    it('should reject $templateCache-stored resourceUrls by default', inject(function($templateCache, $sce, $rootScope) {
+      $rootScope.template = 'http://not-my-house.com/test.tpl';
+      $templateCache.put('http://not-my-house.com/test.tpl', '<div>This is trusted because I put it here myself.</div>');
+      expect(function() { $sce.getTrustedResourceUrl('http://not-my-house.com/test.tpl'); }).toThrowMinErr(
+        '$sce', 'insecurl', 'Blocked loading resource from url not allowed by $sceDelegate policy.  URL: http://not-my-house.com/test.tpl');
+      expect(function() { $sce.parseAsResourceUrl("template")($rootScope); }).toThrowMinErr(
+        '$sce', 'insecurl', 'Blocked loading resource from url not allowed by $sceDelegate policy.  URL: http://not-my-house.com/test.tpl');
+    }));
+
+    it('should accept cache-stored resourceUrls when passed cache name', inject(function($cacheFactory, $sce, $rootScope) {
+      var $templateCache = $cacheFactory('resourceUrls');
+      $rootScope.template = 'test.tpl';
+      $templateCache.put('test.tpl', '<div>This is trusted because I put it here myself.</div>');
+      expect($sce.getTrustedResourceUrl('test.tpl', 'resourceUrls')).toEqual('test.tpl');
+      expect($sce.parseAsResourceUrl("template", 'resourceUrls')($rootScope)).toEqual('test.tpl');
+    }));
+
+    it('should reject cache-stored resourceUrls by default', inject(function($cacheFactory, $sce, $rootScope) {
+      var $templateCache = $cacheFactory('resourceUrls');
+      $rootScope.template = 'http://not-my-house.com/test.tpl';
+      $templateCache.put('http://not-my-house.com/test.tpl', '<div>This is trusted because I put it here myself.</div>');
+      expect(function() { $sce.getTrustedResourceUrl('http://not-my-house.com/test.tpl'); }).toThrowMinErr(
+        '$sce', 'insecurl', 'Blocked loading resource from url not allowed by $sceDelegate policy.  URL: http://not-my-house.com/test.tpl');
+      expect(function() { $sce.parseAsResourceUrl("template")($rootScope); }).toThrowMinErr(
+        '$sce', 'insecurl', 'Blocked loading resource from url not allowed by $sceDelegate policy.  URL: http://not-my-house.com/test.tpl');
+    }));
+
     describe('adjustMatcher', function() {
       it('should rewrite regex into regex and add ^ & $ on either end', function() {
         expect(adjustMatcher(/a.*b/).exec('a.b')).not.toBeNull();


### PR DESCRIPTION
Enables sce.getTrustedResourceUrl and sce.parseAsResourceUrl to optionally look up urls in a $cacheFactory-generated cache, primarily the $templateCache.

I'd like to discuss a few things here:
1. Are things in $cacheFactory caches really trusted? In my mind, they should be. But there may be things I'm missing.
2. How useful would this be for non-template resources? Would it be possible to make it more useful?
3. Is there something I'm missing where perhaps this isn't actually necessary at all? It seemed to be an issue on [plnkr.co](http://plnkr.co/edit/XEtC9UILh7vJ7R4LKrnU?p=preview), although I haven't tested it outside of here just yet.

If it gets merged, it would be a simple thing to modify ng-include and other similar $sce-using core directives to work with it. Or perhaps it might make more sense to enable this as the default behaviour. I'm interested in finding out.
