### PR TITLE
Remove trailing slashes for links to the tutorial

### DIFF
--- a/docs/content/error/index.ngdoc
+++ b/docs/content/error/index.ngdoc
@@ -10,4 +10,4 @@ Other useful references for debugging your app include:
 
 - {@link api/ API Reference} for detailed information about specific features
 - {@link guide/ Developer Guide} for AngularJS concepts
-- {@link tutorial/ Tutorial} for getting started
+- {@link tutorial tutorial} for getting started

--- a/docs/content/guide/compiler.ngdoc
+++ b/docs/content/guide/compiler.ngdoc
@@ -5,7 +5,7 @@
 <div class="alert alert-warning">
 **Note:** this guide is targeted towards developers who are already familiar with AngularJS basics.
 
-If you're just getting started, we recommend the {@link tutorial/ tutorial} first.
+If you're just getting started, we recommend the {@link tutorial tutorial} first.
 If you just want to create custom directives, we recommend the {@link guide/directive directives guide}.
 If you want a deeper look into Angular's compilation process, you're in the right place.
 </div>

--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -5,7 +5,7 @@
 There are some concepts within Angular that you should understand before creating your first application.
 This section touches all important parts of Angular really quickly using a simple example.
 However, it won't explain all details.
-For a more in-depth explanation, have a look at the {@link tutorial/ tutorial}.
+For a more in-depth explanation, have a look at the {@link tutorial tutorial}.
 
 | Concept          | Description                     |
 |------------------|------------------------------------------|

--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -6,7 +6,7 @@
 
 <div class="alert alert-warning">
 **Note:** this guide is targeted towards developers who are already familiar with AngularJS basics.
-If you're just getting started, we recommend the {@link tutorial/ tutorial} first.
+If you're just getting started, we recommend the {@link tutorial tutorial} first.
 If you're looking for the **directives API**, we recently moved it to {@link ng.$compile `$compile`}.
 </div>
 


### PR DESCRIPTION
If the links to "tutorial" contains a slash, they will lead to a blank page. This commit removes them.
