### PR TITLE
fix($rootScope): clear phase if an exception is raised by a watcher

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -562,6 +562,7 @@ function $RootScopeProvider(){
               asyncTask = asyncQueue.shift();
               asyncTask.scope.$eval(asyncTask.expression);
             } catch (e) {
+              clearPhase();
               $exceptionHandler(e);
             }
           }
@@ -594,6 +595,7 @@ function $RootScopeProvider(){
                     }
                   }
                 } catch (e) {
+                  clearPhase();
                   $exceptionHandler(e);
                 }
               }

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -127,6 +127,15 @@ describe('Scope', function() {
       });
     });
 
+    it('should clear phase if an exception interrupt $digest cycle', function() {
+      inject(function($rootScope) {
+        $rootScope.$watch('a', function() {throw new Error('abc');});
+        $rootScope.a = 1;
+        try { $rootScope.$digest(); } catch(e) { }
+        expect($rootScope.$$phase).toBeNull();
+      });
+    });
+
 
     it('should fire watches in order of addition', inject(function($rootScope) {
       // this is not an external guarantee, just our own sanity


### PR DESCRIPTION
Add calls to clearPhase() when an exception is raised by a watcher
while a digest cycle, in order to not be stuck on `$digest` scope phase
