### PR TITLE
fix(ngMock): return immediately from mock $interval.cancel() when no promise argument is supplied

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -504,6 +504,7 @@ angular.mock.$IntervalProvider = function() {
     };
 
     $interval.cancel = function(promise) {
+      if(!promise) return false;
       var fnIndex;
 
       angular.forEach(repeatFns, function(fn, index) {

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -509,6 +509,11 @@ describe('ngMock', function() {
 
       it('should not throw a runtime exception when given an undefined promise',
           inject(function($interval) {
+        var task1 = jasmine.createSpy('task1'),
+            promise1;
+
+        promise1 = $interval(task1, 1000, 1);
+
         expect($interval.cancel()).toBe(false);
       }));
     });


### PR DESCRIPTION
This is a fix for a possible cause of issue #6099. 

Calling `$interval.cancel()` without supplying the expected argument would cause a TypeError. There was a test for this but it was incomplete because it did not setup the instance of $interval with any repeated functions, so the function passed to `forEach` in which the error is thrown is never executed. The test failed when a repeated task was added.

This pull requests prevents the runtime exception by returning from `cancel()` immediately if no promise is supplied (doesn't even get to the loop) and improves the test by setting up a repeating task as the other tests do.
