### PR TITLE
only use window.jQuery if it supports required jQuery.fn.on

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1433,9 +1433,9 @@ function bindJQuery() {
   var originalCleanData;
   // bind to jQuery if present;
   jQuery = window.jQuery;
-
-  // reset to jQuery or default to us.
-  if (jQuery) {
+  // Use jQuery if it exists with proper functionality, otherwise default to us.
+  // Angular 1.2+ requires jQuery 1.7.1+ for on()/off() support.
+  if (jQuery && jQuery.fn.on) {
     jqLite = jQuery;
     extend(jQuery.fn, {
       scope: JQLitePrototype.scope,


### PR DESCRIPTION
This is a safe and simple fix to the legacy jQuery situation referenced in #2163 until the API in issue #608 is refined and implemented.
