### PR TITLE
Add precision for currency filter

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -11,6 +11,9 @@
  *
  * @param {number} amount Input to filter.
  * @param {string=} symbol Currency symbol or identifier to be displayed.
+ * @param {(number|string)=} fractionSize Number of decimal places to round the number to.
+ * If this is not provided then the fraction size is computed from the current locale's number
+ * formatting pattern. In the case of the default locale, it will be 3.
  * @returns {string} Formatted number.
  *
  *
@@ -26,17 +29,20 @@
          <input type="number" ng-model="amount"> <br>
          default currency symbol ($): {{amount | currency}}<br>
          custom currency identifier (USD$): {{amount | currency:"USD$"}}
+         custom currency fractionSize (USD$): {{amount | currency:"USD$":3}}
        </div>
      </doc:source>
      <doc:scenario>
        it('should init with 1234.56', function() {
          expect(binding('amount | currency')).toBe('$1,234.56');
          expect(binding('amount | currency:"USD$"')).toBe('USD$1,234.56');
+         expect(binding('amount | currency:"USD$":3')).toBe('USD$1,234.560');
        });
        it('should update', function() {
          input('amount').enter('-1234');
          expect(binding('amount | currency')).toBe('($1,234.00)');
          expect(binding('amount | currency:"USD$"')).toBe('(USD$1,234.00)');
+         expect(binding('amount | currency:"USD$":3')).toBe('(USD$1,234.000)');
        });
      </doc:scenario>
    </doc:example>
@@ -44,9 +50,10 @@
 currencyFilter.$inject = ['$locale'];
 function currencyFilter($locale) {
   var formats = $locale.NUMBER_FORMATS;
-  return function(amount, currencySymbol){
+  return function(amount, currencySymbol, fractionSize){
     if (isUndefined(currencySymbol)) currencySymbol = formats.CURRENCY_SYM;
-    return formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP).
+    return formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP,
+      fractionSize).
                 replace(/\u00A4/g, currencySymbol);
   };
 }

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -46,7 +46,7 @@ function currencyFilter($locale) {
   var formats = $locale.NUMBER_FORMATS;
   return function(amount, currencySymbol){
     if (isUndefined(currencySymbol)) currencySymbol = formats.CURRENCY_SYM;
-    return formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP, 2).
+    return formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP).
                 replace(/\u00A4/g, currencySymbol);
   };
 }
