### PR TITLE
fix(input.min/max) re-validate input[type=number] when min/max changes

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -595,6 +595,11 @@ function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 
     ctrl.$parsers.push(minValidator);
     ctrl.$formatters.push(minValidator);
+    attr.$observe('min', function() {
+      if (isUndefined(minValidator(ctrl.$viewValue))) {
+        ctrl.$setViewValue(ctrl.$viewValue);
+      }
+    });
   }
 
   if (attr.max) {
@@ -605,6 +610,11 @@ function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 
     ctrl.$parsers.push(maxValidator);
     ctrl.$formatters.push(maxValidator);
+    attr.$observe('max', function() {
+      if (isUndefined(maxValidator(ctrl.$viewValue))) {
+        ctrl.$setViewValue(ctrl.$viewValue);
+      }
+    });
   }
 
   ctrl.$formatters.push(function(value) {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -844,19 +844,28 @@ describe('input', function() {
         expect(scope.form.alias.$error.min).toBeFalsy();
       });
 
-      it('should validate even if min value changes on-the-fly', function(done) {
+      it('should validate even if min value changes on-the-fly', function() {
         scope.min = 10;
         compileInput('<input type="number" ng-model="value" name="alias" min="{{min}}" />');
         scope.$digest();
 
+        expect(inputElm).toBePristine();
+        scope.min = 11;
+        scope.$digest();
+        expect(inputElm).toBePristine();
+
         changeInputValueTo('5');
         expect(inputElm).toBeInvalid();
+        expect(scope.value).toBeFalsy();
+        expect(scope.form.alias.$error.min).toBeTruthy();
+
+        expect(inputElm).toBeDirty();
 
         scope.min = 0;
-        scope.$digest(function () {
-          expect(inputElm).toBeValid();
-          done();
-        });
+        scope.$digest();
+        expect(inputElm).toBeValid();
+        expect(scope.value).toBeUndefined();
+        expect(scope.form.alias.$error.min).toBeFalsy();
       });
     });
 
@@ -878,19 +887,28 @@ describe('input', function() {
         expect(scope.form.alias.$error.max).toBeFalsy();
       });
 
-      it('should validate even if max value changes on-the-fly', function(done) {
+      it('should validate even if max value changes on-the-fly', function() {
         scope.max = 10;
         compileInput('<input type="number" ng-model="value" name="alias" max="{{max}}" />');
         scope.$digest();
 
+        expect(inputElm).toBePristine();
+        scope.max = 11;
+        scope.$digest();
+        expect(inputElm).toBePristine();
+
         changeInputValueTo('5');
         expect(inputElm).toBeValid();
+        expect(scope.value).toBe(5);
+        expect(scope.form.alias.$error.max).toBeFalsy();
+
+        expect(inputElm).toBeDirty();
 
         scope.max = 0;
-        scope.$digest(function () {
-          expect(inputElm).toBeInvalid();
-          done();
-        });
+        scope.$digest();
+        expect(inputElm).toBeInvalid();
+        expect(scope.value).toBeUndefined();
+        expect(scope.form.alias.$error.max).toBeTruthy();
       });
     });
 


### PR DESCRIPTION
Value was not re-evaluated when min/max changed.
