### PR TITLE
fix(ngMock): httpBackend match data with dates (1.2.2 regression)

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1542,7 +1542,8 @@ function MockHttpExpectation(method, url, data, headers) {
     if (angular.isUndefined(data)) return true;
     if (data && angular.isFunction(data.test)) return data.test(d);
     if (data && angular.isFunction(data)) return data(d);
-    if (data && !angular.isString(data)) return angular.equals(data, angular.fromJson(d));
+    if (data && !angular.isString(data))
+      return angular.equals(angular.fromJson(angular.toJson(data)), angular.fromJson(d));
     return data == d;
   };
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -963,6 +963,12 @@ describe('$http', function() {
           });
 
 
+          it('should transform object with date into json', function() {
+            $httpBackend.expect('POST', '/url', {"date": new Date(Date.UTC(2013, 11, 25))}).respond('');
+            $http({method: 'POST', url: '/url', data: {date: new Date(Date.UTC(2013, 11, 25))}});
+          });
+
+
           it('should ignore strings', function() {
             $httpBackend.expect('POST', '/url', 'string-data').respond('');
             $http({method: 'POST', url: '/url', data: 'string-data'});


### PR DESCRIPTION
Expecting a request with a data object containing a date [fails](http://plnkr.co/edit/zRRtf98lwdmTZpebfM2f?p=preview).

Use serialization/deserialization of data to have the same date format as the expectation.
