### PR TITLE
docs(ngRoute): change routes property type to correct one

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -247,7 +247,7 @@ function $RouteProvider(){
      *     - `$scope` - The current route scope.
      *     - `$template` - The current route template HTML.
      *
-     * @property {Array.<Object>} routes Array of all configured routes.
+     * @property {Object} routes Object with all route configuration Objects as its properties.
      *
      * @description
      * `$route` is used for deep-linking URLs to controllers and views (HTML partials).


### PR DESCRIPTION
Request Type: docs

How to reproduce: go to http://docs.angularjs.org/api/ngRoute/service/$route in the **Properties** section > **routes**

Component(s): ngRoute

Impact: 

Complexity: 

This issue is related to: 

**Detailed Description:**

documentation for ngRoute says that routes property should be an Array of Objects, but instead it is an Object with Objects as properties

**Other Comments:**
