### PR TITLE
Clarified that ngSwitchWhen acceptable expressions must be a text litera...

### DIFF
--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -25,8 +25,8 @@
  *
  * @usage
  * <ANY ng-switch="expression">
- *   <ANY ng-switch-when="matchValue1">...</ANY>
- *   <ANY ng-switch-when="matchValue2">...</ANY>
+ *   <ANY ng-switch-when="matchedTextLiteralValue1">...</ANY>
+ *   <ANY ng-switch-when="matchedTextLiteralValue2">...</ANY>
  *   <ANY ng-switch-default>...</ANY>
  * </ANY>
  *


### PR DESCRIPTION
...l

The matchValue is not arbitrary but must be text. In particular, it cannot even be an expression or handle-barred expression resulting in text.
