### PR TITLE
fix(ngAnimate): Unblock transitions before reflow

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -1320,9 +1320,9 @@ angular.module('ngAnimate', ['ng'])
         beforeAddClass : function(element, className, animationCompleted) {
           var cancellationMethod = animateBefore(element, suffixClasses(className, '-add'));
           if(cancellationMethod) {
+            unblockTransitions(element);
+            unblockKeyframeAnimations(element);
             afterReflow(element, function() {
-              unblockTransitions(element);
-              unblockKeyframeAnimations(element);
               animationCompleted();
             });
             return cancellationMethod;
@@ -1337,9 +1337,9 @@ angular.module('ngAnimate', ['ng'])
         beforeRemoveClass : function(element, className, animationCompleted) {
           var cancellationMethod = animateBefore(element, suffixClasses(className, '-remove'));
           if(cancellationMethod) {
+            unblockTransitions(element);
+            unblockKeyframeAnimations(element);
             afterReflow(element, function() {
-              unblockTransitions(element);
-              unblockKeyframeAnimations(element);
               animationCompleted();
             });
             return cancellationMethod;


### PR DESCRIPTION
I have investigated this issue: http://jsfiddle.net/2fnhr/1/

From this question: http://stackoverflow.com/questions/20810791/angular-nganimate-causes-width-animations-to-jump

Commenting the "blockTransitions" call resolves the issue. But there is a comment in the source-code justifying the need of blocking transitions. So, unblocking before reflow (as suggested in this PR) also resolves the issue.

This way or another, the issue needs to be addressed.
