### PR TITLE
chore(doc-gen): add a jquery deploy environment, and give examples one i...

### DIFF
--- a/docs/config/index.js
+++ b/docs/config/index.js
@@ -2,11 +2,13 @@ var _ = require('lodash');
 var path = require('canonical-path');
 var packagePath = __dirname;
 
-var angularjsPackage = require('dgeni-packages/ngdoc');
+var basePackage = require('dgeni-packages/ngdoc');
+var examplesPackage = require('dgeni-packages/examples');
 
 module.exports = function(config) {
 
-  config = angularjsPackage(config);
+  config = basePackage(config);
+  config = examplesPackage(config);
   
   config.append('processing.processors', [
     require('./processors/git-data'),

--- a/docs/config/processors/index-page.js
+++ b/docs/config/processors/index-page.js
@@ -11,7 +11,7 @@ module.exports = {
   init: function(config) {
     deployment = config.deployment;
     if ( !deployment || !deployment.environments ) {
-      throw new Errro('No deployment environments found in the config.');
+      throw new Error('No deployment environments found in the config.');
     }
   },
   process: function(docs) {

--- a/docs/docs.config.js
+++ b/docs/docs.config.js
@@ -25,10 +25,6 @@ module.exports = function(config) {
     { pattern: '**/*.ngdoc', basePath: path.resolve(basePath, 'content') }
   ]);
 
-  config.set('processing.examples.commonFiles', {
-    scripts: [ '../../../angular.js' ],
-    stylesheets: []
-  });
   config.set('processing.examples.dependencyPath', '../../..');
 
 
@@ -41,6 +37,12 @@ module.exports = function(config) {
   config.merge('deployment', {
     environments: [{
       name: 'debug',
+      examples: {
+        commonFiles: {
+          scripts: [ '../../../angular.js' ]
+        },
+        dependencyPath: '../../..'
+      },
       scripts: [
         '../angular.js',
         '../angular-resource.js',
@@ -70,6 +72,12 @@ module.exports = function(config) {
     },
     {
       name: 'default',
+      examples: {
+        commonFiles: {
+          scripts: [ '../../../angular.min.js' ]
+        },
+        dependencyPath: '../../..'
+      },
       scripts: [
         '../angular.min.js',
         '../angular-resource.min.js',
@@ -98,7 +106,52 @@ module.exports = function(config) {
       ]
     },
     {
+      name: 'jquery',
+      examples: {
+        commonFiles: {
+          scripts: [
+            '../../components/jquery-' + getVersion('jquery') + '/jquery.js',
+            '../../../angular.js'
+          ]
+        },
+        dependencyPath: '../../..'
+      },
+      scripts: [
+        'components/jquery-' + getVersion('jquery') + '/jquery.js',
+        '../angular.min.js',
+        '../angular-resource.min.js',
+        '../angular-route.min.js',
+        '../angular-cookies.min.js',
+        '../angular-sanitize.min.js',
+        '../angular-touch.min.js',
+        '../angular-animate.min.js',
+        'components/marked-' + getVersion('marked', '../node_modules', 'package.json') + '/lib/marked.js',
+        'js/angular-bootstrap/bootstrap.js',
+        'js/angular-bootstrap/bootstrap-prettify.js',
+        'js/angular-bootstrap/dropdown-toggle.js',
+        'components/lunr.js-' + getVersion('lunr.js') + '/lunr.min.js',
+        'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/prettify.js',
+        'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/lang-css.js',
+        'js/versions-data.js',
+        'js/pages-data.js',
+        'js/docs.js'
+      ],
+      stylesheets: [
+        'components/bootstrap-' + getVersion('bootstrap') + '/dist/css/bootstrap.min.css',
+        'components/open-sans-fontface-' + getVersion('open-sans-fontface') + '/open-sans.css',
+        'css/prettify-theme.css',
+        'css/docs.css',
+        'css/animations.css'
+      ]
+    },
+    {
       name: 'production',
+      examples: {
+        commonFiles: {
+          scripts: [ cdnUrl + '/angular.min.js' ]
+        },
+        dependencyPath: cdnUrl
+      },
       scripts: [
         cdnUrl + '/angular.min.js',
         cdnUrl + '/angular-resource.min.js',

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "canonical-path": "0.0.2",
     "winston": "~0.7.2",
     "dgeni": "~0.1.0",
-    "dgeni-packages": "~0.1.0",
+    "dgeni-packages": "~0.2.1",
     "gulp-jshint": "~1.4.2",
     "jshint-stylish": "~0.1.5"
   },


### PR DESCRIPTION
...ndex per environment

Adds a jQuery environment, and adds a processor to the docs.angularjs.org package
which runs after example index files have been generated. This processor copies
the index file once for each deployment environment, adding custom shared scripts
described in that env.

This does not yet handle changing the target of the iframe, so those all point
to the default no matter the version of docs being accessed.
