### PR TITLE
Issue ##3078 Updating search.js

### DIFF
--- a/docs/app/src/search.js
+++ b/docs/app/src/search.js
@@ -8,7 +8,7 @@ angular.module('search', [])
   }
 
   $scope.search = function(q) {
-    var MIN_SEARCH_LENGTH = 3;
+    var MIN_SEARCH_LENGTH = 1;
     if(q.length >= MIN_SEARCH_LENGTH) {
       var results = docsSearch(q);
       var totalAreas = 0;


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The issue mentioned that searching the docs for fewer than 4 letters didn't return results and wasn't effective for searching smaller topics such as $q or ngIf. The docs were updated to fewer than 3 but this still doesn't include $q. The anchor tag directive still doesn't show up when the user searches for "a" however.

**Other Comments:**

Searching for the anchor tag directive doesn't work when searching "a" but searching "q" returns $q as a result.
