### PR TITLE
fix($http): allow sending Blob data using $http

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -64,6 +64,7 @@
     "isWindow": false,
     "isScope": false,
     "isFile": false,
+    "isBlob": false,
     "isBoolean": false,
     "trim": false,
     "isElement": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -45,6 +45,7 @@
     -isWindow,
     -isScope,
     -isFile,
+    -isBlob,
     -isBoolean,
     -trim,
     -isElement,
@@ -563,6 +564,11 @@ function isScope(obj) {
 
 function isFile(obj) {
   return toString.call(obj) === '[object File]';
+}
+
+
+function isBlob(obj) {
+  return toString.call(obj) === '[object Blob]';
 }
 
 

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -103,7 +103,7 @@ function $HttpProvider() {
 
     // transform outgoing request data
     transformRequest: [function(d) {
-      return isObject(d) && !isFile(d) ? toJson(d) : d;
+      return isObject(d) && !isFile(d) && !isBlob(d) ? toJson(d) : d;
     }],
 
     // default headers

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -989,6 +989,16 @@ describe('$http', function() {
         });
 
 
+        it('should ignore Blob objects', function () {
+          if (!window.Blob) return;
+
+          var blob = new Blob(['blob!'], { type: 'text/plain' });
+
+          $httpBackend.expect('POST', '/url', '[object Blob]').respond('');
+          $http({ method: 'POST', url: '/url', data: blob });
+        });
+
+
         it('should have access to request headers', function() {
           $httpBackend.expect('POST', '/url', 'header1').respond(200);
           $http.post('/url', 'req', {


### PR DESCRIPTION
Current workaround is to set $http config.transformRequest property to `null`.
