### PR TITLE
docs(guide/compiler): fix url-based links refs to AUTO module

### DIFF
--- a/docs/content/guide/compiler.ngdoc
+++ b/docs/content/guide/compiler.ngdoc
@@ -58,7 +58,7 @@ cloned template only needs to be compiled once, and then linked once for each cl
 A directive is a behavior which should be triggered when specific HTML constructs are encountered
 during the compilation process. The directives can be placed in element names, attributes, class
 names, as well as comments. Here are some equivalent examples of invoking the {@link
-api/ng.directive:ngBind `ng-bind`} directive.
+ng.directive:ngBind `ng-bind`} directive.
 
 ```html
   <span ng-bind="exp"></span>
@@ -68,7 +68,7 @@ api/ng.directive:ngBind `ng-bind`} directive.
 ```
 
 A directive is just a function which executes when the compiler encounters it in the DOM. See {@link
-api/ng.$compileProvider#methods_directive directive API} for in-depth documentation on how
+ng.$compileProvider#methods_directive directive API} for in-depth documentation on how
 to write directives.
 
 Here is a directive which makes any element draggable. Notice the `draggable` attribute on the


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The links do not work. 

I think at commit https://github.com/angular/angular.js/commit/a564160511bf1bbed5a4fe5d2981fae1bb664eca, this correction has been forgotten.

**Other Comments:**
