### PR TITLE
docs(tutorial/step_06): fix url-based links refs to AUTO module

### DIFF
--- a/docs/content/tutorial/step_06.ngdoc
+++ b/docs/content/tutorial/step_06.ngdoc
@@ -62,7 +62,7 @@ now-familiar double-curly brace binding in the `href` attribute values. In step 
 the element attribute.
 
 We also added phone images next to each record using an image tag with the {@link
-api/ng.directive:ngSrc ngSrc} directive. That directive prevents the
+ng.directive:ngSrc ngSrc} directive. That directive prevents the
 browser from treating the angular `{{ expression }}` markup literally, and initiating a request to
 invalid url `http://localhost:8000/app/{{phone.imageUrl}}`, which it would have done if we had only
 specified an attribute binding in a regular `src` attribute (`<img src="{{phone.imageUrl}}">`).


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The links do not work. 

I think at commit https://github.com/angular/angular.js/commit/a564160511bf1bbed5a4fe5d2981fae1bb664eca, this correction has been forgotten.

**Other Comments:**
