### PR TITLE
perf($injector)

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -769,24 +769,8 @@ function createInjector(modulesToLoad) {
         fn = fn[length];
       }
 
-
-      // Performance optimization: http://jsperf.com/apply-vs-call-vs-invoke
-      switch (self ? -1 : args.length) {
-        case  0: return fn();
-        case  1: return fn(args[0]);
-        case  2: return fn(args[0], args[1]);
-        case  3: return fn(args[0], args[1], args[2]);
-        case  4: return fn(args[0], args[1], args[2], args[3]);
-        case  5: return fn(args[0], args[1], args[2], args[3], args[4]);
-        case  6: return fn(args[0], args[1], args[2], args[3], args[4], args[5]);
-        case  7: return fn(args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
-        case  8: return fn(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]);
-        case  9: return fn(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7],
-          args[8]);
-        case 10: return fn(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7],
-          args[8], args[9]);
-        default: return fn.apply(self, args);
-      }
+      //http://jsperf.com/angularjs-invoke-apply-vs-switch
+      return fn.apply(self, args);
     }
 
     function instantiate(Type, locals) {


### PR DESCRIPTION
I did some testing on switch vs apply: http://jsperf.com/angularjs-invoke-apply-vs-switch

The existing benchmark always made calls with the same number of args (4), so I assume branch prediction is what made that so quick. (http://jsperf.com/apply-vs-call-vs-invoke/30)

However, in my benchmark, each invoke call has a different (random) number of arguments, which I feel is closer to real world conditions. Switching back to just `apply` seems to be about 40% faster, and saves a good bit of code as well.

It's also possible I've messed up the benchmark.

Thoughts?

(edited typo in speedup percentage)
