### PR TITLE
fix(doc-gen): Run Gulp on Windows too

### DIFF
--- a/lib/grunt/plugins.js
+++ b/lib/grunt/plugins.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
 
 
   grunt.registerTask('docs', 'create angular docs', function(){
-    var gruntProc = shelljs.exec('node_modules/.bin/gulp --gulpfile docs/gulpfile.js');
+    var gruntProc = shelljs.exec('"node_modules/.bin/gulp" --gulpfile docs/gulpfile.js');
     if (gruntProc.code !== 0) {
       throw new Error('doc generation failed');
     }

--- a/lib/grunt/plugins.js
+++ b/lib/grunt/plugins.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
 
 
   grunt.registerTask('docs', 'create angular docs', function(){
-    var gruntProc = shelljs.exec('node_modules/gulp/bin/gulp.js --gulpfile docs/gulpfile.js');
+    var gruntProc = shelljs.exec('node_modules/.bin/gulp --gulpfile docs/gulpfile.js');
     if (gruntProc.code !== 0) {
       throw new Error('doc generation failed');
     }


### PR DESCRIPTION
Using node_module/.bin/gulp will enable to gulp command to run
both on Windows and Linux. In its current form, opening a Javascript
file on Windows will not run the doc generation.
