### PR TITLE
feat(ngMock): add flushByIndex function

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1439,6 +1439,32 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
     $httpBackend.verifyNoOutstandingExpectation();
   };
 
+  /**
+   * @ngdoc method
+   * @name $httpBackend#flushByIndex
+   * @description
+   * Flushes any number of pending requests starting at the given index using the trained responses.
+   *
+   * @param {number=} index The index of the first response to flush, where 0 corresponds to the
+   *   earliest submitted request. If there is no pending request at the given index when this
+   *   method is called, an exception as thrown.
+   * @param {number=} count Number of responses to flush (in the order they arrived). If undefined,
+   *   only one pending request will be flushed. If there are no pending requests when the flush
+   *   method is called an exception is thrown (as this typically a sign of programming error).
+   */
+  $httpBackend.flushByIndex = function(index, count) {
+    $rootScope.$digest();
+    if (!responses.length) throw new Error('No pending request to flush !');
+    if (!angular.isDefined(index)) throw new Error('Requires an index.');
+    if (!angular.isDefined(count)) count = 1;
+
+    while(count--) {
+      if (index >= responses.length) throw new Error('No more pending request to flush !');
+      responses.splice(index, 1)[0]();
+    }
+
+    $httpBackend.verifyNoOutstandingExpectation();
+  };
 
   /**
    * @ngdoc method

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1266,6 +1266,52 @@ describe('ngMock', function() {
       });
     });
 
+    describe('flushByIndex()', function() {
+      it('should flush given number of pending requests, starting at a given index', function() {
+        var callback2 = jasmine.createSpy('callback2');
+        var callback3 = jasmine.createSpy('callback3');
+
+        hb.when('GET').respond(200, '');
+        hb('GET', '/some', null, callback);
+        hb('GET', '/some', null, callback2);
+        hb('GET', '/some', null, callback3);
+
+        hb.flushByIndex(1, 2);
+        expect(callback).not.toHaveBeenCalled();
+        expect(callback2).toHaveBeenCalled();
+        expect(callback3).toHaveBeenCalled();
+      });
+
+
+      it('should throw exception when flushing more requests than pending', function() {
+        hb.when('GET').respond(200, '');
+        hb('GET', '/url', null, callback);
+
+        expect(function() {hb.flushByIndex(0, 3);}).toThrow('No more pending request to flush !');
+        expect(callback).toHaveBeenCalledOnce();
+      });
+
+
+      it('should throw exception when no request to flush', function() {
+        expect(function() {hb.flushByIndex(0);}).toThrow('No pending request to flush !');
+
+        hb.when('GET').respond(200, '');
+        hb('GET', '/some', null, callback);
+        hb.flushByIndex(0);
+
+        expect(function() {hb.flushByIndex(0);}).toThrow('No pending request to flush !');
+      });
+
+
+      it('should throw exception if not all expectations satisfied', function() {
+        hb.expect('GET', '/url1').respond();
+        hb.expect('GET', '/url2').respond();
+
+        hb('GET', '/url1', null, angular.noop);
+        expect(function() {hb.flushByIndex(0);}).toThrow('Unsatisfied requests: GET /url2');
+      });
+    });
+
 
     it('should abort requests when timeout promise resolves', function() {
       hb.expect('GET', '/url1').respond(200);


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): ngMock

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

I've recently needed to flush httpBackend requests in an arbitrary order to add unit tests around an edge case. This PR satisfies that need.

**Other Comments:**

Adds a flushByIndex function to allow pending requests on httpBackend to be flushed in an arbitrary
order.
