### PR TITLE
fix($sniffer): add window.document to 'document' assignment search tree

### DIFF
--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -21,7 +21,7 @@ function $SnifferProvider() {
         android =
           int((/android (\d+)/.exec(lowercase(($window.navigator || {}).userAgent)) || [])[1]),
         boxee = /Boxee/i.test(($window.navigator || {}).userAgent),
-        document = $document[0] || {},
+        document = $document[0] || window.document || {},
         documentMode = document.documentMode,
         vendorPrefix,
         vendorRegex = /^(Moz|webkit|O|ms)(?=[A-Z])/,


### PR DESCRIPTION
Unit tests were failing for my custom directive that had a text input with an ng-model attribute. The error was that document had no 'createElement' function. Debugging revealed that the document object was using the empty object in the 'document' assignment search tree. Adding window.document prior to that option fixed the issue and I don't think there's any downside to using 'window' here since you're already assuming a browser. There was no functional problem in the usage of my app itself--this only occurred during unit testing in the Karma/Jasmine environment.
