### PR TITLE
feat($parse): Getter/Setter functions as assignable expressions

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -155,7 +155,9 @@
  *   value of `parentModel` on the parent scope. Any changes to `parentModel` will be reflected
  *   in `localModel` and any changes in `localModel` will reflect in `parentModel`. If the parent
  *   scope property doesn't exist, it will throw a NON_ASSIGNABLE_MODEL_EXPRESSION exception. You
- *   can avoid this behavior using `=?` or `=?attr` in order to flag the property as optional.
+ *   can avoid this behavior using `=?` or `=?attr` in order to flag the property as optional. A
+ *   getter/setter function can also be used for this binding, given an expression such as
+ *   `<widget my-attr="parentModel($value)">`. See {@link $parse $parse} for details.
  *
  * * `&` or `&attr` - provides a way to execute an expression in the context of the parent scope.
  *   If no `attr` name is specified then the attribute name is assumed to be the same as the

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1001,6 +1001,50 @@ var VALID_CLASS = 'ng-valid',
     </file>
  * </example>
  *
+ * ## Getter/Setter Function Example
+ *
+ * A getter/setter function can also be used as a model by calling the function with
+ * `$value` in the argument list in your expression. This assumes that calling the
+ * function will act as a getter when called without arguments, and a setter when
+ * called with arguments. See {@link $parse $parse} for more details.
+ *
+ * <example name="NgModelControllerFunction" module="getterSetterFunction">
+    <file name="script.js">
+      angular.module('getterSetterFunction', []).
+        controller('NameCtrl', function($scope) {
+          var name = 'Change me!';
+          $scope.name = function(newName) {
+            if (newName === undefined) {
+              return name;
+            } else {
+              name = newName;
+            }
+          };
+        });
+    </file>
+    <file name="index.html">
+      <div ng-controller="NameCtrl">
+        <form name="myForm">
+          <input type="text" ng-model="name($value)" />
+        </form>
+        <p class="name">
+          {{ name() }}
+        </p>
+      </div>
+    </file>
+    <file name="protractor.js" type="protractor">
+      it('should bind the name function', function() {
+        var input = element(by.css('input'));
+        var binding = element(by.css('.name'));
+        var content = 'Change me!';
+
+        input.clear();
+        input.sendKeys('New name');
+
+        expect(binding.getText()).toEqual('New name');
+      });
+    </file>
+ * </example>
  *
  */
 var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$parse',
@@ -1217,7 +1261,8 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
  * @description
  * The `ngModel` directive binds an `input`,`select`, `textarea` (or custom form control) to a
  * property on the scope using {@link ngModel.NgModelController NgModelController},
- * which is created and exposed by this directive.
+ * which is created and exposed by this directive. A getter/setter function can also be used for
+ * the model. See {@link $parse $parse} for details.
  *
  * `ngModel` is responsible for:
  *

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2597,6 +2597,29 @@ describe('$compile', function() {
         expect(componentScope.ref).toBe('hello misko');
       }));
 
+
+      it('should allow binding to getter/setter functions', inject(function() {
+        var rootName;
+        $rootScope.name = function(newName) {
+          if (newName == null) {
+            return rootName;
+          } else {
+            rootName = newName;
+          }
+        };
+        compile('<div><span my-component ref="name($value)">');
+
+        rootName = 'sean';
+        $rootScope.$apply();
+
+        expect(componentScope.ref).toBe('sean');
+
+        componentScope.ref = 'jim'
+        $rootScope.$apply()
+
+        expect(rootName).toBe('jim');
+      }));
+
       // regression
       it('should stabilize model', inject(function() {
         compile('<div><span my-component reference="name">');

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -447,6 +447,17 @@ describe('input', function() {
   });
 
 
+  it('should bind to a getter/setter function', function() {
+    compileInput('<input type="text" ng-model="name($value)" name="alias" ng-change="change()" />');
+
+    scope.$apply(function() {
+      scope.name = function() { return 'sean'; };
+    });
+
+    expect(inputElm.val()).toBe('sean');
+  });
+
+
   it('should not set readonly or disabled property on ie7', function() {
     this.addMatchers({
       toBeOff: function(attributeName) {
@@ -475,6 +486,15 @@ describe('input', function() {
 
     changeInputValueTo('adam');
     expect(scope.name).toEqual('adam');
+  });
+
+
+  it('should call setter functions on "blur" event', function() {
+    scope.name = jasmine.createSpy('name');
+    compileInput('<input type="text" ng-model="name($value)" name="alias" ng-change="change()" />');
+
+    changeInputValueTo('sean');
+    expect(scope.name).toHaveBeenCalledWith('sean');
   });
 
   if (!(msie < 9)) {

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -947,6 +947,29 @@ describe('parser', function() {
             fn.assign(scope, 123);
             expect(scope).toEqual({a:123});
           }));
+
+
+          it('should allow assignment via a setter function', inject(function($parse) {
+            var fn = $parse('a($value)');
+            expect(fn.assign).toBeTruthy();
+            var scope = jasmine.createSpyObj('scope', ['a']);
+            fn.assign(scope, 123);
+            expect(scope.a).toHaveBeenCalledWith(123);
+          }));
+
+
+          it('does not expose assignment for functions called without `$value`',
+          inject(function($parse) {
+            var fn = $parse('a()');
+            expect(fn.assign).toBeFalsy();
+          }));
+
+
+          it('does not expose assignment when `$value` is passed earlier in the call chain',
+          inject(function($parse) {
+            var fn = $parse('a($value).b()');
+            expect(fn.assign).toBeFalsy();
+          }));
         });
 
 


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): $parse

Impact: 

Complexity: small

This issue is related to: 

**Detailed Description:**

Allow a getter/setter function to be treated as an assignable expression
by calling the function with `$value` in its argument list. It is
assumed that functions called this way will follow the convention used
by angular in its providers, where calling the function with no
arguments acts as a getter, and calling it with arguments acts as a
setter.

Example:

``` html
<input ng-model="name($value)" />
```

``` js
var name;
$scope.name = function(newName) {
  if (newName === undefined) {
    return name;
  } else {
    name = newName;
  }
}
```

In addition to `$parse`, the modules most affected by this change are
`ngModel`, and `$compile` (when adding a bi-directional binding to the
scope by using `'='`). Tests and documentation are included for those modules,
in addition to `$parse`, with a full usage example in `ngModel.NgModelController`.

The overall goal is to better allow support for "computed" properties,
and allow easier delegation between modules, without consuming code
having to change or break encapsulation to bind to these values.

**Other Comments:**

An alternative API would be to have this behavior happen automatically if
the bound expression evaluates to a function, which would allow
consuming code to simply write `<input ng-model="name" />`, and not have
to care about whether name is a property or a getter/setter function.
While this would better follow the uniform access principle, it would
introduce a fair amount of magic, and could lead to unexpected behavior
with bi-directional bindings on directives.
