### PR TITLE
fix($interval): call fn even if invokeApply is false

### DIFF
--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -143,7 +143,11 @@ function $IntervalProvider() {
       promise.then(null, null, fn);
 
       promise.$$intervalId = setInterval(function tick() {
-        deferred.notify(iteration++);
+        if (!skipApply) {
+          deferred.notify(iteration++);
+        } else {
+          fn(iteration++);
+        }
 
         if (count > 0 && iteration >= count) {
           deferred.resolve(iteration);

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -472,7 +472,11 @@ angular.mock.$IntervalProvider = function() {
       promise.$$intervalId = nextRepeatId;
 
       function tick() {
-        deferred.notify(iteration++);
+        if (!skipApply) {
+          deferred.notify(iteration++);
+        } else {
+          fn(iteration++);
+        }
 
         if (count > 0 && iteration >= count) {
           var fnIndex;

--- a/test/ng/intervalSpec.js
+++ b/test/ng/intervalSpec.js
@@ -97,6 +97,24 @@ describe('$interval', function() {
   }));
 
 
+  it('should still call the interval fn if invokeApply is false',
+      inject(function($interval, $rootScope, $window) {
+    var spy = jasmine.createSpy('invokeApply = false');
+
+    $interval(spy, 100, 0, false);
+    expect(spy).not.toHaveBeenCalled();
+
+    $window.flush(100);
+    expect(spy).toHaveBeenCalled();
+
+    $window.flush(100);
+    expect(spy.callCount).toBe(2);
+
+    $window.flush(100);
+    expect(spy.callCount).toBe(3);
+  }));
+
+
   it('should allow you to specify the delay time', inject(function($interval, $window) {
     var counter = 0;
     $interval(function() { counter++; }, 123);

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -367,6 +367,20 @@ describe('ngMock', function() {
         expect(counterA).toEqual(4);
         expect(counterB).toEqual(1);
       }));
+
+      it('should work if invokeApply is set to false', inject(function($interval) {
+        var counter = 0;
+        $interval(function() { counter++; }, 100, 0, false);
+
+        $interval.flush(100);
+        expect(counter).toBe(1);
+
+        $interval.flush(100);
+        expect(counter).toBe(2);
+
+        $interval.flush(100);
+        expect(counter).toBe(3);
+      }));
     });
 
 


### PR DESCRIPTION
Becasue calling the interval function relies on a promise notify
handler, the interval function would not get called without 
invokeApply being true. With this update, if invokeApply is false, the
function is called normally.

Closes #5902
