### PR TITLE
Bugfix for IE8

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1656,7 +1656,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           content = denormalizeTemplate(content);
 
           if (origAsyncDirective.replace) {
-            $template = jqLite('<div>' + trim(content) + '</div>').contents();
+            $template = jqLite('<div/>', {html: trim(content)}).contents();
             compileNode = $template[0];
 
             if ($template.length != 1 || compileNode.nodeType !== 1) {


### PR DESCRIPTION
This solves the bug that angular-ui bootstrap modal is not
showing up in IE8
