### PR TITLE
fix($httpBackend): use ActiveX XHR when making PATCH requests on IE8

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -1,12 +1,11 @@
 'use strict';
 
-var XHR = window.XMLHttpRequest || function() {
-  /* global ActiveXObject */
-  try { return new ActiveXObject("Msxml2.XMLHTTP.6.0"); } catch (e1) {}
-  try { return new ActiveXObject("Msxml2.XMLHTTP.3.0"); } catch (e2) {}
-  try { return new ActiveXObject("Msxml2.XMLHTTP"); } catch (e3) {}
-  throw minErr('$httpBackend')('noxhr', "This browser does not support XMLHttpRequest.");
-};
+function createXhr(method) {
+  // IE8 doesn't support PATCH method, but the ActiveX object does
+  return (msie <= 8 && lowercase(method) === 'patch')
+      ? new ActiveXObject('Microsoft.XMLHTTP')
+      : new window.XMLHttpRequest;
+}
 
 
 /**
@@ -28,11 +27,11 @@ var XHR = window.XMLHttpRequest || function() {
  */
 function $HttpBackendProvider() {
   this.$get = ['$browser', '$window', '$document', function($browser, $window, $document) {
-    return createHttpBackend($browser, XHR, $browser.defer, $window.angular.callbacks, $document[0]);
+    return createHttpBackend($browser, createXhr, $browser.defer, $window.angular.callbacks, $document[0]);
   }];
 }
 
-function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument) {
+function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDocument) {
   var ABORTED = -1;
 
   // TODO(vojta): fix the signature
@@ -57,7 +56,9 @@ function createHttpBackend($browser, XHR, $browserDefer, callbacks, rawDocument)
         delete callbacks[callbackId];
       });
     } else {
-      var xhr = new XHR();
+
+      var xhr = createXhr(method);
+
       xhr.open(method, url, true);
       forEach(headers, function(value, key) {
         if (isDefined(value)) {

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -1,10 +1,12 @@
 'use strict';
 
 function createXhr(method) {
+  /* global ActiveXObject */
   // IE8 doesn't support PATCH method, but the ActiveX object does
-  return (msie <= 8 && lowercase(method) === 'patch')
+  try { return (msie <= 8 && lowercase(method) === 'patch')
       ? new ActiveXObject('Microsoft.XMLHTTP')
-      : new window.XMLHttpRequest;
+      : new window.XMLHttpRequest();
+  } catch (e) { throw minErr('$httpBackend')('noxhr', "This browser does not support XMLHttpRequest."); }
 }
 
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1572,6 +1572,10 @@ function MockHttpExpectation(method, url, data, headers) {
   };
 }
 
+function createMockXhr() {
+  return new MockXhr();
+}
+
 function MockXhr() {
 
   // hack for testing $http, $httpBackend

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -53,7 +53,7 @@ describe('$httpBackend', function() {
         })
       }
     };
-    $backend = createHttpBackend($browser, MockXhr, fakeTimeout, callbacks, fakeDocument);
+    $backend = createHttpBackend($browser, createMockXhr, fakeTimeout, callbacks, fakeDocument);
     callback = jasmine.createSpy('done');
   }));
 
@@ -238,7 +238,7 @@ describe('$httpBackend', function() {
       expect(response).toBe('response');
     });
 
-    $backend = createHttpBackend($browser, SyncXhr);
+    $backend = createHttpBackend($browser, function() { return new SyncXhr() });
     $backend('GET', '/url', null, callback);
     expect(callback).toHaveBeenCalledOnce();
   });
@@ -414,7 +414,7 @@ describe('$httpBackend', function() {
 
 
     it('should convert 0 to 200 if content', function() {
-      $backend = createHttpBackend($browser, MockXhr);
+      $backend = createHttpBackend($browser, createMockXhr);
 
       $backend('GET', 'file:///whatever/index.html', null, callback);
       respond(0, 'SOME CONTENT');
@@ -425,7 +425,7 @@ describe('$httpBackend', function() {
 
 
     it('should convert 0 to 404 if no content', function() {
-      $backend = createHttpBackend($browser, MockXhr);
+      $backend = createHttpBackend($browser, createMockXhr);
 
       $backend('GET', 'file:///whatever/index.html', null, callback);
       respond(0, '');
@@ -453,7 +453,7 @@ describe('$httpBackend', function() {
 
       try {
 
-        $backend = createHttpBackend($browser, MockXhr);
+        $backend = createHttpBackend($browser, createMockXhr);
 
         $backend('GET', '/whatever/index.html', null, callback);
         respond(0, '');
@@ -468,7 +468,7 @@ describe('$httpBackend', function() {
 
 
     it('should return original backend status code if different from 0', function () {
-      $backend = createHttpBackend($browser, MockXhr);
+      $backend = createHttpBackend($browser, createMockXhr);
 
       // request to http://
       $backend('POST', 'http://rest_api/create_whatever', null, callback);


### PR DESCRIPTION
IE8's native XHR doesn't support PATCH requests, but the ActiveX one does.

Closes #2518
Closes #5043
# 

The feature is mainly implemented by @IgorMinar in #5390 - the text above is from his commit.  @caitp found the bug that caused the tests to fail, and I suggested a refactor of her fix, which appears in my commit.

Unfortunately, I don't have a backend running currently that responds to a PATCH request, so I cannot test this in IE8 atm.
