### PR TITLE
fix(ngSanitize): prevent decodeEntities from prepending original text…

### DIFF
--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -373,11 +373,11 @@ function decodeEntities(value) {
   // Note: IE8 does not preserve spaces at the start/end of innerHTML
   var spaceRe = /^(\s*)([\s\S]*?)(\s*)$/;
   var parts = spaceRe.exec(value);
-  parts[0] = '';
   if (parts[2]) {
     hiddenPre.innerHTML=parts[2].replace(/</g,"&lt;");
     parts[2] = hiddenPre.innerText || hiddenPre.textContent;
   }
+  parts[0] = '';
   return parts.join('');
 }
 

--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -410,4 +410,10 @@ describe('HTML', function() {
       expect(sanitizeText('a<div>&</div>c')).toEqual('a&lt;div&gt;&amp;&lt;/div&gt;c');
     });
   });
+
+  describe('decodeEntities', function() {
+    it('should not prepend the original string to the output', function() {
+      expect(decodeEntities('John Due &#9786;')).toEqual('John Due ☺');
+    });
+  });
 });


### PR DESCRIPTION
Clearing the match before the conditional branch seems to (inexplicably)
break Safari 7 on OSX 10.9, except when stepping through line by line.

Moving the assignment to after the conditional branch corrects this
behaviour.

Closes #5192
