### PR TITLE
docs/chore(version stuff): fix how versions are handled in builds and docs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,6 @@
 var files = require('./angularFiles').files;
 var util = require('./lib/grunt/utils.js');
+var versionInfo = require('./lib/versions/version-info');
 var path = require('path');
 
 module.exports = function(grunt) {
@@ -8,9 +9,9 @@ module.exports = function(grunt) {
 
   grunt.loadTasks('lib/grunt');
 
-  var NG_VERSION = util.getVersion();
+  var NG_VERSION = versionInfo.currentVersion;
+  NG_VERSION.cdn = versionInfo.currentPackage.cdnVersion;
   var dist = 'angular-'+ NG_VERSION.full;
-
 
   //global beforeEach
   util.init();

--- a/docs/config/processors/git-data.js
+++ b/docs/config/processors/git-data.js
@@ -1,4 +1,5 @@
 var gruntUtils = require('../../../lib/grunt/utils');
+var versionInfo = require('../../../lib/versions/version-info');
 
 module.exports = {
   name: 'git-data',
@@ -6,9 +7,9 @@ module.exports = {
   description: 'This processor adds information from the local git repository to the extraData injectable',
   init: function(config, injectables) {
     injectables.value('gitData', {
-      version: gruntUtils.getVersion(),
-      versions: gruntUtils.getPreviousVersions(),
-      info: gruntUtils.getGitRepoInfo()
+      version: versionInfo.currentVersion,
+      versions: versionInfo.previousVersions,
+      info: versionInfo.gitRepoInfo
     });
   },
   process: function(extraData, gitData) {

--- a/docs/config/templates/indexPage.template.html
+++ b/docs/config/templates/indexPage.template.html
@@ -175,7 +175,7 @@
         <div class="container main-grid main-header-grid">
           <div class="grid-left">
             <div ng-controller="DocsVersionsCtrl" class="picker version-picker">
-              <select ng-options="v as ('v' + v.full) group by (v.isStable?'Stable':'Unstable') for v in docs_versions"
+              <select ng-options="v as ('v' + v.version + (v.isSnapshot ? ' (snapshot)' : '')) group by (v.isStable?'Stable':'Unstable') for v in docs_versions"
                       ng-model="docs_version"
                       ng-change="jumpToDocsVersion(docs_version)"
                       class="docs-version-jump">

--- a/docs/docs.config.js
+++ b/docs/docs.config.js
@@ -1,13 +1,12 @@
 var path = require('canonical-path');
-var gruntUtils = require('../lib/grunt/utils');
+var versionInfo = require('../lib/versions/version-info');
 var basePath = __dirname;
 
 var basePackage = require('./config');
 
 module.exports = function(config) {
 
-  var version = gruntUtils.getVersion();
-  var cdnUrl = "//ajax.googleapis.com/ajax/libs/angularjs/" + version.cdn;
+  var cdnUrl = "//ajax.googleapis.com/ajax/libs/angularjs/" + versionInfo.currentPackage.cdnVersion;
 
   var getVersion = function(component, sourceFolder, packageFile) {
     sourceFolder = sourceFolder || '../bower_components';

--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -4,8 +4,10 @@ var shell = require('shelljs');
 var grunt = require('grunt');
 var spawn = require('child_process').spawn;
 var semver = require('semver');
+var versionInfo = require('../versions/version-info');
+
 var _ = require('lodash');
-var version, pkg;
+
 var CSP_CSS_HEADER = '/* Include this file in your html if you are using the CSP mode. */\n\n';
 
 var PORT_MIN = 8000;
@@ -23,23 +25,6 @@ var getRandomPorts = function() {
   ];
 };
 
-var getPackage = function() {
-  if ( !pkg ) {
-
-    // Search up the folder hierarchy for the first package.json
-    var packageFolder = path.resolve('.');
-    while ( !fs.existsSync(path.join(packageFolder, 'package.json')) ) {
-      var parent = path.dirname(packageFolder);
-      if ( parent === packageFolder) { break; }
-      packageFolder = parent;
-    }
-    pkg = JSON.parse(fs.readFileSync(path.join(packageFolder,'package.json'), 'UTF-8'));
-
-  }
-
-  return pkg;
-};
-
 
 module.exports = {
 
@@ -49,160 +34,6 @@ module.exports = {
     }
   },
 
-
-  getGitRepoInfo: function() {
-    var GITURL_REGEX = /^https:\/\/github.com\/([^\/]+)\/(.+).git$/;
-    var match = GITURL_REGEX.exec(getPackage().repository.url);
-    var git = {
-      owner: match[1],
-      repo: match[2]
-    };
-    return git;
-  },
-
-
-  getVersion: function(){
-    if (version) return version;
-
-    try {
-
-      var gitTag = getTagOfCurrentCommit();
-      var semVerVersion, codeName, fullVersion;
-      if (gitTag) {
-        // tagged release
-        fullVersion = semVerVersion = semver.valid(gitTag);
-        codeName = getTaggedReleaseCodeName(gitTag);
-      } else {
-        // snapshot release
-        semVerVersion = getSnapshotVersion();
-        fullVersion = semVerVersion + '-' + getSnapshotSuffix();
-        codeName = 'snapshot';
-      }
-
-      var versionParts = semVerVersion.match(/(\d+)\.(\d+)\.(\d+)/);
-
-      version = {
-        full: fullVersion,
-        major: versionParts[1],
-        minor: versionParts[2],
-        dot: versionParts[3],
-        codename: codeName,
-        cdn: getPackage().cdnVersion
-      };
-
-      // Stable versions have an even minor version
-      version.isStable = version.minor%2 === 0;
-
-      return version;
-
-    } catch (e) {
-      grunt.fail.warn(e);
-    }
-
-    function getTagOfCurrentCommit() {
-      var gitTagResult = shell.exec('git describe --exact-match', {silent:true});
-      var gitTagOutput = gitTagResult.output.trim();
-      var branchVersionPattern = new RegExp(getPackage().branchVersion.replace('.', '\\.').replace('*', '\\d+'));
-      if (gitTagResult.code === 0 && gitTagOutput.match(branchVersionPattern)) {
-        return gitTagOutput;
-      } else {
-        return null;
-      }
-    }
-
-    function getTaggedReleaseCodeName(tagName) {
-      var tagMessage = shell.exec('git cat-file -p '+ tagName +' | grep "codename"', {silent:true}).output;
-      var codeName = tagMessage && tagMessage.match(/codename\((.*)\)/)[1];
-      if (!codeName) {
-        throw new Error("Could not extract release code name. The message of tag "+tagName+
-          " must match '*codename(some release name)*'");
-      }
-      return codeName;
-    }
-
-    function getSnapshotVersion() {
-      var oldTags = shell.exec('git tag -l v'+getPackage().branchVersion, {silent:true}).output.trim().split('\n');
-      // ignore non semver versions.
-      oldTags = oldTags.filter(function(version) {
-        return version && semver.valid(version);
-      });
-      if (oldTags.length) {
-        oldTags.sort(semver.compare);
-        semVerVersion = oldTags[oldTags.length-1];
-        if (semVerVersion.indexOf('-') !== -1) {
-          semVerVersion = semver.inc(semVerVersion, 'prerelease');
-        } else {
-          semVerVersion = semver.inc(semVerVersion, 'patch');
-        }
-      } else {
-        semVerVersion = semver.valid(getPackage().branchVersion.replace(/\*/g, '0'));
-      }
-      return semVerVersion;
-    }
-
-    function getSnapshotSuffix() {
-      var jenkinsBuild = process.env.TRAVIS_BUILD_NUMBER || process.env.BUILD_NUMBER || 'local';
-      var hash = shell.exec('git rev-parse --short HEAD', {silent: true}).output.replace('\n', '');
-      return 'build.'+jenkinsBuild+'+sha.'+hash;
-    }
-  },
-
-  getPreviousVersions: function() {
-    var VERSION_REGEX = /([1-9]\d*)\.(\d+)\.(\d+)(?:-?rc\.?(\d+)|-(snapshot))?/;
-
-    // Pad out a number with zeros at the front to make it `digits` characters long
-    function pad(num, digits) {
-      var zeros = Array(digits+1).join('0');
-      return (zeros+num).slice(-digits);
-    }
-
-    function padVersion(version) {
-      // We pad out the version numbers with 0s so they sort nicely
-      // - Non-Release Candidates get 9999 for their release candidate section to make them appear earlier
-      // - Snapshots get 9 added to the front to move them to the top of the list
-      var maxLength = 4;
-      var padded = (version.snapshot ? '9' : '0') + pad(version.major, maxLength) +
-                    pad(version.minor, maxLength) + pad(version.dot, maxLength) +
-                    pad(version.rc || 9999, maxLength);
-      return padded;
-    }
-
-    function getVersionFromTag(tag) {
-      var match = VERSION_REGEX.exec(tag);
-      if ( match ) {
-        var version = {
-          tag: tag,
-          major: match[1], minor: match[2], dot: match[3], rc: match[4],
-          snapshot: !!match[5] && getSnapshotSuffix()
-        };
-
-        if(version.snapshot) {
-          version.full = version.major + '.' + version.minor + '.x (edge)';
-        } else {
-          version.full = version.major + '.' + version.minor + '.' + version.dot +
-                        (version.rc ? '-rc.' + version.rc : '');
-        }
-
-        // Stable versions have an even minor version and are not a release candidate
-        version.isStable = !(version.minor%2 || version.rc);
-
-        // Versions before 1.0.2 had a different docs folder name
-        version.docsUrl = 'http://code.angularjs.org/' + version.full + '/docs';
-        if ( version.major < 1 || (version.major === 1 && version.minor === 0 && version.dot < 2 ) ) {
-          version.docsUrl += '-' + version.full;
-        }
-
-        return version;
-      }
-    }
-
-    var tags = shell.exec('git tag', {silent: true}).output.split(/\s*\n\s*/);
-    return _(tags)
-      .map(getVersionFromTag)
-      .filter()  // getVersion can map to undefined - this clears those out
-      .sortBy(padVersion)
-      .value();
-  },
 
   startKarma: function(config, singleRun, done){
     var browsers = grunt.option('browsers');
@@ -374,7 +205,7 @@ module.exports = {
     var mapFile = minFile + '.map';
     var mapFileName = mapFile.match(/[^\/]+$/)[0];
     var errorFileName = file.replace(/\.js$/, '-errors.json');
-    var versionNumber = this.getVersion().full;
+    var versionNumber = grunt.config('NG_VERSION').full;
     shell.exec(
         'java ' +
             this.java32flags() + ' ' +

--- a/lib/versions/version-info.js
+++ b/lib/versions/version-info.js
@@ -1,0 +1,157 @@
+var fs = require('fs');
+var path = require('path');
+var shell = require('shelljs');
+var semver = require('semver');
+var _ = require('lodash');
+
+var currentPackage, previousVersions;
+
+
+/**
+ * Load information about this project from the package.json
+ * @return {Object} The package information
+ */
+var getPackage = function() {
+  // Search up the folder hierarchy for the first package.json
+  var packageFolder = path.resolve('.');
+  while ( !fs.existsSync(path.join(packageFolder, 'package.json')) ) {
+    var parent = path.dirname(packageFolder);
+    if ( parent === packageFolder) { break; }
+    packageFolder = parent;
+  }
+  return JSON.parse(fs.readFileSync(path.join(packageFolder,'package.json'), 'UTF-8'));
+};
+
+
+/**
+ * Parse the github URL for useful information
+ * @return {Object} An object containing the github owner and repository name
+ */
+var getGitRepoInfo = function() {
+  var GITURL_REGEX = /^https:\/\/github.com\/([^\/]+)\/(.+).git$/;
+  var match = GITURL_REGEX.exec(currentPackage.repository.url);
+  var git = {
+    owner: match[1],
+    repo: match[2]
+  };
+  return git;
+};
+
+
+
+/**
+ * Extract the code name from the tagged commit's message - it should contain the text of the form:
+ * "codename(some-code-name)"
+ * @param  {String} tagName Name of the tag to look in for the codename
+ * @return {String}         The codename if found, otherwise null/undefined
+ */
+var getCodeName = function(tagName) {
+  var tagMessage = shell.exec('git cat-file -p '+ tagName +' | grep "codename"', {silent:true}).output;
+  var codeName = tagMessage && tagMessage.match(/codename\((.*)\)/)[1];
+  if (!codeName) {
+    throw new Error("Could not extract release code name. The message of tag "+tagName+
+      " must match '*codename(some release name)*'");
+  }
+  return codeName;
+};
+
+
+/**
+ * Compute a build segment for the version, from the Jenkins build number and current commit SHA
+ * @return {String} The build segment of the version
+ */
+function getBuild() {
+  var hash = shell.exec('git rev-parse --short HEAD', {silent: true}).output.replace('\n', '');
+  return 'sha.'+hash;
+}
+
+
+/**
+ * If the current commit is tagged as a version get that version
+ * @return {SemVer} The version or null
+ */
+var getTaggedVersion = function() {
+  var gitTagResult = shell.exec('git describe --exact-match', {silent:true});
+
+  if ( gitTagResult.code === 0 ) {
+    var tag = gitTagResult.output;
+    var version = semver.parse(tag);
+    if ( version ) {
+      if ( version.satisfies(currentPackage.branchVersion) ) {
+        version.codeName = getCodeName(tag);
+      }
+      version.full = version.version + '+' + version.build;
+      return version;
+    }
+  }
+};
+
+/**
+ * Stable versions have an even minor version and have no prerelease
+ * @param  {SemVer}  version The version to test
+ * @return {Boolean}         True if the version is stable
+ */
+var isStable = function(version) {
+  return semver.satisfies(version, '1.0 || 1.2') && version.prerelease.length === 0;
+};
+
+/**
+ * Get a collection of all the previous versions sorted by semantic version
+ * @return {Array.<SemVer>} The collection of previous versions
+ */
+var getPreviousVersions =  function() {
+  var tagResults = shell.exec('git tag', {silent: true});
+  if ( tagResults.code === 0 ) {
+    return _(tagResults.output.trim().split('\n'))
+      .map(function(tag) {
+        var version = semver.parse(tag);
+        return version;
+      })
+      .filter()
+      .map(function(version) {
+        version.isStable = isStable(version);
+
+        version.docsUrl = 'http://code.angularjs.org/' + version.version + '/docs';
+        // Versions before 1.0.2 had a different docs folder name
+        if ( version.major < 1 || (version.major === 1 && version.minor === 0 && version.dot < 2 ) ) {
+          version.docsUrl += '-' + version.version;
+        }
+        return version;
+      })
+      .sort(semver.compare)
+      .value();
+  }
+};
+
+
+/**
+ * Get the unstable snapshot version
+ * @return {SemVer} The snapshot version
+ */
+var getSnapshotVersion = function() {
+
+  version = _(previousVersions)
+    .filter(function(tag) {
+      return semver.satisfies(tag, currentPackage.branchVersion);
+    })
+    .last();
+
+  // We need to clone to ensure that we are not modifying another version
+  version = semver(version.raw);
+
+  var jenkinsBuild = process.env.TRAVIS_BUILD_NUMBER || process.env.BUILD_NUMBER;
+  version.prerelease = jenkinsBuild ? ['build', jenkinsBuild] : ['local'];
+  version.build = getBuild();
+  version.codeName = 'snapshot';
+  version.isSnapshot = true;
+  version.format();
+  version.full = version.version + '+' + version.build;
+
+  return version;
+};
+
+
+exports.currentPackage = currentPackage = getPackage();
+exports.previousVersions = previousVersions = getPreviousVersions();
+exports.currentVersion = getTaggedVersion() || getSnapshotVersion();
+exports.gitRepoInfo = getGitRepoInfo();


### PR DESCRIPTION
There are three somewhat independent commits.
- The first is a simple bug fix in the docs
- The second updates how the versions are managed in the docs
- The third does the same for the build
