### PR TITLE
docs(search): make sure the forward slash doesn't focus on search while on another input element

### DIFF
--- a/docs/src/templates/js/docs.js
+++ b/docs/src/templates/js/docs.js
@@ -145,11 +145,19 @@ docsApp.directive.docsSearchInput = ['$document',function($document) {
     var ESCAPE_KEY_KEYCODE = 27,
         FORWARD_SLASH_KEYCODE = 191;
     angular.element($document[0].body).bind('keydown', function(event) {
-      var input = element[0];
-      if(event.keyCode == FORWARD_SLASH_KEYCODE && document.activeElement != input) {
-        event.stopPropagation();
-        event.preventDefault();
-        input.focus();
+      if(event.keyCode == FORWARD_SLASH_KEYCODE && document.activeElement) {
+        var activeElement = document.activeElement;
+        var activeTagName = activeElement.nodeName.toLowerCase();
+        var hasInputFocus = activeTagName == 'input'  || activeTagName == 'select' ||
+                            activeTagName == 'option' || activeTagName == 'textarea' ||
+                            activeElement.hasAttribute('contenteditable');
+        if(!hasInputFocus) {
+          event.stopPropagation();
+          event.preventDefault();
+
+          var input = element[0];
+          input.focus();
+        }
       }
     });
 


### PR DESCRIPTION
If you're already focussed on an input/textarea/select element and you hit the forward slash "/" then it will switch focus and jump to the search bar. This also makes it impossible to type in "/" into the existing input element. This fix ensures that doesn't happen anymore.

Closes #5969
