### PR TITLE
docs(all): fix @requires directive to support other ng modules

### DIFF
--- a/docs/src/ngdoc.js
+++ b/docs/src/ngdoc.js
@@ -592,7 +592,14 @@ Doc.prototype = {
       }
       dom.h('Dependencies', self.requires, function(require){
         dom.tag('code', function() {
-          dom.tag('a', {href: 'api/ng.' + require.name}, require.name);
+          var name = require.name;
+          var module = name.substr(0, name.indexOf('.'));
+          if (module !== 'AUTO' && module.indexOf('ng') !== 0) {
+            module = 'ng';
+          } else if (module) {
+            name = name.substr(module.length + 1);
+          }
+          dom.tag('a', {href: 'api/' + module + '.' + name}, name);
         });
         dom.html(require.text);
       });

--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -39,7 +39,7 @@ function $ControllerProvider() {
     /**
      * @ngdoc function
      * @name ng.$controller
-     * @requires $injector
+     * @requires AUTO.$injector
      *
      * @param {Function|string} constructor If called with a function then it's considered to be the
      *    controller constructor function. Otherwise it's considered to be a string which is used

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -178,7 +178,7 @@ function $HttpProvider() {
      * @requires $cacheFactory
      * @requires $rootScope
      * @requires $q
-     * @requires $injector
+     * @requires AUTO.$injector
      *
      * @description
      * The `$http` service is a core Angular service that facilitates communication with the remote


### PR DESCRIPTION
This change is necessary to fix the link to $injector in the $controller
documentation.
