### PR TITLE
fix(filterFilter): comparator should return true if deep object key is undefined

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -138,8 +138,10 @@ function filterFilter() {
         comparator = function(obj, text) {
           if (obj && text && typeof obj === 'object' && typeof text === 'object') {
             for (var objKey in obj) {
-              if (objKey.charAt(0) !== '$' && hasOwnProperty.call(obj, objKey) &&
-                  comparator(obj[objKey], text[objKey])) {
+              if (objKey.charAt(0) !== '$' &&
+                  hasOwnProperty.call(obj, objKey) &&
+                  (!isDefined(text[objKey]) || comparator(obj[objKey], text[objKey]))
+              ) {
                 return true;
               }
             }

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -53,6 +53,7 @@ describe('Filter: filter', function() {
     var items = [{first: 'misko', last: 'hevery'},
                  {first: 'adam', last: 'abrons'}];
 
+    expect(filter(items, {first: undefined}).length).toBe(2);
     expect(filter(items, {first:'', last:''}).length).toBe(2);
     expect(filter(items, {first:'', last:'hevery'}).length).toBe(1);
     expect(filter(items, {first:'adam', last:'hevery'}).length).toBe(0);

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -49,7 +49,7 @@ describe('Filter: filter', function() {
     expect(filter(items, function(i) {return i.done;}).length).toBe(1);
   });
 
-  it('should take object as perdicate', function() {
+  it('should take object as predicate', function() {
     var items = [{first: 'misko', last: 'hevery'},
                  {first: 'adam', last: 'abrons'}];
 
@@ -62,7 +62,7 @@ describe('Filter: filter', function() {
   });
 
 
-  it('should support predicat object with dots in the name', function() {
+  it('should support predicate object with dots in the name', function() {
     var items = [{'first.name': 'misko', 'last.name': 'hevery'},
                  {'first.name': 'adam', 'last.name': 'abrons'}];
 
@@ -97,8 +97,8 @@ describe('Filter: filter', function() {
 
   it('should support boolean properties', function() {
     var items = [{name: 'tom', current: true},
-	             {name: 'demi', current: false},
-	             {name: 'sofia'}];
+               {name: 'demi', current: false},
+               {name: 'sofia'}];
 
     expect(filter(items, {current:true}).length).toBe(1);
     expect(filter(items, {current:true})[0].name).toBe('tom');
@@ -121,26 +121,26 @@ describe('Filter: filter', function() {
       expect(filter(items, expr, true)).toEqual([items[1]]);
       expect(filter(items, expr, false)).toEqual([items[1], items[2]]);
 
-      var items = [
+      items = [
         {key: 'value1', nonkey: 1},
         {key: 'value2', nonkey: 2},
         {key: 'value12', nonkey: 3},
         {key: 'value1', nonkey:4},
         {key: 'Value1', nonkey:5}
       ];
-      var expr = {key: 'value1'};
+      expr = {key: 'value1'};
       expect(filter(items, expr, true)).toEqual([items[0], items[3]]);
 
-      var items = [
+      items = [
         {key: 1, nonkey: 1},
         {key: 2, nonkey: 2},
         {key: 12, nonkey: 3},
         {key: 1, nonkey:4}
       ];
-      var expr = { key: 1 };
+      expr = { key: 1 };
       expect(filter(items, expr, true)).toEqual([items[0], items[3]]);
 
-      var expr = 12;
+      expr = 12;
       expect(filter(items, expr, true)).toEqual([items[2]]);
     });
 
@@ -154,7 +154,7 @@ describe('Filter: filter', function() {
       var expr = {key: 10};
       var comparator = function (obj,value) {
         return obj > value;
-      }
+      };
       expect(filter(items, expr, comparator)).toEqual([items[2]]);
 
       expr = 10;

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -75,6 +75,8 @@ describe('Filter: filter', function() {
                  {person: {name: 'Rita'}},
                  {person: {name: 'Billy'}},
                  {person: {name: 'Joan'}}];
+
+    expect(filter(items, {person: {name : undefined}}).length).toBe(4);
     expect(filter(items, {person: {name: 'Jo'}}).length).toBe(2);
     expect(filter(items, {person: {name: 'Jo'}})).toEqual([
       {person: {name: 'John'}}, {person: {name: 'Joan'}}]);


### PR DESCRIPTION
Since the filtering of deep object predicates was fixed in https://github.com/angular/angular.js/commit/b4eed8ad94ce9719540462c1ee969dfd3c6b2355, an undefined  key in a deep object predicate did not return true un the comparator like it does for non-nested object predicates and strings. See this plunker:

http://plnkr.co/edit/uB7Mta?p=preview

At first, p2_filter is undefined, and the filer returns no results. When you type in the input, the filter is set, and when you clear the input, it is set to empty string, returning all results.

The first commit in the pull request adds a check to the comparator to see if a key is undefined.
The second commit adds the same test for non-nested objects predicate, in line with the string filter test
The third commit fixes multiple style issues in filterSpec.js

I separated them to make the actual issue more visible

Closes #6222
