### PR TITLE
Ngrepeat multiline

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -203,7 +203,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
     $$tlb: true,
     link: function($scope, $element, $attr, ctrl, $transclude){
         var expression = $attr.ngRepeat;
-        var match = expression.match(/^\s*(.+)\s+in\s+((?:[\r\n]*.*)*?)\s*(\s+track\s+by\s+(.+)\s*)?$/),
+        var match = expression.match(/^\s*(.+)\s+in\s+([\r\n\s\S]*?)\s*(\s+track\s+by\s+(.+)\s*)?$/),
           trackByExp, trackByExpGetter, trackByIdExpFn, trackByIdArrayFn, trackByIdObjFn,
           lhs, rhs, valueIdentifier, keyIdentifier,
           hashFnLocals = {$id: hashKey};

--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -203,7 +203,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
     $$tlb: true,
     link: function($scope, $element, $attr, ctrl, $transclude){
         var expression = $attr.ngRepeat;
-        var match = expression.match(/^\s*(.+)\s+in\s+(.*?)\s*(\s+track\s+by\s+(.+)\s*)?$/),
+        var match = expression.match(/^\s*(.+)\s+in\s+((?:[\r\n]*.*)*?)\s*(\s+track\s+by\s+(.+)\s*)?$/),
           trackByExp, trackByExpGetter, trackByIdExpFn, trackByIdArrayFn, trackByIdObjFn,
           lhs, rhs, valueIdentifier, keyIdentifier,
           hashFnLocals = {$id: hashKey};

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -177,6 +177,22 @@ describe('ngRepeat', function() {
     });
 
 
+    it('should allow expressions over multiple lines', function() {
+      scope.isTrue = function() {
+        return true;
+      };
+      element = $compile(
+          '<ul>' +
+            '<li ng-repeat="item in items\n' +
+            '| filter:isTrue">{{item.name}}</li>' +
+          '</ul>')(scope);
+      scope.items = [{name: 'igor'}];
+      scope.$digest();
+
+      expect(element.find('li').text()).toBe('igor');
+    });
+
+
     it('should track using provided function when a filter is present', function() {
       scope.newArray = function (items) {
         var newArray = [];


### PR DESCRIPTION
allow new line characters in the expression. This allows cleaner writing in the templates - for instance:

```
<div ng-repeat="item in myItems
    | filter: searchString
    | orderBy: 'name'
    track by 'id'">
```
