### PR TITLE
Added Priority to all of the boolean directives documentation

### DIFF
--- a/src/ng/directive/booleanAttrs.js
+++ b/src/ng/directive/booleanAttrs.js
@@ -155,6 +155,7 @@
  * This complementary directive is not removed by the browser and so provides
  * a permanent reliable place to store the binding information.
  *
+   @priority 100
  * @example
     <doc:example>
       <doc:source>
@@ -205,6 +206,7 @@
     </doc:example>
  *
  * @element INPUT
+ * @priority 100
  * @param {expression} ngChecked If the {@link guide/expression expression} is truthy, 
  *     then special attribute "checked" will be set on the element
  */
@@ -224,6 +226,7 @@
  * This complementary directive is not removed by the browser and so provides
  * a permanent reliable place to store the binding information.
 
+   @priority 100
  * @example
     <doc:example>
       <doc:source>
@@ -258,6 +261,8 @@
  * The `ngSelected` directive solves this problem for the `selected` atttribute.
  * This complementary directive is not removed by the browser and so provides
  * a permanent reliable place to store the binding information.
+ * 
+   @priority 100
  * @example
     <doc:example>
       <doc:source>
@@ -295,7 +300,7 @@
  * This complementary directive is not removed by the browser and so provides
  * a permanent reliable place to store the binding information.
 
- *
+   @priority 100
  * @example
      <doc:example>
        <doc:source>


### PR DESCRIPTION
None of the boolean directives have their priority listed in the docs.  In addition, required and open appear to be missing documentation altogether.  I didn't fix the latter problem since I'm not sure what either of them actually do.
