### PR TITLE
fix: properly remove event listeners for memory leak prevention

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -215,16 +215,20 @@ function jqLiteOff(element, type, fn, unsupported) {
 
   if (isUndefined(type)) {
     forEach(events, function(eventHandler, type) {
-      removeEventListenerFn(element, type, eventHandler);
+      removeEventListenerFn(element, type, handle);
       delete events[type];
     });
   } else {
     forEach(type.split(' '), function(type) {
       if (isUndefined(fn)) {
-        removeEventListenerFn(element, type, events[type]);
+        removeEventListenerFn(element, type, handle);
         delete events[type];
       } else {
         arrayRemove(events[type] || [], fn);
+        if (events[type] && !events[type].length) {
+          removeEventListenerFn(element, type, handle);
+          delete events[type];
+        }
       }
     });
   }
@@ -649,7 +653,7 @@ function createEventHandler(element, events) {
       delete event.isDefaultPrevented;
     }
   };
-  eventHandler.elem = element;
+  // eventHandler.elem = element;
   return eventHandler;
 }
 


### PR DESCRIPTION
This PR is just to show buggy code, and possible fix related to https://github.com/angular/angular.js/issues/5270
The final code should be at least re-factored a bit and correspondent tests should be added.
I'll not be able to do right PR for now...
