### PR TITLE
docs(ngInit): fix declaring ng-init as attribute

### DIFF
--- a/src/ng/directive/ngInit.js
+++ b/src/ng/directive/ngInit.js
@@ -19,7 +19,7 @@
  * **Note**: If you have assignment in `ngInit` along with {@link api/ng.$filter `$filter`}, make
  * sure you have parenthesis for correct precedence:
  * <pre class="prettyprint">
- *   <ng-init="test1 = (data | orderBy:'name')">
+ *   <div ng-init="test1 = (data | orderBy:'name')"></div>
  * </pre>
  * </div>
  *


### PR DESCRIPTION
As discussed in https://github.com/angular/angular.js/commit/42ec95ebae716c81087684b55ed8fa8c13888abc
