### PR TITLE
Update $resource documentation

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -252,7 +252,7 @@ function shallowClearAndCopy(src, dst) {
 
    <pre>
      var User = $resource('/user/:userId', {userId:'@id'});
-     var user = User.get({userId:123}, function() {
+     User.get({userId:123}, function(user) {
        user.abc = true;
        user.$save();
      });
@@ -271,6 +271,16 @@ function shallowClearAndCopy(src, dst) {
          //putResponseHeaders => $http header getter
        });
      });
+   </pre>
+ *
+ * You can also access the raw `$http` promise via the `$promise` property on the object returned
+ *
+   <pre>
+     var User = $resource('/user/:userId', {userId:'@id'});
+     User.get({userId:123})
+         .$promise.then(function(user) {
+           $scope.user = user;
+         });
    </pre>
 
  * # Creating a custom 'PUT' request


### PR DESCRIPTION
This updates the `$resource` docs with information on accessing the `$http` promise, as well as eliminate an outdated pattern that is deprecated (making use of `$parse` unwrapping the promise to access the user from a get request on the resource).
