### PR TITLE
docs(FormController): Provide a list of Angular's built-in validation tokens

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -21,9 +21,20 @@ var nullFormCtrl = {
  * @property {Object} $error Is an object hash, containing references to all invalid controls or
  *  forms, where:
  *
- *  - keys are validation tokens (error names) — such as `required`, `url` or `email`,
+ *  - keys are validation tokens (error names),
  *  - values are arrays of controls or forms that are invalid with given error.
  *
+ *  Built-in validation tokens:
+ *  - `email`
+ *  - `max`
+ *  - `maxlength`
+ *  - `min`
+ *  - `minlength`
+ *  - `number`
+ *  - `pattern`
+ *  - `required`
+ *  - `url`
+ * 
  * @description
  * `FormController` keeps track of all its controls and nested forms as well as state of them,
  * such as being valid/invalid or dirty/pristine.


### PR DESCRIPTION
As requested by a top-rated Disqus comment: http://docs.angularjs.org/api/ng.directive:form.FormController#comment-655325797
