### PR TITLE
fix(ngAnimate): use a fallback CSS property that doesn't break existing styles

### DIFF
--- a/css/angular.css
+++ b/css/angular.css
@@ -15,8 +15,8 @@ ng\:form {
  * when the active class isn't set, or if the active class doesn't
  * contain any styles to transition to, then, if ngAnimate is used,
  * it will appear as if the webpage is broken due to the forever hanging
- * animations. The clip (!ie) and zoom (ie) CSS properties are used
- * since they trigger a transition without making the browser
+ * animations. The border-spacing (!ie) and zoom (ie) CSS properties are
+ * used below since they trigger a transition without making the browser
  * animate anything and they're both highly underused CSS properties */
-.ng-animate-start { clip:rect(0, auto, auto, 0); -ms-zoom:1.0001; }
-.ng-animate-active { clip:rect(-1px, auto, auto, 0); -ms-zoom:1; }
+.ng-animate-start { border-spacing:1px 1px; -ms-zoom:1.0001; }
+.ng-animate-active { border-spacing:0px 0px; -ms-zoom:1; }

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -1012,7 +1012,7 @@ angular.module('ngAnimate', ['ng'])
           var propertyStyle = timings.transitionPropertyStyle;
           if(propertyStyle.indexOf('all') == -1) {
             applyFallbackStyle = true;
-            var fallbackProperty = $sniffer.msie ? '-ms-zoom' : 'clip';
+            var fallbackProperty = $sniffer.msie ? '-ms-zoom' : 'border-spacing';
             style += CSS_PREFIX + 'transition-property: ' + propertyStyle + ', ' + fallbackProperty + '; ';
             style += CSS_PREFIX + 'transition-duration: ' + timings.transitionDurationStyle + ', ' + timings.transitionDuration + 's; ';
           }

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -823,7 +823,7 @@ describe("ngAnimate", function() {
           $timeout.flush();
 
           //IE removes the -ms- prefix when placed on the style
-          var fallbackProperty = $sniffer.msie ? 'zoom' : 'clip';
+          var fallbackProperty = $sniffer.msie ? 'zoom' : 'border-spacing';
           var regExp = new RegExp("transition-property:\\s+color\\s*,\\s*" + fallbackProperty + "\\s*;");
           expect(child2.attr('style') || '').toMatch(regExp);
           expect(child2.hasClass('ng-animate')).toBe(true);


### PR DESCRIPTION
The clip property seems to remove the box-shadow property when an absolute
positioned animation is ongoing. This fix changes the property to be border-spacing
which is also very underused. The border-spacing CSS property is only visible
when border-collapse is set to separate.

Closes #4902
