### PR TITLE
fix($parse): fix CSP nested property evaluation, and issue that prevente...

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -894,16 +894,20 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
           if (pathVal == null) return pathVal;
           pathVal = pathVal[key0];
 
-          if (pathVal == null || !key1) return key1 ? undefined : pathVal;
+          if (!key1) return pathVal;
+          else if (pathVal == null) return undefined;
           pathVal = pathVal[key1];
 
-          if (pathVal == null || !key2) return key2 ? undefined : pathVal;
+          if (!key2) return pathVal;
+          else if (pathVal == null) return undefined;
           pathVal = pathVal[key2];
 
-          if (pathVal == null || !key3) return key3 ? undefined : pathVal;
+          if (!key3) return pathVal;
+          else if (pathVal == null) return undefined;
           pathVal = pathVal[key3];
 
-          if (pathVal == null || !key4) return key4 ? undefined : pathVal;
+          if (!key4) return pathVal;
+          else if (pathVal == null) return undefined;
           pathVal = pathVal[key4];
 
           return pathVal;
@@ -924,8 +928,9 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
             }
             pathVal = pathVal.$$v;
           }
-          if (pathVal == null || !key1) return key1 ? undefined : pathVal;
 
+          if (!key1) return pathVal;
+          else if (pathVal == null) return undefined;
           pathVal = pathVal[key1];
           if (pathVal && pathVal.then) {
             promiseWarning(fullExp);
@@ -936,8 +941,9 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
             }
             pathVal = pathVal.$$v;
           }
-          if (pathVal == null || !key2) return key2 ? undefined : pathVal;
 
+          if (!key2) return pathVal;
+          else if (pathVal == null) return undefined;
           pathVal = pathVal[key2];
           if (pathVal && pathVal.then) {
             promiseWarning(fullExp);
@@ -948,8 +954,9 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
             }
             pathVal = pathVal.$$v;
           }
-          if (pathVal == null || !key3) return key3 ? undefined : pathVal;
 
+          if (!key3) return pathVal;
+          else if (pathVal == null) return undefined;
           pathVal = pathVal[key3];
           if (pathVal && pathVal.then) {
             promiseWarning(fullExp);
@@ -960,8 +967,9 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
             }
             pathVal = pathVal.$$v;
           }
-          if (pathVal == null || !key4) return key4 ? undefined : pathVal;
 
