### PR TITLE
docs(guide/directive): rephrase for consistency

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -734,13 +734,13 @@ own behavior to it.
 We want to run the function we pass by invoking it from the directive's scope, but have it run
 in the context of the scope where its registered.
 
-We saw earlier how to use `=prop` in the `scope` option, but in the above example, we're using
-`&prop` instead. `&` bindings expose a function to an isolated scope allowing the isolated scope
+We saw earlier how to use `=attr` in the `scope` option, but in the above example, we're using
+`&attr` instead. `&` bindings expose a function to an isolated scope allowing the isolated scope
 to invoke it, but maintaining the original scope of the function. So when a user clicks the
-`x` in the dialog, it runs `Ctrl`'s `close` function.
+`x` in the dialog, it runs `Ctrl`'s `hideDialog` function.
 
 <div class="alert alert-success">
-**Best Practice:** use `&prop` in the `scope` option when you want your directive
+**Best Practice:** use `&attr` in the `scope` option when you want your directive
 to expose an API for binding to behaviors.
 </div>
 


### PR DESCRIPTION
- rephrase _prop_ to _attr_ (basically _prop_ refers to property in JS object, _attr_ is for HTML tag and also _attr_ is used in _directive_ api doc)
- change the function name in description to `hideDialog` to match the name in code example
