### PR TITLE
Add example on how to use the injector from outside Angular

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -27,6 +27,18 @@
  *     $rootScope.$digest();
  *   });
  * </pre>
+ * 
+ * If you have a running Angular application and you want to dynamically inject a Controller from outside Angular,
+ * you can do it like this:
+ * <pre>
+ * var $div = $('<div ng-controller="MyCtrl">{{content.label}}</div>');
+ * $(document.body).append($div);
+ * 
+ * angular.element(document).injector().invoke(function($compile) {
+ *   var scope = angular.element($div).scope();
+ *   $compile($div)(scope);
+ * });
+ * 
  */
 
 


### PR DESCRIPTION
Sometimes you integrate Angular in an application that has been there for a while and not all parts of the app are written in Angular. If you need to dynamically add Controllers to that project from outside Angular (let's say jQuery) then this example is for you.
