### PR TITLE
Update ie.ngdoc

### DIFF
--- a/docs/content/guide/ie.ngdoc
+++ b/docs/content/guide/ie.ngdoc
@@ -30,7 +30,7 @@ To make your Angular application work on IE please make sure that:
        <!doctype html>
        <html xmlns:ng="http://angularjs.org">
          <head>
-           <!--[if lte IE 8]>
+           <!--[if lte IE 7]>
              <script src="/path/to/json2.js"></script>
            <![endif]-->
          </head>


### PR DESCRIPTION
**Browser**: IE8
**Component**: docs
**Regression**: no

Text specifies "polyfill JSON.stringify for IE7 and below" conditional comment for loading the polyfill was "lte IE 8". According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify IE8 supports JSON.stringify, so the text was correct, conditional comment was wrong.
