### PR TITLE
fix($httpBackend): wrap withCredentials in try/catch for IE8 with native XMLHTTP disabled

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -88,7 +88,8 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument)
       };
 
       if (withCredentials) {
-        xhr.withCredentials = true;
+        // if native XMLHTTP is not enabled in IE8, setting this property will throw an exception
+        try { xhr.withCredentials = true; } catch (e) {}
       }
 
       if (responseType) {


### PR DESCRIPTION
If native XMLHTTP is disabled in the advanced security settings in IE8, attempting to set
the withCredentials property throws an exception. Swallowing the exception allows
$httpBackend to work in IE8.
