### PR TITLE
docs(tutorial/step_05): fix url-based links refs to AUTO module

### DIFF
--- a/docs/content/tutorial/step_05.ngdoc
+++ b/docs/content/tutorial/step_05.ngdoc
@@ -8,7 +8,7 @@
 
 Enough of building an app with three phones in a hard-coded dataset! Let's fetch a larger dataset
 from our server using one of Angular's built-in {@link guide/dev_guide.services services} called {@link
-api/ng.$http $http}. We will use Angular's {@link guide/di dependency
+ng.$http $http}. We will use Angular's {@link guide/di dependency
 injection (DI)} to provide the service to the `PhoneListCtrl` controller.
 
 


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The links do not work. 

I think at commit https://github.com/angular/angular.js/commit/a564160511bf1bbed5a4fe5d2981fae1bb664eca, this correction has been forgotten.

**Other Comments:**
