### PR TITLE
refactor(filterFilter): simplify code by a ternary op instead of if-else

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -173,23 +173,12 @@ function filterFilter() {
       case "object":
         // jshint +W086
         for (var key in expression) {
-          if (key == '$') {
-            (function() {
-              if (!expression[key]) return;
-              var path = key;
-              predicates.push(function(value) {
-                return search(value, expression[path]);
-              });
-            })();
-          } else {
-            (function() {
-              if (typeof(expression[key]) == 'undefined') { return; }
-              var path = key;
-              predicates.push(function(value) {
-                return search(getter(value,path), expression[path]);
-              });
-            })();
-          }
+          (function(path) {
+            if (typeof expression[path] == 'undefined') return;
+            predicates.push(function(value) {
+              return search(path == '$' ? value : getter(value, path), expression[path]);
+            });
+          })(key);
         }
         break;
       case 'function':

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -60,6 +60,17 @@ describe('Filter: filter', function() {
     expect(filter(items, {first:'misko', last:'hevery'})[0]).toEqual(items[0]);
   });
 
+  it('should match any properties for given "$" property', function() {
+    var items = [{first: 'tom', last: 'hevery'},
+                 {first: 'adam', last: 'hevery', alias: 'tom', done: false},
+                 {first: 'john', last: 'clark', middle: 'tommy'}];
+    expect(filter(items, {$: 'tom'}).length).toBe(3);
+    expect(filter(items, {$: 'a'}).length).toBe(2);
+    expect(filter(items, {$: false}).length).toBe(1);
+    expect(filter(items, {$: 10}).length).toBe(0);
+    expect(filter(items, {$: 'hevery'})[0]).toEqual(items[0]);
+  });
+
   it('should support boolean properties', function() {
     var items = [{name: 'tom', current: true},
 	             {name: 'demi', current: false},


### PR DESCRIPTION
- use only one IIFE and a ternary op in it, instead of invoking separate IIFEs in if-else
  (this also completely fixed the same issue closed by PR #3597)
- also add a spec to verify usage of '$' property in expression object (e.g. `{$: 'a'}`)
