### PR TITLE
fix(ngInit): evaluate ngInit before ngInclude

### DIFF
--- a/src/ng/directive/ngInit.js
+++ b/src/ng/directive/ngInit.js
@@ -16,6 +16,8 @@
  * to initialize values on a scope.
  * </div>
  *
+ * @priority 450
+ *
  * @element ANY
  * @param {expression} ngInit {@link guide/expression Expression} to eval.
  *
@@ -47,6 +49,7 @@
    </doc:example>
  */
 var ngInitDirective = ngDirective({
+  priority: 450,
   compile: function() {
     return {
       pre: function(scope, element, attrs) {

--- a/test/ng/directive/ngInitSpec.js
+++ b/test/ng/directive/ngInitSpec.js
@@ -13,4 +13,30 @@ describe('ngInit', function() {
     element = $compile('<div ng-init="a=123"></div>')($rootScope);
     expect($rootScope.a).toEqual(123);
   }));
+
+
+  it("should be evaluated before ngInclude", inject(function($rootScope, $templateCache, $compile) {
+    $templateCache.put('template1.tpl', '<span>1</span>');
+    $templateCache.put('template2.tpl', '<span>2</span>');
+    $rootScope.template = 'template1.tpl';
+    element = $compile('<div><div ng-include="template" ' +
+                                 'ng-init="template=\'template2.tpl\'"></div></div>')($rootScope);
+    $rootScope.$digest();
+    expect($rootScope.template).toEqual('template2.tpl');
+    expect(element.find('span').text()).toEqual('2');
+  }));
+
+
+  it("should be evaluated after ngController", function() {
+    module(function($controllerProvider) {
+      $controllerProvider.register('TestCtrl', function($scope) {});
+    });
+    inject(function($rootScope, $compile) {
+      element = $compile('<div><div ng-controller="TestCtrl" ' +
+                                   'ng-init="test=123"></div></div>')($rootScope);
+      $rootScope.$digest();
+      expect($rootScope.test).toBeUndefined();
+      expect(element.children('div').scope().test).toEqual(123);
+    });
+  });
 });


### PR DESCRIPTION
The priority of ngInit is adjusted to occur before ngInclude, and after  ngController. This enables ngInit to initiallize values in a controller's  scope, and also to initiallize values before ngInclude executes.

Closes #5167
