### PR TITLE
fix($resource): Always return a resource instance when calling class met...

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -439,7 +439,7 @@ angular.module('ngResource', ['ng']).
           }
           /* jshint +W086 */ /* (purposefully fall through case statements) */
 
-          var isInstanceCall = data instanceof Resource;
+          var isInstanceCall = this instanceof Resource;
           var value = isInstanceCall ? data : (action.isArray ? [] : new Resource(data));
           var httpConfig = {};
           var responseInterceptor = action.interceptor && action.interceptor.response ||
@@ -522,7 +522,7 @@ angular.module('ngResource', ['ng']).
           if (isFunction(params)) {
             error = success; success = params; params = {};
           }
-          var result = Resource[name](params, this, success, error);
+          var result = Resource[name].call(this, params, this, success, error);
           return result.$promise || result;
         };
       });

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -533,6 +533,18 @@ describe("resource", function() {
     expect(person.name).toEqual('misko');
   });
 
+  it('should return a resource instance when calling a class method with a resource instance', function() {
+    $httpBackend.expect('GET', '/Person/123').respond('{"name":"misko"}');
+    var Person = $resource('/Person/:id');
+    var person = Person.get({id:123});
+    $httpBackend.flush();
+    $httpBackend.expect('POST', '/Person').respond('{"name":"misko2"}');
+
+    var person2 = Person.save(person);
+    $httpBackend.flush();
+
+    expect(person2).toEqual(jasmine.any(Person));
+  });
 
   describe('promise api', function() {
 


### PR DESCRIPTION
...hods on resources.

Previously, calling `MyResource.save(myResourceInstance)`returned
a promise, in contrast to the docs for `$resource`. However,
calling `MyResource.save({name: 'Tobias"})`already correctly
returned a resource instance.

Fixes #4545.
