### PR TITLE
fix(ngSanitize): prefer textContent to innerText to avoid layout thrashing

### DIFF
--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -411,3 +411,49 @@ describe('HTML', function() {
     });
   });
 });
+
+describe('decodeEntities', function() {
+  var handler, text,
+      origCreatedElement = document.createElement;
+
+  beforeEach(function() {
+    text = '';
+    handler = {
+      start: function() {},
+      chars: function(text_){
+        text = text_;
+      },
+      end: function() {},
+      comment: function() {}
+    };
+    module('ngSanitize');
+  });
+
+  afterEach(function() {
+    document.createElement = origCreatedElement;
+  });
+
+  it('should use innerText if textContent is not available (IE<9)', function() {
+    document.createElement = function createElement() {
+      return {
+        innerText: 'INNER_TEXT'
+      };
+    };
+    inject(function($sanitize) {
+      htmlParser('<tag>text</tag>', handler);
+      expect(text).toEqual('INNER_TEXT');
+    });
+  });
+  it('should use textContent if available', function() {
+    document.createElement = function createElement() {
+      return {
+        textContent: 'TEXT_CONTENT',
+        innerText: 'INNER_TEXT'
+      };
+    };
+    inject(function($sanitize) {
+      htmlParser('<tag>text</tag>', handler);
+      expect(text).toEqual('TEXT_CONTENT');
+    });
+  });
+});


### PR DESCRIPTION
innerText depends on styling as it doesn't display hidden elements.
Therefore, it's better to use textContent not to cause unnecessary
reflows. However, IE<9 don't support textContent so the innerText
fallback is necessary. Note that we need to check for undefine
and not just reverse the order of these two since for an empty string
innerText would still be checked and a reflow would occur.

Fix #4720.
