### PR TITLE
Fix(filter): Filter objects with circular references

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -118,7 +118,8 @@ function filterFilter() {
     if (!isArray(array)) return array;
 
     var comparatorType = typeof(comparator),
-        predicates = [];
+        predicates = [],
+        evaluatedObjects = [];
 
     predicates.check = function(value) {
       for (var j = 0; j < predicates.length; j++) {
@@ -151,7 +152,7 @@ function filterFilter() {
       }
     }
 
-    var search = function(obj, text, orig){
+    var search = function(obj, text){
       if (typeof text == 'string' && text.charAt(0) === '!') {
         return !search(obj, text.substr(1));
       }
@@ -166,9 +167,14 @@ function filterFilter() {
               return comparator(obj, text);
             default:
               for ( var objKey in obj) {
-                if (obj[objKey] === orig) return;
-                if (objKey.charAt(0) !== '$' && search(obj[objKey], text, obj)) {
-                  return true;
+                var value = obj[objKey];
+                if (evaluatedObjects.indexOf(value) == -1) {
+                  if (typeof value == 'object') {
+                    evaluatedObjects.push(value);
+                  }
+                  if (objKey.charAt(0) !== '$' && search(value, text)) {
+                    return true;
+                  }
                 }
               }
               break;

--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -167,14 +167,15 @@ function filterFilter() {
               return comparator(obj, text);
             default:
               for (var objKey in obj) {
-                var value = obj[objKey];
-                if (typeof value == 'object' || typeof value == 'function') {
-                  if (evaluatedObjects.indexOf(value) == -1) {
+                if (objKey.charAt(0) !== '$') {
+                  var value = obj[objKey];
+                  if (isObject(value) || isFunction(value)) {
+                    if (evaluatedObjects.indexOf(value) >= 0) continue;
                     evaluatedObjects.push(value);
-                    if (objKey.charAt(0) !== '$' && search(value, text)) { return true; }
                   }
-                } else {
-                  if (objKey.charAt(0) !== '$' && search(value, text)) { return true; }
+                  if (search(value, text)) {
+                    return true;
+                  }
                 }
               }
               break;

--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -151,7 +151,7 @@ function filterFilter() {
       }
     }
 
-    var search = function(obj, text){
+    var search = function(obj, text, orig){
       if (typeof text == 'string' && text.charAt(0) === '!') {
         return !search(obj, text.substr(1));
       }
@@ -166,7 +166,8 @@ function filterFilter() {
               return comparator(obj, text);
             default:
               for ( var objKey in obj) {
-                if (objKey.charAt(0) !== '$' && search(obj[objKey], text)) {
+                if (obj[objKey] === orig) return;
+                if (objKey.charAt(0) !== '$' && search(obj[objKey], text, obj)) {
                   return true;
                 }
               }

--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -168,7 +168,7 @@ function filterFilter() {
             default:
               for (var objKey in obj) {
                 var value = obj[objKey];
-                if (typeof value == 'object') {
+                if (typeof value == 'object' || typeof value == 'function') {
                   if (evaluatedObjects.indexOf(value) == -1) {
                     evaluatedObjects.push(value);
                     if (objKey.charAt(0) !== '$' && search(value, text)) { return true; }

--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -166,15 +166,15 @@ function filterFilter() {
             case "object":
               return comparator(obj, text);
             default:
-              for ( var objKey in obj) {
+              for (var objKey in obj) {
                 var value = obj[objKey];
-                if (evaluatedObjects.indexOf(value) == -1) {
-                  if (typeof value == 'object') {
+                if (typeof value == 'object') {
+                  if (evaluatedObjects.indexOf(value) == -1) {
                     evaluatedObjects.push(value);
+                    if (objKey.charAt(0) !== '$' && search(value, text)) { return true; }
                   }
-                  if (objKey.charAt(0) !== '$' && search(value, text)) {
-                    return true;
-                  }
+                } else {
+                  if (objKey.charAt(0) !== '$' && search(value, text)) { return true; }
                 }
               }
               break;

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -34,6 +34,16 @@ describe('Filter: filter', function() {
     expect(filter(items, 'misko').length).toBe(0);
   });
 
+  it('should not re-evaluate circular references', function() {
+    var originalItem   = {name: 'misko'};
+    var referencedItem = {originalItem: originalItem};
+    originalItem.referencedItem = referencedItem;
+
+    var items = [originalItem];
+    expect(function() { filter(items, 'not misko') })
+      .not.toThrow(new Error("Maximum call stack size exceeded"));
+  });
+
   it('should filter on specific property', function() {
     var items = [{ignore: 'a', name: 'a'}, {ignore: 'a', name: 'abc'}];
     expect(filter(items, {}).length).toBe(2);

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -41,7 +41,9 @@ describe('Filter: filter', function() {
 
     var items = [originalItem];
     expect(function() { filter(items, 'not misko') })
-      .not.toThrow(new Error("Maximum call stack size exceeded"));
+      .not.toThrow();
+
+    expect(filter(items, 'misko')).toEqual([originalItem]);
   });
 
   it('should filter on specific property', function() {


### PR DESCRIPTION
**Overview of the issue** - When filtering confronts a circular reference, it causes an infinite recursion & subsequent stack overflow. 

**Motivation for or Use Case** - As modeling libraries evolve for Angular (I've spent quite a bit of time on one myself https://github.com/FacultyCreative/ngActiveResource), circular references on related objects are likely to become more frequent. For instance, you have a post that has many comments:

```
  post.comments[0] = {body: 'great comment', post: post}
```

Currently, the `search` method calls itself on each attribute on each object in the collection being filtered. Since `post` references this particular `comment`, and the `comment` references back, the `search` method will never end.

**Angular Version(s)** - 1.2.13 (current) and before

**Browsers and Operating System** - This is a problem for all browsers

**Reproduce the error** - Test included, plus see this Fiddle: http://jsfiddle.net/S2UY6/9/

**Related issues** - I do not see the same issue reported, though users seem to have particular difficulty with circular references in the DI system and `angular.extend`. 

**Suggest a Fix** - Fix included
