### PR TITLE
Update interval.js

### DIFF
--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -168,7 +168,7 @@ function $IntervalProvider() {
       * @description
       * Cancels a task associated with the `promise`.
       *
-      * @param {number} promise Promise returned by the `$interval` function.
+      * @param {promise} Promise returned by the `$interval` function.
       * @returns {boolean} Returns `true` if the task was successfully canceled.
       */
     interval.cancel = function(promise) {


### PR DESCRIPTION
Docs seemed to show `number` as the type of the parameter the cancel callback accepts when it seems to only accept a promise from the $interval service.
