### PR TITLE
Update directive.ngdoc

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -533,6 +533,8 @@ where:
 * `element` is the jqLite-wrapped element that this directive matches.
 * `attrs` is a hash object with key-value pairs of normalized attribute names and their
   corresponding attribute values.
+  
+Other arguments may be available in certain contexts.
 
 In our `link` function, we want to update the displayed time once a second, or whenever a user
 changes the time formatting string that our directive binds to. We will use the `$interval` service


### PR DESCRIPTION
Spent a far too much time trawling through the internet for information on why there is a ctrl argument in validators when, according to documentation, the link option only takes three arguments. The information is available further down the page but with the rather axiomatic specification in this part I saw no reason to look for it there.
