### PR TITLE
fix(closure): closure compiler shouldn't rename $httpProvide.defaults.transformRequest

### DIFF
--- a/closure/angular.js
+++ b/closure/angular.js
@@ -1053,6 +1053,10 @@ angular.$http;
  */
 angular.$http.Config;
 
+angular.$http.Config.transformRequest;
+
+angular.$http.Config.transformResponse;
+
 // /**
 //  * This extern is currently incomplete as delete is a reserved word.
 //  * To use delete, index $http.
@@ -1158,6 +1162,13 @@ angular.$http.HttpPromise.error = function(callback) {};
  *   }}
  */
 angular.$http.Response;
+
+angular.$HttpProvider;
+
+/**
+ * @type {angular.$http.Config}
+ */
+angular.$HttpProvider.defaults;
 
 /******************************************************************************
  * $injector Service


### PR DESCRIPTION
i would like to be able to have following code working when using Closure JS compiler:

my.module.config(['$httpProvider', function($httpProvider) {
  $httpProvider.defaults.transformResponse = [my.transformHttpResponse];
}]);

unfortunately "transformResponse" is being renamed to random string.

Looks like Closure compiler doesn't respect @tyedef, i could inline all properties of angular.$http.Config but first wanted to get a quick feedback if that change makes sense.
