### PR TITLE
Update forms.ngdoc

### DIFF
--- a/docs/content/guide/forms.ngdoc
+++ b/docs/content/guide/forms.ngdoc
@@ -235,7 +235,7 @@ In the following example we create two directives.
 <script>
   var app = angular.module('form-example1', []);
 
-  var INTEGER_REGEXP = /^\-?\d*$/;
+  var INTEGER_REGEXP = /^\-?\d+$/;
   app.directive('integer', function() {
     return {
       require: 'ngModel',


### PR DESCRIPTION
Right now, non-integers such as 'aawefwae' are valid. 
This ensures that only integers are valid. Hopefully that makes the example more powerful.
