### PR TITLE
docs(faq): update compressed and minified file size

### DIFF
--- a/docs/content/misc/faq.ngdoc
+++ b/docs/content/misc/faq.ngdoc
@@ -67,7 +67,7 @@ illustration we typically build snappy apps with hundreds or thousands of active
 
 ### How big is the angular.js file that I need to include?
 
-The size of the file is < 29KB compressed and minified.
+The size of the file is < 36KB compressed and minified.
 
 
 ### Can I use the open-source Closure Library with Angular?


### PR DESCRIPTION
![gzip](https://f.cloud.github.com/assets/1016365/1587068/9fb1552c-5232-11e3-8aa4-66199b88e096.png)

currently the docs say <a href="http://docs.angularjs.org/misc/faq#faq_questions_whats-angulars-performance-like" target="_blank"> < 29KB</a>
