### PR TITLE
fix(ngRoute): wrong redirect to paths containing optional or special parameters

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -586,7 +586,7 @@ function $RouteProvider(){
         if (i === 0) {
           result.push(segment);
         } else {
-          var segmentMatch = segment.match(/(\w+)([\?|\*])?(.*)/);
+          var segmentMatch = segment.match(/(\w+)([\?\*])?(.*)/);
           var key = segmentMatch[1];
           result.push(params[key]);
           result.push(segmentMatch[3] || '');

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -586,10 +586,10 @@ function $RouteProvider(){
         if (i === 0) {
           result.push(segment);
         } else {
-          var segmentMatch = segment.match(/(\w+)(.*)/);
+          var segmentMatch = segment.match(/(\w+)([\?|\*])?(.*)/);
           var key = segmentMatch[1];
           result.push(params[key]);
-          result.push(segmentMatch[2] || '');
+          result.push(segmentMatch[3] || '');
           delete params[key];
         }
       });


### PR DESCRIPTION
When the path contains optional parameters `?` or special parameters `*` the redirects to those routes are broken, the location will end with the relative encoded character.

To reproduce the issue:
- create a route with optional parameters, es. `$routeProvider.when('/profile/:userId?', ...)`
- angular will add the automatic redirect with or without the trailing **/**, in this case `'/profile/:userId?/'`
- point your browser to the redirect `http://localhost/#!/profile/0/`, you'll see the encoded `? (%3F)` at the end of the url: `http://localhost/#!/profile/0%3F`

Happens also for the special parameters `*` and also for the opposite scenario, when the route has the ending **/** (`/profile/:userId?/`) and you browse the url without slash `/profile/0`. It affects every redirect that uses the function interpolate in combination with special parameters.
