### PR TITLE
docs(compile): transclude is passed to compile, not link

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -285,7 +285,7 @@
  * <div class="alert alert-error">
  * **Note:** The `transclude` function that is passed to the compile function is deperecated, as it
  *   e.g. does not know about the right outer scope. Please use the transclude function that is passed
- *   to the link function instead.
+ *   to the compile function instead.
  * </div>
 
  * A compile function can have a return value which can be either a function or an object.


### PR DESCRIPTION
As far as I can tell, the transclude function is not passed to anything that could be called a "link function" anymore, unless I'm missing something.

If I am in fact missing something, I'd love for this to be clarified!
