### PR TITLE
Rename controller suffix in ngView example: Cntl -> Ctrl

### DIFF
--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -38,7 +38,7 @@ ngRouteModule.directive('ngView', ngViewFillContentFactory);
  * @example
     <example module="ngViewExample" deps="angular-route.js" animations="true">
       <file name="index.html">
-        <div ng-controller="MainCntl as main">
+        <div ng-controller="MainCtrl as main">
           Choose:
           <a href="Book/Moby">Moby</a> |
           <a href="Book/Moby/ch/1">Moby: Ch1</a> |
@@ -121,12 +121,12 @@ ngRouteModule.directive('ngView', ngViewFillContentFactory);
           function($routeProvider, $locationProvider) {
             $routeProvider.when('/Book/:bookId', {
               templateUrl: 'book.html',
-              controller: BookCntl,
+              controller: BookCtrl,
               controllerAs: 'book'
             });
             $routeProvider.when('/Book/:bookId/ch/:chapterId', {
               templateUrl: 'chapter.html',
-              controller: ChapterCntl,
+              controller: ChapterCtrl,
               controllerAs: 'chapter'
             });
 
@@ -134,19 +134,19 @@ ngRouteModule.directive('ngView', ngViewFillContentFactory);
             $locationProvider.html5Mode(true);
         });
 
-        function MainCntl($route, $routeParams, $location) {
+        function MainCtrl($route, $routeParams, $location) {
           this.$route = $route;
           this.$location = $location;
           this.$routeParams = $routeParams;
         }
 
-        function BookCntl($routeParams) {
-          this.name = "BookCntl";
+        function BookCtrl($routeParams) {
+          this.name = "BookCtrl";
           this.params = $routeParams;
         }
 
-        function ChapterCntl($routeParams) {
-          this.name = "ChapterCntl";
+        function ChapterCtrl($routeParams) {
+          this.name = "ChapterCtrl";
           this.params = $routeParams;
         }
       </file>
@@ -155,13 +155,13 @@ ngRouteModule.directive('ngView', ngViewFillContentFactory);
         it('should load and compile correct template', function() {
           element('a:contains("Moby: Ch1")').click();
           var content = element('.doc-example-live [ng-view]').text();
-          expect(content).toMatch(/controller\: ChapterCntl/);
+          expect(content).toMatch(/controller\: ChapterCtrl/);
           expect(content).toMatch(/Book Id\: Moby/);
           expect(content).toMatch(/Chapter Id\: 1/);
 
           element('a:contains("Scarlet")').click();
           content = element('.doc-example-live [ng-view]').text();
-          expect(content).toMatch(/controller\: BookCntl/);
+          expect(content).toMatch(/controller\: BookCtrl/);
           expect(content).toMatch(/Book Id\: Scarlet/);
         });
       </file>


### PR DESCRIPTION
- According to
  https://github.com/angular/angular.js/blob/5bf81bc111a866ec65ef86c01336911e577df5df/docs/content/guide/controller.ngdoc#L166
  Ctrl should be the suffix for a controller
