### PR TITLE
chore(doc-gen): add formatted error messages to error pages

### DIFF
--- a/docs/config/processors/error-docs.js
+++ b/docs/config/processors/error-docs.js
@@ -8,8 +8,15 @@ module.exports = {
   runAfter: ['tags-extracted'],
   init: function(config, injectables) {
     injectables.value('errorNamespaces', {});
+
+    var minerrInfoPath = config.get('processing.errors.minerrInfoPath');
+    if ( !minerrInfoPath ) {
+      throw new Error('Error in configuration: Please provide a path to the minerr info file (errors.json) ' +
+        'in the `config.processing.errors.minerrInfoPath` property');
+    }
+    injectables.value('minerrInfo', require(minerrInfoPath));
   },
-  process: function(docs, partialNames, errorNamespaces) {
+  process: function(docs, partialNames, errorNamespaces, minerrInfo) {
 
     // Create error namespace docs and attach error docs to each
     _.forEach(docs, function(doc) {
@@ -31,6 +38,8 @@ module.exports = {
         // Add this error to the namespace
         namespaceDoc.errors.push(doc);
         doc.namespace = namespaceDoc;
+
+        doc.formattedErrorMessage = minerrInfo.errors[doc.namespace.name][doc.name];
 
       }
 

--- a/docs/config/templates/error.template.html
+++ b/docs/config/templates/error.template.html
@@ -1,0 +1,17 @@
+{% extends "base.template.html" %}
+
+{% block content %}
+<h1>Error: {$ doc.id $}
+  <div><span class='hint'>{$ doc.fullName $}</span></div>
+</h1>
+
+<div>
+    <pre class="minerr-errmsg" error-display="{$ doc.formattedErrorMessage $}">{$ doc.formattedErrorMessage $}</pre>
+</div>
+
+<h2>Description</h2>
+<div class="description">
+  {$ doc.description | marked $}
+</div>
+
+{% endblock %}

--- a/docs/docs.config.js
+++ b/docs/docs.config.js
@@ -31,6 +31,9 @@ module.exports = function(config) {
   });
   config.set('processing.examples.dependencyPath', '../../..');
 
+
+  config.set('processing.errors.minerrInfoPath', path.resolve(basePath, '../build/errors.json'));
+
   config.set('rendering.outputFolder', '../build/docs');
 
   config.set('logging.level', 'info');

--- a/test/e2e/docsAppE2E.js
+++ b/test/e2e/docsAppE2E.js
@@ -39,11 +39,13 @@ describe('docs.angularjs.org', function () {
       expect(code.getText()).toContain('guest!!!');
     });
 
+
     it('should be resilient to trailing slashes', function() {
       browser.get('index-debug.html#!/api/ng/function/angular.noop/');
       var pageBody = element(by.css('h1'));
       expect(pageBody.getText()).toEqual('angular.noop');
     });
+
 
     it('should be resilient to trailing "index"', function() {
       browser.get('index-debug.html#!/api/ng/function/angular.noop/index');
@@ -51,10 +53,17 @@ describe('docs.angularjs.org', function () {
       expect(pageBody.getText()).toEqual('angular.noop');
     });
 
+
     it('should be resilient to trailing "index/"', function() {
       browser.get('index-debug.html#!/api/ng/function/angular.noop/index/');
       var pageBody = element(by.css('h1'));
       expect(pageBody.getText()).toEqual('angular.noop');
+    });
+
+
+    it('should display formatted error messages on error doc pages', function() {
+      browser.get('index-debug.html#!error/ng/areq?p0=Missing&p1=not%20a%20function,%20got%20undefined');
+      expect(element(by.css('.minerr-errmsg')).getText()).toEqual("Argument 'Missing' is not a function, got undefined");
     });
   });
 });


### PR DESCRIPTION
This got missed in the doc migration: When there is an error in an
Angular app, extra information is placed in the URL, which can be used
by the docs application to display a more useful message.

This fix adds that back in.  The error message templates are extracted
by the minerr tool during build and put into the errors.json file. The
errors-doc processor will load this up and attach these message templates
to the error docs.

The display of these templates was already in place, via the errorDisplay
directive in docs/app/js/errors.js.

(Also, moved the error.template.html file into the angular.js repository
from the dgeni-packages repository as this is specific to the angular.js
project and all the other error related stuff is in here.
