### PR TITLE
$http : ability to clear a request from the cache #5968

### DIFF
--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1250,6 +1250,24 @@ describe('$http', function() {
       });
 
 
+      it('should be able to remove a request from the cache', function() {
+        doFirstCacheRequest();
+
+        $http.removeCache({method: 'GET', url: '/url', cache: cache});
+
+        $httpBackend.expect('GET', '/url').respond();
+        $http({method: 'GET', url: '/url', cache: cache});
+      });
+
+
+      it('should be able to bypass and overwrite the cache for a request', function() {
+        doFirstCacheRequest();
+
+        $httpBackend.expect('GET', '/url').respond();
+        $http({method: 'GET', url: '/url', cache: cache, replaceCache: true});
+      });
+
+
       it('should always call callback asynchronously', function() {
         doFirstCacheRequest();
         $http({method: 'get', url: '/url', cache: cache}).then(callback);


### PR DESCRIPTION
Previously it was not possible to remove data from $http cache (without duplicating internal functions in http to calculate the key used, which could change in the future...).

feat($http): change $http to allow removing/replacing individual requests in $http cache

Adds $http.removeCache method.
Adds/implements replaceCache property in $http request configuration.

Closes #5968
