### PR TITLE
typos fixed in Services section

### DIFF
--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -272,8 +272,8 @@ including the configuration of all modules that this module depends on.
 In the example above:
 The template contains the directive `ng-app="invoice2"`. This tells Angular
 to use the `invoice` module as the main module for the application.
-The code snippet `angular.module('invoice', ['finance'])`  specifies that the `invoice` module depends on the
-`finance` module. By this, Angular uses the `InvoiceController` as well as the `currencyConverter` service.
+The code snippet `angular.module('invoice2', ['finance2'])`  specifies that the `invoice2` module depends on the
+`finance2` module. By this, Angular uses the `InvoiceController` as well as the `currencyConverter` service.
 
 Now that Angular knows of all the parts of the application, it needs to create them.
 In the previous section we saw that controllers are created using a factory function.


### PR DESCRIPTION
Code uses module names with '2' as postfix while the explanation used the module names without the postfix. The diagram is correct but also does not postfix the module names.
