### PR TITLE
docs(ngShowHide): update example in description

### DIFF
--- a/src/ng/directive/ngShowHide.js
+++ b/src/ng/directive/ngShowHide.js
@@ -16,7 +16,7 @@
  * <div ng-show="myValue"></div>
  *
  * <!-- when $scope.myValue is falsy (element is hidden) -->
- * <div ng-show="myValue" class="ng-hide"></div>
+ * <div ng-hide="myValue"></div>
  * </pre>
  *
  * When the ngShow expression evaluates to false then the ng-hide CSS class is added to the class attribute


### PR DESCRIPTION
To remove or to add ng-hide class only depends on the boolean value of ngShow/ngHide property. 
So the initial state of ng-hide class does not affect the visibility.

Use ng-show and ng-hide respectively.
