### PR TITLE
Update step_12.ngdoc

### DIFF
--- a/docs/content/tutorial/step_12.ngdoc
+++ b/docs/content/tutorial/step_12.ngdoc
@@ -83,7 +83,7 @@ __`app/js/app.js`.__
 
 ```js
 // ...
-angular.module('phonecat', [
+angular.module('phonecatApp', [
   'ngRoute',
 
   'phonecatAnimations',


### PR DESCRIPTION
docs(tutorial 12): change parameter name  

Fixed wrong app name used in line 86:
- phonecat -> phonecatApp, which meets the code at app.js in tutorial 12
