### PR TITLE
test(date): fix failing test when running in Seoul, Korea time zone (UTC...

### DIFF
--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -333,13 +333,13 @@ describe('filters', function() {
     it('should support different degrees of subsecond precision', function () {
       var format = 'yyyy-MM-dd';
 
-      expect(date('2003-09-10T13:02:03.12345678Z', format)).toEqual('2003-09-10');
-      expect(date('2003-09-10T13:02:03.1234567Z', format)).toEqual('2003-09-10');
-      expect(date('2003-09-10T13:02:03.123456Z', format)).toEqual('2003-09-10');
-      expect(date('2003-09-10T13:02:03.12345Z', format)).toEqual('2003-09-10');
-      expect(date('2003-09-10T13:02:03.1234Z', format)).toEqual('2003-09-10');
-      expect(date('2003-09-10T13:02:03.123Z', format)).toEqual('2003-09-10');
-      expect(date('2003-09-10T13:02:03.12Z', format)).toEqual('2003-09-10');
+      expect(date('2003-09-10T13:02:03.00000001Z', format)).toEqual('2003-09-10');
+      expect(date('2003-09-10T13:02:03.0000001Z', format)).toEqual('2003-09-10');
+      expect(date('2003-09-10T13:02:03.000001Z', format)).toEqual('2003-09-10');
+      expect(date('2003-09-10T13:02:03.00001Z', format)).toEqual('2003-09-10');
+      expect(date('2003-09-10T13:02:03.0001Z', format)).toEqual('2003-09-10');
+      expect(date('2003-09-10T13:02:03.001Z', format)).toEqual('2003-09-10');
+      expect(date('2003-09-10T13:02:03.01Z', format)).toEqual('2003-09-10');
       expect(date('2003-09-10T13:02:03.1Z', format)).toEqual('2003-09-10');
     });
   });


### PR DESCRIPTION
...+09:00)

This is a minor fix to a unit test assertion that fails when running in the Seoul time zone (UTC+09:00):

expect(date('2003-09-10T13:02:03.12345678Z', format)).toEqual('2003-09-10');

Underneath, the JavaScript setUTCHours() function is called and when the millisecond part is larger than 999, it just adds seconds, minutes, or hours to the date.  For example, passing milliseconds of 70500 to this function will actually add 1 minute, 10 seconds, 500 milliseconds.  So adding 12345678 milliseconds, combined with the +09:00 time zone, adds enough hours to shift the day to 11, thus causing the test to fail.  This fix simply changes the milliseconds part to 00000001, which still tests the string parsing and date formatting without changing the date to the next day.
