### PR TITLE
changed html entities lt and gt to < and >

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -82,7 +82,7 @@ function $RouteProvider(){
    *
    *      If `template` is a function, it will be called with the following parameters:
    *
-   *      - `{Array.&lt;Object&gt;}` - route parameters extracted from the current
+   *      - `{Array.<Object>}` - route parameters extracted from the current
    *        `$location.path()` by applying the current route
    *
    *    - `templateUrl` – `{string=|function()=}` – path or function that returns a path to an html
@@ -90,7 +90,7 @@ function $RouteProvider(){
    *
    *      If `templateUrl` is a function, it will be called with the following parameters:
    *
-   *      - `{Array.&lt;Object&gt;}` - route parameters extracted from the current
+   *      - `{Array.<Object>}` - route parameters extracted from the current
    *        `$location.path()` by applying the current route
    *
    *    - `resolve` - `{Object.<string, function>=}` - An optional map of dependencies which should


### PR DESCRIPTION
Request Type: docs

How to reproduce: Go to http://docs.angularjs.org/api/ngRoute/provider/$routeProvider. 

...If templateUrl is a function, it will be called with the following parameters:

{Array.&lt;Object&gt;}

... 

Shows html entities instead of the '<' and '>' chars.

Component(s): ngRoute

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**
