### PR TITLE
fix(angular-mocks): stringify parameters in $httpBackend.expect

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1562,7 +1562,8 @@ function MockHttpExpectation(method, url, data, headers) {
     if (angular.isUndefined(data)) return true;
     if (data && angular.isFunction(data.test)) return data.test(d);
     if (data && angular.isFunction(data)) return data(d);
-    if (data && !angular.isString(data)) return angular.equals(data, angular.fromJson(d));
+    if (data && !angular.isString(data))
+	return angular.equals(angular.fromJson(angular.toJson(data)), angular.fromJson(d));
     return data == d;
   };
 

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1110,6 +1110,22 @@ describe('ngMock', function() {
       });
 
 
+      it ('should not throw an exception when parsed body is equal to expected body object that contain Date', function() {
+        hb.when('GET').respond(200, '', {});
+        var date = new Date();
+        hb.expect('GET', '/match', {a: 1, b: 2, date: date});
+        var dateStr = angular.toJson(date);
+        expect(function() {
+          hb('GET', '/match', '{"a":1,"b":2,"date":'+dateStr+'}', noop, {});
+        }).not.toThrow();
+
+        hb.expect('GET', '/match', {a: 1, b: 2, date:date});
+        expect(function() {
+          hb('GET', '/match', '{"b":2,"a":1,"date":'+dateStr+'}', noop, {});
+        }).not.toThrow();
+      });
+
+
       it ('should throw exception when only parsed body differs from expected body object', function() {
         hb.when('GET').respond(200, '', {});
         hb.expect('GET', '/match', {a: 1, b: 2});


### PR DESCRIPTION
fix(angular-mocks): stringify parameters in $httpBackend.expect

Use angular.fromJon and angular.toJson to make an snapshot of parameters in $httpBackend.expect

Fixes #5333
