### PR TITLE
Update ng-sanitize to allow the size attribute

### DIFF
--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -207,7 +207,7 @@ var validAttrs = angular.extend({}, uriAttrs, makeMap(
     'color,cols,colspan,compact,coords,dir,face,headers,height,hreflang,hspace,'+
     'ismap,lang,language,nohref,nowrap,rel,rev,rows,rowspan,rules,'+
     'scope,scrolling,shape,span,start,summary,target,title,type,'+
-    'valign,value,vspace,width'));
+    'valign,value,vspace,width,size'));
 
 function makeMap(str) {
   var obj = {}, items = str.split(','), i;


### PR DESCRIPTION
The "size" attribute gets set on <font> elements when using HTML5 rich text editors, or elements with the contenteditable attribute, that rely on the 'fontSize' command (execCommand).
