### PR TITLE
feat($LogProvider): flag to allow hide/show of $log.info()/$log.log()

### DIFF
--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -44,6 +44,7 @@
  */
 function $LogProvider(){
   var debug = true,
+	  messages = true,
       self = this;
   
   /**
@@ -62,6 +63,14 @@ function $LogProvider(){
       return debug;
     }
   };
+	this.enableMessages = function(flag){
+		if(isDefined(flag)){
+			messages = flag;
+			return this;
+		}else {
+			return messages;
+		}
+	};
   
   this.$get = ['$window', function($window){
     return {
@@ -73,7 +82,15 @@ function $LogProvider(){
        * @description
        * Write a log message
        */
-      log: consoleLog('log'),
+      log : (function(){
+	      var fn = consoleLog('log');
+
+	      return function() {
+		      if (messages) {
+			      fn.apply(self, arguments);
+		      }
+	      };
+      }()),
 
       /**
        * @ngdoc method
@@ -83,7 +100,15 @@ function $LogProvider(){
        * @description
        * Write an information message
        */
-      info: consoleLog('info'),
+      info : (function(){
+	      var fn = consoleLog('info');
+
+	      return function() {
+		      if (messages) {
+			      fn.apply(self, arguments);
+		      }
+	      };
+      }()),
 
       /**
        * @ngdoc method

--- a/test/ng/logSpec.js
+++ b/test/ng/logSpec.js
@@ -1,15 +1,13 @@
 'use strict';
 
-function initService(debugEnabled) {
+function initService(debugEnabled, msgEnabled) {
     return module(function($logProvider){
       $logProvider.debugEnabled(debugEnabled);
+	  $logProvider.enableMessages(msgEnabled);
     });
   }
-
 describe('$log', function() {
   var $window, logger, log, warn, info, error, debug;
-
-
 
   beforeEach(module(function($provide){
     $window = {navigator: {}, document: {}};
@@ -139,6 +137,30 @@ describe('$log', function() {
   ));
 
   });
+
+	describe("$log.info", function () {
+
+		beforeEach(initService(false, false));
+
+		it("should skip info messages output if disabled", inject(
+			function(){
+				$window.console = {log: log,
+					warn: warn,
+					info: info,
+					error: error,
+					debug: debug};
+			},
+			function($log) {
+				$log.log();
+				$log.warn();
+				$log.info();
+				$log.error();
+				$log.debug();
+				expect(logger).toEqual('log;warn;error;');
+			}
+		));
+
+	});
 
   describe('$log.error', function() {
     var e, $log, errorArgs;


### PR DESCRIPTION
Add method to set a flag to enable/disable $log.info() and $log.log() messages.
**$logProvider.enableMessages(false|true)**
This is similar to how $logProvider.debugEnabled() works.
- I haven’t gotten the tests to pass yet, there’s an error in the logSpec saying $LogProvider undefined.  
