### PR TITLE
docs(api): adds links to top level guides

### DIFF
--- a/docs/content/api/index.ngdoc
+++ b/docs/content/api/index.ngdoc
@@ -5,8 +5,8 @@
 # AngularJS API Docs
 Welcome to the AngularJS API docs page. These pages contain the AngularJS reference materials for version <strong ng-bind="version"></strong>.
 
-The documentation is organized into **modules** which contain various components of an AngularJS application.
-These components are directives, services, filters, providers, types, global APIs and testing mocks.
+The documentation is organized into **{@link guide/module modules}** which contain various components of an AngularJS application.
+These components are {@link guide/directive directives}, {@link guide/dev_guide.services services}, {@link guide/filter filters}, {@link guide/providers providers}, {@link guide/templates types}, global APIs and testing mocks.
 
 <div class="alert alert-info">
 **Angular Namespaces `$` and `$$`**


### PR DESCRIPTION
The main api docs page is probably the main landing page for many devs
looking to learn angular, so linking to the main guide pages would
likely help.
