### PR TITLE
refactor(ngHref, ngSrc, ngSrcset): reset priority to default

### DIFF
--- a/src/ng/directive/booleanAttrs.js
+++ b/src/ng/directive/booleanAttrs.js
@@ -347,7 +347,6 @@ forEach(['src', 'srcset', 'href'], function(attrName) {
   var normalized = directiveNormalize('ng-' + attrName);
   ngAttributeAliasDirectives[normalized] = function() {
     return {
-      priority: 99, // it needs to run after the attributes are interpolated
       link: function(scope, element, attr) {
         attr.$observe(normalized, function(value) {
           if (!value)


### PR DESCRIPTION
There is no need to run after the attributes are interpolated
since this commit 9be82d942fc6ab2772197c84a35a4c374c604cbc
