### PR TITLE
Use exposed equals inside watch and equals

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -820,7 +820,7 @@ function equals(o1, o2) {
         if (!isArray(o2)) return false;
         if ((length = o1.length) == o2.length) {
           for(key=0; key<length; key++) {
-            if (!equals(o1[key], o2[key])) return false;
+            if (!this.equals(o1[key], o2[key])) return false;
           }
           return true;
         }
@@ -833,7 +833,7 @@ function equals(o1, o2) {
         keySet = {};
         for(key in o1) {
           if (key.charAt(0) === '$' || isFunction(o1[key])) continue;
-          if (!equals(o1[key], o2[key])) return false;
+          if (!this.equals(o1[key], o2[key])) return false;
           keySet[key] = true;
         }
         for(key in o2) {

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -820,7 +820,7 @@ function equals(o1, o2) {
         if (!isArray(o2)) return false;
         if ((length = o1.length) == o2.length) {
           for(key=0; key<length; key++) {
-            if (!this.equals(o1[key], o2[key])) return false;
+            if (!angular.equals(o1[key], o2[key])) return false;
           }
           return true;
         }
@@ -833,7 +833,7 @@ function equals(o1, o2) {
         keySet = {};
         for(key in o1) {
           if (key.charAt(0) === '$' || isFunction(o1[key])) continue;
-          if (!this.equals(o1[key], o2[key])) return false;
+          if (!angular.equals(o1[key], o2[key])) return false;
           keySet[key] = true;
         }
         for(key in o2) {

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1427,7 +1427,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 }
                 parentGet = $parse(attrs[attrName]);
                 if (parentGet.literal) {
-                  compare = equals;
+                  compare = angular.equals;
                 } else {
                   compare = function(a,b) { return a === b; };
                 }

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -589,7 +589,7 @@ function $RootScopeProvider(){
                   if (watch) {
                     if ((value = watch.get(current)) !== (last = watch.last) &&
                         !(watch.eq
-                            ? equals(value, last)
+                            ? angular.equals(value, last)
                             : (typeof value == 'number' && typeof last == 'number'
                                && isNaN(value) && isNaN(last)))) {
                       dirty = true;


### PR DESCRIPTION
This will allow using the proxy pattern for providing better equals implementation for specific cases

very good when you use an existing widget that performs watch on some property that you can provide a faster way to equal check it but you want to do it without changing the widget code
