### PR TITLE
feat(ngFilter): Ordinal number suffixes

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -232,6 +232,13 @@ function ampmGetter(date, formats) {
   return date.getHours() < 12 ? formats.AMPMS[0] : formats.AMPMS[1];
 }
 
+function ordinalDateGetter (date) {
+  var ordinals = 'st nd rd th'.split(' ')
+    , d = date.getDate() - 1
+    , i = d > 3 ? 3 : d;
+  return ordinals[i];
+}
+
 var DATE_FORMATS = {
   yyyy: dateGetter('FullYear', 4),
     yy: dateGetter('FullYear', 2, 0, true),
@@ -248,6 +255,7 @@ var DATE_FORMATS = {
      h: dateGetter('Hours', 1, -12),
     mm: dateGetter('Minutes', 2),
      m: dateGetter('Minutes', 1),
+     o: ordinalDateGetter,
     ss: dateGetter('Seconds', 2),
      s: dateGetter('Seconds', 1),
      // while ISO 8601 requires fractions to be prefixed with `.` or `,`
@@ -259,7 +267,7 @@ var DATE_FORMATS = {
      Z: timeZoneGetter
 };
 
-var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|Z))(.*)/,
+var DATE_FORMATS_SPLIT = /((?:[^yMdHhmosaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|o+|s+|a|Z))(.*)/,
     NUMBER_STRING = /^\-?\d+$/;
 
 /**
@@ -289,6 +297,7 @@ var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZE']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+
  *   * `'h'`: Hour in am/pm, (1-12)
  *   * `'mm'`: Minute in hour, padded (00-59)
  *   * `'m'`: Minute in hour (0-59)
+ *   * `'o'`: Ordinal suffix for day in month (st, nd, rd, th)
  *   * `'ss'`: Second in minute, padded (00-59)
  *   * `'s'`: Second in minute (0-59)
  *   * `'.sss' or ',sss'`: Millisecond in second, padded (000-999)

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -233,10 +233,9 @@ function ampmGetter(date, formats) {
 }
 
 function ordinalDateGetter (date) {
-  var ordinals = 'st nd rd th'.split(' ')
-    , d = date.getDate() - 1
-    , i = d > 3 ? 3 : d;
-  return ordinals[i];
+  var ordinals = 'st nd rd th'.split(' ');
+  var d = date.getDate() - 1;
+  return ordinals[d > 3 ? 3 : d];
 }
 
 var DATE_FORMATS = {

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -244,6 +244,24 @@ describe('filters', function() {
 
       expect(date(earlyDate, "MMMM dd, y")).
                       toEqual('September 03, 1');
+
+      expect(date(noon, "EEE, MMM do, yyyy")).
+                      toEqual('Fri, Sep 3rd, 2010');
+
+      var expectedDates = [
+        'Wed, Sep 1st, 2010',
+        'Thu, Sep 2nd, 2010',
+        'Fri, Sep 3rd, 2010',
+        'Sat, Sep 4rd, 2010'
+      ];
+
+      for (var ordinalDate, expectedDate, i = 1; i < 4; ++i) {
+        ordinalDate = new angular.mock.TzDate(+5, '2010-09-0'+i+'T17:05:08.012Z');
+        expectedDate = expectedDates[i-1];
+        expect(date(ordinalDate, "EEE, MMM do, yyyy")).
+                        toEqual(expectedDate);
+      }
+
     });
 
     it('should accept negative numbers as strings', function() {


### PR DESCRIPTION
Allows to use "o" for the ordinal number suffix of the current month's day, e.g.:

"EEE, MMM do, yyyy" would be formatted to Thu, Sep 2nd, 2010
