### PR TITLE
watchCollection: Return correct oldCollection argument to listener

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -503,7 +503,7 @@ function $RootScopeProvider(){
           if (changeDetected) {
             changeFlipFlop = 1 - changeFlipFlop;
             if (oldValue === initWatchVal) {
-              oldValue = internalValue;
+              oldValue = newValue;
             }
           }
 

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -419,10 +419,14 @@ function $RootScopeProvider(){
         var changeDetected;
         var changeFlipFlop = 0;
         var objGetter = $parse(obj);
-        var internalValue;  // Holds simple value or reference to internalArray or internalObject
         var internalArray = [];
         var internalObject = {};
         var internalLength = 0;
+
+        // Holds simple value or reference to internalArray or internalObject.
+        // The special initial value is used to ensure that the listener is called
+        // when the watch is established and that oldValue = newValue.
+        var internalValue = initWatchVal;
 
         function $watchCollectionWatch() {
           var newLength, key, i;
@@ -432,7 +436,7 @@ function $RootScopeProvider(){
 
           if (!isObject(newValue)) {
             if (internalValue !== newValue) {
-              oldValue = copy(internalValue);
+              oldValue = internalValue;
               internalValue = newValue;
               changeDetected++;
             }
@@ -456,10 +460,9 @@ function $RootScopeProvider(){
               }
             }
             if (changeDetected) {
-              // deep copy for report to listener
-              oldValue = copy(internalValue);
+              oldValue = internalValue;
               // copy the items to array cache
-              internalValue = internalArray;
+              internalValue = internalArray = [];
               internalValue.length = internalLength = newLength;
               for (i = 0; i < newLength; i++) {
                 internalValue[i] = newValue[i];
@@ -487,10 +490,9 @@ function $RootScopeProvider(){
               }
             }
             if (changeDetected) {
-              // deep copy for report to listener
-              oldValue = copy(internalValue);
+              oldValue = internalValue;
               // copy the items to object cache
-              internalValue = internalObject;
+              internalValue = internalObject = {};
               internalLength = 0;
               for (key in newValue) {
                 if (newValue.hasOwnProperty(key)) {
@@ -498,17 +500,14 @@ function $RootScopeProvider(){
                   internalValue[key] = newValue[key];
                 }
               }
-              for(key in internalValue) {
-                if (internalValue.hasOwnProperty(key) &&
-                    !newValue.hasOwnProperty(key)) {
-                  delete internalValue[key];
-                }
-              }
             }
           }
 
           if (changeDetected) {
             changeFlipFlop = 1 - changeFlipFlop;
+            if (oldValue === initWatchVal) {
+              oldValue = internalValue;
+            }
           }
 
           return changeFlipFlop;

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -416,7 +416,6 @@ function $RootScopeProvider(){
         var self = this;
         var oldValue;
         var newValue;
-        var changeDetected;
         var changeFlipFlop = 0;
         var objGetter = $parse(obj);
         var internalArray = [];
@@ -429,14 +428,14 @@ function $RootScopeProvider(){
         var internalValue = initWatchVal;
 
         function $watchCollectionWatch() {
-          var newLength, key, i;
+          var newLength, key, i, changeDetected;
 
           newValue = objGetter(self);
+          oldValue = internalValue;
           changeDetected = 0;
 
           if (!isObject(newValue)) {
             if (internalValue !== newValue) {
-              oldValue = internalValue;
               internalValue = newValue;
               changeDetected++;
             }
@@ -460,7 +459,6 @@ function $RootScopeProvider(){
               }
             }
             if (changeDetected) {
-              oldValue = internalValue;
               // copy the items to array cache
               internalValue = internalArray = [];
               internalValue.length = internalLength = newLength;
@@ -490,7 +488,6 @@ function $RootScopeProvider(){
               }
             }
             if (changeDetected) {
-              oldValue = internalValue;
               // copy the items to object cache
               internalValue = internalObject = {};
               internalLength = 0;

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -497,27 +497,27 @@ describe('Scope', function() {
           $rootScope.obj = 'test';
           $rootScope.$digest();
           expect(log).toEqual(['"test"']);
-          expect(logb).toEqual([undefined]);
+          expect(logb).toEqual(['"test"']);
 
           $rootScope.obj = [];
           $rootScope.$digest();
           expect(log).toEqual(['"test"', '[]']);
-          expect(logb).toEqual([undefined, '"test"']);
+          expect(logb).toEqual(['"test"', '"test"']);
 
           $rootScope.obj = {};
           $rootScope.$digest();
           expect(log).toEqual(['"test"', '[]', '{}']);
-          expect(logb).toEqual([undefined, '"test"', '[]']);
+          expect(logb).toEqual(['"test"', '"test"', '[]']);
 
           $rootScope.obj = [];
           $rootScope.$digest();
           expect(log).toEqual(['"test"', '[]', '{}', '[]']);
-          expect(logb).toEqual([undefined, '"test"', '[]', '{}']);
+          expect(logb).toEqual(['"test"', '"test"', '[]', '{}']);
 
           $rootScope.obj = undefined;
           $rootScope.$digest();
           expect(log).toEqual(['"test"', '[]', '{}', '[]', undefined]);
-          expect(logb).toEqual([undefined, '"test"', '[]', '{}', '[]']);
+          expect(logb).toEqual(['"test"', '"test"', '[]', '{}', '[]']);
         });
 
 
@@ -540,12 +540,12 @@ describe('Scope', function() {
           $rootScope.obj.push('a');
           $rootScope.$digest();
           expect(log).toEqual(['[]', '["a"]']);
-          expect(logb).toEqual([undefined, '[]']);
+          expect(logb).toEqual(['[]', '[]']);
 
           $rootScope.obj[0] = 'b';
           $rootScope.$digest();
           expect(log).toEqual(['[]', '["a"]', '["b"]']);
-          expect(logb).toEqual([undefined, '[]', '["a"]']);
+          expect(logb).toEqual(['[]', '[]', '["a"]']);
 
           $rootScope.obj.push([]);
           $rootScope.obj.push({});
@@ -596,7 +596,7 @@ describe('Scope', function() {
           $rootScope.obj = {};
           $rootScope.$digest();
           expect(log).toEqual(['"test"', '{}']);
-          expect(logb).toEqual([undefined, '"test"']);
+          expect(logb).toEqual(['"test"', '"test"']);
         });
 
 
@@ -619,12 +619,12 @@ describe('Scope', function() {
           $rootScope.obj.a= 'A';
           $rootScope.$digest();
           expect(log).toEqual(['{}', '{"a":"A"}']);
-          expect(logb).toEqual([undefined, '{}']);
+          expect(logb).toEqual(['{}', '{}']);
 
           $rootScope.obj.a = 'B';
           $rootScope.$digest();
           expect(log).toEqual(['{}', '{"a":"A"}', '{"a":"B"}']);
-          expect(logb).toEqual([undefined, '{}', '{"a":"A"}']);
+          expect(logb).toEqual(['{}', '{}', '{"a":"A"}']);
 
           $rootScope.obj.b = [];
           $rootScope.obj.c = {};

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -459,12 +459,12 @@ describe('Scope', function() {
       var log, logb, $rootScope, deregister;
 
       beforeEach(inject(function(_$rootScope_) {
-        log = [];
-        logb = [];
+        logb = [];  // list of before values
+        log = [];   // list of after values
         $rootScope = _$rootScope_;
         deregister = $rootScope.$watchCollection('obj', function logger(obj, objb) {
-          log.push(toJson(obj));
           logb.push(toJson(objb));
+          log.push(toJson(obj));
         });
       }));
 
@@ -496,28 +496,28 @@ describe('Scope', function() {
         it('should trigger when property changes into array', function() {
           $rootScope.obj = 'test';
           $rootScope.$digest();
-          expect(log).toEqual(['"test"']);
           expect(logb).toEqual(['"test"']);
+          expect(log).toEqual(['"test"']);
 
           $rootScope.obj = [];
           $rootScope.$digest();
-          expect(log).toEqual(['"test"', '[]']);
           expect(logb).toEqual(['"test"', '"test"']);
+          expect(log).toEqual(['"test"', '[]']);
 
           $rootScope.obj = {};
           $rootScope.$digest();
-          expect(log).toEqual(['"test"', '[]', '{}']);
           expect(logb).toEqual(['"test"', '"test"', '[]']);
+          expect(log).toEqual(['"test"', '[]', '{}']);
 
           $rootScope.obj = [];
           $rootScope.$digest();
-          expect(log).toEqual(['"test"', '[]', '{}', '[]']);
           expect(logb).toEqual(['"test"', '"test"', '[]', '{}']);
+          expect(log).toEqual(['"test"', '[]', '{}', '[]']);
 
           $rootScope.obj = undefined;
           $rootScope.$digest();
-          expect(log).toEqual(['"test"', '[]', '{}', '[]', undefined]);
           expect(logb).toEqual(['"test"', '"test"', '[]', '{}', '[]']);
+          expect(log).toEqual(['"test"', '[]', '{}', '[]', undefined]);
         });
 
 
@@ -539,28 +539,28 @@ describe('Scope', function() {
 
           $rootScope.obj.push('a');
           $rootScope.$digest();
-          expect(log).toEqual(['[]', '["a"]']);
           expect(logb).toEqual(['[]', '[]']);
+          expect(log).toEqual(['[]', '["a"]']);
 
           $rootScope.obj[0] = 'b';
           $rootScope.$digest();
-          expect(log).toEqual(['[]', '["a"]', '["b"]']);
           expect(logb).toEqual(['[]', '[]', '["a"]']);
+          expect(log).toEqual(['[]', '["a"]', '["b"]']);
 
           $rootScope.obj.push([]);
           $rootScope.obj.push({});
-          log = [];
           logb = [];
+          log = [];
           $rootScope.$digest();
-          expect(log).toEqual(['["b",[],{}]']);
           expect(logb).toEqual(['["b"]']);
+          expect(log).toEqual(['["b",[],{}]']);
 
           var temp = $rootScope.obj[1];
           $rootScope.obj[1] = $rootScope.obj[2];
           $rootScope.obj[2] = temp;
           $rootScope.$digest();
-          expect(log).toEqual([ '["b",[],{}]', '["b",{},[]]' ]);
           expect(logb).toEqual([ '["b"]', '["b",[],{}]']);
+          expect(log).toEqual([ '["b",[],{}]', '["b",{},[]]' ]);
 
           $rootScope.obj.shift();
           log = [];
@@ -595,8 +595,8 @@ describe('Scope', function() {
 
           $rootScope.obj = {};
           $rootScope.$digest();
-          expect(log).toEqual(['"test"', '{}']);
           expect(logb).toEqual(['"test"', '"test"']);
+          expect(log).toEqual(['"test"', '{}']);
         });
 
 
@@ -618,35 +618,35 @@ describe('Scope', function() {
 
           $rootScope.obj.a= 'A';
           $rootScope.$digest();
-          expect(log).toEqual(['{}', '{"a":"A"}']);
           expect(logb).toEqual(['{}', '{}']);
+          expect(log).toEqual(['{}', '{"a":"A"}']);
 
           $rootScope.obj.a = 'B';
           $rootScope.$digest();
-          expect(log).toEqual(['{}', '{"a":"A"}', '{"a":"B"}']);
           expect(logb).toEqual(['{}', '{}', '{"a":"A"}']);
+          expect(log).toEqual(['{}', '{"a":"A"}', '{"a":"B"}']);
 
           $rootScope.obj.b = [];
           $rootScope.obj.c = {};
           log = [];
           logb = [];
           $rootScope.$digest();
-          expect(log).toEqual(['{"a":"B","b":[],"c":{}}']);
           expect(logb).toEqual(['{"a":"B"}']);
+          expect(log).toEqual(['{"a":"B","b":[],"c":{}}']);
 
           var temp = $rootScope.obj.a;
           $rootScope.obj.a = $rootScope.obj.b;
           $rootScope.obj.c = temp;
           $rootScope.$digest();
-          expect(log).toEqual([ '{"a":"B","b":[],"c":{}}', '{"a":[],"b":[],"c":"B"}' ]);
           expect(logb).toEqual([ '{"a":"B"}', '{"a":"B","b":[],"c":{}}']);
+          expect(log).toEqual([ '{"a":"B","b":[],"c":{}}', '{"a":[],"b":[],"c":"B"}' ]);
 
           delete $rootScope.obj.a;
-          log = [];
           logb = [];
+          log = [];
           $rootScope.$digest();
-          expect(log).toEqual([ '{"b":[],"c":"B"}' ]);
           expect(logb).toEqual([ '{"a":[],"b":[],"c":"B"}' ]);
+          expect(log).toEqual([ '{"b":[],"c":"B"}' ]);
         });
       });
     });

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -456,13 +456,15 @@ describe('Scope', function() {
 
 
     describe('$watchCollection', function() {
-      var log, $rootScope, deregister;
+      var log, logb, $rootScope, deregister;
 
       beforeEach(inject(function(_$rootScope_) {
         log = [];
+        logb = [];
         $rootScope = _$rootScope_;
-        deregister = $rootScope.$watchCollection('obj', function logger(obj) {
+        deregister = $rootScope.$watchCollection('obj', function logger(obj, objb) {
           log.push(toJson(obj));
+          logb.push(toJson(objb));
         });
       }));
 
@@ -495,22 +497,27 @@ describe('Scope', function() {
           $rootScope.obj = 'test';
           $rootScope.$digest();
           expect(log).toEqual(['"test"']);
+          expect(logb).toEqual([undefined]);
 
           $rootScope.obj = [];
           $rootScope.$digest();
           expect(log).toEqual(['"test"', '[]']);
+          expect(logb).toEqual([undefined, '"test"']);
 
           $rootScope.obj = {};
           $rootScope.$digest();
           expect(log).toEqual(['"test"', '[]', '{}']);
+          expect(logb).toEqual([undefined, '"test"', '[]']);
 
           $rootScope.obj = [];
           $rootScope.$digest();
           expect(log).toEqual(['"test"', '[]', '{}', '[]']);
+          expect(logb).toEqual([undefined, '"test"', '[]', '{}']);
 
           $rootScope.obj = undefined;
           $rootScope.$digest();
           expect(log).toEqual(['"test"', '[]', '{}', '[]', undefined]);
+          expect(logb).toEqual([undefined, '"test"', '[]', '{}', '[]']);
         });
 
 
@@ -533,22 +540,27 @@ describe('Scope', function() {
           $rootScope.obj.push('a');
           $rootScope.$digest();
           expect(log).toEqual(['[]', '["a"]']);
+          expect(logb).toEqual([undefined, '[]']);
 
           $rootScope.obj[0] = 'b';
           $rootScope.$digest();
           expect(log).toEqual(['[]', '["a"]', '["b"]']);
+          expect(logb).toEqual([undefined, '[]', '["a"]']);
 
           $rootScope.obj.push([]);
           $rootScope.obj.push({});
           log = [];
+          logb = [];
           $rootScope.$digest();
           expect(log).toEqual(['["b",[],{}]']);
+          expect(logb).toEqual(['["b"]']);
 
           var temp = $rootScope.obj[1];
           $rootScope.obj[1] = $rootScope.obj[2];
           $rootScope.obj[2] = temp;
           $rootScope.$digest();
           expect(log).toEqual([ '["b",[],{}]', '["b",{},[]]' ]);
+          expect(logb).toEqual([ '["b"]', '["b",[],{}]']);
 
           $rootScope.obj.shift();
           log = [];
@@ -584,6 +596,7 @@ describe('Scope', function() {
           $rootScope.obj = {};
           $rootScope.$digest();
           expect(log).toEqual(['"test"', '{}']);
+          expect(logb).toEqual([undefined, '"test"']);
         });
 
 
@@ -606,27 +619,34 @@ describe('Scope', function() {
           $rootScope.obj.a= 'A';
           $rootScope.$digest();
           expect(log).toEqual(['{}', '{"a":"A"}']);
+          expect(logb).toEqual([undefined, '{}']);
 
           $rootScope.obj.a = 'B';
           $rootScope.$digest();
           expect(log).toEqual(['{}', '{"a":"A"}', '{"a":"B"}']);
+          expect(logb).toEqual([undefined, '{}', '{"a":"A"}']);
 
           $rootScope.obj.b = [];
           $rootScope.obj.c = {};
           log = [];
+          logb = [];
           $rootScope.$digest();
           expect(log).toEqual(['{"a":"B","b":[],"c":{}}']);
+          expect(logb).toEqual(['{"a":"B"}']);
 
           var temp = $rootScope.obj.a;
           $rootScope.obj.a = $rootScope.obj.b;
           $rootScope.obj.c = temp;
           $rootScope.$digest();
           expect(log).toEqual([ '{"a":"B","b":[],"c":{}}', '{"a":[],"b":[],"c":"B"}' ]);
+          expect(logb).toEqual([ '{"a":"B"}', '{"a":"B","b":[],"c":{}}']);
 
           delete $rootScope.obj.a;
           log = [];
+          logb = [];
           $rootScope.$digest();
           expect(log).toEqual([ '{"b":[],"c":"B"}' ]);
+          expect(logb).toEqual([ '{"a":[],"b":[],"c":"B"}' ]);
         });
       });
     });

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -458,6 +458,28 @@ describe('Scope', function() {
     describe('$watchCollection', function() {
       var log, logb, $rootScope, deregister;
 
+      it('should return oldCollection === newCollection on first call (only) to listener', inject(function($rootScope) {
+        var paramsEqual;
+        $rootScope.obj = {'a': 'b'};
+        deregister = $rootScope.$watchCollection('obj', function listener(obj, objb) {
+          paramsEqual = (obj === objb);
+        });
+
+        // equal first time
+        $rootScope.$digest();
+        expect(paramsEqual).toBeTruthy();
+
+        $rootScope.obj.a = 'c';
+        $rootScope.$digest();
+        expect(paramsEqual).toBeFalsy();
+
+        $rootScope.obj = undefined;
+        $rootScope.$digest();
+        expect(paramsEqual).toBeFalsy();
+
+      }));
+
+
       beforeEach(inject(function(_$rootScope_) {
         logb = [];  // list of before values
         log = [];   // list of after values


### PR DESCRIPTION
Fixes #2621.

At present, when watchCollection calls a registered listener, the oldCollection argument has the same value as
the newCollection argument. This does not accord with the API description: "The newCollection object is the newly modified data obtained from the obj expression and the oldCollection object is a copy of the former collection data.".

This fix caches the collection value correctly. It also includes some optimisations to avoid copy activity when the collection is unchanged.
