### PR TITLE
chore(grunt): update to latest jshint task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,45 +106,38 @@ module.exports = function(grunt) {
     },
 
     jshint: {
+      options: {
+        jshintrc: true,
+      },
       ng: {
         files: { src: files['angularSrc'] },
-        options: { jshintrc: 'src/.jshintrc' }
       },
       ngAnimate: {
         files: { src: 'src/ngAnimate/**/*.js' },
-        options: { jshintrc: 'src/ngAnimate/.jshintrc' }
       },
       ngCookies: {
         files: { src: 'src/ngCookies/**/*.js' },
-        options: { jshintrc: 'src/ngCookies/.jshintrc' }
       },
       ngLocale: {
         files: { src: 'src/ngLocale/**/*.js' },
-        options: { jshintrc: 'src/ngLocale/.jshintrc' }
       },
       ngMock: {
         files: { src: 'src/ngMock/**/*.js' },
-        options: { jshintrc: 'src/ngMock/.jshintrc' }
       },
       ngResource: {
         files: { src: 'src/ngResource/**/*.js' },
-        options: { jshintrc: 'src/ngResource/.jshintrc' }
       },
       ngRoute: {
         files: { src: 'src/ngRoute/**/*.js' },
-        options: { jshintrc: 'src/ngRoute/.jshintrc' }
       },
       ngSanitize: {
         files: { src: 'src/ngSanitize/**/*.js' },
-        options: { jshintrc: 'src/ngSanitize/.jshintrc' }
       },
       ngScenario: {
         files: { src: 'src/ngScenario/**/*.js' },
-        options: { jshintrc: 'src/ngScenario/.jshintrc' }
       },
       ngTouch: {
         files: { src: 'src/ngTouch/**/*.js' },
-        options: { jshintrc: 'src/ngTouch/.jshintrc' }
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     }
   ],
   "dependencies": {
-    "grunt-contrib-jshint": "~0.6.4"
+    "grunt-contrib-jshint": "~0.7.2"
   }
 }


### PR DESCRIPTION
Upgrade JSHint task from ~0.6.4 to ~0.7.2. Two useful changes: ability
to set jshintrc option to use jshint's native ability for finding .jshintrc
files relative to the linted files and update jshint to 2.3.0.

Closes #5143
