### PR TITLE
Update step_00.ngdoc

### DIFF
--- a/docs/content/tutorial/step_00.ngdoc
+++ b/docs/content/tutorial/step_00.ngdoc
@@ -124,7 +124,7 @@ being the element on which the `ngApp` directive was defined.
 
           Nothing here {{'yet' + '!'}}
 
-  This line demonstrates the core feature of Angular's templating capabilities – a binding, denoted
+  This line demonstrates the core feature of Angular's templating capabilities (a binding), denoted
   by double-curlies `{{ }}` as well as a simple expression `'yet' + '!'` used in this binding.
 
   The binding tells Angular that it should evaluate an expression and insert the result into the


### PR DESCRIPTION
The - (hyphen) renders as a special character in many browsers and make the document difficult to read.
