### PR TITLE
Missing closing parentheses in $q code example

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -165,7 +165,7 @@
  *      // Propagate promise resolution to 'then' functions using $apply().
  *      $rootScope.$apply();
  *      expect(resolvedValue).toEqual(123);
- *    });
+ *    }));
  *  </pre>
  */
 function $QProvider() {


### PR DESCRIPTION
The $q documentation page is missing a closing parentheses in the it "should simulate a promise" code example.
