### PR TITLE
fix(ngRoute): remove extra decodeURIComponent

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -465,9 +465,7 @@ function $RouteProvider(){
       for (var i = 1, len = m.length; i < len; ++i) {
         var key = keys[i - 1];
 
-        var val = 'string' == typeof m[i]
-              ? decodeURIComponent(m[i])
-              : m[i];
+	var val = m[i];
 
         if (key && val) {
           params[key.name] = val;

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -242,6 +242,12 @@ describe('$route', function() {
       $rootScope.$digest();
       expect($route.current).toBeDefined();
     }));
+
+    it('matches a URL with even more special chars', inject(function($route, $location, $rootScope) {
+      $location.path('/$test.23/foo*(bar)/~!@#$%^&*()_+=-`');
+      $rootScope.$digest();
+      expect($route.current).toBeDefined();
+    }));
   });
 
 


### PR DESCRIPTION
Since `$location.$$path` is already decoded, doing an extra `decodeURIComponent` is both unnecessary and can cause problems. Specifically, if the path originally included an encoded `%` (aka `%25`), then ngRoute will throw "URIError: URI malformed".

Closes #6326
