### PR TITLE
feat(limitTo): extend the filter to take a beginning index argument

### DIFF
--- a/src/ng/filter/limitTo.js
+++ b/src/ng/filter/limitTo.js
@@ -7,14 +7,16 @@
  *
  * @description
  * Creates a new array or string containing only a specified number of elements. The elements
- * are taken from either the beginning or the end of the source array or string, as specified by
- * the value and sign (positive or negative) of `limit`.
+ * are taken from either the beginning or the end or specified beginning index of the source array
+ * or string, as specified by the value and sign (positive or negative) of `limit`.
  *
  * @param {Array|string} input Source array or string to be limited.
- * @param {string|number} limit The length of the returned array or string. If the `limit` number 
+ * @param {string|number} limit The length of the returned array or string. If the `limit` number
  *     is positive, `limit` number of items from the beginning of the source array/string are copied.
- *     If the number is negative, `limit` number  of items from the end of the source array/string 
+ *     If the number is negative, `limit` number  of items from the end of the source array/string
  *     are copied. The `limit` will be trimmed if it exceeds `array.length`
+ * @param {string|number} begin Index at which to begin limitation. As a negative index, `begin`
+ *     indicates an offset from the end of `input`. Defaults to `0`.
  * @returns {Array|string} A new sub-array or substring of length `limit` or less if input array
  *     had less than `limit` elements.
  *
