### PR TITLE
Fixed inconsistency in $location.path() behaviour on the $locationChangeStart  event when using back/forward buttons in the browser or manually changing the url in the address bar.

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -612,16 +612,17 @@ function $LocationProvider(){
     // update $location when $browser url changes
     $browser.onUrlChange(function(newUrl) {
       if ($location.absUrl() != newUrl) {
-        if ($rootScope.$broadcast('$locationChangeStart', newUrl,
-                                  $location.absUrl()).defaultPrevented) {
-          $browser.url($location.absUrl());
-          return;
-        }
         $rootScope.$evalAsync(function() {
           var oldUrl = $location.absUrl();
 
           $location.$$parse(newUrl);
-          afterLocationChange(oldUrl);
+          if ($rootScope.$broadcast('$locationChangeStart', newUrl,
+                                    oldUrl).defaultPrevented) {
+            $location.$$parse(oldUrl);
+            $browser.url(oldUrl);
+          } else {
+            afterLocationChange(oldUrl);
+          }
         });
         if (!$rootScope.$$phase) $rootScope.$digest();
       }

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1377,6 +1377,31 @@ describe('$location', function() {
         dealoc($rootElement);
       });
     });
+
+    it('should return the same $location.path() when $locationChangeStart event occurs no matter the cause of url change', function() {
+      inject(function($location, $rootScope, $browser, $window) {
+        var log = '',
+            base = $browser.url();
+
+        $rootScope.$on('$locationChangeStart', function() {
+          log += $location.path();
+        });
+
+        // change through $location service
+        $location.path('/b');
+        $rootScope.$apply();
+
+        // reset location
+        $location.path('');
+        $rootScope.$apply();
+
+        // change through $browser 
+        $browser.url(base + '#/b');
+        $browser.poll();
+
+        expect(log).toEqual('/b//b');
+      });
+    });
   });
 
   describe('LocationHtml5Url', function() {


### PR DESCRIPTION
This is related to https://github.com/angular/angular.js/issues/4989
