### PR TITLE
re-assign history after BFCache back

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -148,8 +148,9 @@ function Browser(window, document, $log, $sniffer) {
    * @param {boolean=} replace Should new url replace current history record ?
    */
   self.url = function(url, replace) {
-    // Android Browser BFCache causes location reference to become stale.
+    // Android Browser BFCache causes location, history reference to become stale.
     if (location !== window.location) location = window.location;
+    if (history !== window.history) history = window.history;
 
     // setter
     if (url) {


### PR DESCRIPTION
History variable should be handled like the location variable after BFCache back
