### PR TITLE
feat($q): manage bulk promises as a promise

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -516,10 +516,74 @@ function qFactory(nextTick, exceptionHandler) {
     return deferred.promise;
   }
 
+  /**
+   * @ngdoc method
+   * @name $q#some
+   * @function
+   *
+   * @description
+   * Combines multiple promises into a single promise that is resolved when all of the input
+   * promises are resolved, and rejected if at least one of them is rejected.
+   *
+   * @param {Array.<Promise>|Object.<Promise>} promises An array or hash of promises.
+   * @returns {Promise} Returns a single promise that will be resolved or rejected with a hash with fields
+   *   an array/hash of values, each value corresponding to the promise at the same index/key in the
+   *   `promises` array/hash.
+   *   If any of the promises is resolved with a rejection, this resulting promise will be rejected
+   *   with the same rejection value.
+   *   The difference between `$q#some` and `$q#all` is that `$q#some` will collect result from all
+   *   `promises`, that can be independent.
+   */
+  function some(promises) {
+    var deferred = defer(),
+        counter = 0,
+        wasRejected = false,
+        resolvedResults = isArray(promises) ? [] : {},
+        rejectedResults = isArray(promises) ? [] : {},
+        results = {resolved: resolvedResults,
+          rejected: rejectedResults
+        };
+
+    var checkIsAllProcessed = function() {
+      if (!(--counter)) {
+        if (wasRejected) {
+          deferred.reject(results);
+        } else {
+          deferred.resolve(results);
+        }
+      }
+    };
+
+    forEach(promises, function(promise, key) {
+      counter++;
+      ref(promise).then(function(value) {
+        if (resolvedResults.hasOwnProperty(key) || rejectedResults.hasOwnProperty(key)) {
+          return;
+        }
+        resolvedResults[key] = value;
+        checkIsAllProcessed();
+      }, function(reason) {
+        if (resolvedResults.hasOwnProperty(key) || rejectedResults.hasOwnProperty(key)) {
+          return;
+        }
+        wasRejected = true;
+        rejectedResults[key] = reason;
+        checkIsAllProcessed();
+      });
+    });
+
+    if (counter === 0) {
+      deferred.resolve(results);
+    }
+
+    return deferred.promise;
+  }
+
   return {
     defer: defer,
     reject: reject,
     when: when,
-    all: all
+    all: all,
+    some: some
   };
 }

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -183,7 +183,7 @@ describe('q', function() {
   beforeEach(function() {
     q = qFactory(mockNextTick.nextTick, noop),
     defer = q.defer;
-    deferred =  defer()
+    deferred =  defer();
     promise = deferred.promise;
     log = [];
     mockNextTick.queue = [];
@@ -1282,6 +1282,7 @@ describe('q', function() {
     });
   });
 
+
   describe('all (hash)', function() {
     it('should resolve all or nothing', function() {
       var result;
@@ -1348,6 +1349,78 @@ describe('q', function() {
       expect(logStr()).toBe('success({"first":"done","second":"done","third":"done"})->{"first":"done","second":"done","third":"done"}');
     });
   });
+
+
+  describe('some (hash)', function() {
+    it('should resolve all or nothing', function() {
+      var result;
+      q.some({}).then(function(r) { result = r; });
+      mockNextTick.flush();
+      expect(result).toEqual({resolved: {}, rejected: {}});
+    });
+
+
+    it('should take a hash of promises and return a promise for a hash of results', function() {
+      var deferred1 = defer(),
+          deferred2 = defer();
+
+      q.some({en: promise, fr: deferred1.promise, es: deferred2.promise}).then(success(), error());
+      expect(logStr()).toBe('');
+      syncResolve(deferred, 'hi');
+      expect(logStr()).toBe('');
+      syncResolve(deferred2, 'hola');
+      expect(logStr()).toBe('');
+      syncResolve(deferred1, 'salut');
+      expect(logStr()).toBe('success({"resolved":{"en":"hi","es":"hola","fr":"salut"},"rejected":{}})->{"resolved":{"en":"hi","es":"hola","fr":"salut"},"rejected":{}}');
+    });
+
+
+    it('should reject the derived promise if at least one of the promises in the hash is rejected, but should collect all succeded promises',
+        function() {
+      var deferred1 = defer(),
+          deferred2 = defer();
+
+      q.some({en: promise, fr: deferred1.promise, es: deferred2.promise}).then(success(), error());
+      expect(logStr()).toBe('');
+      syncResolve(deferred2, 'hola');
+      expect(logStr()).toBe('');
+      syncReject(deferred1, 'oops');
+      expect(logStr()).toBe('');
+      syncResolve(deferred, 'go ahead');
+
+      expect(logStr()).toBe('error({"resolved":{"es":"hola","en":"go ahead"},"rejected":{"fr":"oops"}})->reject({"resolved":{"es":"hola","en":"go ahead"},"rejected":{"fr":"oops"}})');
+    });
+
+
+    it('should ignore multiple resolutions of an (evil) hash promise', function() {
+      var evilPromise = {
+        then: function(success, error) {
+          evilPromise.success = success;
+          evilPromise.error = error;
+        }
+      };
+
+      q.some({good: promise, evil: evilPromise}).then(success(), error());
+      expect(logStr()).toBe('');
+
+      evilPromise.success('first');
+      evilPromise.success('muhaha');
+      evilPromise.error('arghhh');
+      expect(logStr()).toBe('');
+
+      syncResolve(deferred, 'done');
+      expect(logStr()).toBe('success({"resolved":{"evil":"first","good":"done"},"rejected":{}})->{"resolved":{"evil":"first","good":"done"},"rejected":{}}');
+    });
+
+    it('should handle correctly situation when given the same promise several times', function() {
+      q.some({first: promise, second: promise, third: promise}).then(success(), error());
+      expect(logStr()).toBe('');
+
+      syncResolve(deferred, 'done');
+      expect(logStr()).toBe('success({"resolved":{"first":"done","second":"done","third":"done"},"rejected":{}})->{"resolved":{"first":"done","second":"done","third":"done"},"rejected":{}}');
+    });
+  });
+
 
   describe('exception logging', function() {
     var mockExceptionLogger = {


### PR DESCRIPTION
As $q.all() reject with a first rejected promise, $q.some() proceed execution until all promises
are rejected or resolved. It can be useful for independent bulk promises.

No breaking changes.
