### PR TITLE
refactor(ng-pluralize): simplify the `isWhen` regexp

### DIFF
--- a/src/ng/directive/ngPluralize.js
+++ b/src/ng/directive/ngPluralize.js
@@ -180,7 +180,7 @@ var ngPluralizeDirective = ['$locale', '$interpolate', function($locale, $interp
           whensExpFns = {},
           startSymbol = $interpolate.startSymbol(),
           endSymbol = $interpolate.endSymbol(),
-          isWhen = /^when(Minus)?(.+)$/;
+          isWhen = /^when(Minus)?./;
 
       forEach(attr, function(expression, attributeName) {
         if (isWhen.test(attributeName)) {


### PR DESCRIPTION
This change should also make the code marginally faster as the simplified regexp is shorter and will be parsed faster
