### PR TITLE
feat(ngRepeat): ngRepeat is now immune to removing or moving its elements without its corresponding comment node

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -116,6 +116,7 @@
     "jqNextId": false,
     "camelCase": false,
     "jqLitePatchJQueryRemove": false,
+    "jqLitePatchJQueryInsert": false,
     "JQLite": false,
     "jqLiteClone": false,
     "jqLiteDealoc": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1270,6 +1270,16 @@ function bindJQuery() {
     jqLitePatchJQueryRemove('remove', true, true, false);
     jqLitePatchJQueryRemove('empty', false, false, false);
     jqLitePatchJQueryRemove('html', false, false, true);
+
+    // Method signature:
+    //     jqLitePatchJQueryInsert(name)
+    // all jQuery methods that can insert an element into DOM
+    jqLitePatchJQueryInsert('append');
+    jqLitePatchJQueryInsert('prepend');
+    jqLitePatchJQueryInsert('before');
+    jqLitePatchJQueryInsert('after');
+    jqLitePatchJQueryInsert('replaceWith');
+    jqLitePatchJQueryInsert('wrapAll');
   } else {
     jqLite = JQLite;
   }

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -166,9 +166,9 @@ function jqLitePatchJQueryRemove(name, dispatchThis, filterElems, getterIfNoArgu
         }
       }
     }
-    if(name === 'remove'){
-      var elementsDetached = jQuery(this);
-      if(elementsDetached){
+    if(dispatchThis){
+      var elementsDetached = param ? jQuery(this).filter(param) : jQuery(this);
+      if(elementsDetached.length){
         elementsDetached.triggerHandler('$detach', elementsDetached);
       }
     }
@@ -184,8 +184,21 @@ function jqLitePatchJQueryInsert(name){
 
   function insertPatch() {
     // jshint -W040
-    var elementsAttached = jQuery(arguments[0]),
-      originalResult = originalJqFn.apply(this, arguments);
+    var elementsAttached,
+        arg = arguments[0];
+    if(typeof arg === "function"){
+      elementsAttached = jQuery();
+      var res,
+          self = this;
+      this.each(function(index){
+        res = arg.call(this, index, self.html());
+        elementsAttached = elementsAttached.add(res);
+      });
+    }
+    else{
+      elementsAttached = jQuery(arg);
+    }
+    var originalResult = originalJqFn.apply(this, arguments);
     if(elementsAttached){
       elementsAttached.triggerHandler('$attach', elementsAttached);
     }

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -946,7 +946,7 @@ forEach({
        }
      }
     }
- 
+
     // jQuery 'detach' method calls jQuery 'remvove' method with additional parameter
     // this casues that the jqLitePatchJQueryRemove that patches jQuery remove triggers $destroy events as well
     // the following function mimics this behaviour

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -166,7 +166,30 @@ function jqLitePatchJQueryRemove(name, dispatchThis, filterElems, getterIfNoArgu
         }
       }
     }
+    if(name === 'remove'){
+      var elementsDetached = jQuery(this);
+      if(elementsDetached){
+        elementsDetached.triggerHandler('$detach', elementsDetached);
+      }
+    }
     return originalJqFn.apply(this, arguments);
+  }
+}
+
+function jqLitePatchJQueryInsert(name){
+  var originalJqFn = jQuery.fn[name];
+  originalJqFn = originalJqFn.$original || originalJqFn;
+  insertPatch.$original = originalJqFn;
+  jQuery.fn[name] = insertPatch;
+
+  function insertPatch() {
+    // jshint -W040
+    var elementsAttached = jQuery(arguments[0]),
+      originalResult = originalJqFn.apply(this, arguments);
+    if(elementsAttached){
+      elementsAttached.triggerHandler('$attach', elementsAttached);
+    }
+    return originalResult;
   }
 }
 
