### PR TITLE
Update dev_guide.e2e-testing.ngdoc

### DIFF
--- a/docs/content/guide/dev_guide.e2e-testing.ngdoc
+++ b/docs/content/guide/dev_guide.e2e-testing.ngdoc
@@ -5,7 +5,7 @@
 
 **If you're starting a new Angular project, you may want to look into
 using {@link https://github.com/angular/protractor Protractor}, as it is going to
-replace the current method of E2E Testing in the near future.**
+replace the current method of E2E Testing in the near future. None of the information below is related to Protractor. **
 
 As applications grow in size and complexity, it becomes unrealistic to rely on manual testing to
 verify the correctness of new features, catch bugs and notice regressions.


### PR DESCRIPTION
All of the documentation belongs to old angular e2e not to protractor. For protractor documentation people need to go to the protractor github page
