### PR TITLE
style: enable jscs requireLeftStickedOperators rule

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -1,5 +1,6 @@
 {
   "disallowKeywords": ["with"],
   "disallowTrailingWhitespace": true,
-  "requireRightStickedOperators": ["!"]
+  "requireRightStickedOperators": ["!"],
+  "requireLeftStickedOperators": [","]
 }

--- a/.jscs.json.todo
+++ b/.jscs.json.todo
@@ -8,7 +8,6 @@
   "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "try", "catch"],
   "disallowLeftStickedOperators": ["?", "+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
   "disallowRightStickedOperators": ["?", "+", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
-  "requireLeftStickedOperators": [","],
   "disallowImplicitTypeConversion": ["string"],
   "disallowMultipleLineBreaks": true,
   "disallowKeywordsOnNewLine": ["else"],

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -457,7 +457,7 @@ forEach({
     return jqLite(element).data('$isolateScope') || jqLite(element).data('$isolateScopeNoTemplate');
   },
 
-  controller: jqLiteController ,
+  controller: jqLiteController,
 
   injector: function(element) {
     return jqLiteInheritedData(element, '$injector');

--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -254,7 +254,7 @@ function htmlParser( html, handler ) {
         match = html.match( DOCTYPE_REGEXP );
 
         if ( match ) {
-          html = html.replace( match[0] , '');
+          html = html.replace( match[0], '');
           chars = false;
         }
       // end tag

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -163,7 +163,7 @@ describe('injector', function() {
       function $f_n0 /*
           */(
           $a, // x, <-- looks like an arg but it is a comment
-          b_ , /* z, <-- looks like an arg but it is a
+          b_, /* z, <-- looks like an arg but it is a
                  multi-line comment
                  function (a, b) {}
                  */

--- a/test/ng/sceSpecs.js
+++ b/test/ng/sceSpecs.js
@@ -109,7 +109,7 @@ describe('SCE', function() {
     }));
 
     it('should NOT wrap unknown contexts', inject(function($sce) {
-      expect(function() { $sce.trustAs('unknown1' , '123'); }).toThrowMinErr(
+      expect(function() { $sce.trustAs('unknown1', '123'); }).toThrowMinErr(
           '$sce', 'icontext', 'Attempted to trust a value in invalid context. Context: unknown1; Value: 123');
     }));
 

--- a/test/ngTouch/directive/ngSwipeSpec.js
+++ b/test/ngTouch/directive/ngSwipeSpec.js
@@ -222,6 +222,6 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
   });
 }
 
-swipeTests('touch', true  /* restrictBrowers */, 'touchstart', 'touchmove', 'touchend');
-swipeTests('mouse', false /* restrictBrowers */, 'mousedown',  'mousemove', 'mouseup');
+swipeTests('touch', /* restrictBrowers */ true, 'touchstart', 'touchmove', 'touchend');
+swipeTests('mouse', /* restrictBrowers */ false, 'mousedown',  'mousemove', 'mouseup');
 

--- a/test/ngTouch/swipeSpec.js
+++ b/test/ngTouch/swipeSpec.js
@@ -387,6 +387,6 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
   });
 }
 
-swipeTests('touch', true  /* restrictBrowers */, 'touchstart', 'touchmove', 'touchend');
-swipeTests('mouse', false /* restrictBrowers */, 'mousedown',  'mousemove', 'mouseup');
+swipeTests('touch', /* restrictBrowers */ true, 'touchstart', 'touchmove', 'touchend');
+swipeTests('mouse', /* restrictBrowers */ false, 'mousedown',  'mousemove', 'mouseup');
 


### PR DESCRIPTION
Request Type: 

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Enable the **jscs** `requireLeftStickedOperators` rule.

**Other Comments:**

Some attribute comments have been moved from

```
, true  /* restrictBrowers */ ,
```

to 

```
, /* restrictBrowers */ true,
```
