### PR TITLE
Added support for route parameter regular expression constraints

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -185,7 +185,7 @@ function $RouteProvider(){
 
     path = path
       .replace(/([().])/g, '\\$1')
-      .replace(/(\/)?:(\w+)([\?\*])?/g, function(_, slash, key, option){
+      .replace(/(\/)?:(\w+)(?::([^\/]+))?([?*])?/g, function (_, slash, key, rxconstraint, option) {
         var optional = option === '?' ? option : null;
         var star = option === '*' ? option : null;
         keys.push({ name: key, optional: !!optional });
@@ -194,7 +194,7 @@ function $RouteProvider(){
           + (optional ? '' : slash)
           + '(?:'
           + (optional ? slash : '')
-          + (star && '(.+?)' || '([^/]+)')
+          + (star && '(.+?)' || rxconstraint && ('(' + rxconstraint + ')') || '([^/]+)')
           + (optional || '')
           + ')'
           + (optional || '');


### PR DESCRIPTION
Adds support for route parameters with regular expression constraints:

```
/route/:parameter:regex/continued
```

This makes it possible to create two seemingly similar but different routes i.e.

```
/user/:id:\\d+/:name?
/user/:name:[a-z]+
```

Where parameter `:id` has numeric regular expression constraint and `:name` in second route has a letter constraint. Double backslash has to be used because single one is stripped out by Javascript as it's an escape character and since "d" doesn't need escaping, it gets stripped out. We have to use double to preserve single backslashes.

Route constraints work as follows:
1. parameters with constraints can't be optional or greedy
2. constraint regular expression can't have capture groups as all "(" and ")" are being escaped anyway (existing functionality)
3. regular expressions can't have forward slashes ("/") in them as they're route segment delimiters
