### PR TITLE
feat($interpolate): escape interpolated expressions

### DIFF
--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -93,7 +93,8 @@ function $InterpolateProvider() {
     var startSymbolLength = startSymbol.length,
         endSymbolLength = endSymbol.length,
         escapedStartLength = escapedStartSymbol.length,
-        escapedEndLength = escapedEndSymbol.length;
+        escapedEndLength = escapedEndSymbol.length,
+        similarStartSymbols = escapedStartSymbol.indexOf(startSymbol) === 0;
 
     /**
      * @ngdoc service
@@ -193,6 +194,13 @@ function $InterpolateProvider() {
         if (((startIndex = text.indexOf(startSymbol, i)) != -1) &&
              ((endIndex = text.indexOf(endSymbol, startIndex + startSymbolLength)) != -1) &&
              (!escaped || escapedEnd < startIndex || escapedStart > endIndex + endSymbolLength) ) {
+          if (escapedEnd < 0 && similarStartSymbols) {
+            while (escapedStart >= 0 && startIndex === escapedStart &&
+                 text.indexOf(startSymbol, startIndex) === startIndex) {
+              startIndex = escapedStart + startSymbolLength;
+              escapedStart = text.indexOf(escapedStartSymbol, startIndex + startSymbolLength);
+            }
+          }
           if (index !== startIndex) hasText = true;
           separators.push(unescape(text.substring(index, startIndex)));
           exp = text.substring(startIndex + startSymbolLength, endIndex);

--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -61,6 +61,34 @@ describe('$interpolate', function() {
   }));
 
 
+  it('should not parse escaped interpolation expressions', inject(function($interpolate, $rootScope) {
+    $rootScope.foo = 'World';
+    expect($interpolate('Hello, {{{{foo}}}}!')($rootScope)).toBe('Hello, {{foo}}!');
+  }));
+
+
+  it('should parse expressions before escaped expressions', inject(function($interpolate, $rootScope) {
+    $rootScope.foo = 'World';
+    expect($interpolate('Hello, {{foo}}! ({{{{foo}}}})')($rootScope)).toBe('Hello, World! ({{foo}})');
+  }));
+
+
+  it('should parse expressions after escaped expressions', inject(function($interpolate, $rootScope) {
+    $rootScope.foo = 'World';
+    expect($interpolate('Hello, {{{{foo}}}} ({{foo}}!)')($rootScope)).toBe('Hello, {{foo}} (World!)');
+  }));
+
+
+  it('should not parse naively escaped expressions', inject(function($interpolate, $rootScope) {
+    $rootScope.abc = 'Hello';
+    $rootScope.def = 'world';
+    expect($interpolate('{{{{abc}}}}}}{{{{def}}}}')($rootScope)).toBe('{{abc}}}}{{def}}');
+    expect($interpolate('{{{{{{abc}}}}{{{{def}}}}')($rootScope)).toBe('{{{{abc}}{{def}}');
+    expect($interpolate('{{{{abc}}}}{{{{def}}}}}}')($rootScope)).toBe('{{abc}}{{def}}}}');
+    expect($interpolate('{{{{abc}}}}{{{{{{def}}}}')($rootScope)).toBe('{{abc}}{{{{def}}');
+  }));
+
+
   describe('interpolating in a trusted context', function() {
     var sce;
     beforeEach(function() {

--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -86,6 +86,8 @@ describe('$interpolate', function() {
     expect($interpolate('{{{{{{abc}}}}{{{{def}}}}')($rootScope)).toBe('{{{{abc}}{{def}}');
     expect($interpolate('{{{{abc}}}}{{{{def}}}}}}')($rootScope)).toBe('{{abc}}{{def}}}}');
     expect($interpolate('{{{{abc}}}}{{{{{{def}}}}')($rootScope)).toBe('{{abc}}{{{{def}}');
+    expect($interpolate('}}}}abc{{abc}}}}{{{{def}}}')($rootScope)).toBe('}}}}abcHello}}{{world}');
+    expect($interpolate('{{{{{{abc{{def}}}}}}')($rootScope)).toBe('{{{{abc{{def}}}}');
   }));
 
 


### PR DESCRIPTION
By default, the escaped interpolation start and end symbols are `{{{{` and `}}}}`, respectively.

These symbols will be replaced with the proper interpolation start and end  symbols during interpolation, without parsing the expression.

Fixes #5601

These tests might be made better, and the implementation might be improved. Comments welcome :3
