### PR TITLE
feat(form): interpolate form names

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -46,8 +46,8 @@ var nullFormCtrl = {
  *
  */
 //asks for $scope to fool the BC controller module
-FormController.$inject = ['$element', '$attrs', '$scope'];
-function FormController(element, attrs) {
+FormController.$inject = ['$element', '$attrs', '$scope', '$interpolate'];
+function FormController(element, attrs, $scope, $interpolate) {
   var form = this,
       parentForm = element.parent().controller('form') || nullFormCtrl,
       invalidCount = 0, // used to easily determine if we are valid
@@ -55,7 +55,7 @@ function FormController(element, attrs) {
       controls = [];
 
   // init state
-  form.$name = attrs.name || attrs.ngForm;
+  form.$name = $interpolate(attrs.name || attrs.ngForm || '', false)($scope);
   form.$dirty = false;
   form.$pristine = true;
   form.$valid = true;

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -95,6 +95,24 @@ describe('form', function() {
     expect(scope.obj.myForm).toBeTruthy();
   });
 
+  it('should support a template as form name', function() {
+    scope.data = [ 'first', 'second' ];
+    doc = $compile(
+      '<form name="myForm">' +
+        '<div ng-repeat="(key, value) in data" ng-form name="children_{{ key }}"></div>' +
+//        '<div ng-repeat="(key, value) in data" ng-form name="children[{{ key }}]"></div>' +
+      '</form>')(scope);
+
+    scope.$apply();
+
+    expect(scope.myForm).toBeDefined();
+    expect(scope.myForm.children_0).toBeDefined();
+    expect(scope.myForm.children_1).toBeDefined();
+//    expect(scope.myForm.children).toBeDefined();
+//    expect(scope.myForm.children[0]).toBeDefined();
+//    expect(scope.myForm.children[1]).toBeDefined();
+  })
+
 
   it('should support two forms on a single scope', function() {
     doc = $compile(


### PR DESCRIPTION
This PR, in addition to https://github.com/angular/angular.js/pull/2988, will also interpolate the value in the form name. Especially useful when adding a collection of forms based on an array.

It'd be especially neat if the commented version of the code could work, but I'm not sure how to make this work.
