### PR TITLE
fix(ngRoute): instantiate controller when template is empty

### DIFF
--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -199,7 +199,7 @@ function ngViewFactory(   $route,   $anchorScroll,   $animate) {
           var locals = $route.current && $route.current.locals,
               template = locals && locals.$template;
 
-          if (template) {
+          if (angular.isDefined(template)) {
             var newScope = scope.$new();
             var current = $route.current;
 

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -56,6 +56,29 @@ describe('ngView', function() {
   });
 
 
+  it('should instantiate controller for empty template', function() {
+    var log = [], controllerScope,
+        Ctrl = function($scope) {
+          controllerScope = $scope;
+          log.push('ctrl-init');
+        };
+
+    module(function($routeProvider) {
+      $routeProvider.when('/some', {templateUrl: '/tpl.html', controller: Ctrl});
+    });
+
+    inject(function($route, $rootScope, $templateCache, $location) {
+      $templateCache.put('/tpl.html', [200, '', {}]);
+      $location.path('/some');
+      $rootScope.$digest();
+
+      expect(controllerScope.$parent).toBe($rootScope);
+      expect(controllerScope).toBe($route.current.scope);
+      expect(log).toEqual(['ctrl-init']);
+    });
+  });
+
+
   it('should instantiate controller with an alias', function() {
     var log = [], controllerScope,
         Ctrl = function($scope) {


### PR DESCRIPTION
Before this change, $route controllers are not instantiated if the template is falsy, which includes the empty string. This change tests if the template is not undefined, rather than just falsy, in order to ensure that templates are instantiated even when the template is empty, which people may have some reason to do.

This "bug" was reported in http://robb.weblaws.org/2013/06/21/angularjs-vs-emberjs/, as a "gotcha" for AngularJS / ngRoute.

http://plnkr.co/edit/ugXbMOinzRg05CH3LUkO?p=preview a demo of it in practice
