### PR TITLE
docs($compile): fixed syntax error.

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1196,7 +1196,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           hasTranscludeDirective = true;
 
           // Special case ngIf and ngRepeat so that we don't complain about duplicate transclusion.
-          // This option should only be used by directives that know how to how to safely handle element transclusion,
+          // This option should only be used by directives that know how to safely handle element transclusion,
           // where the transcluded nodes are added or replaced after linking.
           if (!directive.$$tlb) {
             assertNoDuplicate('transclusion', nonTlbTranscludeDirective, directive, $compileNode);


### PR DESCRIPTION
"how to" was written twice in a row.
