### PR TITLE
docs(routeProvider): Corrected "slashs" to "slashes"

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -59,10 +59,10 @@ function $RouteProvider(){
    *    * `path` can contain optional named groups with a question mark: e.g.`:name?`.
    *
    *    For example, routes like `/color/:color/largecode/:largecode*\/edit` will match
-   *    `/color/brown/largecode/code/with/slashs/edit` and extract:
+   *    `/color/brown/largecode/code/with/slashes/edit` and extract:
    *
    *    * `color: brown`
-   *    * `largecode: code/with/slashs`.
+   *    * `largecode: code/with/slashes`.
    *
    *
    * @param {Object} route Mapping information to be assigned to `$route.current` on route


### PR DESCRIPTION
Another small fix to the docs
