### PR TITLE
recommend pre-compiling external templates

### DIFF
--- a/docs/content/guide/dev_guide.unit-testing.ngdoc
+++ b/docs/content/guide/dev_guide.unit-testing.ngdoc
@@ -334,6 +334,9 @@ We inject the $compile service and $rootScope before each jasmine test. The $com
 to render the aGreatEye directive. After rendering the directive we ensure that the directive has
 replaced the content and "lidless, wreathed in flame, 2 times" is present.
 
+### Testing Directives With External Templates
+
+If your directive externalizes its' template (uses <pre>templateUrl</pre>) consider using {@link https://github.com/karma-runner/karma-ng-html2js-preprocessor karma-ng-html2js-preprocessor} to pre-compile HTML and thus avoid attempts to load those templates over HTTP during test execution. Otherwise you may run into template URI path resolution issues if your test directory hierarchy differs from application's.
 
 ## Sample project
 See the {@link https://github.com/angular/angular-seed angular-seed} project for an example.


### PR DESCRIPTION
quite a few folks struggle with how to test directives with external templates. karma-ng-html2js-preprocessor provides an easy solution but the issues is not raised in the docs.
