### PR TITLE
feat($parse): allow for assignments in ternary operator branches

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -620,9 +620,9 @@ Parser.prototype = {
     var middle;
     var token;
     if ((token = this.expect('?'))) {
-      middle = this.ternary();
+      middle = this.assignment();
       if ((token = this.expect(':'))) {
-        return this.ternaryFn(left, middle, this.ternary());
+        return this.ternaryFn(left, middle, this.assignment());
       } else {
         this.throwError('expected :', token);
       }

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -398,6 +398,17 @@ describe('parser', function() {
           expect(scope.b).toEqual(234);
         });
 
+        it('should evaluate assignments in ternary operator', function() {
+          scope.$eval('a = 1 ? 2 : 3');
+          expect(scope.a).toBe(2);
+
+          scope.$eval('0 ? a = 2 : a = 3');
+          expect(scope.a).toBe(3);
+
+          scope.$eval('1 ? a = 2 : a = 3');
+          expect(scope.a).toBe(2);
+        });
+
         it('should evaluate function call without arguments', function() {
           scope['const'] =  function(a,b){return 123;};
           expect(scope.$eval("const()")).toEqual(123);


### PR DESCRIPTION
Currently in angular expressions, the ternary operator is defined as:

```
TernaryOperatorExpression :
    LogicalORExpression ? LogicalORExpression : LogicalORExpression
```

but [in javascript](http://es5.github.io/#x11.12), it's

```
TernaryOperatorExpression :
    LogicalORExpression ? AssignmentExpression : AssignmentExpression
```

So I thought it would be good for ternary operator in ng-expression to behave the same way as in js.

---

Given the following expression

``` js
1 ? a : b = null
```

currently it's evaluated as 

``` js
(1 ? a : b) = null
```

which throws an error

It will now be evaluated as

``` js
1 ? a : (b = null)
```

---

CLA signed as Rodric Haddad
