### PR TITLE
fix(input): don't dirty model when input event triggered due to placeholder change

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -435,6 +435,7 @@ function validate(ctrl, validatorName, validity, value){
 }
 
 function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
+  var placeholder = element[0].placeholder, noevent = {};
   // In composition mode, users are still inputing intermediate text buffer,
   // hold the listener until composition is done.
   // More about composition events: https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent
@@ -451,9 +452,17 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
     });
   }
 
-  var listener = function() {
+  var listener = function(event) {
     if (composing) return;
     var value = element.val();
+
+    // Some versions of MSIE emit an 'input' event when the placeholder attribute/property
+    // change. This hack prevents an otherwise pristine field from being dirtied on IE
+    // browsers.
+    if (msie && (event || noevent).type === 'input' && element[0].placeholder !== placeholder) {
+      placeholder = element[0].placeholder;
+      return;
+    }
 
     // By default we will trim the value
     // If the attribute ng-trim exists we will avoid trimming

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -520,6 +520,23 @@ describe('input', function() {
     }
   });
 
+  it('should not dirty the model on an input event in response to a placeholder change', inject(function($sniffer) {
+    if (msie && $sniffer.hasEvent('input')) {
+      compileInput('<input type="text" ng-model="name" name="name" />');
+      inputElm.attr('placeholder', 'Test');
+      browserTrigger(inputElm, 'input');
+
+      expect(inputElm.attr('placeholder')).toBe('Test');
+      expect(inputElm).toBePristine();
+
+      inputElm.attr('placeholder', 'Test Again');
+      browserTrigger(inputElm, 'input');
+
+      expect(inputElm.attr('placeholder')).toBe('Test Again');
+      expect(inputElm).toBePristine();
+    }
+  }));
+
   describe('"change" event', function() {
     function assertBrowserSupportsChangeEvent(inputEventSupported) {
       // Force browser to report a lack of an 'input' event


### PR DESCRIPTION
Certain versions of IE inexplicably trigger an input event in response to a placeholder being set.

It is not possible to sniff for this behaviour nicely as the event is not triggered if the element is not attached to the document, and the event triggers asynchronously so it is not possible to accomplish this without deferring DOM compilation and slowing down load times.

Closes #2614
Closes #5960 

---

This that could theoretically go wrong:
- If a value change and a placeholder change both occur and emit a single coalesced event (rather than two independent events), this may lead to a model occasionally not being updated. I imagine this would be pretty rare in practice.
- If a test for `lastValue === value` is added to the exit condition, then the same issue above still potentially happens when an empty string becomes an invalid string and constraint validation gives us an empty string.

There are probably a few more holes in this, unfortunately, which is why it would be better if MS would hotfix the affected browsers. But it's not breaking any tests and if it doesn't break any apps which dogfood it then that's probably fine.
