### PR TITLE
Docs: Add link to MIT license from the FAQ page

### DIFF
--- a/docs/content/misc/faq.ngdoc
+++ b/docs/content/misc/faq.ngdoc
@@ -100,7 +100,7 @@ Watch the July 17, 2012 talk
 
 ### How is Angular licensed?
 
-The MIT License.
+The {@link http://opensource.org/licenses/MIT MIT License}.
 
 ### Can I download and use the Angular logo artwork?
 


### PR DESCRIPTION
The FAQ page was lacking a link to the MIT license so I added it.
