### PR TITLE
docs(interval.js) alerting the developer

### DIFF
--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -24,6 +24,12 @@ function $IntervalProvider() {
       * In tests you can use {@link ngMock.$interval#methods_flush `$interval.flush(millis)`} to
       * move forward by `millis` milliseconds and trigger any functions scheduled to run in that
       * time.
+      * 
+      * <div class="alert alert-warning">
+      * **Note**: The interval craeted by this service is not cleared during the $scope.$destroy() event.
+      * The developer should take this into consideration and make sure to always cancel the interval 
+      * inside a broadcasted 'destroy' event.
+      * </div>
       *
       * @param {function()} fn A function that should be called repeatedly.
       * @param {number} delay Number of milliseconds between each function call.


### PR DESCRIPTION
Many times $intervals are used inside of directives or controllers. If a directive/controller is destroyed, then the $interval should be destroyed as well. The interval created by this service does not have a way to track an associated $scope. This could cause some issues with developers who assume that the $interval will be cleared for them when the $scope is destroyed.
