### PR TITLE
script.onreadystatechange Does not exist in IE11

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -135,7 +135,7 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument,
     script.type = 'text/javascript';
     script.src = url;
 
-    if (msie) {
+    if (msie && script.onreadystatechange) {
       script.onreadystatechange = function() {
         if (/loaded|complete/.test(script.readyState)) doneWrapper();
       };


### PR DESCRIPTION
In order for Jsonp to work correctly in IE11 this is needed.
