### PR TITLE
feat($routeProvider): add support for regular expressions routes 

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -182,26 +182,27 @@ function $RouteProvider(){
           regexp: path
         },
         keys = ret.keys = [];
+    if (!(path instanceof RegExp)) {
+        path = path
+          .replace(/([().])/g, '\\$1')
+          .replace(/(\/)?:(\w+)([\?|\*])?/g, function(_, slash, key, option){
+            var optional = option === '?' ? option : null;
+            var star = option === '*' ? option : null;
+            keys.push({ name: key, optional: !!optional });
+            slash = slash || '';
+            return ''
+              + (optional ? '' : slash)
+              + '(?:'
+              + (optional ? slash : '')
+              + (star && '(.+?)' || '([^/]+)')
+              + (optional || '')
+              + ')'
+              + (optional || '');
+          })
+          .replace(/([\/$\*])/g, '\\$1');
 
-    path = path
-      .replace(/([().])/g, '\\$1')
-      .replace(/(\/)?:(\w+)([\?|\*])?/g, function(_, slash, key, option){
-        var optional = option === '?' ? option : null;
-        var star = option === '*' ? option : null;
-        keys.push({ name: key, optional: !!optional });
-        slash = slash || '';
-        return ''
-          + (optional ? '' : slash)
-          + '(?:'
-          + (optional ? slash : '')
-          + (star && '(.+?)' || '([^/]+)')
-          + (optional || '')
-          + ')'
-          + (optional || '');
-      })
-      .replace(/([\/$\*])/g, '\\$1');
-
-    ret.regexp = new RegExp('^' + path + '$', insensitive ? 'i' : '');
+        ret.regexp = new RegExp('^' + path + '$', insensitive ? 'i' : '');
+    }
     return ret;
   }
 
@@ -478,6 +479,8 @@ function $RouteProvider(){
 
         if (key && val) {
           params[key.name] = val;
+        } else if (val) {
+            params[["regexp_param", i].join("")] = val;
         }
       }
       return params;

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -1077,5 +1077,46 @@ describe('$route', function() {
         });
       });
     });
+    describe('regularExpressionRoute', function() {
+
+      it('should load regular expression route', function() {
+        var routeChangeSpy = jasmine.createSpy('route change');
+
+        module(function($routeProvider) {
+          $routeProvider.when('/route', {controller: angular.noop, reloadOnSearch: false});
+          $routeProvider.when(/^\/home$/, {controller: angular.noop, reloadOnSearch: false});
+          $routeProvider.when(/^\/home\/([0-9]+)$/, {controller: angular.noop, reloadOnSearch: false});
+          $routeProvider.when('/route/:abc', {controller: angular.noop, reloadOnSearch: false});
+        });
+
+        inject(function($route, $location, $rootScope, $routeParams) {
+          $rootScope.$on('$routeChangeSuccess', routeChangeSpy);
+
+          $location.path('/home');
+          $rootScope.$digest();
+          expect($routeParams).toEqual({});
+          expect(routeChangeSpy).toHaveBeenCalledOnce();
+          routeChangeSpy.reset();
+
+          $location.path('/home/123');
+          $rootScope.$digest();
+          expect($routeParams).toEqual({regexp_param1:'123'});
+          expect(routeChangeSpy).toHaveBeenCalledOnce();
+          routeChangeSpy.reset();
+
+          $location.path('/route');
+          $rootScope.$digest();
+          expect($routeParams).toEqual({});
+          expect(routeChangeSpy).toHaveBeenCalledOnce();
+          routeChangeSpy.reset();
+
+          $location.path('/route/1234');
+          $rootScope.$digest();
+          expect($routeParams).toEqual({abc: '1234'});
+          expect(routeChangeSpy).toHaveBeenCalledOnce();
+          routeChangeSpy.reset();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
I had a requirement for doing a pure regexp route with parameter grabbing.  I attempted to choose a generic naming using regexp_param(n).  The original path string sterilization is wrapped in an if condition to determine if it is a regular expression.  
