### PR TITLE
Fix for number filter checking for numbers

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -118,7 +118,7 @@ function numberFilter($locale) {
 
 var DECIMAL_SEP = '.';
 function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
-  if (isNaN(number) || !isFinite(number)) return '';
+  if (number == null || !isFinite(number) || isObject(number)) return '';
 
   var isNegative = number < 0;
   number = Math.abs(number);

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -128,6 +128,11 @@ describe('filters', function() {
       expect(number(1234)).toEqual('1,234');
       expect(number(1234.5678)).toEqual('1,234.568');
       expect(number(Number.NaN)).toEqual('');
+      expect(number(null)).toEqual('');
+      expect(number({})).toEqual('');
+      expect(number([])).toEqual('');
+      expect(number(+Infinity)).toEqual('');
+      expect(number(-Infinity)).toEqual('');
       expect(number("1234.5678")).toEqual('1,234.568');
       expect(number(1/0)).toEqual("");
       expect(number(1,        2)).toEqual("1.00");


### PR DESCRIPTION
Fix for number filter when passing not a number to a filter. isNaN is
broken, so we should use isNumber function in formatNumber function.
Close #6188
