### PR TITLE
feat(angular.isEmptyObject): check object for enumerable properties

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -36,6 +36,7 @@
     -isUndefined,
     -isDefined,
     -isObject,
+    -isEmptyObject,
     -isString,
     -isNumber,
     -isDate,
@@ -427,6 +428,26 @@ function isDefined(value){return typeof value !== 'undefined';}
  * @returns {boolean} True if `value` is an `Object` but not `null`.
  */
 function isObject(value){return value != null && typeof value === 'object';}
+
+
+/**
+* @ngdoc function
+* @name angular.isEmptyObject
+* @function
+*
+* @description
+* Determines if a object is empty. (contains no enumerable properties).
+*
+* @param {*} value Reference to check.
+* @returns {boolean} True if `value` has no properties.
+*/
+function isEmptyObject(value) {
+  var name;
+  for ( name in value ) {
+    return false;
+  }
+  return true;
+}
 
 
 /**

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -117,6 +117,7 @@ function publishExternalAPI(angular){
     'isString': isString,
     'isFunction': isFunction,
     'isObject': isObject,
+    'isEmptyObject': isEmptyObject,
     'isNumber': isNumber,
     'isElement': isElement,
     'isArray': isArray,

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1128,4 +1128,15 @@ describe('angular', function() {
       });
     }));
   });
+  
+  describe('isEmptyObject', function() {
+    it('should return true for empty object', function() {
+      expect(isEmptyObject({})).toBe(true);
+      expect(isEmptyObject(null).toBe(true);
+    });
+
+    it('should return false for non empty object', function() {
+      expect(isEmptyObject({a:1}).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Would like to submit feature for checking if an object is empty `{}` or `null`.
Pretty useful in removing duplicate code in checking empty objects or null.
e.g. in cases where an async request returns {} 
