### PR TITLE
docs(guide/di): Use square bracket notation for $inject annotation

### DIFF
--- a/docs/content/guide/di.ngdoc
+++ b/docs/content/guide/di.ngdoc
@@ -146,7 +146,7 @@ of service names to inject.
   var MyController = function(renamed$scope, renamedGreeter) {
     ...
   }
-  MyController.$inject = ['$scope', 'greeter'];
+  MyController['$inject'] = ['$scope', 'greeter'];
 </pre>
 
 In this scenario the ordering of the values in the '$inject' array must match the ordering of the arguments to inject.


### PR DESCRIPTION
This recommendation is better as it ensures that the `$inject` property doesn't get minified when aggressively obfuscating code.

Re: CLA -- I work at Google.
