### PR TITLE
Add documentation to $interval.cancel();

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -491,7 +491,17 @@ angular.mock.$IntervalProvider = function() {
       nextRepeatId++;
       return promise;
     };
-
+    /**
+     * @ngdoc method
+     * @name $interval#cancel
+     * @description
+     *
+     * Clears the interval.
+     *
+     * @param {promise} The promise of the interval to cancel.
+     *
+     * @return {boolean} 
+     */
     $interval.cancel = function(promise) {
       if(!promise) return false;
       var fnIndex;


### PR DESCRIPTION
I have been looking around and was not able to find any informations on how to clear the $interval but reading the source code, sharing is caring!