@@ -99,7 +99,6 @@ function currencyFilter($locale) {
    </doc:example>
  */
 
-
 numberFilter.$inject = ['$locale'];
 function numberFilter($locale) {
   var formats = $locale.NUMBER_FORMATS;
@@ -122,7 +121,7 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
   var hasExponent = false;
   if (numStr.indexOf('e') !== -1) {
     var match = numStr.match(/([\d\.]+)e(-?)(\d+)/);
-    if (match && match[2] == '-' && match[3] > fractionSize + 1) {
+    if (match && match[2] == '-' && match[3] > (fractionSize || pattern.maxFrac) + 1) {
       numStr = '0';
     } else {
       formatedText = numStr;

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -208,6 +208,11 @@ describe('filters', function() {
       expect(currency(0.003)).toBe('$0.00');
     });
 
+    it('should handle overriding the default locale fractionSize', function() {
+      expect(currency(0.008, "$", 3)).toBe('$0.008');
+      expect(currency(0.008, "$", 0)).toBe('$0');
+    });
+
     it('should apply locale number format min and max fractionSize', function() {
       locale.NUMBER_FORMATS.PATTERNS[1].maxFrac = 3;
       locale.NUMBER_FORMATS.PATTERNS[1].minFrac = 2;

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -2,9 +2,107 @@
 
 describe('filters', function() {
 
-  var filter;
-
-  beforeEach(inject(function($filter){
+  var filter, locale;
+  beforeEach(module( function ($provide) {
+    locale = {
+      "DATETIME_FORMATS": {
+        "AMPMS": [
+          "AM",
+          "PM"
+        ],
+        "DAY": [
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday"
+        ],
+        "MONTH": [
+          "January",
+          "February",
+          "March",
+          "April",
+          "May",
+          "June",
+          "July",
+          "August",
+          "September",
+          "October",
+          "November",
+          "December"
+        ],
+        "SHORTDAY": [
+          "Sun",
+          "Mon",
+          "Tue",
+          "Wed",
+          "Thu",
+          "Fri",
+          "Sat"
+        ],
+        "SHORTMONTH": [
+          "Jan",
+          "Feb",
+          "Mar",
+          "Apr",
+          "May",
+          "Jun",
+          "Jul",
+          "Aug",
+          "Sep",
+          "Oct",
+          "Nov",
+          "Dec"
+        ],
+        "fullDate": "EEEE, MMMM d, y",
+        "longDate": "MMMM d, y",
+        "medium": "MMM d, y h:mm:ss a",
+        "mediumDate": "MMM d, y",
+        "mediumTime": "h:mm:ss a",
+        "short": "M/d/yy h:mm a",
+        "shortDate": "M/d/yy",
+        "shortTime": "h:mm a"
+      },
+      "NUMBER_FORMATS": {
+        "CURRENCY_SYM": "$",
+        "DECIMAL_SEP": ".",
+        "GROUP_SEP": ",",
+        "PATTERNS": [
+          {
+            "gSize": 3,
+            "lgSize": 3,
+            "macFrac": 0,
+            "maxFrac": 3,
+            "minFrac": 0,
+            "minInt": 1,
+            "negPre": "-",
+            "negSuf": "",
+            "posPre": "",
+            "posSuf": ""
+          },
+          {
+            "gSize": 3,
+            "lgSize": 3,
+            "macFrac": 0,
+            "maxFrac": 2,
+            "minFrac": 2,
+            "minInt": 1,
+            "negPre": "(\u00a4",
+            "negSuf": ")",
+            "posPre": "\u00a4",
+            "posSuf": ""
+          }
+        ]
+      },
+      "id": "en-us",
+      "pluralCat": function (n) {  if (n == 1) {   return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+    };
+    var PLURAL_CATEGORY = {ZERO: "zero", ONE: "one", TWO: "two", FEW: "few", MANY: "many", OTHER: "other"};
+    $provide.value("$locale", locale);
+  }));
+  beforeEach(inject(function($filter) {
     filter = $filter;
   }));
 
@@ -22,7 +120,7 @@ describe('filters', function() {
     var pattern;
 
     beforeEach(function() {
-      pattern = { minInt: 1,
+      pattern = {
                   minFrac: 0,
                   maxFrac: 3,
                   posPre: '',
@@ -108,6 +206,18 @@ describe('filters', function() {
       expect(currency(1.07 + 1 - 2.07)).toBe('$0.00');
       expect(currency(0.008)).toBe('$0.01');
       expect(currency(0.003)).toBe('$0.00');
+    });
+
+    it('should apply locale number format min and max fractionSize', function() {
+      locale.NUMBER_FORMATS.PATTERNS[1].maxFrac = 3;
+      locale.NUMBER_FORMATS.PATTERNS[1].minFrac = 2;
+
+      expect(currency(0.0008)).toBe('$0.001');
+      expect(currency(0.00)).toBe('$0.00');
+
+      //reset values for other tests
+      locale.NUMBER_FORMATS.PATTERNS[1].maxFrac = 2;
+      locale.NUMBER_FORMATS.PATTERNS[1].minFrac = 2;
     });
   });
 


### PR DESCRIPTION
Depends on #5672. 

This adds the fractionSize parameter to the currency filter. 

For some, the common fractionSize of 2 needs to be overridden in certain scenarios.  

Example: gas pricing in the US where the price is actually accurate to 3 decimal places.
