### PR TITLE
switching out global controller definitions to angular module syntax

### DIFF
--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -121,14 +121,15 @@ ngRouteModule.directive('ngView', ngViewFillContentFactory);
       <file name="script.js">
         angular.module('ngViewExample', ['ngRoute', 'ngAnimate'],
           function($routeProvider, $locationProvider) {
-            $routeProvider.when('/Book/:bookId', {
+            $routeProvider
+            .when('/Book/:bookId', {
               templateUrl: 'book.html',
-              controller: BookCtrl,
+              controller: 'BookCtrl',
               controllerAs: 'book'
-            });
-            $routeProvider.when('/Book/:bookId/ch/:chapterId', {
+            })
+            .when('/Book/:bookId/ch/:chapterId', {
               templateUrl: 'chapter.html',
-              controller: ChapterCtrl,
+              controller: 'ChapterCtrl',
               controllerAs: 'chapter'
             });
 
@@ -136,21 +137,21 @@ ngRouteModule.directive('ngView', ngViewFillContentFactory);
             $locationProvider.html5Mode(true);
         });
 
-        function MainCtrl($route, $routeParams, $location) {
-          this.$route = $route;
-          this.$location = $location;
-          this.$routeParams = $routeParams;
-        }
+        angular.module('ngViewExample')
+            .controller('MainCtrl', function ($route, $routeParams, $location) {
+                this.$route = $route;
+                this.$location = $location;
+                this.$routeParams = $routeParams;
+            })
+            .controller('BookCtrl', function ($routeParams) {
+                this.name = "BookCtrl";
+                this.params = $routeParams;
+            })
+            .controller('ChapterCtrl', function ($routeParams) {
+                this.name = "ChapterCtrl";
+                this.params = $routeParams;
+            });
 
-        function BookCtrl($routeParams) {
-          this.name = "BookCtrl";
-          this.params = $routeParams;
-        }
-
-        function ChapterCtrl($routeParams) {
-          this.name = "ChapterCtrl";
-          this.params = $routeParams;
-        }
       </file>
 
       <file name="protractor.js" type="protractor">


### PR DESCRIPTION
Request Type: docs

Component(s): ngRoute

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

docs(ngView): change global controller declarations to module format in example
- remove global function declarations
- replace with module `.controller` syntax
- replace controller function references in `$routeProvider` definitions with string tokens
