### PR TITLE
feat(filter): orderBy for object collections

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -62,9 +62,19 @@
  */
 orderByFilter.$inject = ['$parse'];
 function orderByFilter($parse){
-  return function(array, sortPredicate, reverseOrder) {
-    if (!isArray(array)) return array;
-    if (!sortPredicate) return array;
+  return function(sortable, sortPredicate, reverseOrder) {
+    if (!isArray(sortable) && !isObject(sortable)) return sortable;
+    if (!sortPredicate) return sortable;
+    var array = sortable;
+    if(isObject(sortable)) {
+      array = [];
+      for (var key in sortable) {
+        if (sortable.hasOwnProperty(key) && key.charAt(0) != '$') {
+          array.push(sortable[key]);
+        }
+      }
+    }
+
     sortPredicate = isArray(sortPredicate) ? sortPredicate: [sortPredicate];
     sortPredicate = map(sortPredicate, function(predicate){
       var descending = false, get = predicate || identity;

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -31,4 +31,9 @@ describe('Filter: orderBy', function() {
     toEqual([{a:2, b:1},{a:15, b:1}]);
   });
 
+  it('can sort a hash collection', function() {
+    expect(orderBy({c: {name: 'c'}, a: {name: 'a'}, b: {name: 'b'}}, 'name')).toEqualData([{name: 'a'}, {name: 'b'}, {name: 'c'}]);
+    expect(orderBy({c: {name: 'c'}, a: {name: 'a'}, b: {name: 'b'}}, '-name')).toEqualData([{name: 'c'}, {name: 'b'}, {name: 'a'}]);
+  });
+
 });


### PR DESCRIPTION
Allows to use orderBy filter on collection objects and not only arrays.

eg:

```
var c = {
    b: {name: 'b'},
    c: {name: 'c'},
    a: {name: 'a'}
};
orderBy(c, 'name'); // => [{name: 'a'}, {name: 'b'}, {name: 'c'}];
```

Closes: #6210
