### PR TITLE
chore(build): remove IE8 target from all test configs

### DIFF
--- a/jenkins_build.sh
+++ b/jenkins_build.sh
@@ -7,10 +7,10 @@ echo "#################################"
 # Enable tracing and exit on first failure
 set -xe
 
-# Define reasonable set of browsers in case we are running manually from commandline
+# This is the default set of browsers to use on the CI server unless overridden via env variable
 if [[ -z "$BROWSERS" ]]
 then
-  BROWSERS="Chrome,Firefox,Opera,/Users/jenkins/bin/safari.sh,/Users/jenkins/bin/ie8.sh,/Users/jenkins/bin/ie9.sh"
+  BROWSERS="Chrome,Firefox,Opera,/Users/jenkins/bin/safari.sh,/Users/jenkins/bin/ie9.sh"
 fi
 
 # CLEAN #

--- a/karma-shared.conf.js
+++ b/karma-shared.conf.js
@@ -45,12 +45,6 @@ module.exports = function(config, specificOptions) {
         platform: 'OS X 10.9',
         version: '7'
       },
-      'SL_IE_8': {
-        base: 'SauceLabs',
-        browserName: 'internet explorer',
-        platform: 'Windows 7',
-        version: '8'
-      },
       'SL_IE_9': {
         base: 'SauceLabs',
         browserName: 'internet explorer',
@@ -87,13 +81,6 @@ module.exports = function(config, specificOptions) {
         browser: 'firefox',
         os: 'Windows',
         os_version: '8'
-      },
-      'BS_IE_8': {
-        base: 'BrowserStack',
-        browser: 'ie',
-        browser_version: '8.0',
-        os: 'Windows',
-        os_version: '7'
       },
       'BS_IE_9': {
         base: 'BrowserStack',

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -7,8 +7,8 @@ export SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
 if [ $JOB = "unit" ]; then
   grunt ci-checks
   grunt test:promises-aplus
-  grunt test:unit --browsers SL_Chrome,SL_Safari,SL_Firefox,SL_IE_8,SL_IE_9,SL_IE_10,SL_IE_11 --reporters dots
-  grunt test:docs --browsers SL_Chrome,SL_Safari,SL_Firefox,SL_IE_8,SL_IE_9,SL_IE_10,SL_IE_11 --reporters dots
+  grunt test:unit --browsers SL_Chrome,SL_Safari,SL_Firefox,SL_IE_9,SL_IE_10,SL_IE_11 --reporters dots
+  grunt test:docs --browsers SL_Chrome,SL_Safari,SL_Firefox,SL_IE_9,SL_IE_10,SL_IE_11 --reporters dots
 elif [ $JOB = "e2e" ]; then
   export TARGET_SPECS="build/docs/ptore2e/**/*jqlite_test.js"
   if [ $TEST_TARGET = "jquery" ]; then


### PR DESCRIPTION
BREAKING CHANGE: As communicated before, IE8 is no longer supported.

more info: http://blog.angularjs.org/2013/12/angularjs-13-new-release-approaches.html
