### PR TITLE
fix($compile): fix duplicate style attributes

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1645,7 +1645,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           safeAddClass($element, value);
           dst['class'] = (dst['class'] ? dst['class'] + ' ' : '') + value;
         } else if (key == 'style') {
-          $element.attr('style', $element.attr('style') + ';' + value);
+          if($element.attr("style") !== value) {
+            $element.attr('style', $element.attr('style') + ';' + value);
+          }
           dst['style'] = (dst['style'] ? dst['style'] + ';' : '') + value;
           // `dst` will never contain hasOwnProperty as DOM parser won't let it.
           // You will get an "InvalidCharacterError: DOM Exception 5" error if you

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -541,6 +541,14 @@ describe('$compile', function() {
             replace: true,
             template: '<tfoot><tr><td>TD</td></tr></tfoot>'
           }));
+          directive('replaceWithNonInterpolatedStyle', valueFn({
+            replace: true,
+            template: '<div style="color: red;">Replace with non-interpolated style!</div>',
+            compile: function(element, attr) {
+              attr.$set('compiled', 'COMPILED');
+              expect(element).toBe(attr.$$element);
+            }
+          }));
         }));
 
 
@@ -634,6 +642,13 @@ describe('$compile', function() {
               expect(element.css('width')).toBe('2px');
           }));
         }
+
+        it('should handle non-interpolated css style from replacing directive', inject(
+          function($compile, $rootScope) {
+            element = $compile('<div replace-with-non-interpolated-style></div>')($rootScope);
+            $rootScope.$digest();
+            expect(element.attr('style')).toMatch(/^color\: red;?$/ig);
+          }));
 
         it('should merge interpolated css class', inject(function($compile, $rootScope) {
           element = $compile('<div class="one {{cls}} three" replace></div>')($rootScope);


### PR DESCRIPTION
This fix avoids duplicating style attributes in directives that specify
'replace: true' and 'template: &lt;div style="..." /&gt;'.

Closes #6239
