### PR TITLE
chore(Gruntfile.js, package.json): use load-grunt-tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,18 +4,8 @@ var path = require('path');
 
 module.exports = function(grunt) {
   //grunt plugins
-  grunt.loadNpmTasks('grunt-bump');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-connect');
-  grunt.loadNpmTasks('grunt-contrib-compress');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-ddescribe-iit');
-  grunt.loadNpmTasks('grunt-jasmine-node');
-  grunt.loadNpmTasks("grunt-jscs-checker");
-  grunt.loadNpmTasks('grunt-merge-conflict');
-  grunt.loadNpmTasks('grunt-parallel');
-  grunt.loadNpmTasks('grunt-shell');
+  require('load-grunt-tasks')(grunt);
+
   grunt.loadTasks('lib/grunt');
 
   var NG_VERSION = util.getVersion();

--- a/package.json
+++ b/package.json
@@ -9,12 +9,20 @@
   },
   "devDependencies": {
     "grunt": "~0.4.2",
-    "bower": "~1.2.2",
     "grunt-bump": "~0.0.13",
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-compress": "~0.5.2",
     "grunt-contrib-connect": "~0.5.0",
+    "grunt-contrib-compress": "~0.5.2",
     "grunt-contrib-copy": "~0.4.1",
+    "grunt-contrib-jshint": "~0.7.2",
+    "grunt-ddescribe-iit": "~0.0.1",
+    "grunt-jasmine-node": "git://github.com/vojtajina/grunt-jasmine-node.git#fix-grunt-exit-code",
+    "grunt-jscs-checker": "~0.3.2",
+    "grunt-merge-conflict": "~0.0.1",
+    "grunt-parallel": "~0.3.1",
+    "grunt-shell": "~0.4.0",
+    "load-grunt-tasks": "~0.3.0",
+    "bower": "~1.2.2",
     "jasmine-node": "~1.11.0",
     "q": "~0.9.2",
     "q-io": "~1.10.6",
@@ -33,16 +41,10 @@
     "yaml-js": "~0.0.8",
     "marked": "0.2.9",
     "rewire": "1.1.3",
-    "grunt-jasmine-node": "git://github.com/vojtajina/grunt-jasmine-node.git#fix-grunt-exit-code",
-    "grunt-parallel": "~0.3.1",
-    "grunt-ddescribe-iit": "~0.0.1",
-    "grunt-merge-conflict": "~0.0.1",
     "promises-aplus-tests": "~1.3.2",
-    "grunt-shell": "~0.4.0",
     "semver": "~2.1.0",
     "lodash": "~2.1.0",
-    "browserstacktunnel-wrapper": "~1.1.1",
-    "grunt-jscs-checker": "~0.3.2"
+    "browserstacktunnel-wrapper": "~1.1.1"
   },
   "licenses": [
     {
@@ -50,7 +52,5 @@
       "url": "https://github.com/angular/angular.js/blob/master/LICENSE"
     }
   ],
-  "dependencies": {
-    "grunt-contrib-jshint": "~0.7.2"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
I added load-grunt-tasks so you wont have to load each grunt plugin and moved grunt-contrib-jshint into devDependencies from dependencies
