### PR TITLE
fix($$RAFProvider): check for webkitCancelRequestAnimationFrame.

### DIFF
--- a/src/ng/raf.js
+++ b/src/ng/raf.js
@@ -6,7 +6,8 @@ function $$RAFProvider(){ //rAF
                                 $window.webkitRequestAnimationFrame;
 
     var cancelAnimationFrame = $window.cancelAnimationFrame ||
-                               $window.webkitCancelAnimationFrame;
+                               $window.webkitCancelAnimationFrame ||
+                               $window.webkitCancelRequestAnimationFrame;
 
     var raf = function(fn) {
       var id = requestAnimationFrame(fn);

--- a/test/ng/rafSpec.js
+++ b/test/ng/rafSpec.js
@@ -44,4 +44,29 @@ describe('$$rAF', function() {
       }
     }));
   });
+
+  describe('mobile', function() {
+    it('should provide a cancellation method for an older version of Android', function() {
+
+      //we need to create our own injector to work around the ngMock overrides
+      var injector = createInjector(['ng', function($provide) {
+        $provide.value('$window', {
+          webkitRequestAnimationFrame: jasmine.createSpy('$window.webkitRequestAnimationFrame'),
+          webkitCancelRequestAnimationFrame: jasmine.createSpy('$window.webkitCancelRequestAnimationFrame')
+        });
+      }]);
+
+      var $$rAF = injector.get('$$rAF');
+      var $window = injector.get('$window');
+      var cancel = $$rAF(function() {});
+
+      expect($$rAF.supported).toBe(true);
+
+      try {
+        cancel();
+      } catch(e) {}
+
+      expect($window.webkitCancelRequestAnimationFrame).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Request Type: bug

How to reproduce: Use AngularJS 1.2.14 together with ngAnimate in Cordova/PhoneGap WebView on Android 4.3

Component(s): ngAnimate

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

RAFProvider is checking for `cancelAnimationFrame` and `webkitCancelAnimationFrame` ( see https://github.com/angular/angular.js/blob/04d7317cdd95ba00783389f89f6e9a7e1fc418f8/src/ng/raf.js#L8 )
For Android 4.3 we need to check for `webkitCancelRequestAnimationFrame` too, otherwise the animations will fail.

**Other Comments:**

No breaking changes, closes #6526
