### PR TITLE
Add missing npm package name `Karma`

### DIFF
--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -73,7 +73,7 @@ directory.</p></li>
       <p>Additionally install <a href="http://karma-runner.github.io/">Karma</a> and its plugins if you
       don't have it already:</p>
       <pre>
-      npm install
+      npm install -g karma
       </pre></li>
       <li><p>You will need an http server running on your system. Mac and Linux machines typically
 have Apache pre-installed, but If you don't already have one installed, you can use <code>node</code>


### PR DESCRIPTION
The actual name of the package that is needed to be installed is missing, I added it by going to the webpage of the linked package. It instructs to run `npm install -g karma` which I've added to the document.
