### PR TITLE
Allow automatic rewriting of links to be disabled in ngLocation

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -541,7 +541,8 @@ function locationGetterSetter(property, preprocess) {
  */
 function $LocationProvider(){
   var hashPrefix = '',
-      html5Mode = false;
+      html5Mode = false,
+      rewriteLinks = true;
 
   /**
    * @ngdoc property
@@ -572,6 +573,23 @@ function $LocationProvider(){
       return this;
     } else {
       return html5Mode;
+    }
+  };
+
+  /**
+   * @ngdoc property
+   * @name ng.$locationProvider#rewriteLinks
+   * @methodOf ng.$locationProvider
+   * @description
+   * @param {boolean=} allowRewrite Automatically rewrite links on the page.
+   * @returns {*} current value if used as getter or itself (chaining) if used as setter
+   */
+  this.rewriteLinks = function(allowRewrite) {
+    if (isDefined(allowRewrite)) {
+      rewriteLinks = allowRewrite;
+      return this;
+    } else {
+      return rewriteLinks;
     }
   };
 
@@ -624,7 +642,7 @@ function $LocationProvider(){
       // TODO(vojta): rewrite link when opening in new tab/window (in legacy browser)
       // currently we open nice url link and redirect then
 
-      if (event.ctrlKey || event.metaKey || event.which == 2) return;
+      if (!rewriteLinks || event.ctrlKey || event.metaKey || event.which == 2) return;
 
       var elm = jqLite(event.target);
 

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -779,9 +779,12 @@ describe('$location', function() {
 
     var root, link, originalBrowser, lastEventPreventDefault;
 
-    function configureService(linkHref, html5Mode, supportHist, attrs, content) {
+    function configureService(linkHref, html5Mode, supportHist, attrs, content, allowRewrite) {
       module(function($provide, $locationProvider) {
         attrs = attrs ? ' ' + attrs + ' ' : '';
+        if (!isDefined(allowRewrite)) {
+          allowRewrite = true
+        }
 
         // fake the base behavior
         if (linkHref[0] == '/') {
@@ -795,6 +798,7 @@ describe('$location', function() {
         $provide.value('$sniffer', {history: supportHist});
         $locationProvider.html5Mode(html5Mode);
         $locationProvider.hashPrefix('!');
+        $locationProvider.rewriteLinks(allowRewrite);
         return function($rootElement, $document) {
           $rootElement.append(link);
           root = $rootElement[0];
@@ -946,6 +950,19 @@ describe('$location', function() {
 
     it('should not rewrite links with target specified', function() {
       configureService('/a?b=c', true, true, 'target="some-frame"');
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser) {
+          browserTrigger(link, 'click');
+          expectNoRewrite($browser);
+        }
+      );
+    });
+
+
+    it ('should not rewrite links when rewriting links is disabled', function() {
+      configureService('/a?b=c', true, true, '', 'some content', false);
       inject(
         initBrowser(),
         initLocation(),


### PR DESCRIPTION
Currently, when the location provider is set to html5 mode, all links
on the page are hijacked and automatically rewritten. While this may be
desirable behavior in some cases (such as using ngRoute), not all cases
where html5 mode are enabled imply the desire for this behavior.

One example would be an application using the
[ui-router](https://github.com/angular-ui/ui-router) library, with some
pages that exist outside of angular. Links that are meant to go through
the router use the `ui-sref` directive, so the rewrite behavior is
unnecessary.

This adds the ability to disable the behavior by calling

``` javascript
$locationProvider.rewriteLinks(false);
```

For backwards compatibility, the default value of this option is `true`
