### PR TITLE
improve $interval#cancel documentation, TODO add example usage

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -492,16 +492,15 @@ angular.mock.$IntervalProvider = function() {
       return promise;
     };
     /**
-     * @ngdoc method
-     * @name $interval#cancel
-     * @description
-     *
-     * Clears the interval.
-     *
-     * @param {promise} The promise of the interval to cancel.
-     *
-     * @return {boolean}
-     */
+      * @ngdoc method
+      * @name $interval#cancel
+      *
+      * @description
+      * Cancels a task associated with the `promise`.
+      *
+      * @param {number} promise Promise returned by the `$interval` function.
+      * @returns {boolean} Returns `true` if the task was successfully canceled.
+      */
     $interval.cancel = function(promise) {
       if(!promise) return false;
       var fnIndex;


### PR DESCRIPTION
It seems like the last pull request messed with the documentation see :
[[http://new.tinygrab.com/96acd8f458722475e407c9363ed3101f74ad366f12.PNG]]
This one is much better (copied from the ng/interval.js file); 
Related to #6367 
Sorry for messing up :)
