### PR TITLE
fix trivial format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,26 +201,26 @@ The animation mock module has been renamed from `mock.animate` to `ngAnimateMock
 ## Breaking Changes
 
 - **$http:** due to [e1cfb195](https://github.com/angular/angular.js/commit/e1cfb1957feaf89408bccf48fae6f529e57a82fe),
-	   it is now necessary to seperately specify default HTTP headers for PUT, POST and PATCH requests, as these no longer share a single object.
-		 
-	To migrate your code, follow the example below:
-	
-	Before:
-	
-		// Will apply to POST, PUT and PATCH methods
-		$httpProvider.defaults.headers.post = {
-			"X-MY-CSRF-HEADER": "..."
-		};
+     it is now necessary to seperately specify default HTTP headers for PUT, POST and PATCH requests, as these no longer share a single object.
 
-	After:
+  To migrate your code, follow the example below:
 
-		// POST, PUT and PATCH default headers must be specified seperately,
-		// as they do not share data.
-		$httpProvider.defaults.headers.post =
-			$httpProvider.defaults.headers.put =
-			$httpProviders.defaults.headers.patch = {
-				"X-MY-CSRF-HEADER": "..."
-			};
+  Before:
+
+    // Will apply to POST, PUT and PATCH methods
+    $httpProvider.defaults.headers.post = {
+      "X-MY-CSRF-HEADER": "..."
+    };
+
+  After:
+
+    // POST, PUT and PATCH default headers must be specified seperately,
+    // as they do not share data.
+    $httpProvider.defaults.headers.post =
+      $httpProvider.defaults.headers.put =
+      $httpProviders.defaults.headers.patch = {
+        "X-MY-CSRF-HEADER": "..."
+      };
 
 <a name="1.2.8"></a>
 # 1.2.8 interdimensional-cartography (2014-01-10)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,13 +34,13 @@ project.
 
 
 ## Want a Doc Fix?
-If you want to help improve the docs, it's a good idea to let others know what you're working on to 
-minimize duplication of effort. Before starting, check out the issue queue for [Milestone:Docs Only](https://github.com/angular/angular.js/issues?milestone=24&state=open). 
+If you want to help improve the docs, it's a good idea to let others know what you're working on to
+minimize duplication of effort. Before starting, check out the issue queue for [Milestone:Docs Only](https://github.com/angular/angular.js/issues?milestone=24&state=open).
 Comment on an issue to let others know what you're working on, or create a new issue if your work
 doesn't fit within the scope of any of the existing doc fix projects.
 
 For large fixes, please build and test the documentation before submitting the PR to be sure you haven't
-accidentally introduced any layout or formatting issues.You should also make sure that your commit message 
+accidentally introduced any layout or formatting issues.You should also make sure that your commit message
 is labeled "docs:" and follows the **Git Commit Guidelines** outlined below.
 
 If you're just making a small change, don't worry about filing an issue first. Use the friendly blue "Improve this doc" button at the top right of the doc page to fork the repository in-place and make a quick change on the fly.


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

While this may be no big deal, I found some issues format style.

"CHANGELOG.md" contain 2-space indent and tab indent.

"CONTRIBUTING.md" contain wasted spaces.

**Other Comments:**

Truth be told, I want to do more great things for ruby, but because my ability clumsy yet, start with these ...!
