### PR TITLE
Ignore module function return value

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -622,7 +622,13 @@ function createInjector(modulesToLoad) {
           }));
 
 
-  forEach(loadModules(modulesToLoad), function(fn) { instanceInjector.invoke(fn || noop); });
+  forEach(loadModules(modulesToLoad), function(fn) {
+    fn = fn || noop;
+    if(!angular.isFunction(fn)) {
+      fn = noop;
+    }
+    instanceInjector.invoke(fn);
+  });
 
   return instanceInjector;
 

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -823,6 +823,15 @@ describe('ngMock', function() {
           expect(log).toEqual('module');
         });
       });
+
+      describe('returning a value', function() {
+        it('should ignore returned value if it is not a function', function() {
+          module(function(){
+            return {}
+          });
+          inject();
+        })
+      });
     });
 
     describe('inject', function() {


### PR DESCRIPTION
Fixes the following issue https://groups.google.com/forum/#!topic/angular/gCGF_B4eQkc
I understand it's partially coffee script related. But if the return value is not used anyway I don't see a reason to not just ignore it and replace invoke with noop function call if it's not a function. 
