### PR TITLE
Removed refs to window.angular and instead ref'd local variable; window....

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -28,7 +28,7 @@ var XHR = window.XMLHttpRequest || function() {
  */
 function $HttpBackendProvider() {
   this.$get = ['$browser', '$window', '$document', function($browser, $window, $document) {
-    return createHttpBackend($browser, XHR, $browser.defer, $window.angular.callbacks, $document[0]);
+    return createHttpBackend($browser, XHR, $browser.defer, angular.callbacks, $document[0]);
   }];
 }
 

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -638,7 +638,7 @@ function $LocationProvider(){
           $location.$$parse(rewrittenUrl);
           $rootScope.$apply();
           // hack to work around FF6 bug 684208 when scenario runner clicks on links
-          window.angular['ff-684208-preventDefault'] = true;
+          angular['ff-684208-preventDefault'] = true;
         }
       }
     });


### PR DESCRIPTION
fix($http,$location): fix undefined global after use of noConflict()

The angular global is not available after using noConflict() so local copy must be used.