+          if (!key4) return pathVal;
+          else if (pathVal == null) return undefined;
           pathVal = pathVal[key4];
           if (pathVal && pathVal.then) {
             promiseWarning(fullExp);

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1226,6 +1226,8 @@ function $ParseProvider() {
 
 
   this.$get = ['$filter', '$sniffer', '$log', function($filter, $sniffer, $log) {
+    $parseOptions.csp = $sniffer.csp;
+
     promiseWarning = function promiseWarningFn(fullExp) {
       if (!$parseOptions.logPromiseWarnings || promiseWarningCache.hasOwnProperty(fullExp)) return;
       promiseWarningCache[fullExp] = true;
@@ -1243,9 +1245,6 @@ function $ParseProvider() {
             return cache[exp];
           }
 
-          // The csp option has to be set here because in tests the $sniffer service sets its csp
-          // property after $get has executed.
-          $parseOptions.csp = $sniffer.csp;
           var lexer = new Lexer($parseOptions);
           var parser = new Parser(lexer, $filter, $parseOptions);
           parsedExpression = parser.parse(exp, false);

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -895,19 +895,19 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
           pathVal = pathVal[key0];
 
           if (!key1) return pathVal;
-          else if (pathVal == null) return undefined;
+          if (pathVal == null) return undefined;
           pathVal = pathVal[key1];
 
           if (!key2) return pathVal;
-          else if (pathVal == null) return undefined;
+          if (pathVal == null) return undefined;
           pathVal = pathVal[key2];
 
           if (!key3) return pathVal;
-          else if (pathVal == null) return undefined;
+          if (pathVal == null) return undefined;
           pathVal = pathVal[key3];
 
           if (!key4) return pathVal;
-          else if (pathVal == null) return undefined;
+          if (pathVal == null) return undefined;
           pathVal = pathVal[key4];
 
           return pathVal;
@@ -930,7 +930,7 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
           }
 
           if (!key1) return pathVal;
-          else if (pathVal == null) return undefined;
+          if (pathVal == null) return undefined;
           pathVal = pathVal[key1];
           if (pathVal && pathVal.then) {
             promiseWarning(fullExp);
@@ -943,7 +943,7 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
           }
 
           if (!key2) return pathVal;
-          else if (pathVal == null) return undefined;
+          if (pathVal == null) return undefined;
           pathVal = pathVal[key2];
           if (pathVal && pathVal.then) {
             promiseWarning(fullExp);
@@ -956,7 +956,7 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
           }
 
           if (!key3) return pathVal;
-          else if (pathVal == null) return undefined;
+          if (pathVal == null) return undefined;
           pathVal = pathVal[key3];
           if (pathVal && pathVal.then) {
             promiseWarning(fullExp);
@@ -969,7 +969,7 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
           }
 
           if (!key4) return pathVal;
-          else if (pathVal == null) return undefined;
+          if (pathVal == null) return undefined;
           pathVal = pathVal[key4];
           if (pathVal && pathVal.then) {
             promiseWarning(fullExp);

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -894,20 +894,16 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
           if (pathVal == null) return pathVal;
           pathVal = pathVal[key0];
 
-          if (!key1) return pathVal;
-          if (pathVal == null) return key1 ? undefined : pathVal;
+          if (pathVal == null || !key1) return key1 ? undefined : pathVal;
           pathVal = pathVal[key1];
 
-          if (!key2) return pathVal;
-          if (pathVal == null) return key2 ? undefined : pathVal;
+          if (pathVal == null || !key2) return key2 ? undefined : pathVal;
           pathVal = pathVal[key2];
 
-          if (!key3) return pathVal;
-          if (pathVal == null) return key3 ? undefined : pathVal;
+          if (pathVal == null || !key3) return key3 ? undefined : pathVal;
           pathVal = pathVal[key3];
 
-          if (!key4) return pathVal;
-          if (pathVal == null) return key4 ? undefined : pathVal;
+          if (pathVal == null || !key4) return key4 ? undefined : pathVal;
           pathVal = pathVal[key4];
 
           return pathVal;
@@ -928,8 +924,7 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
             }
             pathVal = pathVal.$$v;
           }
-          if (!key1) return pathVal;
-          if (pathVal == null) return key1 ? undefined : pathVal;
+          if (pathVal == null || !key1) return key1 ? undefined : pathVal;
 
           pathVal = pathVal[key1];
           if (pathVal && pathVal.then) {
@@ -941,8 +936,7 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
             }
             pathVal = pathVal.$$v;
           }
-          if (!key2) return pathVal;
-          if (pathVal == null) return key2 ? undefined : pathVal;
+          if (pathVal == null || !key2) return key2 ? undefined : pathVal;
 
           pathVal = pathVal[key2];
           if (pathVal && pathVal.then) {
@@ -954,8 +948,7 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
             }
             pathVal = pathVal.$$v;
           }
-          if (!key3) return pathVal;
-          if (pathVal == null) return key3 ? undefined : pathVal;
+          if (pathVal == null || !key3) return key3 ? undefined : pathVal;
 
           pathVal = pathVal[key3];
           if (pathVal && pathVal.then) {
@@ -967,8 +960,7 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
             }
             pathVal = pathVal.$$v;
           }
-          if (!key4) return pathVal;
-          if (pathVal == null) return key4 ? undefined : pathVal;
+          if (pathVal == null || !key4) return key4 ? undefined : pathVal;
 
           pathVal = pathVal[key4];
           if (pathVal && pathVal.then) {

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -894,15 +894,19 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
           if (pathVal == null) return pathVal;
           pathVal = pathVal[key0];
 
+          if (!key1) return pathVal;
           if (pathVal == null) return key1 ? undefined : pathVal;
           pathVal = pathVal[key1];
 
+          if (!key2) return pathVal;
           if (pathVal == null) return key2 ? undefined : pathVal;
           pathVal = pathVal[key2];
 
+          if (!key3) return pathVal;
           if (pathVal == null) return key3 ? undefined : pathVal;
           pathVal = pathVal[key3];
 
+          if (!key4) return pathVal;
           if (pathVal == null) return key4 ? undefined : pathVal;
           pathVal = pathVal[key4];
 
@@ -924,6 +928,7 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
             }
             pathVal = pathVal.$$v;
           }
+          if (!key1) return pathVal;
           if (pathVal == null) return key1 ? undefined : pathVal;
 
           pathVal = pathVal[key1];
@@ -936,6 +941,7 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
             }
             pathVal = pathVal.$$v;
           }
+          if (!key2) return pathVal;
           if (pathVal == null) return key2 ? undefined : pathVal;
 
           pathVal = pathVal[key2];
@@ -948,6 +954,7 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
             }
             pathVal = pathVal.$$v;
           }
+          if (!key3) return pathVal;
           if (pathVal == null) return key3 ? undefined : pathVal;
 
           pathVal = pathVal[key3];
@@ -960,6 +967,7 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, options) {
             }
             pathVal = pathVal.$$v;
           }
+          if (!key4) return pathVal;
           if (pathVal == null) return key4 ? undefined : pathVal;
 
           pathVal = pathVal[key4];
