### PR TITLE
feat(testing): run end to end tests on firefox and safari as well as chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ node_js:
 env:
   matrix:
     - JOB=unit
-    - JOB=e2e
+    - JOB=e2e-chrome
+    - JOB=e2e-firefox
+    - JOB=e2e-safari
   global:
     - SAUCE_USERNAME=angular-ci
     - SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -90,7 +90,7 @@ module.exports = function(grunt) {
     },
 
 
-    runprotractor: {
+    protractor: {
       normal: 'protractor-conf.js',
       jenkins: 'protractor-jenkins-conf.js'
     },
@@ -291,8 +291,8 @@ module.exports = function(grunt) {
   grunt.registerTask('test:modules', 'Run the Karma module tests with Karma', ['tests:modules']);
   grunt.registerTask('test:docs', 'Run the doc-page tests with Karma', ['package', 'tests:docs']);
   grunt.registerTask('test:unit', 'Run unit, jQuery and Karma module tests with Karma', ['tests:jqlite', 'tests:jquery', 'tests:modules']);
-  grunt.registerTask('test:protractor', 'Run the end to end tests with Protractor and keep a test server running in the background', ['webdriver', 'connect:testserver', 'runprotractor:normal']);
-  grunt.registerTask('test:ci-protractor', 'Run the end to end tests with Protractor and keep a test server running in the background', ['webdriver', 'connect:testserver', 'runprotractor:jenkins']);
+  grunt.registerTask('test:protractor', 'Run the end to end tests with Protractor and keep a test server running in the background', ['webdriver', 'connect:testserver', 'protractor:normal']);
+  grunt.registerTask('test:ci-protractor', 'Run the end to end tests with Protractor and keep a test server running in the background', ['webdriver', 'connect:testserver', 'protractor:jenkins']);
   grunt.registerTask('test:e2e', 'Alias for test:protractor', ['test:protractor']);
   grunt.registerTask('test:docgen', ['jasmine_node']);
   grunt.registerTask('test:promises-aplus',['build:promises-aplus-adapter','shell:promises-aplus-tests']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -91,7 +91,8 @@ module.exports = function(grunt) {
 
 
     runprotractor: {
-      normal: 'protractor-conf.js'
+      normal: 'protractor-conf.js',
+      jenkins: 'protractor-jenkins-conf.js'
     },
 
 
@@ -291,6 +292,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test:docs', 'Run the doc-page tests with Karma', ['package', 'tests:docs']);
   grunt.registerTask('test:unit', 'Run unit, jQuery and Karma module tests with Karma', ['tests:jqlite', 'tests:jquery', 'tests:modules']);
   grunt.registerTask('test:protractor', 'Run the end to end tests with Protractor and keep a test server running in the background', ['webdriver', 'connect:testserver', 'runprotractor:normal']);
+  grunt.registerTask('test:ci-protractor', 'Run the end to end tests with Protractor and keep a test server running in the background', ['webdriver', 'connect:testserver', 'runprotractor:jenkins']);
   grunt.registerTask('test:e2e', 'Alias for test:protractor', ['test:protractor']);
   grunt.registerTask('test:docgen', ['jasmine_node']);
   grunt.registerTask('test:promises-aplus',['build:promises-aplus-adapter','shell:promises-aplus-tests']);

--- a/docs/content/guide/dev_guide.e2e-testing.ngdoc
+++ b/docs/content/guide/dev_guide.e2e-testing.ngdoc
@@ -3,9 +3,10 @@
 @name Developer Guide: E2E Testing
 @description
 
-**If you're starting a new Angular project, you may want to look into
-using {@link https://github.com/angular/protractor Protractor}, as it is going to
-replace the current method of E2E Testing in the near future.**
+**Angular Scenario Runner is in maintenance mode - If you're starting a new Angular project,
+consider using {@link https://github.com/angular/protractor Protractor}.**
+
+
 
 As applications grow in size and complexity, it becomes unrealistic to rely on manual testing to
 verify the correctness of new features, catch bugs and notice regressions.

--- a/docs/content/guide/expression.ngdoc
+++ b/docs/content/guide/expression.ngdoc
@@ -110,6 +110,10 @@ prevent accidental access to the global state (a common source of subtle bugs).
 </doc:source>
 <doc:protractor>
   it('should calculate expression in binding', function() {
+    if (browser.params.browser = 'safari') {
+      // Safari can't handle dialogs.
+      return;
+    };
     element(by.css('[ng-click="greet()"]')).click();
 
     var alertDialog = browser.switchTo().alert();

--- a/docs/content/misc/contribute.ngdoc
+++ b/docs/content/misc/contribute.ngdoc
@@ -135,7 +135,7 @@ made available a local web server based on Node.js.
 
 ## Running the Unit Test Suite
 
-We write unit and integration tests with Jasmine and execute them with Karma. To run all of the
+We write unit tests with Jasmine and execute them with Karma. To run all of the
 tests once on Chrome run:
 
 ```shell
@@ -178,11 +178,11 @@ grunt --help
 
 ## Running the End-to-end Test Suite
 
-Simply run:
+Angular's end to end tests are run with Protractor. Simply run:
 
 ```shell
 grunt test:e2e
 ```
 
-This will start the webserver and run the tests.
+This will start the webserver and run the tests on Chrome.
 

--- a/docs/content/misc/contribute.ngdoc
+++ b/docs/content/misc/contribute.ngdoc
@@ -135,7 +135,7 @@ made available a local web server based on Node.js.
 
 ## Running the Unit Test Suite
 
-We write unit tests with Jasmine and execute them with Karma. To run all of the
+We write unit and integration tests with Jasmine and execute them with Karma. To run all of the
 tests once on Chrome run:
 
 ```shell

--- a/docs/src/ngdoc.js
+++ b/docs/src/ngdoc.js
@@ -1113,14 +1113,25 @@ function scenarios(docs){
 function writeProtractorTest(doc){
   var lines = [];
   lines.push('describe("' + doc.section + '/' + doc.id + '", function() {');
-  lines.push('  beforeEach(function() {');
-  lines.push('    browser.get("index-nocache.html#!/' + doc.section + '/' + doc.id + '");');
-  lines.push('  });');
+  lines.push('  describe("angular+jqLite", function() {')
+  lines.push('    beforeEach(function() {');
+  lines.push('      browser.get("index-nocache.html#!/' + doc.section + '/' + doc.id + '");');
+  lines.push('    });');
   lines.push('');
   doc.protractorTests.forEach(function(test){
-    lines.push(indentCode(trim(test), 2));
+    lines.push(indentCode(trim(test), 4));
     lines.push('');
   });
+  lines.push('  });');
+  lines.push('  describe("angular+jQuery", function() {')
+  lines.push('    beforeEach(function() {');
+  lines.push('      browser.get("index-jq-nocache.html#!/' + doc.section + '/' + doc.id + '");');
+  lines.push('    });');
+  doc.protractorTests.forEach(function(test){
+    lines.push(indentCode(trim(test), 4));
+    lines.push('');
+  });
+  lines.push('  });');
   lines.push('});');
   lines.push('');
   return lines.join('\n');

--- a/jenkins_build.sh
+++ b/jenkins_build.sh
@@ -35,7 +35,6 @@ grunt test:docgen --no-color
 grunt test:unit --browsers $BROWSERS --reporters=dots,junit --no-colors --no-color
 
 # END TO END TESTS #
-grunt test:e2e --browsers $BROWSERS_E2E --reporters=dots,junit --no-colors --no-color
 grunt test:protractor
 
 # Promises/A+ TESTS #

--- a/jenkins_build.sh
+++ b/jenkins_build.sh
@@ -13,12 +13,6 @@ then
   BROWSERS="Chrome,Firefox,Opera,/Users/jenkins/bin/safari.sh,/Users/jenkins/bin/ie8.sh,/Users/jenkins/bin/ie9.sh"
 fi
 
-if [[ -z "$BROWSERS_E2E" ]]
-then
-  BROWSERS_E2E="Chrome,Firefox,/Users/jenkins/bin/safari.sh"
-fi
-
-
 # CLEAN #
 rm -f angular.min.js.gzip.size
 rm -f angular.js.size
@@ -28,6 +22,8 @@ rm -f angular.js.size
 npm install --color false
 grunt ci-checks package --no-color
 
+mkdir test_out
+
 # DOCS generator unit tests #
 grunt test:docgen --no-color
 
@@ -35,7 +31,9 @@ grunt test:docgen --no-color
 grunt test:unit --browsers $BROWSERS --reporters=dots,junit --no-colors --no-color
 
 # END TO END TESTS #
-grunt test:protractor
+grunt test:ci-protractor
+grunt test:ci-protractor --browser safari
+grunt test:ci-protractor --browser firefox
 
 # Promises/A+ TESTS #
 grunt test:promises-aplus --no-color

--- a/lib/grunt/plugins.js
+++ b/lib/grunt/plugins.js
@@ -65,7 +65,7 @@ module.exports = function(grunt) {
     util.updateWebdriver.call(util, this.async());
   });
 
-  grunt.registerMultiTask('runprotractor', 'Run Protractor integration tests', function() {
+  grunt.registerMultiTask('protractor', 'Run Protractor integration tests', function() {
     util.startProtractor.call(util, this.data, this.async());
   });
 

--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -136,7 +136,12 @@ module.exports = {
   },
 
 
-  updateWebdriver: function(done){
+  updateWebdriver: function(done){    
+    if (process.env.TRAVIS) {
+      // Skip the webdriver-manager update on Travis, since the browsers will
+      // be provided remotely.
+      done();
+    }
     var p = spawn('node', ['node_modules/protractor/bin/webdriver-manager', 'update']);
     p.stdout.pipe(process.stdout);
     p.stderr.pipe(process.stderr);

--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -141,6 +141,7 @@ module.exports = {
       // Skip the webdriver-manager update on Travis, since the browsers will
       // be provided remotely.
       done();
+      return;
     }
     var p = spawn('node', ['node_modules/protractor/bin/webdriver-manager', 'update']);
     p.stdout.pipe(process.stdout);
@@ -156,11 +157,16 @@ module.exports = {
     var sauceKey = grunt.option('sauceKey');
     var tunnelIdentifier = grunt.option('capabilities.tunnel-identifier');
     var sauceBuild = grunt.option('capabilities.build');
+    var browser = grunt.option('browser');
     var args = ['node_modules/protractor/bin/protractor', config];
     if (sauceUser) args.push('--sauceUser=' + sauceUser);
     if (sauceKey) args.push('--sauceKey=' + sauceKey);
     if (tunnelIdentifier) args.push('--capabilities.tunnel-identifier=' + tunnelIdentifier);
     if (sauceBuild) args.push('--capabilities.build=' + sauceBuild);
+    if (browser) {
+      args.push('--browser=' + browser);
+      args.push('--params.browser=' + browser);
+    }
 
 
     var p = spawn('node', args);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "karma-sauce-launcher": "0.2.0",
     "karma-script-launcher": "0.1.0",
     "karma-browserstack-launcher": "0.0.7",
-    "protractor": "~0.17.0",
+    "protractor": "~0.18.0",
     "yaml-js": "~0.0.8",
     "marked": "0.2.9",
     "rewire": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "promises-aplus-tests": "~1.3.2",
     "semver": "~2.1.0",
     "lodash": "~2.1.0",
-    "browserstacktunnel-wrapper": "~1.1.1"
+    "browserstacktunnel-wrapper": "~1.1.1",
+    "grunt-jscs-checker": "~0.3.2",
+    "jasmine-reporters": "~0.2.1"
   },
   "licenses": [
     {

--- a/protractor-jenkins-conf.js
+++ b/protractor-jenkins-conf.js
@@ -1,0 +1,36 @@
+exports.config = {
+  allScriptsTimeout: 11000,
+
+  specs: [
+    'build/docs/ptore2e/**/*.js',
+    'test/e2e/docsAppE2E.js'
+  ],
+
+  capabilities: {
+    'browserName': 'chrome'
+  },
+
+  baseUrl: 'http://localhost:8000/build/docs/',
+
+  framework: 'jasmine',
+
+  onPrepare: function() {
+    // Disable animations so e2e tests run more quickly
+    var disableNgAnimate = function() {
+      angular.module('disableNgAnimate', []).run(function($animate) {
+        $animate.enabled(false);
+      });
+    };
+
+    browser.addMockModule('disableNgAnimate', disableNgAnimate);
+
+    require('jasmine-reporters');
+    jasmine.getEnv().addReporter(
+      new jasmine.JUnitXmlReporter('test_out/e2e-' + this.capabilities.browserName + '-', true, true));
+  },
+
+  jasmineNodeOpts: {
+    defaultTimeoutInterval: 30000,
+    showColors: false
+  }
+};

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -3,20 +3,19 @@
 set -e
 
 export SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
+export BROWSER=${JOB#*-}
 
 if [ $JOB = "unit" ]; then
   grunt ci-checks
   grunt test:docgen
   grunt test:promises-aplus
   grunt test:unit --browsers SL_Chrome,SL_Safari,SL_Firefox,SL_IE_8,SL_IE_9,SL_IE_10,SL_IE_11 --reporters dots
-elif [ $JOB = "e2e" ]; then
-  export SAUCE_OPTIONS="--sauceUser $SAUCE_USERNAME \
+elif [[ $JOB == e2e* ]]; then
+  grunt test:protractor --sauceUser $SAUCE_USERNAME \
       --sauceKey $SAUCE_ACCESS_KEY \
       --capabilities.tunnel-identifier=$TRAVIS_JOB_NUMBER \
-      --capabilities.build=$TRAVIS_BUILD_NUMBER"
-  grunt test:protractor $SAUCE_OPTIONS
-  grunt test:protractor $SAUCE_OPTIONS --browser=firefox
-  grunt test:protractor $SAUCE_OPTIONS --browser=safari
+      --capabilities.build=$TRAVIS_BUILD_NUMBER \
+      --browser=$BROWSER
 else
-  echo "Unknown job type. Please set JOB=unit or JOB=e2e."
+  echo "Unknown job type. Please set JOB=unit or JOB=e2e-*."
 fi

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -10,10 +10,13 @@ if [ $JOB = "unit" ]; then
   grunt test:promises-aplus
   grunt test:unit --browsers SL_Chrome,SL_Safari,SL_Firefox,SL_IE_8,SL_IE_9,SL_IE_10,SL_IE_11 --reporters dots
 elif [ $JOB = "e2e" ]; then
-  grunt test:protractor --sauceUser $SAUCE_USERNAME \
+  export SAUCE_OPTIONS="--sauceUser $SAUCE_USERNAME \
       --sauceKey $SAUCE_ACCESS_KEY \
       --capabilities.tunnel-identifier=$TRAVIS_JOB_NUMBER \
-      --capabilities.build=$TRAVIS_BUILD_NUMBER
+      --capabilities.build=$TRAVIS_BUILD_NUMBER"
+  grunt test:protractor $SAUCE_OPTIONS
+  grunt test:protractor $SAUCE_OPTIONS --browser=firefox
+  grunt test:protractor $SAUCE_OPTIONS --browser=safari
 else
   echo "Unknown job type. Please set JOB=unit or JOB=e2e."
 fi

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -955,11 +955,17 @@ var VALID_CLASS = 'ng-valid',
     </file>
     <file name="protractorTest.js">
       it('should data-bind and become invalid', function() {
+        if (browser.params.browser = 'safari') {
+          // SafariDriver can't handle contenteditable.
+          return;
+        };
         var contentEditable = element(by.css('.doc-example-live [contenteditable]'));
 
         expect(contentEditable.getText()).toEqual('Change me!');
 
-        contentEditable.clear();
+        // Firefox driver doesn't trigger the proper events on 'clear', so do this hack
+        contentEditable.click();
+        contentEditable.sendKeys(protractor.Key.chord(protractor.Key.COMMAND, "a"));
         contentEditable.sendKeys(protractor.Key.BACK_SPACE);
 
         expect(contentEditable.getText()).toEqual('');

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -119,12 +119,21 @@
       });
 
       it('should load template2.html', function() {
+        if (browser.params.browser == 'firefox') {
+          // Firefox can't handle using selects
+          // See https://github.com/angular/protractor/issues/480
+          return;
+        }
         templateSelect.click();
         templateSelect.element.all(by.css('option')).get(2).click();
         expect(includeElem.getText()).toMatch(/Content of template2.html/);
       });
 
       it('should change to blank', function() {
+        if (browser.params.browser == 'firefox') {
+          // Firefox can't handle using selects
+          return;
+        }
         templateSelect.click();
         templateSelect.element.all(by.css('option')).get(0).click();
         expect(includeElem.isPresent()).toBe(false);

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -34,9 +34,13 @@
          expect(element(by.binding('amount | currency:"USD$"')).getText()).toBe('USD$1,234.56');
        });
        it('should update', function() {
+         if (browser.params.browser == 'safari') {
+           // Safari does not understand the minus key. See
+           // https://github.com/angular/protractor/issues/481
+           return;
+         }
          element(by.model('amount')).clear();
-         element(by.model('amount')).sendKeys('-1234');
-         expect(element(by.id('currency-default')).getText()).toBe('($1,234.00)');
+         element(by.model('amount')).sendKeys('-1234');         expect(element(by.id('currency-default')).getText()).toBe('($1,234.00)');
          expect(element(by.binding('amount | currency:"USD$"')).getText()).toBe('(USD$1,234.00)');
        });
      </doc:protractor>

--- a/test/e2e/docsAppE2E.js
+++ b/test/e2e/docsAppE2E.js
@@ -30,7 +30,6 @@ describe('docs.angularjs.org', function () {
       browser.sleep(500);
 
       var nameInput = element(by.input('user.name'));
-      nameInput.click();
       nameInput.sendKeys('!!!');
 
       var code = element(by.css('.doc-example-live tt'));


### PR DESCRIPTION
Update the Travis and Jenkins configs to run protractor tests on Safari and Firefox as well,
and make the Travis tests run output XML and turn off color.

Fix tests which were failing in Firefox due to clear() not working as expected.

Fix tests which were failing in Safari due to SafariDriver not understanding the minus key,
and disable tests which SafariDriver has no support for.
