### PR TITLE
chore(protractor-jenkins-config): don't use `this` inside onPrepare

### DIFF
--- a/protractor-jenkins-conf.js
+++ b/protractor-jenkins-conf.js
@@ -26,7 +26,7 @@ exports.config = {
 
     require('jasmine-reporters');
     jasmine.getEnv().addReporter(
-      new jasmine.JUnitXmlReporter('test_out/e2e-' + this.capabilities.browserName + '-', true, true));
+      new jasmine.JUnitXmlReporter('test_out/e2e-' + exports.config.capabilities.browserName + '-', true, true));
   },
 
   jasmineNodeOpts: {


### PR DESCRIPTION
The jenkins build was failing because onPrepare was not bound to the config object and so was not accessing the correct `this` object.
