### PR TITLE
chore: ignore IntelliJ IDEA module files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ angular.js.tmproj
 /bower_components/
 angular.xcodeproj
 .idea
+*.iml
 .agignore
 libpeerconnection.log
 npm-debug.log


### PR DESCRIPTION
Ignore IntelliJ IDEA modules files in the git repository
