### PR TITLE
Added get method to $q

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -325,9 +325,10 @@ function qFactory(nextTick, exceptionHandler) {
           });
         },
         get: function(key) {
-          return this.then(function(obj) {
+          function getKey(obj) {
             return obj[key];
-          });
+          }
+          return this.then(getKey, getKey);
         }
       }
     };

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -323,6 +323,11 @@ function qFactory(nextTick, exceptionHandler) {
           }, function(error) {
             return handleCallback(error, false);
           });
+        },
+        get: function(key) {
+          return this.then(function(obj) {
+            return obj[key];
+          });
         }
       }
     };

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -524,6 +524,10 @@ describe('q', function() {
         expect(typeof promise['finally']).toBe('function');
       });
 
+      it('should have a get method', function() {
+        expect(typeof promise.get).toBe('function');
+      });
+
 
       describe('then', function() {
         it('should allow registration of a success callback without an errback or progressback ' +


### PR DESCRIPTION
This adds a nice utility method present in [Q](https://github.com/kriskowal/q/wiki/API-Reference#wiki-promisegetpropertyname) which will allow you to fetch a particular key's value from a resolved/rejected value of a promise.

This is useful for doing stuff like `$http.get(url).get('data')` instead of having to do `$http.get(url).then(function(res) { return res.data; })`.  In addition, we can do

<pre>
promise = foo.bar();
newPromise = promise.get('reallyreallyreallyreallyreallyreallyLongKey')
                    .then(moo);
anotherPromise = promise.get('anotherreallyreallyreallyreallyreallyLongKey')
                        .then(foobar)
                        .then(bar)
                        .then(baz);
return $q.all[newPromise, anotherPromise];
</pre>
