### PR TITLE
fix(orderBy): support string predicates containing non-ident characters

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -74,6 +74,12 @@ function orderByFilter($parse){
           predicate = predicate.substring(1);
         }
         get = $parse(predicate);
+        if (get.constant) {
+          var key = get();
+          return reverseComparator(function(a,b) {
+            return compare(a[key], b[key]);
+          }, descending);
+        }
       }
       return reverseComparator(function(a,b){
         return compare(get(a),get(b));

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -31,4 +31,16 @@ describe('Filter: orderBy', function() {
     toEqual([{a:2, b:1},{a:15, b:1}]);
   });
 
+  it('should support string predicates with names containing non-identifier characters', function() {
+    expect(orderBy([{"Tip %": .25}, {"Tip %": .15}, {"Tip %": .40}], '"Tip %"'))
+      .toEqualData([{"Tip %": .15}, {"Tip %": .25}, {"Tip %": .40}]);
+    expect(orderBy([{"원": 76000}, {"원": 31000}, {"원": 156000}], '"원"'))
+      .toEqualData([{"원": 31000}, {"원": 76000}, {"원": 156000}])
+  });
+
+  it('should throw if quoted string predicate is quoted incorrectly', function() {
+    expect(function() {
+      return orderBy([{"Tip %": .15}, {"Tip %": .25}, {"Tip %": .40}], '"Tip %\'');
+    }).toThrow();
+  });
 });


### PR DESCRIPTION
The orderBy filter now allows string predicates passed to the orderBy filter
to make use property name predicates containing non-ident strings, such as
spaces or percent signs, or non-latin characters.

Closes #6143
