### PR TITLE
docs(css): RegExp doesn't have .type-hint-regexp class

### DIFF
--- a/docs/app/assets/css/docs.css
+++ b/docs/app/assets/css/docs.css
@@ -464,6 +464,10 @@ iframe.example {
   background:rgb(189, 63, 66);
 }
 
+.type-hint-regexp {
+  background: rgb(90, 84, 189);
+}
+
 .runnable-example-frame {
   width:100%;
   height:300px;


### PR DESCRIPTION
Request Type: docs

How to reproduce: Please see the description of the issue #6596

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

type-hint-regexp gets a nice color

closes #6596
