### PR TITLE
WIP: angular + universal module definition

### DIFF
--- a/src/angular.prefix
+++ b/src/angular.prefix
@@ -3,4 +3,14 @@
  * (c) 2010-2014 Google, Inc. http://angularjs.org
  * License: MIT
  */
-(function(window, document, undefined) {
+(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('angular', [], function() {
+      return factory(root, document);
+    });
+  } else if (typeof exports === 'object') {
+    module.exports = factory(root, document);
+  } else {
+    factory(root, document);
+  }
+})(this, function(window, document, undefined) {

--- a/src/angular.suffix
+++ b/src/angular.suffix
@@ -8,4 +8,6 @@
     angularInit(document, bootstrap);
   });
 
-})(window, document);
+  return angular;
+
+});

--- a/src/module.prefix
+++ b/src/module.prefix
@@ -3,4 +3,14 @@
  * (c) 2010-2014 Google, Inc. http://angularjs.org
  * License: MIT
  */
-(function(window, angular, undefined) {
+(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(['angular'], function(angular) {
+      return factory(root, angular);
+    });
+  } else if (typeof exports === 'object') {
+    module.exports = factory(root, require('angular'));
+  } else {
+    factory(root, root.angular);
+  }
+})(this, function(window, angular, undefined) {

--- a/src/module.suffix
+++ b/src/module.suffix
@@ -1,2 +1,2 @@
 
-})(window, window.angular);
+});


### PR DESCRIPTION
Here is a WIP at making angular work with UMD (based on [this format](https://github.com/umdjs/umd/blob/master/returnExports.js)).

I did not attempt to remove angular from the window. That's a bigger project; so much of the source relies upon window.angular. Instead I just made angular export itself as a define/module.exports in addition to the window.

I still don't know how to test the umd code, since tests don't include *.prefix and *.suffix files.  

I thought of moving the UMD code out of `angular.prefix`/`module.prefix` and into the code somewhere - but don't know where.  Feedback is welcome - I will add tests as soon as it's possible.

Related Issue: #4919
