### PR TITLE
fix(orderBy): support sorting by value

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -87,8 +87,8 @@ orderByFilter.$inject = ['$parse'];
 function orderByFilter($parse){
   return function(array, sortPredicate, reverseOrder) {
     if (!isArray(array)) return array;
-    if (!sortPredicate || sortPredicate == '+') return array.sort();
-    if (sortPredicate == '-') return array.sort().reverse();
+    if (!sortPredicate || sortPredicate == '+') return angular.copy(array).sort();
+    if (sortPredicate == '-') return angular.copy(array).sort().reverse();
     sortPredicate = isArray(sortPredicate) ? sortPredicate: [sortPredicate];
     sortPredicate = map(sortPredicate, function(predicate){
       var descending = false, get = predicate || identity;

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -87,7 +87,8 @@ orderByFilter.$inject = ['$parse'];
 function orderByFilter($parse){
   return function(array, sortPredicate, reverseOrder) {
     if (!isArray(array)) return array;
-    if (!sortPredicate) return array;
+    if (!sortPredicate || sortPredicate == '+') return array.sort();
+    if (sortPredicate == '-') return array.sort().reverse();
     sortPredicate = isArray(sortPredicate) ? sortPredicate: [sortPredicate];
     sortPredicate = map(sortPredicate, function(predicate){
       var descending = false, get = predicate || identity;

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -6,9 +6,8 @@ describe('Filter: orderBy', function() {
     orderBy = $filter('orderBy');
   }));
 
-  it('should return same array if predicate is falsy', function() {
-    var array = [1, 2, 3];
-    expect(orderBy(array)).toBe(array);
+  it('should return sorted array if predicate is falsy', function() {
+    expect(orderBy([2, 1, 3])).toEqual([1, 2, 3]);
   });
 
   it('shouldSortArrayInReverse', function() {
@@ -18,6 +17,9 @@ describe('Filter: orderBy', function() {
   });
 
   it('should sort array by predicate', function() {
+    expect(orderBy([2, 1, 3], '+')).toEqualData([1, 2, 3]);
+    expect(orderBy([2, 1, 3], '-')).toEqualData([3, 2, 1]);
+
     expect(orderBy([{a:15, b:1}, {a:2, b:1}], ['a', 'b'])).toEqualData([{a:2, b:1}, {a:15, b:1}]);
     expect(orderBy([{a:15, b:1}, {a:2, b:1}], ['b', 'a'])).toEqualData([{a:2, b:1}, {a:15, b:1}]);
     expect(orderBy([{a:15, b:1}, {a:2, b:1}], ['+b', '-a'])).toEqualData([{a:15, b:1}, {a:2, b:1}]);


### PR DESCRIPTION
Fixes issue #4579, adding support for:

`<p ng-repeat="item in items | orderBy">{{item}}</p>`
`<p ng-repeat="item in items | orderBy:'+'">{{item}}</p>`
`<p ng-repeat="item in items | orderBy:'-'">{{item}}</p>`

It seems unnecessary and redundant in this particular scenario to support the `reverseOrder` parameter and taking `sortPredicate` as an array, so they are ignored (i.e. the following):

`<p ng-repeat="item in items | orderBy:'+':false">{{item}}</p>`
`<p ng-repeat="item in items | orderBy:['+']">{{item}}</p>`
