### PR TITLE
feat($compile, jqLite): Change directive definition object to allow temp...

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1260,6 +1260,7 @@ function bindJQuery() {
       injector: JQLitePrototype.injector,
       inheritedData: JQLitePrototype.inheritedData
     });
+    jqLite.createElementWithNS = JQLite.createElementWithNS;
     // Method signature:
     //     jqLitePatchJQueryRemove(name, dispatchThis, filterElems, getterIfNoArguments)
     jqLitePatchJQueryRemove('remove', true, true, false);

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -234,6 +234,14 @@
  * api/ng.$sce#methods_getTrustedResourceUrl $sce.getTrustedResourceUrl}.
  *
  *
+ * #### `templateNS`
+ * You can specify the xml namespace the elements defined in the template should be in.  This would be useful
+ * if you were creating a fragment of xml content such as svg.
+ *
+ * You can specify `templateNS` as a string representing the default namespace.  Or as an object hash where
+ * key is namespace prefix and value is the namespace
+ *
+ *
  * #### `replace`
  * specify where the template should be inserted. Defaults to `false`.
  *
@@ -1239,6 +1247,10 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             $template = jqLite('<div>' +
                                  trim(directiveValue) +
                                '</div>').contents();
+            if(directive.templateNS)
+            {
+              $template = jqLite.createElementWithNS(trim(directiveValue),directive.templateNS,"application/xml");
+            }
             compileNode = $template[0];
 
             if ($template.length != 1 || compileNode.nodeType !== 1) {

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1452,4 +1452,44 @@ describe('jqLite', function() {
    });
   });
 
+
+  describe('namespaces',function(){
+    it('should create element with specifed default namespace',function(){
+      var nodes = jqLite.createElementWithNS("<someRandomElement></someRandomElement>","http://randomNamespace","application/xml");
+      expect(nodes[0].namespaceURI).toBe("http://randomNamespace");
+    });
+
+
+    it('should construct element with the default namespace when none specified',function(){
+      var namespacesUnderTest = ["",null, undefined];
+      for(index=0; index < namespacesUnderTest.length; index++)
+      {
+        var nodes = jqLite.createElementWithNS("<someRandomElement/>",namespacesUnderTest[index],"application/xml");
+        expect(nodes[0].namespaceURI).toBe("http://www.w3.org/1999/xhtml");
+      }
+    });
+
+
+    it('should be able to construct elements with prefix',function(){
+      var namespaceHash = { xmlns: "http://defaultNamespace",
+                            test:   "http://testNamespace" };
+      var nodes = jqLite.createElementWithNS("<someRandomElement/><test:anotherElement/>",namespaceHash,"application/xml");
+      expect(nodes[0].namespaceURI).toBe("http://defaultNamespace");
+      expect(nodes[1].namespaceURI).toBe("http://testNamespace");
+    });
+  });
+
+
+  describe('convertNamespaceHashToString',function(){
+      it('should convert a hash containing the default namespace to a string',function(){
+         var expectedString = ' xmlns="http://test"';
+         expect(convertNamespaceHashToString({'xmlns':"http://test"})).toBe(expectedString);
+      });
+
+
+      it('should convert a hash containing the default namespace and another prefix to a string',function(){
+          var expectedString = ' xmlns="http://test" xmlns:test="http://test"';
+          expect(convertNamespaceHashToString({'xmlns':'http://test', 'test':'http://test'})).toBe(expectedString);
+      });
+  })
 });

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -512,6 +512,12 @@ describe('$compile', function() {
               expect(element).toBe(attr.$$element);
             }
           }));
+          directive('replaceWithNamespace',valueFn({
+            restrict: 'E',
+            replace: true,
+            template: '<path></path>',
+            templateNS: 'http://www.w3.org/2000/svg'
+          }));
         }));
 
 
@@ -519,6 +525,12 @@ describe('$compile', function() {
           element = $compile('<div><div replace>ignore</div><div>')($rootScope);
           expect(element.text()).toEqual('Replace!');
           expect(element.find('div').attr('compiled')).toEqual('COMPILED');
+        }));
+
+
+        it('should replace element with template with given namespace', inject(function($compile,$rootScope) {
+            element = $compile('<replace-with-namespace></replace-with-namespace>')($rootScope);
+            expect(element[0].namespaceURI).toBe('http://www.w3.org/2000/svg');
         }));
 
 


### PR DESCRIPTION
...lates to be created within a given xml namespace

When creating a new directive and a template was specified, along with the replace option being set to true in the Directive Definition Object angular would create the elements contained within the template with the namespace of the HTML page.  Whilst this is fine for the vast majority of the cases if you ever need to use xml in your template as in SVG this causes a problem. As the newly created elements are in the HTML namespace and not SVG.

This change introduces a new property on the Directive Definition Object "templateNS". This new property allows you to pass in a string to serve as the default namespace for the elements or to pass in an object.  Where key is the xml prefix and value is the namespace.
