### PR TITLE
feat($cacheFactory): add expiration option to $cacheFactory

### DIFF
--- a/src/ng/cacheFactory.js
+++ b/src/ng/cacheFactory.js
@@ -26,6 +26,7 @@
  * @param {object=} options Options object that specifies the cache behavior. Properties:
  *
  *   - `{number=}` `capacity` — turns the cache into LRU cache.
+ *   - `{number=}` `maxAge` — sets a max age in milliseconds valid for each key individually.
  *
  * @returns {object} Newly created cache object with the following set of methods:
  *
@@ -53,6 +54,8 @@ function $CacheFactoryProvider() {
           data = {},
           capacity = (options && options.capacity) || Number.MAX_VALUE,
           lruHash = {},
+          timestamps = {},
+          maxAge = (options && options.maxAge) || null,
           freshEnd = null,
           staleEnd = null;
 
@@ -67,6 +70,8 @@ function $CacheFactoryProvider() {
           if (!(key in data)) size++;
           data[key] = value;
 
+          timestamps[key] = new Date().getTime();
+
           if (size > capacity) {
             this.remove(staleEnd.key);
           }
@@ -79,6 +84,11 @@ function $CacheFactoryProvider() {
           var lruEntry = lruHash[key];
 
           if (!lruEntry) return;
+
+          if (maxAge && timestamps[key] + maxAge < new Date().getTime()) {
+            this.remove(key);
+            return;
+          }
 
           refresh(lruEntry);
 

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -135,7 +135,8 @@ function $HttpProvider() {
   this.$get = ['$httpBackend', '$browser', '$cacheFactory', '$rootScope', '$q', '$injector',
       function($httpBackend, $browser, $cacheFactory, $rootScope, $q, $injector) {
 
-    var defaultCache = $cacheFactory('$http');
+    // In case the cache is already defined with some options, try to get it first
+    var defaultCache = $cacheFactory.get('$http') || $cacheFactory('$http');
 
     /**
      * Interceptors stored in reverse order. Inner interceptors before outer interceptors.

--- a/test/ng/cacheFactorySpec.js
+++ b/test/ng/cacheFactorySpec.js
@@ -173,6 +173,47 @@ describe('$cacheFactory', function() {
   });
 
 
+  describe('expiring cache', function() {
+    var cache;
+
+    beforeEach(inject(function($cacheFactory) {
+      cache = $cacheFactory('expiringTest', { maxAge: 2 });
+      timerCallback = jasmine.createSpy('timerCallback');
+    }));
+
+    describe('expiration', function() {
+
+      it('should return a key from the cache which has not expired yet', inject(function($timeout) {
+        var keyValue = 'foo', returnedKeyValue;
+        cache.put('key', keyValue);
+
+        returnedKeyValue = cache.get('key');
+
+        expect(returnedKeyValue).toEqual(keyValue);
+      }));
+
+
+      it('should remove an expired key from the cache', inject(function($timeout) {
+        var timedOut = false;
+        runs(function() {
+          setTimeout(function() {
+            timedOut = true;
+          }, 3);
+        });
+
+        waitsFor(function() {
+          return timedOut;
+        }, 'returning from a 4 msec lapse', 4);
+
+        runs(function() {
+          returnedKeyValue = cache.get('key');
+          expect(returnedKeyValue).toBeUndefined();
+        });
+      }));
+    });
+  });
+
+
   describe('LRU cache', function() {
 
     it('should create cache with defined capacity', inject(function($cacheFactory) {


### PR DESCRIPTION
Adds an option to $cacheFactory to define the expiration of a key after a given amount of elapsed milliseconds.

The change additionally alters the defaultCache for $http so that it can be configured during the run phase.

---

I'd like to discuss about this feature being implemented into the AngularJS core. I know there are more powerful cache factories out there and the cache factory of AngularJS should be simple and lightweight. However, for requests to a REST API it should be possible to automatically invalidate the results after a given amount of time, while everything is still simple and lightweight. So I added this small amount of code to the `$cacheFactory`.

Tests for the change in `src/ng/http.js` are missing since I don't know how to test this properly. Hopefully someone can tell me how this could be achieved or point me to the right direction and I'll add a test for that, too.  The change has been implemented so one can configure the `defaultCache` with a `maxAge` as follows:

``` javascript
'use strict';

angular.module('app', [
    'ngResource'
])
.run(["$cacheFactory", function($cacheFactory) {
    $cacheFactory('$http', { maxAge: 10000 });
}]);
```

Additionally I want to mention that the time for adding this change and pull request (as well as the upcoming test for the `$http` change) has been payed by PAYMILL GmbH, Munich. I have been asked whether this could be mentioned somewhere once the code gets approved but wouldn't be an obstacle. I and PAYMILL would like to see this code in AngularJS and is the primary goal of this PR.

P.S.: CLA already signed. Anything else missing?