@@ -1218,8 +1226,6 @@ function $ParseProvider() {
 
 
   this.$get = ['$filter', '$sniffer', '$log', function($filter, $sniffer, $log) {
-    $parseOptions.csp = $sniffer.csp;
-
     promiseWarning = function promiseWarningFn(fullExp) {
       if (!$parseOptions.logPromiseWarnings || promiseWarningCache.hasOwnProperty(fullExp)) return;
       promiseWarningCache[fullExp] = true;
@@ -1237,6 +1243,9 @@ function $ParseProvider() {
             return cache[exp];
           }
 
+          // The csp option has to be set here because in tests the $sniffer service sets its csp
+          // property after $get has executed.
+          $parseOptions.csp = $sniffer.csp;
           var lexer = new Lexer($parseOptions);
           var parser = new Parser(lexer, $filter, $parseOptions);
           parsedExpression = parser.parse(exp, false);

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -204,13 +204,17 @@ describe('parser', function() {
 
       describe('csp: ' + cspEnabled + ", unwrapPromises: " + unwrapPromisesEnabled, function() {
 
+        beforeEach(function() {
+          // Needed for the $parse service to pick up the CSP setting at injection time.
+          window.document.securityPolicy = {isActive : cspEnabled};
+        });
+
         beforeEach(module(function ($parseProvider) {
           $parseProvider.unwrapPromises(unwrapPromisesEnabled);
         }));
 
-        beforeEach(inject(function ($rootScope, $sniffer) {
+        beforeEach(inject(function ($rootScope) {
           scope = $rootScope;
-          $sniffer.csp = cspEnabled;
         }));
 
         it('should parse expressions', function() {
@@ -1093,6 +1097,11 @@ describe('parser', function() {
           $parseProvider.unwrapPromises(true);
         }));
 
+        beforeEach(function() {
+          // Needed for the $parse service to pick up the CSP setting at injection time.
+          window.document.securityPolicy = {isActive : cspEnabled};
+        });
+
         beforeEach(inject(function($rootScope, $q, _$log_) {
           scope = $rootScope;
 
@@ -1167,9 +1176,14 @@ describe('parser', function() {
         }));
 
 
-        beforeEach(inject(function($rootScope, $sniffer, $q) {
+        beforeEach(function() {
+          // Needed for the $parse service to pick up the CSP setting at injection time.
+          window.document.securityPolicy = {isActive : cspEnabled};
+        });
+
+
+        beforeEach(inject(function($rootScope, $q) {
           scope = $rootScope;
-          $sniffer.csp = cspEnabled;
 
           q = $q;
           deferred = q.defer();

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -349,7 +349,7 @@ describe('parser', function() {
             // Create a nested object {x2: {x3: {x4: ... {x[n]: 42} ... }}}.
             var obj = 42;
             for (var i = pathLength; i >= 2; i--) {
-              var newObj = {}
+              var newObj = {};
               newObj['x' + i] = obj;
               obj = newObj;
             }

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -344,6 +344,25 @@ describe('parser', function() {
           expect(scope.$eval("a.b.c.d.e.f.g.h.i.j.k.l.m.n", scope)).toBe('nooo!');
         });
 
+        forEach([2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 42, 99], function(pathLength) {
+          it('should resolve nested paths of length ' + pathLength, function() {
+            // Create a nested object {x2: {x3: {x4: ... {x[n]: 42} ... }}}.
+            var obj = 42;
+            for (var i = pathLength; i >= 2; i--) {
+              var newObj = {}
+              newObj['x' + i] = obj;
+              obj = newObj;
+            }
+            // Assign to x1 and build path 'x1.x2.x3. ... .x[n]' to access the final value.
+            scope.x1 = obj;
+            var path = 'x1';
+            for (var i = 2; i <= pathLength; i++) {
+              path += '.x' + i;
+            }
+            expect(scope.$eval(path)).toBe(42);
+          });
+        });
+
         it('should be forgiving', function() {
           scope.a = {b: 23};
           expect(scope.$eval('b')).toBeUndefined();

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1093,14 +1093,14 @@ describe('parser', function() {
         var $log;
         var PROMISE_WARNING_REGEXP = /\[\$parse\] Promise found in the expression `[^`]+`. Automatic unwrapping of promises in Angular expressions is deprecated\./;
 
-        beforeEach(module(function($parseProvider) {
-          $parseProvider.unwrapPromises(true);
-        }));
-
         beforeEach(function() {
           // Needed for the $parse service to pick up the CSP setting at injection time.
           window.document.securityPolicy = {isActive : cspEnabled};
         });
+
+        beforeEach(module(function($parseProvider) {
+          $parseProvider.unwrapPromises(true);
+        }));
 
         beforeEach(inject(function($rootScope, $q, _$log_) {
           scope = $rootScope;


### PR DESCRIPTION
...d its tests from failing

cspSafeGetterFn incorrectly returned undefined if any of its key parameters were undefined. This
wasn't caught by the $parse unit tests because of a timing problem where $ParseProvider was reading the CSP flag before the tests manually set it, so the CSP property evaluation tests never ran. Add
test that verifies evaluation of nested properties of multiple lengths.

Fixes <a href="https://github.com/angular/angular.js/issues/5591">#5591</a>
