### PR TITLE
fix($location): return '/' for root path in hashbang mode

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -184,6 +184,10 @@ function LocationHashbangUrl(appBase, hashPrefix) {
 
     this.$$compose();
 
+    if (!this.$$path) {
+      this.$$path = '/';
+    }
+
     /*
      * In Windows, on an anchor node on documents loaded from
      * the filesystem, the browser will return a pathname

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1487,6 +1487,16 @@ describe('$location', function() {
       expect(location.url()).toBe('/not-starting-with-slash');
       expect(location.absUrl()).toBe('http://server/pre/index.html#/not-starting-with-slash');
     });
+
+
+    it("should return / for path for the application root path", function() {
+      location = new LocationHashbangUrl('http://server/pre/index.html', '#');
+      location.$$parse('http://server/pre/index.html');
+      expect(location.path()).toBe('/');
+
+      location.$$parse('http://server/pre/');
+      expect(location.path()).toBe('/');
+    });
   });
 
 


### PR DESCRIPTION
Before this change, on the root of the application, $location.path() would return the empty string. Following this change, it will always return a root of '/'.

Closes #5650
