### PR TITLE
Fix the ngMock issue with ngAnimate

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -757,43 +757,29 @@ angular.mock.TzDate = function (offset, timestamp) {
 angular.mock.TzDate.prototype = Date.prototype;
 /* jshint +W101 */
 
-// TODO(matias): remove this IMMEDIATELY once we can properly detect the
-// presence of a registered module
-var animateLoaded;
-try {
-  angular.module('ngAnimate');
-  animateLoaded = true;
-} catch(e) {}
+angular.mock.animate = angular.module('ngAnimateMock', ['ng'])
 
-if(animateLoaded) {
-  angular.module('ngAnimate').config(['$provide', function($provide) {
+  .config(['$provide', function($provide) {
     var reflowQueue = [];
+
     $provide.value('$$animateReflow', function(fn) {
       reflowQueue.push(fn);
       return angular.noop;
     });
-    $provide.decorator('$animate', function($delegate) {
-      $delegate.triggerReflow = function() {
-        if(reflowQueue.length === 0) {
-          throw new Error('No animation reflows present');
-        }
-        angular.forEach(reflowQueue, function(fn) {
-          fn();
-        });
-        reflowQueue = [];
-      };
-      return $delegate;
-    });
-  }]);
-}
 
-angular.mock.animate = angular.module('mock.animate', ['ng'])
-
-  .config(['$provide', function($provide) {
     $provide.decorator('$animate', function($delegate) {
       var animate = {
         queue : [],
         enabled : $delegate.enabled,
+        triggerReflow : function() {
+          if(reflowQueue.length === 0) {
+            throw new Error('No animation reflows present');
+          }
+          angular.forEach(reflowQueue, function(fn) {
+            fn();
+          });
+          reflowQueue = [];
+        }
       };
 
       angular.forEach(['enter','leave','move','addClass','removeClass'], function(method) {

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -790,37 +790,20 @@ if(animateLoaded) {
 angular.mock.animate = angular.module('mock.animate', ['ng'])
 
   .config(['$provide', function($provide) {
-
     $provide.decorator('$animate', function($delegate) {
       var animate = {
         queue : [],
         enabled : $delegate.enabled,
-        flushNext : function(name) {
-          var tick = animate.queue.shift();
-
-          if (!tick) throw new Error('No animation to be flushed');
-          if(tick.method !== name) {
-            throw new Error('The next animation is not "' + name +
-              '", but is "' + tick.method + '"');
-          }
-          tick.fn();
-          return tick;
-        }
       };
 
       angular.forEach(['enter','leave','move','addClass','removeClass'], function(method) {
         animate[method] = function() {
-          var params = arguments;
           animate.queue.push({
-            method : method,
-            params : params,
-            element : angular.isElement(params[0]) && params[0],
-            parent  : angular.isElement(params[1]) && params[1],
-            after   : angular.isElement(params[2]) && params[2],
-            fn : function() {
-              $delegate[method].apply($delegate, params);
-            }
+            event : method,
+            element : arguments[0],
+            args : arguments
           });
+          $delegate[method].apply($delegate, arguments);
         };
       });
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4490,7 +4490,7 @@ describe('$compile', function() {
 
   describe('$animate animation hooks', function() {
 
-    beforeEach(module('mock.animate'));
+    beforeEach(module('ngAnimateMock'));
 
     it('should automatically fire the addClass and removeClass animation hooks',
       inject(function($compile, $animate, $rootScope) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4506,8 +4506,9 @@ describe('$compile', function() {
         $rootScope.val2 = 'rice';
         $rootScope.$digest();
 
-        data = $animate.flushNext('addClass');
-        expect(data.params[1]).toBe('ice rice');
+        data = $animate.queue.shift();
+        expect(data.event).toBe('addClass');
+        expect(data.args[1]).toBe('ice rice');
 
         expect(element.hasClass('ice')).toBe(true);
         expect(element.hasClass('rice')).toBe(true);
@@ -4516,10 +4517,12 @@ describe('$compile', function() {
         $rootScope.val2 = 'dice';
         $rootScope.$digest();
 
-        data = $animate.flushNext('removeClass');
-        expect(data.params[1]).toBe('rice');
-        data = $animate.flushNext('addClass');
-        expect(data.params[1]).toBe('dice');
+        data = $animate.queue.shift();
+        expect(data.event).toBe('removeClass');
+        expect(data.args[1]).toBe('rice');
+        data = $animate.queue.shift();
+        expect(data.event).toBe('addClass');
+        expect(data.args[1]).toBe('dice');
 
         expect(element.hasClass('ice')).toBe(true);
         expect(element.hasClass('dice')).toBe(true);
@@ -4529,8 +4532,9 @@ describe('$compile', function() {
         $rootScope.val2 = '';
         $rootScope.$digest();
 
-        data = $animate.flushNext('removeClass');
-        expect(data.params[1]).toBe('ice dice');
+        data = $animate.queue.shift();
+        expect(data.event).toBe('removeClass');
+        expect(data.args[1]).toBe('ice dice');
 
         expect(element.hasClass('ice')).toBe(false);
         expect(element.hasClass('dice')).toBe(false);

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -309,7 +309,7 @@ describe('ngClass animations', function() {
   var body, element, $rootElement;
 
   it("should avoid calling addClass accidentally when removeClass is going on", function() {
-    module('mock.animate');
+    module('ngAnimateMock');
     inject(function($compile, $rootScope, $animate, $timeout) {
       var element = angular.element('<div ng-class="val"></div>');
       var body = jqLite(document.body);
@@ -416,7 +416,7 @@ describe('ngClass animations', function() {
   });
 
   it("should not remove classes if they're going to be added back right after", function() {
-    module('mock.animate');
+    module('ngAnimateMock');
 
     inject(function($rootScope, $compile, $animate) {
       var className;

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -320,23 +320,23 @@ describe('ngClass animations', function() {
 
       $rootScope.val = 'one';
       $rootScope.$digest();
-      $animate.flushNext('addClass');
+      expect($animate.queue.shift().event).toBe('addClass');
       expect($animate.queue.length).toBe(0);
 
       $rootScope.val = '';
       $rootScope.$digest();
-      $animate.flushNext('removeClass'); //only removeClass is called
+      expect($animate.queue.shift().event).toBe('removeClass'); //only removeClass is called
       expect($animate.queue.length).toBe(0);
 
       $rootScope.val = 'one';
       $rootScope.$digest();
-      $animate.flushNext('addClass');
+      expect($animate.queue.shift().event).toBe('addClass');
       expect($animate.queue.length).toBe(0);
 
       $rootScope.val = 'two';
       $rootScope.$digest();
-      $animate.flushNext('removeClass');
-      $animate.flushNext('addClass');
+      expect($animate.queue.shift().event).toBe('removeClass');
+      expect($animate.queue.shift().event).toBe('addClass');
       expect($animate.queue.length).toBe(0);
     });
   });
@@ -430,16 +430,18 @@ describe('ngClass animations', function() {
       $rootScope.$digest();
 
       //this fires twice due to the class observer firing
-      className = $animate.flushNext('addClass').params[1];
-      expect(className).toBe('one two three');
+      var item = $animate.queue.shift();
+      expect(item.event).toBe('addClass');
+      expect(item.args[1]).toBe('one two three');
 
       expect($animate.queue.length).toBe(0);
 
       $rootScope.three = false;
       $rootScope.$digest();
 
-      className = $animate.flushNext('removeClass').params[1];
-      expect(className).toBe('three');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('removeClass');
+      expect(item.args[1]).toBe('three');
 
       expect($animate.queue.length).toBe(0);
 
@@ -447,11 +449,13 @@ describe('ngClass animations', function() {
       $rootScope.three = true;
       $rootScope.$digest();
 
-      className = $animate.flushNext('removeClass').params[1];
-      expect(className).toBe('two');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('removeClass');
+      expect(item.args[1]).toBe('two');
 
-      className = $animate.flushNext('addClass').params[1];
-      expect(className).toBe('three');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('addClass');
+      expect(item.args[1]).toBe('three');
 
       expect($animate.queue.length).toBe(0);
     });

--- a/test/ng/directive/ngIfSpec.js
+++ b/test/ng/directive/ngIfSpec.js
@@ -245,8 +245,9 @@ describe('ngIf animations', function () {
       $rootScope.$digest();
       $scope.$apply('value = true');
 
-      item = $animate.flushNext('enter').element;
-      expect(item.text()).toBe('Hi');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('enter');
+      expect(item.element.text()).toBe('Hi');
 
       expect(element.children().length).toBe(1);
   }));
@@ -262,14 +263,16 @@ describe('ngIf animations', function () {
       ))($scope);
       $scope.$apply('value = true');
 
-      item = $animate.flushNext('enter').element;
-      expect(item.text()).toBe('Hi');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('enter');
+      expect(item.element.text()).toBe('Hi');
 
-      $scope.$apply('value = false');
       expect(element.children().length).toBe(1);
+      $scope.$apply('value = false');
 
-      item = $animate.flushNext('leave').element;
-      expect(item.text()).toBe('Hi');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('leave');
+      expect(item.element.text()).toBe('Hi');
 
       expect(element.children().length).toBe(0);
   }));

--- a/test/ng/directive/ngIfSpec.js
+++ b/test/ng/directive/ngIfSpec.js
@@ -210,7 +210,7 @@ describe('ngIf animations', function () {
     return element;
   }
 
-  beforeEach(module('mock.animate'));
+  beforeEach(module('ngAnimateMock'));
 
   beforeEach(module(function() {
     // we need to run animation on attached elements;

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -367,7 +367,7 @@ describe('ngInclude', function() {
       });
 
       expect(autoScrollSpy).not.toHaveBeenCalled();
-      $animate.flushNext('enter');
+      expect($animate.queue.shift().event).toBe('enter');
       $timeout.flush();
 
       expect(autoScrollSpy).toHaveBeenCalledOnce();
@@ -384,7 +384,7 @@ describe('ngInclude', function() {
         $rootScope.value = true;
       });
 
-      $animate.flushNext('enter');
+      expect($animate.queue.shift().event).toBe('enter');
       $timeout.flush();
 
       $rootScope.$apply(function () {
@@ -392,8 +392,8 @@ describe('ngInclude', function() {
         $rootScope.value = 'some-string';
       });
 
-      $animate.flushNext('leave');
-      $animate.flushNext('enter');
+      expect($animate.queue.shift().event).toBe('leave');
+      expect($animate.queue.shift().event).toBe('enter');
       $timeout.flush();
 
       $rootScope.$apply(function() {
@@ -401,8 +401,8 @@ describe('ngInclude', function() {
         $rootScope.value = 100;
       });
 
-      $animate.flushNext('leave');
-      $animate.flushNext('enter');
+      expect($animate.queue.shift().event).toBe('leave');
+      expect($animate.queue.shift().event).toBe('enter');
       $timeout.flush();
 
       expect(autoScrollSpy).toHaveBeenCalled();
@@ -418,7 +418,7 @@ describe('ngInclude', function() {
         $rootScope.tpl = 'template.html';
       });
 
-      $animate.flushNext('enter');
+      expect($animate.queue.shift().event).toBe('enter');
       $timeout.flush();
       expect(autoScrollSpy).not.toHaveBeenCalled();
     }));
@@ -434,7 +434,7 @@ describe('ngInclude', function() {
         $rootScope.value = false;
       });
 
-      $animate.flushNext('enter');
+      expect($animate.queue.shift().event).toBe('enter');
       $timeout.flush();
 
       $rootScope.$apply(function () {
@@ -456,7 +456,7 @@ describe('ngInclude', function() {
           expect(autoScrollSpy).not.toHaveBeenCalled();
 
           $rootScope.$apply("tpl = 'template.html'");
-          $animate.flushNext('enter');
+          expect($animate.queue.shift().event).toBe('enter');
           $timeout.flush();
 
           expect(autoScrollSpy).toHaveBeenCalledOnce();
@@ -608,8 +608,9 @@ describe('ngInclude animations', function() {
       ))($rootScope);
       $rootScope.$digest();
 
-      item = $animate.flushNext('enter').element;
-      expect(item.text()).toBe('data');
+      var animation = $animate.queue.pop();
+      expect(animation.event).toBe('enter');
+      expect(animation.element.text()).toBe('data');
   }));
 
   it('should fire off the leave animation',
@@ -624,14 +625,16 @@ describe('ngInclude animations', function() {
       ))($rootScope);
       $rootScope.$digest();
 
-      item = $animate.flushNext('enter').element;
-      expect(item.text()).toBe('data');
+      var animation = $animate.queue.shift();
+      expect(animation.event).toBe('enter');
+      expect(animation.element.text()).toBe('data');
 
       $rootScope.tpl = '';
       $rootScope.$digest();
 
-      item = $animate.flushNext('leave').element;
-      expect(item.text()).toBe('data');
+      animation = $animate.queue.shift();
+      expect(animation.event).toBe('leave');
+      expect(animation.element.text()).toBe('data');
   }));
 
   it('should animate two separate ngInclude elements',
@@ -647,14 +650,14 @@ describe('ngInclude animations', function() {
       ))($rootScope);
       $rootScope.$digest();
 
-      item = $animate.flushNext('enter').element;
-      expect(item.text()).toBe('one');
+      var item1 = $animate.queue.shift().element;
+      expect(item1.text()).toBe('one');
 
       $rootScope.tpl = 'two';
       $rootScope.$digest();
 
-      var itemA = $animate.flushNext('leave').element;
-      var itemB = $animate.flushNext('enter').element;
+      var itemA = $animate.queue.shift().element;
+      var itemB = $animate.queue.shift().element;
       expect(itemA.attr('ng-include')).toBe('tpl');
       expect(itemB.attr('ng-include')).toBe('tpl');
       expect(itemA).not.toEqual(itemB);

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -353,7 +353,7 @@ describe('ngInclude', function() {
       };
     }
 
-    beforeEach(module(spyOnAnchorScroll(), 'mock.animate'));
+    beforeEach(module(spyOnAnchorScroll(), 'ngAnimateMock'));
     beforeEach(inject(
         putIntoCache('template.html', 'CONTENT'),
         putIntoCache('another.html', 'CONTENT')));
@@ -589,7 +589,7 @@ describe('ngInclude animations', function() {
     dealoc(element);
   });
 
-  beforeEach(module('mock.animate'));
+  beforeEach(module('ngAnimateMock'));
 
   afterEach(function(){
     dealoc(element);

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -1182,14 +1182,17 @@ describe('ngRepeat animations', function() {
     $rootScope.items = ['1','2','3'];
     $rootScope.$digest();
 
-    item = $animate.flushNext('enter').element;
-    expect(item.text()).toBe('1');
+    item = $animate.queue.shift();
+    expect(item.event).toBe('enter');
+    expect(item.element.text()).toBe('1');
 
-    item = $animate.flushNext('enter').element;
-    expect(item.text()).toBe('2');
+    item = $animate.queue.shift();
+    expect(item.event).toBe('enter');
+    expect(item.element.text()).toBe('2');
 
-    item = $animate.flushNext('enter').element;
-    expect(item.text()).toBe('3');
+    item = $animate.queue.shift();
+    expect(item.event).toBe('enter');
+    expect(item.element.text()).toBe('3');
   }));
 
   it('should fire off the leave animation',
@@ -1207,20 +1210,24 @@ describe('ngRepeat animations', function() {
     $rootScope.items = ['1','2','3'];
     $rootScope.$digest();
 
-    item = $animate.flushNext('enter').element;
-    expect(item.text()).toBe('1');
+    item = $animate.queue.shift();
+    expect(item.event).toBe('enter');
+    expect(item.element.text()).toBe('1');
 
-    item = $animate.flushNext('enter').element;
-    expect(item.text()).toBe('2');
+    item = $animate.queue.shift();
+    expect(item.event).toBe('enter');
+    expect(item.element.text()).toBe('2');
 
-    item = $animate.flushNext('enter').element;
-    expect(item.text()).toBe('3');
+    item = $animate.queue.shift();
+    expect(item.event).toBe('enter');
+    expect(item.element.text()).toBe('3');
 
     $rootScope.items = ['1','3'];
     $rootScope.$digest();
 
-    item = $animate.flushNext('leave').element;
-    expect(item.text()).toBe('2');
+    item = $animate.queue.shift();
+    expect(item.event).toBe('leave');
+    expect(item.element.text()).toBe('2');
   }));
 
   it('should fire off the move animation',
@@ -1239,23 +1246,28 @@ describe('ngRepeat animations', function() {
       $rootScope.items = ['1','2','3'];
       $rootScope.$digest();
 
-      item = $animate.flushNext('enter').element;
-      expect(item.text()).toBe('1');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('enter');
+      expect(item.element.text()).toBe('1');
 
-      item = $animate.flushNext('enter').element;
-      expect(item.text()).toBe('2');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('enter');
+      expect(item.element.text()).toBe('2');
 
-      item = $animate.flushNext('enter').element;
-      expect(item.text()).toBe('3');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('enter');
+      expect(item.element.text()).toBe('3');
 
       $rootScope.items = ['2','3','1'];
       $rootScope.$digest();
 
-      item = $animate.flushNext('move').element;
-      expect(item.text()).toBe('2');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('move');
+      expect(item.element.text()).toBe('2');
 
-      item = $animate.flushNext('move').element;
-      expect(item.text()).toBe('1');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('move');
+      expect(item.element.text()).toBe('3');
   }));
 
 });

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -1149,7 +1149,7 @@ describe('ngRepeat animations', function() {
     return element;
   }
 
-  beforeEach(module('mock.animate'));
+  beforeEach(module('ngAnimateMock'));
 
   beforeEach(module(function() {
     // we need to run animation on attached elements;

--- a/test/ng/directive/ngShowHideSpec.js
+++ b/test/ng/directive/ngShowHideSpec.js
@@ -73,7 +73,7 @@ describe('ngShow / ngHide animations', function() {
     body.removeAttr('ng-animation-running');
   });
 
-  beforeEach(module('mock.animate'));
+  beforeEach(module('ngAnimateMock'));
 
   beforeEach(module(function($animateProvider, $provide) {
     return function(_$rootElement_) {

--- a/test/ng/directive/ngShowHideSpec.js
+++ b/test/ng/directive/ngShowHideSpec.js
@@ -91,16 +91,18 @@ describe('ngShow / ngHide animations', function() {
       ))($scope);
       $scope.$digest();
 
-      item = $animate.flushNext('removeClass').element;
-      expect(item.text()).toBe('data');
-      expect(item).toBeShown();
+      item = $animate.queue.shift();
+      expect(item.event).toBe('removeClass');
+      expect(item.element.text()).toBe('data');
+      expect(item.element).toBeShown();
 
       $scope.on = false;
       $scope.$digest();
 
-      item = $animate.flushNext('addClass').element;
-      expect(item.text()).toBe('data');
-      expect(item).toBeHidden();
+      item = $animate.queue.shift();
+      expect(item.event).toBe('addClass');
+      expect(item.element.text()).toBe('data');
+      expect(item.element).toBeHidden();
     }));
   });
 
@@ -114,16 +116,18 @@ describe('ngShow / ngHide animations', function() {
       ))($scope);
       $scope.$digest();
 
-      item = $animate.flushNext('addClass').element;
-      expect(item.text()).toBe('datum');
-      expect(item).toBeHidden();
+      item = $animate.queue.shift();
+      expect(item.event).toBe('addClass');
+      expect(item.element.text()).toBe('datum');
+      expect(item.element).toBeHidden();
 
       $scope.off = false;
       $scope.$digest();
 
-      item = $animate.flushNext('removeClass').element;
-      expect(item.text()).toBe('datum');
-      expect(item).toBeShown();
+      item = $animate.queue.shift();
+      expect(item.event).toBe('removeClass');
+      expect(item.element.text()).toBe('datum');
+      expect(item.element).toBeShown();
     }));
   });
 });

--- a/test/ng/directive/ngSwitchSpec.js
+++ b/test/ng/directive/ngSwitchSpec.js
@@ -223,7 +223,7 @@ describe('ngSwitch animations', function() {
     return element;
   }
 
-  beforeEach(module('mock.animate'));
+  beforeEach(module('ngAnimateMock'));
 
   beforeEach(module(function() {
     // we need to run animation on attached elements;

--- a/test/ng/directive/ngSwitchSpec.js
+++ b/test/ng/directive/ngSwitchSpec.js
@@ -255,8 +255,9 @@ describe('ngSwitch animations', function() {
       $scope.val = 'one';
       $scope.$digest();
 
-      item = $animate.flushNext('enter').element;
-      expect(item.text()).toBe('one');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('enter');
+      expect(item.element.text()).toBe('one');
   }));
 
 
@@ -276,17 +277,20 @@ describe('ngSwitch animations', function() {
       $scope.val = 'two';
       $scope.$digest();
 
-      item = $animate.flushNext('enter').element;
-      expect(item.text()).toBe('two');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('enter');
+      expect(item.element.text()).toBe('two');
 
       $scope.val = 'three';
       $scope.$digest();
 
-      item = $animate.flushNext('leave').element;
-      expect(item.text()).toBe('two');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('leave');
+      expect(item.element.text()).toBe('two');
 
-      item = $animate.flushNext('enter').element;
-      expect(item.text()).toBe('three');
+      item = $animate.queue.shift();
+      expect(item.event).toBe('enter');
+      expect(item.element.text()).toBe('three');
   }));
 
 });

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -3,6 +3,7 @@
 describe("ngAnimate", function() {
 
   beforeEach(module('ngAnimate'));
+  beforeEach(module('ngAnimateMock'));
 
 
   it("should disable animations on bootstrap for structural animations even after the first digest has passed", function() {

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -684,7 +684,7 @@ describe('ngView animations', function() {
 
   describe('hooks', function() {
     beforeEach(module('ngAnimate'));
-    beforeEach(module('mock.animate'));
+    beforeEach(module('ngAnimateMock'));
 
     it('should fire off the enter animation',
         inject(function($compile, $rootScope, $location, $timeout, $animate) {
@@ -702,7 +702,7 @@ describe('ngView animations', function() {
 
       var item;
       $templateCache.put('/foo.html', [200, '<div>foo</div>', {}]);
-      element = $compile(html('<ng-view></div>'))($rootScope);
+      element = $compile(html('<div ng-view></div>'))($rootScope);
 
       $location.path('/foo');
       $rootScope.$digest();
@@ -863,7 +863,7 @@ describe('ngView animations', function() {
       };
     }
 
-    beforeEach(module(spyOnAnchorScroll(), 'mock.animate'));
+    beforeEach(module(spyOnAnchorScroll(), 'ngAnimateMock'));
     beforeEach(inject(spyOnAnimateEnter()));
 
     it('should call $anchorScroll if autoscroll attribute is present', inject(


### PR DESCRIPTION
BREAKING CHANGE

This will break existing use of `mock.animate`. But the module itself is undocumented so it shouldn't be an issue.

Closes #5822
Closes #5917
