### PR TITLE
feat(filterFilter): support deeply nested predicate objects

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -81,6 +81,7 @@
     -assertNotHasOwnProperty,
     -getter,
     -getBlockElements,
+    -hasOwnProperty,
 
 */
 
@@ -96,7 +97,7 @@
  * @returns {string} Lowercased string.
  */
 var lowercase = function(string){return isString(string) ? string.toLowerCase() : string;};
-
+var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 /**
  * @ngdoc function

--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -136,6 +136,15 @@ function filterFilter() {
         };
       } else {
         comparator = function(obj, text) {
+          if (obj && text && typeof obj === 'object' && typeof text === 'object') {
+            for (var objKey in obj) {
+              if (objKey.charAt(0) !== '$' && hasOwnProperty.call(obj, objKey) &&
+                  comparator(obj[objKey], text[objKey])) {
+                return true;
+              }
+            }
+            return false;
+          }
           text = (''+text).toLowerCase();
           return (''+obj).toLowerCase().indexOf(text) > -1;
         };

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -70,6 +70,17 @@ describe('Filter: filter', function() {
   });
 
 
+  it('should support deep predicate objects', function() {
+    var items = [{person: {name: 'John'}},
+                 {person: {name: 'Rita'}},
+                 {person: {name: 'Billy'}},
+                 {person: {name: 'Joan'}}];
+    expect(filter(items, {person: {name: 'Jo'}}).length).toBe(2);
+    expect(filter(items, {person: {name: 'Jo'}})).toEqual([
+      {person: {name: 'John'}}, {person: {name: 'Joan'}}]);
+  });
+
+
   it('should match any properties for given "$" property', function() {
     var items = [{first: 'tom', last: 'hevery'},
                  {first: 'adam', last: 'hevery', alias: 'tom', done: false},


### PR DESCRIPTION
Due to 339a165, it became impossible to filter nested properties of an object
using the filterFilter. A proposed solution to this was to enable the use of
nested predicate objects. This fix enables the use of these nested predicate
objects.

Example:

``` html
<div ng-repeat="it in items | filter:{ address: { country: 'Canuckistan'}}"></div>
```

Or

``` js
$filter('filter')(items, { address: { country: 'Canuckistan' } });
```

Related to #6009
