### PR TITLE
fix($http): do not add trailing question

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -1025,7 +1025,10 @@ function $HttpProvider() {
                          encodeUriQuery(v));
             });
           });
-          return url + ((url.indexOf('?') == -1) ? '?' : '&') + parts.join('&');
+          if(parts.length > 0) {
+            url += ((url.indexOf('?') == -1) ? '?' : '&') + parts.join('&');
+          }
+          return url;
         }
 
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -452,6 +452,11 @@ describe('$http', function() {
         $httpBackend.expect('GET', '/Path?!do%26h=g%3Da+h&:bar=$baz@1').respond('');
         $http({url: '/Path', params: {':bar': '$baz@1', '!do&h': 'g=a h'}, method: 'GET'});
       });
+
+      it('should not add question mark when params is empty', function() {
+        $httpBackend.expect('GET', '/url').respond('');
+        $http({url: '/url', params: {}, method: 'GET'});
+      })
     });
 
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -330,7 +330,7 @@ describe("resource", function() {
 
 
   it('should not throw TypeError on null default params', function() {
-    $httpBackend.expect('GET', '/Path?').respond('{}');
+    $httpBackend.expect('GET', '/Path').respond('{}');
     var R = $resource('/Path', {param: null}, {get: {method: 'GET'}});
 
     expect(function() {


### PR DESCRIPTION
Now if you pass empty object into params you will get url with unnecessary question mark.
It may cause some issues, like this [stackoverflow question](http://stackoverflow.com/questions/19575565/angularjs-resource-url-causes-question-mark-to-appear-with-no-params).
Moreover it makes unit test less readable, because that need to add redundant question to end of some  `$httpBackend` expectations.
