### PR TITLE
fix(win8): Make Angular work on Windows 8 JS Apps

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -23,6 +23,8 @@
     /* angular.js */
     "angular": false,
     "msie": false,
+    "windowsStore": false,
+    "MSApp": false,
     "jqLite": false,
     "jQuery": false,
     "slice": false,
@@ -119,6 +121,7 @@
     "jqNextId": false,
     "camelCase": false,
     "jqLitePatchJQueryRemove": false,
+    "jqLitePatchJQueryForWindowsStore": false,
     "JQLite": false,
     "jqLiteClone": false,
     "jqLiteDealoc": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -4,6 +4,7 @@
 /* global
     -angular,
     -msie,
+    -windowsStore,
     -jqLite,
     -jQuery,
     -slice,
@@ -153,6 +154,7 @@ if ('i' !== 'I'.toLowerCase()) {
 
 var /** holds major version number for IE or NaN for real browsers */
     msie,
+    windowsStore,     // Windows Store JS apps
     jqLite,           // delay binding since jQuery could be loaded after us.
     jQuery,           // delay binding
     slice             = [].slice,
@@ -177,6 +179,9 @@ if (isNaN(msie)) {
   msie = int((/trident\/.*; rv:(\d+)/.exec(lowercase(navigator.userAgent)) || [])[1]);
 }
 
+// The MSApp object is supported only in Windows Store JavaScript apps.
+// http://msdn.microsoft.com/en-us/library/windows/apps/hh767332.aspx
+windowsStore = typeof window.MSApp != 'undefined' ? true : false;
 
 /**
  * @private
@@ -1309,6 +1314,8 @@ function bindJQuery() {
     jqLitePatchJQueryRemove('remove', true, true, false);
     jqLitePatchJQueryRemove('empty', false, false, false);
     jqLitePatchJQueryRemove('html', false, false, true);
+    // additional tweaks for Windows Store apps
+    jqLitePatchJQueryForWindowsStore();
   } else {
     jqLite = JQLite;
   }

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -249,7 +249,7 @@ function Browser(window, document, $log, $sniffer) {
    */
   self.baseHref = function() {
     var href = baseElement.attr('href');
-    return href ? href.replace(/^(https?\:)?\/\/[^\/]*/, '') : '';
+    return href ? href.replace(/^((https?|ms-appx)\:)?\/\/[^\/]*/, '') : '';
   };
 
   //////////////////////////////////////////////////////////////

--- a/src/ng/sanitizeUri.js
+++ b/src/ng/sanitizeUri.js
@@ -5,8 +5,8 @@
  * Private service to sanitize uris for links and images. Used by $compile and $sanitize.
  */
 function $$SanitizeUriProvider() {
-  var aHrefSanitizationWhitelist = /^\s*(https?|ftp|mailto|tel|file):/,
-    imgSrcSanitizationWhitelist = /^\s*(https?|ftp|file|blob):|data:image\//;
+  var aHrefSanitizationWhitelist = /^\s*(https?|ftp|mailto|tel|file|ms-appx|ms-appdata|x-wmapp\d):/,
+    imgSrcSanitizationWhitelist = /^\s*(https?|ftp|file|blob|ms-appx|ms-appdata|x-wmapp\d):|data:image\//;
 
   /**
    * @description

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -614,5 +614,13 @@ describe('browser', function() {
       fakeDocument.basePath = '//google.com/base/path/';
       expect(browser.baseHref()).toEqual('/base/path/');
     });
+
+    it('should correctly resolve <base href> beginning with \'ms-appx://\' (Windows Store JS app) ', function() {
+      fakeDocument.basePath = 'ms-appx://io.mypackage.appname/base/path/';
+      expect(browser.baseHref()).toEqual('/base/path/');
+
+      fakeDocument.basePath = 'ms-appx://io.mypackage.appname/base/path/index.html';
+      expect(browser.baseHref()).toEqual('/base/path/index.html');
+    });
   });
 });


### PR DESCRIPTION
**Browser:** Other
**Component:** misc core
**Regression:** no
#### Make Angular JS work on Windows 8 JavaScript apps.

In order to ensure the right level of security, the Windows platform prevents certain things to be done in JavaScript code, therefore developers have to make some adjustments to their Web code.
The changes in the pull request for AngularJS are in line with Windows 8 recommendations without breaking the Web. 
All the unit test cases for the web have been run. The scenario runners have also been run on Windows Store apps to ensure that these changes work. 

With these changes, developers can use AngularJS for Windows Store apps the exact same way they do for their Web apps.
