### PR TITLE
Chore locale: Add quotation mark to reserved keyword used as property accessor

### DIFF
--- a/src/ng/locale.js
+++ b/src/ng/locale.js
@@ -53,7 +53,7 @@ function $LocaleProvider(){
         SHORTDAY: 'Sun,Mon,Tue,Wed,Thu,Fri,Sat'.split(','),
         AMPMS: ['AM','PM'],
         medium: 'MMM d, y h:mm:ss a',
-        short: 'M/d/yy h:mm a',
+        'short': 'M/d/yy h:mm a',
         fullDate: 'EEEE, MMMM d, y',
         longDate: 'MMMM d, y',
         mediumDate: 'MMM d, y',


### PR DESCRIPTION
I don't like the inconsistency of this. The ES5 spec is very vague on this part, but this seems
like the right thing to do. Fixes #5320 
