### PR TITLE
Make the quote type explicit, and make it stand out

### DIFF
--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -32,7 +32,7 @@
  * @priority 400
  *
  * @param {string} ngInclude|src angular expression evaluating to URL. If the source is a string constant,
- *                 make sure you wrap it in quotes, e.g. `src="'myPartialTemplate.html'"`.
+ *                 make sure you wrap it in <b>single</b> quotes, e.g. `src="<b>'</b>myPartialTemplate.html<b>'</b>"`.
  * @param {string=} onload Expression to evaluate when a new partial is loaded.
  *
  * @param {string=} autoscroll Whether `ngInclude` should call {@link ng.$anchorScroll


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): $parse

Impact: medium

Complexity: small

This issue is related to: 

**Detailed Description:**

Documentation to make it easier to get this right.  Might also help to make the error message better, but for now this is easily doable.

**Other Comments:**

Should help close #6614
