### PR TITLE
Update index.ngdoc

### DIFF
--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -107,7 +107,7 @@ directory.</p>
 executed from the Windows command line.</li>
       <li><p>You need an http server running on your system, but if you don't already have one
 already installed, you can use <code>node</code> to run a simple
-bundled http server: <code>node scripts\web-server.js</code>.</p></li>
+bundled http server: <code>node scripts\\web-server.js</code>.</p></li>
     </ol>
   </div>
 


### PR DESCRIPTION
Added extra backslash `(\)` character due to the backslash being used as an escape char
