### PR TITLE
docs: fix the 'view source' button for snapshots

### DIFF
--- a/docs/src/ngdoc.js
+++ b/docs/src/ngdoc.js
@@ -548,7 +548,7 @@ Doc.prototype = {
       minerrMsg;
 
     var gitTagFromFullVersion = function(version) {
-      var match = version.match(/-(\w{7})/);
+      var match = version.match(/sha\.(\w{7})/);
 
       if (match) {
         // git sha


### PR DESCRIPTION
this potentially breaks every time the format of gruntUtil.getVersion().full changes

fixes #5590
