### PR TITLE
fix($compile): throw an exception when an attribute is unassigned

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1906,8 +1906,12 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 break;
 
               case '=':
-                if (optional && !attrs[attrName]) {
-                  return;
+                if (!attrs[attrName]) {
+                  if (optional) {
+                    return;
+                  }
+                  throw Error('Non-assignable model expression: ' + attrs[attrName]
+                    + ' (directive: ' + newIsolateScopeDirective.name + ')');
                 }
                 parentGet = $parse(attrs[attrName]);
                 if (parentGet.literal) {


### PR DESCRIPTION
Documentation states that NON_ASSIGNABLE_MODEL_EXPRESSION exception should be thrown if
a two-way attribute doesn't exist. This commit adds a simple test and throws an error
if the property is missing. Note that the documentation should probably be updated
and a different exception should be thrown using minErr.

This commit refers to issue #6060
