### PR TITLE
#3183: Added necessary fix for Firefox when using <option value="">

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -531,7 +531,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
                   lastElement.val(existingOption.id = option.id);
                 }
                 // lastElement.prop('selected') provided by jQuery has side-effects
-                if (lastElement[0].selected !== option.selected) {
+                if (lastElement[0].selected !== option.selected && lastElement[0].value) {
                   lastElement.prop('selected', (existingOption.selected = option.selected));
                 }
               } else {


### PR DESCRIPTION
#3183 seems to mostly not appear, but it does appear in Firefox still when I have select elements when
1.  The select element is not nested in a form element, or
2.  When `<option value="">` is used

However, there seems to be some additional condition(s) where this arises - I'm having problems reproducing this.  It is something similar to what I have in this [Plunker](http://plnkr.co/edit/SX74hewnm0YPuwJHvKYH?p=preview), although more complicated than what is there.

This additional check stops a weird edge case from appearing on occasion.
