### PR TITLE
Update route.js

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -421,6 +421,23 @@ function $RouteProvider(){
      * instance of the Controller.
      */
 
+    /**
+     * @ngdoc event
+     * @name ngRoute.$route#beforeRouteChange
+     * @eventOf ngRoute.$route
+     * @eventType broadcast on root scope
+     * @description
+     * Broadcasted at the same time as locationChangeStart, passes through the event so the locationChange can be cancelled. 
+     * Passes two other objects that represent the Routes of the current location and the one of the possible next. 
+     *
+     * `$beforeRouteChange` is fired.
+     *
+     * @param {Object} angularEvent Synthetic event object.
+     * @param {Route} currentRoute current route information.
+     * @param {Route}  nextRoute route information of the future route.
+     * @param {Object} angularEvent Synthetic event object of locationChangeStart.
+     */
+
     var forceReload = false,
         $route = {
           routes: routes,
@@ -444,6 +461,13 @@ function $RouteProvider(){
         };
 
     $rootScope.$on('$locationChangeSuccess', updateRoute);
+
+    $rootScope.$on("$locationChangeStart", function (event, next, current) {
+        var nextRoute = parseRoute(),
+            lastRoute = $route.current;
+
+        $rootScope.$broadcast('$beforeRouteChange', lastRoute, nextRoute, event);
+    });
 
     return $route;
 


### PR DESCRIPTION
feat(ngRoute): change

This change adds a new event on ngRoute called beforeRouteChange. With this change it is possible to cancel a locationChange based on route data. The problem that I am trying to fix here is described in https://github.com/angular/angular.js/issues/5581
