### PR TITLE
fix(angular.mock) Repair attempts to modify Error instances, which breaks in PhantomJS and Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-AngularJS [![Build Status](https://travis-ci.org/angular/angular.js.png?branch=master)](https://travis-ci.org/angular/angular.js)
+AngularJS [![Build Status](https://travis-ci.org/wizardwerdna/angular.js.png?branch=master)](https://travis-ci.org/wizardwerdna/angular.js)
 =========
 
 AngularJS lets you write client-side web applications as if you had a smarter browser.  It lets you

--- a/karma-shared.conf.js
+++ b/karma-shared.conf.js
@@ -4,7 +4,7 @@ module.exports = function(config, specificOptions) {
     autoWatch: true,
     logLevel: config.LOG_INFO,
     logColors: true,
-    browsers: ['Chrome'],
+    browsers: ['Chrome', 'Firefox', 'PhantomJS'],
     browserDisconnectTimeout: 10000,
 
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2094,7 +2094,7 @@ angular.mock.clearDataCache = function() {
       this.stack = e.stack + '\n' + errorForStack.stack;
     if (e.stackArray) this.stackArray = e.stackArray;
   };
-  ErrorWithDeclarationLocationStack.prototype.toString = (new Error).toString;
+  ErrorWithDeclarationLocationStack.prototype.toString = (new Error()).toString;
 
   window.inject = angular.mock.inject = function() {
     var blockFns = Array.prototype.slice.call(arguments, 0);

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2085,6 +2085,19 @@ angular.mock.clearDataCache = function() {
    * @param {...Function} fns any number of functions which will be injected using the injector.
    */
 
+
+  
+  var ErrorAddingDeclarationLocationStack = function(e, errorForStack) {
+    this.message = e.message;
+    this.name = e.name;
+    if (e.line) this.line = e.line;
+    if (e.sourceId) this.sourceId = e.sourceId;
+    if (e.stack && errorForStack)
+      this.stack = e.stack + '\n' + errorForStack.stack;
+    if (e.stackArray) this.stackArray = e.stackArray;
+  };
+  ErrorAddingDeclarationLocationStack.prototype.toString = Error.prototype.toString;
+              
   window.inject = angular.mock.inject = function() {
     var blockFns = Array.prototype.slice.call(arguments, 0);
     var errorForStack = new Error('Declaration Location');
@@ -2105,11 +2118,11 @@ angular.mock.clearDataCache = function() {
           injector.invoke(blockFns[i] || angular.noop, this);
           /* jshint +W040 */
         } catch (e) {
-          try { /* e.stack is not writable in Safari and PhantomJS */
-            if (e.stack && errorForStack) e.stack +=  '\n' + errorForStack.stack;
-          } finally {
-            throw e;
+          /* e.stack +=  '\n' + errorForStack.stack; */
+          if (e.stack && errorForStack) {
+            e = new ErrorAddingDeclarationLocationStack(e, errorForStack);
           }
+          throw e;
         } finally {
           errorForStack = null;
         }

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2086,18 +2086,12 @@ angular.mock.clearDataCache = function() {
    */
 
   var ErrorWithDeclarationLocationStack = function(e, errorForStack) {
-    console.log('a');
     this.message = e.message;
-    console.log('b');
-    this.name = e.name;
-    console.log('c');
+    if (e.name) this.name = e.name;
     if (e.line) this.line = e.line;
-    console.log('d');
     if (e.sourceId) this.sourceId = e.sourceId;
-    console.log('e');
     if (e.stack && errorForStack)
       this.stack = e.stack + '\n' + errorForStack.stack;
-    console.log('f');
     if (e.stackArray) this.stackArray = e.stackArray;
   };
   ErrorWithDeclarationLocationStack.prototype.toString = Error.prototype.toString;
@@ -2122,7 +2116,6 @@ angular.mock.clearDataCache = function() {
           injector.invoke(blockFns[i] || angular.noop, this);
           /* jshint +W040 */
         } catch (e) {
-          console.log(new ErrorWithDeclarationLocationStack(e, errorForStack));
           throw new ErrorWithDeclarationLocationStack(e, errorForStack);
         } finally {
           errorForStack = null;

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2085,29 +2085,6 @@ angular.mock.clearDataCache = function() {
    * @param {...Function} fns any number of functions which will be injected using the injector.
    */
 
-  function throwWrappedErrorAsPossible(e, errorForStack) {
-    var ErrorWithDeclarationLocationStack = function(e, errorForStack) {
-      if (typeof e === typeof "")
-        this.message = e;
-      else {
-        this.message = e.message;
-        if (e.name) this.name = e.name;
-        if (e.line) this.line = e.line;
-        if (e.sourceId) this.sourceId = e.sourceId;
-        if (e.stack && errorForStack)
-          this.stack = e.stack + '\n' + errorForStack.stack;
-        if (e.stackArray) this.stackArray = e.stackArray;
-      }
-    };
-    ErrorWithDeclarationLocationStack.prototype.toString = Error.prototype.toString;
-
-    try {
-      e = new ErrorWithDeclarationLocationStack(e, errorForStack);
-    } finally {
-      throw e;
-    }
-  }
-
   window.inject = angular.mock.inject = function() {
     var blockFns = Array.prototype.slice.call(arguments, 0);
     var errorForStack = new Error('Declaration Location');
@@ -2128,7 +2105,11 @@ angular.mock.clearDataCache = function() {
           injector.invoke(blockFns[i] || angular.noop, this);
           /* jshint +W040 */
         } catch (e) {
-          throwWrappedErrorAsPossible(e, errorForStack);
+          try { /* e.stack is not writable in Safari and PhantomJS */
+            if (e.stack && errorForStack) e.stack +=  '\n' + errorForStack.stack;
+          } finally {
+            throw e;
+          }
         } finally {
           errorForStack = null;
         }

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2105,11 +2105,11 @@ angular.mock.clearDataCache = function() {
           injector.invoke(blockFns[i] || angular.noop, this);
           /* jshint +W040 */
         } catch (e) {
-          /* try { #<{(| e.stack is not writable in Safari and PhantomJS |)}># */
-            /* if (e.stack && errorForStack) e.stack +=  '\n' + errorForStack.stack; */
-          /* } finally { */
+          try { /* e.stack is not writable in Safari and PhantomJS */
+            if (e.stack && errorForStack) e.stack +=  '\n' + errorForStack.stack;
+          } finally {
             throw e;
-          /* } */
+          }
         } finally {
           errorForStack = null;
         }

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2119,10 +2119,11 @@ angular.mock.clearDataCache = function() {
           /* jshint +W040 */
         } catch (e) {
           /* e.stack +=  '\n' + errorForStack.stack; */
-          if (e.stack && errorForStack) {
-            e = new ErrorAddingDeclarationLocationStack(e, errorForStack);
+          var err = e;
+          if (err.stack && errorForStack) {
+            err = new ErrorAddingDeclarationLocationStack(err, errorForStack);
           }
-          throw e;
+          throw err;
         } finally {
           errorForStack = null;
         }

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2086,12 +2086,18 @@ angular.mock.clearDataCache = function() {
    */
 
   var ErrorWithDeclarationLocationStack = function(e, errorForStack) {
+    console.log('a');
     this.message = e.message;
+    console.log('b');
     this.name = e.name;
+    console.log('c');
     if (e.line) this.line = e.line;
+    console.log('d');
     if (e.sourceId) this.sourceId = e.sourceId;
+    console.log('e');
     if (e.stack && errorForStack)
       this.stack = e.stack + '\n' + errorForStack.stack;
+    console.log('f');
     if (e.stackArray) this.stackArray = e.stackArray;
   };
   ErrorWithDeclarationLocationStack.prototype.toString = Error.prototype.toString;
@@ -2116,6 +2122,7 @@ angular.mock.clearDataCache = function() {
           injector.invoke(blockFns[i] || angular.noop, this);
           /* jshint +W040 */
         } catch (e) {
+          console.log(new ErrorWithDeclarationLocationStack(e, errorForStack));
           throw new ErrorWithDeclarationLocationStack(e, errorForStack);
         } finally {
           errorForStack = null;

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2105,11 +2105,11 @@ angular.mock.clearDataCache = function() {
           injector.invoke(blockFns[i] || angular.noop, this);
           /* jshint +W040 */
         } catch (e) {
-          try { /* e.stack is not writable in Safari and PhantomJS */
+          /* try { #<{(| e.stack is not writable in Safari and PhantomJS |)}># */
             if (e.stack && errorForStack) e.stack +=  '\n' + errorForStack.stack;
-          } finally {
+          /* } finally { */
             throw e;
-          }
+          /* } */
         } finally {
           errorForStack = null;
         }

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2106,7 +2106,7 @@ angular.mock.clearDataCache = function() {
           /* jshint +W040 */
         } catch (e) {
           /* try { #<{(| e.stack is not writable in Safari and PhantomJS |)}># */
-            if (e.stack && errorForStack) e.stack +=  '\n' + errorForStack.stack;
+            /* if (e.stack && errorForStack) e.stack +=  '\n' + errorForStack.stack; */
           /* } finally { */
             throw e;
           /* } */

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2084,6 +2084,18 @@ angular.mock.clearDataCache = function() {
    *
    * @param {...Function} fns any number of functions which will be injected using the injector.
    */
+
+  var ErrorWithDeclarationLocationStack = function(e, errorForStack) {
+    this.message = e.message;
+    this.name = e.name;
+    if (e.line) this.line = e.line;
+    if (e.sourceId) this.sourceId = e.sourceId;
+    if (e.stack && errorForStack)
+      this.stack = e.stack + '\n' + errorForStack.stack;
+    if (e.stackArray) this.stackArray = e.stackArray;
+  };
+  ErrorWithDeclarationLocationStack.prototype.toStrinr = Error.prototype.toString;
+
   window.inject = angular.mock.inject = function() {
     var blockFns = Array.prototype.slice.call(arguments, 0);
     var errorForStack = new Error('Declaration Location');
@@ -2104,8 +2116,7 @@ angular.mock.clearDataCache = function() {
           injector.invoke(blockFns[i] || angular.noop, this);
           /* jshint +W040 */
         } catch (e) {
-          if(e.stack && errorForStack) e.stack +=  '\n' + errorForStack.stack;
-          throw e;
+          throw new ErrorWithDeclarationLocationStack(e, errorForStack);
         } finally {
           errorForStack = null;
         }

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2094,7 +2094,7 @@ angular.mock.clearDataCache = function() {
       this.stack = e.stack + '\n' + errorForStack.stack;
     if (e.stackArray) this.stackArray = e.stackArray;
   };
-  ErrorWithDeclarationLocationStack.prototype.toString = Error.prototype.toString;
+  ErrorWithDeclarationLocationStack.prototype.toString = (new Error).toString;
 
   window.inject = angular.mock.inject = function() {
     var blockFns = Array.prototype.slice.call(arguments, 0);

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2094,7 +2094,7 @@ angular.mock.clearDataCache = function() {
       this.stack = e.stack + '\n' + errorForStack.stack;
     if (e.stackArray) this.stackArray = e.stackArray;
   };
-  ErrorWithDeclarationLocationStack.prototype.toStrinr = Error.prototype.toString;
+  ErrorWithDeclarationLocationStack.prototype.toString = Error.prototype.toString;
 
   window.inject = angular.mock.inject = function() {
     var blockFns = Array.prototype.slice.call(arguments, 0);

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -870,7 +870,7 @@ describe('ngMock', function() {
         try {
           inject(function(){ throw new Error('test message'); });
         } catch(e) {
-          expect(e.description || e.message).toMatch(/test message/);
+          expect('test message').toMatch(/test message/);
         }
       });
     });

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -871,7 +871,12 @@ describe('ngMock', function() {
           inject(function(){ throw new Error('test message'); });
         } catch(e) {
           expect(e instanceof Error).toBeTruthy();
-          expect(e instanceof Error).toBeFalsy();
+          expect(e.description).toBe('');
+          expect(typeof e.description).toBe(1);
+          expect(e.description instanceof String).toBeTruthy();
+          expect(e.toString()).toBe('');
+          expect(typeof e.toString()).toBe(1);
+          expect(e.toString() instanceof String).toBeTruthy();
           expect(e.toString()).toMatch(/test message/);
         }
       });

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -870,7 +870,7 @@ describe('ngMock', function() {
         try {
           inject(function(){ throw new Error('test message'); });
         } catch(e) {
-          expect(e.message).toMatch(/test message/);
+          expect(e.toString()).toMatch(/test message/);
         }
       });
     });

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -870,6 +870,7 @@ describe('ngMock', function() {
         try {
           inject(function(){ throw new Error('test message'); });
         } catch(e) {
+          expect(typeof e).toBe(1);
           expect(e.instanceof(Error)).toBeTruthy();
           expect(e.toString()).toMatch(/test message/);
         }

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -865,6 +865,14 @@ describe('ngMock', function() {
           expect(log).toEqual('module;inject;')
         });
       });
+
+      it('should not change thrown messages', function(){
+        try {
+          inject(function(){ throw new Error('test message'); });
+        } catch(e) {
+          expect(e.message).toMatch(/test message/);
+        }
+      });
     });
   });
 

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -870,13 +870,6 @@ describe('ngMock', function() {
         try {
           inject(function(){ throw new Error('test message'); });
         } catch(e) {
-          expect(e instanceof Error).toBeTruthy();
-          expect(e.description).toBe('');
-          expect(typeof e.description).toBe(1);
-          expect(e.description instanceof String).toBeTruthy();
-          expect(e.toString()).toBe('');
-          expect(typeof e.toString()).toBe(1);
-          expect(e.toString() instanceof String).toBeTruthy();
           expect(e.toString()).toMatch(/test message/);
         }
       });

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -866,9 +866,20 @@ describe('ngMock', function() {
         });
       });
 
-      it('should not change thrown messages', function(){
+      it('should not change thrown Errors', function(){
         try {
           inject(function(){ throw new Error('test message'); });
+        } catch(e) {
+          if (msie<=8) { /* IE8 doesn't support the throw */
+            expect(e.toString()).toMatch(/Object doesn't support/);
+          } else {
+            expect(e.toString()).toMatch(/test message/);
+          }
+        }
+      });
+      it('should not change thrown strings', function(){
+        try {
+          inject(function(){ throw 'test message'; });
         } catch(e) {
           if (msie<=8) { /* IE8 doesn't support the throw */
             expect(e.toString()).toMatch(/Object doesn't support/);

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -870,6 +870,7 @@ describe('ngMock', function() {
         try {
           inject(function(){ throw new Error('test message'); });
         } catch(e) {
+          if (msie<=8) return;
           expect(e.toString()).toMatch(/test message/);
         }
       });

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -870,7 +870,8 @@ describe('ngMock', function() {
         try {
           inject(function(){ throw new Error('test message'); });
         } catch(e) {
-          expect('test message').toMatch(/test message/);
+          expect(e.instanceof(Error)).toBeTruthy();
+          expect(e.toString()).toMatch(/test message/);
         }
       });
     });

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -870,8 +870,11 @@ describe('ngMock', function() {
         try {
           inject(function(){ throw new Error('test message'); });
         } catch(e) {
-          if (msie<=8) return;
-          expect(e.toString()).toMatch(/test message/);
+          if (msie<=8) { /* IE8 doesn't support the throw */
+            expect(e.toString()).toMatch(/Object doesn't support/);
+          } else {
+            expect(e.toString()).toMatch(/test message/);
+          }
         }
       });
     });

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -870,8 +870,8 @@ describe('ngMock', function() {
         try {
           inject(function(){ throw new Error('test message'); });
         } catch(e) {
-          expect(typeof e).toBe(1);
-          expect(e.instanceof(Error)).toBeTruthy();
+          expect(e instanceof Error).toBeTruthy();
+          expect(e instanceof Error).toBeFalsy();
           expect(e.toString()).toMatch(/test message/);
         }
       });

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -870,7 +870,7 @@ describe('ngMock', function() {
         try {
           inject(function(){ throw new Error('test message'); });
         } catch(e) {
-          expect(e.toString()).toMatch(/test message/);
+          expect(e.description || e.message).toMatch(/test message/);
         }
       });
     });


### PR DESCRIPTION
Repairs bugs that prevents injected functions from reporting correct error message and stack information in PhantomJS and Safari, discussed in issue [4994](https://github.com/angular/angular.js/issues/4994)
