### PR TITLE
chore(docs): fix layout between 769px and 992px

### DIFF
--- a/docs/app/assets/css/docs.css
+++ b/docs/app/assets/css/docs.css
@@ -562,6 +562,15 @@ ul.events > li {
   margin-bottom:40px;
 }
 
+@media only screen and (min-width: 769px) and (max-width: 991px) {
+  .main-body-grid {
+    margin-top: 160px;
+  }
+  .main-body-grid > .grid-left {
+    top: 160px;
+  }
+}
+
 @media only screen and (max-width : 768px) {
   .picker, .picker select {
     width:auto;


### PR DESCRIPTION
Left nav and main content were tucked slightly under the version picker / breadcrumb navbar

![angulardocs](https://f.cloud.github.com/assets/1153097/2283956/f793dcf4-9fc3-11e3-9b7b-ab5a947e16ac.PNG)
