### PR TITLE
fix(tests): Correct tests for IE11

### DIFF
--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -596,8 +596,8 @@ describe('$compile', function() {
           expect(element).toHaveClass('class_2');
         }));
 
-        if (!msie || msie > 10) {
-          // style interpolation not working on IE<11.
+        if (!msie || msie > 11) {
+          // style interpolation not working on IE (including IE11).
           it('should handle interpolated css style from replacing directive', inject(
             function($compile, $rootScope) {
               element = $compile('<div replace-with-interpolated-style></div>')($rootScope);

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -334,8 +334,11 @@ describe('$sniffer', function() {
     });
   });
 
-  it('should return true for msie when internet explorer is being used', inject(function($sniffer) {
-    expect($sniffer.msie > 0).toBe(window.navigator.appName == 'Microsoft Internet Explorer');
+  it('should return the internal msie flag', inject(function($sniffer) {
+    expect(isNaN($sniffer.msie)).toBe(isNaN(msie));
+    if (msie) {
+      expect($sniffer.msie).toBe(msie);
+    }
   }));
 
   it('should return document.documentMode as msieDocumentMode', function() {

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1,10 +1,7 @@
 'use strict';
 
-var msie = +((/msie (\d+)/.exec(navigator.userAgent.toLowerCase()) || [])[1]);
-
 describe('ngMock', function() {
   var noop = angular.noop;
-
 
   describe('TzDate', function() {
 
@@ -686,10 +683,10 @@ describe('ngMock', function() {
       expect(d($rootScope)).toMatch(/{"abc":"123"}/);
     }));
 
-    it('should serialize scope that has overridden "hasOwnProperty"', inject(function($rootScope){
+    it('should serialize scope that has overridden "hasOwnProperty"', inject(function($rootScope, $sniffer){
       // MS IE8 just doesn't work for this kind of thing, since "for ... in" doesn't return
       // things like hasOwnProperty even if it is explicitly defined on the actual object!
-      if (msie<=8) return;
+      if ($sniffer.msie<=8) return;
       $rootScope.hasOwnProperty = 'X';
       expect(d($rootScope)).toMatch(/Scope\(.*\): \{/);
       expect(d($rootScope)).toMatch(/hasOwnProperty: "X"/);


### PR DESCRIPTION
Some tests were wrong. However, src/\* did not contain problems.

Fixes #5046
