### PR TITLE
feat($browser): add expires to cookies() method

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -297,7 +297,7 @@ function Browser(window, document, $log, $sniffer) {
           var  rawCookie = escape(name) + '=' + escape(value) +
                             ';path=' + cookiePath;
 
-          if (expires !== undefined) { 
+          if (expires !== undefined) {
             rawCookie = rawCookie + ";expires=" + expires;
           }
 

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -297,7 +297,7 @@ function Browser(window, document, $log, $sniffer) {
           var  rawCookie = escape(name) + '=' + escape(value) +
                             ';path=' + cookiePath;
 
-          if (expires != undefined) { 
+          if (expires !== undefined) { 
             rawCookie = rawCookie + ";expires=" + expires;
           }
 

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -278,8 +278,7 @@ function Browser(window, document, $log, $sniffer) {
    * - cookies() -> hash of all cookies, this is NOT a copy of the internal state, so do not modify
    *   it
    * - cookies(name, value) -> set name to value, if value is undefined delete the cookie
-   * - cookies(name, value, expires) -> set name to value, if value is undefined delete the cookie, 
-   *   the cookie will expire in the days specified in expires 
+   * - cookies(name, value, expires) -> set name to value, and the expire date to expires
    * - cookies(name) -> the same as (name, undefined) == DELETES (no one calls it right now that
    *   way)
    * 

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -294,14 +294,13 @@ function Browser(window, document, $log, $sniffer) {
                                 ";expires=Thu, 01 Jan 1970 00:00:00 GMT";
       } else {
         if (isString(value)) {
-          var rawCookie
-          if (expires == undefined) { 
-            rawCookie = escape(name) + '=' + escape(value) +
+          var  rawCookie = escape(name) + '=' + escape(value) +
                             ';path=' + cookiePath;
-          }else{
-            rawCookie = escape(name) + '=' + escape(value) +
-                            ';path=' + cookiePath + ";expires=" + expires;
+
+          if (expires != undefined) { 
+            rawCookie = rawCookie + ";expires=" + expires;
           }
+
           cookieLength = (rawDocument.cookie = rawCookie).length + 1;
 
           // per http://www.ietf.org/rfc/rfc2109.txt browser must allow at minimum:

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -278,12 +278,14 @@ function Browser(window, document, $log, $sniffer) {
    * - cookies() -> hash of all cookies, this is NOT a copy of the internal state, so do not modify
    *   it
    * - cookies(name, value) -> set name to value, if value is undefined delete the cookie
+   * - cookies(name, value, expires) -> set name to value, if value is undefined delete the cookie, 
+   *   the cookie will expire in the days specified in expires 
    * - cookies(name) -> the same as (name, undefined) == DELETES (no one calls it right now that
    *   way)
    * 
    * @returns {Object} Hash of all cookies (if called without any parameter)
    */
-  self.cookies = function(name, value) {
+  self.cookies = function(name, value, expires ) {
     /* global escape: false, unescape: false */
     var cookieLength, cookieArray, cookie, i, index;
 
@@ -293,8 +295,15 @@ function Browser(window, document, $log, $sniffer) {
                                 ";expires=Thu, 01 Jan 1970 00:00:00 GMT";
       } else {
         if (isString(value)) {
-          cookieLength = (rawDocument.cookie = escape(name) + '=' + escape(value) +
-                                ';path=' + cookiePath).length + 1;
+          var rawCookie
+          if (expires == undefined) { 
+            rawCookie = escape(name) + '=' + escape(value) +
+                            ';path=' + cookiePath;
+          }else{
+            rawCookie = escape(name) + '=' + escape(value) +
+                            ';path=' + cookiePath + ";expires=" + expires;
+          }
+          cookieLength = (rawDocument.cookie = rawCookie).length + 1;
 
           // per http://www.ietf.org/rfc/rfc2109.txt browser must allow at minimum:
           // - 300 cookies

--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -96,7 +96,7 @@ angular.module('ngCookies', ['ng']).
         //update all cookies updated in $cookies
         for(name in cookies) {
           value = cookies[name];
-          if(value != undefined){
+          if(value !== null && value !== undefined){
             expires = value.expires;
           }
           if (!angular.isString(value)) {

--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -82,6 +82,7 @@ angular.module('ngCookies', ['ng']).
       function push() {
         var name,
             value,
+            expires,
             browserCookies,
             updated;
 
@@ -95,6 +96,9 @@ angular.module('ngCookies', ['ng']).
         //update all cookies updated in $cookies
         for(name in cookies) {
           value = cookies[name];
+          if(value != undefined){
+            expires = value.expires;
+          }
           if (!angular.isString(value)) {
             if (angular.isDefined(lastCookies[name])) {
               cookies[name] = lastCookies[name];
@@ -102,7 +106,7 @@ angular.module('ngCookies', ['ng']).
               delete cookies[name];
             }
           } else if (value !== lastCookies[name]) {
-            $browser.cookies(name, value);
+            $browser.cookies(name, value, expires);
             updated = true;
           }
         }

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -289,9 +289,8 @@ describe('browser', function() {
       });
 
       it('when expire is set to 1st jan 1970 the cookie is deleted ', function() {
-        var expireDate = "Thu, 01 Jan 1970 00:00:00 GMT";
         document.cookie = 'foo=bar;path=/';
-        browser.cookies('foo', 'bar', expireDate);
+        browser.cookies('foo', 'bar', "Thu, 01 Jan 1970 00:00:00 GMT");
         expect(document.cookie).toEqual('');
         expect(browser.cookies()).toEqual({});
       });

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -279,6 +279,25 @@ describe('browser', function() {
       });
     });
 
+    describe('put via cookies(cookieName, string, expires)', function() {
+
+      it('when expire is set to tomorrow the cookie is valid', function() {
+        var expireDate = Date.now() + 1; 
+        browser.cookies('foo', 'bar', expireDate);
+        expect(document.cookie).toMatch(/foo=bar;? ?/);
+        expect(browser.cookies()).toEqual({'foo':'bar'});
+      });
+
+      it('when expire is set to 1st jan 1970 the cookie is deleted ', function() {
+        var expireDate = "Thu, 01 Jan 1970 00:00:00 GMT";
+        document.cookie = 'foo=bar;path=/';
+        browser.cookies('foo', 'bar', expireDate);
+        expect(document.cookie).toEqual('');
+        expect(browser.cookies()).toEqual({});
+      });
+
+    });
+
     describe('put via cookies(cookieName, string), if no <base href> ', function () {
       beforeEach(function () {
         fakeDocument.basePath = undefined;


### PR DESCRIPTION
This PR add a new optional parameter to the cookies() method to allow the expire date to be explicit. Please note the test cannot check the expire date so the only way to test is to check its validity if its set in the past or in the future. If you have a better idea on how to test it I can improve it. 
