### PR TITLE
Add options for number filter

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -66,9 +66,9 @@ function currencyFilter($locale) {
  * @param {(object)=} options Object with overrides for current locale NUMBER_FORMATS
  * If this is not provided then the fraction size is computed from the current locale's number
  * formatting pattern. In the case of the default locale, it will be 3.
- * @returns {string} Number localized using your current locale, rounded to decimalPlaces 
- * and places a (options|$local)groupSeparator after each third digit. 
- * 
+ * @returns {string} Number localized using your current locale, rounded to decimalPlaces
+ * and places a (options|$local)groupSeparator after each third digit.
+ *
  *
  * @example
    <doc:example>
@@ -111,7 +111,6 @@ function currencyFilter($locale) {
              pattern: {
                'gSize': 3,
                'lgSize': 3,
-               'macFrac': 0,
                'maxFrac': 2,
                'minFrac': 2,
                'minInt': 1,
@@ -154,10 +153,10 @@ numberFilter.$inject = ['$locale'];
 function numberFilter($locale) {
   var formats = $locale.NUMBER_FORMATS;
   return function(number, fractionSize, options) {
-    return formatNumber(number, 
-      options.pattern || formats.PATTERNS[0], 
-      options.groupSeparator || formats.GROUP_SEP, 
-      options.decimalSeparator || formats.DECIMAL_SEP,
+    return formatNumber(number,
+      options && options.pattern || formats.PATTERNS[0],
+      options && options.groupSeparator || formats.GROUP_SEP,
+      options && options.decimalSeparator || formats.DECIMAL_SEP,
       fractionSize);
   };
 }

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -100,8 +100,7 @@ function currencyFilter($locale) {
        });
      </doc:scenario>
    </doc:example>
- */
- /* @example
+ * Example with optional options parameter
    <doc:example>
      <doc:source>
        <script>
@@ -113,7 +112,6 @@ function currencyFilter($locale) {
                'lgSize': 3,
                'maxFrac': 2,
                'minFrac': 2,
-               'minInt': 1,
                'negPre': '(&',
                'negSuf': ')',
                'posPre': '&',
@@ -126,23 +124,23 @@ function currencyFilter($locale) {
        </script>
        <div ng-controller="Ctrl">
          Enter number: <input ng-model='val'><br>
-         Default formatting: {{val | number}}<br>
-         No fractions: {{val | number:0}}<br>
-         Negative number: {{-val | number:4}}
+         Default formatting: {{val | number:3:filterOptions}}<br>
+         No fractions: {{val | number:0:filterOptions}}<br>
+         Negative number: {{-val | number:4:filterOptions}}
        </div>
      </doc:source>
      <doc:scenario>
        it('should format numbers', function() {
-         expect(binding('val | number')).toBe('1,234.568');
-         expect(binding('val | number:0')).toBe('1,235');
-         expect(binding('-val | number:4')).toBe('-1,234.5679');
+         expect(binding('val | number:3:filterOptions')).toBe('&1^234-568');
+         expect(binding('val | number:0:filterOptions')).toBe('&1^235');
+         expect(binding('-val | number:4:filterOptions')).toBe('(&1^234-5679)');
        });
 
        it('should update', function() {
          input('val').enter('3374.333');
-         expect(binding('val | number')).toBe('3,374.333');
-         expect(binding('val | number:0')).toBe('3,374');
-         expect(binding('-val | number:4')).toBe('-3,374.3330');
+         expect(binding('val | number:3:filterOptions')).toBe('&3^374-333');
+         expect(binding('val | number:0:filterOptions')).toBe('&3^374');
+         expect(binding('-val | number:4:filterOptions')).toBe('(&3^374-3330)');
        });
      </doc:scenario>
    </doc:example>

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -63,9 +63,12 @@ function currencyFilter($locale) {
  *
  * @param {number|string} number Number to format.
  * @param {(number|string)=} fractionSize Number of decimal places to round the number to.
+ * @param {(object)=} options Object with overrides for current locale NUMBER_FORMATS
  * If this is not provided then the fraction size is computed from the current locale's number
  * formatting pattern. In the case of the default locale, it will be 3.
- * @returns {string} Number rounded to decimalPlaces and places a “,” after each third digit.
+ * @returns {string} Number localized using your current locale, rounded to decimalPlaces 
+ * and places a (options|$local)groupSeparator after each third digit. 
+ * 
  *
  * @example
    <doc:example>
@@ -98,13 +101,63 @@ function currencyFilter($locale) {
      </doc:scenario>
    </doc:example>
  */
+ /* @example
+   <doc:example>
+     <doc:source>
+       <script>
+         function Ctrl($scope) {
+           $scope.val = 1234.56789;
+           $scope.filterOptions = {
+             pattern: {
+               'gSize': 3,
+               'lgSize': 3,
+               'macFrac': 0,
+               'maxFrac': 2,
+               'minFrac': 2,
+               'minInt': 1,
+               'negPre': '(&',
+               'negSuf': ')',
+               'posPre': '&',
+               'posSuf': ''
+             },
+             groupSeparator: '^',
+             decimalSeparator: '-'
+           }
+         }
+       </script>
+       <div ng-controller="Ctrl">
+         Enter number: <input ng-model='val'><br>
+         Default formatting: {{val | number}}<br>
+         No fractions: {{val | number:0}}<br>
+         Negative number: {{-val | number:4}}
+       </div>
+     </doc:source>
+     <doc:scenario>
+       it('should format numbers', function() {
+         expect(binding('val | number')).toBe('1,234.568');
+         expect(binding('val | number:0')).toBe('1,235');
+         expect(binding('-val | number:4')).toBe('-1,234.5679');
+       });
+
+       it('should update', function() {
+         input('val').enter('3374.333');
+         expect(binding('val | number')).toBe('3,374.333');
+         expect(binding('val | number:0')).toBe('3,374');
+         expect(binding('-val | number:4')).toBe('-3,374.3330');
+       });
+     </doc:scenario>
+   </doc:example>
+ */
 
 
 numberFilter.$inject = ['$locale'];
 function numberFilter($locale) {
   var formats = $locale.NUMBER_FORMATS;
-  return function(number, fractionSize) {
-    return formatNumber(number, formats.PATTERNS[0], formats.GROUP_SEP, formats.DECIMAL_SEP,
+  return function(number, fractionSize, options) {
+    return formatNumber(number, 
+      options.pattern || formats.PATTERNS[0], 
+      options.groupSeparator || formats.GROUP_SEP, 
+      options.decimalSeparator || formats.DECIMAL_SEP,
       fractionSize);
   };
 }

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -22,7 +22,7 @@ describe('filters', function() {
     var pattern;
 
     beforeEach(function() {
-      pattern = { minInt: 1,
+      pattern = {
                   minFrac: 0,
                   maxFrac: 3,
                   posPre: '',
@@ -143,6 +143,45 @@ describe('filters', function() {
       expect(number(1234.567, 0)).toEqual("1,235");
       expect(number(1234.567, 1)).toEqual("1,234.6");
       expect(number(1234.567, 2)).toEqual("1,234.57");
+    });
+
+    it('should do basic filter with modified options', function() {
+      var options =  {
+         pattern: {
+           'gSize': 2,
+           'lgSize': 4,
+           'maxFrac': 4,
+           'minFrac': 3,
+           'negPre': '^-',
+           'negSuf': '^',
+           'posPre': '|',
+           'posSuf': '|'
+         },
+         groupSeparator: '^',
+         decimalSeparator: '-'
+       }
+      expect(number(0, 0, options)).toEqual('|0|');
+      expect(number(-999, undefined, options)).toEqual('^-999-000^');
+      expect(number(123, undefined, options)).toEqual('|123-000|');
+      expect(number(1234567, undefined, options)).toEqual('|1^23^4567-000|');
+      expect(number(1234, undefined, options)).toEqual('|1234-000|');
+      expect(number(1234.56789, undefined, options)).toEqual('|1234-5679|');
+      expect(number(Number.NaN, undefined, options)).toEqual('');
+      expect(number("1234.5678")).toEqual('1,234.568');
+      expect(number(1/0, undefined, options)).toEqual("");
+      expect(number(1,        2, options)).toEqual("|1-00|");
+      expect(number(.1,       2, options)).toEqual("|0-10|");
+      expect(number(.01,      2, options)).toEqual("|0-01|");
+      expect(number(.001,     3, options)).toEqual("|0-001|");
+      expect(number(.0001,    3, options)).toEqual("|0-000|");
+      expect(number(9,        2, options)).toEqual("|9-00|");
+      expect(number(.9,       2, options)).toEqual("|0-90|");
+      expect(number(.99,      2, options)).toEqual("|0-99|");
+      expect(number(.999,     3, options)).toEqual("|0-999|");
+      expect(number(.9999,    3, options)).toEqual("|1-000|");
+      expect(number(1234.567, 0, options)).toEqual("|1235|");
+      expect(number(1234.567, 1, options)).toEqual("|1234-6|");
+      expect(number(1234.567, 2, options)).toEqual("|1234-57|");
     });
 
     it('should filter exponentially large numbers', function() {


### PR DESCRIPTION
The angular number format function is very robust.  It is quite the shame that it is not available except in a very limited manner.  This extension extends the existing number filter to allow users to configure the filter on demand.  Useful for those of us who need to have custom prefixes and suffixes dependent on the data we are presenting.
