### PR TITLE
Decrease menu width

### DIFF
--- a/docs/config/templates/indexPage.template.html
+++ b/docs/config/templates/indexPage.template.html
@@ -87,7 +87,7 @@
             </a>
           </div>
           <div class="row">
-            <ul class="nav navbar-nav col-md-7">
+            <ul class="nav navbar-nav col-md-6">
               <li class="divider-vertical"></li>
               <li><a href="http://angularjs.org"><i class="icon-home icon-white"></i> Home</a></li>
               <li class="divider-vertical"></li>


### PR DESCRIPTION
This prevents the search input from appearing on a new row on md window sizes ((992px -> 1200px).
