### PR TITLE
fix($timeout.$flush): make $flush follow the timeline

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -105,19 +105,21 @@ angular.mock.$Browser = function() {
    * @param {number=} number of milliseconds to flush. See {@link #defer.now}
    */
   self.defer.flush = function(delay) {
-    if (angular.isDefined(delay)) {
-      self.defer.now += delay;
-    } else {
+    if (!angular.isDefined(delay)) {
       if (self.deferredFns.length) {
-        self.defer.now = self.deferredFns[self.deferredFns.length-1].time;
+        delay = self.deferredFns[self.deferredFns.length-1].time - self.defer.now;
       } else {
         throw new Error('No deferred tasks to be flushed');
       }
     }
 
-    while (self.deferredFns.length && self.deferredFns[0].time <= self.defer.now) {
+    while (self.deferredFns.length && self.deferredFns[0].time <= self.defer.now + delay) {
+      delay -= (self.deferredFns[0].time - self.defer.now);
+      self.defer.now = self.deferredFns[0].time;
       self.deferredFns.shift().fn();
     }
+
+    self.defer.now += delay;
   };
 
   self.$$baseHref = '';

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -291,8 +291,10 @@ describe('ngMock', function() {
       expect(counter).toBe(1);
 
       $interval.flush(1000);
-
       expect(counter).toBe(2);
+
+      $interval.flush(2000);
+      expect(counter).toBe(4);
     }));
 
 
@@ -655,6 +657,30 @@ describe('ngMock', function() {
       expect(count).toBe(1);
       $timeout.flush(123);
       expect(count).toBe(2);
+    }));
+
+    it('should resolve timeout functions following the timeline', inject(function($timeout) {
+      var count1 = 0, count2 = 0;
+      var iterate1 = function() {
+        count1++;
+        $timeout(iterate1, 100);
+      };
+      var iterate2 = function() {
+        count2++;
+        $timeout(iterate2, 150);
+      };
+
+      $timeout(iterate1, 100);
+      $timeout(iterate2, 150);
+      $timeout.flush(150);
+      expect(count1).toBe(1);
+      expect(count2).toBe(1);
+      $timeout.flush(50);
+      expect(count1).toBe(2);
+      expect(count2).toBe(1);
+      $timeout.flush(400);
+      expect(count1).toBe(6);
+      expect(count2).toBe(4);
     }));
   });
 


### PR DESCRIPTION
Make the mock $timeout.$flush follow the timeline when the function
being calls $timeout
