### PR TITLE
feature(style): expressions in style tags

### DIFF
--- a/src/ng/directive/style.js
+++ b/src/ng/directive/style.js
@@ -2,5 +2,5 @@
 
 var styleDirective = valueFn({
   restrict: 'E',
-  terminal: true
+  terminal: false
 });

--- a/test/ng/directive/styleSpec.js
+++ b/test/ng/directive/styleSpec.js
@@ -9,13 +9,20 @@ describe('style', function() {
   });
 
 
-  it('should not compile style element', inject(function($compile, $rootScope) {
-    element = jqLite('<style type="text/css">should {{notBound}}</style>');
+  it('should compile style element', inject(function($compile, $rootScope) {
+    element = jqLite('<style type="text/css">.some-container{ width: {{elementWidth}}px; }</style>');
     $compile(element)($rootScope);
     $rootScope.$digest();
 
     // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe('should {{notBound}}');
+    expect(trim(element[0].innerHTML)).toBe('.some-container{ width: px; }');
+
+    $rootScope.$apply(function() {
+      $rootScope.elementWidth = 200;
+    });
+
+    // read innerHTML and trim to pass on IE8
+    expect(trim(element[0].innerHTML)).toBe('.some-container{ width: 200px; }');
   }));
 
 

--- a/test/ng/directive/styleSpec.js
+++ b/test/ng/directive/styleSpec.js
@@ -9,20 +9,38 @@ describe('style', function() {
   });
 
 
-  it('should compile style element', inject(function($compile, $rootScope) {
-    element = jqLite('<style type="text/css">' +
-      '.navigation{font-size:1.5em; h3{font-size:1.5em}}' +
-      '.footer{h3{font-size:{{fontSize}}em}}' +
-      '.header{font-size:1.5em; h3{font-size:{{fontSize}}{{unit}}}}' +
-      '</style>');
+  it('should compile style element without binding', inject(function($compile, $rootScope) {
+    element = jqLite('<style type="text/css">.header{font-size:1.5em; h3{font-size:1.5em}}</style>');
     $compile(element)($rootScope);
     $rootScope.$digest();
 
     // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe(
-      '.navigation{font-size:1.5em; h3{font-size:1.5em}}' +
-      '.footer{h3{font-size:em}}' +
-      '.header{font-size:1.5em; h3{font-size:}}');
+    expect(trim(element[0].innerHTML)).toBe('.header{font-size:1.5em; h3{font-size:1.5em}}');
+  }));
+
+  it('should compile style element with one bind', inject(function($compile, $rootScope) {
+    element = jqLite('<style type="text/css">.header{h3{font-size:{{fontSize}}em}}</style>');
+    $compile(element)($rootScope);
+    $rootScope.$digest();
+
+    // read innerHTML and trim to pass on IE8
+    expect(trim(element[0].innerHTML)).toBe('.header{h3{font-size:em}}');
+
+    $rootScope.$apply(function() {
+      $rootScope.fontSize = 1.5;
+    });
+
+    // read innerHTML and trim to pass on IE8
+    expect(trim(element[0].innerHTML)).toBe('.header{h3{font-size:1.5em}}');
+  }));
+
+  it('should compile style element with two binds', inject(function($compile, $rootScope) {
+    element = jqLite('<style type="text/css">.header{h3{font-size:{{fontSize}}{{unit}}}}</style>');
+    $compile(element)($rootScope);
+    $rootScope.$digest();
+
+    // read innerHTML and trim to pass on IE8
+    expect(trim(element[0].innerHTML)).toBe('.header{h3{font-size:}}');
 
     $rootScope.$apply(function() {
       $rootScope.fontSize = 1.5;
@@ -30,12 +48,8 @@ describe('style', function() {
     });
 
     // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe(
-      '.navigation{font-size:1.5em; h3{font-size:1.5em}}' +
-      '.footer{h3{font-size:1.5em}}' +
-      '.header{font-size:1.5em; h3{font-size:1.5em}}');
+    expect(trim(element[0].innerHTML)).toBe('.header{h3{font-size:1.5em}}');
   }));
-
 
   it('should compile content of element with style attr', inject(function($compile, $rootScope) {
     element = jqLite('<div style="some">{{bind}}</div>');

--- a/test/ng/directive/styleSpec.js
+++ b/test/ng/directive/styleSpec.js
@@ -10,19 +10,30 @@ describe('style', function() {
 
 
   it('should compile style element', inject(function($compile, $rootScope) {
-    element = jqLite('<style type="text/css">.some-container{ width: {{elementWidth}}px; }</style>');
+    element = jqLite('<style type="text/css">' +
+      '.navigation{font-size:1.5em; h3{font-size:1.5em}}' +
+      '.footer{h3{font-size:{{fontSize}}em}}' +
+      '.header{font-size:1.5em; h3{font-size:{{fontSize}}{{unit}}}}' +
+      '</style>');
     $compile(element)($rootScope);
     $rootScope.$digest();
 
     // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe('.some-container{ width: px; }');
+    expect(trim(element[0].innerHTML)).toBe(
+      '.navigation{font-size:1.5em; h3{font-size:1.5em}}' +
+      '.footer{h3{font-size:em}}' + 
+      '.header{font-size:1.5em; h3{font-size:}}');
 
     $rootScope.$apply(function() {
-      $rootScope.elementWidth = 200;
+      $rootScope.fontSize = 1.5;
+      $rootScope.unit = 'em';
     });
 
     // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe('.some-container{ width: 200px; }');
+    expect(trim(element[0].innerHTML)).toBe(
+      '.navigation{font-size:1.5em; h3{font-size:1.5em}}' +
+      '.footer{h3{font-size:1.5em}}' +
+      '.header{font-size:1.5em; h3{font-size:1.5em}}');
   }));
 
 

--- a/test/ng/directive/styleSpec.js
+++ b/test/ng/directive/styleSpec.js
@@ -21,7 +21,7 @@ describe('style', function() {
     // read innerHTML and trim to pass on IE8
     expect(trim(element[0].innerHTML)).toBe(
       '.navigation{font-size:1.5em; h3{font-size:1.5em}}' +
-      '.footer{h3{font-size:em}}' + 
+      '.footer{h3{font-size:em}}' +
       '.header{font-size:1.5em; h3{font-size:}}');
 
     $rootScope.$apply(function() {

--- a/test/ng/directive/styleSpec.js
+++ b/test/ng/directive/styleSpec.js
@@ -18,29 +18,45 @@ describe('style', function() {
     expect(trim(element[0].innerHTML)).toBe('.header{font-size:1.5em; h3{font-size:1.5em}}');
   }));
 
-  it('should compile style element with one bind', inject(function($compile, $rootScope) {
-    element = jqLite('<style type="text/css">.header{h3{font-size:{{fontSize}}em}}</style>');
+  it('should compile style element with one simple bind', inject(function($compile, $rootScope) {
+    element = jqLite('<style type="text/css">.some-container{ width: {{elementWidth}}px; }</style>');
     $compile(element)($rootScope);
     $rootScope.$digest();
 
     // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe('.header{h3{font-size:em}}');
+    expect(trim(element[0].innerHTML)).toBe('.some-container{ width: px; }');
+
+    $rootScope.$apply(function() {
+      $rootScope.elementWidth = 200;
+    });
+
+    // read innerHTML and trim to pass on IE8
+    expect(trim(element[0].innerHTML)).toBe('.some-container{ width: 200px; }');
+  }));
+
+  it('should compile style element with one bind', inject(function($compile, $rootScope) {
+    element = jqLite('<style type="text/css">.header{ h3 { font-size: {{fontSize}}em }}</style>');
+    $compile(element)($rootScope);
+    $rootScope.$digest();
+
+    // read innerHTML and trim to pass on IE8
+    expect(trim(element[0].innerHTML)).toBe('.header{ h3 { font-size: em }}');
 
     $rootScope.$apply(function() {
       $rootScope.fontSize = 1.5;
     });
 
     // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe('.header{h3{font-size:1.5em}}');
+    expect(trim(element[0].innerHTML)).toBe('.header{ h3 { font-size: 1.5em }}');
   }));
 
   it('should compile style element with two binds', inject(function($compile, $rootScope) {
-    element = jqLite('<style type="text/css">.header{h3{font-size:{{fontSize}}{{unit}}}}</style>');
+    element = jqLite('<style type="text/css">.header{ h3 { font-size: {{fontSize}}{{unit}} }}</style>');
     $compile(element)($rootScope);
     $rootScope.$digest();
 
     // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe('.header{h3{font-size:}}');
+    expect(trim(element[0].innerHTML)).toBe('.header{ h3 { font-size:  }}');
 
     $rootScope.$apply(function() {
       $rootScope.fontSize = 1.5;
@@ -48,7 +64,7 @@ describe('style', function() {
     });
 
     // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe('.header{h3{font-size:1.5em}}');
+    expect(trim(element[0].innerHTML)).toBe('.header{ h3 { font-size: 1.5em }}');
   }));
 
   it('should compile content of element with style attr', inject(function($compile, $rootScope) {


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): $compile

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Data-binding for style tag doesn't work (see style.js, terminal:true). Setting terminal to false in the directive will enable data-binding. Test provided.

**Other Comments:**

Enable data-binding for style tags

closes #2387
