### PR TITLE
ngAnimate enhancements

### DIFF
--- a/karma-docs.conf.js
+++ b/karma-docs.conf.js
@@ -10,12 +10,12 @@ module.exports = function(config) {
 
       'build/angular.js',
       'build/angular-cookies.js',
-      'build/angular-mocks.js',
       'build/angular-resource.js',
       'build/angular-touch.js',
       'build/angular-sanitize.js',
       'build/angular-route.js',
       'build/angular-animate.js',
+      'build/angular-mocks.js',
 
       'build/docs/components/lunr.js',
       'build/docs/components/google-code-prettify.js',

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -930,8 +930,12 @@ angular.module('ngAnimate', ['ng'])
         animationElementQueue.push(element);
 
         var elementData = element.data(NG_ANIMATE_CSS_DATA_KEY);
-        closingAnimationTime = Math.max(closingAnimationTime,
-          (elementData.maxDelay + elementData.maxDuration) * CLOSING_TIME_BUFFER * ONE_SECOND);
+
+        var stagger = elementData.stagger;
+        var staggerTime = elementData.itemIndex * (Math.max(stagger.animationDelay, stagger.transitionDelay) || 0);
+
+        var animationTime = (elementData.maxDelay + elementData.maxDuration) * CLOSING_TIME_BUFFER;
+        closingAnimationTime = Math.max(closingAnimationTime, (staggerTime + animationTime) * ONE_SECOND);
 
         //by placing a counter we can avoid an accidental
         //race condition which may close an animation when
@@ -1058,9 +1062,9 @@ angular.module('ngAnimate', ['ng'])
         var cacheKey = getCacheKey(element);
         var eventCacheKey = cacheKey + ' ' + className;
         var stagger = {};
-        var ii = lookupCache[eventCacheKey] ? ++lookupCache[eventCacheKey].total : 0;
+        var itemIndex = lookupCache[eventCacheKey] ? ++lookupCache[eventCacheKey].total : 0;
 
-        if(ii > 0) {
+        if(itemIndex > 0) {
           var staggerClassName = className + '-stagger';
           var staggerCacheKey = cacheKey + ' ' + staggerClassName;
           var applyClasses = !lookupCache[staggerCacheKey];
@@ -1113,7 +1117,7 @@ angular.module('ngAnimate', ['ng'])
           classes : className + ' ' + activeClassName,
           timings : timings,
           stagger : stagger,
-          ii : ii
+          itemIndex : itemIndex
         });
 
         return true;
@@ -1158,7 +1162,7 @@ angular.module('ngAnimate', ['ng'])
         var maxDelayTime = Math.max(timings.transitionDelay, timings.animationDelay) * ONE_SECOND;
         var startTime = Date.now();
         var css3AnimationEvents = ANIMATIONEND_EVENT + ' ' + TRANSITIONEND_EVENT;
-        var ii = elementData.ii;
+        var itemIndex = elementData.itemIndex;
 
         var style = '', appliedStyles = [];
         if(timings.transitionDuration > 0) {
@@ -1171,17 +1175,17 @@ angular.module('ngAnimate', ['ng'])
           }
         }
 
-        if(ii > 0) {
+        if(itemIndex > 0) {
           if(stagger.transitionDelay > 0 && stagger.transitionDuration === 0) {
             var delayStyle = timings.transitionDelayStyle;
             style += CSS_PREFIX + 'transition-delay: ' +
-                     prepareStaggerDelay(delayStyle, stagger.transitionDelay, ii) + '; ';
+                     prepareStaggerDelay(delayStyle, stagger.transitionDelay, itemIndex) + '; ';
             appliedStyles.push(CSS_PREFIX + 'transition-delay');
           }
 
           if(stagger.animationDelay > 0 && stagger.animationDuration === 0) {
             style += CSS_PREFIX + 'animation-delay: ' +
-                     prepareStaggerDelay(timings.animationDelayStyle, stagger.animationDelay, ii) + '; ';
+                     prepareStaggerDelay(timings.animationDelayStyle, stagger.animationDelay, itemIndex) + '; ';
             appliedStyles.push(CSS_PREFIX + 'animation-delay');
           }
         }

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -647,10 +647,11 @@ angular.module('ngAnimate', ['ng'])
           return;
         }
 
+        var ONE_SPACE = ' ';
         //this value will be searched for class-based CSS className lookup. Therefore,
         //we prefix and suffix the current className value with spaces to avoid substring
         //lookups of className tokens
-        var futureClassName = ' ' + currentClassName + ' ';
+        var futureClassName = ONE_SPACE + currentClassName + ONE_SPACE;
         if(ngAnimateState.running) {
           //if an animation is currently running on the element then lets take the steps
           //to cancel that animation and fire any required callbacks
@@ -671,8 +672,8 @@ angular.module('ngAnimate', ['ng'])
             //will be invalid. Therefore the same string manipulation that would occur within the
             //DOM operation will be performed below so that the class comparison is valid...
             futureClassName = ngAnimateState.event == 'removeClass' ?
-              futureClassName.replace(ngAnimateState.className, '') :
-              futureClassName + ngAnimateState.className + ' ';
+              futureClassName.replace(ONE_SPACE + ngAnimateState.className + ONE_SPACE, ONE_SPACE) :
+              futureClassName + ngAnimateState.className + ONE_SPACE;
           }
         }
 
