### PR TITLE
fix(ngMockE2E): added function parameter to $delegate on request passThrough

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1110,7 +1110,9 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
   }
 
   // TODO(vojta): change params to: method, url, data, headers, callback
-  function $httpBackend(method, url, data, callback, headers, timeout, withCredentials) {
+  function $httpBackend(
+    method, url, data, callback, headers, timeout, withCredentials, responseType) {
+    
     var xhr = new MockXhr(),
         expectation = expectations[0],
         wasExpected = false;
@@ -1169,7 +1171,7 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
           // if $browser specified, we do auto flush all requests
           ($browser ? $browser.defer : responsesPush)(wrapResponse(definition));
         } else if (definition.passThrough) {
-          $delegate(method, url, data, callback, headers, timeout, withCredentials);
+          $delegate(method, url, data, callback, headers, timeout, withCredentials, responseType);
         } else throw new Error('No response defined !');
         return;
       }

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1383,10 +1383,10 @@ describe('ngMockE2E', function() {
     describe('passThrough()', function() {
       it('should delegate requests to the real backend when passThrough is invoked', function() {
         hb.when('GET', /\/passThrough\/.*/).passThrough();
-        hb('GET', '/passThrough/23', null, callback, {}, null, true);
+        hb('GET', '/passThrough/23', null, callback, {}, null, true, 'blob');
 
         expect(realHttpBackend).toHaveBeenCalledOnceWith(
-            'GET', '/passThrough/23', null, callback, {}, null, true);
+            'GET', '/passThrough/23', null, callback, {}, null, true, 'blob');
       });
     });
 


### PR DESCRIPTION
The ngMockE2E $httpBackend has a mechanism to allows requests to pass through if one wants
to send a real http request instead of mocking. The responseType of the request was never
passed through to the real http module, as it was missing in the function parameter list.

closes #5415
