### PR TITLE
feat(ngResource): Add $abort method to objects returned by $resource "class" actions

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -506,8 +506,9 @@ angular.module('ngResource', ['ng']).
           // If parameters do not contain `timeout` which is a promise, create it,
           // so that later this call can be aborted by resolving this promise
           var timeout = httpConfig.timeout;
+          var timeoutDeferred;
           if (!timeout || !timeout.then) {
-            var timeoutDeferred = $q.defer();
+            timeoutDeferred = $q.defer();
             httpConfig.timeout = timeoutDeferred.promise;
             // If timeout is specified in milliseconds, use it to abort via promise
             if (timeout) $timeout(timeoutDeferred.resolve, timeout);

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -504,7 +504,7 @@ angular.module('ngResource', ['ng']).
           });
 
           // If parameters do not contain `timeout` which is a promise, create it,
-          // so that later this call can be aborted by resolving this promise
+          // so that later this call can be aborted by resolving this promise.
           var timeout = httpConfig.timeout;
           var timeoutDeferred;
           if (!timeout || !timeout.then) {

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -674,6 +674,22 @@ describe("resource", function() {
       });
 
 
+      it('should add $abort method to the result object', function(){
+        $httpBackend.expect('POST', '/CreditCard/123!charge?amount=10', '{"auth":"abc"}').respond({success: 'ok'});
+        var errorCallback = jasmine.createSpy();
+        var cc = CreditCard.charge({id:123, amount:10}, {auth:'abc'});
+        cc.$promise.then(callback, errorCallback);
+
+        expect(cc.$abort).toEqual(jasmine.any(Function));
+        cc.$abort();
+
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+        expect(callback).not.toHaveBeenCalled();
+        expect(errorCallback).toHaveBeenCalled();
+      });
+
+
       it('should return promise from action method calls', function() {
         $httpBackend.expect('GET', '/CreditCard/123').respond({id: 123, number: '9876'});
         var cc = new CreditCard({name: 'Mojo'});
@@ -836,6 +852,22 @@ describe("resource", function() {
         $httpBackend.flush();
         expect(callback).toHaveBeenCalledOnce();
         expect(ccs.$resolved).toBe(true);
+      });
+
+
+      it('should add $abort method to the result object', function(){
+        $httpBackend.expect('GET', '/CreditCard?key=value').respond([{id: 1}, {id: 2}]);
+        var errorCallback = jasmine.createSpy();
+        var ccs = CreditCard.query({key: 'value'});
+        ccs.$promise.then(callback, errorCallback);
+
+        expect(ccs.$abort).toEqual(jasmine.any(Function));
+        ccs.$abort();
+
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+        expect(callback).not.toHaveBeenCalled();
+        expect(errorCallback).toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
`$resource` "class" actions delegate to `$http` in a fashion that does not allow to pass `timeout` promise to individual requests. Hence these individual requests can not be cancelled. This patch adds `$abort` method to the object returned by `$resource` "class" actions.

Closes #5612  
