### PR TITLE
#5001: Fixes jqLite not correctly adding & removing classes in IE9

### DIFF
--- a/docs/src/example.js
+++ b/docs/src/example.js
@@ -6,7 +6,8 @@ var makeUnique = {
   'script.js': true,
   'unit.js': true,
   'spec.js': true,
-  'scenario.js': true
+  'scenario.js': true,
+  'protractorTest.js': true
 }
 
 function ids(list) {
@@ -14,7 +15,7 @@ function ids(list) {
 };
 
 
-exports.Example = function(scenarios) {
+exports.Example = function(scenarios, protractorTests) {
   this.module = '';
   this.deps = ['angular.js'];
   this.html = [];
@@ -24,6 +25,8 @@ exports.Example = function(scenarios) {
   this.unit = [];
   this.scenario = [];
   this.scenarios = scenarios;
+  this.protractorTest = [];
+  this.protractorTests = protractorTests;
 }
 
 exports.Example.prototype.setModule = function(module) {
@@ -44,6 +47,10 @@ exports.Example.prototype.addSource = function(name, content) {
   var ext = name == 'scenario.js' ? 'scenario' : name.split('.')[1],
       id = name;
 
+  if (name == 'protractorTest.js') {
+    ext = 'protractorTest';
+  }
+
   if (makeUnique[name] && usedIds[id]) {
     id = name + '-' + (seqCount++);
   }
@@ -55,6 +62,9 @@ exports.Example.prototype.addSource = function(name, content) {
   }
   if (ext == 'scenario') {
     this.scenarios.push(content);
+  }
+  if (ext == 'protractorTest') {
+    this.protractorTests.push(content);
   }
 };
 
@@ -92,6 +102,7 @@ exports.Example.prototype.toHtmlEdit = function() {
   out.push(' source-edit-json="' + ids(this.json) + '"');
   out.push(' source-edit-unit="' + ids(this.unit) + '"');
   out.push(' source-edit-scenario="' + ids(this.scenario) + '"');
+  out.push(' source-edit-protractor="' + ids(this.protractorTest) + '"');
   out.push('></div>\n');
   return out.join('');
 };
@@ -107,6 +118,7 @@ exports.Example.prototype.toHtmlTabs = function() {
   htmlTabs(this.json);
   htmlTabs(this.unit);
   htmlTabs(this.scenario);
+  htmlTabs(this.protractorTest);
   out.push('</div>');
   return out.join('');
 
@@ -119,7 +131,8 @@ exports.Example.prototype.toHtmlTabs = function() {
       if (name === 'index.html') {
         wrap = ' ng-html-wrap="' + self.module + ' ' + self.deps.join(' ') + '"';
       }
-      if (name == 'scenario.js') name = 'End to end test';
+      if (name == 'scenario.js') name = 'ngScenario e2e test';
+      if (name == 'protractorTest.js') name = 'Protractor e2e test';
 
       out.push(
         '<div class="tab-pane" title="' + name + '">\n' +

--- a/docs/src/gen-docs.js
+++ b/docs/src/gen-docs.js
@@ -18,6 +18,8 @@ writer.makeDir('build/docs/', true).then(function() {
 }).then(function() {
   return writer.makeDir('build/docs/components/font-awesome');
 }).then(function() {
+  return writer.makeDir('build/docs/e2etests');
+}).then(function() {
   console.log('Generating AngularJS Reference Documentation...');
   return reader.collect();
 }).then(function generateHtmlDocPartials(docs_) {
@@ -53,6 +55,10 @@ writer.makeDir('build/docs/', true).then(function() {
     var id = doc.id.replace('angular.Module', 'angular.IModule');
 
     fileFutures.push(writer.output('partials/' + doc.section + '/' + id + '.html', doc.html()));
+    // If it has a sample Protractor test, output that as well.
+    if (doc.protractorTests.length) {
+      fileFutures.push(writer.output('ptore2e/' + doc.section + '/' + id + '_test.js', ngdoc.writeProtractorTest(doc)));
+    }
   });
 
   ngdoc.checkBrokenLinks(docs);

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -307,8 +307,7 @@ function jqLiteRemoveClass(element, cssClasses) {
           .replace(" " + trim(cssClass) + " ", " "))
       );
     });
-  }
-  else if (msie === 9) {
+  } else if (msie === 9) {
     forEach(cssClasses.split(' '), function(cssClass) {
       element.className = trim(
           (" " + (element.className || '') + " ")

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -299,20 +299,13 @@ function jqLiteHasClass(element, selector) {
 }
 
 function jqLiteRemoveClass(element, cssClasses) {
-  if (cssClasses && element.setAttribute) {
+  var setter = element.setAttribute ? function(value) { element.setAttribute('class', value) } : function(value) { element.className = value};
+  if (cssClasses && (element.setAttribute || msie === 9)) {
     forEach(cssClasses.split(' '), function(cssClass) {
-      element.setAttribute('class', trim(
+      setter(trim(
           (" " + (element.getAttribute('class') || '') + " ")
           .replace(/[\n\t]/g, " ")
           .replace(" " + trim(cssClass) + " ", " "))
-      );
-    });
-  } else if (msie === 9) {
-    forEach(cssClasses.split(' '), function(cssClass) {
-      element.className = trim(
-          (" " + (element.className || '') + " ")
-          .replace(/[\n\t]/g, " ")
-          .replace(" " + trim(cssClass) + " ", " ")
       );
     });
   }

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -308,11 +308,20 @@ function jqLiteRemoveClass(element, cssClasses) {
       );
     });
   }
+  else if (msie === 9) {
+    forEach(cssClasses.split(' '), function(cssClass) {
+      element.className = trim(
+          (" " + (element.className || '') + " ")
+          .replace(/[\n\t]/g, " ")
+          .replace(" " + trim(cssClass) + " ", " ")
+      );
+    });
+  }
 }
 
 function jqLiteAddClass(element, cssClasses) {
   if (cssClasses && element.setAttribute) {
-    var existingClasses = (' ' + (element.getAttribute('class') || '') + ' ')
+    var existingClasses = (' ' + (element.getAttribute('class') || element.className || '') + ' ')
                             .replace(/[\n\t]/g, " ");
 
     forEach(cssClasses.split(' '), function(cssClass) {
@@ -322,7 +331,8 @@ function jqLiteAddClass(element, cssClasses) {
       }
     });
 
-    element.setAttribute('class', trim(existingClasses));
+    (msie === 9 && !(element instanceof SVGElement)) ? element.className = trim(existingClasses) :
+      element.setAttribute('class', trim(existingClasses));
   }
 }
 

--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -20,13 +20,13 @@
       </button>
       count: {{count}}
      </doc:source>
-     <doc:scenario>
+     <doc:protractor>
        it('should check ng-click', function() {
-         expect(binding('count')).toBe('0');
-         element('.doc-example-live :button').click();
-         expect(binding('count')).toBe('1');
+         expect(element(by.binding('count')).getText()).toMatch('0');
+         element(by.css('.doc-example-live button')).click();
+         expect(element(by.binding('count')).getText()).toMatch('1');
        });
-     </doc:scenario>
+     </doc:protractor>
    </doc:example>
  */
 /*

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -579,6 +579,14 @@ describe('jqLite', function() {
         expect(jqLite(b).hasClass('abc')).toEqual(true);
       });
 
+      it('should allow adding of class in IE9', function() {
+        if (msie !== 9) return; // IE9 doesn't support node.setAttribute
+        var selector = jqLite([a, b]);
+        expect(selector.addClass('abc')).toEqual(selector);
+        expect(jqLite(a).hasClass('abc')).toEqual(true);
+        expect(jqLite(b).hasClass('abc')).toEqual(true);
+      });
+
 
       it('should ignore falsy values', function() {
         var jqA = jqLite(a);

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -582,9 +582,9 @@ describe('jqLite', function() {
       it('should allow adding of class in IE9', function() {
         if (msie !== 9) return; // IE9 doesn't support node.setAttribute
         var selector = jqLite([a, b]);
-        expect(selector.addClass('abc')).toEqual(selector);
-        expect(jqLite(a).hasClass('abc')).toEqual(true);
-        expect(jqLite(b).hasClass('abc')).toEqual(true);
+        expect(selector.addClass('abc')).toBe(selector);
+        expect(jqLite(a).hasClass('abc')).toBe(true);
+        expect(jqLite(b).hasClass('abc')).toBe(true);
       });
 
 


### PR DESCRIPTION
This is a condensed version of [#5669](https://github.com/angular/angular.js/pull/5669) that does not break the tests. 
