### PR TITLE
feat(jqLite): add withDataAndEvents to clone method

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -194,8 +194,22 @@ function JQLite(element) {
   }
 }
 
-function jqLiteClone(element) {
-  return element.cloneNode(true);
+function jqLiteClone(element, withDataAndEvents) {
+  var clone = element.cloneNode(true);
+  if (withDataAndEvents) {
+    forEach(jqLiteData(element), function (value, key) {
+      jqLiteData(clone, key, value);
+    });
+
+    var jqClone = new JQLite(clone);
+    forEach(jqLiteExpandoStore(element, 'events'), function (value, key) {
+      var fns = isArray(value) ? value : [value];
+      forEach(fns, function (fn) {
+        jqClone.on(key, fn);
+      });
+    });
+  }
+  return clone;
 }
 
 function jqLiteDealoc(element){

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1136,6 +1136,59 @@ describe('jqLite', function() {
     }
   });
 
+  describe('clone', function() {
+    var clone;
+
+    beforeEach(function() {
+      clone = undefined;
+    });
+
+    afterEach(function() {
+      dealoc(clone);
+    });
+
+    it('should clone an element', function() {
+      var original = jqLite(a).text('original');
+      clone = original.clone().text('clone');
+      expect(original.text()).toEqual('original');
+      expect(clone.text()).toEqual('clone');
+    });
+
+    it('should clone an element with data', function() {
+      var original = jqLite(a).data('myKey', 'myValue');
+      clone = original.clone(true);
+      expect(clone.data('myKey')).toBe('myValue');
+    });
+
+    it('should clone an element with events', function() {
+      var original = jqLite(a);
+      callback = jasmine.createSpy('callback');
+
+      original.on('click', callback);
+
+      browserTrigger(original, 'click');
+      expect(callback).toHaveBeenCalled();
+
+      clone = original.clone(true);
+      browserTrigger(clone, 'click');
+      expect(callback).toHaveBeenCalled();
+      expect(callback.callCount).toBe(2);
+    });
+
+    it('should clone an element with multiple events', function() {
+      var original = jqLite(a);
+      callback = jasmine.createSpy('callback');
+      callback2 = jasmine.createSpy('callback2');
+
+      original.on('click', callback);
+      original.on('click', callback2);
+
+      clone = original.clone(true);
+      browserTrigger(clone, 'click');
+      expect(callback).toHaveBeenCalled();
+      expect(callback2).toHaveBeenCalled();
+    });
+  });
 
   describe('replaceWith', function() {
     it('should replaceWith', function() {


### PR DESCRIPTION
While writing a custom directive I needed to clone an element and retain the events. The jQuery version of clone takes a second parameter that allows copying the events and data, so I thought I'd implement that.

**Found jqCache references that were not deallocated!**
The only thing left is cloning the data.
The problem I'm facing is that karma is telling my that I've got a leak.

Any suggestions why?
