### PR TITLE
docs(ngRepeat): add info about aliasing special properties of ngRepeat

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -20,7 +20,9 @@
  * | `$even`   | {@type boolean} | true if the iterator position `$index` is even (otherwise false).           |
  * | `$odd`    | {@type boolean} | true if the iterator position `$index` is odd (otherwise false).            |
  *
- *
+ * Creating aliases for these properties is possible with {@link api/ng.directive:ngInit `ngInit`}.  
+ * This may be useful when, for instance, nesting ngRepeats.
+ * 
  * # Special repeat start and end points
  * To repeat a series of elements instead of just one parent element, ngRepeat (as well as other ng directives) supports extending
  * the range of the repeater by defining explicit start and end points by using **ng-repeat-start** and **ng-repeat-end** respectively.


### PR DESCRIPTION
This will safe peoples' time, since ngRepeat's docs, not ngInit's, is the first place where one would search for such info.
