### PR TITLE
fix(input):URL validation does not recognize URLs with no protocol

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -8,7 +8,7 @@
     -DIRTY_CLASS
 */
 
-var URL_REGEXP = /^(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/;
+var URL_REGEXP = /^(((ftp|https?):\/\/)(www\.)?|www\.)([\da-z-_\.]+)([a-z\.]{2,7})([\/\w\.-_\?\&#]*)*\/?$/;
 var EMAIL_REGEXP = /^[a-z0-9!#$%&'*+/=?^_`{|}~.-]+@[a-z0-9-]+(\.[a-z0-9-]+)*$/i;
 var NUMBER_REGEXP = /^\s*(\-|\+)?(\d+|(\d*(\.\d*)))\s*$/;
 var DATE_REGEXP = /^(\d{4})-(\d{2})-(\d{2})$/;

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1697,6 +1697,22 @@ describe('input', function() {
         expect(URL_REGEXP.test('http://server:123/path')).toBe(true);
         expect(URL_REGEXP.test('a@B.c')).toBe(false);
       });
+
+
+      it('should pass on valid url', function() {
+        expect(URL_REGEXP.test('http://server:123/path')).toBe(true);
+        expect(URL_REGEXP.test('http://foo.com/angular#directives')).toBe(true);
+        expect(URL_REGEXP.test('www.angularjs.org')).toBe(true);
+        expect(URL_REGEXP.test('http://localhost:8080/?angular=cool&i=loveit')).toBe(true);
+      });
+
+
+      it('should fail on invalid url', function() {
+        expect(URL_REGEXP.test('http://')).toBe(false);
+        expect(URL_REGEXP.test('http://w')).toBe(false);
+        expect(URL_REGEXP.test('http://www.angularjs. org')).toBe(false);
+        expect(URL_REGEXP.test('htp://localhost:8080/?angular=cool&i=loveit')).toBe(false);
+      });
     });
   });
 


### PR DESCRIPTION
Request Type: 

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Now recognizes URLs without protocol but it is far away from full-blown URL validator

**Other Comments:**

change the url regexp to recognize urls without protocol

closes #6634
