### PR TITLE
fix(input): setViewValue on compositionend

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -447,6 +447,7 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 
     element.on('compositionend', function() {
       composing = false;
+      listener();
     });
   }
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -509,6 +509,17 @@ describe('input', function() {
     });
   }
 
+  it('should update the model on "compositionend"', function() {
+    compileInput('<input type="text" ng-model="name" name="alias" />');
+    if (!(msie < 9)) {
+      browserTrigger(inputElm, 'compositionstart');
+      changeInputValueTo('caitp');
+      expect(scope.name).toBeUndefined();
+      browserTrigger(inputElm, 'compositionend');
+      expect(scope.name).toEqual('caitp');
+    }
+  });
+
   describe('"change" event', function() {
     function assertBrowserSupportsChangeEvent(inputEventSupported) {
       // Force browser to report a lack of an 'input' event


### PR DESCRIPTION
Because of a4e6d962, model is not updated on input/change between the  compositionstart and compositionend events. Unfortunately, the compositionend event does not always happen prior to an input/change event.

This changeset calls the listener function to update the model after a compositionend event is received.

This seems to also be an issue on IE10 with certain IMEs

---

http://plnkr.co/edit/euPnjrLk918G31aTDPjN?p=preview test-case which gives me adequate results on Nexus S

Fixes #5308, #5323
