### PR TITLE
docs(devguide.services): Use $log service properly

### DIFF
--- a/docs/content/guide/dev_guide.services.managing_dependencies.ngdoc
+++ b/docs/content/guide/dev_guide.services.managing_dependencies.ngdoc
@@ -55,7 +55,7 @@ of which depend on other services that are provided by the Angular framework:
 
       function log() {
         if (messageQueue.length) {
-          $log('batchLog messages: ', messageQueue);
+          $log.log('batchLog messages: ', messageQueue);
           messageQueue = [];
         }
       }


### PR DESCRIPTION
Need to call one of the logging functions exposed by the `$log` service.

Even though the example isn't focused on how the `$log` service works, most people reading the document will be new to angular, so they should be exposed to proper use of common services.
