### PR TITLE
fix(ngCloack): ng-cloak directive gets removed too early

### DIFF
--- a/src/ng/directive/ngCloak.js
+++ b/src/ng/directive/ngCloak.js
@@ -38,6 +38,7 @@
  * class `ng-cloak` in addition to the `ngCloak` directive as shown in the example below.
  *
  * @element ANY
+ * @priority -500
  *
  * @example
    <doc:example>
@@ -57,6 +58,7 @@
  *
  */
 var ngCloakDirective = ngDirective({
+  priority: -500,
   compile: function(element, attr) {
     attr.$set('ngCloak', undefined);
     element.removeClass('ng-cloak');


### PR DESCRIPTION
**Browser:** Chrome
**Component:** misc core
**Regression:** no

add priority -500 to ngCloack to make sure the direcive will be compiled after all others

closes #5692
