### PR TITLE
docs(angular.module): 'MyModule' -> 'myModule'

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -62,7 +62,7 @@ function setupModuleLoader(window) {
      * Then you can create an injector and load your modules like this:
      *
      * <pre>
-     * var injector = angular.injector(['ng', 'MyModule'])
+     * var injector = angular.injector(['ng', 'myModule'])
      * </pre>
      *
      * However it's more likely that you'll just use


### PR DESCRIPTION
The module in the example is created in lower camel case:

```
 var myModule = angular.module('myModule', []);
```

So it should be:

```
var injector = angular.injector(['ng', 'myModule'])
```
