### PR TITLE
refactor($sce): Use $sniffer instead of $document for feature detection.

### DIFF
--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -199,8 +199,8 @@ function $SceDelegateProvider() {
     return resourceUrlBlacklist;
   };
 
-  this.$get = ['$log', '$document', '$injector', function(
-                $log,   $document,   $injector) {
+  this.$get = ['$injector', function(
+               $injector) {
 
     var htmlSanitizer = function htmlSanitizer(html) {
       throw $sceMinErr('unsafe', 'Attempting to use an unsafe value in a safe context.');
@@ -731,18 +731,15 @@ function $SceProvider() {
    * sce.js and sceSpecs.js would need to be aware of this detail.
    */
 
-  this.$get = ['$parse', '$document', '$sceDelegate', function(
-                $parse,   $document,   $sceDelegate) {
+  this.$get = ['$parse', '$sniffer', '$sceDelegate', function(
+                $parse,   $sniffer,   $sceDelegate) {
     // Prereq: Ensure that we're not running in IE8 quirks mode.  In that mode, IE allows
     // the "expression(javascript expression)" syntax which is insecure.
-    if (enabled && msie) {
-      var documentMode = $document[0].documentMode;
-      if (documentMode !== undefined && documentMode < 8) {
-        throw $sceMinErr('iequirks',
-          'Strict Contextual Escaping does not support Internet Explorer version < 9 in quirks ' +
-          'mode.  You can fix this by adding the text <!doctype html> to the top of your HTML ' +
-          'document.  See http://docs.angularjs.org/api/ng.$sce for more information.');
-      }
+    if (enabled && $sniffer.msie && $sniffer.msieDocumentMode < 8) {
+      throw $sceMinErr('iequirks',
+        'Strict Contextual Escaping does not support Internet Explorer version < 9 in quirks ' +
+        'mode.  You can fix this by adding the text <!doctype html> to the top of your HTML ' +
+        'document.  See http://docs.angularjs.org/api/ng.$sce for more information.');
     }
 
     var sce = copy(SCE_CONTEXTS);

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -22,6 +22,7 @@ function $SnifferProvider() {
           int((/android (\d+)/.exec(lowercase(($window.navigator || {}).userAgent)) || [])[1]),
         boxee = /Boxee/i.test(($window.navigator || {}).userAgent),
         document = $document[0] || {},
+        documentMode = document.documentMode,
         vendorPrefix,
         vendorRegex = /^(Moz|webkit|O|ms)(?=[A-Z])/,
         bodyStyle = document.body && document.body.style,
@@ -66,7 +67,7 @@ function $SnifferProvider() {
       // jshint +W018
       hashchange: 'onhashchange' in $window &&
                   // IE8 compatible mode lies
-                  (!document.documentMode || document.documentMode > 7),
+                  (!documentMode || documentMode > 7),
       hasEvent: function(event) {
         // IE9 implements 'input' event it's so fubared that we rather pretend that it doesn't have
         // it. In particular the event is not fired when backspace or delete key are pressed or
@@ -84,7 +85,8 @@ function $SnifferProvider() {
       vendorPrefix: vendorPrefix,
       transitions : transitions,
       animations : animations,
-      msie : msie
+      msie : msie,
+      msieDocumentMode: documentMode
     };
   }];
 }

--- a/test/ng/sceSpecs.js
+++ b/test/ng/sceSpecs.js
@@ -29,10 +29,10 @@ describe('SCE', function() {
   describe('IE8 quirks mode', function() {
     function runTest(enabled, documentMode, expectException) {
       module(function($provide) {
-        $provide.value('$document', [{
-          documentMode: documentMode,
-          createElement: function() {}
-        }]);
+        $provide.value('$sniffer', {
+          msie: documentMode,
+          msieDocumentMode: documentMode
+        });
         $provide.value('$sceDelegate', {trustAs: null, valueOf: null, getTrusted: null});
       });
 
@@ -43,22 +43,15 @@ describe('SCE', function() {
           return $injector.invoke(sceProvider.$get, sceProvider);
         }
 
-        var origMsie = $window.msie;
-        try {
-          $window.msie = true;
-          if (expectException) {
-            expect(constructSce).toThrowMinErr(
-                '$sce', 'iequirks', 'Strict Contextual Escaping does not support Internet Explorer ' +
-                'version < 9 in quirks mode.  You can fix this by adding the text <!doctype html> to ' +
-                'the top of your HTML document.  See http://docs.angularjs.org/api/ng.$sce for more ' +
-                'information.');
-          } else {
-            // no exception.
-            constructSce();
-          }
-        }
-        finally {
-          $window.msie = origMsie;
+        if (expectException) {
+          expect(constructSce).toThrowMinErr(
+            '$sce', 'iequirks', 'Strict Contextual Escaping does not support Internet Explorer ' +
+              'version < 9 in quirks mode.  You can fix this by adding the text <!doctype html> to ' +
+              'the top of your HTML document.  See http://docs.angularjs.org/api/ng.$sce for more ' +
+              'information.');
+        } else {
+          // no exception.
+          constructSce();
         }
       });
     }

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -337,4 +337,9 @@ describe('$sniffer', function() {
   it('should return true for msie when internet explorer is being used', inject(function($sniffer) {
     expect($sniffer.msie > 0).toBe(window.navigator.appName == 'Microsoft Internet Explorer');
   }));
+
+  it('should return document.documentMode as msieDocumentMode', function() {
+    var someDocumentMode = 123;
+    expect(sniffer({}, {documentMode: someDocumentMode}).msieDocumentMode).toBe(someDocumentMode);
+  });
 });


### PR DESCRIPTION
Also adds `$sniffer.msieDocumentMode` property.

Fixes #4931.
