### PR TITLE
feat(testing): include iOS and Android Browser for unit testing

### DIFF
--- a/karma-shared.conf.js
+++ b/karma-shared.conf.js
@@ -63,7 +63,27 @@ module.exports = function(config, specificOptions) {
         platform: 'Windows 8.1',
         version: '11'
       },
-
+      'SL_iOS_7': {
+        base: 'SauceLabs',
+        browserName: 'iphone',
+        'device-orientation': 'portrait',
+        platform: 'OS X 10.9',
+        version: '7'
+      },
+      'SL_iOS_6': {
+        base: 'SauceLabs',
+        browserName: 'iphone',
+        'device-orientation': 'portrait',
+        platform: 'OS X 10.8',
+        version: '6.1'
+      },
+      'SL_Android_JellyBean': {
+        base: 'SauceLabs',
+        browserName: 'android',
+        'device-orientation': 'portrait',
+        platform: 'Linux',
+        version: '4.3'
+      },
       'BS_Chrome': {
         base: 'BrowserStack',
         browser: 'chrome',
@@ -102,6 +122,38 @@ module.exports = function(config, specificOptions) {
         browser_version: '11.0',
         os: 'Windows',
         os_version: '8.1'
+      },
+      'BS_iOS_7_iPhone': {
+        base: 'BrowserStack',
+        browser: "iphone",
+        browser_version: null,
+        device: "iPhone 5S",
+        os: "ios",
+        os_version: "7.0"
+      },
+      'BS_iOS_6_iPhone': {
+        base: 'BrowserStack',
+        browser: "iphone",
+        browser_version: null,
+        device: "iPhone 5",
+        os: "ios",
+        os_version: "6.0"
+      },
+      'BS_Android_Phone': {
+        base: 'BrowserStack',
+        browser: "android",
+        browser_version: null,
+        device: "LG Nexus 4",
+        os: "android",
+        os_version: "4.2"
+      },
+      'BS_Android_Tablet': {
+        base: 'BrowserStack',
+        browser: "android",
+        browser_version: null,
+        device: "Google Nexus 7",
+        os: "android",
+        os_version: "4.1"
       }
     }
   });

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -7,8 +7,8 @@ export SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
 if [ $JOB = "unit" ]; then
   grunt ci-checks
   grunt test:promises-aplus
-  grunt test:unit --browsers SL_Chrome,SL_Safari,SL_Firefox,SL_IE_9,SL_IE_10,SL_IE_11 --reporters dots
-  grunt test:docs --browsers SL_Chrome,SL_Safari,SL_Firefox,SL_IE_9,SL_IE_10,SL_IE_11 --reporters dots
+  grunt test:unit --browsers SL_Chrome,SL_Safari,SL_Firefox,SL_IE_9,SL_IE_10,SL_IE_11,SL_iOS_7,SL_iOS_6,SL_Android_JellyBean --reporters dots
+  grunt test:docs --browsers SL_Chrome,SL_Safari,SL_Firefox,SL_IE_9,SL_IE_10,SL_IE_11,SL_iOS_7,SL_iOS_6,SL_Android_JellyBean --reporters dots
 elif [ $JOB = "e2e" ]; then
   export TARGET_SPECS="build/docs/ptore2e/**/*jqlite_test.js"
   if [ $TEST_TARGET = "jquery" ]; then


### PR DESCRIPTION
We currently have no coverage for mobile browsers, including tablets. This updated config will include
testing for iOS 6.0 and 7.0 (iPhone) and Android Jelly Bean (4.3) via Sauce Labs WebDriver.
