### PR TITLE
Added array and error decoration

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -528,7 +528,10 @@ angular.module('ngResource', ['ng']).
                 // Decorate the array with the properties on the response data
                 if (action.arrayDecorate) {
                   for (var i in data) {
-                    if (data.hasOwnProperty(i) && angular.isUndefined(value[i]) && !/^[0-9]+$/.test(i)) {
+                    if (data.hasOwnProperty(i)
+                      && angular.isUndefined(value[i])
+                      && !/^[0-9]+$/.test(i)
+                    ) {
                       value[i] = data[i];
                     }
                   }

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -525,6 +525,14 @@ angular.module('ngResource', ['ng']).
               // jshint +W018
               if (action.isArray) {
                 value.length = 0;
+                // Decorate the array with the properties on the response data
+                if (action.arrayDecorate) {
+                  for (var i in data) {
+                    if (data.hasOwnProperty(i) && angular.isUndefined(value[i]) && !/^[0-9]+$/.test(i)) {
+                      value[i] = data[i];
+                    }
+                  }
+                }
                 forEach(data, function(item) {
                   value.push(new Resource(item));
                 });
@@ -540,6 +548,16 @@ angular.module('ngResource', ['ng']).
 
             return response;
           }, function(response) {
+            // Decorate the existing object with the properties on the response data
+            if (action.errorDecorate) {
+              var promise = value.$promise;
+              forEach(response.data, function(property, key) {
+                value[key] = property;
+              });
+              value.$promise = promise;
+              response.resource = value;
+            }
+
             value.$resolved = true;
 
             (error||noop)(response);


### PR DESCRIPTION
Array decoration allows metadata properties set on an array during transformation to be copied over to the resulting data. This allows us to do things like add pagination metadata to the result array.

Error decoration allows metadata properties set during transformation to be copied over to the resulting data, on error, without removing existing, non-conflicting properties. This allows us to do things like creating am 'error' property on an existing model, without losing the model's existing property values.
