### PR TITLE
docs(tutorial): minimum required node.js version is 0.10 (Windows too)

### DIFF
--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -85,7 +85,7 @@ to run <code>scripts/web-server.js</code>,  a simple bundled http server.</p></l
   <div class="tab-pane well" id="git-win" title="Git on Windows">
     <ol>
       <li><p>You will need Node.js and Karma to run unit tests, so please verify that you have
-        <a href="http://nodejs.org/">Node.js</a> v0.8 or better installed
+        <a href="http://nodejs.org/">Node.js</a> v0.10 or better installed
         and that the <code>node</code> executable is on your <code>PATH</code> by running the following
         command in a terminal window:</p>
         <pre>node --version</pre>


### PR DESCRIPTION
The doc has been modified by the following commit: https://github.com/angular/angular.js/commit/bcc6e8d4f64a18039e0ed2eee0b54c17471b43e3
But the change was not made ​​for the part of Windows.
