### PR TITLE
docs($window): move use of $window to controller

### DIFF
--- a/src/ng/window.js
+++ b/src/ng/window.js
@@ -20,13 +20,15 @@
      <doc:source>
        <script>
          function Ctrl($scope, $window) {
-           $scope.$window = $window;
            $scope.greeting = 'Hello, World!';
+           $scope.doGreeting = function(greeting) {
+               $window.alert(greeting);
+           };
          }
        </script>
        <div ng-controller="Ctrl">
          <input type="text" ng-model="greeting" />
-         <button ng-click="$window.alert(greeting)">ALERT</button>
+         <button ng-click="doGreeting(greeting)">ALERT</button>
        </div>
      </doc:source>
      <doc:scenario>


### PR DESCRIPTION
Move use of $window from expression to controller, because accessing
$window in expressions is now dissalowed and doesn't work.

Code example doesn't work, this PR will fix this.
