### PR TITLE
fix(input): don't apply textInput to <input type="file">

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -424,7 +424,8 @@ var inputType = {
   'hidden': noop,
   'button': noop,
   'submit': noop,
-  'reset': noop
+  'reset': noop,
+  'file': noop
 };
 
 // A helper function to call $setValidity and return the value / undefined,


### PR DESCRIPTION
Browser: Chrome Component: misc core Regression: (sort of)

textInput shouldn't be applied to file inputs to ease writing of custom file input directives

Related #6243
Closes #6231
