### PR TITLE
docs(contribute) add platform agnostic git install link

### DIFF
--- a/docs/content/misc/contribute.ngdoc
+++ b/docs/content/misc/contribute.ngdoc
@@ -23,7 +23,7 @@ for how to contribute your own code to AngularJS.
 Before you can build AngularJS, you must install and configure the following dependencies on your
 machine:
 
-* {@link http://git-scm.com/ Git}: The {@link http://help.github.com/mac-git-installation Github Guide to
+* {@link http://git-scm.com/ Git}: The {@link https://help.github.com/articles/set-up-git Github Guide to
 Installing Git} is a good source of information.
 
 * {@link http://nodejs.org Node.js}: We use Node to generate the documentation, run a


### PR DESCRIPTION
changed
http://help.github.com/mac-git-installation
to
https://help.github.com/articles/set-up-git
