### PR TITLE
Fixing reference to ngClass documentation

### DIFF
--- a/docs/content/guide/animations.ngdoc
+++ b/docs/content/guide/animations.ngdoc
@@ -258,7 +258,7 @@ The table below explains in detail which animation events are triggered
 | {@link api/ng.directive:ngInclude#usage_animations ngInclude}                             | enter and leave                          |
 | {@link api/ng.directive:ngSwitch#usage_animations ngSwitch}                               | enter and leave                          |
 | {@link api/ng.directive:ngIf#usage_animations ngIf}                                       | enter and leave                          |
-| {@link api/ng.directive:ngShow#usage_animations ngClass or &#123;&#123;class&#125;&#125;} | add and remove                           |
+| {@link api/ng.directive:ngClass#usage_animations ngClass or &#123;&#123;class&#125;&#125;} | add and remove                           |
 | {@link api/ng.directive:ngShow#usage_animations ngShow & ngHide}                          | add and remove (the ng-hide class value) |
 
 For a full breakdown of the steps involved during each animation event, refer to the {@link api/ngAnimate.$animate API docs}.


### PR DESCRIPTION
I have fixed an linking error in the documentation - the ngClass was referencing the ngShow document by mistake.
