### PR TITLE
-Updated code to allow 304 as successful rather than failure-Updated tes...

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -79,7 +79,7 @@ function transformData(data, headers, fns) {
 
 
 function isSuccess(status) {
-  return 200 <= status && status < 300;
+  return 200 <= status && (status < 300 || status === 304); //304 isn't an error code
 }
 
 
@@ -218,7 +218,7 @@ function $HttpProvider() {
      * an object representing the response. See the API signature and type info below for more
      * details.
      *
-     * A response status code between 200 and 299 is considered a success status and
+     * A response status code between 200 and 299, as well as 304, is considered a success status and
      * will result in the success callback being called. Note that if the response is a redirect,
      * XMLHttpRequest will transparently follow it, meaning that the error callback will not be
      * called for such responses.

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -486,6 +486,22 @@ describe('$http', function() {
         expect(callback).toHaveBeenCalledOnce();
       });
 
+      it('should reject the response promise when the error code is gte 300 but not 304', function() {
+        var cb;
+
+        cb = jasmine.createSpy();
+        $httpBackend.expect('GET', '/url').respond(301, 'Moved', {'request-id': '123'});
+        $http({url: '/url', method: 'GET'}).error(cb);
+        $httpBackend.flush();
+        expect(cb).toHaveBeenCalled();
+
+        cb = jasmine.createSpy();
+        $httpBackend.expect('GET', '/url').respond(304, 'Not Modified', {'request-id': '123'});
+        $http({url: '/url', method: 'GET'}).success(cb);
+        $httpBackend.flush();
+        expect(cb).toHaveBeenCalled();
+      });
+
 
       describe('success', function() {
         it('should allow http specific callbacks to be registered via "success"', function() {


### PR DESCRIPTION
...ts to account for successful 304 but failure on other 30x code-Updated documentation on  service to dictate success between codes 200-299, as well as code 304
