### PR TITLE
fix(sanitizeUri): Allow references to WP8 Isolated Storage

### DIFF
--- a/src/ng/sanitizeUri.js
+++ b/src/ng/sanitizeUri.js
@@ -5,8 +5,8 @@
  * Private service to sanitize uris for links and images. Used by $compile and $sanitize.
  */
 function $$SanitizeUriProvider() {
-  var aHrefSanitizationWhitelist = /^\s*(https?|ftp|mailto|tel|file):/,
-    imgSrcSanitizationWhitelist = /^\s*(https?|ftp|file):|data:image\//;
+  var aHrefSanitizationWhitelist = /^\s*(https?|ftp|mailto|tel|file|x-wmapp0):/,
+    imgSrcSanitizationWhitelist = /^\s*(https?|ftp|file|x-wmapp0):|data:image\//;
 
   /**
    * @description

--- a/test/ng/sanitizeUriSpec.js
+++ b/test/ng/sanitizeUriSpec.js
@@ -113,6 +113,10 @@ describe('sanitizeUri', function() {
       expect(sanitizeImg(testUrl)).toBe('file:///foo/bar.html');
     });
 
+	it('should allow image references to local content in Windows Phone 8', function() {
+		testUrl = "x-wmapp0://www/image.png";
+		expect(sanitizeImg(testUrl)).toBe('x-wmapp0://www/image.png');
+	});
 
     it('should allow reconfiguration of the src whitelist', function() {
       var returnVal;
@@ -212,7 +216,13 @@ describe('sanitizeUri', function() {
       expect(sanitizeHref(testUrl)).toBe('file:///foo/bar.html');
     }));
 
-    it('should allow reconfiguration of the href whitelist', function() {
+	it('should allow reference to local content in Windows Phone 8', function() {
+	  testUrl = "x-wmapp0://www/index.html";
+	  expect(sanitizeHref(testUrl)).toBe('x-wmapp0://www/index.html');
+	});
+
+
+	  it('should allow reconfiguration of the href whitelist', function() {
       var returnVal;
       expect(sanitizeUriProvider.aHrefSanitizationWhitelist() instanceof RegExp).toBe(true);
       returnVal = sanitizeUriProvider.aHrefSanitizationWhitelist(/javascript:/);


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): $compile

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Make generated links in Angular apps packaged with Apache Cordova work out of the box without requiring the app programmer to explicitly set img/aHref-SanitizationWhitelists on the $compileProvider. Also avoids the hassle of keeping these explicit whitelists in sync with the Angular default if that is upgraded in newer versions of Angular

**Other Comments:**

Fixes the original reporters problem in #2303 (I think)
