### PR TITLE
perf($interpolate/$compile): port optimization from dart

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1803,9 +1803,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 bindings = parent.data('$binding') || [];
             bindings.push(interpolateFn);
             safeAddClass(parent.data('$binding', bindings), 'ng-binding');
-            scope.$watch(interpolateFn, function interpolateFnWatchAction(value) {
+            scope.$watchSet(interpolateFn.expressions, interpolateFn.$$invoke(function(value) {
               node[0].nodeValue = value;
-            });
+            }));
           })
         });
       }
@@ -1866,7 +1866,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 attr[name] = interpolateFn(scope);
                 ($$observers[name] || ($$observers[name] = [])).$$inter = true;
                 (attr.$$observers && attr.$$observers[name].$$scope || scope).
-                  $watch(interpolateFn, function interpolateFnWatchAction(newValue, oldValue) {
+                  $watchSet(interpolateFn.expressions, interpolateFn.$$invoke(function (newValue, oldValue) {
                     //special case for class attribute addition + removal
                     //so that class changes can tap into the animation
                     //hooks provided by the $animate service. Be sure to
@@ -1878,7 +1878,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                     } else {
                       attr.$set(name, newValue);
                     }
-                  });
+                  }));
               }
             };
           }

--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -125,32 +125,33 @@ function $InterpolateProvider() {
       var startIndex,
           endIndex,
           index = 0,
-          parts = [],
-          length = text.length,
+          separators = [],
+          expressions = [],
           hasInterpolation = false,
+          hasText = false,
           fn,
           exp,
           concat = [];
 
-      while(index < length) {
+      while(index < text.length) {
         if ( ((startIndex = text.indexOf(startSymbol, index)) != -1) &&
              ((endIndex = text.indexOf(endSymbol, startIndex + startSymbolLength)) != -1) ) {
-          (index != startIndex) && parts.push(text.substring(index, startIndex));
-          parts.push(fn = $parse(exp = text.substring(startIndex + startSymbolLength, endIndex)));
+          if (index !== startIndex) hasText = true;
+          separators.push(text.substring(index, startIndex));
+          expressions.push(fn = interpolateParse(exp = text.substring(startIndex + startSymbolLength, endIndex)));
           fn.exp = exp;
           index = endIndex + endSymbolLength;
           hasInterpolation = true;
         } else {
-          // we did not find anything, so we have to add the remainder to the parts array
-          (index != length) && parts.push(text.substring(index));
-          index = length;
+          // we did not find an interpolation, so we have to add the remainder to the separators array
+          if (index !== text.length) hasText = true;
+          separators.push(text.substring(index));
+          break;
         }
       }
 
-      if (!(length = parts.length)) {
-        // we added, nothing, must have been an empty string.
-        parts.push('');
-        length = 1;
+      if (separators.length === expressions.length) {
+        separators.push('');
       }
 
       // Concatenating expressions makes it hard to reason about whether some combination of
@@ -159,7 +160,7 @@ function $InterpolateProvider() {
       // that's used is assigned or constructed by some JS code somewhere that is more testable or
       // make it obvious that you bound the value to some user controlled value.  This helps reduce
       // the load when auditing for XSS issues.
-      if (trustedContext && parts.length > 1) {
+      if (trustedContext && hasInterpolation && (hasText || expressions.length > 1)) {
           throw $interpolateMinErr('noconcat',
               "Error while interpolating: {0}\nStrict Contextual Escaping disallows " +
               "interpolations that concatenate multiple expressions when a trusted value is " +
@@ -167,36 +168,54 @@ function $InterpolateProvider() {
       }
 
       if (!mustHaveExpression  || hasInterpolation) {
-        concat.length = length;
-        fn = function(context) {
-          try {
-            for(var i = 0, ii = length, part; i<ii; i++) {
-              if (typeof (part = parts[i]) == 'function') {
-                part = part(context);
-                if (trustedContext) {
-                  part = $sce.getTrusted(trustedContext, part);
-                } else {
-                  part = $sce.valueOf(part);
-                }
-                if (part === null || isUndefined(part)) {
-                  part = '';
-                } else if (typeof part != 'string') {
-                  part = toJson(part);
-                }
-              }
-              concat[i] = part;
-            }
-            return concat.join('');
+        concat.length = separators.length + expressions.length;
+        var computeFn = function (values, context) {
+          for(var i = 0, ii = expressions.length; i<ii; i++) {
+            concat[2*i] = separators[i];
+            concat[(2*i)+1] = values ? values[i] : expressions[i](context);
           }
-          catch(err) {
+          concat[2*ii] = separators[ii];
+          return concat.join('');
+        };
+
+        fn = function(context) {
+          return computeFn(null, context);
+        };
+        fn.exp = text;
+        fn.$$invoke = function (listener) {
+          return function (values, oldValues, scope) {
+            var current = computeFn(values, scope);
+            listener(current, this.$$lastInter == null ? current : this.$$lastInter, scope);
+            this.$$lastInter = current;
+          };
+        };
+        fn.separators = separators;
+        fn.expressions = expressions;
+        return fn;
+      }
+
+      function interpolateParse(expression) {
+        var exp = $parse(expression);
+        return function (scope) {
+          try {
+            var value = exp(scope);
+            if (trustedContext) {
+              value = $sce.getTrusted(trustedContext, value);
+            } else {
+              value = $sce.valueOf(value);
+            }
+            if (value === null || isUndefined(value)) {
+              value = '';
+            } else if (typeof value != 'string') {
+              value = toJson(value);
+            }
+            return value;
+          } catch(err) {
             var newErr = $interpolateMinErr('interr', "Can't interpolate: {0}\n{1}", text,
-                err.toString());
+              err.toString());
             $exceptionHandler(newErr);
           }
         };
-        fn.exp = text;
-        fn.parts = parts;
-        return fn;
       }
     }
 

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -354,6 +354,68 @@ function $RootScopeProvider(){
         };
       },
 
+      /**
+       * @ngdoc method
+       * @name $rootScope.Scope#$watchSet
+       * @function
+       *
+       * @description
+       * A variant of {@link ng.$rootScope.Scope#$watch $watch()} where it watches an array of `watchExpressions`.
+       * If any one expression in the collection changes the `listener` is executed.
+       *
+       * - The items in the `watchCollection` array are observed via standard $watch operation and are examined on every
+       *   call to $digest() to see if any items changes.
+       * - The `listener` is called whenever any expression in the `watchExpressions` array changes.
+       *
+       * @param {Array.<string|Function(scope)>} watchExpressions Array of expressions that will be individually
+       * watched using {@link ng.$rootScope.Scope#$watch $watch()}
+       *
+       * @param {function(newValues, oldValues, scope)} listener Callback called whenever the return value of any
+       *    expression in `watchExpressions` changes
+       *    The `newValues` array contains the current values of the `watchExpressions`, with the indexes matching
+       *    those of `watchExpression`
+       *    and the `oldValues` array contains the previous values of the `watchExpressions`, with the indexes matching
+       *    those of `watchExpression`
+       *    The `scope` refers to the current scope.
+       *
+       * @returns {function()} Returns a de-registration function for all listeners.
+       */
+      $watchSet: function (watchExpressions, listener) {
+        if (watchExpressions.length === 0) return noop;
+
+        var oldValues = new Array(watchExpressions.length),
+            newValues = new Array(watchExpressions.length);
+
+        if (watchExpressions.length === 1) {
+          // Special case size of one
+          return this.$watch(watchExpressions[0], function (value, oldValue, scope) {
+            newValues[0] = value;
+            oldValues[0] = oldValue;
+            listener.call(this, newValues, oldValues, scope);
+          });
+        }
+        var deregisterFns = [],
+            changeCount = 0;
+
+        forEach(watchExpressions, function (expr, i) {
+          deregisterFns.push(this.$watch(expr, function (value, oldValue) {
+            newValues[i] = value;
+            oldValues[i] = oldValue;
+            changeCount++;
+          }));
+        }, this);
+
+        deregisterFns.push(this.$watch(function () {return changeCount;}, function (c, o, scope) {
+          listener.call(this, newValues, oldValues, scope);
+        }));
+
+        return function () {
+          forEach(deregisterFns, function (fn) {
+            fn();
+          });
+        };
+      },
+
 
       /**
        * @ngdoc method

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -383,30 +383,23 @@ function $RootScopeProvider(){
       $watchSet: function (watchExpressions, listener) {
         if (watchExpressions.length === 0) return noop;
 
-        var oldValues = new Array(watchExpressions.length),
+        var self = this,
+            oldValues = new Array(watchExpressions.length),
             newValues = new Array(watchExpressions.length);
 
-        if (watchExpressions.length === 1) {
-          // Special case size of one
-          return this.$watch(watchExpressions[0], function (value, oldValue, scope) {
-            newValues[0] = value;
-            oldValues[0] = oldValue;
-            listener.call(this, newValues, oldValues, scope);
-          });
-        }
         var deregisterFns = [],
             changeCount = 0;
 
         forEach(watchExpressions, function (expr, i) {
-          deregisterFns.push(this.$watch(expr, function (value, oldValue) {
+          deregisterFns.push(self.$watch(expr, function (value, oldValue) {
             newValues[i] = value;
             oldValues[i] = oldValue;
             changeCount++;
           }));
-        }, this);
+        });
 
-        deregisterFns.push(this.$watch(function () {return changeCount;}, function (c, o, scope) {
-          listener.call(this, newValues, oldValues, scope);
+        deregisterFns.push(this.$watch(function () {return changeCount;}, function () {
+          listener.call(this, newValues, oldValues, self);
         }));
 
         return function () {

--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -314,8 +314,8 @@ _jQuery.fn.bindings = function(windowJquery, bindExp) {
         }
         for(var fns, j=0, jj=binding.length;  j<jj; j++) {
           fns = binding[j];
-          if (fns.parts) {
-            fns = fns.parts;
+          if (fns.expressions) {
+            fns = fns.expressions;
           } else {
             fns = [fns];
           }

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -733,6 +733,76 @@ describe('Scope', function() {
     });
   });
 
+  describe('$watchSet', function() {
+    var scope;
+    beforeEach(inject(function($rootScope) {
+      scope = $rootScope.$new();
+    }));
+
+    it('should skip empty sets', function() {
+      expect(scope.$watchSet([], null)()).toBeUndefined();
+    });
+
+    it('should treat set of 1 as direct watch', function() {
+      var lastValues = ['foo'];
+      var log = '';
+      var clean = scope.$watchSet(['a'], function(values, oldValues, s) {
+        log += values.join(',') + ';';
+        expect(s).toBe(scope);
+        expect(oldValues).toEqual(lastValues);
+        lastValues = values.slice();
+      });
+
+      scope.a = 'foo';
+      scope.$digest();
+      expect(log).toEqual('foo;');
+
+      scope.$digest();
+      expect(log).toEqual('foo;');
+
+      scope.a = 'bar';
+      scope.$digest();
+      expect(log).toEqual('foo;bar;');
+
+      clean();
+      scope.a = 'xxx';
+      scope.$digest();
+      expect(log).toEqual('foo;bar;');
+    });
+
+    it('should detect a change to any one in a set', function() {
+      var lastValues = ['foo', 'bar'];
+      var log = '';
+      var clean = scope.$watchSet(['a', 'b'], function(values, oldValues, s) {
+        log += values.join(',') + ';';
+        expect(s).toBe(scope);
+        expect(oldValues).toEqual(lastValues);
+        lastValues = values.slice();
+      });
+
+      scope.a = 'foo';
+      scope.b = 'bar';
+      scope.$digest();
+      expect(log).toEqual('foo,bar;');
+
+      scope.$digest();
+      expect(log).toEqual('foo,bar;');
+
+      scope.a = 'a';
+      scope.$digest();
+      expect(log).toEqual('foo,bar;a,bar;');
+
+      scope.a = 'A';
+      scope.b = 'B';
+      scope.$digest();
+      expect(log).toEqual('foo,bar;a,bar;A,B;');
+
+      clean();
+      scope.a = 'xxx';
+      scope.$digest();
+      expect(log).toEqual('foo,bar;a,bar;A,B;');
+    });
+  });
 
   describe('$destroy', function() {
     var first = null, middle = null, last = null, log = null;


### PR DESCRIPTION
Motivated by [#4556 (comment)](https://github.com/angular/angular.js/pull/4556#issuecomment-35121623)

More info about the optimization can be found in that PR.

**Brief description:**
This PR makes that given text like:
`{{a}} text {{b}}`
Instead of computing the whole string on each digest for dirty-checking,
We watch each expression individually, and only concatenate stuff when something changes.

To accomplish this, we use [`$scope.$watchSet`](https://github.com/angular/angular.dart/blob/4bf9447cc64650d6c73b66c844fb5396b4a2ae27/lib/core/scope.dart#L278). It has been implemented in AngularDart, but has been removed recently in favor of the change_detection lib

Edit: Travis tests are failing because npm failed? I'll try to have travis run again tomorrow
