### PR TITLE
fix($scope): fix when calling the $on remove function twice

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -884,11 +884,12 @@ function $RootScopeProvider(){
        * @returns {function()} Returns a deregistration function for this listener.
        */
       $on: function(name, listener) {
-        var namedListeners = this.$$listeners[name];
+        var namedListeners = this.$$listeners[name],
+          listenerWrap = {listener: listener};
         if (!namedListeners) {
           this.$$listeners[name] = namedListeners = [];
         }
-        namedListeners.push(listener);
+        namedListeners.push(listenerWrap);
 
         var current = this;
         do {
@@ -900,8 +901,11 @@ function $RootScopeProvider(){
 
         var self = this;
         return function() {
-          namedListeners[indexOf(namedListeners, listener)] = null;
-          decrementListenerCount(self, 1, name);
+          var idx = indexOf(namedListeners, listenerWrap);
+          if (idx >= 0) {
+            namedListeners[idx] = null;
+            decrementListenerCount(self, 1, name);
+          }
         };
       },
 
@@ -960,7 +964,7 @@ function $RootScopeProvider(){
             }
             try {
               //allow all listeners attached to the current scope to run
-              namedListeners[i].apply(null, listenerArgs);
+              namedListeners[i].listener.apply(null, listenerArgs);
             } catch (e) {
               $exceptionHandler(e);
             }
@@ -1026,7 +1030,7 @@ function $RootScopeProvider(){
             }
 
             try {
-              listeners[i].apply(null, listenerArgs);
+              listeners[i].listener.apply(null, listenerArgs);
             } catch(e) {
               $exceptionHandler(e);
             }

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1239,6 +1239,24 @@ describe('Scope', function() {
         }));
 
 
+        it('should not decrement twice if the deregistration function is called twice', inject(function($rootScope) {
+          var spy = jasmine.createSpy(),
+            child = $rootScope.$new(),
+            listenerRemove1,
+            listenerRemove2;
+
+          listenerRemove1 = child.$on('abc', spy);
+          listenerRemove2 = child.$on('abc', spy);
+
+          expect($rootScope.$$listenerCount['abc']).toBe(2);
+          listenerRemove1();
+          expect($rootScope.$$listenerCount['abc']).toBe(1);
+          listenerRemove1();
+          expect($rootScope.$$listenerCount['abc']).toBe(1);
+          listenerRemove2();
+          expect($rootScope.$$listenerCount['abc']).toBeUndefined();
+        }));
+
         it('should decrement ancestor $$listenerCount entries', inject(function($rootScope) {
           var child1 = $rootScope.$new(),
               child2 = child1.$new(),


### PR DESCRIPTION
When calling twice the remove function returned from $on, remove the listener once
