### PR TITLE
docs(guides/directive): document the C and M directive options

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -174,9 +174,9 @@ For example, we could fix the example above by instead writing:
 
 ## Creating Directives
 
-First let's talk about the API for registering directives. Much like controllers, directives are
-registered on modules. To register a directive, you use the `module.directive` API.
-`module.directive` takes the
+First let's talk about the {@link api/ng.$compile API for registering directives}. Much like
+controllers, directives are registered on modules. To register a directive, you use the
+`module.directive` API. `module.directive` takes the
 {@link guide/directive#creating-custom-directives_matching-directives normalized} directive name
 followed by a **factory function.** This factory function should return an object with the different
 options to tell `$compile` how the directive should behave when matched.


### PR DESCRIPTION
I was looking at some code that had:

```
restrict: 'CA',
```

I had a super hard time figuring out what it did. It would be nice to mention this in the comments.
