### PR TITLE
docs(*): ensure jsdoc type expressions are valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "gulp-concat": "~2.1.7",
     "canonical-path": "0.0.2",
     "winston": "~0.7.2",
-    "dgeni": "~0.1.0",
-    "dgeni-packages": "^0.2.2",
+    "dgeni": "~0.2.0",
+    "dgeni-packages": "^0.3.0",
     "gulp-jshint": "~1.4.2",
     "jshint-stylish": "~0.1.5"
   },

--- a/src/ng/directive/script.js
+++ b/src/ng/directive/script.js
@@ -12,7 +12,7 @@
  * `<script>` element must be specified as `text/ng-template`, and a cache name for the template must be
  * assigned through the element's `id`, which can then be used as a directive's `templateUrl`.
  *
- * @param {'text/ng-template'} type Must be set to `'text/ng-template'`.
+ * @param {string} type Must be set to `'text/ng-template'`.
  * @param {string} id Cache name of the template.
  *
  * @example

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -573,7 +573,7 @@ function $HttpProvider() {
      *   - **headers** – `{function([headerName])}` – Header getter function.
      *   - **config** – `{Object}` – The configuration object that was used to generate the request.
      *
-     * @property {Array.&ltObject&gt;} pendingRequests Array of config objects for currently pending
+     * @property {Array.<Object>} pendingRequests Array of config objects for currently pending
      *   requests. This is primarily meant to be used for debugging purposes.
      *
      *
@@ -875,7 +875,6 @@ function $HttpProvider() {
         /**
          * @ngdoc property
          * @name $http#defaults
-         * @propertyOf ng.$http
          *
          * @description
          * Runtime equivalent of the `$httpProvider.defaults` property. Allows configuration of

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -870,7 +870,7 @@ function $RootScopeProvider(){
        *   - `defaultPrevented` - `{boolean}`: true if `preventDefault` was called.
        *
        * @param {string} name Event name to listen on.
-       * @param {function(event, args...)} listener Function to call when the event is emitted.
+       * @param {function(event, ...args)} listener Function to call when the event is emitted.
        * @returns {function()} Returns a deregistration function for this listener.
        */
       $on: function(name, listener) {

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -97,7 +97,7 @@ function shallowClearAndCopy(src, dst) {
  *   If the parameter value is prefixed with `@` then the value of that parameter is extracted from
  *   the data object (useful for non-GET operations).
  *
- * @param {Object.&lt;Object&gt;=} actions Hash with declaration of custom action that should extend
+ * @param {Object.<Object>=} actions Hash with declaration of custom action that should extend
  *   the default set of resource actions. The declaration should be created in the format of {@link
  *   ng.$http#usage_parameters $http.config}:
  *

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -247,7 +247,7 @@ function $RouteProvider(){
      *     - `$scope` - The current route scope.
      *     - `$template` - The current route template HTML.
      *
-     * @property {Array.&lt;Object&gt;} routes Array of all configured routes.
+     * @property {Array.<Object>} routes Array of all configured routes.
      *
      * @description
      * `$route` is used for deep-linking URLs to controllers and views (HTML partials).


### PR DESCRIPTION
These changes are to coincide with the forthcoming change to dgeni-packages: https://github.com/angular/dgeni-packages/pull/10

There are a bunch of invalid jsdoc type expressions that will break if you use the new dgeni tagParser.  This PR will fix those.  Unfortunately, the docs will look wrong if we merge them before the new tagParser arrives.
