### PR TITLE
docs($q): correct count from three to two differences in the 'Difference...

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -136,7 +136,7 @@
  *
  * # Differences between Kris Kowal's Q and $q
  *
- *  There are three main differences:
+ *  There are two main differences:
  *
  * - $q is integrated with the {@link ng.$rootScope.Scope} Scope model observation
  *   mechanism in angular, which means faster propagation of resolution or rejection into your


### PR DESCRIPTION
At the $q doc is a listing with the differences between Q and $q

"There are three main differences"
But only a list with two items.

Change wording from "three" -> "two"
