### PR TITLE
fix(ngClick): make ngTouch adhere to MOVE_TOLERANCE on click event

### DIFF
--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -185,7 +185,9 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
         tapElement,  // Used to blur the element after a tap.
         startTime,   // Used to check if the tap was held too long.
         touchStartX,
-        touchStartY;
+        touchStartY,
+        clickStartX,
+        clickStartY;
 
     function resetState() {
       tapping = false;
@@ -258,6 +260,14 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     // - But the browser's follow-up slow click will be "busted" before it reaches this handler.
     // Therefore it's safe to use this directive on both mobile and desktop.
     element.on('click', function(event, touchend) {
+      if (!touchend) {
+        // If we have no touchend event, we should still check MOVE_TOLERANCE
+        // for standard browser clicks. Otherwise if we create directives that
+        // use the `swipe` service, the element will still receive clicks.
+        var x = event.clientX, y = event.clientY;
+        var dist = Math.sqrt( Math.pow(x - clickStartX, 2) + Math.pow(y - clickStartY, 2) );
+        if (dist >= MOVE_TOLERANCE) return;
+      }
       scope.$apply(function() {
         clickHandler(scope, {$event: (touchend || event)});
       });
@@ -265,6 +275,8 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
 
     element.on('mousedown', function(event) {
       element.addClass(ACTIVE_CLASS_NAME);
+      clickStartX = event.clientX;
+      clickStartY = event.clientY;
     });
 
     element.on('mousemove mouseup', function(event) {


### PR DESCRIPTION
JSFiddle: http://jsfiddle.net/dK25u/

On Desktop if you swipe within the blue box and release, both the swipe's done function and click's done function are called together. This bug is also apparent on some mobile devices, for example wp8 that still call native `click` event handlers.

If you compare this JSFiddle on a Android Touch device you will notice the click's done function does not get called when swiped.

With this fix the click's done function is only called if within the MOVE_TOLERANCE amount, therefore the behaviour is consistent between mobile / pointer event mobile and desktop environments.
