### PR TITLE
fix(input): ng-required conflicts with ng-true-value

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -673,7 +673,7 @@ function checkboxInputType(scope, element, attr, ctrl) {
 
   // Override the standard `$isEmpty` because a value of `false` means empty in a checkbox.
   ctrl.$isEmpty = function(value) {
-    return value !== trueValue;
+    return value !== true;
   };
 
   ctrl.$formatters.push(function(value) {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1111,6 +1111,37 @@ describe('input', function() {
       expect(inputElm[0].checked).toBe(false);
       expect(inputElm).toBeInvalid();
     });
+
+    it('should allow custom enumaration even if it is required', function() {
+      compileInput('<input type="checkbox" ng-model="name" ng-true-value="y" ' +
+          'ng-false-value="n" ng-required="true">');
+
+      scope.$apply(function() {
+        scope.name = 'y';
+      });
+      expect(inputElm[0].checked).toBe(true);
+      expect(inputElm).toBeValid();
+
+      scope.$apply(function() {
+        scope.name = 'n';
+      });
+      expect(inputElm[0].checked).toBe(false);
+      expect(inputElm).toBeInvalid();
+
+      scope.$apply(function() {
+        scope.name = 'something else';
+      });
+      expect(inputElm[0].checked).toBe(false);
+      expect(inputElm).toBeInvalid();
+
+      browserTrigger(inputElm, 'click');
+      expect(scope.name).toEqual('y');
+      expect(inputElm).toBeValid();
+
+      browserTrigger(inputElm, 'click');
+      expect(scope.name).toEqual('n');
+      expect(inputElm).toBeInvalid();
+    });
   });
 
 


### PR DESCRIPTION
Before this change, overridden "isEmpty" method which is called in "requiredDirective" would return a wrong result when the parameter is given as "true". This change corrects the statement value within method.

Closes #5164
