### PR TITLE
currency update for Latvian locale

### DIFF
--- a/src/ngLocale/angular-locale_lv-lv.js
+++ b/src/ngLocale/angular-locale_lv-lv.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "Ls",
+    "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [

--- a/src/ngLocale/angular-locale_lv.js
+++ b/src/ngLocale/angular-locale_lv.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "Ls",
+    "CURRENCY_SYM": "\u20ac",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [


### PR DESCRIPTION
Latvian locale now should use Euro sign for currency display
http://europa.eu/rapid/press-release_IP-13-1307_en.htm
