### PR TITLE
Load tasks with a one-liner

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,18 +3,8 @@ var util = require('./lib/grunt/utils.js');
 var path = require('path');
 
 module.exports = function(grunt) {
-  //grunt plugins
-  grunt.loadNpmTasks('grunt-bump');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-connect');
-  grunt.loadNpmTasks('grunt-contrib-compress');
-  grunt.loadNpmTasks('grunt-jasmine-node');
-  grunt.loadNpmTasks('grunt-ddescribe-iit');
-  grunt.loadNpmTasks('grunt-merge-conflict');
-  grunt.loadNpmTasks('grunt-parallel');
-  grunt.loadNpmTasks('grunt-shell');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
+  // Load grunt tasks automatically
+  require('load-grunt-tasks')(grunt);
   grunt.loadTasks('lib/grunt');
 
   var NG_VERSION = util.getVersion();

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "grunt-contrib-compress": "~0.5.2",
     "grunt-contrib-connect": "~0.5.0",
     "grunt-contrib-copy": "~0.4.1",
+    "load-grunt-tasks": "~0.2.1",
     "jasmine-node": "~1.11.0",
     "q": "~0.9.2",
     "q-io": "~1.10.6",


### PR DESCRIPTION
Make more maintainable the Gruntfile. This automatically load any tasks listed in devDependencies.
