### PR TITLE
feat(ngResource): Add transformParams to the actions object

### DIFF
--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1065,6 +1065,49 @@ describe("resource", function() {
     expect(person.id).toEqual(456);
   });
 
+  it('data should include all params', function() {
+    var Person = $resource('/Person/:id/card/:cardId', {}, {
+      fetch: {
+          method: 'GET',
+          params: {id: 123, cardId: '@cardId'},
+          transformParams: function(data) {
+            expect(data).toEqualData({id: 123, cardId: 321});
+            return data;
+          }
+      }
+    });
+    $httpBackend.expect('GET', '/Person/123/card/321').respond(null);
+    Person.fetch({cardId: 321});
+  });
+
+  it('should transform param', function() {
+    var Person = $resource('/Person/:id', {}, {
+      fetch: {
+          method: 'GET',
+          params: {id: '@id'},
+          transformParams: function(data) {
+            return {id: 321};
+          }
+      }
+    });
+
+    $httpBackend.expect('GET', '/Person/321').respond(null);
+    Person.fetch({id: 123});
+    $httpBackend.flush();
+  });
+
+  it('should fail from transformParams being an object, when it expects an lambda', function() {
+    expect(function() {
+      var Person = $resource('/Person/:id', {}, {
+        badTransform: {
+          method: 'POST',
+          transformParams: {}
+        }
+      });
+      Person.badTransform();
+    }).toThrowMinErr('$resource','badcfg', '[$resource:badcfg] Error in transformParams. Expected function but got an object');
+  });
+
   describe('suffix parameter', function() {
 
     describe('query', function() {


### PR DESCRIPTION
transformParams provides a public API to serialize params for an action.
Before if you wanted to a custom serialization for a complex datatype
you would have to transform the object higher in the stack, with this
change you can keep your logic at the REST level.

Closes #5521
