### PR TITLE
feat(ngModelController): expose $setModelValue

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1000,7 +1000,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
   this.$name = $attr.name;
 
   var ngModelGet = $parse($attr.ngModel),
-      ngModelSet = ngModelGet.assign;
+      ngModelSet = this.$setModelValue = ngModelGet.assign;
 
   if (!ngModelSet) {
     throw minErr('ngModel')('nonassign', "Expression '{0}' is non-assignable. Element: {1}",


### PR DESCRIPTION
### General usecase:
- allow other directives requiring `ngModel` to easily assign model value
- `$setViewValue` works only with basic "flat" values like strings or numbers (eg not objects).

currently similar thing can be achieved by using 

``` javascript
$parse(attr.ngModel).assign(scope.$parent,modelValue)
```

but this approach gets more complicated with multiple directives and isolate scopes.
### Specific usecase:

AutoComplete input directive returning objects instead of values.

``` html
<input type="text" auto-complete-user ng-model="user">
```

parser:

``` javascript
function(value){ return {name:value} )
```

formatter:

``` javascript
function(value){
  return angular.isObject(value) ? value.name : value 
}
```

the user list dropdown template:

``` html
<li ng-repeat="user in users" ng-click="select(user)">{{user.name}}</li>
```

and the `select` function would be:

``` javascript
function(user){
  ngModel.$setModelValue(user)
}
```
