### PR TITLE
Refactor resource instance creation so prototype chain is respected

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -440,7 +440,8 @@ angular.module('ngResource', ['ng']).
           /* jshint +W086 */ /* (purposefully fall through case statements) */
 
           var isInstanceCall = this instanceof Resource;
-          var value = isInstanceCall ? data : (action.isArray ? [] : new this(data));
+          var ResourceConstructor = this;
+          var value = isInstanceCall ? data : (action.isArray ? [] : new ResourceConstructor(data));
           var httpConfig = {};
           var responseInterceptor = action.interceptor && action.interceptor.response ||
                                     defaultResponseInterceptor;

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -440,7 +440,7 @@ angular.module('ngResource', ['ng']).
           /* jshint +W086 */ /* (purposefully fall through case statements) */
 
           var isInstanceCall = this instanceof Resource;
-          var value = isInstanceCall ? data : (action.isArray ? [] : new Resource(data));
+          var value = isInstanceCall ? data : (action.isArray ? [] : new this(data));
           var httpConfig = {};
           var responseInterceptor = action.interceptor && action.interceptor.response ||
                                     defaultResponseInterceptor;

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -746,6 +746,17 @@ describe("resource", function() {
         expect(promiseValue).toEqual({ value: 'transformed' });
         expect(successValue).toBe(promiseValue);
       });
+
+      it('should get instantiated with the correct constructor function', function(){
+        $httpBackend.expect('GET', '/CreditCard/123').respond({id: 123, number: '9876'});
+
+        CreditCard.prototype.someCustomMethod = function(){ return 'hello'; };
+
+        var cc = CreditCard.get({id: 123});
+
+        expect(cc.someCustomMethod).toBe(CreditCard.prototype.someCustomMethod);
+        expect(cc.someCustomMethod()).toBe('hello');
+      });
     });
 
 


### PR DESCRIPTION
### The problem:

Consider a CustomResource object:

```
var CustomResource = new Resource();
CustomResource.prototype.someCustomMethod = function(){};
```

Then the following will work:

```
var resource = new CustomResource();
resource.someCustomMethod(); // Works fine
```

But when an resource is instantiated through a non-instance method, the prototype is lost:

```
var resource = CustomerResource.get({id: 1});
resource.someCustomMethod(); // Does not work because prototype is lost
```

This is a result of instantiating the new resource instance object directly from the `Resource` constructor and not the constructor of the current resource object.
### The fix:

This PR fixes the problem and makes sure that the prototype is chained correctly:

```
var CustomResource = new Resource();
CustomResource.prototype.someCustomMethod = function(){};

var resource = new CustomResource();
resource.someCustomMethod(); // Will still work as before

var resource = CustomerResource.get({id: 1});
resource.someCustomMethod(); // Will also work now!
```

A unit test is also included and the full test suite runs fine.
