### PR TITLE
fix($q): make $q.reject support `finally` and `catch`

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -223,7 +223,7 @@ function qFactory(nextTick, exceptionHandler) {
 
 
       reject: function(reason) {
-        deferred.resolve(reject(reason));
+        deferred.resolve(_reject(reason));
       },
 
 
@@ -380,6 +380,12 @@ function qFactory(nextTick, exceptionHandler) {
    * @returns {Promise} Returns a promise that was already resolved as rejected with the `reason`.
    */
   var reject = function(reason) {
+    var result = defer();
+    result.reject(reason);
+    return result.promise;
+  };
+
+  var _reject = function(reason) {
     return {
       then: function(callback, errback) {
         var result = defer();

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -959,6 +959,13 @@ describe('q', function() {
       mockNextTick.flush();
       expect(log).toEqual(['errorBroken(rejected)->throw(catch me!)', 'errorAffected(catch me!)->reject(catch me!)']);
     });
+
+
+    it('should have functions `finally` and `catch`', function() {
+      var rejectedPromise = q.reject('rejected');
+      expect(rejectedPromise['finally']).not.toBeUndefined();
+      expect(rejectedPromise['catch']).not.toBeUndefined();
+    });
   });
 
 


### PR DESCRIPTION
Add support for the functions `finally` and `catch` to the promise returned by `$q.reject`

Closes #6048
