### PR TITLE
fix($compile): ensure isolated local watches lastValue is always in syn...

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1444,7 +1444,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                       parentSet(scope, parentValue = lastValue = isolateScope[scopeName]);
                     }
                   }
-                  return parentValue;
+                  return lastValue = parentValue;
                 });
                 break;
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2386,6 +2386,24 @@ describe('$compile', function() {
         expect(componentScope.refAlias).toBe($rootScope.name);
       }));
 
+      it('should not break if local and origin both change to the same value', inject(function() {
+        $rootScope.name = 'aaa';
+
+        compile('<div><span my-component ref="name">');
+
+        //change both sides to the same item withing the same digest cycle
+        componentScope.ref = 'same';
+        $rootScope.name = 'same';
+        $rootScope.$apply();
+
+        //change origin back to it's previous value
+        $rootScope.name = 'aaa';
+        $rootScope.$apply();
+
+        expect($rootScope.name).toBe('aaa');
+        expect(componentScope.ref).toBe('aaa');
+      }));
+
       it('should complain on non assignable changes', inject(function() {
         compile('<div><span my-component ref="\'hello \' + name">');
         $rootScope.name = 'world';


### PR DESCRIPTION
...c

When using two-way binding with isolate scope, under some circumstances
the lastValue variable captured in the parentValueWatch function can get
out of sync.

Specifically, if both the value in the origin scope as well as the value
in the isolate scope get independently updated to the same value within
one digest cycle, the lastValue is never updated. This potentially causes
the watch to make the wrong decision as to which side to update on subsequent
passes.

This fixes things by ensuring lastValue is always set to the last seen
value even if the watch's logic was shrot circuited because there was no
difference between the values in the original and isolate scopes.
