### PR TITLE
docs($resource): Fix statement about instance actions

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -153,9 +153,9 @@ function shallowClearAndCopy(src, dst) {
  *
  *   Calling these methods invoke an {@link ng.$http} with the specified http method,
  *   destination and parameters. When the data is returned from the server then the object is an
- *   instance of the resource class. The actions `save`, `remove` and `delete` are available on it
- *   as  methods with the `$` prefix. This allows you to easily perform CRUD operations (create,
- *   read, update, delete) on server-side data like this:
+ *   instance of the resource class. The actions `save`, `remove` and `delete`, as well as custom
+ *   non-GET actions, are available on it as methods with the `$` prefix. This allows you to easily
+ *   perform CRUD operations (create, read, update, delete) on server-side data like this:
  *   <pre>
         var User = $resource('/user/:userId', {userId:'@id'});
         var user = User.get({userId:123}, function() {


### PR DESCRIPTION
Before it led to misbelief, that only default $resource actions can be invoked using instance fashion.
