### PR TITLE
link to angular.equals in $watch documentation

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -313,7 +313,8 @@ function $RootScopeProvider(){
        *    - `function(newValue, oldValue, scope)`: called with current and previous values as
        *      parameters.
        *
-       * @param {boolean=} objectEquality Compare object for equality rather than for reference.
+       * @param {boolean=} objectEquality Compare for object equality using {@link angular.equals} instead of
+       *     comparing for reference equality.
        * @returns {function()} Returns a deregistration function for this listener.
        */
       $watch: function(watchExp, listener, objectEquality) {


### PR DESCRIPTION
Incorporates by reference the precise definition of object equality in this case; helpful for those new to Angular, and increases awareness of Angular's quite useful helper library.
