### PR TITLE
Clear out {{braces text}} when compiling an interpolated text node

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1072,7 +1072,7 @@ function $CompileProvider($provide) {
             scope.$watch(interpolateFn, function interpolateFnWatchAction(value) {
               node[0].nodeValue = value;
             });
-            node[0].nodeValue = '';
+            node[0].nodeValue = interpolateFn();
           })
         });
       }

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1072,6 +1072,7 @@ function $CompileProvider($provide) {
             scope.$watch(interpolateFn, function interpolateFnWatchAction(value) {
               node[0].nodeValue = value;
             });
+            node[0].nodeValue = '';
           })
         });
       }


### PR DESCRIPTION
After setting up the ng-binding directive, clear out the old text content from a curly-braces text interpolation, to avoid momentarily (or longer, as observed in IE and mobile safari) visibly rendering the curly braces on the page.
