### PR TITLE
#5001: Fixes jqLite not correctly adding & removing classes in IE9

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -358,9 +358,10 @@ function jqLiteHasClass(element, selector) {
 }
 
 function jqLiteRemoveClass(element, cssClasses) {
-  if (cssClasses && element.setAttribute) {
+  var setter = element.setAttribute ? function(value) { element.setAttribute('class', value) } : function(value) { element.className = value};
+  if (cssClasses && (element.setAttribute || msie === 9)) {
     forEach(cssClasses.split(' '), function(cssClass) {
-      element.setAttribute('class', trim(
+      setter(trim(
           (" " + (element.getAttribute('class') || '') + " ")
           .replace(/[\n\t]/g, " ")
           .replace(" " + trim(cssClass) + " ", " "))
@@ -371,7 +372,7 @@ function jqLiteRemoveClass(element, cssClasses) {
 
 function jqLiteAddClass(element, cssClasses) {
   if (cssClasses && element.setAttribute) {
-    var existingClasses = (' ' + (element.getAttribute('class') || '') + ' ')
+    var existingClasses = (' ' + (element.getAttribute('class') || element.className || '') + ' ')
                             .replace(/[\n\t]/g, " ");
 
     forEach(cssClasses.split(' '), function(cssClass) {
@@ -381,7 +382,8 @@ function jqLiteAddClass(element, cssClasses) {
       }
     });
 
-    element.setAttribute('class', trim(existingClasses));
+    (msie === 9 && !(element instanceof SVGElement)) ? element.className = trim(existingClasses) :
+      element.setAttribute('class', trim(existingClasses));
   }
 }
 

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -358,7 +358,7 @@ function jqLiteHasClass(element, selector) {
 }
 
 function jqLiteRemoveClass(element, cssClasses) {
-  var setter = element.setAttribute ? function(value) { element.setAttribute('class', value) } : function(value) { element.className = value};
+  var setter = element.setAttribute ? function(value) { element.setAttribute('class', value); } : function(value) { element.className = value; };
   if (cssClasses && (element.setAttribute || msie === 9)) {
     forEach(cssClasses.split(' '), function(cssClass) {
       setter(trim(

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -362,7 +362,7 @@ function jqLiteRemoveClass(element, cssClasses) {
   if (cssClasses && (element.setAttribute || msie === 9)) {
     forEach(cssClasses.split(' '), function(cssClass) {
       setter(trim(
-          (" " + (element.getAttribute('class') || '') + " ")
+          (" " + (element.getAttribute('class') || element.className || '') + " ")
           .replace(/[\n\t]/g, " ")
           .replace(" " + trim(cssClass) + " ", " "))
       );

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -714,7 +714,7 @@ describe('jqLite', function() {
       });
 
       it('should allow adding of class in IE9', function() {
-        if (msie !== 9) return; // IE9 doesn't support node.setAttribute
+        if (!(jqLite(a).setAttribute && jqLite(a).getAttribute)) return; // IE9 doesn't support node.setAttribute
         var selector = jqLite([a, b]);
         expect(selector.addClass('abc')).toBe(selector);
         expect(jqLite(a).hasClass('abc')).toBe(true);

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -713,6 +713,14 @@ describe('jqLite', function() {
         expect(jqLite(b).hasClass('abc')).toEqual(true);
       });
 
+      it('should allow adding of class in IE9', function() {
+        if (msie !== 9) return; // IE9 doesn't support node.setAttribute
+        var selector = jqLite([a, b]);
+        expect(selector.addClass('abc')).toBe(selector);
+        expect(jqLite(a).hasClass('abc')).toBe(true);
+        expect(jqLite(b).hasClass('abc')).toBe(true);
+      });
+
 
       it('should ignore falsy values', function() {
         var jqA = jqLite(a);


### PR DESCRIPTION
This PR is a cleaned up version of [#5686](https://github.com/angular/angular.js/pull/5686).  This is for #5001.

Somehow my history got polluted due to bouncing between two different computers.
