### PR TITLE
docs: Added a parenthetical comment about ngModel being required

### DIFF
--- a/docs/content/guide/forms.ngdoc
+++ b/docs/content/guide/forms.ngdoc
@@ -116,7 +116,7 @@ This ensures that the user is not distracted with an error until after interacti
 A form is an instance of {@link api/ng.directive:form.FormController FormController}.
 The form instance can optionally be published into the scope using the `name` attribute.
 Similarly, control is an instance of {@link api/ng.directive:ngModel.NgModelController NgModelController}.
-The control instance can similarly be published into the form instance using the `name` attribute.
+The control instance can similarly be published into the form instance using the `name` attribute (the control instance must use the `ngModel` directive).
 This implies that the internal state of both the form and the control is available for binding in the view using the standard binding primitives.
 
 This allows us to extend the above example with these features:


### PR DESCRIPTION
This PR is to make absolutely clear to users that `ngModel` is required in order to take advantage of `FormController` from the form directive for publishing inputs onto $scope.
