### PR TITLE
docs(ngModel): describe $viewChangeListeners property

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -840,6 +840,10 @@ var VALID_CLASS = 'ng-valid',
  *      }
  *      ngModel.$formatters.push(formatter);
  *      </pre>
+ * @property {Array.<Function>} $viewChangeListeners Array of functions to execute, as a pipeline,
+ *     whenever the view value has changed. It is called with no arguments, and its return value
+ *     is ignored. This can be used in place of additional $watches against the model value.
+ *
  * @property {Object} $error An object hash with all errors as keys.
  *
  * @property {boolean} $pristine True if user has not interacted with the control yet.


### PR DESCRIPTION
**Justification:**

I'm not sure if this is intended to be a private property or not, but
I think it might be a good idea to mention it in the docs, so that
people are aware of alternatives to adding redundant scope $watch functions.

---

At any rate, clarifying its public/private-ness would be a good thing to do,
as well as providing some warnings about ways it could be mistakenly abused.
