### PR TITLE
feat($rootScope): add diff support for $digest / equals

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -820,7 +820,7 @@ function equals(o1, o2, diff) {
       if (isArray(o1)) {
         if (!isArray(o2)) return false;
         if ((length = o1.length) == o2.length) {
-          if (!Array.isArray(diff)) {
+          if (!isArray(diff)) {
             skipDiff = true;
           }
           for(key=0; key<length; key++) {
@@ -844,7 +844,7 @@ function equals(o1, o2, diff) {
       } else {
         if (isScope(o1) || isScope(o2) || isWindow(o1) || isWindow(o2) || isArray(o2)) return false;
         keySet = {};
-        if (!Array.isArray(diff)) {
+        if (!isArray(diff)) {
           skipDiff = true;
         }
         for(key in o1) {

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -554,6 +554,7 @@ function $RootScopeProvider(){
             length,
             dirty, ttl = TTL,
             next, current, target = this,
+            diff = [],
             watchLog = [],
             logIdx, logMsg, asyncTask;
 
@@ -589,13 +590,17 @@ function $RootScopeProvider(){
                   if (watch) {
                     if ((value = watch.get(current)) !== (last = watch.last) &&
                         !(watch.eq
-                            ? equals(value, last)
+                            ? equals(value, last, diff)
                             : (typeof value == 'number' && typeof last == 'number'
                                && isNaN(value) && isNaN(last)))) {
                       dirty = true;
                       lastDirtyWatch = watch;
                       watch.last = watch.eq ? copy(value) : value;
-                      watch.fn(value, ((last === initWatchVal) ? value : last), current);
+                      if (diff.length > 0) {
+                        watch.fn(value, ((last === initWatchVal) ? value : last), current, diff);
+                      } else {
+                        watch.fn(value, ((last === initWatchVal) ? value : last), current);
+                      }
                       if (ttl < 5) {
                         logIdx = 4 - ttl;
                         if (!watchLog[logIdx]) watchLog[logIdx] = [];


### PR DESCRIPTION
when firing watchers in $digest, Angular includes the old and the new
value. In case of arrays of objects, it's impossible to tell which
properties changed in which objects without manually doing a diff of the
old and the new values. with this small change, it's possible for apps and
custom directive implementations to know exactly what changed, without
doing this diffs every time.
