### PR TITLE
bug(mocks): Correctly calls workFn with "this".

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2125,7 +2125,7 @@ if(window.jasmine || window.mocha) {
   window.inject = angular.mock.inject = function() {
     var blockFns = Array.prototype.slice.call(arguments, 0);
     var errorForStack = new Error('Declaration Location');
-    return isSpecRunning() ? workFn() : workFn;
+    return isSpecRunning() ? workFn.call(this) : workFn;
     /////////////////////
     function workFn() {
       var modules = currentSpec.$modules || [];


### PR DESCRIPTION
Currently, the workFn is called with the implied, global "this" instead of the current context as it should be.
See this bin for the problem and suggested solution:
http://jsbin.com/EDohOlih/1/edit
