### PR TITLE
docs($location): fix link to $rootScope.Scope.$on

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -574,7 +574,7 @@ function $LocationProvider(){
    * @eventType broadcast on root scope
    * @description
    * Broadcasted before a URL will change. This change can be prevented by calling
-   * `preventDefault` method of the event. See {@link ng.$rootScope.Scope#$on} for more
+   * `preventDefault` method of the event. See {@link ng.$rootScope.Scope#methods_$on} for more
    * details about event object. Upon successful change
    * {@link ng.$location#events_$locationChangeSuccess $locationChangeSuccess} is fired.
    *


### PR DESCRIPTION
Previously missing the methods_ prefix.
