### PR TITLE
docs($location): fix link to $locationChangeSuccess event

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -580,7 +580,7 @@ function $LocationProvider(){
    * Broadcasted before a URL will change. This change can be prevented by calling
    * `preventDefault` method of the event. See {@link ng.$rootScope.Scope#$on} for more
    * details about event object. Upon successful change
-   * {@link ng.$location#$locationChangeSuccess $locationChangeSuccess} is fired.
+   * {@link ng.$location#events_$locationChangeSuccess $locationChangeSuccess} is fired.
    *
    * @param {Object} angularEvent Synthetic event object.
    * @param {string} newUrl New URL


### PR DESCRIPTION
Apparently this event link, as well as the link to $rootScope.$on are broken, huh.
