### PR TITLE
Adds Closure externs for Cache factory.

### DIFF
--- a/closure/angular.js
+++ b/closure/angular.js
@@ -964,6 +964,12 @@ angular.$cacheFactory.Options;
  */
 angular.$cacheFactory.Cache;
 
+angular.$cacheFactory.Cache.put = function(a, b) {};
+angular.$cacheFactory.Cache.get = function(a) {};
+angular.$cacheFactory.Cache.remove = function(a) {};
+angular.$cacheFactory.Cache.removeAll = function() {};
+angular.$cacheFactory.Cache.destroy = function() {};
+
 /**
  * @typedef {{
  *   id: string,

--- a/closure/angular.js
+++ b/closure/angular.js
@@ -964,11 +964,11 @@ angular.$cacheFactory.Options;
  */
 angular.$cacheFactory.Cache;
 
-angular.$cacheFactory.Cache.put = function(a, b) {};
+angular.$cacheFactory.Cache.put = function(key, value) {};
 
-angular.$cacheFactory.Cache.get = function(a) {};
+angular.$cacheFactory.Cache.get = function(key) {};
 
-angular.$cacheFactory.Cache.remove = function(a) {};
+angular.$cacheFactory.Cache.remove = function(key) {};
 
 angular.$cacheFactory.Cache.removeAll = function() {};
 

--- a/closure/angular.js
+++ b/closure/angular.js
@@ -965,9 +965,13 @@ angular.$cacheFactory.Options;
 angular.$cacheFactory.Cache;
 
 angular.$cacheFactory.Cache.put = function(a, b) {};
+
 angular.$cacheFactory.Cache.get = function(a) {};
+
 angular.$cacheFactory.Cache.remove = function(a) {};
+
 angular.$cacheFactory.Cache.removeAll = function() {};
+
 angular.$cacheFactory.Cache.destroy = function() {};
 
 /**


### PR DESCRIPTION
Namaste,

The Closure compiler renames methods like removeAll, get, etc as
defined on the cache object. This patch adds externs to prevent
the Closure compiler from renaming them.

Thank you.

Cheers,
Yesudeep.
