### PR TITLE
test(input): Minmaxlength databinding

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -509,8 +509,8 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 
   // min length validator
   if (attr.ngMinlength) {
-    var minlength = int(attr.ngMinlength);
     var minLengthValidator = function(value) {
+      var minlength = int(attr.ngMinlength);
       return validate(ctrl, 'minlength', ctrl.$isEmpty(value) || value.length >= minlength, value);
     };
 
@@ -520,8 +520,8 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 
   // max length validator
   if (attr.ngMaxlength) {
-    var maxlength = int(attr.ngMaxlength);
     var maxLengthValidator = function(value) {
+      var maxlength = int(attr.ngMaxlength);
       return validate(ctrl, 'maxlength', ctrl.$isEmpty(value) || value.length <= maxlength, value);
     };
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -733,6 +733,21 @@ describe('input', function() {
       changeInputValueTo('aaa');
       expect(scope.value).toBe('aaa');
     });
+
+
+    it('should be updatable via binding', function(){
+      scope.boundLength = 3;
+      compileInput('<input type="text" ng-model="value" ng-minlength="{{boundLength}}" />');
+      
+      changeInputValueTo('aaaa');
+      expect(scope.value).toBe('aaaa');
+
+      scope.boundLength = 6;
+      scope.$digest();
+      changeInputValueTo('aabb'); // TODO: this shouldn't need to changed to invalidate, but is (?)
+
+      expect(scope.value).toBeUndefined();
+    });
   });
 
 
@@ -746,6 +761,20 @@ describe('input', function() {
 
       changeInputValueTo('aaa');
       expect(scope.value).toBe('aaa');
+    });
+
+
+    it('should be updatable via binding', function(){
+      scope.boundLength = 6;
+      compileInput('<input type="text" ng-model="value" ng-maxlength="{{boundLength}}" />');
+      
+      changeInputValueTo('aaaa');
+      expect(scope.value).toBe('aaaa');
+
+      scope.boundLength = 3;
+      scope.$digest();
+      changeInputValueTo('aaab'); // TODO: this shouldn't need to changed to invalidate, but is (?)
+      expect(scope.value).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
In some other threads we talked about testing for interpolated databinding in ngMaxLength / ngMinLength and I finally got around to it.

The databinding works fine, except if you change the length value without firing an input event. If I comment out the second calls to `changeInputValueTo(...)` below, the tests will fail.

How should we handle this?
