### PR TITLE
fix(ngSelect): Support static options on multi-select drop down

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -477,14 +477,12 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
               selected: selected                   // determine if we should be selected
             });
           }
-          if (!multiple) {
-            if (nullOption || modelValue === null) {
-              // insert null option if we have a placeholder, or the model is null
-              optionGroups[''].unshift({id:'', label:'', selected:!selectedSet});
-            } else if (!selectedSet) {
-              // option could not be found, we have to insert the undefined item
-              optionGroups[''].unshift({id:'?', label:'', selected:true});
-            }
+          if (nullOption || modelValue === null) {
+            // insert null option if we have a placeholder, or the model is null
+            optionGroups[''].unshift({id:'', label:'', selected:!selectedSet});
+          } else if (!selectedSet) {
+            // option could not be found, we have to insert the undefined item
+            optionGroups[''].unshift({id:'?', label:'', selected:true});
           }
 
           // Now we need to update the list of DOM nodes to match the optionGroups we computed above

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1148,6 +1148,40 @@ describe('select', function() {
       });
 
 
+      it('should include static option', function() {
+        createMultiSelect('<option value="">Choose One</option>');
+
+        scope.$apply(function() {
+          scope.values = [{name: 'A'}, {name: 'B'}];
+          scope.selected = [];
+        });
+
+        expect(element.find('option').length).toEqual(3);
+        expect(element.find('option')[0].selected).toBeFalsy();
+        expect(element.find('option')[1].selected).toBeFalsy();
+        expect(element.find('option')[2].selected).toBeFalsy();
+
+        scope.$apply(function() {
+          scope.selected.push(scope.values[0]);
+        });
+
+        expect(element.find('option').length).toEqual(3);
+
+        expect(element.find('option')[0].selected).toBeFalsy();
+        expect(element.find('option')[1].selected).toBeTruthy();
+        expect(element.find('option')[2].selected).toBeFalsy();
+
+        scope.$apply(function() {
+          scope.selected.push(scope.values[1]);
+        });
+
+        expect(element.find('option').length).toEqual(3);
+        expect(element.find('option')[0].selected).toBeFalsy();
+        expect(element.find('option')[1].selected).toBeTruthy();
+        expect(element.find('option')[2].selected).toBeTruthy();
+      });
+
+
       it('should update model on change', function() {
         createMultiSelect();
 


### PR DESCRIPTION
Removes a condition where static options are not added as part of render function when multiple attribute is enabled

Closes #4325
