### PR TITLE
fix(jqLite): make jqLite('<iframe src="someurl">').contents() return iframe document, as in jQuery

### DIFF
--- a/karma-jqlite.conf.js
+++ b/karma-jqlite.conf.js
@@ -5,7 +5,12 @@ module.exports = function(config) {
   sharedConfig(config, {testName: 'AngularJS: jqLite', logFile: 'karma-jqlite.log'});
 
   config.set({
-    files: angularFiles.mergeFilesFor('karma'),
+    files: angularFiles.mergeFilesFor('karma').concat({
+      pattern: "test/fixtures/**/*.html",
+      served: true,
+      watched: true,
+      included: false
+    }),
     exclude: angularFiles.mergeFilesFor('karmaExclude'),
 
     junitReporter: {

--- a/karma-jquery.conf.js
+++ b/karma-jquery.conf.js
@@ -5,7 +5,12 @@ module.exports = function(config) {
   sharedConfig(config, {testName: 'AngularJS: jQuery', logFile: 'karma-jquery.log'});
 
   config.set({
-    files: angularFiles.mergeFilesFor('karmaJquery'),
+    files: angularFiles.mergeFilesFor('karmaJquery').concat({
+      pattern: "test/fixtures/**/*.html",
+      served: true,
+      watched: true,
+      included: false
+    }),
     exclude: angularFiles.mergeFilesFor('karmaJqueryExclude'),
 
     junitReporter: {

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -793,7 +793,7 @@ forEach({
   },
 
   contents: function(element) {
-    return element.childNodes || [];
+    return element.contentDocument || element.childNodes || [];
   },
 
   append: function(element, node) {

--- a/test/fixtures/iframe.html
+++ b/test/fixtures/iframe.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Iframe Test</title>
+  </head>
+  <body>
+    <span>Text</span>
+  </body>
+</html>

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1299,6 +1299,30 @@ describe('jqLite', function() {
       expect(contents[0].data).toEqual(' some comment ');
       expect(contents[1].data).toEqual('before-');
     });
+
+    // IE8 does not like this test, although the functionality may still work there.
+    if (!msie || msie > 8) {
+      it('should select all types iframe contents', function() {
+        var iframe_ = document.createElement('iframe'), tested,
+            iframe = jqLite(iframe_);
+        function test() {
+          var contents = iframe.contents();
+          expect(contents[0]).toBeTruthy();
+          expect(contents.length).toBe(1);
+          expect(contents.prop('nodeType')).toBe(9);
+          expect(contents[0].body).toBeTruthy();
+          expect(jqLite(contents[0].body).contents().length).toBe(3);
+          iframe.remove();
+          tested = true;
+        }
+        iframe_.onload = iframe_.onreadystatechange = function() {
+          if (iframe_.contentDocument) test();
+        };
+        iframe_.src = "/base/test/fixtures/iframe.html";
+        jqLite(document).find('body').append(iframe);
+        waitsFor(function() { return tested; }, 500);
+      });
+    }
   });
 
 


### PR DESCRIPTION
This is a very tiny change to make behaviour consistent with jQuery.

Closes #6320
