### PR TITLE
fix($httpBackend): cancelled JSONP requests should not throw error

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -54,7 +54,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
         } else {
           completeRequest(callback, status || -2);
         }
-        delete callbacks[callbackId];
+        callbacks[callbackId] = angular.noop;
       });
     } else {
 

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -328,7 +328,7 @@ describe('$httpBackend', function() {
         script.onload();
       }
 
-      expect(callbacks[callbackId]).toBeUndefined();
+      expect(callbacks[callbackId]).toBe(angular.noop);
       expect(fakeDocument.body.removeChild).toHaveBeenCalledOnceWith(script);
     });
 
@@ -395,7 +395,7 @@ describe('$httpBackend', function() {
     });
 
 
-    it('should abort request on timeout', function() {
+    it('should abort request on timeout and replace callback with noop', function() {
       callback.andCallFake(function(status, response) {
         expect(status).toBe(-1);
       });
@@ -404,9 +404,14 @@ describe('$httpBackend', function() {
       expect(fakeDocument.$$scripts.length).toBe(1);
       expect(fakeTimeout.delays[0]).toBe(2000);
 
+      var script = fakeDocument.$$scripts.shift(),
+        callbackId = script.src.match(SCRIPT_URL)[2];
+
       fakeTimeout.flush();
       expect(fakeDocument.$$scripts.length).toBe(0);
       expect(callback).toHaveBeenCalledOnce();
+
+      expect(callbacks[callbackId]).toBe(angular.noop);
     });
 
 


### PR DESCRIPTION
When you cancel a JSONP request, angular deletes the callback for it. However the script still executes, and since the callback is now deleted and undefined, the script throws an exception visible in the console. The quick fix for this is not to delete the callback, but replace it with `angular.noop`.

Closes #5615
