### PR TITLE
Sample code appears unformatted in $interpolate docs

### DIFF
--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -99,11 +99,11 @@ function $InterpolateProvider() {
      * interpolation markup.
      *
      *
-       ```js
-         var $interpolate = ...; // injected
-         var exp = $interpolate('Hello {{name | uppercase}}!');
-         expect(exp({name:'Angular'}).toEqual('Hello ANGULAR!');
-       ```
+     * ```js
+     *   var $interpolate = ...; // injected
+     *   var exp = $interpolate('Hello {{name | uppercase}}!');
+     *   expect(exp({name:'Angular'}).toEqual('Hello ANGULAR!');
+     * ```
      *
      *
      * @param {string} text The text with markup to interpolate.


### PR DESCRIPTION
Request Type: docs

How to reproduce: It can be seen at the top of http://docs.angularjs.org/api/ng/service/$interpolate

Component(s): $compile

Impact: large

Complexity: small

This issue is related to: 

**Detailed Description:**

The code was appearing unformatted

**Other Comments:**
