### PR TITLE
Error thrown in xhr.onreadystatechange when javascript execution is suspended/resumed on iOS

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -83,6 +83,11 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
         // we can't set xhr.onreadystatechange to undefined or delete it because that breaks IE8 (method=PATCH) and
         // Safari respectively.
         if (xhr && xhr.readyState == 4) {
+          // onreadystatechange might by called multiple times
+          // with readyState === 4 on mobile webkit caused by
+          // xhrs that are resolved while the app is in the background (see #5426).
+          xhr.onreadystatechange = function(){};
+
           var responseHeaders = null,
               response = null;
 

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -93,6 +93,24 @@ describe('$httpBackend', function() {
   // onreadystatechange might by called multiple times
   // with readyState === 4 on mobile webkit caused by
   // xhrs that are resolved while the app is in the background (see #5426).
+  it('should remove onreadystatechange when it is called with readyState=4 to ignore multiple calls', function() {
+    $backend('GET', 'URL', null, callback);
+    xhr = MockXhr.$$lastInstance;
+
+    xhr.status = 200;
+    xhr.readyState = 4;
+
+    var orig = xhr.onreadystatechange
+
+    xhr.onreadystatechange();
+    expect(xhr.onreadystatechange).toNotBe(orig);
+
+    xhr.onreadystatechange(); // empty function
+  });
+
+  // onreadystatechange might by called multiple times
+  // with readyState === 4 on mobile webkit caused by
+  // xhrs that are resolved while the app is in the background (see #5426).
   it('should not process onreadystatechange callback with readyState == 4 more than once', function() {
     $backend('GET', 'URL', null, callback);
     xhr = MockXhr.$$lastInstance;


### PR DESCRIPTION
Request Type: bug

How to reproduce: On iOS, javascript execution is suspended when user switches to another tab in browser, closes browser, performs back/forward using swipe gestions.
In our application, if http request is occurred when javascript execution is suspended/resumed, sometimes (apprx one time per dozen tries) the following error is thrown:

TypeError: 'null' is not an object (evaluating 'xhr.readyState')

  src/ng/httpBackend.js
  xhr.onreadystatechange = function() {
    if (xhr.readyState == 4) {  // Error is thrown in this line
Debugging showed that xhr.onreadystatechange was invoked several times with readyState=4. On the first invocation xhr was nullified in completeRequest function, and then, on subsequent invocations, error was thrown.

Unfortunately, I could not reproduce the problem in small example. But I found that jQuery and Zepto have appropriate guards. Please see, for example, madrobby/zepto#633

Component(s): $http

Impact: large

Complexity: small

This issue is related to: 

**Detailed Description:**

In certain cases Webkit will call the onreadystatechange method of a single XMLHttpRequest object multiple times indicating that it is ready (readyState == 4).

**Other Comments:**

The actual approach didn't work. I took the Zepto.js approach (see: https://github.com/madrobby/zepto/pull/633).

In addition to manual and unit tests, I run a angular website with 250k unique visitor a day, I tested this patch there using getsentry.com and got no erros.

See: #5426
