### PR TITLE
fix($rootScope): prevent infinite $digest loop by also checking if asyncQueue is empty when decrementing ttl

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -631,7 +631,7 @@ function $RootScopeProvider(){
 
           // `break traverseScopesLoop;` takes us to here
 
-          if(dirty && !(ttl--)) {
+          if((dirty || asyncQueue.length) && !(ttl--)) {
             clearPhase();
             throw $rootScopeMinErr('infdig',
                 '{0} $digest() iterations reached. Aborting!\n' +

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -258,6 +258,31 @@ describe('Scope', function() {
     }));
 
 
+    it('should prevent infinite loop when creating and resolving a promise in a watched expression', function() {
+      module(function($rootScopeProvider) {
+          $rootScopeProvider.digestTtl(10);
+      });
+      inject(function($rootScope, $q) {
+          var d = $q.defer();
+
+          d.resolve('Hello, world.');
+          $rootScope.$watch(function () {
+              var $d2 = $q.defer();
+              $d2.resolve('Goodbye, cruel world.');
+              $d2.promise.then(function () { });
+              return d.promise;
+          }, function () { return 0; });
+
+          expect(function() {
+              $rootScope.$digest();
+          }).toThrowMinErr('$rootScope', 'infdig', '10 $digest() iterations reached. Aborting!\n'+
+                  'Watchers fired in the last 5 iterations: []');
+
+          expect($rootScope.$$phase).toBeNull();
+      });
+      });
+
+
     it('should not fire upon $watch registration on initial $digest', inject(function($rootScope) {
       var log = '';
       $rootScope.a = 1;


### PR DESCRIPTION
An infinite $digest loop can be caused by expressions that invoke a promise. The problem is that $digest does not
decrement ttl unless it finds dirty changes; it should check also if asyncQueue is empty.
Generally the condition for decrementing ttl should be the same as the condition for terminating the $digest loop.

Closes #2622
