### PR TITLE
fix(ngShow/ngHide): follow javscript `truthy`/`falsy` logic

### DIFF
--- a/src/ng/directive/ngShowHide.js
+++ b/src/ng/directive/ngShowHide.js
@@ -142,8 +142,8 @@
  */
 var ngShowDirective = ['$animate', function($animate) {
   return function(scope, element, attr) {
-    scope.$watch(attr.ngShow, function ngShowWatchAction(value){
-      $animate[toBoolean(value) ? 'removeClass' : 'addClass'](element, 'ng-hide');
+    scope.$watch('!!(' + attr.ngShow + ')', function ngShowWatchAction(value){
+      $animate[value ? 'removeClass' : 'addClass'](element, 'ng-hide');
     });
   };
 }];
@@ -291,8 +291,8 @@ var ngShowDirective = ['$animate', function($animate) {
  */
 var ngHideDirective = ['$animate', function($animate) {
   return function(scope, element, attr) {
-    scope.$watch(attr.ngHide, function ngHideWatchAction(value){
-      $animate[toBoolean(value) ? 'addClass' : 'removeClass'](element, 'ng-hide');
+    scope.$watch('!!(' + attr.ngHide + ')', function ngHideWatchAction(value){
+      $animate[value ? 'addClass' : 'removeClass'](element, 'ng-hide');
     });
   };
 }];

--- a/test/BinderSpec.js
+++ b/test/BinderSpec.js
@@ -272,7 +272,7 @@ describe('Binder', function() {
     $rootScope.hidden = 'false';
     $rootScope.$apply();
 
-    assertVisible(element);
+    assertHidden(element);
 
     $rootScope.hidden = '';
     $rootScope.$apply();
@@ -291,7 +291,7 @@ describe('Binder', function() {
     $rootScope.show = 'false';
     $rootScope.$apply();
 
-    assertHidden(element);
+    assertVisible(element);
 
     $rootScope.show = '';
     $rootScope.$apply();

--- a/test/ng/directive/ngShowHideSpec.js
+++ b/test/ng/directive/ngShowHideSpec.js
@@ -28,6 +28,17 @@ describe('ngShow / ngHide', function() {
       $rootScope.$digest();
       expect(element).toBeShown();
     }));
+
+    it('should follow javascript `truthy`/`falsy` logic', inject(function($rootScope, $compile) {
+      var cases = ['[]', 'f', [], [''], 'false', {}, function() {}, function(f) {}, 0, false, null, undefined, '', NaN];
+      element = jqLite('<div ng-show="exp"></div>');
+      element = $compile(element)($rootScope);
+      angular.forEach(cases, function(value) {
+        $rootScope.exp = value;
+        $rootScope.$digest();
+        expect(element)[value ? 'toBeShown' : 'toBeHidden']();
+      });
+    }));
   });
 
   describe('ngHide', function() {
@@ -38,6 +49,17 @@ describe('ngShow / ngHide', function() {
       $rootScope.exp = true;
       $rootScope.$digest();
       expect(element).toBeHidden();
+    }));
+
+    it('should follow javascript `truthy`/`falsy` logic', inject(function($rootScope, $compile) {
+      var cases = ['[]', 'f', [], [''], 'false', {}, function() {}, function(f) {}, 0, false, null, undefined, '', NaN];
+      element = jqLite('<div ng-hide="exp"></div>');
+      element = $compile(element)($rootScope);
+      angular.forEach(cases, function(value) {
+        $rootScope.exp = value;
+        $rootScope.$digest();
+        expect(element)[value ? 'toBeHidden' : 'toBeShown']();
+      });
     }));
   });
 });


### PR DESCRIPTION
Make ngShow and ngHide follow javascript `truthy`/`falsy` logic and
not the custom toBoolean logic

Closes #5414
Closes #4277
