### PR TITLE
feat(angular) - add optional deep extend

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -318,21 +318,41 @@ function setHashKey(obj, h) {
  * Extends the destination object `dst` by copying all of the properties from the `src` object(s)
  * to `dst`. You can specify multiple `src` objects.
  *
+ * - `extend(dst, src)` will default to a shallow extension of the `dst` object or array.
+ * - `extend(deep, dst, src)` will do a "deep" extension of the `dst` object if `deep` is `true`
+ *
+ * @param {Boolean} deep Optional, defaults to `false`. Determines whether extension recursively extends properties.
  * @param {Object} dst Destination object.
  * @param {...Object} src Source object(s).
  * @returns {Object} Reference to `dst`.
  */
 function extend(dst) {
-  var h = dst.$$hashKey;
-  forEach(arguments, function(obj){
-    if (obj !== dst) {
-      forEach(obj, function(value, key){
-        dst[key] = value;
-      });
-    }
+  var deep = false,
+      srcStart = 1,
+      src, h;
+
+  if(isBoolean(dst)) {
+    deep = dst;
+    dst = arguments[1];
+    srcStart = 2;
+  }
+
+  src = [].slice.call(arguments, srcStart);
+  h = dst.$$hashKey;
+
+  forEach(src, function(obj) {
+    forEach(obj, function(value, key) {
+      if(obj !== src) {
+        if(deep && isObject(value)) {
+          extend(deep, dst[key], value);
+        } else {
+          dst[key] = value;
+        }
+      }
+    });
   });
 
-  setHashKey(dst,h);
+  setHashKey(dst, h);
   return dst;
 }
 

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -180,6 +180,73 @@ describe('angular', function() {
       // make sure we retain the old key
       expect(hashKey(dst)).toEqual(h);
     });
+
+    it('should do shallow extensions', function (){
+      var src, dst, h;
+      src = {
+        alter: 'from source',
+        brandnew: 'from source',
+        child: {
+          brandnew: 'from source'
+        }
+      };
+      dst = {
+        alter: 'from destination',
+        untouched: 'from destination',
+        child: {
+          untouched: 'from destination'
+        }
+      };
+      h = hashKey(dst);
+
+      extend(dst, src);
+
+      expect(dst.alter).toBe('from source');
+      expect(dst.brandnew).toBe('from source');
+      expect(dst.untouched).toBe('from destination');
+
+      //same reference because it's a shallow extend
+      expect(dst.child).toBe(src.child);
+
+      // make sure we retain the old key
+      expect(hashKey(dst)).toEqual(h);
+    });
+
+    it('should do deep extensions', function(){
+      var src, dst, h;
+      src = {
+        alter: 'from source',
+        brandnew: 'from source',
+        child: {
+          alter: 'from source',
+          brandnew: 'from source'
+        }
+      };
+      dst = {
+        alter: 'from destination',
+        untouched: 'from destination',
+        child: {
+          alter: 'from destination',
+          untouched: 'from destination'
+        }
+      };
+      h = hashKey(dst);
+
+      extend(true, dst, src);
+
+      expect(dst.alter).toBe('from source');
+      expect(dst.brandnew).toBe('from source');
+      expect(dst.untouched).toBe('from destination');
+
+      // NOT same reference because it's a deep extend
+      expect(dst.child).not.toBe(src.child);
+      expect(dst.child.untouched).toBe('from destination');
+      expect(dst.child.brandnew).toBe('from source');
+      expect(dst.child.alter).toBe('from source');
+
+      // make sure we retain the old key
+      expect(hashKey(dst)).toEqual(h);
+    });
   });
 
   describe('shallow copy', function() {


### PR DESCRIPTION
Add optional deep extend that mirrors existing implementations (jQuery)
Add unit tests to test shallow and deep extensions of objects

Created to address issue #5842
