### PR TITLE
Fix z-indexes - they were back to front

### DIFF
--- a/docs/content/tutorial/step_12.ngdoc
+++ b/docs/content/tutorial/step_12.ngdoc
@@ -230,7 +230,7 @@ __`app/css/animations.css`.__
   -moz-animation: 0.5s fade-in;
   -o-animation: 0.5s fade-in;
   animation: 0.5s fade-in;
-  z-index: 100;
+  z-index: 99;
 }
 
 .view-frame.ng-leave {
@@ -238,7 +238,7 @@ __`app/css/animations.css`.__
   -moz-animation: 0.5s fade-out;
   -o-animation: 0.5s fade-out;
   animation: 0.5s fade-out;
-  z-index:99;
+  z-index:100;
 }
 
 &#64;keyframes fade-in {


### PR DESCRIPTION
In the original form, with ng-enter at z-index:100 and ng-leave at z-index:99 the transition stutters. With them swapped, the transition is smooth. The swap also makes the CSS match the description that the new page should be on top.
