### PR TITLE
Add expire date to cookies

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -294,7 +294,7 @@ function Browser(window, document, $log, $sniffer) {
       } else {
         if (isString(value)) {
           cookieLength = (rawDocument.cookie = escape(name) + '=' + escape(value) +
-                                ';path=' + cookiePath).length + 1;
+                                ';path=' + cookiePath + ";expires=Tue, 01 Jan 2030 00:00:00 GMT").length + 1;
 
           // per http://www.ietf.org/rfc/rfc2109.txt browser must allow at minimum:
           // - 300 cookies


### PR DESCRIPTION
Cookies are supposed to be persistent storage so we want them to live as
long as possible.
