### PR TITLE
docs: html codes binding from component listing description

### DIFF
--- a/docs/src/templates/js/docs.js
+++ b/docs/src/templates/js/docs.js
@@ -220,7 +220,7 @@ docsApp.directive.docModuleComponents = function() {
               '        </tr>' +
               '        <tr ng-repeat="component in section.components">' +
               '          <td><a ng-href="{{ component.url }}">{{ component.shortName }}</a></td>' +
-              '          <td>{{ component.shortDescription }}</td>' +
+              '          <td ng-bind-html="component.shortDescription"></td>' +
               '        </tr>' +
               '      </table>' +
               '    </div>' +


### PR DESCRIPTION
&#123;… codes replacement by using html bind way
fix by instance here http://docs.angularjs.org/api/ng on ngHref
description
Using Angular markup like &#123;&#123;hash&#125;&#125; in an href
attribute will
