### PR TITLE
fix($compile): copy expandostore data into replaced nodes

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1673,7 +1673,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             }
 
             tempTemplateAttrs = {$attr: {}};
+            var data = $compileNode.data();
             replaceWith($rootElement, $compileNode, compileNode);
+            $compileNode.data(data);
             var templateDirectives = collectDirectives(compileNode, [], tempTemplateAttrs);
 
             if (isObject(origAsyncDirective.scope)) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1391,6 +1391,30 @@ describe('$compile', function() {
             expect(element.html()).toContain('i = 1');
           });
         });
+
+        it('should copy compileNode data into linkNode\'s data', function() {
+          module(function($compileProvider) {
+            $compileProvider.directive('tplDir', function(log) {
+              return {
+                scope: true,
+                templateUrl: 'tplDir.html',
+                replace: true,
+                link: function(scope, element) {
+                  log(scope.$id);
+                  log(element.scope().$id);
+                }
+              };
+            });
+          });
+          inject(function($compile, $rootScope, $templateCache, log) {
+            $templateCache.put('tplDir.html', '<div></div>');
+            element = $compile('<div tpl-dir></div>')($rootScope);
+            $rootScope.$digest();
+            var $log = log.toArray();
+            expect($log.length).toBe(2);
+            expect($log[0]).toBe($log[1]);
+          });
+        });
       });
 
 


### PR DESCRIPTION
Before this patch, with modern versions of jQuery being used, the element data cache was not being copied over into the new element when replacing an asynchronous directive's compile node with its template. This caused an issue where the element passed into a post link function's scope() method would return the incorrect scope.

The test which is added passes regardless of the change in jQuery 1.10.2, which is currently checked into the tree, but fails without the change in jQuery 2.0.3.

Closes #5099
