### PR TITLE
Make the default log behavior really not logging debug message

### DIFF
--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -11,7 +11,7 @@
  * 
  * The main purpose of this service is to simplify debugging and troubleshooting.
  *
- * The default is not to log `debug` messages. You can use
+ * The default is not to `debug` messages. You can use
  * {@link ng.$logProvider ng.$logProvider#debugEnabled} to change this.
  *
  * @example


### PR DESCRIPTION
~~I think the [documented](https://github.com/angular/angular.js/blob/v1.2.0/src/ng/log.js#L14) behavior makes more sense, so it should be respected.~~

We keep the behavior to avoid BC, I am just updating the doc.
