### PR TITLE
fix($http): parse JSON only if Content-Type header contains string 'json'

### DIFF
--- a/docs/src/example.js
+++ b/docs/src/example.js
@@ -115,14 +115,14 @@ exports.Example.prototype.toHtmlTabs = function() {
   htmlTabs(this.html);
   htmlTabs(this.css);
   htmlTabs(this.js);
-  htmlTabs(this.json);
+  htmlTabs(this.json, 'application/json');
   htmlTabs(this.unit);
   htmlTabs(this.scenario);
   htmlTabs(this.protractorTest);
   out.push('</div>');
   return out.join('');
 
-  function htmlTabs(sources) {
+  function htmlTabs(sources, contentType) {
     sources.forEach(function(source) {
       var wrap = '',
           isCss = source.name.match(/\.css$/),
@@ -139,7 +139,9 @@ exports.Example.prototype.toHtmlTabs = function() {
           '<pre class="prettyprint linenums" ng-set-text="' + source.id + '"' + wrap + '></pre>\n' +
           (isCss
              ? ('<style type="text/css" id="' + source.id + '">' + source.content + '</style>\n')
-             : ('<script type="text/ng-template" id="' + source.id + '">' + source.content + '</script>\n') ) +
+             : ('<script type="text/ng-template"' + (' id="' + source.id + '"') +
+                (contentType ? ' content-type="' + contentType + '"' : '') + '>' +
+               source.content + '</script>\n') ) +
         '</div>\n');
     });
   }

--- a/src/ng/directive/script.js
+++ b/src/ng/directive/script.js
@@ -41,9 +41,14 @@ var scriptDirective = ['$templateCache', function($templateCache) {
       if (attr.type == 'text/ng-template') {
         var templateUrl = attr.id,
             // IE is not consistent, in scripts we have to read .text but in other nodes we have to read .textContent
-            text = element[0].text;
+            text = element[0].text,
+            headers = {};
 
-        $templateCache.put(templateUrl, text);
+        if (attr.contentType || '') {
+          headers['content-type'] = attr.contentType;
+        }
+
+        $templateCache.put(templateUrl, [200, text, headers]);
       }
     }
   };

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -91,11 +91,13 @@ function $HttpProvider() {
 
   var defaults = this.defaults = {
     // transform incoming response data
-    transformResponse: [function(data) {
+    transformResponse: [function(data, headers) {
       if (isString(data)) {
         // strip json vulnerability protection prefix
+        var contentType = isFunction(headers) && headers('Content-Type');
         data = data.replace(PROTECTION_PREFIX, '');
-        if (JSON_START.test(data) && JSON_END.test(data))
+        if (JSON_START.test(data) && JSON_END.test(data) &&
+            (contentType && contentType.indexOf('json') >= 0))
           data = fromJson(data);
       }
       return data;

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -89,19 +89,40 @@ function $HttpProvider() {
       PROTECTION_PREFIX = /^\)\]\}',?\n/,
       CONTENT_TYPE_APPLICATION_JSON = {'Content-Type': 'application/json;charset=utf-8'};
 
+  var parseJsonSelectively = function(data, headers) {
+    if (isString(data)) {
+      // strip json vulnerability protection prefix
+      var contentType = isFunction(headers) && headers('Content-Type');
+      data = data.replace(PROTECTION_PREFIX, '');
+      if (JSON_START.test(data) && JSON_END.test(data) &&
+          (contentType && contentType.indexOf('json') >= 0))
+        data = fromJson(data);
+    }
+    return data;
+  };
+
+  var autoParseJSON = function(data) {
+    if (isString(data)) {
+      // strip json vulnerability protection prefix
+      data = data.replace(PROTECTION_PREFIX, '');
+      if (JSON_START.test(data) && JSON_END.test(data))
+        data = fromJson(data);
+    }
+    return data;
+  };
+
+  var parseMode = parseJsonSelectively;
+
+  this.autoParseJSON = function(value) {
+    var i = indexOf(defaults.transformResponse, value ? parseJsonSelectively : autoParseJSON);
+    if (i >= 0) {
+      defaults.transformResponse.splice(i, 1, value ? autoParseJSON : parseJsonSelectively);
+    }
+  };
+
   var defaults = this.defaults = {
     // transform incoming response data
-    transformResponse: [function(data, headers) {
-      if (isString(data)) {
-        // strip json vulnerability protection prefix
-        var contentType = isFunction(headers) && headers('Content-Type');
-        data = data.replace(PROTECTION_PREFIX, '');
-        if (JSON_START.test(data) && JSON_END.test(data) &&
-            (contentType && contentType.indexOf('json') >= 0))
-          data = fromJson(data);
-      }
-      return data;
-    }],
+    transformResponse: [parseJsonSelectively],
 
     // transform outgoing request data
     transformRequest: [function(d) {

--- a/test/ng/directive/scriptSpec.js
+++ b/test/ng/directive/scriptSpec.js
@@ -15,7 +15,7 @@ describe('scriptDirective', function() {
                    '<script id="/ignore">ignore me</script>' +
                    '<script type="text/ng-template" id="/myTemplate.html"><x>{{y}}</x></script>' +
                  '</div>' );
-        expect($templateCache.get('/myTemplate.html')).toBe('<x>{{y}}</x>');
+        expect($templateCache.get('/myTemplate.html')[1]).toBe('<x>{{y}}</x>');
         expect($templateCache.get('/ignore')).toBeUndefined();
       }
   ));

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1014,8 +1014,10 @@ describe('$http', function() {
 
         describe('default', function() {
 
-          it('should deserialize json objects', function() {
-            $httpBackend.expect('GET', '/url').respond('{"foo":"bar","baz":23}');
+          it('should deserialize json objects with json content-type', function() {
+            $httpBackend.expect('GET', '/url').respond('{"foo":"bar","baz":23}', {
+              'Content-Type': 'application/json'
+            });
             $http({method: 'GET', url: '/url'}).success(callback);
             $httpBackend.flush();
 
@@ -1024,8 +1026,10 @@ describe('$http', function() {
           });
 
 
-          it('should deserialize json arrays', function() {
-            $httpBackend.expect('GET', '/url').respond('[1, "abc", {"foo":"bar"}]');
+          it('should deserialize json arrays with json content-type', function() {
+            $httpBackend.expect('GET', '/url').respond('[1, "abc", {"foo":"bar"}]', {
+              'Content-Type': 'application/json'
+            });
             $http({method: 'GET', url: '/url'}).success(callback);
             $httpBackend.flush();
 
@@ -1034,8 +1038,10 @@ describe('$http', function() {
           });
 
 
-          it('should deserialize json with security prefix', function() {
-            $httpBackend.expect('GET', '/url').respond(')]}\',\n[1, "abc", {"foo":"bar"}]');
+          it('should deserialize json with security prefix with json content-type', function() {
+            $httpBackend.expect('GET', '/url').respond(')]}\',\n[1, "abc", {"foo":"bar"}]', {
+              'Content-Type': 'application/json'
+            });
             $http({method: 'GET', url: '/url'}).success(callback);
             $httpBackend.flush();
 
@@ -1044,8 +1050,10 @@ describe('$http', function() {
           });
 
 
-          it('should deserialize json with security prefix ")]}\'"', function() {
-            $httpBackend.expect('GET', '/url').respond(')]}\'\n\n[1, "abc", {"foo":"bar"}]');
+          it('should deserialize json with security prefix ")]}\'" with json content-type', function() {
+            $httpBackend.expect('GET', '/url').respond(')]}\'\n\n[1, "abc", {"foo":"bar"}]', {
+              'Content-Type': 'application/json'
+            });
             $http({method: 'GET', url: '/url'}).success(callback);
             $httpBackend.flush();
 
@@ -1054,14 +1062,26 @@ describe('$http', function() {
           });
 
 
-          it('should not deserialize tpl beginning with ng expression', function() {
-            $httpBackend.expect('GET', '/url').respond('{{some}}');
+          it('should not deserialize tpl beginning with ng expression with json content-type', function() {
+            $httpBackend.expect('GET', '/url').respond('{{some}}', {
+              'Content-Type': 'application/json'
+            });
             $http.get('/url').success(callback);
             $httpBackend.flush();
 
             expect(callback).toHaveBeenCalledOnce();
             expect(callback.mostRecentCall.args[0]).toEqual('{{some}}');
           });
+        });
+
+
+        it('should not deserialize JSON response without Content-Type header matching \'json\'', function() {
+          $httpBackend.expect('GET', '/url').respond('{ "foo": "bar" }');
+          $http.get('/url').success(callback);
+          $httpBackend.flush();
+
+          expect(callback).toHaveBeenCalledOnce();
+          expect(callback.mostRecentCall.args[0]).toBe('{ "foo": "bar" }');
         });
 
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -534,7 +534,9 @@ describe("resource", function() {
   it('should exercise full stack', function() {
     var Person = $resource('/Person/:id');
 
-    $httpBackend.expect('GET', '/Person/123').respond('\n{\n"name":\n"misko"\n}\n');
+    $httpBackend.expect('GET', '/Person/123').respond('\n{\n"name":\n"misko"\n}\n', {
+      'Content-Type': 'application/json'
+    });
     var person = Person.get({id:123});
     $httpBackend.flush();
     expect(person.name).toEqual('misko');


### PR DESCRIPTION
The default behaviour causes issues with a wide variety of custom
interpolation markers. Even if the JSON test regexps were strengthened to
closer match the standard JSON format, it would still limit the possibilities
of different custom interpolation markers.

BREAKING CHANGE: Previously, responses would be parsed as JSON if their
content looked vaguely like JSON. Now, they are only parsed as JSON if their
Content-Type response header contains the term 'json', and if they are not
coming from the $templateCache.

Closes #5756
Closes #2973
