### PR TITLE
docs(ng/core module): fix typo

### DIFF
--- a/docs/content/api/ng.ngdoc
+++ b/docs/content/api/ng.ngdoc
@@ -3,6 +3,6 @@
 @description
 
 # ng (core module)
-The ng module is loaded by default when an AngularJS application is started. The module itself contains the essential components to for an AngularJS application to function. The table below lists a high level breakdown of each of the services/factories, filters, directives and testing components available within this core module.
+The ng module is loaded by default when an AngularJS application is started. The module itself contains the essential components for an AngularJS application to function. The table below lists a high level breakdown of each of the services/factories, filters, directives and testing components available within this core module.
 
 <div doc-module-components="ng"></div>


### PR DESCRIPTION
Removed unnecessary 'to'
