### PR TITLE
Update ngEventDirs.js

### DIFF
--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -298,8 +298,8 @@ forEach(
  * Enables binding angular expressions to onsubmit events.
  *
  * Additionally it prevents the default action (which for form means sending the request to the
- * server and reloading the current page) **but only if the form does not contain an `action`
- * attribute**.
+ * server and reloading the current page) **but only if the form does not contain `action` or `data-action`
+ * attributes**.
  *
  * @element form
  * @priority 0


### PR DESCRIPTION
NgSubmit
The documentation states only the "action" attribute triggers a page submission, which is incorrect. When using the attribute "data-action" (as for AJAX control, attempting to bypass the "action" attribute but still make it obvious what it's for), Angular thinks this is also classified as the attribute "action" and continues with the page submission.
