### PR TITLE
fix(jqLite): traverse `host` property for DocumentFragment in inheritedData()

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -364,11 +364,15 @@ function jqLiteInheritedData(element, name, value) {
   var names = isArray(name) ? name : [name];
 
   while (element.length) {
-
+    var node = element[0];
     for (var i = 0, ii = names.length; i < ii; i++) {
       if ((value = element.data(names[i])) !== undefined) return value;
     }
-    element = element.parent();
+
+    // If dealing with a document fragment node with a host element, and no parent, use the host
+    // element as the parent. This enables directives within a Shadow DOM or polyfilled Shadow DOM
+    // to lookup parent controllers.
+    element = jqLite(node.parentNode || (node.nodeType === 11 && node.host));
   }
 }
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -168,6 +168,19 @@ describe('jqLite', function() {
 
       dealoc(ul);
     });
+
+    it('should pass through DocumentFragment boundaries via host', function() {
+      var host = jqLite('<div></div>'),
+          frag = document.createDocumentFragment(),
+          $frag = jqLite(frag);
+      frag.host = host[0];
+      host.data("foo", 123);
+      host.append($frag);
+      expect($frag.inheritedData("foo")).toBe(123);
+
+      dealoc(host);
+      dealoc($frag);
+    });
   });
 
 


### PR DESCRIPTION
If dealing with a document fragment node with a host element, and no parent, use the host element as the parent. This enables directives within a Shadow DOM or polyfilled Shadow DOM to lookup parent controllers.

This is something which would be well-suited for 1.2.x as well as a 1.3 beta, in my opinion, as use of the shadowDOM may become more commonplace. This solution works for both the Polymer polyfill as well as the native implementation in Canary

(might technically be a feature, but it feels like "fixing things to work with modern web", really)
