### PR TITLE
docs(tutorial): display button icons (Previous, Live Demo, ...)

### DIFF
--- a/docs/app/src/tutorials.js
+++ b/docs/app/src/tutorials.js
@@ -21,10 +21,10 @@ angular.module('tutorials', [])
       element.addClass('btn-group');
       element.addClass('tutorial-nav');
       element.append(templateMerge(
-        '<a href="tutorial/{{prev}}"><li class="btn btn-primary"><i class="icon-step-backward"></i> Previous</li></a>\n' +
-        '<a href="http://angular.github.com/angular-phonecat/step-{{seq}}/app"><li class="btn btn-primary"><i class="icon-play"></i> Live Demo</li></a>\n' +
-        '<a href="https://github.com/angular/angular-phonecat/compare/step-{{diffLo}}...step-{{diffHi}}"><li class="btn btn-primary"><i class="icon-search"></i> Code Diff</li></a>\n' +
-        '<a href="tutorial/{{next}}"><li class="btn btn-primary">Next <i class="icon-step-forward"></i></li></a>', props));
+        '<a href="tutorial/{{prev}}"><li class="btn btn-primary"><i class="glyphicon glyphicon-step-backward"></i> Previous</li></a>\n' +
+        '<a href="http://angular.github.com/angular-phonecat/step-{{seq}}/app"><li class="btn btn-primary"><i class="glyphicon glyphicon-play"></i> Live Demo</li></a>\n' +
+        '<a href="https://github.com/angular/angular-phonecat/compare/step-{{diffLo}}...step-{{diffHi}}"><li class="btn btn-primary"><i class="glyphicon glyphicon-search"></i> Code Diff</li></a>\n' +
+        '<a href="tutorial/{{next}}"><li class="btn btn-primary">Next <i class="glyphicon glyphicon-step-forward"></i></li></a>', props));
     }
   };
 })


### PR DESCRIPTION
Request Type: docs

How to reproduce: For example, see http://docs.angularjs.org/tutorial/step_00

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

In relation to https://github.com/angular/dgeni-packages/pull/8

The icons are not visible yet, this commit do the necessary.
