### PR TITLE
Add support for <input type="week"/>

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -12,7 +12,8 @@ var URL_REGEXP = /^(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\
 var EMAIL_REGEXP = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}$/;
 var NUMBER_REGEXP = /^\s*(\-|\+)?(\d+|(\d*(\.\d*)))\s*$/;
 var DATE_REGEXP = /^(\d{4})-(\d{2})-(\d{2})$/;
-var DATETIMELOCAL_REGEXP = /^(\d{4})-(\d\d)-(\d\d)T(\d\d):(\d\d)$/;
+var DATETIMELOCAL_REGEXP = /^(\d{4})-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)$/;
+var WEEK_REGEXP = /^(\d{4})-W(\d\d)$/;
 
 var inputType = {
 
@@ -164,7 +165,7 @@ var inputType = {
     * @description
     * HTML5 or text input with datetime validation and transformation. In browsers that do not yet support
     * the HTML5 date input, a text element will be used. The text must be entered in a valid ISO-8601
-    * local datetime format (yyyy-MM-ddTHH:mm), for example: `2010-12-28T14:57`. Will also accept a valid ISO
+    * local datetime format (yyyy-MM-ddTHH:mm:ss), for example: `2010-12-28T14:57:12`. Will also accept a valid ISO
     * datetime string or Date object as model input, but will always output a Date object to the model.
     *
     * @param {string} ngModel Assignable angular expression to data-bind to.
@@ -180,49 +181,115 @@ var inputType = {
     *
     * @example
     <doc:example>
-      <doc:source>
-        <script>
-        function Ctrl($scope) {
-              $scope.value = '2010-12-28T14:57';
-            }
-        </script>
-        <form name="myForm" ng-controller="Ctrl as dateCtrl">
-          Pick a date in 2013:
-          <input type="datetime-local" name="input" ng-model="value"
-          placeholder="yyyy-MM-ddTHH:mm" min="2013-01-01T00:00" max="2013-12-31T00:00" required />
-          <span class="error" ng-show="myForm.input.$error.required">
-          Required!</span>
-          <span class="error" ng-show="myForm.input.$error.datetimelocal">
-          Not a valid date!</span>
-          <tt>value = {{value}}</tt><br/>
-          <tt>myForm.input.$valid = {{myForm.input.$valid}}</tt><br/>
-          <tt>myForm.input.$error = {{myForm.input.$error}}</tt><br/>
-          <tt>myForm.$valid = {{myForm.$valid}}</tt><br/>
-          <tt>myForm.$error.required = {{!!myForm.$error.required}}</tt><br/>
-        </form>
-      </doc:source>
-      <doc:scenario>
-        it('should initialize to model', function() {
-          expect(binding('value')).toEqual('2010-12-28T14:57');
+    <doc:source>
+    <script>
+    function Ctrl($scope) {
+          $scope.value = '2010-12-28T14:57:12';
+        }
+    </script>
+    <form name="myForm" ng-controller="Ctrl as dateCtrl">
+    Pick a date between in 2013:
+    <input type="datetime-local" name="input" ng-model="value"
+    placeholder="yyyy-MM-dd" min="2013-01-01T00:00" max="2013-12-31T00:00" required />
+    <span class="error" ng-show="myForm.input.$error.required">
+    Required!</span>
+    <span class="error" ng-show="myForm.input.$error.datetimelocal">
+    Not a valid date!</span>
+    <tt>value = {{value}}</tt><br/>
+    <tt>myForm.input.$valid = {{myForm.input.$valid}}</tt><br/>
+    <tt>myForm.input.$error = {{myForm.input.$error}}</tt><br/>
+    <tt>myForm.$valid = {{myForm.$valid}}</tt><br/>
+    <tt>myForm.$error.required = {{!!myForm.$error.required}}</tt><br/>
+    </form>
+    </doc:source>
+    <doc:scenario>
+    it('should initialize to model', function() {
+      expect(binding('value')).toEqual('2010-12-28T14:57');
+      expect(binding('myForm.input.$valid')).toEqual('true');
+    });
+
+    it('should be invalid if empty', function() {
+      input('value').enter('');
+      expect(binding('value')).toEqual('');
+      expect(binding('myForm.input.$valid')).toEqual('false');
+    });
+
+    it('should be invalid if over max', function() {
+      input('value').enter('2015-01-01T23:59');
+      expect(binding('value')).toEqual('');
+      expect(binding('myForm.input.$valid')).toEqual('false');
+    });
+    </doc:scenario>
+    </doc:example>
+    */
+  'datetime-local': dateTimeLocalInputType,
+
+   /**
+    * @ngdoc inputType
+    * @name ng.directive:input.week
+    *
+    * @description
+    * HTML5 or text input with week-of-the-year validation and transformation to Date. In browsers that do not yet support
+    * the HTML5 week input, a text element will be used. The text must be entered in a valid ISO-8601
+    * week format (yyyy-W##), for example: `2013-W02`. Will also accept a valid ISO
+    * week string or Date object as model input, but will always output a Date object to the model.
+    *
+    * @param {string} ngModel Assignable angular expression to data-bind to.
+    * @param {string=} name Property name of the form under which the control is published.
+    * @param {string=} min Sets the `min` validation error key if the value entered is less than `min`.
+    * @param {string=} max Sets the `max` validation error key if the value entered is greater than `max`.
+    * @param {string=} required Sets `required` validation error key if the value is not entered.
+    * @param {string=} ngRequired Adds `required` attribute and `required` validation constraint to
+    *    the element when the ngRequired expression evaluates to true. Use `ngRequired` instead of
+    *    `required` when you want to data-bind to the `required` attribute.
+    * @param {string=} ngChange Angular expression to be executed when input changes due to user
+    *    interaction with the input element.
+    *
+    * @example
+    <doc:example>
+    <doc:source>
+    <script>
+    function Ctrl($scope) {
+          $scope.value = '2013-W01';
+        }
+    </script>
+    <form name="myForm" ng-controller="Ctrl as dateCtrl">
+    Pick a date between in 2013:
+    <input type="date" name="input" ng-model="value"
+    placeholder="yyyy-MM-dd" min="2012-W32" max="2013-W52" required />
+    <span class="error" ng-show="myForm.input.$error.required">
+    Required!</span>
+    <span class="error" ng-show="myForm.input.$error.week">
+    Not a valid date!</span>
+    <tt>value = {{value}}</tt><br/>
+    <tt>myForm.input.$valid = {{myForm.input.$valid}}</tt><br/>
+    <tt>myForm.input.$error = {{myForm.input.$error}}</tt><br/>
+    <tt>myForm.$valid = {{myForm.$valid}}</tt><br/>
+    <tt>myForm.$error.required = {{!!myForm.$error.required}}</tt><br/>
+    </form>
+    </doc:source>
+    <doc:scenario>
+    it('should initialize to model', function() {
+          expect(binding('value')).toEqual('2013-W01');
           expect(binding('myForm.input.$valid')).toEqual('true');
         });
 
-        it('should be invalid if empty', function() {
+    it('should be invalid if empty', function() {
           input('value').enter('');
           expect(binding('value')).toEqual('');
           expect(binding('myForm.input.$valid')).toEqual('false');
         });
 
-        it('should be invalid if over max', function() {
-          input('value').enter('2015-01-01T23:59');
+    it('should be invalid if over max', function() {
+          input('value').enter('2015-W01');
           expect(binding('value')).toEqual('');
           expect(binding('myForm.input.$valid')).toEqual('false');
         });
-      </doc:scenario>
+    </doc:scenario>
     </doc:example>
     */
-  'datetime-local': dateTimeLocalInputType,
-
+  'week': weekInputType,
+   
   /**
    * @ngdoc inputType
    * @name ng.directive:input.number
@@ -663,6 +730,119 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   }
 }
 
+
+function weekInputType(scope, element, attr, ctrl, $sniffer, $browser, $filter) {
+   textInputType(scope, element, attr, ctrl, $sniffer, $browser);
+
+   ctrl.$parsers.push(function(value) {
+      if(ctrl.$isEmpty(value)) {
+         ctrl.$setValidity('week', true);
+         return value;
+      }
+
+      if(WEEK_REGEXP.test(value)) {
+         ctrl.$setValidity('week', true);
+         return new Date(getTime(value).time);
+      }
+
+      ctrl.$setValidity('week', false);
+      return undefined;
+   });
+
+   ctrl.$formatters.push(function(value) {
+      if(isDate(value)) {
+         return $filter('date')(value, 'yyyy-Www');
+      }
+      return ctrl.$isEmpty(value) ? '' : ''+value;
+   });
+
+   if(attr.min) {
+      var minValidator = function(value) {
+         var valTime = getTime(value),
+            minTime = getTime(attr.min);
+
+         var valid = ctrl.$isEmpty(value) ||
+            valTime.time >= minTime.time;
+
+         ctrl.$setValidity('min', valid);
+         return valid ? value : undefined;
+      };
+
+      ctrl.$parsers.push(minValidator);
+      ctrl.$formatters.push(minValidator);
+   }
+
+   if(attr.max) {
+      var maxValidator = function(value) {
+         debugger;
+         var valTime = getTime(value),
+            maxTime = getTime(attr.max);
+
+         var valid = ctrl.$isEmpty(value) ||
+            valTime.time <= maxTime.time;
+
+         ctrl.$setValidity('max', valid);
+         return valid ? value : undefined;
+      };
+
+      ctrl.$parsers.push(maxValidator);
+      ctrl.$formatters.push(maxValidator);
+   }
+
+   function getFirstThursday(year) {
+      var d = 1, date;
+      while(true) {
+         date = new Date(year, 0, d++);
+         if(date.getDay() === 4) {
+            return date;
+         }
+      }
+   }
+
+   function getThisThursday(date) {
+      return new Date(date.getFullYear(), date.getMonth(), date.getDate() + (4 - date.getDay()));
+   }
+
+   var MILLISECONDS_PER_WEEK = 6.048e8;
+
+   function getWeek(date) {
+      var firstThurs = getFirstThursday(date.getFullYear()),
+        thisThurs = getThisThursday(date),
+        diff = +thisThurs - +firstThurs;
+
+      return 1 + Math.round(diff / MILLISECONDS_PER_WEEK);
+   }
+
+   function getTime(isoWeek) {
+      if(isDate(isoWeek)) {
+         return {
+            year: isoWeek.getFullYear(),
+            week: getWeek(isoWeek),
+            time: +isoWeek
+         };
+      }
+
+      if(isString(isoWeek)) {
+         WEEK_REGEXP.lastIndex = 0;
+         var parts = WEEK_REGEXP.exec(isoWeek);
+         if(parts) {
+            var year = +parts[1],
+               week = +parts[2],
+               firstThurs = getFirstThursday(year),
+               addDays = (week - 1) * 7;
+
+            return {
+               time: +new Date(year, 0, firstThurs.getDate() + addDays),
+               week: week,
+               year: year
+            };
+         }
+      }
+
+      return NaN;
+   }
+}
+
 function dateTimeLocalInputType(scope, element, attr, ctrl, $sniffer, $browser, $filter) {
    textInputType(scope, element, attr, ctrl, $sniffer, $browser);
 
@@ -683,7 +863,7 @@ function dateTimeLocalInputType(scope, element, attr, ctrl, $sniffer, $browser, 
 
    ctrl.$formatters.push(function(value) {
       if(isDate(value)) {
-         return $filter('date')(value, 'yyyy-MM-ddTHH:mm');
+         return $filter('date')(value, 'yyyy-MM-ddTHH:mm:ss');
       }
       return ctrl.$isEmpty(value) ? '' : '' + value;
    });
@@ -724,9 +904,10 @@ function dateTimeLocalInputType(scope, element, attr, ctrl, $sniffer, $browser, 
             MM = +parts[2] - 1,
             dd = +parts[3],
             HH = +parts[4],
-            mm = +parts[5];
+            mm = +parts[5],
+            ss = +parts[6];
 
-         return +new Date(yyyy, MM, dd, HH, mm);
+         return +new Date(yyyy, MM, dd, HH, mm, ss);
       }
 
       return NaN;

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -12,6 +12,7 @@ var URL_REGEXP = /^(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\
 var EMAIL_REGEXP = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}$/;
 var NUMBER_REGEXP = /^\s*(\-|\+)?(\d+|(\d*(\.\d*)))\s*$/;
 var DATE_REGEXP = /^(\d{4})-(\d{2})-(\d{2})$/;
+var DATETIMELOCAL_REGEXP = /^(\d{4})-(\d\d)-(\d\d)T(\d\d):(\d\d)$/;
 
 var inputType = {
 
@@ -155,6 +156,72 @@ var inputType = {
      </doc:example>
      */
   'date': dateInputType,
+
+   /**
+    * @ngdoc inputType
+    * @name ng.directive:input.dateTimeLocal
+    *
+    * @description
+    * HTML5 or text input with datetime validation and transformation. In browsers that do not yet support
+    * the HTML5 date input, a text element will be used. The text must be entered in a valid ISO-8601
+    * local datetime format (yyyy-MM-ddTHH:mm), for example: `2010-12-28T14:57`. Will also accept a valid ISO
+    * datetime string or Date object as model input, but will always output a Date object to the model.
+    *
+    * @param {string} ngModel Assignable angular expression to data-bind to.
+    * @param {string=} name Property name of the form under which the control is published.
+    * @param {string=} min Sets the `min` validation error key if the value entered is less than `min`.
+    * @param {string=} max Sets the `max` validation error key if the value entered is greater than `max`.
+    * @param {string=} required Sets `required` validation error key if the value is not entered.
+    * @param {string=} ngRequired Adds `required` attribute and `required` validation constraint to
+    *    the element when the ngRequired expression evaluates to true. Use `ngRequired` instead of
+    *    `required` when you want to data-bind to the `required` attribute.
+    * @param {string=} ngChange Angular expression to be executed when input changes due to user
+    *    interaction with the input element.
+    *
+    * @example
+    <doc:example>
+      <doc:source>
+        <script>
+        function Ctrl($scope) {
+              $scope.value = '2010-12-28T14:57';
+            }
+        </script>
+        <form name="myForm" ng-controller="Ctrl as dateCtrl">
+          Pick a date in 2013:
+          <input type="datetime-local" name="input" ng-model="value"
+          placeholder="yyyy-MM-ddTHH:mm" min="2013-01-01T00:00" max="2013-12-31T00:00" required />
+          <span class="error" ng-show="myForm.input.$error.required">
+          Required!</span>
+          <span class="error" ng-show="myForm.input.$error.datetimelocal">
+          Not a valid date!</span>
+          <tt>value = {{value}}</tt><br/>
+          <tt>myForm.input.$valid = {{myForm.input.$valid}}</tt><br/>
+          <tt>myForm.input.$error = {{myForm.input.$error}}</tt><br/>
+          <tt>myForm.$valid = {{myForm.$valid}}</tt><br/>
+          <tt>myForm.$error.required = {{!!myForm.$error.required}}</tt><br/>
+        </form>
+      </doc:source>
+      <doc:scenario>
+        it('should initialize to model', function() {
+          expect(binding('value')).toEqual('2010-12-28T14:57');
+          expect(binding('myForm.input.$valid')).toEqual('true');
+        });
+
+        it('should be invalid if empty', function() {
+          input('value').enter('');
+          expect(binding('value')).toEqual('');
+          expect(binding('myForm.input.$valid')).toEqual('false');
+        });
+
+        it('should be invalid if over max', function() {
+          input('value').enter('2015-01-01T23:59');
+          expect(binding('value')).toEqual('');
+          expect(binding('myForm.input.$valid')).toEqual('false');
+        });
+      </doc:scenario>
+    </doc:example>
+    */
+  'datetime-local': dateTimeLocalInputType,
 
   /**
    * @ngdoc inputType
@@ -596,7 +663,77 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   }
 }
 
-function dateInputType(scope, element, attr, ctrl, $sniffer, $browser) {
+function dateTimeLocalInputType(scope, element, attr, ctrl, $sniffer, $browser, $filter) {
+   textInputType(scope, element, attr, ctrl, $sniffer, $browser);
+
+   ctrl.$parsers.push(function(value) {
+      if(ctrl.$isEmpty(value)) {
+         ctrl.$setValidity('datetimelocal', true);
+         return value;
+      }
+
+      if(DATETIMELOCAL_REGEXP.test(value)) {
+         ctrl.$setValidity('datetimelocal', true);
+         return new Date(getTime(value));
+      }
+
+      ctrl.$setValidity('datetimelocal', false);
+      return undefined;
+   });
+
+   ctrl.$formatters.push(function(value) {
+      if(isDate(value)) {
+         return $filter('date')(value, 'yyyy-MM-ddTHH:mm');
+      }
+      return ctrl.$isEmpty(value) ? '' : '' + value;
+   });
+
+   if(attr.min) {
+      var minValidator = function(value) {
+         var valid = ctrl.$isEmpty(value) ||
+            (getTime(value) >= getTime(attr.min));
+         ctrl.$setValidity('min', valid);
+         return valid ? value : undefined;
+      };
+
+      ctrl.$parsers.push(minValidator);
+      ctrl.$formatters.push(minValidator);
+   }
+
+   if(attr.max) {
+      var maxValidator = function(value) {
+         var valid = ctrl.$isEmpty(value) ||
+            (getTime(value) <= getTime(attr.max));
+         ctrl.$setValidity('max', valid);
+         return valid ? value : undefined;
+      };
+
+      ctrl.$parsers.push(maxValidator);
+      ctrl.$formatters.push(maxValidator);
+   }
+
+   function getTime(iso) {
+      if(isDate(iso)) {
+         return +iso;
+      }
+
+      if(isString(iso)) {
+         DATETIMELOCAL_REGEXP.lastIndex = 0;
+         var parts = DATETIMELOCAL_REGEXP.exec(iso),
+            yyyy = +parts[1],
+            MM = +parts[2] - 1,
+            dd = +parts[3],
+            HH = +parts[4],
+            mm = +parts[5];
+
+         return +new Date(yyyy, MM, dd, HH, mm);
+      }
+
+      return NaN;
+   }
+}
+
+function dateInputType(scope, element, attr, ctrl, $sniffer, $browser, $filter) {
    textInputType(scope, element, attr, ctrl, $sniffer, $browser);
 
    ctrl.$parsers.push(function(value) {
@@ -616,13 +753,7 @@ function dateInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 
    ctrl.$formatters.push(function(value) {
        if(isDate(value)) {
-           var year = value.getFullYear(),
-               month = value.getMonth() + 1,
-               day = value.getDate();
-
-           month = (month < 10 ? '0' : '') + month;
-           day = (day < 10 ? '0' : '') + day;
-           return  year + '-' + month + '-' + day;
+          return $filter('date')(value, 'yyyy-MM-dd');
        }
        return ctrl.$isEmpty(value) ? '' : '' + value;
    });
@@ -912,14 +1043,14 @@ function checkboxInputType(scope, element, attr, ctrl) {
       </doc:scenario>
     </doc:example>
  */
-var inputDirective = ['$browser', '$sniffer', function($browser, $sniffer) {
+var inputDirective = ['$browser', '$sniffer', '$filter', function($browser, $sniffer, $filter) {
   return {
     restrict: 'E',
     require: '?ngModel',
     link: function(scope, element, attr, ctrl) {
       if (ctrl) {
         (inputType[lowercase(attr.type)] || inputType.text)(scope, element, attr, ctrl, $sniffer,
-                                                            $browser);
+                                                            $browser, $filter);
       }
     }
   };

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -228,6 +228,35 @@ function timeZoneGetter(date) {
   return paddedZone;
 }
 
+function getFirstThursday(year) {
+   var d = 1,
+      date = new Date(year, 0, d);
+   while(date.getDay() !== 4) {
+      d++;
+      date = new Date(year, 0, d);
+   }
+   return date;
+}
+
+function getThursdayThisWeek(date) {
+   var day = date.getDay(),
+      d = date.getDate();
+
+   return new Date(date.getFullYear(), date.getMonth(), d + (4 - day));
+}
+
+function weekGetter(size) {
+   return function(date) {
+      var firstThurs = getFirstThursday(date.getFullYear()),
+         thisThurs = getThursdayThisWeek(date);
+
+      var diff = +thisThurs - +firstThurs,
+         result = 1 + Math.round(diff / 6.048e8);
+
+      return padNumber(result, size);
+   };
+}
+
 function ampmGetter(date, formats) {
   return date.getHours() < 12 ? formats.AMPMS[0] : formats.AMPMS[1];
 }
@@ -256,10 +285,12 @@ var DATE_FORMATS = {
   EEEE: dateStrGetter('Day'),
    EEE: dateStrGetter('Day', true),
      a: ampmGetter,
-     Z: timeZoneGetter
+     Z: timeZoneGetter,
+    ww: weekGetter(2),
+     w: weekGetter(1)
 };
 
-var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|Z))(.*)/,
+var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZEw']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|Z|w+))(.*)/,
     NUMBER_STRING = /^\-?\d+$/;
 
 /**
@@ -294,6 +325,8 @@ var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+
  *   * `'.sss' or ',sss'`: Millisecond in second, padded (000-999)
  *   * `'a'`: am/pm marker
  *   * `'Z'`: 4 digit (+sign) representation of the timezone offset (-1200-+1200)
+ *   * `'ww'`: ISO-8601 week of year (00-53)
+ *   * `'w'`: ISO-8601 week of year (0-53)
  *
  *   `format` string can also be one of the following predefined
  *   {@link guide/i18n localizable formats}:

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -752,6 +752,122 @@ describe('input', function() {
 
   // INPUT TYPES
 
+  describe('date', function () {
+    it('should set the view if the model is valid ISO8601 date', function() {
+        compileInput('<input type="date" ng-model="birthday"/>');
+
+        scope.$apply(function(){
+            scope.birthday = '1977-10-22';
+        });
+
+        expect(inputElm.val()).toBe('1977-10-22');
+    });
+
+    it('should set the view if the model if a valid Date object.', function(){
+        compileInput('<input type="date" ng-model="christmas"/>');
+
+        scope.$apply(function (){
+            scope.christmas = new Date(2013, 11, 25);
+        });
+
+        expect(inputElm.val()).toBe('2013-12-25');
+    });
+
+    it('should set the model undefined if the view is invalid', function (){
+        compileInput('<input type="date" ng-model="arrMatey"/>');
+
+        scope.$apply(function (){
+            scope.arrMatey = new Date(2014, 8, 14);
+        });
+
+        expect(inputElm.val()).toBe('2014-09-14');
+
+        try {
+            //set to text for browsers with date validation.
+            inputElm[0].setAttribute('type', 'text');
+        } catch(e) {
+            //for IE8
+        }
+
+        changeInputValueTo('1-2-3');
+        expect(inputElm.val()).toBe('1-2-3');
+        expect(scope.arrMatey).toBeUndefined();
+        expect(inputElm).toBeInvalid();
+    });
+
+    describe('min', function (){
+        beforeEach(function (){
+           compileInput('<input type="date" ng-model="value" name="alias" min="2000-01-01" />');
+           scope.$digest();
+        });
+
+        it('should invalidate', function (){
+           changeInputValueTo('1999-12-31');
+           expect(inputElm).toBeInvalid();
+           expect(scope.value).toBeFalsy();
+           expect(scope.form.alias.$error.min).toBeTruthy();
+        });
+
+        it('should validate', function (){
+            changeInputValueTo('2000-01-01');
+            expect(inputElm).toBeValid();
+            expect(+scope.value).toBe(+new Date(2000, 0, 1));
+            expect(scope.form.alias.$error.min).toBeFalsy();
+        });
+    });
+
+    describe('max', function (){
+        beforeEach(function (){
+           compileInput('<input type="date" ng-model="value" name="alias" max="2019-01-01" />');
+           scope.$digest();
+        });
+
+        it('should invalidate', function (){
+            changeInputValueTo('2019-12-31');
+            expect(inputElm).toBeInvalid();
+            expect(scope.value).toBeFalsy();
+            expect(scope.form.alias.$error.max).toBeTruthy();
+        });
+
+        it('should validate', function() {
+            changeInputValueTo('2000-01-01');
+            expect(inputElm).toBeValid();
+            expect(+scope.value).toBe(+new Date(2000, 0, 1));
+            expect(scope.form.alias.$error.max).toBeFalsy();
+        });
+    });
+
+    it('should validate even if max value changes on-the-fly', function(done) {
+      scope.max = '2013-01-01';
+      compileInput('<input type="date" ng-model="value" name="alias" max="{{max}}" />');
+      scope.$digest();
+
+      changeInputValueTo('2014-01-01');
+      expect(inputElm).toBeInvalid();
+
+      scope.max = '2001-01-01';
+      scope.$digest(function () {
+         expect(inputElm).toBeValid();
+         done();
+      });
+    });
+
+    it('should validate even if min value changes on-the-fly', function(done) {
+       scope.min = '2013-01-01';
+       compileInput('<input type="date" ng-model="value" name="alias" min="{{min}}" />');
+       scope.$digest();
+
+       changeInputValueTo('2010-01-01');
+       expect(inputElm).toBeInvalid();
+
+       scope.min = '2014-01-01';
+       scope.$digest(function () {
+          expect(inputElm).toBeValid();
+          done();
+       });
+    });
+  });
+
   describe('number', function() {
 
     it('should reset the model if view is invalid', function() {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -752,6 +752,123 @@ describe('input', function() {
 
   // INPUT TYPES
 
+
+   describe('datetime-local', function () {
+      it('should set the view if the model is valid ISO8601 local datetime', function() {
+         compileInput('<input type="datetime-local" ng-model="lunchtime"/>');
+
+         scope.$apply(function(){
+            scope.lunchtime = '2013-12-16T11:30:15';
+         });
+
+         expect(inputElm.val()).toBe('2013-12-16T11:30:15');
+      });
+
+      it('should set the view if the model if a valid Date object.', function(){
+         compileInput('<input type="datetime-local" ng-model="tenSecondsToNextYear"/>');
+
+         scope.$apply(function (){
+            scope.tenSecondsToNextYear = new Date(2013, 11, 31, 23, 59, 50);
+         });
+
+         expect(inputElm.val()).toBe('2013-12-31T23:59:50');
+      });
+
+      it('should set the model undefined if the view is invalid', function (){
+         compileInput('<input type="datetime-local" ng-model="breakMe"/>');
+
+         scope.$apply(function (){
+            scope.breakMe = new Date(2009, 0, 6, 16, 25, 10);
+         });
+
+         expect(inputElm.val()).toBe('2009-01-06T16:25:10');
+
+         try {
+            //set to text for browsers with datetime-local validation.
+            inputElm[0].setAttribute('type', 'text');
+         } catch(e) {
+            //for IE8
+         }
+
+         changeInputValueTo('stuff');
+         expect(inputElm.val()).toBe('stuff');
+         expect(scope.breakMe).toBeUndefined();
+         expect(inputElm).toBeInvalid();
+      });
+
+      describe('min', function (){
+         beforeEach(function (){
+            compileInput('<input type="datetime-local" ng-model="value" name="alias" min="2000-01-01T12:30:10" />');
+            scope.$digest();
+         });
+
+         it('should invalidate', function (){
+            changeInputValueTo('1999-12-31T01:02:03');
+            expect(inputElm).toBeInvalid();
+            expect(scope.value).toBeFalsy();
+            expect(scope.form.alias.$error.min).toBeTruthy();
+         });
+
+         it('should validate', function (){
+            changeInputValueTo('2000-01-01T23:02:01');
+            expect(inputElm).toBeValid();
+            expect(+scope.value).toBe(+new Date(2000, 0, 1, 23, 2, 1));
+            expect(scope.form.alias.$error.min).toBeFalsy();
+         });
+      });
+
+      describe('max', function (){
+         beforeEach(function (){
+            compileInput('<input type="datetime-local" ng-model="value" name="alias" max="2019-01-01T01:02:03" />');
+            scope.$digest();
+         });
+
+         it('should invalidate', function (){
+            changeInputValueTo('2019-12-31T01:02:03');
+            expect(inputElm).toBeInvalid();
+            expect(scope.value).toBeFalsy();
+            expect(scope.form.alias.$error.max).toBeTruthy();
+         });
+
+         it('should validate', function() {
+            changeInputValueTo('2000-01-01T01:02:03');
+            expect(inputElm).toBeValid();
+            expect(+scope.value).toBe(+new Date(2000, 0, 1, 1, 2, 3));
+            expect(scope.form.alias.$error.max).toBeFalsy();
+         });
+      });
+
+      it('should validate even if max value changes on-the-fly', function(done) {
+         scope.max = '2013-01-01T01:02:03';
+         compileInput('<input type="datetime-local" ng-model="value" name="alias" max="{{max}}" />');
+         scope.$digest();
+
+         changeInputValueTo('2014-01-01T12:34:56');
+         expect(inputElm).toBeInvalid();
+
+         scope.max = '2001-01-01T01:02:03';
+         scope.$digest(function () {
+            expect(inputElm).toBeValid();
+            done();
+         });
+      });
+
+      it('should validate even if min value changes on-the-fly', function(done) {
+         scope.min = '2013-01-01T01:02:03';
+         compileInput('<input type="datetime-local" ng-model="value" name="alias" min="{{min}}" />');
+         scope.$digest();
+
+         changeInputValueTo('2010-01-01T12:34:56');
+         expect(inputElm).toBeInvalid();
+
+         scope.min = '2014-01-01T01:02:03';
+         scope.$digest(function () {
+            expect(inputElm).toBeValid();
+            done();
+         });
+      });
+   });
+
   describe('date', function () {
     it('should set the view if the model is valid ISO8601 date', function() {
         compileInput('<input type="date" ng-model="birthday"/>');

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -752,6 +752,94 @@ describe('input', function() {
 
   // INPUT TYPES
 
+   describe('week', function (){
+      it('should set the view if the model is valid ISO8601 week', function() {
+         compileInput('<input type="week" ng-model="secondWeek"/>');
+
+         scope.$apply(function(){
+            scope.secondWeek = '2013-W02';
+         });
+
+         expect(inputElm.val()).toBe('2013-W02');
+      });
+
+      it('should set the view if the model is a valid Date object', function (){
+         compileInput('<input type="week" ng-model="secondWeek"/>');
+
+         scope.$apply(function(){
+            scope.secondWeek = new Date(2013, 0, 11);
+         });
+
+         expect(inputElm.val()).toBe('2013-W02');
+      });
+
+      it('should set the model undefined if the input is an invalid week string', function () {
+         compileInput('<input type="week" ng-model="value"/>');
+
+         scope.$apply(function(){
+            scope.value = new Date(2013, 0, 11);
+         });
+
+
+         expect(inputElm.val()).toBe('2013-W02');
+
+         try {
+            //set to text for browsers with datetime-local validation.
+            inputElm[0].setAttribute('type', 'text');
+         } catch(e) {
+            //for IE8
+         }
+
+         changeInputValueTo('stuff');
+         expect(inputElm.val()).toBe('stuff');
+         expect(scope.value).toBeUndefined();
+         expect(inputElm).toBeInvalid();
+      });
+
+
+
+      describe('min', function (){
+         beforeEach(function (){
+            compileInput('<input type="week" ng-model="value" name="alias" min="2013-W01" />');
+            scope.$digest();
+         });
+
+         it('should invalidate', function (){
+            changeInputValueTo('2012-W12');
+            expect(inputElm).toBeInvalid();
+            expect(scope.value).toBeFalsy();
+            expect(scope.form.alias.$error.min).toBeTruthy();
+         });
+
+         it('should validate', function (){
+            changeInputValueTo('2013-W03');
+            expect(inputElm).toBeValid();
+            expect(+scope.value).toBe(+new Date(2013, 0, 17));
+            expect(scope.form.alias.$error.min).toBeFalsy();
+         });
+      });
+
+      describe('max', function(){
+         beforeEach(function (){
+            compileInput('<input type="week" ng-model="value" name="alias" max="2013-W01" />');
+            scope.$digest();
+         });
+
+         it('should validate', function (){
+            changeInputValueTo('2012-W01');
+            expect(inputElm).toBeValid();
+            expect(+scope.value).toBe(+new Date(2012, 0, 5));
+            expect(scope.form.alias.$error.max).toBeFalsy();
+         });
+
+         it('should invalidate', function (){
+            changeInputValueTo('2013-W03');
+            expect(inputElm).toBeInvalid();
+            expect(scope.value).toBeUndefined();
+            expect(scope.form.alias.$error.max).toBeTruthy();
+         });
+      });
+   });
 
    describe('datetime-local', function () {
       it('should set the view if the model is valid ISO8601 local datetime', function() {

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -192,7 +192,7 @@ describe('filters', function() {
     var noon =     new angular.mock.TzDate(+5, '2010-09-03T17:05:08.012Z'); //12pm
     var midnight = new angular.mock.TzDate(+5, '2010-09-03T05:05:08.123Z'); //12am
     var earlyDate = new angular.mock.TzDate(+5, '0001-09-03T05:05:08.000Z');
-
+    var secondWeek = new angular.mock.TzDate(+5, '2013-01-11T12:00:00.000Z'); //Friday Jan 11, 2012
     var date;
 
     beforeEach(inject(function($filter) {
@@ -215,6 +215,12 @@ describe('filters', function() {
     });
 
     it('should accept various format strings', function() {
+      expect(date(secondWeek, 'yyyy-Ww')).
+                      toEqual('2013-W2');
+
+      expect(date(secondWeek, 'yyyy-Www')).
+                      toEqual('2013-W02');
+
       expect(date(morning, "yy-MM-dd HH:mm:ss")).
                       toEqual('10-09-03 07:05:08');
 


### PR DESCRIPTION
This is to add support for the week input type. This follows the HTML5 spec which specifies using ISO-8601 standards for identifying dates. As such, the date output to the model is the Thursday of the week. Per ISO-8601, the "first week" of the year is whatever week has the first Thursday of the year.

Also added output for week-of-the-year to `$filter('date')`. This allows the date of the year to be output as follows:

```
 var value = new Date(2013, 0, 12); // Jan 12, 2013
 console.log($filter('date')(value, 'yyyy-Www'); // 2013-W01
```
