### PR TITLE
ngTransclude memory leak fix

### DIFF
--- a/src/ng/directive/ngTransclude.js
+++ b/src/ng/directive/ngTransclude.js
@@ -55,26 +55,21 @@
    </doc:example>
  *
  */
-var ngTranscludeDirective = ngDirective({
-  controller: ['$element', '$transclude', function($element, $transclude) {
-    if (!$transclude) {
-      throw minErr('ngTransclude')('orphan',
-          'Illegal use of ngTransclude directive in the template! ' +
-          'No parent directive that requires a transclusion found. ' +
-          'Element: {0}',
-          startingTag($element));
+var ngTranscludeDirective = function() {
+  return {
+    link: function(scope, element, attrs, ctrl, transclude){
+      if (!transclude) {
+        throw minErr('ngTransclude')('orphan',
+            'Illegal use of ngTransclude directive in the template! ' +
+            'No parent directive that requires a transclusion found. ' +
+            'Element: {0}',
+            startingTag(element));
+      }
+
+      transclude(function(clone) {
+        element.empty();
+        element.append(clone);
+      });
     }
-
-    // remember the transclusion fn but call it during linking so that we don't process transclusion before directives on
-    // the parent element even when the transclusion replaces the current element. (we can't use priority here because
-    // that applies only to compile fns and not controllers
-    this.$transclude = $transclude;
-  }],
-
-  link: function($scope, $element, $attrs, controller) {
-    controller.$transclude(function(clone) {
-      $element.empty();
-      $element.append(clone);
-    });
   }
-});
+};

--- a/src/ng/directive/ngTransclude.js
+++ b/src/ng/directive/ngTransclude.js
@@ -71,5 +71,5 @@ var ngTranscludeDirective = function() {
         element.append(clone);
       });
     }
-  }
+  };
 };


### PR DESCRIPTION
I've been profiling a one page app using Angular.js and have had a tough time nailing down this memory leak. I'm using Angularjs for a custom template system that outputs data from a content DSL containing educational content. In this system I swap out a lot of templates full of other angular directives which in themselves sometimes compile/transclude content. After a few days of searching I've finally narrowed down one of the larger memory leaks. Using `transclude: true` in a directive is fine, no problems with leaks, but as soon as `ng-include` is used within the template I was getting a lot of detached DOM fragments in the Chrome memory profiler.

Here is a sample app which replicates the problem:

``` html
<!DOCTYPE html>
<html>
<head>
  <title>angular.js bug test</title>
</head>
<body ng-app="app">
  <first-level></first-level>
</body>
  <script src="angular.js"></script>
  <script>
    app = angular.module('app', []);

    app.directive('ngTranscludeFixed', function(){
      return {
        restrict: 'AC',
        link: function(scope, element, attrs, ctrl, transclude){
          if (!transclude) {
            throw minErr('ngTransclude')('orphan',
                'Illegal use of ngTransclude directive in the template! ' +
                'No parent directive that requires a transclusion found. ' +
                'Element: {0}',
                startingTag(element));
          }

          transclude(function(clone) {
            element.empty();
            element.append(clone);
          });
        }
      }
    });

    app.directive('secondLevel', function(){
      return {
        replace: true,
        restrict: 'E',
        scope: {},
        transclude: true,
        template: "<div><div class='number-2' ng-transclude></div>"
      }
    });

    app.directive('firstLevel', function($compile){
      return {
        replace: true,
        restrict: 'E',
        scope: {},
        template: "<div class='number-1'><button ng-click='switchContents(1)'>One</button><button ng-click='switchContents(2)'>two</button><p></p></div>",
        link: function(scope, element, attrs){
          var content1 = "<second-level>hello world! 1</second-level>"
          var content2 = "<second-level>hello world! 2</second-level>"
          var pEl = element.find('p')
          var childScope = null;

          scope.switchContents = function(number){
            if(childScope) {
              childScope.$destroy();
              childScope = null;
            }

            pEl.empty()
            childScope = scope.$new()
            if(number == 1) {
              pEl.append(angular.element(content1));
            }else{
              pEl.append(angular.element(content2));
            }

            $compile(pEl.contents())(childScope);
          }
        }
      }
    });
  </script>
</html>
```

So running this using `ng-transclude` in the `secondLevel` directive, you can click the buttons a few times to see the transclude working, but when profiled in dev tools we get:

![screen shot 2014-02-07 at 2 16 42 pm](https://f.cloud.github.com/assets/599521/2113722/0cbe0782-9031-11e3-8a5e-26a1119df673.png)

As you can see there are 4 detached Dom node Trees as a result, not a huge deal in this smaller app, but in my larger app it's causing 350+ detached nodes and about 5mb heap increase per template change. This is a fairly large problem for a one page app since we never reload the page.

Now if we swap out `ng-transclude` with the proposed changes (`ng-transclude-fix`) we get:
![screen shot 2014-02-07 at 2 19 20 pm](https://f.cloud.github.com/assets/599521/2113725/1375f40e-9031-11e3-8001-40df4e6b4bae.png)

No detached dom nodes!

The tests pass, I'm not entirely sure how you would even test for detached Dom nodes and memory heap size. From my testing, it seems like the act of assigning $transclude to the controller (or scope for that matter) causes the detached nodes. This fix uses the new transclude function included within the `link` function to handle the transclude, instead of passing the $transclude object from the controller to the linking function. This is functionally the same, and eliminates the leak.
