### PR TITLE
fix(ngResource): restore shallowClearAndCopy properties fitlering condition

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -772,7 +772,7 @@ function shallowCopy(src, dst) {
   for(var key in src) {
     // shallowCopy is only ever called by $compile nodeLinkFn, which has control over src
     // so we don't need to worry about using our custom hasOwnProperty here
-    if (src.hasOwnProperty(key) && key.charAt(0) !== '$' && key.charAt(1) !== '$') {
+    if (src.hasOwnProperty(key) && !(key.charAt(0) === '$' && key.charAt(1) === '$')) {
       dst[key] = src[key];
     }
   }

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -35,7 +35,7 @@ function shallowClearAndCopy(src, dst) {
   });
 
   for (var key in src) {
-    if (src.hasOwnProperty(key) && key.charAt(0) !== '$' && key.charAt(1) !== '$') {
+    if (src.hasOwnProperty(key) && !(key.charAt(0) === '$' && key.charAt(1) === '$')) {
       dst[key] = src[key];
     }
   }

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -198,6 +198,14 @@ describe('angular', function() {
       expect(clone.$$some).toBeUndefined();
       expect(clone.$$).toBeUndefined();
     });
+
+    it('should not remove $ properties from copy', function() {
+      var original = {$some: true};
+      var clone = {};
+
+      expect(shallowCopy(original, clone)).toBe(clone);
+      expect(clone.$some).toBe(original.$some);
+    });
   });
 
   describe('elementHTML', function() {

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -93,6 +93,31 @@ describe("resource", function() {
     expect(typeof CreditCard.query).toBe('function');
   });
 
+  describe('shallow copy', function() {
+    it('should make a copy', function() {
+      var original = {key:{}};
+      var copy = shallowClearAndCopy(original);
+      expect(copy).toEqual(original);
+      expect(copy.key).toBe(original.key);
+    });
+
+    it('should not copy $$ properties nor prototype properties', function() {
+      var original = {$$some: true, $$: true};
+      var clone = {};
+
+      expect(shallowClearAndCopy(original, clone)).toBe(clone);
+      expect(clone.$$some).toBeUndefined();
+      expect(clone.$$).toBeUndefined();
+    });
+
+    it('should not remove $ properties from copy', function() {
+      var original = {$some: true};
+      var clone = {};
+
+      expect(shallowClearAndCopy(original, clone)).toBe(clone);
+      expect(clone.$some).toBe(original.$some);
+    });
+  });
 
   it('should default to empty parameters', function() {
     $httpBackend.expect('GET', 'URL').respond({});


### PR DESCRIPTION
Change the way properties are fitlered to create a resource from a
JavaScript Object.

in angular version >= 1.2.6 properties of a resource with a name
beginning by a single '$' were fitlered from the created resource.
Problem cames from the upgrade of the condition to filter properties that
have a '$$' prefix in the shallow copy. See commit cb29632.

Restore the behavior ngResource had in angular 1.2.5 and inferior
versions.
