### PR TITLE
fix($browser): fix a INFDIG error when history back before onload event.

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -154,7 +154,16 @@ function Browser(window, document, $log, $sniffer) {
 
     // setter
     if (url) {
-      if (lastBrowserUrl == url) return;
+      if (lastBrowserUrl == url) {
+        // Basically the $browser.url method is not called when the URL is changed by history back event.
+        // This case is handled by popstate event handler.
+        // But popstate event is triggered only after onload event
+        // So, the $browser.url method is called when the URL is changed by history back event before onload event.
+        // $locationWatch can cause INFDIG error
+        // because lastBrowserUrl == url == $location.absUrl() != $browser.url()
+        if (lastBrowserUrl != self.url()) fireUrlChange();
+        return;
+      }
       lastBrowserUrl = url;
       if ($sniffer.history) {
         if (replace) history.replaceState(null, '', url);


### PR DESCRIPTION
Basically the $browser.url method is not called when the URL is changed by history back event.
This case is handled by popstate event handler.
But popstate event is triggered only after onload event
So, the $browser.url method is called when the URL is changed by history back event before onload event.
in this case, $locationWatch can cause INFDIG error
because lastBrowserUrl == url == $location.absUrl() != $browser.url()

scenario after onload event. (normal)

[browser URL : A]
[browser URL : B]
-> history back
[browser URL : A / location.absUrl() : A] 

scenario before onload event.

[browser URL : A]
[browser URL : B]
-> history back
[browser URL : A / location.absUrl() : B] - because popstate event is not triggered
