### PR TITLE
fix(jqLite): trim HTML string in jqLite constructor

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -176,7 +176,7 @@ function JQLite(element) {
     return element;
   }
   if (!(this instanceof JQLite)) {
-    if (isString(element) && element.charAt(0) != '<') {
+    if (isString(element) && (element = trim(element)).charAt(0) != '<') {
       throw jqLiteMinErr('nosel', 'Looking up elements via selectors is not supported by jqLite! See: http://docs.angularjs.org/api/angular.element');
     }
     return new JQLite(element);

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -65,6 +65,17 @@ describe('jqLite', function() {
     });
 
 
+    it('should allow construction of html with leading whitespace', function() {
+      var nodes = jqLite('  \n\r   \r\n<div>1</div><span>2</span>');
+      expect(nodes[0].parentNode).toBeDefined();
+      expect(nodes[0].parentNode.nodeType).toBe(11); /** Document Fragment **/;
+      expect(nodes[0].parentNode).toBe(nodes[1].parentNode);
+      expect(nodes.length).toBe(2);
+      expect(nodes[0].innerHTML).toBe('1');
+      expect(nodes[1].innerHTML).toBe('2');
+    });
+
+
     it('should allow creation of comment tags', function() {
       var nodes = jqLite('<!-- foo -->');
       expect(nodes.length).toBe(1);


### PR DESCRIPTION
jQuery will construct DOM nodes containing leading whitespace. Prior to this change, jqLite would throw a nosel minErr due to the first character of the string not being '<'. This change corrects this behaviour by trimming the element string in jqLite constructor before testing for '<'.

Closes #6053
