### PR TITLE
fix($parse): reduce false-positives in isElement tests

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -569,7 +569,7 @@ var trim = (function() {
 function isElement(node) {
   return !!(node &&
     (node.nodeName  // we are a direct element
-    || (node.on && node.find)));  // we have an on and find method part of jQuery API
+    || (node.prop && node.attr && node.find)));  // we have an on and find method part of jQuery API
 }
 
 /**

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -55,7 +55,7 @@ function ensureSafeObject(obj, fullExpression) {
           'Referencing the Window in Angular expressions is disallowed! Expression: {0}',
           fullExpression);
     } else if (// isElement(obj)
-        obj.children && (obj.nodeName || (obj.on && obj.find))) {
+        obj.children && (obj.nodeName || (obj.prop && obj.attr && obj.find))) {
       throw $parseMinErr('isecdom',
           'Referencing DOM nodes in Angular expressions is disallowed! Expression: {0}',
           fullExpression);

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1106,5 +1106,25 @@ describe('angular', function() {
         expect(result).toEqual(expected[idx]);
       });
     }));
+
+    // Issue #4805
+    it('should return false for objects resembling a Backbone Collection', function() {
+      // Backbone stuff is sort of hard to mock, if you have a better way of doing this,
+      // please fix this.
+      var fakeBackboneCollection = {
+        children: [{}, {}, {}],
+        find: function() {},
+        on: function() {},
+        off: function() {},
+        bind: function() {}
+      };
+      expect(isElement(fakeBackboneCollection)).toBe(false);
+    });
+
+    it('should return false for arrays with node-like properties', function() {
+      var array = [1,2,3];
+      array.on = true;
+      expect(isElement(array)).toBe(false);
+    });
   });
 });

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -784,6 +784,28 @@ describe('parser', function() {
                       '$parse', 'isecdom', 'Referencing DOM nodes in Angular expressions is ' +
                       'disallowed! Expression: a.b.doc.on("click")');
             }));
+
+            // Issue #4805
+            it('should NOT throw isecdom when referencing a Backbone Collection', function() {
+              // Backbone stuff is sort of hard to mock, if you have a better way of doing this,
+              // please fix this.
+              var fakeBackboneCollection = {
+                children: [{}, {}, {}],
+                find: function() {},
+                on: function() {},
+                off: function() {},
+                bind: function() {}
+              };
+              scope.backbone = fakeBackboneCollection;
+              expect(function() { scope.$eval('backbone'); }).not.toThrow();
+            });
+
+            it('should NOT throw isecdom when referencing an array with node properties', function() {
+              var array = [1,2,3];
+              array.on = array.attr = array.prop = array.bind = true;
+              scope.array = array;
+              expect(function() { scope.$eval('array'); }).not.toThrow();
+            });
           });
         });
 


### PR DESCRIPTION
There are always going to be false positives here, unfortunately. But testing
different properties will hopefully reduce the number of false positives in a
meaningful way, without harming performance too much.

Closes #4805
