### PR TITLE
fix($route): update current route upon service instantiation

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -443,6 +443,7 @@ function $RouteProvider(){
           }
         };
 
+    updateRoute();
     $rootScope.$on('$locationChangeSuccess', updateRoute);
 
     return $route;

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -389,7 +389,7 @@ describe('$route', function() {
         var onChangeSpy = jasmine.createSpy('onChange');
 
         $rootScope.$on('$routeChangeStart', onChangeSpy);
-        expect($route.current).toBeUndefined();
+        expect($route.current).toBeDefined();
         expect(onChangeSpy).not.toHaveBeenCalled();
 
         $location.path('/unknownRoute');
@@ -426,7 +426,7 @@ describe('$route', function() {
 
         // init
         $rootScope.$on('$routeChangeStart', onChangeSpy);
-        expect($route.current).toBeUndefined();
+        expect($route.current).toBeDefined();
         expect(onChangeSpy).not.toHaveBeenCalled();
 
 
@@ -434,7 +434,7 @@ describe('$route', function() {
         $location.path('/unknownRoute');
         $rootScope.$digest();
 
-        expect(currentRoute).toBeUndefined();
+        expect(currentRoute).toBeDefined();
         expect(nextRoute.templateUrl).toBe('404.html');
         expect($route.current.templateUrl).toBe('404.html');
         expect(onChangeSpy).toHaveBeenCalled();
@@ -770,7 +770,7 @@ describe('$route', function() {
         var onChangeSpy = jasmine.createSpy('onChange');
 
         $rootScope.$on('$routeChangeStart', onChangeSpy);
-        expect($route.current).toBeUndefined();
+        expect($route.current).toBeDefined();
         expect(onChangeSpy).not.toHaveBeenCalled();
 
         $location.path('/');


### PR DESCRIPTION
This fixes cases where the first ngView is loaded in a template asynchronously (such as through ngInclude), as the service will miss the first $locationChangeSuccess event otherwise.

Closes #4957
