### PR TITLE
fix($animate): ensure class-based animations are always skipped before structural digests are run

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -610,9 +610,14 @@ angular.module('ngAnimate', ['ng'])
         }
 
         var animations = [];
+
         //only add animations if the currently running animation is not structural
         //or if there is no animation running at all
-        if(!ngAnimateState.running || !(isClassBased && ngAnimateState.structural)) {
+        var allowAnimations = isClassBased ?
+          !ngAnimateState.disabled && (!ngAnimateState.running || !ngAnimateState.structural) :
+          true;
+
+        if(allowAnimations) {
           forEach(matches, function(animation) {
             //add the animation to the queue to if it is allowed to be cancelled
             if(!animation.allowCancel || animation.allowCancel(element, animationEvent, className)) {

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -538,6 +538,27 @@ describe("ngAnimate", function() {
           expect(completed).toBe(true);
         }));
 
+        it("should skip class-based animations if animations are directly disabled on the same element", function() {
+          var capture;
+          module(function($animateProvider) {
+            $animateProvider.register('.capture', function() {
+              return {
+                addClass : function(element, className, done) {
+                  capture = true;
+                  done();
+                }
+              };
+            });
+          });
+          inject(function($animate, $rootScope, $sniffer, $timeout) {
+            $animate.enabled(true);
+            $animate.enabled(false, element);
+
+            $animate.addClass(element, 'capture');
+            expect(element.hasClass('capture')).toBe(true);
+            expect(capture).not.toBe(true);
+          });
+        });
 
         it("should fire the cancel/end function with the correct flag in the parameters",
           inject(function($animate, $rootScope, $sniffer, $timeout) {


### PR DESCRIPTION
Closes #5582
