### PR TITLE
Update route.js

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -52,13 +52,13 @@ function $RouteProvider(){
    *    `$location.path` will be updated to add or drop the trailing slash to exactly match the
    *    route definition.
    *
-   *      * `path` can contain named groups starting with a colon (`:name`). All characters up
+   *      * `path` can contain named groups starting with a colon: e.g. `:name`. All characters up
    *        to the next slash are matched and stored in `$routeParams` under the given `name`
    *        when the route matches.
-   *      * `path` can contain named groups starting with a colon and ending with a star (`:name*`).
+   *      * `path` can contain named groups starting with a colon and ending with a star: e.g.`:name*`.
    *        All characters are eagerly stored in `$routeParams` under the given `name`
    *        when the route matches.
-   *      * `path` can contain optional named groups with a question mark (`:name?`).
+   *      * `path` can contain optional named groups with a question mark: e.g.`:name?`.
    *
    *    For example, routes like `/color/:color/largecode/:largecode*\/edit` will match
    *    `/color/brown/largecode/code/with/slashs/edit` and extract:


### PR DESCRIPTION
docs($routeProvider): don't wrap route parameter examples in braces

Wrapping the param examples in braces, for example (:param?) is confusing, as it make it seem that the braces are required in the route, which is not the case.
