### PR TITLE
fix (filterFilter): 

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -188,7 +188,7 @@ function filterFilter() {
           (function(path) {
             if (typeof expression[path] == 'undefined') return;
             predicates.push(function(value) {
-              return search(path == '$' ? value : (value && value[path]), expression[path]);
+              return search(path == '$' ? value : ( (value && value[path]) || getter(value, path)), expression[path]);
             });
           })(key);
         }

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -61,21 +61,21 @@ describe('Filter: filter', function() {
   });
 
 
-  it('should also support nested objects in predicate', function() {
-    var items = [{'person': 'misko hevery', 'job': {name: 'bit jockey'}},
-                 {'person': 'adam abrons', 'job': {name: 'pixelmancer'}}];
-
-    expect(filter(items, {'job.name':''}).length).toBe(2);
-    expect(filter(items, {'job.name':'bit'})).toEqual([items[0]]);
-  });
-
-
   it('should support predicate object with dots in the name', function() {
     var items = [{'first.name': 'misko', 'last.name': 'hevery'},
                  {'first.name': 'adam', 'last.name': 'abrons'}];
 
     expect(filter(items, {'first.name':'', 'last.name':''}).length).toBe(2);
     expect(filter(items, {'first.name':'misko', 'last.name':''})).toEqual([items[0]]);
+  }); 
+  
+
+  it('should also support nested objects in predicate', function() {
+    var items = [{'person': 'misko hevery', 'job': {name: 'bit jockey'}},
+                 {'person': 'adam abrons', 'job': {name: 'pixelmancer'}}];
+
+    expect(filter(items, {'job.name':''}).length).toBe(2);
+    expect(filter(items, {'job.name':'bit'})).toEqual([items[0]]);
   }); 
 
 

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -49,7 +49,7 @@ describe('Filter: filter', function() {
     expect(filter(items, function(i) {return i.done;}).length).toBe(1);
   });
 
-  it('should take object as perdicate', function() {
+  it('should take object as predicate', function() {
     var items = [{first: 'misko', last: 'hevery'},
                  {first: 'adam', last: 'abrons'}];
 
@@ -61,13 +61,22 @@ describe('Filter: filter', function() {
   });
 
 
-  it('should support predicat object with dots in the name', function() {
+  it('should also support nested objects in predicate', function() {
+    var items = [{'person': 'misko hevery', 'job': {name: 'bit jockey'}},
+                 {'person': 'adam abrons', 'job': {name: 'pixelmancer'}}];
+
+    expect(filter(items, {'job.name':''}).length).toBe(2);
+    expect(filter(items, {'job.name':'bit'})).toEqual([items[0]]);
+  });
+
+
+  it('should support predicate object with dots in the name', function() {
     var items = [{'first.name': 'misko', 'last.name': 'hevery'},
                  {'first.name': 'adam', 'last.name': 'abrons'}];
 
     expect(filter(items, {'first.name':'', 'last.name':''}).length).toBe(2);
     expect(filter(items, {'first.name':'misko', 'last.name':''})).toEqual([items[0]]);
-  });
+  }); 
 
 
   it('should match any properties for given "$" property', function() {


### PR DESCRIPTION
allow both dotted predicate object fields, and nested predicate objects in filters.
