### PR TITLE
fix(input): ensure ngModelWatch() triggers second digest pass when appro...

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1154,6 +1154,8 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
         ctrl.$render();
       }
     }
+
+    return value;
   });
 }];
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -383,6 +383,29 @@ describe('ngModel', function() {
       dealoc(element);
     });
   });
+
+  it('should keep previously defined watches consistent when changes in validity are made',
+   inject(function($compile, $rootScope) {
+
+     var isFormValid;
+     $rootScope.$watch('myForm.$valid', function(value) { isFormValid = value; });
+
+     var element = $compile('<form name="myForm">' +
+      '<input  name="myControl" ng-model="value" required >' +
+      '</form>')($rootScope);
+
+     $rootScope.$apply();
+     expect(isFormValid).toBe(false);
+     expect($rootScope.myForm.$valid).toBe(false);
+
+     $rootScope.value='value';
+     $rootScope.$apply();
+     expect(isFormValid).toBe(true);
+     expect($rootScope.myForm.$valid).toBe(true);
+
+     dealoc(element);
+   }));
+
 });
 
 


### PR DESCRIPTION
...priate

Due to an earlier change, ngModelWatch() no longer returns a value to the
caller. This means the digest loop has no way to tell if the watch actually
modified anything and so can not schedule another pass.

This means any watches that watch form or model controller changes
(e.g. watches on form.$valid) that are scheduled prior to an ngModelWatch()
will not be able to see any changes made therin.

This commit fixes this behavior by returning the latest evaluated ng-model
value.

Closes #5258
