### PR TITLE
fix(ngShow/ngHide, ngIf): functions with zero args should be truthy

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -959,7 +959,9 @@ function fromJson(json) {
 
 
 function toBoolean(value) {
-  if (value && value.length !== 0) {
+  if (typeof value === 'function') {
+    value = true;
+  } else if (value && value.length !== 0) {
     var v = lowercase("" + value);
     value = !(v == 'f' || v == '0' || v == 'false' || v == 'no' || v == 'n' || v == '[]');
   } else {

--- a/test/ng/directive/ngShowHideSpec.js
+++ b/test/ng/directive/ngShowHideSpec.js
@@ -20,6 +20,16 @@ describe('ngShow / ngHide', function() {
     }));
 
 
+    // https://github.com/angular/angular.js/issues/5414
+    it('should show if the expression is a function with a single argument', inject(function($rootScope, $compile) {
+      element = jqLite('<div ng-show="exp"></div>');
+      element = $compile(element)($rootScope);
+      $rootScope.exp = function(){};
+      $rootScope.$digest();
+      expect(element).toBeShown();
+    }));
+
+
     it('should make hidden element visible', inject(function($rootScope, $compile) {
       element = jqLite('<div class="ng-hide" ng-show="exp"></div>');
       element = $compile(element)($rootScope);


### PR DESCRIPTION
Previously, expressions that were a function with one or more arguments evaluated to true, but functions with zero arguments evaluated to false.

This behavior seems both unintentional and undesirable. This patch makes a function truthy regardless of its number of arguments.

Closes #5414
