### PR TITLE
fix(ngRoute): pipe preceding route param no longer masks ? or * operator

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -185,7 +185,7 @@ function $RouteProvider(){
 
     path = path
       .replace(/([().])/g, '\\$1')
-      .replace(/(\/)?:(\w+)([\?|\*])?/g, function(_, slash, key, option){
+      .replace(/(\/)?:(\w+)([\?\*])?/g, function(_, slash, key, option){
         var optional = option === '?' ? option : null;
         var star = option === '*' ? option : null;
         keys.push({ name: key, optional: !!optional });


### PR DESCRIPTION
Before this change,

``` js
$routeProvider.when('/foo/:bar|?', { ... });
```

would not have the expected effect --- the parameter would not be optional, and the pipe would not be included in the parameter name.

Following this change, the presence of the pipe operator will typically cause an exception to be thrown due to the fact that the generated regexp is invalid.

The net result of this change is that ? and \* operators will not be masked, and pipe operators will need to be removed, although it's unexpected that these are being used anywhere.
