### PR TITLE
fix($browser): remove base href domain when url begins with '//'

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -253,7 +253,7 @@ function Browser(window, document, $log, $sniffer) {
    */
   self.baseHref = function() {
     var href = baseElement.attr('href');
-    return href ? href.replace(/^https?\:\/\/[^\/]*/, '') : '';
+    return href ? href.replace(/^(https?\:)?\/\/[^\/]*/, '') : '';
   };
 
   //////////////////////////////////////////////////////////////

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -609,5 +609,10 @@ describe('browser', function() {
       fakeDocument.basePath = 'http://host.com/base/path/index.html';
       expect(browser.baseHref()).toEqual('/base/path/index.html');
     });
+
+    it('should remove domain from <base href> beginning with \'//\'', function() {
+      fakeDocument.basePath = '//google.com/base/path/';
+      expect(browser.baseHref()).toEqual('/base/path/');
+    });
   });
 });


### PR DESCRIPTION
This change prevents an incorrect appBase url from being calculated when the
<base> href's domain begins with '//'.

Related to #5292, tangentially.

I don't know for sure if this is the correct behaviour, but it doesn't seem
totally unreasonable.

Before this change, if an app used `<base href="//my.domain.com/app">`, the entire href would be treated as a path, and $location would behave incorrectly, due to appending it to the initial domain.

So, that's a thing.