@@ -759,16 +782,21 @@ forEach({
   },
 
   replaceWith: function(element, replaceNode) {
-    var index, parent = element.parentNode;
+    var nodeElem = new JQLite(replaceNode),
+        args = [],
+        index, parent = element.parentNode;
     jqLiteDealoc(element);
-    forEach(new JQLite(replaceNode), function(node){
+    forEach(nodeElem, function(node){
       if (index) {
         parent.insertBefore(node, index.nextSibling);
+        args = args.concat(node);
       } else {
         parent.replaceChild(node, element);
+        args = args.concat(node);
       }
       index = node;
     });
+    nodeElem.triggerHandler('$attach', args);
   },
 
   children: function(element) {
@@ -785,43 +813,59 @@ forEach({
   },
 
   append: function(element, node) {
-    forEach(new JQLite(node), function(child){
+    var nodeElem = new JQLite(node),
+        args = [];
+    forEach(nodeElem, function(child){
       if (element.nodeType === 1 || element.nodeType === 11) {
         element.appendChild(child);
+        args = args.concat(child);
       }
     });
+    nodeElem.triggerHandler('$attach', args);
   },
 
   prepend: function(element, node) {
+    var nodeElem = new JQLite(node),
+        args = [];
     if (element.nodeType === 1) {
       var index = element.firstChild;
-      forEach(new JQLite(node), function(child){
+      forEach(nodeElem, function(child){
         element.insertBefore(child, index);
+        args = args.concat(child);
       });
     }
+    nodeElem.triggerHandler('$attach', args);
   },
 
   wrap: function(element, wrapNode) {
-    wrapNode = jqLite(wrapNode)[0];
+    var wrapElem = jqLite(wrapNode);
+    wrapNode = wrapElem[0];
     var parent = element.parentNode;
     if (parent) {
       parent.replaceChild(wrapNode, element);
     }
     wrapNode.appendChild(element);
+    wrapElem.triggerHandler('$attach', wrapElem);
   },
 
   remove: function(element) {
+    var jelement = new JQLite(element);
+    jelement.triggerHandler('$detach', jelement);
     jqLiteDealoc(element);
     var parent = element.parentNode;
     if (parent) parent.removeChild(element);
   },
 
   after: function(element, newElement) {
-    var index = element, parent = element.parentNode;
-    forEach(new JQLite(newElement), function(node){
+    var nodeElem = new JQLite(newElement),
+        args = [],
+        index = element, parent = element.parentNode;
+    forEach(nodeElem, function(node){
       parent.insertBefore(node, index.nextSibling);
       index = node;
+      args = args.concat(node);
     });
+    nodeElem.triggerHandler('$attach', args);
   },
 
   addClass: jqLiteAddClass,
@@ -875,6 +919,29 @@ forEach({
     forEach(eventFns, function(fn) {
       fn.apply(element, event.concat(eventData));
     });
+  },
+
+  detach: function(element) {
+    var jelement = new JQLite(element);
+    jelement.triggerHandler('$detach', jelement);
+
+    function triggerDestroy(el){
+     if(el.nodeType === 1){
+       new JQLite(el).triggerHandler('$destroy');
+       for ( var i = 0, children = el.childNodes || []; i < children.length; i++) {
+         triggerDestroy(children[i]);
+       }
+     }
+    }
+ 
+    // jQuery 'detach' method calls jQuery 'remvove' method with additional parameter
+    // this casues that the jqLitePatchJQueryRemove that patches jQuery remove triggers $destroy events as well
+    // the following function mimics this behaviour
+    triggerDestroy(element);
+
+    var parent = element.parentNode;
+    if (parent) parent.removeChild(element);
+    return jelement;
   }
 }, function(fn, name){
   /**

--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -372,7 +372,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
                   clone.on('$attach', function(event, origElem, origComment){
                     // should append the original corresponding comment element
                     if(origComment !== correspondingCommentElement){
-                      var parent = origElem.parentElement;
+                      var parent = origElem.parentNode;
                       if(parent){
                         if(origElem.nextSibling)
                           parent.insertBefore(correspondingCommentElement, origElem.nextSibling);
@@ -394,7 +394,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
                   clone.on('$detach', function(event, origElem, origComment){
                     // should remove the original corresponding comment element
                     if(origComment !== correspondingCommentElement){
-                      var parent = correspondingCommentElement.parentElement;
+                      var parent = correspondingCommentElement.parentNode;
                       if(parent)
                         parent.removeChild(correspondingCommentElement);
                     }

--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -399,7 +399,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
                         parent.removeChild(correspondingCommentElement);
                     }
                   });
-                  $scope.$on('$destroy', function(){
+                  childScope.$on('$destroy', function(){
                     clone.off('$attach');
                     clone.off('$detach');
                   });


### PR DESCRIPTION
This PR closes issues: #5054, #4954, #5619.

The ngRepeatDirective internally checks if one of its elements is being removed/inserted properly (with its corresponding comment element as ngRepeat does) or not. And if not (as sortable functions/directives do) it removes the comment node when needed, and then inserts it when needed and where it's supposed to. Now any sortable directive will work properly (e.g. https://github.com/mostr/angular-ui-multi-sortable or even raw jQuery (multi)sortable)
