### PR TITLE
feat(ngRepeat): support a new range syntax for integer arrays

### DIFF
--- a/docs/content/error/ngRepeat/range.ngdoc
+++ b/docs/content/error/ngRepeat/range.ngdoc
@@ -1,0 +1,24 @@
+@ngdoc error
+@name ngRepeat:range
+@fullName Invalid Range
+@description
+
+Occurs when there is an error with the $range function of an {@link api/ng.directive:ngRepeat ngRepeat}'s expression.
+
+To resolve, specify a valid range in the form of $range(_from_, _to_) where both _from_ and _to_ evaluate to integers.
+
+Examples of *invalid* syntax:
+
+```
+<div ng-repeat="i in $range('0', '3')"></div>
+<div ng-repeat="char in $range('a', 'z')"></div>
+```
+
+Examples of *valid* syntax:
+
+```
+<div ng-repeat="i in $range(0, 3)"></div>
+<div ng-repeat="i in $range(from, to)"></div>
+```
+
+Please consult the api documentation of {@link api/ng.directive:ngRepeat ngRepeat} to learn more about valid syntax.

--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -203,21 +203,28 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
     priority: 1000,
     terminal: true,
     $$tlb: true,
-    link: function($scope, $element, $attr, ctrl, $transclude){
-        var expression = $attr.ngRepeat;
-        var match = expression.match(/^\s*([\s\S]+?)\s+in\s+([\s\S]+?)(?:\s+track\s+by\s+([\s\S]+?))?\s*$/),
-          trackByExp, trackByExpGetter, trackByIdExpFn, trackByIdArrayFn, trackByIdObjFn,
-          lhs, rhs, valueIdentifier, keyIdentifier,
-          hashFnLocals = {$id: hashKey};
+    link: function($scope, $element, $attr, ctrl, $transclude) {
+        var expression = $attr.ngRepeat,
+            match = expression.match(/^\s*([\s\S]+?)\s+in\s+([\s\S]+?)(?:\s+track\s+by\s+([\s\S]+?))?\s*$/),
+            lhs, rhs, trackByExp,
+            valueIdentifier, keyIdentifier,
+            trackByExpGetter, trackByIdExpFn, trackByIdArrayFn, trackByIdObjFn,
+            hashFnLocals = {$id: hashKey};
 
-        if (!match) {
-          throw ngRepeatMinErr('iexp', "Expected expression in form of '_item_ in _collection_[ track by _id_]' but got '{0}'.",
-            expression);
-        }
+        if (!match) throw ngRepeatMinErr('iexp',
+        "Expected expression in form of '_item_ in _collection_[ track by _id_]' but got '{0}'.", expression);
 
         lhs = match[1];
         rhs = match[2];
         trackByExp = match[3];
+
+        match = lhs.match(/^(?:([\$\w]+)|\(([\$\w]+)\s*,\s*([\$\w]+)\))$/);
+
+        if (!match) throw ngRepeatMinErr('iidexp',
+        "'_item_' in '_item_ in _collection_' should be an identifier or '(_key_, _value_)' expression, but got '{0}'.", lhs);
+
+        valueIdentifier = match[3] || match[1];
+        keyIdentifier = match[2];
 
         if (trackByExp) {
           trackByExpGetter = $parse(trackByExp);
@@ -226,6 +233,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
             if (keyIdentifier) hashFnLocals[keyIdentifier] = key;
             hashFnLocals[valueIdentifier] = value;
             hashFnLocals.$index = index;
+
             return trackByExpGetter($scope, hashFnLocals);
           };
         } else {
@@ -236,14 +244,6 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
             return key;
           };
         }
-
-        match = lhs.match(/^(?:([\$\w]+)|\(([\$\w]+)\s*,\s*([\$\w]+)\))$/);
-        if (!match) {
-          throw ngRepeatMinErr('iidexp', "'_item_' in '_item_ in _collection_' should be an identifier or '(_key_, _value_)' expression, but got '{0}'.",
-                                                                    lhs);
-        }
-        valueIdentifier = match[3] || match[1];
-        keyIdentifier = match[2];
 
         // Store a list of elements from previous run. This is a hash where key is the item from the
         // iterator, and the value is objects with following properties.

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -119,6 +119,79 @@ describe('ngRepeat', function() {
     expect(element.text()).toEqual('age:20|codename:20|dogname:Bingo|prodname:Bingo|wealth:20|');
   });
 
+  describe('$range', function() {
+    it('should iterate over a range of integers', function() {
+      element = $compile(
+        '<ul>' +
+          '<li ng-repeat="i in $range(from, to)">{{i}}/</li>' +
+        '</ul>')(scope);
+
+      scope.from = -3;
+      scope.to = 3;
+      scope.$digest();
+
+      expect(element.text()).toEqual('-3/-2/-1/0/1/2/3/');
+    });
+
+    it('should handle both ascending and descending orders as well as reversion of order', function() {
+      element = $compile(
+        '<ul>' +
+          '<li ng-repeat="i in $range(from, to)">{{i}}/</li>' +
+        '</ul>')(scope);
+
+      scope.from = 0;
+      scope.to = 5;
+      scope.$digest();
+
+      expect(element.text()).toEqual('0/1/2/3/4/5/');
+
+      scope.from = 3;
+      scope.to = -3;
+      scope.$digest();
+
+      expect(element.text()).toEqual('3/2/1/0/-1/-2/-3/');
+    });
+
+    it('should work with filter', function() {
+      element = $compile(
+        '<ul>' +
+          '<li ng-repeat="i in $range(from, to) | filter: positive">{{i}}/</li>' +
+        '</ul>')(scope);
+
+      scope.positive = function(x) {return x > 0;};
+      scope.from = -1;
+      scope.to = 2;
+      scope.$digest();
+
+      expect(element.text()).toEqual('1/2/');
+
+      scope.from = 5;
+      scope.to = -3;
+      scope.$digest();
+
+      expect(element.text()).toEqual('5/4/3/2/1/');
+    });
+
+    it("should throw an exception if the range can't be parsed", function() {
+      element = $compile(
+        '<ul>' +
+          '<li ng-repeat="i in $range(from, to)">{{i}}/</li>' +
+        '</ul>')(scope);
+
+      scope.from = 0;
+      scope.to = 2;
+      scope.$digest();
+
+      expect(element.text()).toEqual('0/1/2/');
+
+      scope.from = 'what';
+      scope.to = 'to';
+      scope.$digest();
+
+      expect($exceptionHandler.errors.shift().message).toMatch(/^\[ngRepeat:range\] Expected expression in the form of '\$range\(_from_, _to_\)' with valid parameters, but got \$range\(what, to\)./);
+    });
+  });
+
   describe('track by', function() {
     it('should track using expression function', function() {
       element = $compile(
@@ -390,7 +463,7 @@ describe('ngRepeat', function() {
     element = jqLite('<ul><li ng-repeat="i dont parse"></li></ul>');
     $compile(element)(scope);
     expect($exceptionHandler.errors.shift()[0].message).
-        toMatch(/^\[ngRepeat:iexp\] Expected expression in form of '_item_ in _collection_\[ track by _id_\]' but got 'i dont parse'\./);
+        toMatch(/^\[ngRepeat:iexp\] Expected expression in the form of '_item_ in _collection_\[ track by _id_\]', but got 'i dont parse'\./);
   });
 
 


### PR DESCRIPTION
Provide a range syntax [_from_.._to_] as a shorthand when iterating over an array of integers.

Closes #3861
Closes #5268

---

The refactoring commit has been wrapped independently as a separate PR (#5556).