@@ -680,7 +681,7 @@ angular.module('ngAnimate', ['ng'])
         //(on addClass) or doesn't contain (on removeClass) the className being animated.
         //The reason why this is being called after the previous animations are cancelled
         //is so that the CSS classes present on the element can be properly examined.
-        var classNameToken = ' ' + className + ' ';
+        var classNameToken = ONE_SPACE + className + ONE_SPACE;
         if((animationEvent == 'addClass'    && futureClassName.indexOf(classNameToken) >= 0) ||
            (animationEvent == 'removeClass' && futureClassName.indexOf(classNameToken) == -1)) {
           fireDOMOperation();

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -756,6 +756,26 @@ angular.mock.TzDate = function (offset, timestamp) {
 angular.mock.TzDate.prototype = Date.prototype;
 /* jshint +W101 */
 
+angular.module('ngAnimate').config(['$provide', function($provide) {
+  var reflowQueue = [];
+  $provide.value('$$animateReflow', function(fn) {
+    reflowQueue.push(fn);
+    return angular.noop;
+  });
+  $provide.decorator('$animate', function($delegate) {
+    $delegate.triggerReflow = function() {
+      if(reflowQueue.length === 0) {
+        throw new Error('No animation reflows present');
+      }
+      angular.forEach(reflowQueue, function(fn) {
+        fn();
+      });
+      reflowQueue = [];
+    };
+    return $delegate;
+  });
+}]);
+
 angular.mock.animate = angular.module('mock.animate', ['ng'])
 
   .config(['$provide', function($provide) {
@@ -1911,7 +1931,6 @@ angular.mock.clearDataCache = function() {
     }
   }
 };
-
 
 
 if(window.jasmine || window.mocha) {

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -280,7 +280,7 @@ describe("ngAnimate", function() {
           $rootScope.$digest();
 
           if($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
             expect(child.hasClass('ng-enter')).toBe(true);
             expect(child.hasClass('ng-enter-active')).toBe(true);
             browserTrigger(element, 'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
@@ -298,7 +298,7 @@ describe("ngAnimate", function() {
           $rootScope.$digest();
 
           if($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
             expect(child.hasClass('ng-leave')).toBe(true);
             expect(child.hasClass('ng-leave-active')).toBe(true);
             browserTrigger(child,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
@@ -322,7 +322,7 @@ describe("ngAnimate", function() {
           $animate.move(child1, element, child2);
           $rootScope.$digest();
           if($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
           }
           expect(element.text()).toBe('21');
         }));
@@ -336,7 +336,7 @@ describe("ngAnimate", function() {
           expect(child).toBeHidden();
           $animate.removeClass(child, 'ng-hide');
           if($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
             expect(child.hasClass('ng-hide-remove')).toBe(true);
             expect(child.hasClass('ng-hide-remove-active')).toBe(true);
             browserTrigger(child,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
@@ -354,7 +354,7 @@ describe("ngAnimate", function() {
           expect(child).toBeShown();
           $animate.addClass(child, 'ng-hide');
           if($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
             expect(child.hasClass('ng-hide-add')).toBe(true);
             expect(child.hasClass('ng-hide-add-active')).toBe(true);
             browserTrigger(child,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
@@ -374,7 +374,7 @@ describe("ngAnimate", function() {
           //enter
           $animate.enter(child, element);
           $rootScope.$digest();
-          $timeout.flush();
+          $animate.triggerReflow();
 
           expect(child.attr('class')).toContain('ng-enter');
           expect(child.attr('class')).toContain('ng-enter-active');
@@ -385,7 +385,7 @@ describe("ngAnimate", function() {
           element.append(after);
           $animate.move(child, element, after);
           $rootScope.$digest();
-          $timeout.flush();
+          $animate.triggerReflow();
 
           expect(child.attr('class')).toContain('ng-move');
           expect(child.attr('class')).toContain('ng-move-active');
@@ -394,14 +394,14 @@ describe("ngAnimate", function() {
 
           //hide
           $animate.addClass(child, 'ng-hide');
-          $timeout.flush();
+          $animate.triggerReflow();
           expect(child.attr('class')).toContain('ng-hide-add');
           expect(child.attr('class')).toContain('ng-hide-add-active');
           browserTrigger(child,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
 
           //show
           $animate.removeClass(child, 'ng-hide');
-          $timeout.flush();
+          $animate.triggerReflow();
           expect(child.attr('class')).toContain('ng-hide-remove');
           expect(child.attr('class')).toContain('ng-hide-remove-active');
           browserTrigger(child,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
@@ -409,7 +409,7 @@ describe("ngAnimate", function() {
           //leave
           $animate.leave(child);
           $rootScope.$digest();
-          $timeout.flush();
+          $animate.triggerReflow();
           expect(child.attr('class')).toContain('ng-leave');
           expect(child.attr('class')).toContain('ng-leave-active');
           browserTrigger(child,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
@@ -435,7 +435,7 @@ describe("ngAnimate", function() {
           element.addClass('ng-hide');
           $animate.removeClass(element, 'ng-hide');
           if($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
           }
           expect(element.text()).toBe('memento');
         }));
@@ -455,7 +455,9 @@ describe("ngAnimate", function() {
 
           $animate.leave(child);
           $rootScope.$digest();
-          $timeout.flush();
+          if($sniffer.transitions) {
+            $animate.triggerReflow();
+          }
           expect(child).toBeHidden(); //hides instantly
 
           //lets change this to prove that done doesn't fire anymore for the previous hide() operation
@@ -485,7 +487,7 @@ describe("ngAnimate", function() {
           $rootScope.$digest();
 
           if($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
 
             //this is to verify that the existing style is appended with a semicolon automatically 
             expect(child.attr('style')).toMatch(/width: 20px;.+?/i);
@@ -504,6 +506,7 @@ describe("ngAnimate", function() {
           child.addClass('custom-delay ng-hide');
           $animate.removeClass(child, 'ng-hide');
           if($sniffer.transitions) {
+            $animate.triggerReflow();
             browserTrigger(child,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
           }
           $timeout.flush(2000);
@@ -530,7 +533,7 @@ describe("ngAnimate", function() {
 
           expect(completed).toBe(false);
           if($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
             browserTrigger(child,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
           }
           $timeout.flush();
@@ -661,7 +664,7 @@ describe("ngAnimate", function() {
 
             $animate.removeClass(element, 'ng-hide');
             if ($sniffer.animations) {
-              $timeout.flush();
+              $animate.triggerReflow();
               browserTrigger(element,'animationend', { timeStamp: Date.now() + 4000, elapsedTime: 4 });
             }
             expect(element).toBeShown();
@@ -686,7 +689,7 @@ describe("ngAnimate", function() {
 
             $animate.removeClass(element, 'ng-hide');
             if ($sniffer.animations) {
-              $timeout.flush();
+              $animate.triggerReflow();
               browserTrigger(element,'animationend', { timeStamp: Date.now() + 6000, elapsedTime: 6 });
             }
             expect(element).toBeShown();
@@ -713,7 +716,7 @@ describe("ngAnimate", function() {
 
             $animate.removeClass(element, 'ng-hide');
             if ($sniffer.transitions) {
-              $timeout.flush();
+              $animate.triggerReflow();
               browserTrigger(element,'animationend', { timeStamp : Date.now() + 20000, elapsedTime: 10 });
             }
             expect(element).toBeShown();
@@ -751,7 +754,7 @@ describe("ngAnimate", function() {
               $animate.removeClass(element, 'ng-hide');
 
               if($sniffer.animations) {
-                $timeout.flush();
+                $animate.triggerReflow();
                 expect(element.hasClass('ng-hide-remove')).toBe(true);
                 expect(element.hasClass('ng-hide-remove-active')).toBe(true);
               }
@@ -762,7 +765,7 @@ describe("ngAnimate", function() {
 
 
               if($sniffer.animations) { //cleanup some pending animations
-                $timeout.flush();
+                $animate.triggerReflow();
                 expect(element.hasClass('ng-hide-add')).toBe(true);
                 expect(element.hasClass('ng-hide-add-active')).toBe(true);
                 browserTrigger(element,'animationend', { timeStamp: Date.now() + 2000, elapsedTime: 2 });
@@ -806,7 +809,7 @@ describe("ngAnimate", function() {
             };
 
             $rootScope.$digest();
-            $timeout.flush();
+            $animate.triggerReflow();
 
             expect(elements[0].attr('style')).toBeFalsy();
             expect(elements[1].attr('style')).toMatch(/animation-delay: 0\.1\d*s/);
@@ -823,7 +826,13 @@ describe("ngAnimate", function() {
             };
 
             $rootScope.$digest();
-            $timeout.flush();
+            var expectFailure = true;
+            try {
+              $animate.triggerReflow();
+              expectFailure = false;
+            } catch(e) {}
+
+            expect(expectFailure).toBe(true);
 
             expect(elements[0].attr('style')).toBeFalsy();
             expect(elements[1].attr('style')).not.toMatch(/animation-delay: 0\.1\d*s/);
@@ -859,7 +868,7 @@ describe("ngAnimate", function() {
             };
 
             $rootScope.$digest();
-            $timeout.flush();
+            $animate.triggerReflow();
 
             expect(elements[0].attr('style')).toBeFalsy();
             expect(elements[1].attr('style')).toMatch(/animation-delay: 1\.1\d*s,\s*2\.1\d*s/);
@@ -896,7 +905,7 @@ describe("ngAnimate", function() {
 
             $animate.removeClass(element, 'ng-hide');
             if ($sniffer.transitions) {
-              $timeout.flush();
+              $animate.triggerReflow();
               browserTrigger(element,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
             }
             expect(element).toBeShown();
@@ -920,7 +929,7 @@ describe("ngAnimate", function() {
               $animate.removeClass(element, 'ng-hide');
 
               if ($sniffer.transitions) {
-                $timeout.flush();
+                $animate.triggerReflow();
                 var now = Date.now();
                 browserTrigger(element,'transitionend', { timeStamp: now + 1000, elapsedTime: 1 });
                 browserTrigger(element,'transitionend', { timeStamp: now + 1000, elapsedTime: 1 });
@@ -948,7 +957,6 @@ describe("ngAnimate", function() {
 
               element.addClass('ng-hide');
               $animate.removeClass(element, 'ng-hide');
-              $timeout.flush(0);
               expect(element).toBeShown();
               $animate.enabled(true);
 
@@ -957,7 +965,7 @@ describe("ngAnimate", function() {
 
               $animate.removeClass(element, 'ng-hide');
               if ($sniffer.transitions) {
-                $timeout.flush();
+                $animate.triggerReflow();
                 var now = Date.now();
                 browserTrigger(element,'transitionend', { timeStamp: now + 1000, elapsedTime: 1 });
                 browserTrigger(element,'transitionend', { timeStamp: now + 3000, elapsedTime: 3 });
@@ -985,7 +993,7 @@ describe("ngAnimate", function() {
 
               $animate.removeClass(element, 'ng-hide');
 
-              $timeout.flush();
+              $animate.triggerReflow();
 
               var now = Date.now();
               browserTrigger(element,'transitionend', { timeStamp: now + 1000, elapsedTime: 1 });
@@ -1014,7 +1022,7 @@ describe("ngAnimate", function() {
 
               $animate.removeClass(element, 'ng-hide');
               if ($sniffer.transitions) {
-                $timeout.flush();
+                $animate.triggerReflow();
               }
               expect(element).toBeShown();
               if ($sniffer.transitions) {
@@ -1039,7 +1047,7 @@ describe("ngAnimate", function() {
               $animate.removeClass(element, 'ng-hide');
 
               if($sniffer.transitions) {
-                $timeout.flush();
+                $animate.triggerReflow();
                 expect(element.hasClass('ng-hide-remove')).toBe(true);
                 expect(element.hasClass('ng-hide-remove-active')).toBe(true);
                 browserTrigger(element,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
@@ -1051,7 +1059,7 @@ describe("ngAnimate", function() {
               $animate.addClass(element, 'ng-hide');
 
               if($sniffer.transitions) {
-                $timeout.flush();
+                $animate.triggerReflow();
                 expect(element.hasClass('ng-hide-add')).toBe(true);
                 expect(element.hasClass('ng-hide-add-active')).toBe(true);
               }
@@ -1092,7 +1100,7 @@ describe("ngAnimate", function() {
             };
 
             $rootScope.$digest();
-            $timeout.flush();
+            $animate.triggerReflow();
 
             expect(elements[0].attr('style')).toBeFalsy();
             expect(elements[1].attr('style')).toMatch(/transition-delay: 0\.1\d*s/);
@@ -1109,7 +1117,14 @@ describe("ngAnimate", function() {
             };
 
             $rootScope.$digest();
-            $timeout.flush();
+
+            var expectFailure = true;
+            try {
+              $animate.triggerReflow();
+              expectFailure = false;
+            } catch(e) {}
+
+            expect(expectFailure).toBe(true);
 
             expect(elements[0].attr('style')).toBeFalsy();
             expect(elements[1].attr('style')).not.toMatch(/transition-delay: 0\.1\d*s/);
@@ -1145,7 +1160,7 @@ describe("ngAnimate", function() {
             };
 
             $rootScope.$digest();
-            $timeout.flush();
+            $animate.triggerReflow();
 
             expect(elements[0].attr('style')).toMatch(/transition-duration: 1\d*s,\s*3\d*s;/);
             expect(elements[0].attr('style')).not.toContain('transition-delay');
@@ -1167,7 +1182,7 @@ describe("ngAnimate", function() {
 
             $animate.addClass(element, 'some-class');
 
-            $timeout.flush(10); //reflow
+            $animate.triggerReflow(); //reflow
             expect(element.hasClass('some-class-add-active')).toBe(true);
 
             $timeout.flush(7500); //closing timeout
@@ -1195,7 +1210,7 @@ describe("ngAnimate", function() {
             }
             $rootScope.$digest();
 
-            $timeout.flush(10); //reflow
+            $animate.triggerReflow(); //reflow
             expect(element.children().length).toBe(5);
 
             for(var i = 0; i < 5; i++) {
@@ -1231,12 +1246,12 @@ describe("ngAnimate", function() {
 
             $animate.addClass(element, 'some-class');
 
-            $timeout.flush(10); //reflow
+            $animate.triggerReflow(); //reflow
             expect(element.hasClass('some-class-add-active')).toBe(true);
 
             $animate.removeClass(element, 'some-class');
 
-            $timeout.flush(10); //second reflow
+            $animate.triggerReflow(); //second reflow
 
             $timeout.flush(7500); //closing timeout for the first animation
             expect(element.hasClass('some-class-remove-active')).toBe(true);
@@ -1279,7 +1294,7 @@ describe("ngAnimate", function() {
           };
 
           $rootScope.$digest();
-          $timeout.flush();
+          $animate.triggerReflow();
 
           expect(elements[0].attr('style')).toBeFalsy();
 
@@ -1317,7 +1332,7 @@ describe("ngAnimate", function() {
           $rootScope.$digest();
 
           if ($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
             expect(element.hasClass('abc')).toBe(true);
             expect(element.hasClass('ng-enter')).toBe(true);
             expect(element.hasClass('ng-enter-active')).toBe(true);
@@ -1331,7 +1346,7 @@ describe("ngAnimate", function() {
           $rootScope.$digest();
 
           if ($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
             expect(element.hasClass('xyz')).toBe(true);
             expect(element.hasClass('ng-enter')).toBe(true);
             expect(element.hasClass('ng-enter-active')).toBe(true);
@@ -1359,7 +1374,7 @@ describe("ngAnimate", function() {
           $rootScope.$digest();
 
           if($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
             expect(element.hasClass('one')).toBe(true);
             expect(element.hasClass('two')).toBe(true);
             expect(element.hasClass('ng-enter')).toBe(true);
@@ -1567,6 +1582,9 @@ describe("ngAnimate", function() {
           });
 
           $animate.addClass(element, 'ng-hide'); //earlier animation cancelled
+          if($sniffer.transitions) {
+            $animate.triggerReflow();
+          }
           $timeout.flush();
           expect(signature).toBe('AB');
         }));
@@ -1697,7 +1715,7 @@ describe("ngAnimate", function() {
 
           if($sniffer.transitions) {
             expect(element.hasClass('klass-add')).toBe(true);
-            $timeout.flush();
+            $animate.triggerReflow();
             expect(element.hasClass('klass')).toBe(true);
             expect(element.hasClass('klass-add-active')).toBe(true);
             browserTrigger(element,'transitionend', { timeStamp: Date.now() + 3000, elapsedTime: 3 });
@@ -1712,7 +1730,7 @@ describe("ngAnimate", function() {
           if($sniffer.transitions) {
             expect(element.hasClass('klass-remove')).toBe(true);
 
-            $timeout.flush();
+            $animate.triggerReflow();
             expect(element.hasClass('klass')).toBe(false);
             expect(element.hasClass('klass-add')).toBe(false);
             expect(element.hasClass('klass-add-active')).toBe(false);
@@ -1776,7 +1794,7 @@ describe("ngAnimate", function() {
           });
 
           if($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
             expect(element.hasClass('klass-add')).toBe(true);
             expect(element.hasClass('klass-add-active')).toBe(true);
             browserTrigger(element,'transitionend', { timeStamp: Date.now() + 11000, elapsedTime: 11 });
@@ -1792,7 +1810,7 @@ describe("ngAnimate", function() {
           });
 
           if($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
             expect(element.hasClass('klass-remove')).toBe(true);
             expect(element.hasClass('klass-remove-active')).toBe(true);
             browserTrigger(element,'transitionend', { timeStamp: Date.now() + 11000, elapsedTime: 11 });
@@ -1826,7 +1844,7 @@ describe("ngAnimate", function() {
           });
 
           if($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
             expect(element.hasClass('one-add')).toBe(true);
             expect(element.hasClass('two-add')).toBe(true);
 
@@ -1872,7 +1890,7 @@ describe("ngAnimate", function() {
           });
 
           if($sniffer.transitions) {
-            $timeout.flush();
+            $animate.triggerReflow();
             expect(element.hasClass('one-remove')).toBe(true);
             expect(element.hasClass('two-remove')).toBe(true);
 
@@ -1926,7 +1944,7 @@ describe("ngAnimate", function() {
       $rootScope.$digest();
 
       if($sniffer.transitions) {
-        $timeout.flush();
+        $animate.triggerReflow();
         expect(child.hasClass('ng-enter')).toBe(true);
         expect(child.hasClass('ng-enter-active')).toBe(true);
         browserTrigger(child,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
@@ -1950,7 +1968,7 @@ describe("ngAnimate", function() {
       $rootScope.$digest();
 
       if($sniffer.transitions) {
-        $timeout.flush();
+        $animate.triggerReflow();
         expect(child.hasClass('ng-enter')).toBe(true);
         expect(child.hasClass('ng-enter-active')).toBe(true);
         browserTrigger(child,'transitionend', { timeStamp: Date.now() + 9000, elapsedTime: 9 });
@@ -2004,9 +2022,8 @@ describe("ngAnimate", function() {
         $animate.enter(child, element);
         $rootScope.$digest();
 
-        $timeout.flush(10);
-
         if($sniffer.transitions) {
+          $animate.triggerReflow();
           browserTrigger(child,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
         }
 
@@ -2040,7 +2057,7 @@ describe("ngAnimate", function() {
 
         //this is added/removed right away otherwise
         if($sniffer.transitions) {
-          $timeout.flush();
+          $animate.triggerReflow();
           expect(child.hasClass('ng-enter')).toBe(true);
           expect(child.hasClass('ng-enter-active')).toBe(true);
         }
@@ -2080,7 +2097,7 @@ describe("ngAnimate", function() {
         $animate.leave(child);
         $rootScope.$digest();
 
-        $timeout.flush();
+        $animate.triggerReflow();
         expect(child.hasClass('ng-enter-active')).toBe(false);
       });
     });
@@ -2275,7 +2292,7 @@ describe("ngAnimate", function() {
 
         var empty = true;
         try {
-          $timeout.flush();
+          $animate.triggerReflow();
           empty = false;
         }
         catch(e) {}
@@ -2301,7 +2318,7 @@ describe("ngAnimate", function() {
 
       $animate.enter(child, element);
       $rootScope.$digest();
-      $timeout.flush();
+      $animate.triggerReflow();
 
       expect(child.hasClass('ng-enter')).toBe(true);
       expect(child.hasClass('ng-enter-active')).toBe(true);
@@ -2361,7 +2378,7 @@ describe("ngAnimate", function() {
         expect(animationState).toBe('enter');
         if($sniffer.transitions) {
           expect(child.hasClass('ng-enter')).toBe(true);
-          $timeout.flush();
+          $animate.triggerReflow();
           expect(child.hasClass('ng-enter-active')).toBe(true);
         }
 
@@ -2378,7 +2395,7 @@ describe("ngAnimate", function() {
 
         $animate.addClass(child, 'something');
         if($sniffer.transitions) {
-          $timeout.flush();
+          $animate.triggerReflow();
         }
         expect(animationState).toBe('addClass');
         if($sniffer.transitions) {
@@ -2397,7 +2414,7 @@ describe("ngAnimate", function() {
 
 
     it("should wait until a queue of animations are complete before performing a reflow",
-      inject(function($rootScope, $compile, $timeout,$sniffer) {
+      inject(function($rootScope, $compile, $timeout, $sniffer, $animate) {
 
       if(!$sniffer.transitions) return;
 
@@ -2409,7 +2426,7 @@ describe("ngAnimate", function() {
 
       $rootScope.$digest();
       expect(element[0].querySelectorAll('.ng-enter-active').length).toBe(0);
-      $timeout.flush();
+      $animate.triggerReflow();
       expect(element[0].querySelectorAll('.ng-enter-active').length).toBe(5);
 
       forEach(element.children(), function(kid) {
@@ -2470,7 +2487,7 @@ describe("ngAnimate", function() {
     });
 
 
-    it("should disable all child animations on structural animations until the first reflow has passed", function() {
+    it("should disable all child animations on structural animations until the post animation timeout has passed", function() {
       var intercepted;
       module(function($animateProvider) {
         $animateProvider.register('.animated', function() {
@@ -2584,7 +2601,6 @@ describe("ngAnimate", function() {
           $animate.enter(kid, element);
         }
         $rootScope.$digest();
-        $timeout.flush();
 
         //called three times since the classname is the same
         expect(count).toBe(2);
@@ -2598,7 +2614,6 @@ describe("ngAnimate", function() {
         }
 
         $rootScope.$digest();
-        $timeout.flush();
 
         expect(count).toBe(20);
       });
@@ -2666,7 +2681,7 @@ describe("ngAnimate", function() {
       expect(element.hasClass('green')).toBe(false);
       expect(element.hasClass('red')).toBe(false);
 
-      $timeout.flush();
+      $animate.triggerReflow();
 
       expect(element.hasClass('green')).toBe(true);
       expect(element.hasClass('red')).toBe(true);
@@ -2826,7 +2841,7 @@ describe("ngAnimate", function() {
       expect(element.hasClass('base-class')).toBe(false);
 
       //the reflow...
-      $timeout.flush();
+      $animate.triggerReflow();
 
       //the reflow DOM operation was commenced but it ran before so it
       //shouldn't run agaun
@@ -2860,9 +2875,10 @@ describe("ngAnimate", function() {
         node._setAttribute(prop, val);
       };
 
+      expect(capturedProperty).toBe('none');
       $animate.addClass(element, 'trigger-class');
 
-      $timeout.flush();
+      $animate.triggerReflow();
 
       expect(capturedProperty).not.toBe('none');
     }));
@@ -2889,7 +2905,7 @@ describe("ngAnimate", function() {
 
       expect(node.style[animationKey]).toContain('none');
 
-      $timeout.flush();
+      $animate.triggerReflow();
 
       expect(node.style[animationKey]).not.toContain('none');
     }));
@@ -2934,7 +2950,7 @@ describe("ngAnimate", function() {
         expect(element[0].style[prop]).toContain('none');
         expect($window.getComputedStyle(element[0])[prop + 'Duration']).toBe('0s');
 
-        $timeout.flush();
+        $animate.triggerReflow();
       });
     });
 
@@ -2953,7 +2969,7 @@ describe("ngAnimate", function() {
         $animate.leave(element);
         $rootScope.$digest();
 
-        $timeout.flush();
+        $animate.triggerReflow();
 
         browserTrigger(element, 'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 0.50999999991 });
 
@@ -2977,7 +2993,7 @@ describe("ngAnimate", function() {
           }
         });
       });
-      inject(function($rootScope, $compile, $rootElement, $document, $timeout, $templateCache, $sniffer) {
+      inject(function($rootScope, $compile, $rootElement, $document, $timeout, $templateCache, $sniffer, $animate) {
         if(!$sniffer.transitions) return;
 
         $templateCache.put('item-template', 'item: #{{ item }} ');
@@ -2996,7 +3012,7 @@ describe("ngAnimate", function() {
         $rootScope.tpl = 'item-template';
         $rootScope.items = [1,2,3];
         $rootScope.$digest();
-        $timeout.flush();
+        $animate.triggerReflow();
 
         expect(capturedAnimation).toBe('enter');
         expect(element.text()).toContain('item: #1');
@@ -3008,7 +3024,7 @@ describe("ngAnimate", function() {
 
         $rootScope.items = [];
         $rootScope.$digest();
-        $timeout.flush();
+        $animate.triggerReflow();
 
         expect(capturedAnimation).toBe('leave');
       });
@@ -3086,7 +3102,7 @@ describe("ngAnimate", function() {
         ready = true;
       });
 
-      $timeout.flush(10);
+      $animate.triggerReflow();
       browserTrigger(element, 'transitionend', { timeStamp: Date.now(), elapsedTime: 1 });
       $timeout.flush(1);
       expect(ready).toBe(false);
@@ -3100,7 +3116,7 @@ describe("ngAnimate", function() {
         ready = true;
       });
 
-      $timeout.flush(10);
+      $animate.triggerReflow();
       browserTrigger(element, 'transitionend', { timeStamp: Date.now(), elapsedTime: 1 });
       $timeout.flush(1);
       expect(ready).toBe(true);
@@ -3168,7 +3184,7 @@ describe("ngAnimate", function() {
       $timeout.flush(1);
       expect(signature).toBe('AB');
 
-      $timeout.flush(10);
+      $animate.triggerReflow();
       browserTrigger(element, 'transitionend', { timeStamp: Date.now(), elapsedTime: 2000 });
       $timeout.flush(1);
 

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -2665,6 +2665,37 @@ describe("ngAnimate", function() {
       expect(element.hasClass('red')).toBe(true);
     }));
 
+    it("should avoid mixing up substring classes during add and remove operations", function() {
+      var currentAnimation, currentFn;
+      module(function($animateProvider) {
+        $animateProvider.register('.on', function() {
+          return {
+            beforeAddClass : function(element, className, done) {
+              currentAnimation = 'addClass';
+              currentFn = done;
+            },
+            beforeRemoveClass : function(element, className, done) {
+              currentAnimation = 'removeClass';
+              currentFn = done;
+            }
+          };
+        });
+      });
+      inject(function($compile, $rootScope, $animate, $sniffer, $timeout) {
+        var element = $compile('<div class="animation-enabled only"></div>')($rootScope);
+        $rootElement.append(element);
+        jqLite($document[0].body).append($rootElement);
+
+        $animate.addClass(element, 'on');
+        expect(currentAnimation).toBe('addClass');
+        currentFn();
+
+        $animate.removeClass(element, 'on');
+        $animate.addClass(element, 'on');
+
+        expect(currentAnimation).toBe('addClass');
+      });
+    });
 
     it('should enable and disable animations properly on the root element', function() {
       var count = 0;

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1155,7 +1155,7 @@ describe("ngAnimate", function() {
           }));
 
 
-          it("apply a closing timeout to close all pending transitions",
+          it("should apply a closing timeout to close all pending transitions",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout) {
 
             if (!$sniffer.transitions) return;
@@ -1172,6 +1172,48 @@ describe("ngAnimate", function() {
 
             $timeout.flush(7500); //closing timeout
             expect(element.hasClass('some-class-add-active')).toBe(false);
+          }));
+
+          it("apply a closing timeout with respect to a staggering animation",
+            inject(function($animate, $rootScope, $compile, $sniffer, $timeout) {
+
+            if (!$sniffer.transitions) return;
+
+            ss.addRule('.entering-element.ng-enter',
+              '-webkit-transition:5s linear all;' +
+                      'transition:5s linear all;');
+
+            ss.addRule('.entering-element.ng-enter-stagger',
+              '-webkit-transition-delay:0.5s;' +
+                      'transition-delay:0.5s;');
+
+            element = $compile(html('<div></div>'))($rootScope);
+            var kids = [];
+            for(var i = 0; i < 5; i++) {
+              kids.push(angular.element('<div class="entering-element"></div>'));
+              $animate.enter(kids[i], element);
+            }
+            $rootScope.$digest();
+
+            $timeout.flush(10); //reflow
+            expect(element.children().length).toBe(5);
+
+            for(var i = 0; i < 5; i++) {
+              expect(kids[i].hasClass('ng-enter-active')).toBe(true);
+            }
+
+            $timeout.flush(7500);
+
+            for(var i = 0; i < 5; i++) {
+              expect(kids[i].hasClass('ng-enter-active')).toBe(true);
+            }
+
+            //(stagger * index) + (duration + delay) * 150%
+            $timeout.flush(9500); //0.5 * 4 + 5 * 1.5 = 9500;
+
+            for(var i = 0; i < 5; i++) {
+              expect(kids[i].hasClass('ng-enter-active')).toBe(false);
+            }
           }));
 
 

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1918,41 +1918,6 @@ describe("ngAnimate", function() {
     }));
 
 
-    it("should not set the transition property flag if only CSS animations are used",
-      inject(function($compile, $rootScope, $animate, $sniffer, $timeout) {
-
-      if (!$sniffer.animations) return;
-
-      ss.addRule('.sleek-animation.ng-enter', '-webkit-animation: my_animation 2s linear;' +
-                                              'animation: my_animation 2s linear');
-
-      ss.addRule('.trans.ng-enter',  '-webkit-transition:1s linear all;' +
-                                             'transition:1s linear all');
-
-      var propertyKey = ($sniffer.vendorPrefix == 'Webkit' ? '-webkit-' : '') + 'transition-property';
-
-      var element = html($compile('<div>...</div>')($rootScope));
-      var child = $compile('<div class="skeep-animation">...</div>')($rootScope);
-      child.css(propertyKey,'background-color');
-
-      $animate.enter(child, element);
-      $rootScope.$digest();
-      $timeout.flush();
-
-      browserTrigger(child,'transitionend', { timeStamp: Date.now() + 2000, elapsedTime: 2 });
-
-      expect(child.css(propertyKey)).toBe('background-color');
-      child.remove();
-
-      child = $compile('<div class="sleek-animation">...</div>')($rootScope);
-      child.attr('class','trans');
-      $animate.enter(child, element);
-      $rootScope.$digest();
-
-      expect(child.css(propertyKey)).not.toBe('background-color');
-    }));
-
-
     it("should skip animations if the browser does not support CSS3 transitions and CSS3 animations",
       inject(function($compile, $rootScope, $animate, $sniffer) {
 

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1496,6 +1496,68 @@ describe("ngAnimate", function() {
           expect(signature).toBe('AB');
         }));
 
+        it('should fire DOM callbacks on the element being animated',
+          inject(function($animate, $rootScope, $compile, $sniffer, $rootElement, $timeout) {
+
+          if(!$sniffer.transitions) return;
+
+          $animate.enabled(true);
+
+          ss.addRule('.klass-add', '-webkit-transition:1s linear all;' +
+                                           'transition:1s linear all;');
+
+          var element = jqLite('<div></div>');
+          $rootElement.append(element);
+          body.append($rootElement);
+
+          var steps = [];
+          element.on('$animate:before', function(e, data) {
+            steps.push(['before', data.className, data.event]);
+          });
+
+          element.on('$animate:after', function(e, data) {
+            steps.push(['after', data.className, data.event]);
+          });
+
+          $animate.addClass(element, 'klass');
+
+          $timeout.flush(1);
+
+          expect(steps.pop()).toEqual(['before', 'klass', 'addClass']);
+
+          $animate.triggerReflow();
+          $timeout.flush(1);
+
+          expect(steps.pop()).toEqual(['after', 'klass', 'addClass']);
+        })); 
+
+        it('should fire the DOM callbacks even if no animation is rendered',
+          inject(function($animate, $rootScope, $compile, $sniffer, $rootElement, $timeout) {
+
+          $animate.enabled(true);
+
+          var parent = jqLite('<div></div>');
+          var element = jqLite('<div></div>');
+          $rootElement.append(parent);
+          body.append($rootElement);
+
+          var steps = [];
+          element.on('$animate:before', function(e, data) {
+            steps.push(['before', data.className, data.event]);
+          });
+
+          element.on('$animate:after', function(e, data) {
+            steps.push(['after', data.className, data.event]);
+          });
+
+          $animate.enter(element, parent);
+          $rootScope.$digest();
+
+          $timeout.flush(1);
+
+          expect(steps.shift()).toEqual(['before', 'ng-enter', 'enter']);
+          expect(steps.shift()).toEqual(['after',  'ng-enter', 'enter']);
+        })); 
 
         it("should fire a done callback when provided with no animation",
           inject(function($animate, $rootScope, $compile, $sniffer, $rootElement, $timeout) {


### PR DESCRIPTION
## Fixes to Transitions / Keyframe Animations

NgAnimate and natural CSS transitions are not 1-1 in terms of behaviour (yet), but this fix brings 1.2 to work alongside natural CSS transitions much better. With 1.3 the API will be changed so things are more fluid, but this fix should handle a good amount of the class-based bugs that are appearing in ngAnimate.

Long story short, if you remove ngAnimate from your application it should perform the exact same for CSS-based transitions and keyframe animations triggered by $animate.addClass and/or ngClass.

Closes #5588 
Closes #5191

Here's an example of what should happen:

Natural CSS animations without ngAnimate
http://jsfiddle.net/7vk7p/3/

And this is how it is expected to be with ngAnimate
https://s3.amazonaws.com/angularjs-dev/ng-animate-race-condition-fix/example/animate.html

This is how it currently is:
http://jsfiddle.net/7vk7p/2/
## Cleanup

Remove a useless test from ngAnimate
## Fixes to Staggering animations

Broken with 1.2.5+ due to closing timeout feature.
## Fixes to performance

Use `requestAnimationFrame` instead of $timeout to issue a forced reflow.
## Animation callbacks

Added a new feature to tap into callbacks before and after animations DOM events are called.
