### PR TITLE
fix($http) - allow for user removal of default headers by passing header functions

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -756,10 +756,6 @@ function $HttpProvider() {
 
         defHeaders = extend({}, defHeaders.common, defHeaders[lowercase(config.method)]);
 
-        // execute if header value is function
-        execHeaders(defHeaders);
-        execHeaders(reqHeaders);
-
         // using for-in instead of forEach to avoid unecessary iteration after header has been found
         defaultHeadersIteration:
         for (defHeaderName in defHeaders) {
@@ -774,6 +770,8 @@ function $HttpProvider() {
           reqHeaders[defHeaderName] = defHeaders[defHeaderName];
         }
 
+        // execute if header value is a function for merged headers
+        execHeaders(reqHeaders);
         return reqHeaders;
 
         function execHeaders(headers) {

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -747,6 +747,18 @@ describe('$http', function() {
         $httpBackend.flush();
       });
 
+      it('should delete default headers if custom header function returns null', function () {
+
+        $httpBackend.expect('POST', '/url', 'messageBody', function(headers) {
+          return headers['Accept'] === undefined;
+        }).respond('');
+
+        $http({url: '/url', method: 'POST', data: 'messageBody', headers: {
+          'Accept': function() { return null; }
+        }});
+        $httpBackend.flush();
+      });
+
       it('should override default headers with custom in a case insensitive manner', function() {
         $httpBackend.expect('POST', '/url', 'messageBody', function(headers) {
           return headers['accept'] == 'Rewritten' &&


### PR DESCRIPTION
Adds additional testing and fixes #5784

CLA is signed perekyle@gmail.com, 2 additional tests (1 that failed) in the latest build of angular.js
