### PR TITLE
Remove wrong method call

### DIFF
--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -124,9 +124,6 @@ var $AnimateProvider = ['$provide', function($provide) {
         if (after) {
           after.after(element);
         } else {
-          if (!parent || !parent[0]) {
-            parent = after.parent();
-          }
           parent.append(element);
         }
         done && $timeout(done, 0, false);


### PR DESCRIPTION
The invocation of the method `parent` will cause TypeError since `after` is evaluated to false.
