### PR TITLE
Updated email regex to support 11 character TLDs

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -9,7 +9,7 @@
 */
 
 var URL_REGEXP = /^(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/;
-var EMAIL_REGEXP = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}$/;
+var EMAIL_REGEXP = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,11}$/;
 var NUMBER_REGEXP = /^\s*(\-|\+)?(\d+|(\d*(\.\d*)))\s*$/;
 
 var inputType = {


### PR DESCRIPTION
fix(ng.directive:input.text): Email validation regular expression update to support 11 character TLDs

Update EMAIL_REGEXP
- Allow for 11 character TLD's instead of the previous 6
