### PR TITLE
fix(angular.toJson): only strip properties beginning with $$, not $

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -948,7 +948,7 @@ function bind(self, fn) {
 function toJsonReplacer(key, value) {
   var val = value;
 
-  if (typeof key === 'string' && key.charAt(0) === '$') {
+  if (typeof key === 'string' && key.charAt(0) === '$' && key.charAt(1) === '$') {
     val = undefined;
   } else if (isWindow(value)) {
     val = '$WINDOW';
@@ -969,7 +969,7 @@ function toJsonReplacer(key, value) {
  * @function
  *
  * @description
- * Serializes input into a JSON-formatted string. Properties with leading $ characters will be
+ * Serializes input into a JSON-formatted string. Properties with leading $$ characters will be
  * stripped since angular uses this notation internally.
  *
  * @param {Object|Array|Date|string|number} obj Input to be serialized into JSON.

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -493,6 +493,13 @@ angular.module('ngResource', ['ng']).
           shallowClearAndCopy(value || {}, this);
         }
 
+        Resource.prototype.toJSON = function () {
+          var data = extend({}, this);
+          delete data.$promise;
+          delete data.$resolved;
+          return data;
+        };
+
         forEach(actions, function (action, name) {
           var hasBody = /^(POST|PUT|PATCH)$/i.test(action.method);
 

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1093,8 +1093,13 @@ describe('angular', function() {
     });
 
 
-    it('should not serialize properties starting with $', function() {
-      expect(toJson({$few: 'v', $$some:'value'}, false)).toEqual('{}');
+    it('should not serialize properties starting with $$', function() {
+      expect(toJson({$$some:'value'}, false)).toEqual('{}');
+    });
+
+
+    it('should serialize properties starting with $', function() {
+      expect(toJson({$few: 'v'}, false)).toEqual('{"$few":"v"}');
     });
 
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -647,6 +647,20 @@ describe("resource", function() {
     expect(person2).toEqual(jasmine.any(Person));
   });
 
+  it('should not include $promise and $resolved when resource is toJson\'ed', function() {
+    $httpBackend.expect('GET', '/CreditCard/123').respond({id: 123, number: '9876'});
+    var cc = CreditCard.get({id: 123});
+    $httpBackend.flush();
+
+    expect(cc.$promise).toBeDefined();
+    expect(cc.$resolved).toBe(true);
+
+    var json = JSON.parse(angular.toJson(cc));
+    expect(json.$promise).not.toBeDefined();
+    expect(json.$resolved).not.toBeDefined();
+    expect(json).toEqual({id: 123, number: '9876'});
+  });
+
   describe('promise api', function() {
 
     var $rootScope;


### PR DESCRIPTION
This PR makes `angular.toJson` strip properties beginning with `$$`, instead of `$`
##### Rationale behind this:

2 years ago, angular switched from using it's own json serializer to the native `JSON.stringify` in 35125d25137ac2da13ed1ca3e652ec8f2c945053.
In the old serializer, angular was stripping the following properties: `this`, `$parent` and anything starting [with `$$`](https://github.com/angular/angular.js/blob/87f5c6e5b716100e203ec59c5874c3e927f83fa0/src/JSON.js#L141)

When we switched to the native `JSON.stringify`, this got changed to stripping anything starting [with](https://github.com/angular/angular.js/blob/35125d25137ac2da13ed1ca3e652ec8f2c945053/src/JSON.js#L5) [`$`](https://github.com/angular/angular.js/commit/6c59e770084912d2345e7f83f983092a2d305ae3#diff-1d54c5f722aebc473dbe96f836ddf974R784)

I don't know if this greedier stripping resulted from an internal discussion, but it seems to be causing problems to those who use properties beginning with `$` in their model (see #1463)
So I reverted to having `angular.toJson` only strip props that start with `$$`

There's the _issue_ that ngResource now defines the `$promise` and `$resolved` props on any resource instance: two properties that we don't want serialized and sent to the server on `$save`.
I worked around this by having resources utilize the [`toJSON`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON_behavior) method to not include both these properties on serialization.

I didn't go with the whitelist approach mentioned in #1463 because it would require a lookup in an array/hash for every property of an object being serialized, and it would be an app-wide config potentially requiring a lot of whitelisting. A better alternative would be a blacklist of [$$hashKey, $promise, $resolved], or what I'm doing here.
