### PR TITLE
chore(travis): don't run Travis-CI builds for G3 branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 node_js:
   - 0.10
 
+branches:
+  except:
+    - /^g3_.*$/
+
 env:
   matrix:
     - JOB=unit


### PR DESCRIPTION
Building the G3 commits occupies a lot of time, and these branches have 
already been tested. (Based on http://docs.travis-ci.com/user/build-configuration/#White--or-blacklisting-branches)
