### PR TITLE
fix(ngMock window.inject): Remove Error 'stack' property changes

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2084,6 +2084,20 @@ angular.mock.clearDataCache = function() {
    *
    * @param {...Function} fns any number of functions which will be injected using the injector.
    */
+
+
+  
+  var ErrorAddingDeclarationLocationStack = function(e, errorForStack) {
+    this.message = e.message;
+    this.name = e.name;
+    if (e.line) this.line = e.line;
+    if (e.sourceId) this.sourceId = e.sourceId;
+    if (e.stack && errorForStack)
+      this.stack = e.stack + '\n' + errorForStack.stack;
+    if (e.stackArray) this.stackArray = e.stackArray;
+  };
+  ErrorAddingDeclarationLocationStack.prototype.toString = Error.prototype.toString;
+              
   window.inject = angular.mock.inject = function() {
     var blockFns = Array.prototype.slice.call(arguments, 0);
     var errorForStack = new Error('Declaration Location');
@@ -2104,7 +2118,10 @@ angular.mock.clearDataCache = function() {
           injector.invoke(blockFns[i] || angular.noop, this);
           /* jshint +W040 */
         } catch (e) {
-          if(e.stack && errorForStack) e.stack +=  '\n' + errorForStack.stack;
+          /* e.stack +=  '\n' + errorForStack.stack; */
+          if (e.stack && errorForStack) {
+            throw new ErrorAddingDeclarationLocationStack(e, errorForStack);
+          }
           throw e;
         } finally {
           errorForStack = null;

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -865,6 +865,29 @@ describe('ngMock', function() {
           expect(log).toEqual('module;inject;')
         });
       });
+
+      it('should not change thrown Errors', function(){
+        try {
+          inject(function(){ throw new Error('test message'); });
+        } catch(e) {
+          if (msie<=8) { /* IE8 doesn't support the throw */
+            expect(e.toString()).toMatch(/Object doesn't support/);
+          } else {
+            expect(e.toString()).toMatch(/test message/);
+          }
+        }
+      });
+      it('should not change thrown strings', function(){
+        try {
+          inject(function(){ throw 'test message'; });
+        } catch(e) {
+          if (msie<=8) { /* IE8 doesn't support the throw */
+            expect(e.toString()).toMatch(/Object doesn't support/);
+          } else {
+            expect(e.toString()).toMatch(/test message/);
+          }
+        }
+      });
     });
   });
 


### PR DESCRIPTION
Recent browsers, particularly PhantomJS 1.9.2 and Safari 7.0
treat the stack property as non-configurable and unwritable.

Because window.inject captures the stack at the time of the inject,
and attempts to insert it into a captured throw from the injected
function by modifying e.stack, a meaningless error message and
stack is thrown instead.

This commit inserts two tests exposing the problem, and implements
a solution passing those tests.  The solution provides an object that
mimics the old Error object, with the additional stack information, where
possible (Error is not standardized on stack, line and file information), and
then captures the toString function from the Error object prototype.

An exception is IE8 or less, which fails to yield meaningful messages
under both the status quo and this instant commit.  Accordingly, the test
memorializes the current IE8 behavior as a passing example.

modified:   src/ngMock/angular-mocks.js
modified:   test/ngMock/angular-mocksSpec.js
