### PR TITLE
fix(ngOptions): isolated scope options refresh IE9

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -570,6 +570,10 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
             while(existingOptions.length > index) {
               existingOptions.pop().element.remove();
             }
+            // force OPTIONs refresh in IE <= 9
+            if (msie && msie <= 9 && selectElement[0].options.length) {
+                selectElement[0].options[0].label = "" + selectElement[0].options[0].label;
+            }
           }
           // remove any excessive OPTGROUPs from select
           while(optionGroupsCache.length > groupIndex) {

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -572,7 +572,8 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
             }
             // force OPTIONs refresh in IE <= 9
             if (msie && msie <= 9 && selectElement[0].options.length) {
-                selectElement[0].options[0].label = "" + selectElement[0].options[0].label;
+              selectElement[0].options[0].label = "" + selectElement[0].options[0].label;
+              jqLite(selectElement[0].options[0]).removeAttr('label');
             }
           }
           // remove any excessive OPTGROUPs from select


### PR DESCRIPTION
Request Type: bug

How to reproduce: http://jsfiddle.net/ySmah/12/

Component(s): forms

Impact: medium

Complexity: small

This issue is related to: 

**Detailed Description:**

ng-options placeholder in select not removed in IE9: wrong option selected on click
rendering issues in IE9 (showing only first character on each option)

**Other Comments:**

Fixes #6211
