### PR TITLE
Added array and error decoration

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -524,6 +524,14 @@ angular.module('ngResource', ['ng']).
               // jshint +W018
               if (action.isArray) {
                 value.length = 0;
+                // Decorate the array with the properties on the response data
+                if (action.arrayDecorate) {
+                  for (var i in data) {
+                    if (data.hasOwnProperty(i) && angular.isUndefined(value[i]) && !/^[0-9]+$/.test(i)) {
+                      value[i] = data[i];
+                    }
+                  }
+                }
                 forEach(data, function(item) {
                   value.push(new Resource(item));
                 });
@@ -539,6 +547,16 @@ angular.module('ngResource', ['ng']).
 
             return response;
           }, function(response) {
+            // Decorate the existing object with the properties on the response data
+            if (action.errorDecorate) {
+              var promise = value.$promise;
+              forEach(response.data, function(property, key) {
+                value[key] = property;
+              });
+              value.$promise = promise;
+              response.resource = value;
+            }
+
             value.$resolved = true;
 
             (error||noop)(response);

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -528,8 +528,7 @@ angular.module('ngResource', ['ng']).
                 if (action.arrayDecorate) {
                   for (var i in data) {
                     if (data.hasOwnProperty(i)
-                      && angular.isUndefined(value[i])
-                      && !/^[0-9]+$/.test(i)
+                      && !angular.isNumber(i)
                     ) {
                       value[i] = data[i];
                     }
@@ -553,9 +552,13 @@ angular.module('ngResource', ['ng']).
             // Decorate the existing object with the properties on the response data
             if (action.errorDecorate) {
               var promise = value.$promise;
-              forEach(response.data, function(property, key) {
-                value[key] = property;
-              });
+              for (var i in response.data) {
+                if (response.data.hasOwnProperty(i)
+                  && !angular.isNumber(i)
+                ) {
+                  value[i] = response.data[i];
+                }
+              }
               value.$promise = promise;
               response.resource = value;
             }

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -528,7 +528,7 @@ angular.module('ngResource', ['ng']).
                 if (action.arrayDecorate) {
                   for (var i in data) {
                     if (data.hasOwnProperty(i)
-                      && !angular.isNumber(i)
+                      && !/^[0-9]+$/.test(i)
                     ) {
                       value[i] = data[i];
                     }
@@ -554,7 +554,7 @@ angular.module('ngResource', ['ng']).
               var promise = value.$promise;
               for (var i in response.data) {
                 if (response.data.hasOwnProperty(i)
-                  && !angular.isNumber(i)
+                  && !/^[0-9]+$/.test(i)
                 ) {
                   value[i] = response.data[i];
                 }

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -527,7 +527,10 @@ angular.module('ngResource', ['ng']).
                 // Decorate the array with the properties on the response data
                 if (action.arrayDecorate) {
                   for (var i in data) {
-                    if (data.hasOwnProperty(i) && angular.isUndefined(value[i]) && !/^[0-9]+$/.test(i)) {
+                    if (data.hasOwnProperty(i)
+                      && angular.isUndefined(value[i])
+                      && !/^[0-9]+$/.test(i)
+                    ) {
                       value[i] = data[i];
                     }
                   }

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1272,8 +1272,9 @@ describe('resource', function() {
     $httpBackend.flush();
 
     // Should have array and metadata
-    expect(models[0]).toBe(result[0]);
-    expect(models[1]).toBe(result[1]);
+    expect(models.length).toBe(2);
+    expect(models[0].thing).toEqual(result[0].thing);
+    expect(models[1].thing).toEqual(result[1].thing);
     expect(models.meta).toBe('data');
   });
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1251,5 +1251,79 @@ describe('resource', function() {
       )
   });
 
+  it('should decorate array', function() {
+    var result = [
+      { thing: 'value1' },
+      { thing: 'value2' }
+    ];
+    result.meta = 'data';
+
+    $httpBackend.expectGET('URL').respond({});
+    var models = $resource('URL', { }, {
+      query: {
+        method: 'GET',
+        isArray: true,
+        arrayDecorate: true,
+        transformResponse: function() {
+          return result;
+        }
+      }
+    }).query();
+    $httpBackend.flush();
+
+    // Should have array and metadata
+    expect(models[0]).toBe(result[0]);
+    expect(models[1]).toBe(result[1]);
+    expect(models.meta).toBe('data');
+  });
+
+  it('should decorate on error', function() {
+    var model = {
+      untouched: true,
+      error: 'No Error'
+    };
+
+    model = new ($resource('URL', { }, {
+      save: {
+        method: 'POST',
+        errorDecorate: true
+      }
+    }))(model);
+
+    // Should have the config we passed the constructor
+    expect(model.untouched).toBe(true);
+    expect(model.error).toBe('No Error');
+
+    $httpBackend.expectPOST('URL').respond(500, { error: 'An error occurred' });
+    model.$save();
+    $httpBackend.flush();
+
+    // Should have the same config as before; decorated with props from response
+    expect(model.untouched).toBe(true);
+    expect(model.error).toBe('An error occurred');
+  });
+
+  it('should decorate array on error', function() {
+    var result = [];
+    result.meta = 'data';
+
+    $httpBackend.expectGET('URL').respond(500, { error: 'An error occurred' });
+    var models = $resource('URL', { }, {
+      query: {
+        method: 'GET',
+        isArray: true,
+        arrayDecorate: true,
+        errorDecorate: true,
+        transformResponse: function() {
+          return result;
+        }
+      }
+    }).query();
+    $httpBackend.flush();
+
+    // Should have the same config as before; decorated with props from response
+    expect(angular.isArray(models)).toBeTruthy();
+    expect(models.meta).toBe('data');
+  });
 
 });


### PR DESCRIPTION
Array decoration allows metadata properties set on an array during transformation to be copied over to the resulting data. This allows us to do things like add pagination metadata to the result array.

Error decoration allows metadata properties set during transformation to be copied over to the resulting data, on error, without removing existing, non-conflicting properties. This allows us to do things like creating am 'error' property on an existing model, without losing the model's existing property values.
