### PR TITLE
Improved $controller documentation to include an example for use.

### DIFF
--- a/docs/content/tutorial/step_02.ngdoc
+++ b/docs/content/tutorial/step_02.ngdoc
@@ -226,7 +226,7 @@ To run the test, do the following:
 
   Refresh your browser and verify that it says "Hello, World!".
 
-* Update the unit test for the controler in ./tests/unit/controlersSpec.js to refelct the previous change. For example by adding:
+* Update the unit test for the controler in ./tests/unit/controlersSpec.js to reflect the previous change. For example by adding:
 
           expect(scope.name).toBe('World');
 

--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -56,6 +56,26 @@ function $ControllerProvider() {
      *
      * It's just a simple call to {@link auto.$injector $injector}, but extracted into
      * a service, so that one can override this service with [BC version](https://gist.github.com/1649788).
+     * @example
+       <example>
+         <file name="index.html">
+           <div ng-controller="LargeCtrl">
+             <p ng-bind="tinyMessage"></p>
+             <p ng-bind="largeMessage"></p>
+           </div>
+         </file>
+         <file name="script.js">
+           function LargeCtrl($scope, $controller) {
+             $controller('TinyCtrl', {$scope: $scope});
+
+             $scope.largeMessage = "I am large controller, from the dom!";
+           }
+
+           function TinyCtrl($scope) {
+             $scope.tinyMessage = "I am tiny controller, from the $controller factory!";
+           }
+         </file>
+       </example>
      */
     return function(expression, locals) {
       var instance, match, constructor, identifier;


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

$controller had no working examples, this is just a good look at how it can be used in other places at runtime to create controllers.

**Other Comments:**