@@ -70,15 +72,25 @@
    </doc:example>
  */
 function limitToFilter(){
-  return function(input, limit) {
+  return function(input, limit, begin) {
     if (!isArray(input) && !isString(input)) return input;
-    
+
     limit = int(limit);
+    begin = (!begin || isNaN(begin)) ? 0 : int(begin);
+    begin = (begin < 0 && begin >= -input.length) ? input.length + begin : begin;
 
     if (isString(input)) {
       //NaN check on limit
       if (limit) {
-        return limit >= 0 ? input.slice(0, limit) : input.slice(limit, input.length);
+        if (limit >= 0) {
+          return input.slice(begin, begin + limit);
+        } else {
+          if (begin === 0) {
+            return input.slice(limit, input.length);
+          } else {
+            return input.slice(Math.max(0, begin + limit), begin);
+          }
+        }
       } else {
         return "";
       }
@@ -94,15 +106,22 @@ function limitToFilter(){
       limit = -input.length;
 
     if (limit > 0) {
-      i = 0;
-      n = limit;
+      i = begin;
+      n = begin + limit;
     } else {
-      i = input.length + limit;
-      n = input.length;
+      if (begin) {
+        i = limit + begin;
+        n = begin;
+      } else {
+        i = input.length + limit;
+        n = input.length;
+      }
     }
 
     for (; i<n; i++) {
-      out.push(input[i]);
+      if (input[i]) {
+        out.push(input[i]);
+      }
     }
 
     return out;

--- a/test/ng/filter/limitToSpec.js
+++ b/test/ng/filter/limitToSpec.js
@@ -19,6 +19,19 @@ describe('Filter: limitTo', function() {
     expect(limitTo(str, '3')).toEqual("tuv");
   });
 
+  it('should return the first X items beginning from index Y when X and Y are positive', function() {
+    expect(limitTo(items, 3, '3')).toEqual(['d', 'e', 'f']);
+    expect(limitTo(items, '3', 3)).toEqual(['d', 'e', 'f']);
+    expect(limitTo(str, 3, 3)).toEqual("wxy");
+    expect(limitTo(str, '3', '3')).toEqual("wxy");
+  });
+
+  it('should return the first X items beginning from index Y when X is positive and Y is negative', function() {
+    expect(limitTo(items, 3, '-3')).toEqual(['f', 'g', 'h']);
+    expect(limitTo(items, '3', -3)).toEqual(['f', 'g', 'h']);
+    expect(limitTo(str, 3, -3)).toEqual("xyz");
+    expect(limitTo(str, '3', '-3')).toEqual("xyz");
+  });
 
   it('should return the last X items when X is negative', function() {
     expect(limitTo(items, -3)).toEqual(['f', 'g', 'h']);
@@ -27,6 +40,19 @@ describe('Filter: limitTo', function() {
     expect(limitTo(str, '-3')).toEqual("xyz");
   });
 
+  it('should return the last X items until index Y when X and Y are negative', function() {
+    expect(limitTo(items, -3, '-3')).toEqual(['c', 'd', 'e']);
+    expect(limitTo(items, '-3', -3)).toEqual(['c', 'd', 'e']);
+    expect(limitTo(str, -3, -3)).toEqual("uvw");
+    expect(limitTo(str, '-3', '-3')).toEqual("uvw");
+  });
+
+  it('should return the last X items until index Y when X is negative and Y is positive', function() {
+    expect(limitTo(items, -3, '4')).toEqual(['b', 'c', 'd']);
+    expect(limitTo(items, '-3', 4)).toEqual(['b', 'c', 'd']);
+    expect(limitTo(str, -3, 4)).toEqual("uvw");
+    expect(limitTo(str, '-3', '4')).toEqual("uvw");
+  });
 
   it('should return an empty array when X cannot be parsed', function() {
     expect(limitTo(items, 'bogus')).toEqual([]);
@@ -42,6 +68,19 @@ describe('Filter: limitTo', function() {
     expect(limitTo(str, 'undefined')).toEqual("");
     expect(limitTo(str, null)).toEqual("");
     expect(limitTo(str, undefined)).toEqual("");
+  });
+
+  it('should take 0 as beginning index value when Y cannot be parsed', function() {
+    expect(limitTo(items, 3, 'bogus')).toEqual(limitTo(items, 3, 0));
+    expect(limitTo(items, -3, 'null')).toEqual(limitTo(items, -3));
+    expect(limitTo(items, '3', 'undefined')).toEqual(limitTo(items, '3', 0));
+    expect(limitTo(items, '-3', null)).toEqual(limitTo(items, '-3'));
+    expect(limitTo(items, 3, undefined)).toEqual(limitTo(items, 3, 0));
+    expect(limitTo(str, 3, 'bogus')).toEqual(limitTo(str, 3));
+    expect(limitTo(str, -3, 'null')).toEqual(limitTo(str, -3, 0));
+    expect(limitTo(str, '3', 'undefined')).toEqual(limitTo(str, '3'));
+    expect(limitTo(str, '-3', null)).toEqual(limitTo(str, '-3', 0));
+    expect(limitTo(str, 3, undefined)).toEqual(limitTo(str, 3));
   });
 
 
@@ -67,5 +106,33 @@ describe('Filter: limitTo', function() {
     expect(limitTo(str, '9')).toEqual(str);
     expect(limitTo(str, -9)).toEqual(str);
     expect(limitTo(str, '-9')).toEqual(str);
-  })
+  });
+
+  it('should return an empty array if Y exceeds input length', function() {
+    expect(limitTo(items, '3', 12)).toEqual([]);
+    expect(limitTo(items, 4, '-12')).toEqual([]);
+    expect(limitTo(items, -3, '12')).toEqual([]);
+    expect(limitTo(items, '-4', -12)).toEqual([]);
+  });
+
+  it('should return an empty string if Y exceeds input length', function() {
+    expect(limitTo(str, '3', 12)).toEqual("");
+    expect(limitTo(str, 4, '-12')).toEqual("");
+    expect(limitTo(str, -3, '12')).toEqual("");
+    expect(limitTo(str, '-4', -12)).toEqual("");
+  });
+
+  it('should return the entire string beginning from Y if X is positive and X+Y exceeds input length', function() {
+    expect(limitTo(items, 7, 3)).toEqual(['d', 'e', 'f', 'g', 'h']);
+    expect(limitTo(items, 7, -3)).toEqual(['f', 'g', 'h']);
+    expect(limitTo(str, 6, 3)).toEqual("wxyz");
+    expect(limitTo(str, 6, -3)).toEqual("xyz");
+  });
+
+  it('should return the entire string until index Y if X is negative and X+Y exceeds input length', function() {
+    expect(limitTo(items, -7, 3)).toEqual(['a', 'b', 'c']);
+    expect(limitTo(items, -7, -3)).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(limitTo(str, -6, 3)).toEqual("tuv");
+    expect(limitTo(str, -6, -3)).toEqual("tuvw");
+  });
 });


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

Extend the limitTo filter to take an optional argument for beginning index. It provides a slice-alike functionality to manipulate the input.

Closes #5355
