### PR TITLE
fix($location): parse query string when path is empty in hashbang mode

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -178,6 +178,11 @@ function LocationHashbangUrl(appBase, hashPrefix) {
       throw $locationMinErr('ihshprfx', 'Invalid url "{0}", missing hash prefix "{1}".', url,
           hashPrefix);
     }
+
+    if (withoutHashUrl === '' && withoutBaseUrl.charAt(0) === '?') {
+      withoutHashUrl = withoutBaseUrl;
+    }
+
     parseAppUrl(withoutHashUrl, this, appBase);
 
     this.$$path = removeWindowsDriveName(this.$$path, withoutHashUrl, appBase);
@@ -228,10 +233,14 @@ function LocationHashbangUrl(appBase, hashPrefix) {
    */
   this.$$compose = function() {
     var search = toKeyValue(this.$$search),
-        hash = this.$$hash ? '#' + encodeUriSegment(this.$$hash) : '';
+        hash = this.$$hash ? '#' + encodeUriSegment(this.$$hash) : '',
+        url = '';
 
     this.$$url = encodePath(this.$$path) + (search ? '?' + search : '') + hash;
-    this.$$absUrl = appBase + (this.$$url ? hashPrefix + this.$$url : '');
+    if (this.$$url) {
+      url = this.$$path ? hashPrefix + this.$$url : this.$$url;
+    }
+    this.$$absUrl = appBase + url;
   };
 
   this.$$rewrite = function(url) {

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1487,6 +1487,30 @@ describe('$location', function() {
       expect(location.url()).toBe('/not-starting-with-slash');
       expect(location.absUrl()).toBe('http://server/pre/index.html#/not-starting-with-slash');
     });
+
+    describe("search()", function() {
+      it("should return a populated search object for search query when path is empty", function() {
+        location = new LocationHashbangUrl('http://server/pre/index.html', '!');
+
+        location.$$parse('http://server/pre/?foo=1&bar=2&baz=3');
+        expect(location.path()).toBe('');
+        expect(location.absUrl()).toBe('http://server/pre/index.html?foo=1&bar=2&baz=3')
+        expect(location.search()).toEqual({
+          foo: '1',
+          bar: '2',
+          baz: '3'
+        });
+
+        location.$$parse('http://server/pre/index.html?foo=1&bar=2&baz=3');
+        expect(location.path()).toBe('');
+        expect(location.absUrl()).toBe('http://server/pre/index.html?foo=1&bar=2&baz=3')
+        expect(location.search()).toEqual({
+          foo: '1',
+          bar: '2',
+          baz: '3'
+        });
+      });
+    });
   });
 
 


### PR DESCRIPTION
Before this fix, search queries in hashbang mode were ignored if the hash was not present in the url. This patch corrects this by ensuring that the search query is available to be parsed by urlResolve when the hashbang is not present.

Closes #5964
