### PR TITLE
Issue #5811 - Install node.js dependencies: fails

### DIFF
--- a/docs/content/misc/contribute.ngdoc
+++ b/docs/content/misc/contribute.ngdoc
@@ -87,6 +87,16 @@ grunt package
 Administrator). This is because `grunt package` creates some symbolic links.
 </div>
 
+<div class="alert alert-warning">
+**Note:** If you're using Linux, and npm install fails with the message 
+'Please try running this command again as root/Administrator.', you may need to globally install grunt and bower:
+<ul>
+<li>sudo npm install -g grunt-cli</li>
+<li>sudo npm install -g bower</li>
+</ul>
+
+</div>
+
 The build output can be located under the `build` directory. It consists of the following files and
 directories:
 


### PR DESCRIPTION
I found this issue in Linux Mint 16 Cinnamon 64bit
