### PR TITLE
fix headers common, tests pass: closes #5742

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -111,9 +111,9 @@ function $HttpProvider() {
       common: {
         'Accept': 'application/json, text/plain, */*'
       },
-      post:   CONTENT_TYPE_APPLICATION_JSON,
-      put:    CONTENT_TYPE_APPLICATION_JSON,
-      patch:  CONTENT_TYPE_APPLICATION_JSON
+      post:   copy(CONTENT_TYPE_APPLICATION_JSON),
+      put:    copy(CONTENT_TYPE_APPLICATION_JSON),
+      patch:  copy(CONTENT_TYPE_APPLICATION_JSON)
     },
 
     xsrfCookieName: 'XSRF-TOKEN',
@@ -324,7 +324,7 @@ function $HttpProvider() {
      * to `push` or `unshift` a new transformation function into the transformation chain. You can
      * also decide to completely override any default transformations by assigning your
      * transformation functions to these properties directly without the array wrapper.  These defaults
-     * are again available on the $http factory at run-time, which may be useful if you have run-time 
+     * are again available on the $http factory at run-time, which may be useful if you have run-time
      * services you wish to be involved in your transformations.
      *
      * Similarly, to locally override the request/response transforms, augment the

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1430,12 +1430,6 @@ describe('$http', function() {
 
       it('should expose the defaults object at runtime', function() {
         expect($http.defaults).toBeDefined();
-        expect($http.defaults.headers.post).not.toBe($http.defaults.headers.put);
-        expect($http.defaults.headers.post).not.toBe($http.defaults.headers.patch);
-        expect($http.defaults.headers.put).not.toBe($http.defaults.headers.patch);
-        expect($http.defaults.headers.put).not.toBe($http.defaults.headers.post);
-        expect($http.defaults.headers.patch).not.toBe($http.defaults.headers.put);
-        expect($http.defaults.headers.patch).not.toBe($http.defaults.headers.post);
 
         $http.defaults.headers.common.foo = 'bar';
         $httpBackend.expect('GET', '/url', undefined, function(headers) {
@@ -1445,6 +1439,13 @@ describe('$http', function() {
         $http.get('/url');
         $httpBackend.flush();
       });
+
+      it('should have seperate opbjects for defaults PUT and POST', function() {
+        expect($http.defaults.headers.post).not.toBe($http.defaults.headers.put);
+        expect($http.defaults.headers.post).not.toBe($http.defaults.headers.patch);
+        expect($http.defaults.headers.put).not.toBe($http.defaults.headers.post);
+        expect($http.defaults.headers.put).not.toBe($http.defaults.headers.patch);
+      })
     });
   });
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1443,7 +1443,6 @@ describe('$http', function() {
       it('should have seperate opbjects for defaults PUT and POST', function() {
         expect($http.defaults.headers.post).not.toBe($http.defaults.headers.put);
         expect($http.defaults.headers.post).not.toBe($http.defaults.headers.patch);
-        expect($http.defaults.headers.put).not.toBe($http.defaults.headers.post);
         expect($http.defaults.headers.put).not.toBe($http.defaults.headers.patch);
       })
     });

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1430,6 +1430,12 @@ describe('$http', function() {
 
       it('should expose the defaults object at runtime', function() {
         expect($http.defaults).toBeDefined();
+        expect($http.defaults.headers.post).not.toBe($http.defaults.headers.put);
+        expect($http.defaults.headers.post).not.toBe($http.defaults.headers.patch);
+        expect($http.defaults.headers.put).not.toBe($http.defaults.headers.patch);
+        expect($http.defaults.headers.put).not.toBe($http.defaults.headers.post);
+        expect($http.defaults.headers.patch).not.toBe($http.defaults.headers.put);
+        expect($http.defaults.headers.patch).not.toBe($http.defaults.headers.post);
 
         $http.defaults.headers.common.foo = 'bar';
         $httpBackend.expect('GET', '/url', undefined, function(headers) {


### PR DESCRIPTION
updated http common headers object values to be passed through copy() first. Write new specs. All specs green.
