### PR TITLE
docs(guide/i18n): fix url-based links refs to AUTO module

### DIFF
--- a/docs/content/guide/i18n.ngdoc
+++ b/docs/content/guide/i18n.ngdoc
@@ -22,10 +22,10 @@ Currently, Angular supports i18n/l10n for
 [currency](http://docs.angularjs.org/#!/api/ng.filter:currency) filters.
 
 Additionally, Angular supports localizable pluralization support provided by the {@link
-api/ng.directive:ngPluralize ngPluralize directive}.
+ng.directive:ngPluralize ngPluralize directive}.
 
 All localizable Angular components depend on locale-specific rule sets managed by the {@link
-api/ng.$locale $locale service}.
+ng.$locale $locale service}.
 
 For readers who want to jump straight into examples, we have a few web pages that showcase how to
 use Angular filters with various locale rule sets. You can find these examples either on


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The links do not work. 

I think at commit https://github.com/angular/angular.js/commit/a564160511bf1bbed5a4fe5d2981fae1bb664eca, this correction has been forgotten.

**Other Comments:**
