### PR TITLE
fix (ngAnimate $rAF): fix requestAnimationFrame for old version of Firefox

### DIFF
--- a/src/ng/raf.js
+++ b/src/ng/raf.js
@@ -3,10 +3,12 @@
 function $$RAFProvider(){ //rAF
   this.$get = ['$window', function($window) {
     var requestAnimationFrame = $window.requestAnimationFrame ||
-                                $window.webkitRequestAnimationFrame;
+                                $window.webkitRequestAnimationFrame ||
+                                $window.mozRequestAnimationFrame;
 
     var cancelAnimationFrame = $window.cancelAnimationFrame ||
-                               $window.webkitCancelAnimationFrame;
+                               $window.webkitCancelAnimationFrame ||
+                               $window.mozCancelAnimationFrame;
 
     var raf = function(fn) {
       var id = requestAnimationFrame(fn);


### PR DESCRIPTION
Request Type: bug

How to reproduce: Load a page with Angular >= 1.2.14 and ngAnimate >= 1.2.14 on a old version of Firefox (20 for example)

Component(s): ngAnimate

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The recent $$RAFProvider which is a wrapper for the native
requestAnimationFrame method doesn't use the mozRequestAnimationFrame.
Old versions of FF (20 for example) crash if ngAnimate is included

**Other Comments:**

No breaking changes and fix issue https://github.com/angular/angular.js/issues/6535
