### PR TITLE
fix(ngTouch): ngSwipe outside the boundaries

### DIFF
--- a/src/ngTouch/swipe.js
+++ b/src/ngTouch/swipe.js
@@ -21,7 +21,7 @@
      * documentation for `bind` below.
      */
 
-ngTouch.factory('$swipe', [function() {
+ngTouch.factory('$swipe', ['$window', function($window) {
   // The total distance in any direction before we make the call on swipe vs. scroll.
   var MOVE_BUFFER_RADIUS = 10;
 
@@ -78,7 +78,7 @@ ngTouch.factory('$swipe', [function() {
       var lastPos;
       // Whether a swipe is active.
       var active = false;
-
+      
       element.on('touchstart mousedown', function(event) {
         startCoords = getCoordinates(event);
         active = true;
@@ -88,12 +88,12 @@ ngTouch.factory('$swipe', [function() {
         eventHandlers['start'] && eventHandlers['start'](startCoords, event);
       });
 
-      element.on('touchcancel', function(event) {
+      angular.element($window).on('touchcancel', function(event) {
         active = false;
         eventHandlers['cancel'] && eventHandlers['cancel'](event);
       });
 
-      element.on('touchmove mousemove', function(event) {
+      angular.element($window).on('touchmove mousemove', function(event) {
         if (!active) return;
 
         // Android will send a touchcancel if it thinks we're starting to scroll.
@@ -127,7 +127,7 @@ ngTouch.factory('$swipe', [function() {
         }
       });
 
-      element.on('touchend mouseup', function(event) {
+      angular.element($window).on('touchend mouseup', function(event) {
         if (!active) return;
         active = false;
         eventHandlers['end'] && eventHandlers['end'](getCoordinates(event), event);
@@ -135,5 +135,3 @@ ngTouch.factory('$swipe', [function() {
     }
   };
 }]);
-
-

--- a/test/ngTouch/directive/ngSwipeSpec.js
+++ b/test/ngTouch/directive/ngSwipeSpec.js
@@ -30,8 +30,9 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       dealoc(element);
     });
 
-    it('should swipe to the left', inject(function($rootScope, $compile) {
+    it('should swipe to the left', inject(function($rootScope, $compile, $window) {
       element = $compile('<div ng-swipe-left="swiped = true"></div>')($rootScope);
+      angular.element($window.document.body).append(element);
       $rootScope.$digest();
       expect($rootScope.swiped).toBeUndefined();
 
@@ -48,8 +49,9 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBe(true);
     }));
 
-    it('should swipe to the right', inject(function($rootScope, $compile) {
+    it('should swipe to the right', inject(function($rootScope, $compile, $window) {
       element = $compile('<div ng-swipe-right="swiped = true"></div>')($rootScope);
+      angular.element($window.document.body).append(element);
       $rootScope.$digest();
       expect($rootScope.swiped).toBeUndefined();
 
@@ -66,8 +68,9 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBe(true);
     }));
 
-    it('should pass event object', inject(function($rootScope, $compile) {
+    it('should pass event object', inject(function($rootScope, $compile, $window) {
       element = $compile('<div ng-swipe-left="event = $event"></div>')($rootScope);
+      angular.element($window.document.body).append(element);
       $rootScope.$digest();
 
       browserTrigger(element, startEvent, {
@@ -83,9 +86,9 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.event).toBeDefined();
     }));
 
-    it('should not swipe if you move too far vertically', inject(function($rootScope, $compile, $rootElement) {
+    it('should not swipe if you move too far vertically', inject(function($rootScope, $compile, $window) {
       element = $compile('<div ng-swipe-left="swiped = true"></div>')($rootScope);
-      $rootElement.append(element);
+      angular.element($window.document.body).append(element);
       $rootScope.$digest();
 
       expect($rootScope.swiped).toBeUndefined();
@@ -109,9 +112,9 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBeUndefined();
     }));
 
-    it('should not swipe if you slide only a short distance', inject(function($rootScope, $compile, $rootElement) {
+    it('should not swipe if you slide only a short distance', inject(function($rootScope, $compile, $window) {
       element = $compile('<div ng-swipe-left="swiped = true"></div>')($rootScope);
-      $rootElement.append(element);
+      angular.element($window.document.body).append(element);
       $rootScope.$digest();
 
       expect($rootScope.swiped).toBeUndefined();
@@ -130,9 +133,9 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBeUndefined();
     }));
 
-    it('should not swipe if the swipe leaves the element', inject(function($rootScope, $compile, $rootElement) {
+    it('should not swipe if the swipe leaves the element', inject(function($rootScope, $compile, $window) {
       element = $compile('<div ng-swipe-right="swiped = true"></div>')($rootScope);
-      $rootElement.append(element);
+      angular.element($window.document.body).append(element);
       $rootScope.$digest();
 
       expect($rootScope.swiped).toBeUndefined();
@@ -151,9 +154,9 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBeUndefined();
     }));
 
-    it('should not swipe if the swipe starts outside the element', inject(function($rootScope, $compile, $rootElement) {
+    it('should not swipe if the swipe starts outside the element', inject(function($rootScope, $compile, $window) {
       element = $compile('<div ng-swipe-right="swiped = true"></div>')($rootScope);
-      $rootElement.append(element);
+      angular.element($window.document.body).append(element);
       $rootScope.$digest();
 
       expect($rootScope.swiped).toBeUndefined();
@@ -172,9 +175,9 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBeUndefined();
     }));
 
-    it('should emit "swipeleft" events for left swipes', inject(function($rootScope, $compile, $rootElement) {
+    it('should emit "swipeleft" events for left swipes', inject(function($rootScope, $compile, $window) {
       element = $compile('<div ng-swipe-left="swiped = true"></div>')($rootScope);
-      $rootElement.append(element);
+      angular.element($window.document.body).append(element);
       $rootScope.$digest();
 
       expect($rootScope.swiped).toBeUndefined();
@@ -196,9 +199,9 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect(eventFired).toEqual(true);
     }));
 
-    it('should emit "swiperight" events for right swipes', inject(function($rootScope, $compile, $rootElement) {
+    it('should emit "swiperight" events for right swipes', inject(function($rootScope, $compile, $window) {
       element = $compile('<div ng-swipe-right="swiped = true"></div>')($rootScope);
-      $rootElement.append(element);
+      angular.element($window.document.body).append(element);
       $rootScope.$digest();
 
       expect($rootScope.swiped).toBeUndefined();
@@ -219,9 +222,46 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       });
       expect(eventFired).toEqual(true);
     }));
+
+    it('should swipe to the left, even if swipe completed outside ngSwipeLeft div', inject(function($rootScope, $compile, $window) {
+      element = $compile('<div ng-swipe-left="swiped = true"></div>')($rootScope);
+      angular.element($window.document.body).append(element);
+      $rootScope.$digest();
+      expect($rootScope.swiped).toBeUndefined();
+
+      browserTrigger(element, startEvent, {
+        keys : [],
+        x : 100,
+        y : 20
+      });
+      browserTrigger($window.document.body, endEvent,{
+        keys: [],
+        x: 20,
+        y: 20
+      });
+      expect($rootScope.swiped).toBe(true);
+    }));
+
+    it('should swipe to the right, even if swipe completed outside ngSwipeRight div', inject(function($rootScope, $compile, $window) {
+      element = $compile('<div ng-swipe-right="swiped = true"></div>')($rootScope);
+      angular.element($window.document.body).append(element);
+      $rootScope.$digest();
+      expect($rootScope.swiped).toBeUndefined();
+
+      browserTrigger(element, startEvent, {
+        keys : [],
+        x : 20,
+        y : 20
+      });
+      browserTrigger($window.document.body, endEvent,{
+        keys: [],
+        x: 100,
+        y: 20
+      });
+      expect($rootScope.swiped).toBe(true);
+    }));
   });
 }
 
 swipeTests('touch', true  /* restrictBrowers */, 'touchstart', 'touchmove', 'touchend');
 swipeTests('mouse', false /* restrictBrowers */, 'mousedown',  'mousemove', 'mouseup');
-

--- a/test/ngTouch/swipeSpec.js
+++ b/test/ngTouch/swipeSpec.js
@@ -59,8 +59,9 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect(events.end).not.toHaveBeenCalled();
     }));
 
-    it('should trigger the "move" event after a "start"', inject(function($rootScope, $swipe, $compile) {
+    it('should trigger the "move" event after a "start"', inject(function($rootScope, $swipe, $compile, $window) {
       element = $compile('<div></div>')($rootScope);
+      angular.element($window.document.body).append(element);
       var events = {
         start: jasmine.createSpy('startSpy'),
         move: jasmine.createSpy('moveSpy'),
@@ -156,8 +157,9 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect(events.end).not.toHaveBeenCalled();
     }));
 
-    it('should trigger a "start", many "move"s and an "end"', inject(function($rootScope, $swipe, $compile) {
+    it('should trigger a "start", many "move"s and an "end"', inject(function($rootScope, $swipe, $compile, $window) {
       element = $compile('<div></div>')($rootScope);
+      angular.element($window.document.body).append(element);
       var events = {
         start: jasmine.createSpy('startSpy'),
         move: jasmine.createSpy('moveSpy'),
@@ -239,8 +241,9 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect(events.cancel).not.toHaveBeenCalled();
     }));
 
-    it('should not start sending "move"s until enough horizontal motion is accumulated', inject(function($rootScope, $swipe, $compile) {
+    it('should not start sending "move"s until enough horizontal motion is accumulated', inject(function($rootScope, $swipe, $compile, $window) {
       element = $compile('<div></div>')($rootScope);
+      angular.element($window.document.body).append(element);
       var events = {
         start: jasmine.createSpy('startSpy'),
         move: jasmine.createSpy('moveSpy'),
@@ -312,8 +315,9 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect(events.cancel).not.toHaveBeenCalled();
     }));
 
-    it('should stop sending anything after vertical motion dominates', inject(function($rootScope, $swipe, $compile) {
+    it('should stop sending anything after vertical motion dominates', inject(function($rootScope, $swipe, $compile, $window) {
       element = $compile('<div></div>')($rootScope);
+      angular.element($window.document.body).append(element);
       var events = {
         start: jasmine.createSpy('startSpy'),
         move: jasmine.createSpy('moveSpy'),


### PR DESCRIPTION
Fix #5732
If the user releases swipe outside of the element's boundaries, the touchend /
mouseup listeners wont be called.

Plunker from #5732: http://plnkr.co/edit/VebWtE3HiFX3xHWzJmif
