### PR TITLE
fix($httpBackend): fix HTTP PATCH requests in IE8

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -1,5 +1,15 @@
 'use strict';
 
+// We need to be able to detect IE8 so we can use the right AJAX method below
+var ie = (function(v, p, needle, undef) {
+  needle = p.getElementsByTagName('br');
+  while(
+    p.innerHTML = '<!--[if gt IE ' + (++v) + ']><br><![endif]-->',
+    needle[0]
+  );
+  return v > 4 ? v : undef;
+})(3, document.createElement('p'));
+
 var XHR = window.XMLHttpRequest || function() {
   /* global ActiveXObject */
   try { return new ActiveXObject("Msxml2.XMLHTTP.6.0"); } catch (e1) {}
@@ -7,6 +17,15 @@ var XHR = window.XMLHttpRequest || function() {
   try { return new ActiveXObject("Msxml2.XMLHTTP"); } catch (e3) {}
   throw minErr('$httpBackend')('noxhr', "This browser does not support XMLHttpRequest.");
 };
+// Fix for IE8's native XMLHttpRequest not supporting PATCH
+if (ie === 8) {
+  XHR = function (method) {
+    if (method === 'PATCH') {
+      return new ActiveXObject('Microsoft.XMLHTTP');
+    }
+    return new window.XMLHttpRequest();
+  };
+}
 
 
 /**

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -75,6 +75,15 @@ describe('$httpBackend', function() {
     expect(xhr.$$data).toBe(null);
   });
 
+  it('should use ActiveXObject for PATCH on IE8', function () {
+    xhr = new XHR('PATCH');
+    if (msie <= 8) {
+      expect(function() {xhr.toString();}).toThrow();
+    } else {
+      expect(xhr.toString()).toMatch(/\[object .+\]/);
+    }
+  });
+
   it('should normalize IE\'s 1223 status code into 204', function() {
     callback.andCallFake(function(status) {
       expect(status).toBe(204);


### PR DESCRIPTION
In Internet Explorer 8, the native XMLHttpRequest object does not allow the HTTP PATCH method. In order to accomplish a PATCH, you need to use the ActiveX object. Update the default XHR to use the ActiveX object when doing a PATCH in IE8. See the following for documentation:
- http://blogs.msdn.com/b/ieinternals/archive/2009/07/23/the-ie8-native-xmlhttprequest-object.aspx
- http://bugs.jquery.com/ticket/13240
- http://codepen.io/jeffschenck/full/yjczt (to quickly replicate the issue in IE8)

Discussed previously in #2518. I wanted to put together an example of how we could fix this, and Travis reports a green light on this branch. I'm not too familiar with the structure and internals of the project yet, though, so if you point me in the direction of how to add tests for HttpBackend (which appears to be mocked in testing) and any cleanup needed, I'm happy to work on it. 
