### PR TITLE
docs($resource): fix typo in server response example

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -218,7 +218,7 @@ function lookupDottedPath(obj, path) {
      newCard.name = "Mike Smith";
      newCard.$save();
      // POST: /user/123/card {number:'0123', name:'Mike Smith'}
-     // server returns: {id:789, number:'01234', name: 'Mike Smith'};
+     // server returns: {id:789, number:'0123', name: 'Mike Smith'};
      expect(newCard.id).toEqual(789);
  * </pre>
  *


### PR DESCRIPTION
The server is supposed to return the same card number as in the client request.
Adjust server response example to the value given in the client request.
