### PR TITLE
docs(guide/di): fix url-based links refs to AUTO module

### DIFF
--- a/docs/content/guide/di.ngdoc
+++ b/docs/content/guide/di.ngdoc
@@ -50,7 +50,7 @@ code that constructs `SomeClass`.
 <img class="pull-right" style="padding-left: 3em; padding-bottom: 1em;" src="img/guide/concepts-module-injector.png">
 
 To manage the responsibility of dependency creation, each Angular application has an {@link
-api/angular.injector injector}. The injector is a service locator that is responsible for
+angular.injector injector}. The injector is a service locator that is responsible for
 construction and lookup of dependencies.
 
 Here is an example of using the injector service:


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The links do not work. 

I think at commit https://github.com/angular/angular.js/commit/a564160511bf1bbed5a4fe5d2981fae1bb664eca, this correction has been forgotten.

**Other Comments:**
