### PR TITLE
feat(ngTouch): add optional ngSwipeDisableMouse attribute to ngSwipe

### DIFF
--- a/src/ngTouch/directive/ngSwipe.js
+++ b/src/ngTouch/directive/ngSwipe.js
@@ -12,6 +12,9 @@
  * Though ngSwipeLeft is designed for touch-based devices, it will work with a mouse click and drag
  * too.
  *
+ * To disable the mouse click and drag functionality, add `ng-swipe-disable-mouse` to
+ * the `ng-swipe-left` or `ng-swipe-right` DOM Element.
+ *
  * Requires the {@link ngTouch `ngTouch`} module to be installed.
  *
  * @element ANY
@@ -96,6 +99,7 @@ function makeSwipeDirective(directiveName, direction, eventName) {
       }
 
       $swipe.bind(element, {
+        'disableMouseEvents': angular.isDefined(attr['ngSwipeDisableMouse']),
         'start': function(coords, event) {
           startCoords = coords;
           valid = true;

--- a/src/ngTouch/swipe.js
+++ b/src/ngTouch/swipe.js
@@ -78,7 +78,11 @@ ngTouch.factory('$swipe', [function() {
       // Whether a swipe is active.
       var active = false;
 
-      element.on('touchstart mousedown', function(event) {
+      var optionalMouseEventStart = '';
+      if(!eventHandlers.disableMouseEvents){
+        optionalMouseEventStart += ' mousedown';
+      }
+      element.on('touchstart' + optionalMouseEventStart, function(event) {
         startCoords = getCoordinates(event);
         active = true;
         totalX = 0;
@@ -92,7 +96,11 @@ ngTouch.factory('$swipe', [function() {
         eventHandlers['cancel'] && eventHandlers['cancel'](event);
       });
 
-      element.on('touchmove mousemove', function(event) {
+      var optionalMouseEventMove = '';
+      if(!eventHandlers.disableMouseEvents){
+        optionalMouseEventMove += ' mousemove';
+      }
+      element.on('touchmove' + optionalMouseEventMove, function(event) {
         if (!active) return;
 
         // Android will send a touchcancel if it thinks we're starting to scroll.
@@ -126,7 +134,11 @@ ngTouch.factory('$swipe', [function() {
         }
       });
 
-      element.on('touchend mouseup', function(event) {
+      var optionalMouseEventEnd = '';
+      if(!eventHandlers.disableMouseEvents){
+        optionalMouseEventEnd += ' mouseup';
+      }
+      element.on('touchend' + optionalMouseEventEnd, function(event) {
         if (!active) return;
         active = false;
         eventHandlers['end'] && eventHandlers['end'](getCoordinates(event), event);

--- a/test/ngTouch/directive/ngSwipeSpec.js
+++ b/test/ngTouch/directive/ngSwipeSpec.js
@@ -66,6 +66,53 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBe(true);
     }));
 
+    it('should not swipe to the left if ng-swipe-disable-mouse attribute is set', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-swipe-left="swiped = true" ng-swipe-disable-mouse></div>')($rootScope);
+      $rootScope.$digest();
+      expect($rootScope.swiped).toBeUndefined();
+
+      browserTrigger(element, startEvent, {
+        keys : [],
+        x : 100,
+        y : 20
+      });
+      browserTrigger(element, endEvent,{
+        keys: [],
+        x: 20,
+        y: 20
+      });
+      if(description === 'mouse'){
+        expect($rootScope.swiped).toBeUndefined();
+      }
+      else{
+        expect($rootScope.swiped).toBe(true);
+      }
+    }));
+
+
+    it('should not swipe to the left if ng-swipe-disable-mouse attribute is set', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-swipe-left="swiped = true" ng-swipe-disable-mouse></div>')($rootScope);
+      $rootScope.$digest();
+      expect($rootScope.swiped).toBeUndefined();
+
+      browserTrigger(element, startEvent, {
+        keys : [],
+        x : 100,
+        y : 20
+      });
+      browserTrigger(element, endEvent,{
+        keys: [],
+        x: 20,
+        y: 20
+      });
+      if(description === 'mouse'){
+        expect($rootScope.swiped).toBeUndefined();
+      }
+      else{
+        expect($rootScope.swiped).toBe(true);
+      }
+    }));
+
     it('should pass event object', inject(function($rootScope, $compile) {
       element = $compile('<div ng-swipe-left="event = $event"></div>')($rootScope);
       $rootScope.$digest();

--- a/test/ngTouch/swipeSpec.js
+++ b/test/ngTouch/swipeSpec.js
@@ -239,6 +239,87 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect(events.cancel).not.toHaveBeenCalled();
     }));
 
+    it('should not trigger a "start", many "move"s and an "end" for mouse if "disableMouseEvents" is set to "true"', inject(function($rootScope, $swipe, $compile) {
+      element = $compile('<div></div>')($rootScope);
+      var events = {
+        disableMouseEvents: 'true',
+        start: jasmine.createSpy('startSpy'),
+        move: jasmine.createSpy('moveSpy'),
+        cancel: jasmine.createSpy('cancelSpy'),
+        end: jasmine.createSpy('endSpy')
+      };
+
+      $swipe.bind(element, events);
+
+      expect(events.start).not.toHaveBeenCalled();
+      expect(events.move).not.toHaveBeenCalled();
+      expect(events.cancel).not.toHaveBeenCalled();
+      expect(events.end).not.toHaveBeenCalled();
+
+      browserTrigger(element, startEvent,{
+        keys: [],
+        x: 100,
+        y: 40
+      });
+
+      browserTrigger(element, moveEvent,{
+        keys: [],
+        x: 120,
+        y: 40
+      });
+      browserTrigger(element, moveEvent,{
+        keys: [],
+        x: 130,
+        y: 40
+      });
+      browserTrigger(element, moveEvent,{
+        keys: [],
+        x: 140,
+        y: 40
+      });
+      browserTrigger(element, moveEvent,{
+        keys: [],
+        x: 150,
+        y: 40
+      });
+      browserTrigger(element, moveEvent,{
+        keys: [],
+        x: 160,
+        y: 40
+      });
+      browserTrigger(element, moveEvent,{
+        keys: [],
+        x: 170,
+        y: 40
+      });
+      browserTrigger(element, moveEvent,{
+        keys: [],
+        x: 180,
+        y: 40
+      });
+
+      browserTrigger(element, endEvent,{
+        keys: [],
+        x: 200,
+        y: 40
+      });
+
+
+      if(description === 'mouse'){
+        expect(events.start).not.toHaveBeenCalled();
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+      }
+      else{
+        expect(events.start).toHaveBeenCalled();
+        expect(events.move.calls.length).toBe(7);
+        expect(events.end).toHaveBeenCalled();
+
+        expect(events.cancel).not.toHaveBeenCalled();
+      }
+    }));
+
     it('should not start sending "move"s until enough horizontal motion is accumulated', inject(function($rootScope, $swipe, $compile) {
       element = $compile('<div></div>')($rootScope);
       var events = {


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): ngTouch

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

add optional ngSwipeDisableMouse attribute to ngSwipe directives to ignore mouse events
This is a proposal for https://github.com/angular/angular.js/issues/6626 opened by @nesQuick 

Let's discuss this.
If it's okay - we should also extend the docs. 
