### PR TITLE
fix(docs): version drop down should be naturally sorted

### DIFF
--- a/docs/src/ngdoc.js
+++ b/docs/src/ngdoc.js
@@ -130,7 +130,11 @@ exports.ngVersions = function() {
     for(var key in obj) {
       keys.push(key);
     };
-    keys.sort(true);
+    keys.sort(function (a, b) {
+      var aa = a.split(/\./),
+        bb = b.split(/\./);
+      return aa[0] - bb[0] || aa[1] - bb[1] || aa[2] - bb[2];
+    });
     return keys;
   };
 };


### PR DESCRIPTION
Change the version sorting function at the docs generation so versions are ordered using natural order

Closes #6029
