### PR TITLE
Independent sub FormController via `not-required` attribute

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -41,6 +41,11 @@ function FormController(element, attrs) {
       errors = form.$error = {},
       controls = [];
 
+  // do not link to parent form if not-required attr is defined
+  if (attrs.notRequired) {
+    parentForm = nullFormCtrl;
+  }
+  
   // init state
   form.$name = attrs.name || attrs.ngForm;
   form.$dirty = false;


### PR DESCRIPTION
This PR implements ability to prevent FormController from linking to parentForm if `not-required` attr is defined on the `[ng-]form` element.

It is useful for scenario like below, where `aux` subform can be independently validated without invalidating `parent` form. Without this patch (and `not-required` on the subforms), master "Save" button is disabled when aux input fields are not filled out. Idea is to use them only temporarily before adding to master model and then clears them out.

Alternatively, if subform inputs are not marked as required, then subform "Add" buttons will always be enabled. Options are either user or programmer un-friendly.

(The only workaround I found is to use `ng-if` on the subform to add it to DOM only when requested, but often we need subforms visible all the time, and we can't place them elsewhere in the DOM.)

``` html
<ngForm name="parent" ng-submit='saveModel(model)'>
  <button ng-disabled='parent.$valid'>Save</button>

  <!-- Colours -->
  Selected colours:
  <ul>
    <li ng-repeat="colour in model.colours">{{colour.name}}</li>
  </ul>

  <!-- colour selector subform -->
  <ngForm name="aux" not-required>
    <input type='text' ng-pattern='colour' required ng-model='newColour' />
    <button ng-disabled='aux.$valid' ng-click='addColour(colours, newColour); newColour=null'>Add</button>
  </ngForm>


  <!-- Fabrics -->
  Selected fabrics:
  <ul>
    <li ng-repeat="fabric in model.fabrics">{{fabric.name}}</li>
  </ul>

  <!-- fabric selector subform -->
  <ngForm name="aux" not-required>
    <select ng-options='opt in fabricOptions' required ng-model='newFabric'>
      <option value=''></option>
    </select>
    <button ng-disabled='aux.$valid' ng-click='addFabric(fabrics, newFabric); newFabric=null'>Add</button>
  </ngForm>
...
```
