### PR TITLE
fix($location): remove query args when passed in object

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -417,6 +417,14 @@ LocationHashbangInHtml5Url.prototype =
         if (isString(search)) {
           this.$$search = parseKeyValue(search);
         } else if (isObject(search)) {
+          // remove object undefined or null properties
+          for (var property in search) {
+            if (search.hasOwnProperty(property)) {
+              if (isUndefined(search[property]) || search[property] === null) {
+                delete search[property];
+              }
+            }
+          }
           this.$$search = search;
         } else {
           throw $locationMinErr('isrcharg',

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -117,6 +117,15 @@ describe('$location', function() {
     });
 
 
+    it('search() should remove multiple parameters', function() {
+      url.search({one: 1, two: true});
+      expect(url.search()).toEqual({one: 1, two: true});
+      url.search({one: null, two: null});
+      expect(url.search()).toEqual({});
+      expect(url.absUrl()).toBe('http://www.domain.com:9877/path/b#hash');
+    });
+
+
     it('search() should handle multiple value', function() {
       url.search('a&b');
       expect(url.search()).toEqual({a: true, b: true});


### PR DESCRIPTION
Request Type: 

How to reproduce: 

Component(s): $location

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Please read the description from the issue #6565

**Other Comments:**

Query args will be removed from $location search object if they are passed in as null or undefined object properties.

Uses Object.keys() to fix the bug so it will not work for IE8

closes #6565
