### PR TITLE
fix(rootScope): $watchCollection returns in oldCollection a copy of the ...

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -415,6 +415,7 @@ function $RootScopeProvider(){
       $watchCollection: function(obj, listener) {
         var self = this;
         var oldValue;
+        var oldArray;
         var newValue;
         var changeDetected = 0;
         var objGetter = $parse(obj);
@@ -424,6 +425,7 @@ function $RootScopeProvider(){
 
         function $watchCollectionWatch() {
           newValue = objGetter(self);
+          oldArray = null;
           var newLength, key;
 
           if (!isObject(newValue)) {
@@ -438,6 +440,8 @@ function $RootScopeProvider(){
               oldLength = oldValue.length = 0;
               changeDetected++;
             }
+
+            oldArray = oldValue.length > 0 ? Array.prototype.slice.call(oldValue, 0) : [];
 
             newLength = newValue.length;
 
@@ -492,7 +496,7 @@ function $RootScopeProvider(){
         }
 
         function $watchCollectionAction() {
-          listener(newValue, oldValue, self);
+          listener(newValue, oldArray || oldValue, self);
         }
 
         return this.$watch($watchCollectionWatch, $watchCollectionAction);

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -572,6 +572,65 @@ describe('Scope', function() {
           $rootScope.$digest();
           expect(arrayLikelog).toEqual(['x', 'y']);
         });
+
+        it('should return a new array with old values', function(){
+          var watchArgs;
+          $rootScope.$watchCollection('obj', function (newValues, oldValues) {
+            watchArgs = {
+              newValues: newValues,
+              oldValues: oldValues
+            };
+          });
+
+          $rootScope.obj = ['a'];
+          $rootScope.$digest();
+
+          expect(watchArgs.newValues).toEqual($rootScope.obj);
+          expect(watchArgs.oldValues).toEqual([]);
+
+          $rootScope.obj.push('b');
+          $rootScope.$digest();
+
+          expect(watchArgs.newValues).toEqual(['a', 'b']);
+          expect(watchArgs.oldValues).toEqual(['a']);
+        });
+
+        it('should return a new array with old values from array like objects', function(){
+          var watchArgs;
+          $rootScope.$watchCollection('arrayLikeObject', function (newValues, oldValues) {
+            watchArgs = {
+              newValues: [],
+              oldValues: []
+            };
+            forEach(newValues, function (element){
+              watchArgs.newValues.push(element.name);
+            });
+            forEach(oldValues, function (element){
+              watchArgs.oldValues.push(element.name);
+            });
+          });
+
+          document.body.innerHTML = "<p>" +
+                                      "<a name='x'>a</a>" +
+                                      "<a name='y'>b</a>" +
+                                      "<a name='z'>c</a>" +
+                                    "</p>";
+
+          $rootScope.arrayLikeObject = document.getElementsByTagName('a');
+          $rootScope.$digest();
+
+          document.body.innerHTML = "<p>" +
+                                      "<a name='x'>a</a>" +
+                                      "<a name='y'>b</a>" +
+                                    "</p>";
+
+          $rootScope.arrayLikeObject.length = 2;
+          $rootScope.$digest();
+
+          expect(watchArgs.newValues).toEqual(['x', 'y']);
+          expect(watchArgs.oldValues).toEqual(['x', 'y', 'z']);
+        });
+
       });
 
 


### PR DESCRIPTION
...former array data

related to #1751
When watching arrays, $watchCollection returned the new data both in the newCollection
and the oldCollection arguments of the listener

Split from PR #3865
