### PR TITLE
fix(ngCookie): convert non-string values to string

### DIFF
--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -95,12 +95,10 @@ angular.module('ngCookies', ['ng']).
         for(name in cookies) {
           value = cookies[name];
           if (!angular.isString(value)) {
-            if (angular.isDefined(lastCookies[name])) {
-              cookies[name] = lastCookies[name];
-            } else {
-              delete cookies[name];
-            }
-          } else if (value !== lastCookies[name]) {
+            value = '' + value;
+            cookies[name] = value;
+          }
+          if (value !== lastCookies[name]) {
             $browser.cookies(name, value);
             updated = true;
           }

--- a/test/ngCookies/cookiesSpec.js
+++ b/test/ngCookies/cookiesSpec.js
@@ -45,15 +45,25 @@ describe('$cookies', function() {
   }));
 
 
-  it('should drop or reset any cookie that was set to a non-string value',
+  it('should convert non-string values to string',
       inject(function($cookies, $browser, $rootScope) {
     $cookies.nonString = [1, 2, 3];
     $cookies.nullVal = null;
     $cookies.undefVal = undefined;
-    $cookies.preexisting = function() {};
+    var preexisting = $cookies.preexisting = function() {};
     $rootScope.$digest();
-    expect($browser.cookies()).toEqual({'preexisting': 'oldCookie'});
-    expect($cookies).toEqual({'preexisting': 'oldCookie'});
+    expect($browser.cookies()).toEqual({
+      'preexisting': '' + preexisting,
+      'nonString': '1,2,3',
+      'nullVal': 'null',
+      'undefVal': 'undefined'
+    });
+    expect($cookies).toEqual({
+      'preexisting': '' + preexisting,
+      'nonString': '1,2,3',
+      'nullVal': 'null',
+      'undefVal': 'undefined'
+    });
   }));
 
 


### PR DESCRIPTION
Previously, non-string values stored in $cookies would be removed, without warning the user, and
causing difficulty debugging. Now, the value is converted to string before being stored, and the
value is not dropped. Serialization may be customized using the toString() method of an object's
prototype.

Closes #6151
