### PR TITLE
fix($http): resolve cached requests with the proper config when hitting a cached promise

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -941,8 +941,7 @@ function $HttpProvider() {
         if (isDefined(cachedResp)) {
           if (cachedResp.then) {
             // cached request has already been sent, but there is no response yet
-            cachedResp.then(removePendingReq, removePendingReq);
-            return cachedResp;
+            cachedResp.then(cacheDone, cacheDone);
           } else {
             // serving from cache
             if (isArray(cachedResp)) {
@@ -984,6 +983,18 @@ function $HttpProvider() {
 
         resolvePromise(response, status, headersString);
         if (!$rootScope.$$phase) $rootScope.$apply();
+      }
+
+
+      /**
+       * Callback to resolve based on an in-flight cache entry.
+       */
+      function cacheDone(resolution) {
+        if (isUndefined(resolution.status)) {
+          resolvePromise(resolution, 200, {});
+        } else {
+          resolvePromise(resolution.data, resolution.status, resolution.headers);
+        }
       }
 
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1267,6 +1267,30 @@ describe('$http', function() {
       });
 
 
+      it('should resolve with correct config if second request was made before the first returned',
+          function() {
+            $httpBackend.expect('GET', '/url').respond(201, 'fake-response');
+
+            callback.andCallFake(function(response) {
+              expect(response.data).toBe('fake-response');
+              expect(response.status).toBe(201);
+              return response;
+            });
+
+            $http({method: 'GET', url: '/url', cache: cache}).then(callback);
+            $http({method: 'GET', url: '/url', cache: cache, extraData: 'some-data'})
+              .then(callback)
+              .then(function(response) {
+                expect(response.config.extraData).toBe('some-data');
+              });
+
+            $httpBackend.flush();
+            expect(callback).toHaveBeenCalled();
+            expect(callback.callCount).toBe(2);
+          }
+      );
+
+
       it('should allow the cached value to be an empty string', function () {
         cache.put('/abc', '');
 


### PR DESCRIPTION
If an $http request is cached but not yet resolved, and a second request is made to the same
URL; be sure to resolve the second request's promise with the second request's config object.

The way I read the current docs on $http, the original behavior is not described, so
this does not introduce any backwards compatibility concerns.

My use case is to communicate between interceptors on either side of the same request using data stashed in the config object. Since the interceptors are initialized once by the injector I don't see a good way to store the data in a closure instead. This behavior seems more consistent anyway, since the non-cached and cached-and-resolved cases both work as expected.
