### PR TITLE
docs(isolateScope): update guide to reflect usage of element.isolateScope

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -344,6 +344,7 @@ element as a customer component.
 
 
 ### Isolating the Scope of a Directive
+<a name="isolated_scope"></a>
 
 Our `myCustomer` directive above is great, but it has a fatal flaw. We can only use it once within a
 given scope.
@@ -506,6 +507,8 @@ that you explicitly pass in.
 
 <div class="alert alert-warning">
 **Note:** Normally, a scope prototypically inherits from its parent. An isolated scope does not.
+Instead of using `angular.element(aDomElement).scope()` you need to use
+`angular.element(aDomElement).isolateScope()` to retrieve the directive's isolate scope.
 </div>
 
 <div class="alert alert-success">

--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -507,9 +507,7 @@ that you explicitly pass in.
 
 <div class="alert alert-warning">
 **Note:** Normally, a scope prototypically inherits from its parent. An isolated scope does not.
-Instead of using `angular.element(aDomElement).scope()` you need to use
-`angular.element(aDomElement).isolateScope()` to retrieve the directive's isolate scope.
-</div>
+See the {@link api/angular.element element API} for details.</div>
 
 <div class="alert alert-success">
 **Best Practice:** Use the `scope` option to create isolate scopes when making components that you

--- a/docs/content/guide/scope.ngdoc
+++ b/docs/content/guide/scope.ngdoc
@@ -19,7 +19,8 @@ watch {@link guide/expression expressions} and propagate events.
     realm" (controllers, services, Angular event handlers).
 
   - Scopes can be nested to isolate application components while providing access to shared model
-    properties. A scope (prototypically) inherits properties from its parent scope.
+    properties. A scope (prototypically) inherits properties from its parent scope unless it
+    doesn't use an {@link guide/directive#isolated_scope isolated scope}.
 
   - Scopes provide context against which {@link guide/expression expressions} are evaluated. For
     example `{{username}}` expression is meaningless, unless it is evaluated against a specific
@@ -306,6 +307,7 @@ api/ng.directive:ngController ng-controller} and {@link
 api/ng.directive:ngRepeat ng-repeat}, create new child scopes
 and attach the child scope to the corresponding DOM element. You can retrieve a scope for any DOM
 element by using an `angular.element(aDomElement).scope()` method call.
+See the {@link guide/directive#isolated_scope directives guide} for details when using isolate scopes.
 
 ### Controllers and Scopes
 


### PR DESCRIPTION
update developer guide for scope and directives to reflect the changes of https://github.com/angular/angular.js/commit/27e9340b3c25b512e45213b39811098d07e12e3b introducing `element.isolateScope()`

Closes #5274
