### PR TITLE
Do not hold input composition on android

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -395,15 +395,17 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   // In composition mode, users are still inputing intermediate text buffer,
   // hold the listener until composition is done.
   // More about composition events: https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent
-  var composing = false;
+  if (!$sniffer.android) {
+    var composing = false;
 
-  element.on('compositionstart', function() {
-    composing = true;
-  });
+    element.on('compositionstart', function(data) {
+      composing = true;
+    });
 
-  element.on('compositionend', function() {
-    composing = false;
-  });
+    element.on('compositionend', function() {
+      composing = false;
+    });
+  }
 
   var listener = function() {
     if (composing) return;

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -85,6 +85,7 @@ function $SnifferProvider() {
       vendorPrefix: vendorPrefix,
       transitions : transitions,
       animations : animations,
+      android: android,
       msie : msie,
       msieDocumentMode: documentMode
     };

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -303,6 +303,7 @@ describe('$sniffer', function() {
       });
       inject(function($sniffer) {
         expect($sniffer.transitions).toBe(true);
+        expect($sniffer.android).toBe(2);
       });
     });
 


### PR DESCRIPTION
Workaround for chrome for android until #2129 is ready.

Closes #5308, #5323
