### PR TITLE
fix(select): normalize options without value attrs

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -221,6 +221,10 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
 
       // find "null" option
       for(var i = 0, children = element.children(), ii = children.length; i < ii; i++) {
+        if(children[i].nodeName === 'OPTION' && isUndefined(children.eq(i).attr('value'))) {
+          children[i].value = '';
+        }
+
         if (children[i].value === '') {
           emptyOption = nullOption = children.eq(i);
           break;

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -160,6 +160,31 @@ describe('select', function() {
         expect(element).toEqualSelect([''], 'x', 'y');
       });
 
+      it('should support option without a value attribute', function() {
+        compile('<select ng-model="robot">' +
+                  '<option>--select--</option>' +
+                  '<option value="x">robot x</option>' +
+                  '<option value="y">robot y</option>' +
+                '</select>');
+        expect(element).toEqualSelect(["? undefined:undefined ?"], "--select--", 'x', 'y');
+      });
+
+      it('should support option without a value with other HTML attributes', function() {
+        compile('<select ng-model="robot">' +
+                  '<option data-foo="bar">--select--</option>' +
+                  '<option value="x">robot x</option>' +
+                  '<option value="y">robot y</option>' +
+                '</select>');
+        expect(element).toEqualSelect(["? undefined:undefined ?"], "--select--", 'x', 'y');
+      });
+
+      it('should support option without a value attribute using `ng-options`', function() {
+        scope.someOpts = [{name: 'foo'}, {name: 'foo'}];
+        compile('<select ng-model="robot" ng-options="r.name for someOpts in someOpts">' +
+                  '<option>--select--</option>' +
+                '</select>');
+        expect(element).toEqualSelect([""],"0","1");
+      });
 
       it('should support defining an empty option anywhere in the option list', function() {
         compile('<select ng-model="robot">' +


### PR DESCRIPTION
In order to fix #6351 I'm submitting this changes based on @caitp comments.
Note that the [commented expectation](https://github.com/cironunes/angular.js/blob/faeca99fddf40a277489a2ce9d3783904768422f/test/ng/directive/selectSpec.js#L169) is returning `[["? undefined:undefined ?"],"--select--","x","y"]` is it expected?
