### PR TITLE
perf(a): do not link when href or name exists in template

### DIFF
--- a/src/ng/directive/a.js
+++ b/src/ng/directive/a.js
@@ -32,13 +32,15 @@ var htmlAnchorDirective = valueFn({
       element.append(document.createComment('IE fix'));
     }
 
-    return function(scope, element) {
-      element.on('click', function(event){
-        // if we have no href url, then don't navigate anywhere.
-        if (!element.attr('href')) {
-          event.preventDefault();
-        }
-      });
-    };
+    if (!attr.href && !attr.name) {
+      return function(scope, element) {
+        element.on('click', function(event){
+          // if we have no href url, then don't navigate anywhere.
+          if (!element.attr('href')) {
+            event.preventDefault();
+          }
+        });
+      };
+    }
   }
 });

--- a/test/ng/directive/aSpec.js
+++ b/test/ng/directive/aSpec.js
@@ -58,4 +58,30 @@ describe('a', function() {
 
     expect(element.text()).toBe('hello@you');
   });
+
+
+  it('should not link and hookup an event if href is present at compile', function() {
+    var jq = jQuery || jqLite;
+    element = jq('<a href="//a.com">hello@you</a>');
+    var linker = $compile(element);
+
+    spyOn(jq.prototype, 'on');
+
+    linker($rootScope);
+
+    expect(jq.prototype.on).not.toHaveBeenCalled();
+  });
+
+
+  it('should not link and hookup an event if name is present at compile', function() {
+    var jq = jQuery || jqLite;
+    element = jq('<a name="bobby">hello@you</a>');
+    var linker = $compile(element);
+
+    spyOn(jq.prototype, 'on');
+
+    linker($rootScope);
+
+    expect(jq.prototype.on).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
perf(a): do not link when href or name exists in template

Change the a directive to link and hookup a click event only when
there is no href or name in the template element.
In a large Google app, this results in about 800 fewer registrations,
saving a small but measurable amount of time and memory.
