### PR TITLE
feat(scope/timers): add $timeout and $interval methods to scope

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -1029,7 +1029,59 @@ function $RootScopeProvider(){
         } while ((current = next));
 
         return event;
+      },
+
+      /**
+       * @ngdoc function
+       * @name ng.$rootScope.Scope#$timeout
+       * @methodOf ng.$rootScope.Scope
+       * @function
+       *
+       * @description
+       * Returns a promise as {@link ng.$timeout} that will be cancelled when
+       * the scope is destroyed.
+       *
+       * @param {function()} fn A function, whose execution should be delayed.
+       * @param {number=} [delay=0] Delay in milliseconds.
+       * @param {boolean=} [invokeApply=true] If set to `false` skips model dirty checking, otherwise
+       *   will invoke `fn` within the {@link ng.$rootScope.Scope#methods_$apply $apply} block.
+       * @returns {Promise} Promise that will be resolved when the timeout is reached. The value this
+       *   promise will be resolved with is the return value of the `fn` function.
+       *
+       */
+      $timeout: function() {
+        var timeout = $injector.get('$timeout'),
+            promise = timeout.apply(null, arguments);
+        this.$on("$destroy", function (){timeout.cancel(promise);});
+        return promise;
+      },
+
+      /**
+       * @ngdoc function
+       * @name ng.$rootScope.Scope#$interval
+       * @methodOf ng.$rootScope.Scope
+       * @function
+       *
+       * @description
+       * Returns a promise as {@link ng.$interval} that will be cancelled when
+       * the scope is destroyed.
+       *
+       * @param {function()} fn A function that should be called repeatedly.
+       * @param {number} delay Number of milliseconds between each function call.
+       * @param {number=} [count=0] Number of times to repeat. If not set, or 0, will repeat
+       *   indefinitely.
+       * @param {boolean=} [invokeApply=true] If set to `false` skips model dirty checking, otherwise
+       *   will invoke `fn` within the {@link ng.$rootScope.Scope#methods_$apply $apply} block.
+       * @returns {promise} A promise which will be notified on each iteration.
+       *
+       */
+      $interval: function() {
+        var interval = $injector.get('$interval'),
+            promise = interval.apply(null, arguments);
+        this.$on("$destroy", function (){interval.cancel(promise);});
+        return promise;
       }
+
     };
 
     var $rootScope = new Scope();

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1402,6 +1402,72 @@ describe('Scope', function() {
         }));
       });
     });
+
+    describe('$timeout/$interval', function() {
+      describe('scope.$timeout', function() {
+        var scope = null;
+
+        beforeEach(inject(function($rootScope) {
+          scope = $rootScope.$new();
+        }));
+
+        it('should delegate to $timeout', inject(function($timeout) {
+          var counter = 0;
+          scope.$timeout(function() { counter++; });
+
+          expect(counter).toBe(0);
+
+          $timeout.flush();
+          expect(counter).toBe(1);
+        }));
+
+        it('should cancel timer on $destroy', inject(function($rootScope, $timeout) {
+          var counter = 0;
+          scope.$timeout(function() { counter++; });
+          $timeout(noop);
+
+          expect(counter).toBe(0);
+
+          scope.$destroy();
+          scope.$digest();
+
+          $timeout.flush();
+          expect(counter).toBe(0);
+        }));
+      });
+
+      describe('scope.$interval', function() {
+        var scope = null;
+
+        beforeEach(inject(function($rootScope) {
+          scope = $rootScope.$new();
+        }));
+
+        it('should delegate to $interval', inject(function($interval) {
+          var counter = 0;
+          scope.$interval(function() { counter++; }, 1000);
+
+          expect(counter).toBe(0);
+
+          $interval.flush(1000);
+          expect(counter).toBe(1);
+        }));
+
+        it('should cancel timer on $destroy', inject(function($rootScope, $interval) {
+          var counter = 0;
+          scope.$interval(function() { counter++; }, 1000);
+          $interval(noop, 1000);
+
+          expect(counter).toBe(0);
+
+          scope.$destroy();
+          scope.$digest();
+
+          $interval.flush(1000);
+          expect(counter).toBe(0);
+        }));
+      });
+    });
   });
 
   describe("doc examples", function() {


### PR DESCRIPTION
Intervals and timeouts created with scope’s methods will be automatically destroyed
when the scope is destroyed, thus preventing memory leaks.

If controllers and directives use scope.$interval and scope.$timeout instead $interval and $timeout, there is a lower risk of memory leaks, as there is no need to remember to cancel the promises of the timers.

This is not extrictly needed but may be useful.
