### PR TITLE
fix(input): use Chromium's email validation regexp

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -9,7 +9,7 @@
 */
 
 var URL_REGEXP = /^(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/;
-var EMAIL_REGEXP = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}$/;
+var EMAIL_REGEXP = /^[a-z0-9!#$%&'*+/=?^_`{|}~.-]+@[a-z0-9-]+(\.[a-z0-9-]+)*$/i;
 var NUMBER_REGEXP = /^\s*(\-|\+)?(\d+|(\d*(\.\d*)))\s*$/;
 
 var inputType = {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -944,7 +944,8 @@ describe('input', function() {
       it('should validate email', function() {
         expect(EMAIL_REGEXP.test('a@b.com')).toBe(true);
         expect(EMAIL_REGEXP.test('a@b.museum')).toBe(true);
-        expect(EMAIL_REGEXP.test('a@B.c')).toBe(false);
+        expect(EMAIL_REGEXP.test('a@B.c')).toBe(true);
+        expect(EMAIL_REGEXP.test('a@.b.c')).toBe(false);
       });
     });
   });


### PR DESCRIPTION
This change uses the regexp from Chromium/Blink to validate emails, and corrects an error in the validation engine, which previously considered an invalid email to be valid. Additionally, the regexp was invalidating emails with capital letters, however this is not the behaviour recomended in the spec, or implemented in Chromium.

(The regexp can be seen in Blink at https://github.com/mirrors/blink/blob/9d8fc44892f633b1448d0daa638969ffac497bc4/Source/core/html/forms/EmailInputType.cpp#L45-L48)
Closes #5899
