### PR TITLE
chore(mocks): wrap angular-mocks.js in closure

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -178,7 +178,7 @@ module.exports = function(grunt) {
       },
       mocks: {
         dest: 'build/angular-mocks.js',
-        src: files['angularModules']['ngMock'],
+        src: util.wrap(files['angularModules']['ngMock'], 'module'),
         strict: false
       },
       sanitize: {

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -4,8 +4,6 @@
  * @license AngularJS v"NG_VERSION_FULL"
  * (c) 2010-2012 Google, Inc. http://angularjs.org
  * License: MIT
- *
- * TODO(vojta): wrap whole file into closure during build
  */
 
 /**


### PR DESCRIPTION
The `use strict;` that was at the top of this file was bleeding into other files and preventing the use of other test helpers that don't use strict mode. This was in a TODO so I figured it just needed to get committed :)
