### PR TITLE
docs (tutorial/step_11): tidy indenting of a tests return object

### DIFF
--- a/docs/content/tutorial/step_11.ngdoc
+++ b/docs/content/tutorial/step_11.ngdoc
@@ -185,7 +185,7 @@ describe('PhoneCat controllers', function() {
         xyzPhoneData = function() {
           return {
             name: 'phone xyz',
-                images: ['image/url1.png', 'image/url2.png']
+            images: ['image/url1.png', 'image/url2.png']
           }
         };
 


### PR DESCRIPTION
Motivation: want code example indentation to be consistent and easier to read.

Not linked to an issue/ticket.
