### PR TITLE
fix(jqLite): Support unbinding event handler self within handler

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -631,7 +631,10 @@ function createEventHandler(element, events) {
       return event.defaultPrevented || event.returnValue === false;
     };
 
-    forEach(events[type || event.type], function(fn) {
+    // Copy event handlers in case event handlers array is modified during execution.
+    var eventHandlersCopy = shallowCopy(events[type || event.type] || []);
+
+    forEach(eventHandlersCopy, function(fn) {
       fn.call(element, event);
     });
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1099,6 +1099,28 @@ describe('jqLite', function() {
     });
 
 
+    it('should deregister specific listener within the listener and call subsequent listeners', function() {
+      var aElem = jqLite(a),
+          clickOnceSpy = jasmine.createSpy('clickOnce'),
+          clickSpy = jasmine.createSpy('click'),
+          clickOnceListener = function () {
+            aElem.off('click', clickOnceListener);
+            return clickOnceSpy();
+          };
+
+      aElem.on('click', clickOnceListener);
+      aElem.on('click', clickSpy);
+
+      browserTrigger(a, 'click');
+      expect(clickOnceSpy).toHaveBeenCalledOnce();
+      expect(clickSpy).toHaveBeenCalledOnce();
+
+      browserTrigger(a, 'click');
+      expect(clickOnceSpy).toHaveBeenCalledOnce();
+      expect(clickSpy.callCount).toBe(2);
+    });
+
+
     it('should deregister specific listener for multiple types separated by spaces', function() {
       var aElem = jqLite(a),
           masterSpy = jasmine.createSpy('master'),


### PR DESCRIPTION
If an event handler unbinds itself, the next event handler on the same
event and element isn't run.

This works fine in jQuery, and since jqLite doesn't support `.one()` (to bind handlers that only run once), this
might be a common use case.

I also suggest backporting this to the 1.0.x releases if those are still being maintained.
