### PR TITLE
fix(ngAnimate): TypeError Cannot call method 'querySelectorAll' in cancelChildAnimations

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -942,16 +942,21 @@ angular.module('ngAnimate', ['ng'])
 
       function cancelChildAnimations(element) {
         var node = extractElementNode(element);
-        forEach(node.querySelectorAll('.' + NG_ANIMATE_CLASS_NAME), function(element) {
-          element = angular.element(element);
-          var data = element.data(NG_ANIMATE_STATE);
-          if(data && data.active) {
-            angular.forEach(data.active, function(operation) {
-              (operation.done || noop)(true);
-              cancelAnimations(operation.animations);
-            });
-          }
-        });
+        if (node) {
+          var nodes = angular.isFunction(node.getElementsByClassName) ?
+            node.getElementsByClassName(NG_ANIMATE_CLASS_NAME) :
+            node.querySelectorAll('.' + NG_ANIMATE_CLASS_NAME);
+          forEach(nodes, function(element) {
+            element = angular.element(element);
+            var data = element.data(NG_ANIMATE_STATE);
+            if(data && data.active) {
+              angular.forEach(data.active, function(operation) {
+                (operation.done || noop)(true);
+                cancelAnimations(operation.animations);
+              });
+            }
+          });
+        }
       }
 
       function cancelAnimations(animations) {

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -3370,5 +3370,21 @@ describe("ngAnimate", function() {
         expect(stat).toBe('gone');
       });
     });
+
+    it('should not throw an error when only comment nodes are rendered in the animation',
+      inject(function($rootScope, $compile) {
+
+      $rootScope.items = [1,2,3,4,5];
+
+      var element = html($compile('<div><div class="animated" ng-if="valid" ng-repeat="item in items"></div></div>')($rootScope));
+
+      $rootScope.$digest();
+
+      $rootScope.items = [];
+
+      $rootScope.$digest();
+
+      expect(element.children().length).toBe(0);
+    }));
   });
 });


### PR DESCRIPTION
When element with ng-repeat has an ng-if directive and user try to remove any item from array used for ng-repeat, he gets error "TypeError Cannot call method 'querySelectorAll' of undefined". This happens because in method cancelChildAnimations of ngAnimate directive not checked value returned from extractElementNode(element) method.
Fix add a validation for result of extractElementNode(element) method.

Closes #6205
