### PR TITLE
Removing unnecessary white spaces in lib/grunt/utils.js

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -26,7 +26,7 @@ var getRandomPorts = function() {
 var getPackage = function() {
   if ( !pkg ) {
 
-    // Search up the folder hierarchy for the first package.json    
+    // Search up the folder hierarchy for the first package.json
     var packageFolder = path.resolve('.');
     while ( !fs.existsSync(path.join(packageFolder, 'package.json')) ) {
       var parent = path.dirname(packageFolder);
@@ -34,7 +34,7 @@ var getPackage = function() {
       packageFolder = parent;
     }
     pkg = JSON.parse(fs.readFileSync(path.join(packageFolder,'package.json'), 'UTF-8'));
-  
+
   }
 
   return pkg;
@@ -225,7 +225,7 @@ module.exports = {
   },
 
 
-  updateWebdriver: function(done){    
+  updateWebdriver: function(done){
     if (process.env.TRAVIS) {
       // Skip the webdriver-manager update on Travis, since the browsers will
       // be provided remotely.


### PR DESCRIPTION
Request Type: refactor

How to reproduce:

Component(s): misc core

Impact: small

Complexity: small

This issue is related to:
#### Detailed Description:

I removed unnecessary white space in lib/grunt/utils.js
#### Other Comments:

I'm not sure this change is suitable for PR. because the change like this is easily done with repo owners without PR). 
So if this PR is not suitable for angular, please close this. Only I hope improving code quality of angular.js 
