### PR TITLE
$http cache returning a promise

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -290,8 +290,9 @@ function $HttpProvider() {
      * with the lowercased HTTP method name as the key, e.g.
      * `$httpProvider.defaults.headers.get = { 'My-Header' : 'value' }.
      *
-     * Additionally, the defaults can be set at runtime via the `$http.defaults` object in the same
-     * fashion.
+     * The defaults can also be set at runtime via the `$http.defaults` object in the same
+     * fashion. Alternatively, supplying a `headers` object with a map of header names to their values 
+     * will override the defaults without changing them globally.
      *
      *
      * # Transforming Requests and Responses

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -947,6 +947,21 @@ function $HttpProvider() {
           if (cachedResp.then) {
             // cached request has already been sent, but there is no response yet
             cachedResp.then(removePendingReq, removePendingReq);
+            // Wait for cache promise to resolve
+            cachedResp.then(function(value){
+              if(isDefined(value)){
+                if (isArray(value)) {
+                  resolvePromise(value[1], value[0], copy(value[2]));
+                } else {
+                  resolvePromise(value, 200, {});
+                }
+              // Value not in cache
+              } else {
+                $httpBackend(config.method, url, reqData, done, reqHeaders,
+                    config.timeout, config.withCredentials, config.responseType);
+              }
+            });
+
             return cachedResp;
           } else {
             // serving from cache

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1261,6 +1261,28 @@ describe('$http', function() {
         expect(callback).toHaveBeenCalled();
       });
 
+      it('should allow cache to return a promise', inject(function($q, $timeout) {
+        // Use a mock async cache factory
+        cache = {
+          get: function(key){
+            var deferred = $q.defer();    
+            $timeout(function(){
+              deferred.resolve('123');
+            }, 1);
+            return deferred.promise;
+          },
+          put: function(key){}
+        };
+        cache.put('/abc', '');
+
+        $http({method: 'GET', url: '/abc', cache: cache}).success(function (response, status, headers) {
+          expect(response).toBe('');
+          expect(status).toBe(200);
+          callback();
+          expect(callback).toHaveBeenCalled();
+        });
+        $rootScope.$digest();
+      }));
 
       it('should default to status code 200 and empty headers if cache contains a non-array element',
           inject(function($rootScope) {


### PR DESCRIPTION
First stab at adding support for cache factories that return promises. The motivation for this was adding support for using IndexedDB as a backend of the cache factory when most operations on it are asynchronous and must therefore return promises.

I'm not completely happy with the duplication of code in the callback. Also, the mocking of the cache factory may not be the best practice. Feedback appreciated ).
