### PR TITLE
test.sh looks for node_modules/karma

### DIFF
--- a/docs/content/tutorial/step_02.ngdoc
+++ b/docs/content/tutorial/step_02.ngdoc
@@ -192,7 +192,8 @@ To run the test, do the following:
 
 1. In a _separate_ terminal window or tab, go to the `angular-phonecat` directory and run
 `./scripts/test.sh` to start the Karma server (the config file necessary to start the server
-is located at `./config/karma.conf.js`).
+is located at `./config/karma.conf.js`). test.sh expects a 'node_modules' directory inside the 
+'angular-phonecat' directory; this requires a {@link http://karma-runner.github.io/0.10/intro/installation.html Local Installation of Karma}
 
 2. Karma will start a new instance of Chrome browser automatically. Just ignore it and let it run in
    the background. Karma will use this browser for test execution.


### PR DESCRIPTION
For users who installed Karma globally (like me), test.sh threw an error; it could not find../node_modules/karma etc.
I fixed this by changing test.sh to point to my (Windows) C:\Users{User}\AppData\Roaming\npm\node_modules... etc,
But a better solution (?) is to install locally; the tutorial preface did not provide clear instructions about this http://docs.angularjs.org/tutorial
