### PR TITLE
Update basic auth default headers example

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -278,7 +278,7 @@ function $HttpProvider() {
      *
      * ```
      * module.run(function($http) {
-     *   $http.defaults.headers.common.Authentication = 'Basic YmVlcDpib29w'
+     *   $http.defaults.headers.common.Authorization = 'Basic YmVlcDpib29w'
      * });
      * ```
      *


### PR DESCRIPTION
Updating name of basic auth header in example to be 'Authorization' as it should be instead of 'Authentication'
