### PR TITLE
fix(input): ngMinlength/ngMaxlength should not invalidate non-stringlike values

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -998,7 +998,8 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   if (attr.ngMinlength) {
     var minlength = int(attr.ngMinlength);
     var minLengthValidator = function(value) {
-      return validate(ctrl, 'minlength', ctrl.$isEmpty(value) || value.length >= minlength, value);
+      return validate(ctrl, 'minlength', ctrl.$isEmpty(value) ||
+        (!isDefined(value.length) || value.length >= minlength), value);
     };
 
     ctrl.$parsers.push(minLengthValidator);
@@ -1009,7 +1010,8 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   if (attr.ngMaxlength) {
     var maxlength = int(attr.ngMaxlength);
     var maxLengthValidator = function(value) {
-      return validate(ctrl, 'maxlength', ctrl.$isEmpty(value) || value.length <= maxlength, value);
+      return validate(ctrl, 'maxlength', ctrl.$isEmpty(value) ||
+        (!isDefined(value.length) || value.length <= maxlength), value);
     };
 
     ctrl.$parsers.push(maxLengthValidator);

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -744,6 +744,34 @@ describe('input', function() {
       changeInputValueTo('aaa');
       expect(scope.value).toBe('aaa');
     });
+
+
+    it('should invalidate model values shorter than given minlength', function() {
+      compileInput('<input type="text" ng-model="value" ng-minlength="5" />');
+
+      scope.$apply(function() {
+        scope.value = "1234";
+      });
+
+      expect(inputElm).toBeInvalid();
+
+      scope.$apply(function() {
+        scope.value = "123456789";
+      });
+
+      expect(inputElm).toBeValid();
+    });
+
+
+    it('should not invalidate model-values which are not string-like or array-like', function() {
+      compileInput('<input type="text" ng-model="value" ng-minlength="3" />');
+
+      scope.$apply(function() {
+        scope.value = 10;
+      });
+
+      expect(inputElm).toBeValid();
+    });
   });
 
 
@@ -757,6 +785,34 @@ describe('input', function() {
 
       changeInputValueTo('aaa');
       expect(scope.value).toBe('aaa');
+    });
+
+
+    it('should invalidate model values longer than given maxlength', function() {
+      compileInput('<input type="text" ng-model="value" ng-maxlength="5" />');
+
+      scope.$apply(function() {
+        scope.value = "123456789";
+      });
+
+      expect(inputElm).toBeInvalid();
+
+      scope.$apply(function() {
+        scope.value = "1234";
+      });
+
+      expect(inputElm).toBeValid();
+    });
+
+
+    it('should not invalidate model-values which are not string-like or array-like', function() {
+      compileInput('<input type="text" ng-model="value" ng-maxlength="3" />');
+
+      scope.$apply(function() {
+        scope.value = 1000;
+      });
+
+      expect(inputElm).toBeValid();
     });
   });
 


### PR DESCRIPTION
A regression reported in #5936 shows that prior to cdc4d485a6daa0c74e5d07d8def2a3ee68d93d13, an input with an ngMinlength or ngMaxlength validator would not invalidate values where value.length was undefined.

This patch addresses this by making use of the Infinity global when a value's length property is undefined.

The behaviour of this validator is still incorrect in the case of objects with a length property which are not arrays or strings, and will most likely remain that way. This cannot change as it is possibly desirable to use ngMinlength/ngMaxlength in conjunction with ngList.

Closes #5936
Closes #6000
