### PR TITLE
fix($rootScope): allow $destroy of ancestor/self within watcher

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -643,6 +643,7 @@ function $RootScopeProvider(){
             length,
             dirty, ttl = TTL,
             next, current, target = this,
+            currentParents,
             watchLog = [],
             logIdx, logMsg, asyncTask;
 
@@ -653,6 +654,7 @@ function $RootScopeProvider(){
         do { // "while dirty" loop
           dirty = false;
           current = target;
+          currentParents = [target];
 
           while(asyncQueue.length) {
             try {
@@ -714,8 +716,13 @@ function $RootScopeProvider(){
             if (!(next = (current.$$childHead ||
                 (current !== target && current.$$nextSibling)))) {
               while(current !== target && !(next = current.$$nextSibling)) {
-                current = current.$parent;
+                current = currentParents.pop();
               }
+              if (next) {
+                currentParents.push(next);
+              }
+            } else if (next === current.$$childHead) {
+              currentParents.push(current);
             }
           } while ((current = next));
 

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -987,6 +987,44 @@ describe('Scope', function() {
       expect(child.parentModel).toBe('parent');
       expect(child.childModel).toBe('child');
     }));
+
+
+    it('should have no problems destroying itself within its watcher', inject(function($rootScope) {
+      first.$watch(function () {
+        first.$destroy();
+      });
+
+      $rootScope.$digest();
+      expect(log).toBe('123');
+      $rootScope.$digest();
+      expect(log).toBe('12323');
+    }));
+
+
+    it('should have no problems destroying its parent within its watcher', inject(function($rootScope) {
+      var firstSecond = first.$new();
+
+      firstSecond.$watch(function () {
+        first.$destroy();
+      });
+
+      $rootScope.$digest();
+      expect(log).toBe('123');
+    }));
+
+
+    it('should have no problems destroying its ancestor within its watcher', inject(function($rootScope) {
+      var firstSecond = first.$new(),
+          firstSecondSecond = firstSecond.$new();
+
+      firstSecondSecond.$watch(function () {
+        first.$destroy();
+      });
+
+      $rootScope.$digest();
+
+      expect(log).toBe('123');
+    }));
   });
 
 


### PR DESCRIPTION
First stab at this #5658 .

The `$parent` property of a scope maybe null in the case that it is destroyed within a watcher. Hence, just track the parents through a stack.

I'm aware that this fix isn't performant and creates a lot of work for the GC. However, it's a proof of concept of my take on this. It can be refactored to use only one array instead of re-instantiating new arrays. This is just a simple application of the typical DFS algorithm. 

I'll update this PR once I verify that this is an issue at all and this is a use case worth supporting.
Otherwise, if destroying a scope or its ancestor should _not_ be done within its watcher, it must be documented somewhere as a big no-no.

Note: May also want to short-circuit watcher loop if scope is destroyed.
