### PR TITLE
chore(testing): switch Jenkins to test e2e only on chrome

### DIFF
--- a/jenkins_build.sh
+++ b/jenkins_build.sh
@@ -32,8 +32,6 @@ grunt test:unit --browsers $BROWSERS --reporters=dots,junit --no-colors --no-col
 
 # END TO END TESTS #
 grunt test:ci-protractor
-grunt test:ci-protractor --browser safari
-grunt test:ci-protractor --browser firefox
 
 # Promises/A+ TESTS #
 grunt test:promises-aplus --no-color


### PR DESCRIPTION
End to end tests will continue to be run on Safari and Firefox on Travis.
