### PR TITLE
chore(examples): remove final traces of examples from the tree

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -142,8 +142,6 @@ angularFiles = {
     '@angularSrcModules',
     '@angularScenario',
     '@angularTest',
-    'example/personalLog/*.js',
-    'example/personalLog/test/*.js'
   ],
 
   'karmaExclude': [
@@ -178,9 +176,6 @@ angularFiles = {
     '@angularSrcModules',
     '@angularScenario',
     '@angularTest',
-    'example/personalLog/*.js',
-
-    'example/personalLog/test/*.js'
   ],
 
   'karmaJqueryExclude': [


### PR DESCRIPTION
Apparently some example files were referenced in angularFiles.js, and this was
missed when 2f4513339337bb8aa6c9dfe1191d169b4fc57999 was checked in. This
cleans it up.
