### PR TITLE
Remember to include the ngSanitize module when using ng-bind-html

### DIFF
--- a/src/ng/directive/ngBind.js
+++ b/src/ng/directive/ngBind.js
@@ -130,9 +130,12 @@ var ngBindTemplateDirective = ['$interpolate', function($interpolate) {
  * core Angular.)  You may also bypass sanitization for values you know are safe. To do so, bind to
  * an explicitly trusted value via {@link ng.$sce#methods_trustAsHtml $sce.trustAsHtml}.  See the example
  * under {@link ng.$sce#Example Strict Contextual Escaping (SCE)}.
+ * 
+ * Remember to include the Sanitize module, which is not included in the angular.js file. You can find it on Google Api's.'
  *
  * Note: If a `$sanitize` service is unavailable and the bound value isn't explicitly trusted, you
  * will have an exception (instead of an exploit.)
+ * This means it will not show anything if the ngSanitize module is not loaded.
  *
  * @element ANY
  * @param {expression} ngBindHtml {@link guide/expression Expression} to evaluate.


### PR DESCRIPTION
The current 1.2.4 does not through a exception, so when you look up the documentation you are confused.
