### PR TITLE
docs(guide/templates.css-styling): fix "`{{}}`"

### DIFF
--- a/docs/content/guide/dev_guide.templates.css-styling.ngdoc
+++ b/docs/content/guide/dev_guide.templates.css-styling.ngdoc
@@ -13,7 +13,7 @@ Angular sets these CSS classes. It is up to your application to provide useful s
 
 * `ng-binding`
   - **Usage:** angular applies this class to any element that is attached to a data binding, via `ng-bind` or
-    {{}} curly braces, for example. (see {@link guide/databinding databinding} guide)
+    `{{}}` curly braces, for example. (see {@link guide/databinding databinding} guide)
 
 * `ng-invalid`, `ng-valid`
   - **Usage:** angular applies this class to an input widget element if that element's input does


### PR DESCRIPTION
Replace {{}} to `{{}}` so that "{{}}" is rendered in the HTML page
