### PR TITLE
fix(ngMock): don't throw readonly assignment err PhantomJS/Safari 6

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2119,7 +2119,10 @@ angular.mock.clearDataCache = function() {
           injector.invoke(blockFns[i] || angular.noop, this);
           /* jshint +W040 */
         } catch (e) {
-          if(e.stack && errorForStack) e.stack +=  '\n' + errorForStack.stack;
+          // PhantomJS and Safari 6+ will throw readonly assigment when in strict mode
+          try {
+            if(e.stack && errorForStack) e.stack +=  '\n' + errorForStack.stack;
+          } catch (e) {}
           throw e;
         } finally {
           errorForStack = null;


### PR DESCRIPTION
Due to angular-mocks being changed to run in strict mode Safari 6+ and PhantomJS will throw a read only assigment error when trying to concat to the e.stack property.

I've wrapped the assigment in a try/catch to stop the error happening.

I created a [test case](http://plnkr.co/edit/dJoXwDONCUvzU7mkpMTs?p=preview) that will show the error happening where I throw an error and it shows angular-mocks complaining.

![maclion_safari_6 0](https://f.cloud.github.com/assets/143402/1577476/279c9884-516b-11e3-8099-d670a9dd18b3.jpg)

Might need some help on writing a test for this. I was thinking adding something like the following:

``` js
it('should throw correct error message', inject(function() {
  expect(function() {
    foo();
  }).toThrow('Can\'t find variable: foo');
}));
```

So with the fix the read only assigment error won't happen and it should always throw the correct message.
