### PR TITLE
fix(ngSanitize): removed encoding of non alphanumeric on textContent

### DIFF
--- a/src/ngSanitize/filter/linky.js
+++ b/src/ngSanitize/filter/linky.js
@@ -70,10 +70,10 @@
      <doc:scenario>
        it('should linkify the snippet with urls', function() {
          expect(using('#linky-filter').binding('snippet | linky')).
-           toBe('Pretty text with some links:&#10;' +
-                '<a href="http://angularjs.org/">http://angularjs.org/</a>,&#10;' +
-                '<a href="mailto:us@somewhere.org">us@somewhere.org</a>,&#10;' +
-                '<a href="mailto:another@somewhere.org">another@somewhere.org</a>,&#10;' +
+           toBe('Pretty text with some links:\n' +
+                '<a href="http://angularjs.org/">http://angularjs.org/</a>,\n' +
+                '<a href="mailto:us@somewhere.org">us@somewhere.org</a>,\n' +
+                '<a href="mailto:another@somewhere.org">another@somewhere.org</a>,\n' +
                 'and one more: <a href="ftp://127.0.0.1/">ftp://127.0.0.1/</a>.');
        });
 

--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -395,14 +395,16 @@ function decodeEntities(value) {
  * @param value
  * @returns escaped text
  */
-function encodeEntities(value) {
-  return value.
-    replace(/&/g, '&amp;').
-    replace(NON_ALPHANUMERIC_REGEXP, function(value){
+function encodeEntities(value, replace_non_alphanumeric) {
+  value = value.replace(/&/g, '&amp;');
+
+  if(replace_non_alphanumeric) {
+    value = value.replace(NON_ALPHANUMERIC_REGEXP, function(value){
       return '&#' + value.charCodeAt(0) + ';';
-    }).
-    replace(/</g, '&lt;').
-    replace(/>/g, '&gt;');
+    });
+  }
+
+  return value.replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 /**
@@ -435,7 +437,7 @@ function htmlSanitizeWriter(buf, uriValidator){
             out(' ');
             out(key);
             out('="');
-            out(encodeEntities(value));
+            out(encodeEntities(value, true));
             out('"');
           }
         });
@@ -455,7 +457,7 @@ function htmlSanitizeWriter(buf, uriValidator){
       },
     chars: function(chars){
         if (!ignore) {
-          out(encodeEntities(chars));
+          out(encodeEntities(chars, false));
         }
       }
   };

--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -160,7 +160,7 @@ describe('HTML', function() {
 
   it('should handle entities', function() {
     var everything = '<div rel="!@#$%^&amp;*()_+-={}[]:&#34;;\'&lt;&gt;?,./`~ &#295;">' +
-    '!@#$%^&amp;*()_+-={}[]:&#34;;\'&lt;&gt;?,./`~ &#295;</div>';
+    '!@#$%^&amp;*()_+-={}[]:";\'&lt;&gt;?,./`~ ħ</div>';
     expectHTML(everything).toEqual(everything);
   });
 
@@ -191,7 +191,7 @@ describe('HTML', function() {
   });
 
   it('should allow multiline strings', function() {
-    expectHTML('\na\n').toEqual('&#10;a\&#10;');
+    expectHTML('\na\n').toEqual('\na\n');
   });
 
   describe('htmlSanitizerWriter', function() {


### PR DESCRIPTION
This is a fix for issue #5088.
I still let the chars be replaced inside attributes, but now are allowed inside textContent. This could be fixed also, but i dont know how safe this is...
