### PR TITLE
feat(ngRoute): cancel $routeChangeStart via $event.preventDefault()

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -375,8 +375,28 @@ function $RouteProvider(){
      * defined in `resolve` route property. Once  all of the dependencies are resolved
      * `$routeChangeSuccess` is fired.
      *
+     * The route change may be cancelled with angularEvent.preventDefault(), which will
+     * in turn trigger a {@link ngRoute.$route#events_$routeChangeCancelled $routeChangeCancelled}
+     * event.
+     *
      * @param {Object} angularEvent Synthetic event object.
      * @param {Route} next Future route information.
+     * @param {Route} current Current route information.
+     */
+
+    /**
+     * @ngdoc event
+     * @name ngRoute.$route#$routeChangeCancelled
+     * @eventOf ngRoute.$route
+     * @eventType broadcast on root scope
+     * @description
+     * Broadcasted after a route has been cancelled during
+     * {@link ngRoute.$route#events_$routeChangeStart $routeChangStart}, using the
+     * angularEvent.preventDefault() method. This method enables applications to prevent
+     * a route change from occurring without any additional work.
+     *
+     * @param {Object} angularEvent Synthetic event object.
+     * @param {Route} cancelled The cancelled route information.
      * @param {Route} current Current route information.
      */
 
@@ -484,7 +504,7 @@ function $RouteProvider(){
       return params;
     }
 
-    function updateRoute() {
+    function updateRoute($event, newUrl, oldUrl) {
       var next = parseRoute(),
           last = $route.current;
 
@@ -495,8 +515,13 @@ function $RouteProvider(){
         angular.copy(last.params, $routeParams);
         $rootScope.$broadcast('$routeUpdate', last);
       } else if (next || last) {
+        if ($rootScope.$broadcast('$routeChangeStart', next, last).defaultPrevented &&
+            !forceReload) {
+          $location.$$parse($location.$$rewrite(oldUrl));
+          $rootScope.$broadcast('$routeChangeCancelled', next, last);
+          return;
+        }
         forceReload = false;
-        $rootScope.$broadcast('$routeChangeStart', next, last);
         $route.current = next;
         if (next) {
           if (next.redirectTo) {


### PR DESCRIPTION
This change allows ngRoute route changes to be cancelled using
$event.preventDefault.

This enables route changes to be aborted at the discretion of the application.

Route changes may not be cancelled if forceReload is set to true.

Closes #5581
