### PR TITLE
feat(docs): adding the <doc:protractor> ngdoc-tag

### DIFF
--- a/docs/src/example.js
+++ b/docs/src/example.js
@@ -6,7 +6,8 @@ var makeUnique = {
   'script.js': true,
   'unit.js': true,
   'spec.js': true,
-  'scenario.js': true
+  'scenario.js': true,
+  'protractorTest.js': true
 }
 
 function ids(list) {
@@ -14,7 +15,7 @@ function ids(list) {
 };
 
 
-exports.Example = function(scenarios) {
+exports.Example = function(scenarios, protractorTests) {
   this.module = '';
   this.deps = ['angular.js'];
   this.html = [];
@@ -24,6 +25,8 @@ exports.Example = function(scenarios) {
   this.unit = [];
   this.scenario = [];
   this.scenarios = scenarios;
+  this.protractorTest = [];
+  this.protractorTests = protractorTests;
 }
 
 exports.Example.prototype.setModule = function(module) {
@@ -44,6 +47,10 @@ exports.Example.prototype.addSource = function(name, content) {
   var ext = name == 'scenario.js' ? 'scenario' : name.split('.')[1],
       id = name;
 
+  if (name == 'protractorTest.js') {
+    ext = 'protractorTest';
+  }
+
   if (makeUnique[name] && usedIds[id]) {
     id = name + '-' + (seqCount++);
   }
@@ -55,6 +62,9 @@ exports.Example.prototype.addSource = function(name, content) {
   }
   if (ext == 'scenario') {
     this.scenarios.push(content);
+  }
+  if (ext == 'protractorTest') {
+    this.protractorTests.push(content);
   }
 };
 
@@ -92,6 +102,7 @@ exports.Example.prototype.toHtmlEdit = function() {
   out.push(' source-edit-json="' + ids(this.json) + '"');
   out.push(' source-edit-unit="' + ids(this.unit) + '"');
   out.push(' source-edit-scenario="' + ids(this.scenario) + '"');
+  out.push(' source-edit-protractor="' + ids(this.protractorTest) + '"');
   out.push('></div>\n');
   return out.join('');
 };
@@ -107,6 +118,7 @@ exports.Example.prototype.toHtmlTabs = function() {
   htmlTabs(this.json);
   htmlTabs(this.unit);
   htmlTabs(this.scenario);
+  htmlTabs(this.protractorTest);
   out.push('</div>');
   return out.join('');
 
@@ -119,7 +131,8 @@ exports.Example.prototype.toHtmlTabs = function() {
       if (name === 'index.html') {
         wrap = ' ng-html-wrap="' + self.module + ' ' + self.deps.join(' ') + '"';
       }
-      if (name == 'scenario.js') name = 'End to end test';
+      if (name == 'scenario.js') name = 'ngScenario e2e test';
+      if (name == 'protractorTest.js') name = 'Protractor e2e test';
 
       out.push(
         '<div class="tab-pane" title="' + name + '">\n' +

--- a/docs/src/gen-docs.js
+++ b/docs/src/gen-docs.js
@@ -18,6 +18,8 @@ writer.makeDir('build/docs/', true).then(function() {
 }).then(function() {
   return writer.makeDir('build/docs/components/font-awesome');
 }).then(function() {
+  return writer.makeDir('build/docs/e2etests');
+}).then(function() {
   console.log('Generating AngularJS Reference Documentation...');
   return reader.collect();
 }).then(function generateHtmlDocPartials(docs_) {
@@ -53,6 +55,10 @@ writer.makeDir('build/docs/', true).then(function() {
     var id = doc.id.replace('angular.Module', 'angular.IModule');
 
     fileFutures.push(writer.output('partials/' + doc.section + '/' + id + '.html', doc.html()));
+    // If it has a sample Protractor test, output that as well.
+    if (doc.protractorTests.length) {
+      fileFutures.push(writer.output('ptore2e/' + doc.section + '/' + id + '_test.js', ngdoc.writeProtractorTest(doc)));
+    }
   });
 
   ngdoc.checkBrokenLinks(docs);

--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -20,13 +20,13 @@
       </button>
       count: {{count}}
      </doc:source>
-     <doc:scenario>
+     <doc:protractor>
        it('should check ng-click', function() {
-         expect(binding('count')).toBe('0');
-         element('.doc-example-live :button').click();
-         expect(binding('count')).toBe('1');
+         expect(element(by.binding('count')).getText()).toMatch('0');
+         element(by.css('.doc-example-live button')).click();
+         expect(element(by.binding('count')).getText()).toMatch('1');
        });
-     </doc:scenario>
+     </doc:protractor>
    </doc:example>
  */
 /*


### PR DESCRIPTION
This is the first step in migrating tests from doc:scenario to doc:protractor.
In-documentation examples with doc:protractor sections will have their contents
output to a tab on the docs site as well as output to a standalone test file in
build/docs/ptore2e.
