### PR TITLE
fix($http): add support for PATCH short method

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -847,7 +847,7 @@ function $HttpProvider() {
      * @param {Object=} config Optional configuration object
      * @returns {HttpPromise} Future object
      */
-    createShortMethods('get', 'delete', 'head', 'jsonp');
+    createShortMethods('get', 'delete', 'head', 'jsonp', 'patch');
 
     /**
      * @ngdoc method

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -873,6 +873,15 @@ describe('$http', function() {
         $http.head('/url', {headers: {'Custom': 'Header'}});
       });
 
+      it('should have patch()', function() {
+        $httpBackend.expect('PATCH', '/url').respond('');
+        $http.patch('/url');
+      });
+
+      it('patch() should allow config param', function() {
+        $httpBackend.expect('PATCH', '/url', undefined, checkHeader('Custom', 'Header')).respond('');
+        $http.patch('/url', {headers: {'Custom': 'Header'}});
+      });
 
       it('should have post()', function() {
         $httpBackend.expect('POST', '/url', 'some-data').respond('');


### PR DESCRIPTION
Commit 46691c2721735c27426b721d780e8816d502b9f2 removed the short method for PATCH from $http because there were too many unknowns. However, #5823 schedules PATCH to be re-added for the 1.3.x milestone.

This change adds the short method for PATCH back to the $http library, including tests.

Closes #5823
