### PR TITLE
Fix TypeError Cannot call method 'querySelectorAll' of undefined in ngAnimate

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -868,14 +868,16 @@ angular.module('ngAnimate', ['ng'])
 
       function cancelChildAnimations(element) {
         var node = extractElementNode(element);
-        forEach(node.querySelectorAll('.' + NG_ANIMATE_CLASS_NAME), function(element) {
-          element = angular.element(element);
-          var data = element.data(NG_ANIMATE_STATE);
-          if(data) {
-            cancelAnimations(data.animations);
-            cleanup(element);
-          }
-        });
+        if (node) {
+          forEach(node.querySelectorAll('.' + NG_ANIMATE_CLASS_NAME), function(element) {
+            element = angular.element(element);
+            var data = element.data(NG_ANIMATE_STATE);
+            if(data) {
+              cancelAnimations(data.animations);
+              cleanup(element);
+            }
+          });
+        }
       }
 
       function cancelAnimations(animations) {
@@ -1284,7 +1286,7 @@ angular.module('ngAnimate', ['ng'])
           event.stopPropagation();
           var ev = event.originalEvent || event;
           var timeStamp = ev.$manualTimeStamp || ev.timeStamp || Date.now();
-          
+
           /* Firefox (or possibly just Gecko) likes to not round values up
            * when a ms measurement is used for the animation */
           var elapsedTime = parseFloat(ev.elapsedTime.toFixed(ELAPSED_TIME_MAX_DECIMAL_PLACES));


### PR DESCRIPTION
Fix TypeError Cannot call method 'querySelectorAll' of undefined in ngAnimate when use ng-if on ng-repeat fix #6205

More about issue is here https://github.com/angular/angular.js/issues/6205
