### PR TITLE
ngAttr* directive issue with `href` attribute in IE

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1009,9 +1009,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
               nName = directiveNormalize(name.toLowerCase());
               attrsMap[nName] = name;
-              attrs[nName] = value = trim((msie && name == 'href')
-                ? decodeURIComponent(node.getAttribute(name, 2))
-                : attr.value);
+              attrs[nName] = value = trim(attr.value);
               if (getBooleanAttrName(node, nName)) {
                 attrs[nName] = true; // presence means true
               }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4243,7 +4243,13 @@ describe('$compile', function() {
       expect(element.attr('test2')).toBe('Misko');
       expect(element.attr('test3')).toBe('Misko');
     }));
-
+    
+    it('should work with the "href" attribute', inject(function($compile, $rootScope) {
+      $rootScope.value = 'test';
+      element = $compile('<span ng-attr-href="test/{{value}}"></span>')($rootScope);
+      $rootScope.$digest();
+      expect(element.attr('href')).toBe('test/test');
+    }));
 
     it('should work if they are prefixed with x- or data-', inject(function($compile, $rootScope) {
       $rootScope.name = "Misko";

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4246,7 +4246,7 @@ describe('$compile', function() {
     
     it('should work with the "href" attribute', inject(function($compile, $rootScope) {
       $rootScope.value = 'test';
-      element = $compile('<span ng-attr-href="test/{{value}}"></span>')($rootScope);
+      element = $compile('<a ng-attr-href="test/{{value}}"></a>')($rootScope);
       $rootScope.$digest();
       expect(element.attr('href')).toBe('test/test');
     }));


### PR DESCRIPTION
This fixes an issue where any form of `ng-attr-href` directive wasn't correctly processed in IE.

I am not sure why there was the special IE condition for the href attribute but `node.getAttribute(name, 2)` doesn't make any sense since it's trying to fetch the binding value from the attribute we are actually trying to populate.

I have removed the special case handling and every unit tests are still passing.

[Issue Plunkr](http://plnkr.co/edit/b1bqBRdfK904xG77BNej?p=preview)
