### PR TITLE
fix($http): add the PATCH shortcut back

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -869,7 +869,21 @@ function $HttpProvider() {
      * @param {Object=} config Optional configuration object
      * @returns {HttpPromise} Future object
      */
-    createShortMethodsWithData('post', 'put');
+
+     /**
+      * @ngdoc method
+      * @name ng.$http#patch
+      * @methodOf ng.$http
+      *
+      * @description
+      * Shortcut method to perform `PATCH` request.
+      *
+      * @param {string} url Relative or absolute URL specifying the destination of the request
+      * @param {*} data Request content
+      * @param {Object=} config Optional configuration object
+      * @returns {HttpPromise} Future object
+      */
+    createShortMethodsWithData('post', 'put', 'patch');
 
         /**
          * @ngdoc property

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -897,6 +897,15 @@ describe('$http', function() {
         $http.put('/url', 'some-data', {headers: {'Custom': 'Header'}});
       });
 
+      it('should have patch()', function(){
+        $httpBackend.expect('PATCH', '/url', 'some-data').respond('');
+        $http.patch('/url', 'some-data');
+      });
+
+      it('patch() should allow config param', function() {
+        $httpBackend.expect('PATCH', '/url', 'some-data', checkHeader('Custom', 'Header')).respond('');
+        $http.patch('/url', 'some-data', {headers: {'Custom': 'Header'}});
+      });
 
       it('should have jsonp()', function() {
         $httpBackend.expect('JSONP', '/url').respond('');


### PR DESCRIPTION
The shortcut was dropped because it had a lot of unkowns about PATCH.
Since we already know that using PATCH is good (http://www.mnot.net/blog/2012/09/05/patch), and only IE8 has issues with that, let's add the shortcut back.

Closes #5823
