### PR TITLE
perf($parse): un-un-rolling loop for deprecated code

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -881,11 +881,9 @@ var getterFnCache = {};
  * - http://jsperf.com/path-evaluation-simplified/7
  */
 function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
-  ensureSafeMemberName(key0, fullExp);
-  ensureSafeMemberName(key1, fullExp);
-  ensureSafeMemberName(key2, fullExp);
-  ensureSafeMemberName(key3, fullExp);
-  ensureSafeMemberName(key4, fullExp);
+
+  var keys = [key0,key1,key2,key3,key4];
+  for( var i = 0; i < keys.length; i++ ) ensureSafeMemberName(keys[i], fullExp);
 
   return !options.unwrapPromises
       ? function cspSafeGetter(scope, locals) {
@@ -912,65 +910,20 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
           var pathVal = (locals && locals.hasOwnProperty(key0)) ? locals : scope,
               promise;
 
-          if (pathVal === null || pathVal === undefined) return pathVal;
+          for( var i = 0; i < keys.length; i++ ){
+            if (!keys[i] || pathVal === null || pathVal === undefined) return pathVal;
 
-          pathVal = pathVal[key0];
-          if (pathVal && pathVal.then) {
-            promiseWarning(fullExp);
-            if (!("$$v" in pathVal)) {
-              promise = pathVal;
-              promise.$$v = undefined;
-              promise.then(function(val) { promise.$$v = val; });
+            pathVal = pathVal[ keys[i] ];
+            if (pathVal && pathVal.then) {
+              promiseWarning(fullExp);
+              if (!("$$v" in pathVal)) {
+                promise = pathVal;
+                promise.$$v = undefined;
+                promise.then(function(val) { promise.$$v = val; });
+              }
+              pathVal = pathVal.$$v;
             }
-            pathVal = pathVal.$$v;
-          }
-          if (!key1 || pathVal === null || pathVal === undefined) return pathVal;
 
-          pathVal = pathVal[key1];
-          if (pathVal && pathVal.then) {
-            promiseWarning(fullExp);
-            if (!("$$v" in pathVal)) {
-              promise = pathVal;
-              promise.$$v = undefined;
-              promise.then(function(val) { promise.$$v = val; });
-            }
-            pathVal = pathVal.$$v;
-          }
-          if (!key2 || pathVal === null || pathVal === undefined) return pathVal;
-
-          pathVal = pathVal[key2];
-          if (pathVal && pathVal.then) {
-            promiseWarning(fullExp);
-            if (!("$$v" in pathVal)) {
-              promise = pathVal;
-              promise.$$v = undefined;
-              promise.then(function(val) { promise.$$v = val; });
-            }
-            pathVal = pathVal.$$v;
-          }
-          if (!key3 || pathVal === null || pathVal === undefined) return pathVal;
-
-          pathVal = pathVal[key3];
-          if (pathVal && pathVal.then) {
-            promiseWarning(fullExp);
-            if (!("$$v" in pathVal)) {
-              promise = pathVal;
-              promise.$$v = undefined;
-              promise.then(function(val) { promise.$$v = val; });
-            }
-            pathVal = pathVal.$$v;
-          }
-          if (!key4 || pathVal === null || pathVal === undefined) return pathVal;
-
-          pathVal = pathVal[key4];
-          if (pathVal && pathVal.then) {
-            promiseWarning(fullExp);
-            if (!("$$v" in pathVal)) {
-              promise = pathVal;
-              promise.$$v = undefined;
-              promise.then(function(val) { promise.$$v = val; });
-            }
-            pathVal = pathVal.$$v;
           }
           return pathVal;
         };


### PR DESCRIPTION
I spent the evening re-rolling an unrolled loop in $parse, only to find that I had made it slower :(

https://github.com/bwiklund/angular.js/tree/sce-loop-rolling
http://jsperf.com/angularjs-sce-loop-rolling

I got sceSafeGetterFn to create the getter faster, but much to my disappointment, the original, unrolled code was about 25% faster than the vanilla for-loop code. It's a shame, because that saved ~800 bytes of code post-minification.

**However**, most of that savings was in the now deprecated promise unrolling code, which I've rolled back up in this PR. I figure that shrinking the build by a significant amount is worth a slight slowdown to deprecated functionality, but maybe not.

Thoughts?
