### PR TITLE
fix(input): email addresses can have 12 char TLDs

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -9,7 +9,7 @@
 */
 
 var URL_REGEXP = /^(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/;
-var EMAIL_REGEXP = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}$/;
+var EMAIL_REGEXP = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,12}$/;
 var NUMBER_REGEXP = /^\s*(\-|\+)?(\d+|(\d*(\.\d*)))\s*$/;
 
 var inputType = {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -294,6 +294,13 @@ describe('ngModel', function() {
     expect(element.hasClass('ng-valid-email')).toBe(true);
     expect(element.hasClass('ng-invalid-email')).toBe(false);
 
+    element.val('test@test.construction');
+    browserTrigger(element, $sniffer.hasEvent('input') ? 'input' : 'change');
+    expect(element).toBeValid();
+    expect(element).toBeDirty();
+    expect(element.hasClass('ng-valid-email')).toBe(true);
+    expect(element.hasClass('ng-invalid-email')).toBe(false);
+
     dealoc(element);
   }));
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -294,13 +294,6 @@ describe('ngModel', function() {
     expect(element.hasClass('ng-valid-email')).toBe(true);
     expect(element.hasClass('ng-invalid-email')).toBe(false);
 
-    element.val('test@test.construction');
-    browserTrigger(element, $sniffer.hasEvent('input') ? 'input' : 'change');
-    expect(element).toBeValid();
-    expect(element).toBeDirty();
-    expect(element.hasClass('ng-valid-email')).toBe(true);
-    expect(element.hasClass('ng-invalid-email')).toBe(false);
-
     dealoc(element);
   }));
 
@@ -866,7 +859,8 @@ describe('input', function() {
 
       it('should validate email', function() {
         expect(EMAIL_REGEXP.test('a@b.com')).toBe(true);
-        expect(EMAIL_REGEXP.test('a@b.museum')).toBe(true);
+        expect(EMAIL_REGEXP.test('a@b.construction')).toBe(true);
+        expect(EMAIL_REGEXP.test('a@b.longtopleveldomain')).toBe(false);
         expect(EMAIL_REGEXP.test('a@B.c')).toBe(false);
       });
     });


### PR DESCRIPTION
fix(input): email addresses can have 12 char TLDs

Update EMAIL_REGEXP variable
- Allow for 12 character TLD's instead of the previous 6
- See here for reference: http://newgtlds.icann.org//en/program-status/delegated-strings
- Longest new TLD is .CONSTRUCTION with a length of 12
