### PR TITLE
docs(guide/$location) : bad link (error 404)

### DIFF
--- a/docs/content/guide/dev_guide.services.$location.ngdoc
+++ b/docs/content/guide/dev_guide.services.$location.ngdoc
@@ -160,7 +160,7 @@ encoded.
 
 `$location` service has two configuration modes which control the format of the URL in the browser
 address bar: **Hashbang mode** (the default) and the **HTML5 mode** which is based on using the
-HTML5 {@link http://www.w3.org/TR/html5/history.html History API}. Applications use the same API in
+HTML5 {@link http://www.w3.org/TR/html5/browsers.html#history History API}. Applications use the same API in
 both modes and the `$location` service will work with appropriate URL segments and browser APIs to
 facilitate the browser URL change and history management.
 


### PR DESCRIPTION
**Browser:** Other
**Component:** misc core
**Regression:** no

Corrects the link to "History API"
