### PR TITLE
feat(ngResource): allow a resource URL to be a closure called when building URL

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -78,6 +78,8 @@ function shallowClearAndCopy(src, dst) {
  *   `/user/:username`. If you are using a URL with a port number (e.g.
  *   `http://example.com:8080/api`), it will be respected.
  *
+ *   If the URL value is a function, it will be executed and the final URL must be returned.
+ *
  *   If you are using a url with a suffix, just add the suffix, like this:
  *   `$resource('http://example.com/resource.json')` or `$resource('http://example.com/:id.json')`
  *   or even `$resource('http://example.com/resource/:resource_id.:format')`
@@ -372,6 +374,7 @@ angular.module('ngResource', ['ng']).
             val,
             encodedVal;
 
+        if (isFunction(url)) { url = url(); }
         var urlParams = self.urlParams = {};
         forEach(url.split(/\W/), function(param){
           if (param === 'hasOwnProperty') {

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -259,6 +259,14 @@ describe("resource", function() {
     R.get({ relativePath: 'data.json' });
   });
 
+  it('should allow a function as resource url and call it', function () {
+    var P = '/Path/:a',
+        F = function () { return P; },
+        R = $resource(F);
+    $httpBackend.expect('GET', '/Path/foo').respond();
+    R.get({a: 'foo'});
+  });
+
   it('should handle + in url params', function () {
     var R = $resource('/api/myapp/:myresource?from=:from&to=:to&histlen=:histlen');
     $httpBackend.expect('GET', '/api/myapp/pear+apple?from=2012-04-01&to=2012-04-29&histlen=3').respond('{}');


### PR DESCRIPTION
Hi everyone,

I was in need of dynamic URL resources for a project where the user can configure from which API the data is fetched.

I didn't find any way to do this properly, but I saw that URL param value can be a function called to get the effective value, so I did the same with URL.

Thanks.
