### PR TITLE
fix($httpBackend): use ActiveX XHR when making PATCH requests on IE8

### DIFF
--- a/docs/content/error/httpBackend/noxhr.ngdoc
+++ b/docs/content/error/httpBackend/noxhr.ngdoc
@@ -1,9 +1,0 @@
-@ngdoc error
-@name $httpBackend:noxhr
-@fullName Unsupported XHR
-@description
-
-This error occurs in browsers that do not support XmlHttpRequest. AngularJS
-supports Safari, Chrome, Firefox, Opera, IE8 and higher, and mobile browsers
-(Android, Chrome Mobile, iOS Safari). To avoid this error, use an officially
-supported browser.

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -75,7 +75,9 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
           // onreadystatechange might by called multiple times
           // with readyState === 4 on mobile webkit caused by
           // xhrs that are resolved while the app is in the background (see #5426).
-          xhr.onreadystatechange = undefined;
+          //
+          // we must delete the property instead of setting it to undefined/null to make IE8 happy.
+          delete xhr.onreadystatechange;
 
           var responseHeaders = null,
               response = null;

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1572,6 +1572,10 @@ function MockHttpExpectation(method, url, data, headers) {
   };
 }
 
+function createMockXhr() {
+  return new MockXhr();
+}
+
 function MockXhr() {
 
   // hack for testing $http, $httpBackend

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -53,7 +53,7 @@ describe('$httpBackend', function() {
         })
       }
     };
-    $backend = createHttpBackend($browser, MockXhr, fakeTimeout, callbacks, fakeDocument);
+    $backend = createHttpBackend($browser, createMockXhr, fakeTimeout, callbacks, fakeDocument);
     callback = jasmine.createSpy('done');
   }));
 
@@ -250,7 +250,7 @@ describe('$httpBackend', function() {
       expect(response).toBe('response');
     });
 
-    $backend = createHttpBackend($browser, SyncXhr);
+    $backend = createHttpBackend($browser, function() { return new SyncXhr() });
     $backend('GET', '/url', null, callback);
     expect(callback).toHaveBeenCalledOnce();
   });
@@ -426,7 +426,7 @@ describe('$httpBackend', function() {
 
 
     it('should convert 0 to 200 if content', function() {
-      $backend = createHttpBackend($browser, MockXhr);
+      $backend = createHttpBackend($browser, createMockXhr);
 
       $backend('GET', 'file:///whatever/index.html', null, callback);
       respond(0, 'SOME CONTENT');
@@ -437,7 +437,7 @@ describe('$httpBackend', function() {
 
 
     it('should convert 0 to 404 if no content', function() {
-      $backend = createHttpBackend($browser, MockXhr);
+      $backend = createHttpBackend($browser, createMockXhr);
 
       $backend('GET', 'file:///whatever/index.html', null, callback);
       respond(0, '');
@@ -465,7 +465,7 @@ describe('$httpBackend', function() {
 
       try {
 
-        $backend = createHttpBackend($browser, MockXhr);
+        $backend = createHttpBackend($browser, createMockXhr);
 
         $backend('GET', '/whatever/index.html', null, callback);
         respond(0, '');
@@ -480,7 +480,7 @@ describe('$httpBackend', function() {
 
 
     it('should return original backend status code if different from 0', function () {
-      $backend = createHttpBackend($browser, MockXhr);
+      $backend = createHttpBackend($browser, createMockXhr);
 
       // request to http://
       $backend('POST', 'http://rest_api/create_whatever', null, callback);


### PR DESCRIPTION
IE8's native XHR doesn't support PATCH requests, but the ActiveX one does.

Closes #2518
Closes #5043
