### PR TITLE
fix(loader): expose `$$minErr` to modules such as`ngResource`

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -18,6 +18,13 @@ function setupModuleLoader(window) {
   }
 
   return ensure(ensure(window, 'angular', Object), 'module', function() {
+    // We need to expose `angular.$$minErr` to modules such as `ngResource` that reference it during
+    // bootstrap
+    var angular = ensure(window, 'angular', Object);
+    angular.$$minErr = angular.$$minErr || minErr;
+   
+  return ensure(angular, 'module', function() {
+
     /** @type {Object.<string, angular.Module>} */
     var modules = {};
 
@@ -299,5 +306,5 @@ function setupModuleLoader(window) {
       });
     };
   });
-
+});
 }

--- a/test/loaderSpec.js
+++ b/test/loaderSpec.js
@@ -78,4 +78,8 @@ describe('module loader', function() {
       window.angular.module('hasOwnProperty', []);
     }).toThrowMinErr('ng','badname', "hasOwnProperty is not a valid module name");
   });
+
+  it('should expose `$$minErr` on the `angular` object', function() {
+    expect(window.angular.$$minErr).toEqual(jasmine.any(Function));
+  })
 });


### PR DESCRIPTION
This is highlighted in angular-phonecat when you try to use the index-async.html
which needs to load the ngResource module asynchronously but fails when it tries
to call `angular.$$minErr` to create the $resourceMinErr object.

This will finally solve the issues blocking https://github.com/angular/angular-phonecat/pull/90
