### PR TITLE
fix(select): reset select model if valid options changed by ng-options

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -575,6 +575,11 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
           while(optionGroupsCache.length > groupIndex) {
             optionGroupsCache.pop()[0].element.remove();
           }
+
+          if(!multiple && !selectedSet && modelValue !== null) {
+            // no value selected, clear model
+            ctrl.$setViewValue(undefined);
+          }
         }
       }
     }

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1113,6 +1113,28 @@ describe('select', function() {
         browserTrigger(element, 'change');
         expect(scope.selected).toEqual(null);
       });
+
+      it('should clear model if ng-options change to not include selected value (#6379)', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'ng-options': 'item for item in values'
+        });
+
+        scope.$apply(function() {
+          scope.values = ['A','B'];
+          scope.selected = scope.values[0];
+        });
+
+        expect(element.val()).toEqual('0');
+
+        expect(scope.selected).toEqual(scope.values[0]);
+
+        scope.$apply(function() {
+          scope.values = ['C','D'];
+        });
+        expect(element.val()).toEqual('?');
+        expect(scope.selected).toBeUndefined();
+      });
     });
 
 


### PR DESCRIPTION
Request Type: bug

How to reproduce: select model not reset if valid options changed by ng-options #6379

Component(s): forms

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

select model not reset if valid options changed by ng-options #6379

**Other Comments:**

Previously, changing the available options so the current model value was no longer valid would show no selection in the UI
The model value would still be the old value.

Closes #6379

Feedback welcome!
