### PR TITLE
fix(shallowCopy) logic error where '$foo' would be ignored

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -772,7 +772,7 @@ function shallowCopy(src, dst) {
   for(var key in src) {
     // shallowCopy is only ever called by $compile nodeLinkFn, which has control over src
     // so we don't need to worry about using our custom hasOwnProperty here
-    if (src.hasOwnProperty(key) && key.charAt(0) !== '$' && key.charAt(1) !== '$') {
+    if (src.hasOwnProperty(key) && !(key.charAt(0) == '$' && key.charAt(1) == '$') ) {
       dst[key] = src[key];
     }
   }

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -35,7 +35,7 @@ function shallowClearAndCopy(src, dst) {
   });
 
   for (var key in src) {
-    if (src.hasOwnProperty(key) && key.charAt(0) !== '$' && key.charAt(1) !== '$') {
+    if (src.hasOwnProperty(key) && !(key.charAt(0) == '$' && key.charAt(1) == '$')) {
       dst[key] = src[key];
     }
   }


### PR DESCRIPTION
Introduced in this commit : https://github.com/angular/angular.js/commit/cb29632a5802e930262919b3db64ca4806c5cfc7 
