### PR TITLE
fix($sanitize): Use same whitelist mechanism as $compile does.

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -27,6 +27,7 @@ angularFiles = {
     'src/ng/parse.js',
     'src/ng/q.js',
     'src/ng/rootScope.js',
+    'src/ng/sanitizeUri.js',
     'src/ng/sce.js',
     'src/ng/sniffer.js',
     'src/ng/timeout.js',

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -65,6 +65,7 @@
     $ParseProvider,
     $RootScopeProvider,
     $QProvider,
+    $$SanitizeUriProvider,
     $SceProvider,
     $SceDelegateProvider,
     $SnifferProvider,
@@ -136,6 +137,10 @@ function publishExternalAPI(angular){
 
   angularModule('ng', ['ngLocale'], ['$provide',
     function ngModule($provide) {
+      // $$sanitizeUriProvider needs to be before $compileProvider as it is used by it.
+      $provide.provider({
+        $$sanitizeUri: $$SanitizeUriProvider
+      });
       $provide.provider('$compile', $CompileProvider).
         directive({
             a: htmlAnchorDirective,

--- a/src/ng/sanitizeUri.js
+++ b/src/ng/sanitizeUri.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * @description
+ * Private service to sanitize uris for links and images. Used by $compile and $sanitize.
+ */
+function $$SanitizeUriProvider() {
+  var aHrefSanitizationWhitelist = /^\s*(https?|ftp|mailto|tel|file):/,
+    imgSrcSanitizationWhitelist = /^\s*(https?|ftp|file):|data:image\//;
+
+  /**
+   * @description
+   * Retrieves or overrides the default regular expression that is used for whitelisting of safe
+   * urls during a[href] sanitization.
+   *
+   * The sanitization is a security measure aimed at prevent XSS attacks via html links.
+   *
+   * Any url about to be assigned to a[href] via data-binding is first normalized and turned into
+   * an absolute url. Afterwards, the url is matched against the `aHrefSanitizationWhitelist`
+   * regular expression. If a match is found, the original url is written into the dom. Otherwise,
+   * the absolute url is prefixed with `'unsafe:'` string and only then is it written into the DOM.
+   *
+   * @param {RegExp=} regexp New regexp to whitelist urls with.
+   * @returns {RegExp|ng.$compileProvider} Current RegExp if called without value or self for
+   *    chaining otherwise.
+   */
+  this.aHrefSanitizationWhitelist = function(regexp) {
+    if (isDefined(regexp)) {
+      aHrefSanitizationWhitelist = regexp;
+      return this;
+    }
+    return aHrefSanitizationWhitelist;
+  };
+
+
+  /**
+   * @description
+   * Retrieves or overrides the default regular expression that is used for whitelisting of safe
+   * urls during img[src] sanitization.
+   *
+   * The sanitization is a security measure aimed at prevent XSS attacks via html links.
+   *
+   * Any url about to be assigned to img[src] via data-binding is first normalized and turned into
+   * an absolute url. Afterwards, the url is matched against the `imgSrcSanitizationWhitelist`
+   * regular expression. If a match is found, the original url is written into the dom. Otherwise,
+   * the absolute url is prefixed with `'unsafe:'` string and only then is it written into the DOM.
+   *
+   * @param {RegExp=} regexp New regexp to whitelist urls with.
+   * @returns {RegExp|ng.$compileProvider} Current RegExp if called without value or self for
+   *    chaining otherwise.
+   */
+  this.imgSrcSanitizationWhitelist = function(regexp) {
+    if (isDefined(regexp)) {
+      imgSrcSanitizationWhitelist = regexp;
+      return this;
+    }
+    return imgSrcSanitizationWhitelist;
+  };
+
+  this.$get = function() {
+    return function sanitizeUri(uri, isImage) {
+      var regex = isImage ? imgSrcSanitizationWhitelist : aHrefSanitizationWhitelist;
+      var normalizedVal;
+      // NOTE: urlResolve() doesn't support IE < 8 so we don't sanitize for that case.
+      if (!msie || msie >= 8 ) {
+        normalizedVal = urlResolve(uri).href;
+        if (normalizedVal !== '' && !normalizedVal.match(regex)) {
+          return 'unsafe:'+normalizedVal;
+        }
+      }
+      return uri;
+    };
+  };
+}

--- a/src/ngSanitize/filter/linky.js
+++ b/src/ngSanitize/filter/linky.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global htmlSanitizeWriter: false */
+/* global sanitizeText: false */
 
 /**
  * @ngdoc filter
@@ -100,7 +100,7 @@
      </doc:scenario>
    </doc:example>
  */
-angular.module('ngSanitize').filter('linky', function() {
+angular.module('ngSanitize').filter('linky', ['$sanitize', function($sanitize) {
   var LINKY_URL_REGEXP =
         /((ftp|https?):\/\/|(mailto:)?[A-Za-z0-9._%+-]+@)\S*[^\s.;,(){}<>]/,
       MAILTO_REGEXP = /^mailto:/;
@@ -110,28 +110,40 @@ angular.module('ngSanitize').filter('linky', function() {
     var match;
     var raw = text;
     var html = [];
-    // TODO(vojta): use $sanitize instead
-    var writer = htmlSanitizeWriter(html);
     var url;
     var i;
-    var properties = {};
-    if (angular.isDefined(target)) {
-      properties.target = target;
-    }
     while ((match = raw.match(LINKY_URL_REGEXP))) {
       // We can not end in these as they are sometimes found at the end of the sentence
       url = match[0];
       // if we did not match ftp/http/mailto then assume mailto
       if (match[2] == match[3]) url = 'mailto:' + url;
       i = match.index;
-      writer.chars(raw.substr(0, i));
-      properties.href = url;
-      writer.start('a', properties);
-      writer.chars(match[0].replace(MAILTO_REGEXP, ''));
-      writer.end('a');
+      addText(raw.substr(0, i));
+      addLink(url, match[0].replace(MAILTO_REGEXP, ''));
       raw = raw.substring(i + match[0].length);
     }
-    writer.chars(raw);
-    return html.join('');
+    addText(raw);
+    return $sanitize(html.join(''));
+
+    function addText(text) {
+      if (!text) {
+        return;
+      }
+      html.push(sanitizeText(text));
+    }
+
+    function addLink(url, text) {
+      html.push('<a ');
+      if (angular.isDefined(target)) {
+        html.push('target="');
+        html.push(target);
+        html.push('" ');
+      }
+      html.push('href="');
+      html.push(url);
+      html.push('">');
+      addText(text);
+      html.push('</a>');
+    }
   };
-});
+}]);

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3834,6 +3834,7 @@ describe('$compile', function() {
 
 
   describe('img[src] sanitization', function() {
+
     it('should NOT require trusted values for img src', inject(function($rootScope, $compile, $sce) {
       element = $compile('<img src="{{testUrl}}"></img>')($rootScope);
       $rootScope.testUrl = 'http://example.com/image.png';
@@ -3845,127 +3846,6 @@ describe('$compile', function() {
       expect(element.attr('src')).toEqual('http://example.com/image2.png');
     }));
 
-    it('should sanitize javascript: urls', inject(function($compile, $rootScope) {
-      element = $compile('<img src="{{testUrl}}"></a>')($rootScope);
-      $rootScope.testUrl = "javascript:doEvilStuff()";
-      $rootScope.$apply();
-      expect(element.attr('src')).toBe('unsafe:javascript:doEvilStuff()');
-    }));
-
-    it('should sanitize non-image data: urls', inject(function($compile, $rootScope) {
-      element = $compile('<img src="{{testUrl}}"></a>')($rootScope);
-      $rootScope.testUrl = "data:application/javascript;charset=US-ASCII,alert('evil!');";
-      $rootScope.$apply();
-      expect(element.attr('src')).toBe("unsafe:data:application/javascript;charset=US-ASCII,alert('evil!');");
-      $rootScope.testUrl = "data:,foo";
-      $rootScope.$apply();
-      expect(element.attr('src')).toBe("unsafe:data:,foo");
-    }));
-
-
-    it('should not sanitize data: URIs for images', inject(function($compile, $rootScope) {
-      element = $compile('<img src="{{dataUri}}"></img>')($rootScope);
-
-      // image data uri
-      // ref: http://probablyprogramming.com/2009/03/15/the-tiniest-gif-ever
-      $rootScope.dataUri = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
-      $rootScope.$apply();
-      expect(element.attr('src')).toBe('data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==');
-    }));
-
-
-    // Fails on IE <= 10 with "TypeError: Access is denied" when trying to set img[src]
-    if (!msie || msie > 10) {
-      it('should sanitize mailto: urls', inject(function($compile, $rootScope) {
-        element = $compile('<img src="{{testUrl}}"></a>')($rootScope);
-          $rootScope.testUrl = "mailto:foo@bar.com";
-          $rootScope.$apply();
-          expect(element.attr('src')).toBe('unsafe:mailto:foo@bar.com');
-      }));
-    }
-
-    it('should sanitize obfuscated javascript: urls', inject(function($compile, $rootScope) {
-      element = $compile('<img src="{{testUrl}}"></img>')($rootScope);
-
-      // case-sensitive
-      $rootScope.testUrl = "JaVaScRiPt:doEvilStuff()";
-      $rootScope.$apply();
-      expect(element[0].src).toBe('unsafe:javascript:doEvilStuff()');
-
-      // tab in protocol
-      $rootScope.testUrl = "java\u0009script:doEvilStuff()";
-      $rootScope.$apply();
-      expect(element[0].src).toMatch(/(http:\/\/|unsafe:javascript:doEvilStuff\(\))/);
-
-      // space before
-      $rootScope.testUrl = " javascript:doEvilStuff()";
-      $rootScope.$apply();
-      expect(element[0].src).toBe('unsafe:javascript:doEvilStuff()');
-
-      // ws chars before
-      $rootScope.testUrl = " \u000e javascript:doEvilStuff()";
-      $rootScope.$apply();
-      expect(element[0].src).toMatch(/(http:\/\/|unsafe:javascript:doEvilStuff\(\))/);
-
-      // post-fixed with proper url
-      $rootScope.testUrl = "javascript:doEvilStuff(); http://make.me/look/good";
-      $rootScope.$apply();
-      expect(element[0].src).toBeOneOf(
-          'unsafe:javascript:doEvilStuff(); http://make.me/look/good',
-          'unsafe:javascript:doEvilStuff();%20http://make.me/look/good'
-      );
-    }));
-
-    it('should sanitize ng-src bindings as well', inject(function($compile, $rootScope) {
-      element = $compile('<img ng-src="{{testUrl}}"></img>')($rootScope);
-      $rootScope.testUrl = "javascript:doEvilStuff()";
-      $rootScope.$apply();
-
-      expect(element[0].src).toBe('unsafe:javascript:doEvilStuff()');
-    }));
-
-
-    it('should not sanitize valid urls', inject(function($compile, $rootScope) {
-      element = $compile('<img src="{{testUrl}}"></img>')($rootScope);
-
-      $rootScope.testUrl = "foo/bar";
-      $rootScope.$apply();
-      expect(element.attr('src')).toBe('foo/bar');
-
-      $rootScope.testUrl = "/foo/bar";
-      $rootScope.$apply();
-      expect(element.attr('src')).toBe('/foo/bar');
-
-      $rootScope.testUrl = "../foo/bar";
-      $rootScope.$apply();
-      expect(element.attr('src')).toBe('../foo/bar');
-
-      $rootScope.testUrl = "#foo";
-      $rootScope.$apply();
-      expect(element.attr('src')).toBe('#foo');
-
-      $rootScope.testUrl = "http://foo.com/bar";
-      $rootScope.$apply();
-      expect(element.attr('src')).toBe('http://foo.com/bar');
-
-      $rootScope.testUrl = " http://foo.com/bar";
-      $rootScope.$apply();
-      expect(element.attr('src')).toBe(' http://foo.com/bar');
-
-      $rootScope.testUrl = "https://foo.com/bar";
-      $rootScope.$apply();
-      expect(element.attr('src')).toBe('https://foo.com/bar');
-
-      $rootScope.testUrl = "ftp://foo.com/bar";
-      $rootScope.$apply();
-      expect(element.attr('src')).toBe('ftp://foo.com/bar');
-
-      $rootScope.testUrl = "file:///foo/bar.html";
-      $rootScope.$apply();
-      expect(element.attr('src')).toBe('file:///foo/bar.html');
-    }));
-
-
     it('should not sanitize attributes other than src', inject(function($compile, $rootScope) {
       element = $compile('<img title="{{testUrl}}"></img>')($rootScope);
       $rootScope.testUrl = "javascript:doEvilStuff()";
@@ -3974,140 +3854,41 @@ describe('$compile', function() {
       expect(element.attr('title')).toBe('javascript:doEvilStuff()');
     }));
 
+    it('should use $$sanitizeUriProvider for reconfiguration of the src whitelist', function() {
+      module(function($compileProvider, $$sanitizeUriProvider) {
+        var newRe = /javascript:/,
+          returnVal;
+        expect($compileProvider.imgSrcSanitizationWhitelist()).toBe($$sanitizeUriProvider.imgSrcSanitizationWhitelist());
 
-    it('should allow reconfiguration of the src whitelist', function() {
-      module(function($compileProvider) {
-        expect($compileProvider.imgSrcSanitizationWhitelist() instanceof RegExp).toBe(true);
-        var returnVal = $compileProvider.imgSrcSanitizationWhitelist(/javascript:/);
+        returnVal = $compileProvider.imgSrcSanitizationWhitelist(newRe);
         expect(returnVal).toBe($compileProvider);
+        expect($$sanitizeUriProvider.imgSrcSanitizationWhitelist()).toBe(newRe);
+        expect($compileProvider.imgSrcSanitizationWhitelist()).toBe(newRe);
       });
-
-      inject(function($compile, $rootScope) {
-        element = $compile('<img src="{{testUrl}}"></img>')($rootScope);
-
-        // Fails on IE <= 11 with "TypeError: Object doesn't support this property or method" when
-        // trying to set img[src]
-        if (!msie || msie > 11) {
-          $rootScope.testUrl = "javascript:doEvilStuff()";
-          $rootScope.$apply();
-          expect(element.attr('src')).toBe('javascript:doEvilStuff()');
-        }
-
-        $rootScope.testUrl = "http://recon/figured";
-        $rootScope.$apply();
-        expect(element.attr('src')).toBe('unsafe:http://recon/figured');
+      inject(function() {
+        // needed to the module definition above is run...
       });
     });
 
+    it('should use $$sanitizeUri', function() {
+      var $$sanitizeUri = jasmine.createSpy('$$sanitizeUri');
+      module(function($provide) {
+        $provide.value('$$sanitizeUri', $$sanitizeUri);
+      });
+      inject(function($compile, $rootScope) {
+        element = $compile('<img src="{{testUrl}}"></img>')($rootScope);
+        $rootScope.testUrl = "someUrl";
+
+        $$sanitizeUri.andReturn('someSanitizedUrl');
+        $rootScope.$apply();
+        expect(element.attr('src')).toBe('someSanitizedUrl');
+        expect($$sanitizeUri).toHaveBeenCalledWith($rootScope.testUrl, true);
+      });
+    });
   });
 
 
   describe('a[href] sanitization', function() {
-
-    it('should sanitize javascript: urls', inject(function($compile, $rootScope) {
-      element = $compile('<a href="{{testUrl}}"></a>')($rootScope);
-      $rootScope.testUrl = "javascript:doEvilStuff()";
-      $rootScope.$apply();
-
-      expect(element.attr('href')).toBe('unsafe:javascript:doEvilStuff()');
-    }));
-
-
-    it('should sanitize data: urls', inject(function($compile, $rootScope) {
-      element = $compile('<a href="{{testUrl}}"></a>')($rootScope);
-      $rootScope.testUrl = "data:evilPayload";
-      $rootScope.$apply();
-
-      expect(element.attr('href')).toBe('unsafe:data:evilPayload');
-    }));
-
-
-    it('should sanitize obfuscated javascript: urls', inject(function($compile, $rootScope) {
-      element = $compile('<a href="{{testUrl}}"></a>')($rootScope);
-
-      // case-sensitive
-      $rootScope.testUrl = "JaVaScRiPt:doEvilStuff()";
-      $rootScope.$apply();
-      expect(element[0].href).toBe('unsafe:javascript:doEvilStuff()');
-
-      // tab in protocol
-      $rootScope.testUrl = "java\u0009script:doEvilStuff()";
-      $rootScope.$apply();
-      expect(element[0].href).toMatch(/(http:\/\/|unsafe:javascript:doEvilStuff\(\))/);
-
-      // space before
-      $rootScope.testUrl = " javascript:doEvilStuff()";
-      $rootScope.$apply();
-      expect(element[0].href).toBe('unsafe:javascript:doEvilStuff()');
-
-      // ws chars before
-      $rootScope.testUrl = " \u000e javascript:doEvilStuff()";
-      $rootScope.$apply();
-      expect(element[0].href).toMatch(/(http:\/\/|unsafe:javascript:doEvilStuff\(\))/);
-
-      // post-fixed with proper url
-      $rootScope.testUrl = "javascript:doEvilStuff(); http://make.me/look/good";
-      $rootScope.$apply();
-      expect(element[0].href).toBeOneOf(
-          'unsafe:javascript:doEvilStuff(); http://make.me/look/good',
-          'unsafe:javascript:doEvilStuff();%20http://make.me/look/good'
-      );
-    }));
-
-
-    it('should sanitize ngHref bindings as well', inject(function($compile, $rootScope) {
-      element = $compile('<a ng-href="{{testUrl}}"></a>')($rootScope);
-      $rootScope.testUrl = "javascript:doEvilStuff()";
-      $rootScope.$apply();
-
-      expect(element[0].href).toBe('unsafe:javascript:doEvilStuff()');
-    }));
-
-
-    it('should not sanitize valid urls', inject(function($compile, $rootScope) {
-      element = $compile('<a href="{{testUrl}}"></a>')($rootScope);
-
-      $rootScope.testUrl = "foo/bar";
-      $rootScope.$apply();
-      expect(element.attr('href')).toBe('foo/bar');
-
-      $rootScope.testUrl = "/foo/bar";
-      $rootScope.$apply();
-      expect(element.attr('href')).toBe('/foo/bar');
-
-      $rootScope.testUrl = "../foo/bar";
-      $rootScope.$apply();
-      expect(element.attr('href')).toBe('../foo/bar');
-
-      $rootScope.testUrl = "#foo";
-      $rootScope.$apply();
-      expect(element.attr('href')).toBe('#foo');
-
-      $rootScope.testUrl = "http://foo/bar";
-      $rootScope.$apply();
-      expect(element.attr('href')).toBe('http://foo/bar');
-
-      $rootScope.testUrl = " http://foo/bar";
-      $rootScope.$apply();
-      expect(element.attr('href')).toBe(' http://foo/bar');
-
-      $rootScope.testUrl = "https://foo/bar";
-      $rootScope.$apply();
-      expect(element.attr('href')).toBe('https://foo/bar');
-
-      $rootScope.testUrl = "ftp://foo/bar";
-      $rootScope.$apply();
-      expect(element.attr('href')).toBe('ftp://foo/bar');
-
-      $rootScope.testUrl = "mailto:foo@bar.com";
-      $rootScope.$apply();
-      expect(element.attr('href')).toBe('mailto:foo@bar.com');
-
-      $rootScope.testUrl = "file:///foo/bar.html";
-      $rootScope.$apply();
-      expect(element.attr('href')).toBe('file:///foo/bar.html');
-    }));
-
 
     it('should not sanitize href on elements other than anchor', inject(function($compile, $rootScope) {
       element = $compile('<div href="{{testUrl}}"></div>')($rootScope);
@@ -4117,7 +3898,6 @@ describe('$compile', function() {
       expect(element.attr('href')).toBe('javascript:doEvilStuff()');
     }));
 
-
     it('should not sanitize attributes other than href', inject(function($compile, $rootScope) {
       element = $compile('<a title="{{testUrl}}"></a>')($rootScope);
       $rootScope.testUrl = "javascript:doEvilStuff()";
@@ -4126,26 +3906,38 @@ describe('$compile', function() {
       expect(element.attr('title')).toBe('javascript:doEvilStuff()');
     }));
 
+    it('should use $$sanitizeUriProvider for reconfiguration of the href whitelist', function() {
+      module(function($compileProvider, $$sanitizeUriProvider) {
+        var newRe = /javascript:/,
+          returnVal;
+        expect($compileProvider.aHrefSanitizationWhitelist()).toBe($$sanitizeUriProvider.aHrefSanitizationWhitelist());
 
-    it('should allow reconfiguration of the href whitelist', function() {
-      module(function($compileProvider) {
-        expect($compileProvider.aHrefSanitizationWhitelist() instanceof RegExp).toBe(true);
-        var returnVal = $compileProvider.aHrefSanitizationWhitelist(/javascript:/);
+        returnVal = $compileProvider.aHrefSanitizationWhitelist(newRe);
         expect(returnVal).toBe($compileProvider);
+        expect($$sanitizeUriProvider.aHrefSanitizationWhitelist()).toBe(newRe);
+        expect($compileProvider.aHrefSanitizationWhitelist()).toBe(newRe);
       });
-
-      inject(function($compile, $rootScope) {
-        element = $compile('<a href="{{testUrl}}"></a>')($rootScope);
-
-        $rootScope.testUrl = "javascript:doEvilStuff()";
-        $rootScope.$apply();
-        expect(element.attr('href')).toBe('javascript:doEvilStuff()');
-
-        $rootScope.testUrl = "http://recon/figured";
-        $rootScope.$apply();
-        expect(element.attr('href')).toBe('unsafe:http://recon/figured');
+      inject(function() {
+        // needed to the module definition above is run...
       });
     });
+
+    it('should use $$sanitizeUri', function() {
+      var $$sanitizeUri = jasmine.createSpy('$$sanitizeUri');
+      module(function($provide) {
+        $provide.value('$$sanitizeUri', $$sanitizeUri);
+      });
+      inject(function($compile, $rootScope) {
+        element = $compile('<a href="{{testUrl}}"></a>')($rootScope);
+        $rootScope.testUrl = "someUrl";
+
+        $$sanitizeUri.andReturn('someSanitizedUrl');
+        $rootScope.$apply();
+        expect(element.attr('href')).toBe('someSanitizedUrl');
+        expect($$sanitizeUri).toHaveBeenCalledWith($rootScope.testUrl, false);
+      });
+    });
+
   });
 
   describe('interpolation on HTML DOM event handler attributes onclick, onXYZ, formaction', function() {

--- a/test/ng/sanitizeUriSpec.js
+++ b/test/ng/sanitizeUriSpec.js
@@ -1,0 +1,230 @@
+'use strict';
+
+describe('sanitizeUri', function() {
+  var sanitizeHref, sanitizeImg, sanitizeUriProvider, testUrl;
+  beforeEach(function() {
+    module(function(_$$sanitizeUriProvider_) {
+      sanitizeUriProvider = _$$sanitizeUriProvider_;
+    });
+    inject(function($$sanitizeUri) {
+      sanitizeHref = function(uri) {
+        return $$sanitizeUri(uri, false);
+      };
+      sanitizeImg = function(uri) {
+        return $$sanitizeUri(uri, true);
+      }
+    });
+  });
+
+  function isEvilInCurrentBrowser(uri) {
+    var a = document.createElement('a');
+    a.setAttribute('href', uri);
+    return a.href.substring(0, 4) !== 'http';
+  }
+
+  describe('img[src] sanitization', function() {
+
+    it('should sanitize javascript: urls', function() {
+      testUrl = "javascript:doEvilStuff()";
+      expect(sanitizeImg(testUrl)).toBe('unsafe:javascript:doEvilStuff()');
+    });
+
+    it('should sanitize non-image data: urls', function() {
+      testUrl = "data:application/javascript;charset=US-ASCII,alert('evil!');";
+      expect(sanitizeImg(testUrl)).toBe("unsafe:data:application/javascript;charset=US-ASCII,alert('evil!');");
+
+      testUrl = "data:,foo";
+      expect(sanitizeImg(testUrl)).toBe("unsafe:data:,foo");
+    });
+
+    it('should not sanitize data: URIs for images', function() {
+      // image data uri
+      // ref: http://probablyprogramming.com/2009/03/15/the-tiniest-gif-ever
+      testUrl = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+      expect(sanitizeImg(testUrl)).toBe('data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==');
+    });
+
+    it('should sanitize mailto: urls', function() {
+      testUrl = "mailto:foo@bar.com";
+      expect(sanitizeImg(testUrl)).toBe('unsafe:mailto:foo@bar.com');
+    });
+
+    it('should sanitize obfuscated javascript: urls', function() {
+      // case-sensitive
+      testUrl = "JaVaScRiPt:doEvilStuff()";
+      expect(sanitizeImg(testUrl)).toBe('unsafe:javascript:doEvilStuff()');
+
+      // tab in protocol
+      testUrl = "java\u0009script:doEvilStuff()";
+      if (isEvilInCurrentBrowser(testUrl)) {
+        expect(sanitizeImg(testUrl)).toEqual('unsafe:javascript:doEvilStuff()');
+      }
+
+      // space before
+      testUrl = " javascript:doEvilStuff()";
+      expect(sanitizeImg(testUrl)).toBe('unsafe:javascript:doEvilStuff()');
+
+      // ws chars before
+      testUrl = " \u000e javascript:doEvilStuff()";
+      if (isEvilInCurrentBrowser(testUrl)) {
+        expect(sanitizeImg(testUrl)).toEqual('unsafe:javascript:doEvilStuff()');
+      }
+
+      // post-fixed with proper url
+      testUrl = "javascript:doEvilStuff(); http://make.me/look/good";
+      expect(sanitizeImg(testUrl)).toBeOneOf(
+        'unsafe:javascript:doEvilStuff(); http://make.me/look/good',
+        'unsafe:javascript:doEvilStuff();%20http://make.me/look/good'
+      );
+    });
+
+    it('should sanitize ng-src bindings as well', function() {
+      testUrl = "javascript:doEvilStuff()";
+      expect(sanitizeImg(testUrl)).toBe('unsafe:javascript:doEvilStuff()');
+    });
+
+
+    it('should not sanitize valid urls', function() {
+      testUrl = "foo/bar";
+      expect(sanitizeImg(testUrl)).toBe('foo/bar');
+
+      testUrl = "/foo/bar";
+      expect(sanitizeImg(testUrl)).toBe('/foo/bar');
+
+      testUrl = "../foo/bar";
+      expect(sanitizeImg(testUrl)).toBe('../foo/bar');
+
+      testUrl = "#foo";
+      expect(sanitizeImg(testUrl)).toBe('#foo');
+
+      testUrl = "http://foo.com/bar";
+      expect(sanitizeImg(testUrl)).toBe('http://foo.com/bar');
+
+      testUrl = " http://foo.com/bar";
+      expect(sanitizeImg(testUrl)).toBe(' http://foo.com/bar');
+
+      testUrl = "https://foo.com/bar";
+      expect(sanitizeImg(testUrl)).toBe('https://foo.com/bar');
+
+      testUrl = "ftp://foo.com/bar";
+      expect(sanitizeImg(testUrl)).toBe('ftp://foo.com/bar');
+
+      testUrl = "file:///foo/bar.html";
+      expect(sanitizeImg(testUrl)).toBe('file:///foo/bar.html');
+    });
+
+
+    it('should allow reconfiguration of the src whitelist', function() {
+      var returnVal;
+      expect(sanitizeUriProvider.imgSrcSanitizationWhitelist() instanceof RegExp).toBe(true);
+      returnVal = sanitizeUriProvider.imgSrcSanitizationWhitelist(/javascript:/);
+      expect(returnVal).toBe(sanitizeUriProvider);
+
+      testUrl = "javascript:doEvilStuff()";
+      expect(sanitizeImg(testUrl)).toBe('javascript:doEvilStuff()');
+
+      testUrl = "http://recon/figured";
+      expect(sanitizeImg(testUrl)).toBe('unsafe:http://recon/figured');
+    });
+
+  });
+
+
+  describe('a[href] sanitization', function() {
+
+    it('should sanitize javascript: urls', inject(function() {
+      testUrl = "javascript:doEvilStuff()";
+      expect(sanitizeHref(testUrl)).toBe('unsafe:javascript:doEvilStuff()');
+    }));
+
+
+    it('should sanitize data: urls', inject(function() {
+      testUrl = "data:evilPayload";
+      expect(sanitizeHref(testUrl)).toBe('unsafe:data:evilPayload');
+    }));
+
+
+    it('should sanitize obfuscated javascript: urls', inject(function() {
+      // case-sensitive
+      testUrl = "JaVaScRiPt:doEvilStuff()";
+      expect(sanitizeHref(testUrl)).toBe('unsafe:javascript:doEvilStuff()');
+
+      // tab in protocol
+      testUrl = "java\u0009script:doEvilStuff()";
+      if (isEvilInCurrentBrowser(testUrl)) {
+        expect(sanitizeHref(testUrl)).toEqual('unsafe:javascript:doEvilStuff()');
+      }
+
+      // space before
+      testUrl = " javascript:doEvilStuff()";
+      expect(sanitizeHref(testUrl)).toBe('unsafe:javascript:doEvilStuff()');
+
+      // ws chars before
+      testUrl = " \u000e javascript:doEvilStuff()";
+      if (isEvilInCurrentBrowser(testUrl)) {
+        expect(sanitizeHref(testUrl)).toEqual('unsafe:javascript:doEvilStuff()');
+      }
+
+      // post-fixed with proper url
+      testUrl = "javascript:doEvilStuff(); http://make.me/look/good";
+      expect(sanitizeHref(testUrl)).toBeOneOf(
+        'unsafe:javascript:doEvilStuff(); http://make.me/look/good',
+        'unsafe:javascript:doEvilStuff();%20http://make.me/look/good'
+      );
+    }));
+
+
+    it('should sanitize ngHref bindings as well', inject(function() {
+      testUrl = "javascript:doEvilStuff()";
+      expect(sanitizeHref(testUrl)).toBe('unsafe:javascript:doEvilStuff()');
+    }));
+
+
+    it('should not sanitize valid urls', inject(function() {
+      testUrl = "foo/bar";
+      expect(sanitizeHref(testUrl)).toBe('foo/bar');
+
+      testUrl = "/foo/bar";
+      expect(sanitizeHref(testUrl)).toBe('/foo/bar');
+
+      testUrl = "../foo/bar";
+      expect(sanitizeHref(testUrl)).toBe('../foo/bar');
+
+      testUrl = "#foo";
+      expect(sanitizeHref(testUrl)).toBe('#foo');
+
+      testUrl = "http://foo/bar";
+      expect(sanitizeHref(testUrl)).toBe('http://foo/bar');
+
+      testUrl = " http://foo/bar";
+      expect(sanitizeHref(testUrl)).toBe(' http://foo/bar');
+
+      testUrl = "https://foo/bar";
+      expect(sanitizeHref(testUrl)).toBe('https://foo/bar');
+
+      testUrl = "ftp://foo/bar";
+      expect(sanitizeHref(testUrl)).toBe('ftp://foo/bar');
+
+      testUrl = "mailto:foo@bar.com";
+      expect(sanitizeHref(testUrl)).toBe('mailto:foo@bar.com');
+
+      testUrl = "file:///foo/bar.html";
+      expect(sanitizeHref(testUrl)).toBe('file:///foo/bar.html');
+    }));
+
+    it('should allow reconfiguration of the href whitelist', function() {
+      var returnVal;
+      expect(sanitizeUriProvider.aHrefSanitizationWhitelist() instanceof RegExp).toBe(true);
+      returnVal = sanitizeUriProvider.aHrefSanitizationWhitelist(/javascript:/);
+      expect(returnVal).toBe(sanitizeUriProvider);
+
+      testUrl = "javascript:doEvilStuff()";
+        expect(sanitizeHref(testUrl)).toBe('javascript:doEvilStuff()');
+
+      testUrl = "http://recon/figured";
+        expect(sanitizeHref(testUrl)).toBe('unsafe:http://recon/figured');
+    });
+
+  });
+
+});


### PR DESCRIPTION
$sanitize now uses the same mechanism as $compile to validate uris.
By this, the validation in $sanitize is now more general and can be
configured using $compileProvider#imgSrcSanitizationWhitelist and
$compileProvider#aHrefSanitizationWhitelist.

This commit also refactors the linky filter to use $sanitize as a
service instead of directly referencing private functions of $sanitize.

Fixes #3748.
