### PR TITLE
Fix angular.copy to copy non-index properties of array

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -743,8 +743,8 @@ function copy(source, destination){
       "Can't copy! Source and destination are identical.");
     if (isArray(source)) {
       destination.length = 0;
-      for ( var i = 0; i < source.length; i++) {
-        destination.push(copy(source[i]));
+      for ( var property in source) {
+        destination[property] = copy(source[property]);
       }
     } else {
       var h = destination.$$hashKey;

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -72,6 +72,16 @@ describe('angular', function() {
       expect(dst[1]).not.toBe(src[1]);
     });
 
+    it("should deeply copy an array containing non-index properties into a new array", function() {
+      var src = [1, {name: "value"}];
+      src["foo"] = "bar";
+      var dst = copy(src);
+      expect(src["foo"]).toEqual("bar");
+      expect(dst).toEqual(src);
+      expect(dst).not.toBe(src);
+      expect(dst["foo"]).toEqual("bar");
+    });
+
     it('should copy empty array', function() {
       var src = [];
       var dst = [{key: "v"}];


### PR DESCRIPTION
fix(angular.copy): Fix angular.copy not copying non-index properties of array

Old implementation didn't copy non-index properties correctly, causing
arrays to not be fully copied. This commit fixes that problem by
modifying angular.copy's code to handle arrays by using a 'for in' loop
rather than a regular for loop.

Closes #5238
