### PR TITLE
Update $window documentation to support 1.2.2

### DIFF
--- a/src/ng/window.js
+++ b/src/ng/window.js
@@ -20,13 +20,15 @@
      <doc:source>
        <script>
          function Ctrl($scope, $window) {
-           $scope.$window = $window;
+           $scope.greet = function() {
+             $window.alert($scope.greeting);
+           };
            $scope.greeting = 'Hello, World!';
          }
        </script>
        <div ng-controller="Ctrl">
          <input type="text" ng-model="greeting" />
-         <button ng-click="$window.alert(greeting)">ALERT</button>
+         <button ng-click="greet(greeting)">ALERT</button>
        </div>
      </doc:source>
      <doc:scenario>


### PR DESCRIPTION
When you currently run the code example for $window you get the following error in the console:

```
Error: [$parse:isecwindow] http://errors.angularjs.org/1.2.2/$parse/isecwindow?p0=%24window.alert(greeting)
    at Error (<anonymous>)
    at http://ajax.googleapis.com/ajax/libs/angularjs/1.2.2/angular.min.js:6:449
    at Va (http://ajax.googleapis.com/ajax/libs/angularjs/1.2.2/angular.min.js:85:122)
    at http://ajax.googleapis.com/ajax/libs/angularjs/1.2.2/angular.min.js:160:152
    at http://ajax.googleapis.com/ajax/libs/angularjs/1.2.2/angular.min.js:177:167
    at g.$eval (http://ajax.googleapis.com/ajax/libs/angularjs/1.2.2/angular.min.js:101:39)
    at g.$apply (http://ajax.googleapis.com/ajax/libs/angularjs/1.2.2/angular.min.js:101:317)
    at HTMLButtonElement.<anonymous> (http://ajax.googleapis.com/ajax/libs/angularjs/1.2.2/angular.min.js:177:149)
    at http://ajax.googleapis.com/ajax/libs/angularjs/1.2.2/angular.min.js:27:15
    at Array.forEach (native) 
```

This PR fixes that issue.
