### PR TITLE
feat(jqLite): IE7 support for adding/removing CSS classes

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -299,30 +299,52 @@ function jqLiteHasClass(element, selector) {
 }
 
 function jqLiteRemoveClass(element, cssClasses) {
-  if (cssClasses && element.setAttribute) {
-    forEach(cssClasses.split(' '), function(cssClass) {
-      element.setAttribute('class', trim(
-          (" " + (element.getAttribute('class') || '') + " ")
-          .replace(/[\n\t]/g, " ")
-          .replace(" " + trim(cssClass) + " ", " "))
-      );
-    });
+  if (msie && msie < 8) {
+    if (cssClasses) {
+      forEach(cssClasses.split(' '), function(cssClass) {
+        element.className = trim(
+            (" " + element.className + " ")
+            .replace(/[\n\t]/g, " ")
+            .replace(" " + trim(cssClass) + " ", " ")
+        );
+      });
+    }
+  } else {
+    if (cssClasses && element.setAttribute) {
+      forEach(cssClasses.split(' '), function(cssClass) {
+        element.setAttribute('class', trim(
+            (" " + (element.getAttribute('class') || '') + " ")
+            .replace(/[\n\t]/g, " ")
+            .replace(" " + trim(cssClass) + " ", " "))
+        );
+      });
+    }
   }
 }
 
 function jqLiteAddClass(element, cssClasses) {
-  if (cssClasses && element.setAttribute) {
-    var existingClasses = (' ' + (element.getAttribute('class') || '') + ' ')
-                            .replace(/[\n\t]/g, " ");
+  if (msie && msie < 8) {
+    if (cssClasses) {
+      forEach(cssClasses.split(' '), function(cssClass) {
+        if (!jqLiteHasClass(element, cssClass)) {
+          element.className = trim(element.className + ' ' + trim(cssClass));
+        }
+      });
+    }
+  } else {
+    if (cssClasses && element.setAttribute) {
+      var existingClasses = (' ' + (element.getAttribute('class') || '') + ' ')
+                              .replace(/[\n\t]/g, " ");
 
-    forEach(cssClasses.split(' '), function(cssClass) {
-      cssClass = trim(cssClass);
-      if (existingClasses.indexOf(' ' + cssClass + ' ') === -1) {
-        existingClasses += cssClass + ' ';
-      }
-    });
+      forEach(cssClasses.split(' '), function(cssClass) {
+        cssClass = trim(cssClass);
+        if (existingClasses.indexOf(' ' + cssClass + ' ') === -1) {
+          existingClasses += cssClass + ' ';
+        }
+      });
 
-    element.setAttribute('class', trim(existingClasses));
+      element.setAttribute('class', trim(existingClasses));
+    }
   }
 }
 


### PR DESCRIPTION
With this change most of Angular's features work again in IE7. As IE7 and below are not tested,
there is no guarantee what works and what not. Other browsers are not affected by the changes.

See #4562, #4880
