### PR TITLE
feat($animate): proper support for multiple elements

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -570,15 +570,21 @@ angular.module('ngAnimate', ['ng'])
          * Globally enables/disables animations.
          *
         */
-        enabled : function(value, element) {
+        enabled : function(value, contents) {
           switch(arguments.length) {
             case 2:
-              if(value) {
-                cleanup(element);
-              } else {
-                var data = element.data(NG_ANIMATE_STATE) || {};
-                data.disabled = true;
-                element.data(NG_ANIMATE_STATE, data);
+              var content, data;
+              for (var i = 0; i < contents.length; i++) {
+                content = angular.element(contents[i]);
+                if(content[0].nodeType == ELEMENT_NODE) {
+                  if(value) {
+                    cleanup(content);
+                  } else {
+                    data = content.data(NG_ANIMATE_STATE) || {};
+                    data.disabled = true;
+                    content.data(NG_ANIMATE_STATE, data);
+                  }
+                }
               }
             break;
 

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -898,16 +898,21 @@ angular.module('ngAnimate', ['ng'])
         }
       }
 
-      function cancelChildAnimations(element) {
-        var node = extractElementNode(element);
-        forEach(node.querySelectorAll('.' + NG_ANIMATE_CLASS_NAME), function(element) {
-          element = angular.element(element);
-          var data = element.data(NG_ANIMATE_STATE);
-          if(data) {
-            cancelAnimations(data.animations);
-            cleanup(element);
+      function cancelChildAnimations(contents) {
+        var node;
+        for (var i = 0; i < contents.length; i++) {
+          node = contents[i];
+          if (node.nodeType == ELEMENT_NODE) {
+            forEach(node.querySelectorAll('.' + NG_ANIMATE_CLASS_NAME), function(element) {
+              element = angular.element(element);
+              var data = element.data(NG_ANIMATE_STATE);
+              if(data) {
+                cancelAnimations(data.animations);
+                cleanup(element);
+              }
+            });
           }
-        });
+        }
       }
 
       function cancelAnimations(animations) {

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -328,7 +328,7 @@ describe("ngAnimate", function() {
           $rootScope.$digest();
 
           if($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
             expect(contents.hasClass('ng-enter')).toBe(true);
             expect(contents.hasClass('ng-enter-active')).toBe(true);
             browserTrigger(contents, 'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
@@ -2626,7 +2626,7 @@ describe("ngAnimate", function() {
         if($sniffer.transitions) {
           expect(child1.hasClass('ng-enter')).toBe(true);
           expect(child2.hasClass('ng-enter')).toBe(true);
-          $timeout.flush();
+          $animate.triggerReflow();
           expect(child1.hasClass('ng-enter-active')).toBe(true);
           expect(child2.hasClass('ng-enter')).toBe(true);
         }
@@ -2647,7 +2647,7 @@ describe("ngAnimate", function() {
         $animate.addClass(child1, 'something');
         $animate.addClass(child2, 'something');
         if($sniffer.transitions) {
-          $timeout.flush();
+          $animate.triggerReflow();
         }
         expect(animationState).toBe('addClass');
         if($sniffer.transitions) {

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -205,13 +205,14 @@ describe("ngAnimate", function() {
 
       describe("with polyfill", function() {
 
-        var child, after;
+        var child, after, elementsAnimated;
 
         beforeEach(function() {
           module(function($animateProvider) {
             $animateProvider.register('.custom', function() {
               return {
-                start: function(element, done) {
+                enter: function(element, done) {
+                  elementsAnimated.push(element);
                   done();
                 }
               }
@@ -253,6 +254,7 @@ describe("ngAnimate", function() {
               }
             });
             return function($animate, $compile, $rootScope, $rootElement) {
+              elementsAnimated = [];
               element = $compile('<div></div>')($rootScope);
 
               forEach(['.ng-hide-add', '.ng-hide-remove', '.ng-enter', '.ng-leave', '.ng-move'], function(selector) {
@@ -305,6 +307,82 @@ describe("ngAnimate", function() {
           }
 
           expect(element.contents().length).toBe(0);
+        }));
+
+
+        it("should run JS animation only on element node",
+          inject(function($animate, $compile, $rootScope, $timeout, $sniffer) {
+
+          $rootScope.$digest();
+          element.empty();
+
+          // Needs to be wrapped, otherwise $compile wraps text node in span
+          var wrappedContents = $compile('<div>' +
+                                           '<div class="my-div custom"></div>' +
+                                           '<!-- comment -->' +
+                                           'Some text' +
+                                         '</div>')($rootScope),
+              contents = wrappedContents.contents();
+
+          $animate.enter(contents, element);
+          $rootScope.$digest();
+
+          if($sniffer.transitions) {
+            $timeout.flush();
+            expect(contents.hasClass('ng-enter')).toBe(true);
+            expect(contents.hasClass('ng-enter-active')).toBe(true);
+            browserTrigger(contents, 'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
+          }
+
+          expect(contents.hasClass('ng-animate')).toBe(true);
+
+          // Only div element gets animated
+          expect(elementsAnimated.length).toBe(1);
+          expect(elementsAnimated[0].length).toBe(1);
+          expect(elementsAnimated[0].hasClass('my-div')).toBe(true);
+          expect(elementsAnimated[0][0]).toBe(contents[0]);
+          expect(elementsAnimated[0][0].nodeType).toBe(1);
+
+          $timeout.flush();
+          expect(contents.hasClass('ng-animate')).toBe(false);
+          expect(element.contents().length).toBe(3);
+        }));
+
+
+        it("should animate the addClass animation event per-element",
+          inject(function($animate, $compile, $rootScope, $timeout, $sniffer) {
+
+          $rootScope.$digest();
+          element.empty();
+
+          var child1 = $compile('<div class="custom-delay"></div>')($rootScope);
+          var child2 = $compile('<div class="custom-long-delay"></div>')($rootScope);
+          element.append(child1);
+          element.append(child2);
+
+          expect(element.contents().length).toBe(2);
+          $animate.addClass(element.contents(), 'some-class');
+          $rootScope.$digest();
+
+          // Reflow
+          $timeout.flush(10);
+          expect(child1.hasClass('ng-animate')).toBe(true);
+          expect(child2.hasClass('ng-animate')).toBe(true);
+
+          if($sniffer.transitions) {
+            browserTrigger(child1,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
+            browserTrigger(child2,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
+          }
+          $timeout.flush(2000);
+          expect(child1.hasClass('ng-animate')).toBe(false);
+          expect(child1.hasClass('some-class')).toBe(true);
+
+          // Still not done yet with the other element
+          expect(child2.hasClass('ng-animate')).toBe(true);
+
+          $timeout.flush(20000);
+          expect(child2.hasClass('ng-animate')).toBe(false);
+          expect(child2.hasClass('some-class')).toBe(true);
         }));
 
 
@@ -1396,12 +1474,16 @@ describe("ngAnimate", function() {
           module(function($animateProvider) {
             $animateProvider.register('.custom', function($timeout) {
               return {
-                removeClass : function(element, className, done) {
-                  $timeout(done, 2000);
-                }
+                enter : animate,
+                removeClass : animate
+              };
+
+              function animate(element, done) {
+                done = arguments.length == 3 ? arguments[2] : done;
+                $timeout(done, 2000);
               }
             });
-            $animateProvider.register('.other', function() {
+            $animateProvider.register('.other', function($timeout) {
               return {
                 enter : function(element, done) {
                   $timeout(done, 10000);
@@ -1618,6 +1700,31 @@ describe("ngAnimate", function() {
           });
 
           $timeout.flush();
+          expect(flag).toBe(true);
+        }));
+
+
+        it("should fire a done callback when final animation completes for all elements",
+          inject(function($animate, $rootScope, $compile, $sniffer, $rootElement, $timeout) {
+
+          var parent = jqLite('<div>' +
+                                '<span class="custom"></span>' +
+                                '<span class="other"></span>' +
+                              '</div>');
+          $rootElement.append(parent);
+          body.append($rootElement);
+          var element = parent.find('span');
+
+          var flag = false;
+          $animate.enter(element, parent, null, function() {
+            flag = true;
+          });
+          $rootScope.$digest();
+
+          $timeout.flush(2000);
+          expect(flag).toBe(false);
+
+          $timeout.flush(10000 - 2000);
           expect(flag).toBe(true);
         }));
 


### PR DESCRIPTION
Run performAnimation for each node instead of doing it for the first
element node.

Update: Made this less hacky. ~~I made this PR keeping in mind to make as little changes in animate.js and as quickly as possible to get across my point. The code can be more elegant (e.g. introduce another function, etc.).~~

By running the animation on a per-element basis, there will be no issue with comment nodes etc. and the animation methods are now more intuitive and less surprising (more explanation in #5561 for what I'm referring to).

Fixes #4954 , relates to #5561 and #4786 .

Note that this change makes the animations method behaviors asymmetric. When calling `$animate.leave(elements)`, the `leave` animation to fire for each element in `elements`. However, as the current implementation of animations is class-based, I don't see any value in firing the `leave` animation for non-element nodes as they cannot have classes and hence, have no meaning to ngAnimate.
