### PR TITLE
fix($http): don't covert 0 status codes to 404 for non-file protocols

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -144,9 +144,11 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
       jsonpDone = xhr = null;
 
       // fix status code when it is 0 (0 status is undocumented).
-      // Occurs when accessing file resources.
-      // On Android 4.1 stock browser it occurs while retrieving files from application cache.
-      status = (status === 0) ? (response ? 200 : 404) : status;
+      // Occurs when accessing file resources or n Android 4.1 stock browser
+      // while retrieving files from application cache.
+      if (status === 0) {
+        status = response ? 200 : urlResolve(url).protocol == 'file' ? 404 : 0;
+      }
 
       // normalize IE bug (http://bugs.jquery.com/ticket/1450)
       status = status == 1223 ? 204 : status;

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -456,7 +456,17 @@ describe('$httpBackend', function() {
     }
 
 
-    it('should convert 0 to 200 if content', function() {
+    it('should convert 0 to 200 if content and file protocol', function() {
+      $backend = createHttpBackend($browser, createMockXhr);
+
+      $backend('GET', 'file:///whatever/index.html', null, callback);
+      respond(0, 'SOME CONTENT');
+
+      expect(callback).toHaveBeenCalled();
+      expect(callback.mostRecentCall.args[0]).toBe(200);
+    });
+
+    it('should convert 0 to 200 if content for protocols other than file', function() {
       $backend = createHttpBackend($browser, createMockXhr);
 
       $backend('GET', 'someProtocol:///whatever/index.html', null, callback);
@@ -466,17 +476,25 @@ describe('$httpBackend', function() {
       expect(callback.mostRecentCall.args[0]).toBe(200);
     });
 
-
-    it('should convert 0 to 404 if no content', function() {
+    it('should convert 0 to 404 if no content and file protocol', function() {
       $backend = createHttpBackend($browser, createMockXhr);
 
-      $backend('GET', 'someProtocol:///whatever/index.html', null, callback);
+      $backend('GET', 'file:///whatever/index.html', null, callback);
       respond(0, '');
 
       expect(callback).toHaveBeenCalled();
       expect(callback.mostRecentCall.args[0]).toBe(404);
     });
 
+    it('should not convert 0 to 404 if no content for protocols other than file', function() {
+      $backend = createHttpBackend($browser, createMockXhr);
+
+      $backend('GET', 'someProtocol:///whatever/index.html', null, callback);
+      respond(0, '');
+
+      expect(callback).toHaveBeenCalled();
+      expect(callback.mostRecentCall.args[0]).toBe(0);
+    });
 
     it('should convert 0 to 404 if no content - relative url', function() {
       var originalUrlParsingNode = urlParsingNode;
@@ -486,10 +504,10 @@ describe('$httpBackend', function() {
         hash : "#/C:/",
         host : "",
         hostname : "",
-        href : "someProtocol:///C:/base#!/C:/foo",
+        href : "file:///C:/base#!/C:/foo",
         pathname : "/C:/foo",
         port : "",
-        protocol : "someProtocol:",
+        protocol : "file:",
         search : "",
         setAttribute: angular.noop
       };


### PR DESCRIPTION
PR #5547 introduced conversion of all 0 status codes to 404 for cases
where no response was recieved (previously this was done for the
file:// protocol only). But this mechanism is too eager and
masks legitimate cases where status 0 should be returned. This commits
reverts to the previous mechanism of handling 0 status code for the
file:// protocol (converting 0 to 404) while retaining the returned
status code 0 for all the protocols other than file://

Fixes #6074
Fixes #6155
