### PR TITLE
chore(npm): add shrinkwrap to lock down dependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,4325 @@
+{
+  "name": "angularjs",
+  "dependencies": {
+    "bower": {
+      "version": "1.2.8",
+      "from": "https://registry.npmjs.org/bower/-/bower-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.2.8.tgz",
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.4",
+          "from": "abbrev@1.0.4",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.4.tgz"
+        },
+        "archy": {
+          "version": "0.0.2",
+          "from": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz"
+        },
+        "bower-config": {
+          "version": "0.5.0",
+          "from": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.0.tgz",
+          "dependencies": {
+            "mout": {
+              "version": "0.6.0",
+              "from": "https://registry.npmjs.org/mout/-/mout-0.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/mout/-/mout-0.6.0.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "bower-endpoint-parser": {
+          "version": "0.2.1",
+          "from": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.1.tgz"
+        },
+        "bower-json": {
+          "version": "0.4.0",
+          "from": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
+          "dependencies": {
+            "deep-extend": {
+              "version": "0.2.8",
+              "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.8.tgz",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.8.tgz"
+            },
+            "intersect": {
+              "version": "0.0.3",
+              "from": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
+            }
+          }
+        },
+        "bower-logger": {
+          "version": "0.2.2",
+          "from": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
+        },
+        "bower-registry-client": {
+          "version": "0.1.6",
+          "from": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.1.6.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "bower-config": {
+              "version": "0.4.5",
+              "from": "https://registry.npmjs.org/bower-config/-/bower-config-0.4.5.tgz",
+              "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.4.5.tgz",
+              "dependencies": {
+                "mout": {
+                  "version": "0.6.0",
+                  "from": "https://registry.npmjs.org/mout/-/mout-0.6.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mout/-/mout-0.6.0.tgz"
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "request-replay": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
+            }
+          }
+        },
+        "cardinal": {
+          "version": "0.4.4",
+          "from": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
+          "dependencies": {
+            "redeyed": {
+              "version": "0.4.4",
+              "from": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+              "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+              "dependencies": {
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                }
+              }
+            },
+            "ansicolors": {
+              "version": "0.2.1",
+              "from": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
+            }
+          }
+        },
+        "chalk": {
+          "version": "0.2.1",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.2.1.tgz",
+          "dependencies": {
+            "has-color": {
+              "version": "0.1.4",
+              "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.4.tgz"
+            },
+            "ansi-styles": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.2.0.tgz"
+            }
+          }
+        },
+        "chmodr": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz"
+        },
+        "decompress-zip": {
+          "version": "0.0.4",
+          "from": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.4.tgz",
+          "dependencies": {
+            "mkpath": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
+            },
+            "binary": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+              "dependencies": {
+                "chainsaw": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.3.9",
+                      "from": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+                    }
+                  }
+                },
+                "buffers": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                }
+              }
+            },
+            "touch": {
+              "version": "0.0.2",
+              "from": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
+              "dependencies": {
+                "nopt": {
+                  "version": "1.0.10",
+                  "from": "nopt@1.0.10",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.1.11",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.11.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.11.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.25-1",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                },
+                "debuglog": {
+                  "version": "0.0.2",
+                  "from": "https://registry.npmjs.org/debuglog/-/debuglog-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-0.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "fstream": {
+          "version": "0.1.25",
+          "from": "https://registry.npmjs.org/fstream/-/fstream-0.1.25.tgz",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.25.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "fstream-ignore": {
+          "version": "0.0.7",
+          "from": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "glob": {
+          "version": "3.2.9",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "2.0.2",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz"
+        },
+        "handlebars": {
+          "version": "1.0.12",
+          "from": "https://registry.npmjs.org/handlebars/-/handlebars-1.0.12.tgz",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.0.12.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.3.6",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.32",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.3.5",
+          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.3.5.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "1.2.1",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-1.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.2.1.tgz"
+            },
+            "async": {
+              "version": "0.2.10",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "cli-color": {
+              "version": "0.2.3",
+              "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
+              "dependencies": {
+                "es5-ext": {
+                  "version": "0.9.2",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
+                },
+                "memoizee": {
+                  "version": "0.2.6",
+                  "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
+                  "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
+                  "dependencies": {
+                    "event-emitter": {
+                      "version": "0.2.2",
+                      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
+                    },
+                    "next-tick": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mute-stream": {
+              "version": "0.0.3",
+              "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.3.tgz"
+            }
+          }
+        },
+        "junk": {
+          "version": "0.2.2",
+          "from": "https://registry.npmjs.org/junk/-/junk-0.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/junk/-/junk-0.2.2.tgz"
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+        },
+        "mout": {
+          "version": "0.7.1",
+          "from": "https://registry.npmjs.org/mout/-/mout-0.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/mout/-/mout-0.7.1.tgz"
+        },
+        "nopt": {
+          "version": "2.1.2",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz"
+        },
+        "lru-cache": {
+          "version": "2.3.1",
+          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
+        },
+        "open": {
+          "version": "0.0.4",
+          "from": "https://registry.npmjs.org/open/-/open-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/open/-/open-0.0.4.tgz"
+        },
+        "osenv": {
+          "version": "0.0.3",
+          "from": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+        },
+        "promptly": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
+          "dependencies": {
+            "read": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                }
+              }
+            }
+          }
+        },
+        "q": {
+          "version": "0.9.7",
+          "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+        },
+        "request": {
+          "version": "2.27.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
+          "dependencies": {
+            "qs": {
+              "version": "0.6.6",
+              "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
+            },
+            "http-signature": {
+              "version": "0.10.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.2",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                }
+              }
+            },
+            "hawk": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.9.1",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                },
+                "boom": {
+                  "version": "0.4.2",
+                  "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                },
+                "cryptiles": {
+                  "version": "0.2.2",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                },
+                "sntp": {
+                  "version": "0.2.4",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                }
+              }
+            },
+            "aws-sign": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz"
+            },
+            "oauth-sign": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+            },
+            "cookie-jar": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz"
+            },
+            "node-uuid": {
+              "version": "1.4.1",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+            },
+            "mime": {
+              "version": "1.2.11",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            },
+            "form-data": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
+              "dependencies": {
+                "combined-stream": {
+                  "version": "0.0.4",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "async": {
+                  "version": "0.2.10",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                }
+              }
+            }
+          }
+        },
+        "request-progress": {
+          "version": "0.3.1",
+          "from": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+          "dependencies": {
+            "throttleit": {
+              "version": "0.0.2",
+              "from": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+            }
+          }
+        },
+        "retry": {
+          "version": "0.6.0",
+          "from": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
+        },
+        "rimraf": {
+          "version": "2.2.6",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz"
+        },
+        "stringify-object": {
+          "version": "0.1.8",
+          "from": "https://registry.npmjs.org/stringify-object/-/stringify-object-0.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-0.1.8.tgz"
+        },
+        "sudo-block": {
+          "version": "0.2.1",
+          "from": "https://registry.npmjs.org/sudo-block/-/sudo-block-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/sudo-block/-/sudo-block-0.2.1.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.1.1.tgz",
+              "dependencies": {
+                "has-color": {
+                  "version": "0.1.4",
+                  "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.4.tgz"
+                },
+                "ansi-styles": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.1.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "tar": {
+          "version": "0.1.19",
+          "from": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "block-stream": {
+              "version": "0.0.7",
+              "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+            }
+          }
+        },
+        "tmp": {
+          "version": "0.0.23",
+          "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz"
+        },
+        "update-notifier": {
+          "version": "0.1.7",
+          "from": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.1.7.tgz",
+          "dependencies": {
+            "configstore": {
+              "version": "0.1.7",
+              "from": "https://registry.npmjs.org/configstore/-/configstore-0.1.7.tgz",
+              "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.1.7.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+                },
+                "js-yaml": {
+                  "version": "2.1.3",
+                  "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "0.1.15",
+                      "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
+                      "dependencies": {
+                        "underscore": {
+                          "version": "1.4.4",
+                          "from": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+                          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                        },
+                        "underscore.string": {
+                          "version": "2.3.3",
+                          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "which": {
+          "version": "1.0.5",
+          "from": "https://registry.npmjs.org/which/-/which-1.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
+        },
+        "p-throttler": {
+          "version": "0.0.1",
+          "from": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.0.1.tgz"
+        }
+      }
+    },
+    "browserstacktunnel-wrapper": {
+      "version": "1.1.2",
+      "from": "https://registry.npmjs.org/browserstacktunnel-wrapper/-/browserstacktunnel-wrapper-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/browserstacktunnel-wrapper/-/browserstacktunnel-wrapper-1.1.2.tgz"
+    },
+    "canonical-path": {
+      "version": "0.0.2",
+      "from": "https://registry.npmjs.org/canonical-path/-/canonical-path-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-0.0.2.tgz"
+    },
+    "dgeni": {
+      "version": "0.2.2",
+      "from": "https://registry.npmjs.org/dgeni/-/dgeni-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/dgeni/-/dgeni-0.2.2.tgz",
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.6",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz"
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+        },
+        "dependency-graph": {
+          "version": "0.1.0",
+          "from": "dependency-graph@0.1.0",
+          "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.1.0.tgz",
+          "dependencies": {
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@1.4.4",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            }
+          }
+        },
+        "q": {
+          "version": "0.9.7",
+          "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+        },
+        "di": {
+          "version": "0.0.1",
+          "from": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
+        },
+        "marked": {
+          "version": "0.2.10",
+          "from": "marked@0.2.10",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.2.10.tgz"
+        },
+        "glob": {
+          "version": "3.2.9",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2.5.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "dgeni-packages": {
+      "version": "0.6.0",
+      "from": "https://registry.npmjs.org/dgeni-packages/-/dgeni-packages-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/dgeni-packages/-/dgeni-packages-0.6.0.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+        },
+        "graceful-fs": {
+          "version": "2.0.2",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz"
+        },
+        "glob": {
+          "version": "3.2.9",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2.5.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "nunjucks": {
+          "version": "1.0.1",
+          "from": "nunjucks@1.0.1",
+          "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-1.0.1.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@0.6.1",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "catharsis": {
+          "version": "0.7.0",
+          "from": "https://registry.npmjs.org/catharsis/-/catharsis-0.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.7.0.tgz"
+        },
+        "esprima": {
+          "version": "1.0.4",
+          "from": "esprima@1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+        }
+      }
+    },
+    "event-stream": {
+      "version": "3.1.0",
+      "from": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.0.tgz",
+      "dependencies": {
+        "through": {
+          "version": "2.3.4",
+          "from": "https://registry.npmjs.org/through/-/through-2.3.4.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.4.tgz"
+        },
+        "duplexer": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+        },
+        "from": {
+          "version": "0.1.3",
+          "from": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
+        },
+        "map-stream": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+        },
+        "pause-stream": {
+          "version": "0.0.11",
+          "from": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+          "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
+        },
+        "split": {
+          "version": "0.2.10",
+          "from": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+          "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
+        },
+        "stream-combiner": {
+          "version": "0.0.4",
+          "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+        }
+      }
+    },
+    "grunt": {
+      "version": "0.4.2",
+      "from": "https://registry.npmjs.org/grunt/-/grunt-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.2.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+        },
+        "coffee-script": {
+          "version": "1.3.3",
+          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "dateformat": {
+          "version": "1.0.2-1.2.3",
+          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
+        },
+        "eventemitter2": {
+          "version": "0.4.13",
+          "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.13.tgz",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.13.tgz"
+        },
+        "findup-sync": {
+          "version": "0.1.2",
+          "from": "findup-sync@0.1.2",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.2.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "1.0.1",
+              "from": "lodash@1.0.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
+            }
+          }
+        },
+        "glob": {
+          "version": "3.1.21",
+          "from": "glob@3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@1.2.3",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+            },
+            "inherits": {
+              "version": "1.0.0",
+              "from": "inherits@1.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+            }
+          }
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@0.2.3",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        },
+        "iconv-lite": {
+          "version": "0.2.11",
+          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@2.5.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@1.0.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+            }
+          }
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.4",
+              "from": "abbrev@1.0.4",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.4.tgz"
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.0.3",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.0.3.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.1.14",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.1.14.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.1.14.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
+        },
+        "underscore.string": {
+          "version": "2.2.1",
+          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
+        },
+        "which": {
+          "version": "1.0.5",
+          "from": "https://registry.npmjs.org/which/-/which-1.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
+        },
+        "js-yaml": {
+          "version": "2.0.5",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.15",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.4.4",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@1.0.4",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
+        "getobject": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
+        }
+      }
+    },
+    "grunt-bump": {
+      "version": "0.0.13",
+      "from": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.0.13.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.0.13.tgz",
+      "dependencies": {
+        "semver": {
+          "version": "1.1.4",
+          "from": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz"
+        }
+      }
+    },
+    "grunt-contrib-clean": {
+      "version": "0.5.0",
+      "from": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.5.0.tgz",
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.6",
+          "from": "rimraf@2.2.6",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz"
+        }
+      }
+    },
+    "grunt-contrib-compress": {
+      "version": "0.5.3",
+      "from": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-0.5.3.tgz",
+      "dependencies": {
+        "archiver": {
+          "version": "0.4.10",
+          "from": "https://registry.npmjs.org/archiver/-/archiver-0.4.10.tgz",
+          "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.4.10.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.26",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+              "dependencies": {
+                "string_decoder": {
+                  "version": "0.10.25-1",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                }
+              }
+            },
+            "iconv-lite": {
+              "version": "0.2.11",
+              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+            }
+          }
+        },
+        "lazystream": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.26",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+              "dependencies": {
+                "string_decoder": {
+                  "version": "0.10.25-1",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "prettysize": {
+          "version": "0.0.3",
+          "from": "https://registry.npmjs.org/prettysize/-/prettysize-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-0.0.3.tgz"
+        }
+      }
+    },
+    "grunt-contrib-connect": {
+      "version": "0.5.0",
+      "from": "https://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-0.5.0.tgz",
+      "dependencies": {
+        "connect": {
+          "version": "2.7.11",
+          "from": "https://registry.npmjs.org/connect/-/connect-2.7.11.tgz",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-2.7.11.tgz",
+          "dependencies": {
+            "qs": {
+              "version": "0.6.5",
+              "from": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz"
+            },
+            "formidable": {
+              "version": "1.0.14",
+              "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
+              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+            },
+            "cookie-signature": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz"
+            },
+            "buffer-crc32": {
+              "version": "0.2.1",
+              "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
+            },
+            "cookie": {
+              "version": "0.0.5",
+              "from": "https://registry.npmjs.org/cookie/-/cookie-0.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.0.5.tgz"
+            },
+            "send": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/send/-/send-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.1.1.tgz",
+              "dependencies": {
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "range-parser": {
+                  "version": "0.0.4",
+                  "from": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz"
+                }
+              }
+            },
+            "bytes": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.0.tgz"
+            },
+            "fresh": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/fresh/-/fresh-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.1.0.tgz"
+            },
+            "pause": {
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            }
+          }
+        },
+        "connect-livereload": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.2.0.tgz"
+        },
+        "open": {
+          "version": "0.0.4",
+          "from": "https://registry.npmjs.org/open/-/open-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/open/-/open-0.0.4.tgz"
+        }
+      }
+    },
+    "grunt-contrib-copy": {
+      "version": "0.4.1",
+      "from": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.4.1.tgz"
+    },
+    "grunt-contrib-jshint": {
+      "version": "0.7.2",
+      "from": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.7.2.tgz",
+      "dependencies": {
+        "jshint": {
+          "version": "2.3.0",
+          "from": "https://registry.npmjs.org/jshint/-/jshint-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.3.0.tgz",
+          "dependencies": {
+            "shelljs": {
+              "version": "0.1.4",
+              "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz"
+            },
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@1.4.4",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            },
+            "cli": {
+              "version": "0.4.5",
+              "from": "https://registry.npmjs.org/cli/-/cli-0.4.5.tgz",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.5.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.9",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2.5.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "0.1.6",
+              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-ddescribe-iit": {
+      "version": "0.0.4",
+      "from": "https://registry.npmjs.org/grunt-ddescribe-iit/-/grunt-ddescribe-iit-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-ddescribe-iit/-/grunt-ddescribe-iit-0.0.4.tgz"
+    },
+    "grunt-jasmine-node": {
+      "version": "0.1.0",
+      "from": "grunt-jasmine-node@git://github.com/vojtajina/grunt-jasmine-node.git#ced17cbe52c1412b2ada53160432a5b681f37cd7",
+      "resolved": "git://github.com/vojtajina/grunt-jasmine-node.git#ced17cbe52c1412b2ada53160432a5b681f37cd7"
+    },
+    "grunt-jscs-checker": {
+      "version": "0.4.0",
+      "from": "https://registry.npmjs.org/grunt-jscs-checker/-/grunt-jscs-checker-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-jscs-checker/-/grunt-jscs-checker-0.4.0.tgz",
+      "dependencies": {
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@0.2.3",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        },
+        "jscs": {
+          "version": "1.3.0",
+          "from": "https://registry.npmjs.org/jscs/-/jscs-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.3.0.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.3.tgz"
+            },
+            "vow": {
+              "version": "0.3.9",
+              "from": "https://registry.npmjs.org/vow/-/vow-0.3.9.tgz",
+              "resolved": "https://registry.npmjs.org/vow/-/vow-0.3.9.tgz"
+            },
+            "vow-fs": {
+              "version": "0.2.3",
+              "from": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.2.3.tgz",
+              "dependencies": {
+                "node-uuid": {
+                  "version": "1.4.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.0.tgz"
+                },
+                "vow-queue": {
+                  "version": "0.0.2",
+                  "from": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.0.2.tgz"
+                }
+              }
+            },
+            "colors": {
+              "version": "0.6.0-1",
+              "from": "https://registry.npmjs.org/colors/-/colors-0.6.0-1.tgz",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.0-1.tgz"
+            },
+            "commander": {
+              "version": "1.2.0",
+              "from": "commander@1.2.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-1.2.0.tgz",
+              "dependencies": {
+                "keypress": {
+                  "version": "0.1.0",
+                  "from": "keypress@0.1.0",
+                  "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.2.12",
+              "from": "minimatch@0.2.12",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.12.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2.5.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "glob": {
+              "version": "3.2.7",
+              "from": "glob@3.2.7",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.7.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xmlbuilder": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-1.1.2.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.6.0",
+                  "from": "underscore@1.6.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                }
+              }
+            },
+            "strip-json-comments": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.1.tgz"
+            }
+          }
+        },
+        "lodash.assign": {
+          "version": "2.4.1",
+          "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
+          "dependencies": {
+            "lodash._basecreatecallback": {
+              "version": "2.4.1",
+              "from": "lodash._basecreatecallback@2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+              "dependencies": {
+                "lodash.bind": {
+                  "version": "2.4.1",
+                  "from": "lodash.bind@2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._createwrapper": {
+                      "version": "2.4.1",
+                      "from": "lodash._createwrapper@2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._basebind": {
+                          "version": "2.4.1",
+                          "from": "lodash._basebind@2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._basecreate": {
+                              "version": "2.4.1",
+                              "from": "lodash._basecreate@2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._isnative": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._isnative@2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                },
+                                "lodash.noop": {
+                                  "version": "2.4.1",
+                                  "from": "lodash.noop@2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash.isobject": {
+                              "version": "2.4.1",
+                              "from": "lodash.isobject@2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash._basecreatewrapper": {
+                          "version": "2.4.1",
+                          "from": "lodash._basecreatewrapper@2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._basecreate": {
+                              "version": "2.4.1",
+                              "from": "lodash._basecreate@2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._isnative": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._isnative@2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                },
+                                "lodash.noop": {
+                                  "version": "2.4.1",
+                                  "from": "lodash.noop@2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash.isobject": {
+                              "version": "2.4.1",
+                              "from": "lodash.isobject@2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash.isfunction": {
+                          "version": "2.4.1",
+                          "from": "lodash.isfunction@2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._slice": {
+                      "version": "2.4.1",
+                      "from": "lodash._slice@2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.identity": {
+                  "version": "2.4.1",
+                  "from": "lodash.identity@2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
+                },
+                "lodash._setbinddata": {
+                  "version": "2.4.1",
+                  "from": "lodash._setbinddata@2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    },
+                    "lodash.noop": {
+                      "version": "2.4.1",
+                      "from": "lodash.noop@2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.support": {
+                  "version": "2.4.1",
+                  "from": "lodash.support@2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.keys": {
+              "version": "2.4.1",
+              "from": "lodash.keys@2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+              "dependencies": {
+                "lodash._isnative": {
+                  "version": "2.4.1",
+                  "from": "lodash._isnative@2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                },
+                "lodash.isobject": {
+                  "version": "2.4.1",
+                  "from": "lodash.isobject@2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+                },
+                "lodash._shimkeys": {
+                  "version": "2.4.1",
+                  "from": "lodash._shimkeys@2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
+                }
+              }
+            },
+            "lodash._objecttypes": {
+              "version": "2.4.1",
+              "from": "lodash._objecttypes@2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+            }
+          }
+        },
+        "vow": {
+          "version": "0.4.1",
+          "from": "https://registry.npmjs.org/vow/-/vow-0.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.1.tgz"
+        }
+      }
+    },
+    "grunt-merge-conflict": {
+      "version": "0.0.2",
+      "from": "https://registry.npmjs.org/grunt-merge-conflict/-/grunt-merge-conflict-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-merge-conflict/-/grunt-merge-conflict-0.0.2.tgz"
+    },
+    "grunt-parallel": {
+      "version": "0.3.1",
+      "from": "https://registry.npmjs.org/grunt-parallel/-/grunt-parallel-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-parallel/-/grunt-parallel-0.3.1.tgz",
+      "dependencies": {
+        "q": {
+          "version": "0.8.12",
+          "from": "https://registry.npmjs.org/q/-/q-0.8.12.tgz",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.8.12.tgz"
+        },
+        "lpad": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/lpad/-/lpad-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/lpad/-/lpad-0.1.0.tgz"
+        }
+      }
+    },
+    "grunt-shell": {
+      "version": "0.4.0",
+      "from": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-0.4.0.tgz",
+      "dependencies": {
+        "stripcolorcodes": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/stripcolorcodes/-/stripcolorcodes-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/stripcolorcodes/-/stripcolorcodes-0.1.0.tgz"
+        }
+      }
+    },
+    "gulp": {
+      "version": "3.4.0",
+      "from": "https://registry.npmjs.org/gulp/-/gulp-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.4.0.tgz",
+      "dependencies": {
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "gulp-util": {
+          "version": "2.2.14",
+          "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.14.tgz",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.14.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "0.4.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "dependencies": {
+                "has-color": {
+                  "version": "0.1.4",
+                  "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.4.tgz"
+                },
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                }
+              }
+            },
+            "lodash.template": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+              "dependencies": {
+                "lodash.defaults": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.escape": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._escapehtmlchar": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._reunescapedhtml": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._escapestringchar": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+                },
+                "lodash.keys": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    },
+                    "lodash.isobject": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._shimkeys": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
+                },
+                "lodash.values": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+                }
+              }
+            },
+            "lodash._reinterpolate": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.2.3",
+              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+              "dependencies": {
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.26",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+                  "dependencies": {
+                    "string_decoder": {
+                      "version": "0.10.25-1",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "2.1.2",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "dependencies": {
+                    "object-keys": {
+                      "version": "0.4.0",
+                      "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.7-1.2.3",
+              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.7-1.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.7-1.2.3.tgz"
+            },
+            "multipipe": {
+              "version": "0.0.2",
+              "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.0.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.1.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "orchestrator": {
+          "version": "0.3.3",
+          "from": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.3.tgz",
+          "dependencies": {
+            "sequencify": {
+              "version": "0.0.7",
+              "from": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
+            }
+          }
+        },
+        "resolve": {
+          "version": "0.6.1",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.1.tgz"
+        },
+        "findup-sync": {
+          "version": "0.1.2",
+          "from": "findup-sync@0.1.2",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.2.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.1.21",
+              "from": "glob@3.1.21",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@0.2.14",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "1.2.3",
+                  "from": "graceful-fs@1.2.3",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                },
+                "inherits": {
+                  "version": "1.0.0",
+                  "from": "inherits@1.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                }
+              }
+            },
+            "lodash": {
+              "version": "1.0.1",
+              "from": "lodash@1.0.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
+            }
+          }
+        },
+        "pretty-hrtime": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-0.2.0.tgz"
+        },
+        "vinyl-fs": {
+          "version": "0.0.1",
+          "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.0.1.tgz",
+          "dependencies": {
+            "vinyl": {
+              "version": "0.2.3",
+              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+              "dependencies": {
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            },
+            "glob-stream": {
+              "version": "3.1.9",
+              "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.9.tgz",
+              "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.9.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.9",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@0.2.14",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "ordered-read-streams": {
+                  "version": "0.0.7",
+                  "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.0.7.tgz"
+                },
+                "glob2base": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.8.tgz"
+                },
+                "unique-stream": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-0.0.3.tgz"
+                },
+                "through": {
+                  "version": "2.3.4",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.4.tgz",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.4.tgz"
+                }
+              }
+            },
+            "glob-watcher": {
+              "version": "0.0.3",
+              "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.3.tgz",
+              "dependencies": {
+                "gaze": {
+                  "version": "0.4.3",
+                  "from": "https://registry.npmjs.org/gaze/-/gaze-0.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.4.3.tgz",
+                  "dependencies": {
+                    "globule": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "1.0.1",
+                          "from": "lodash@1.0.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
+                        },
+                        "glob": {
+                          "version": "3.1.21",
+                          "from": "glob@3.1.21",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@1.2.3",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            },
+                            "inherits": {
+                              "version": "1.0.0",
+                              "from": "inherits@1.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "minimatch@0.2.14",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.5.0",
+                              "from": "lru-cache@2.5.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.0",
+                              "from": "sigmund@1.0.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "graceful-fs": {
+              "version": "2.0.2",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz"
+            },
+            "map-stream": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+            }
+          }
+        },
+        "semver": {
+          "version": "2.2.1",
+          "from": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz"
+        },
+        "archy": {
+          "version": "0.0.2",
+          "from": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz"
+        }
+      }
+    },
+    "gulp-concat": {
+      "version": "2.1.7",
+      "from": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.1.7.tgz",
+      "dependencies": {
+        "through": {
+          "version": "2.3.4",
+          "from": "https://registry.npmjs.org/through/-/through-2.3.4.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.4.tgz"
+        },
+        "gulp-util": {
+          "version": "2.2.14",
+          "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.14.tgz",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.14.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "0.4.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "dependencies": {
+                "has-color": {
+                  "version": "0.1.4",
+                  "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.4.tgz"
+                },
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                }
+              }
+            },
+            "lodash.template": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+              "dependencies": {
+                "lodash.defaults": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.escape": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._escapehtmlchar": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._reunescapedhtml": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._escapestringchar": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+                },
+                "lodash.keys": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    },
+                    "lodash.isobject": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._shimkeys": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
+                },
+                "lodash.values": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+                }
+              }
+            },
+            "lodash._reinterpolate": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.2.3",
+              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+              "dependencies": {
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.26",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+                  "dependencies": {
+                    "string_decoder": {
+                      "version": "0.10.25-1",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "2.1.2",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "dependencies": {
+                    "object-keys": {
+                      "version": "0.4.0",
+                      "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.7-1.2.3",
+              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.7-1.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.7-1.2.3.tgz"
+            },
+            "multipipe": {
+              "version": "0.0.2",
+              "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.0.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.1.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-jshint": {
+      "version": "1.4.2",
+      "from": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-1.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-1.4.2.tgz",
+      "dependencies": {
+        "map-stream": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+        },
+        "jshint": {
+          "version": "2.4.4",
+          "from": "https://registry.npmjs.org/jshint/-/jshint-2.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.4.4.tgz",
+          "dependencies": {
+            "shelljs": {
+              "version": "0.1.4",
+              "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz"
+            },
+            "underscore": {
+              "version": "1.4.4",
+              "from": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            },
+            "cli": {
+              "version": "0.4.5",
+              "from": "https://registry.npmjs.org/cli/-/cli-0.4.5.tgz",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.5.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.9",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2.5.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "htmlparser2": {
+              "version": "3.3.0",
+              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
+              "dependencies": {
+                "domhandler": {
+                  "version": "2.1.0",
+                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz"
+                },
+                "domutils": {
+                  "version": "1.1.6",
+                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz"
+                },
+                "domelementtype": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.0.26",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+                  "dependencies": {
+                    "string_decoder": {
+                      "version": "0.10.25-1",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "0.1.6",
+              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz"
+            },
+            "exit": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+            }
+          }
+        },
+        "gulp-util": {
+          "version": "2.2.14",
+          "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.14.tgz",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.14.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "0.4.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "dependencies": {
+                "has-color": {
+                  "version": "0.1.4",
+                  "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.4.tgz"
+                },
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                }
+              }
+            },
+            "lodash.template": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+              "dependencies": {
+                "lodash.defaults": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.escape": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._escapehtmlchar": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._reunescapedhtml": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._escapestringchar": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+                },
+                "lodash.keys": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    },
+                    "lodash.isobject": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._shimkeys": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
+                },
+                "lodash.values": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+                }
+              }
+            },
+            "lodash._reinterpolate": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.2.3",
+              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+              "dependencies": {
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.26",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+                  "dependencies": {
+                    "string_decoder": {
+                      "version": "0.10.25-1",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "2.1.2",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "dependencies": {
+                    "object-keys": {
+                      "version": "0.4.0",
+                      "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.7-1.2.3",
+              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.7-1.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.7-1.2.3.tgz"
+            },
+            "multipipe": {
+              "version": "0.0.2",
+              "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.0.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.1.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "lodash.clone": {
+          "version": "2.4.1",
+          "from": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-2.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-2.4.1.tgz",
+          "dependencies": {
+            "lodash._baseclone": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-2.4.1.tgz",
+              "dependencies": {
+                "lodash.assign": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash.keys": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                        },
+                        "lodash._shimkeys": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.foreach": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz"
+                },
+                "lodash.forown": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash.keys": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                        },
+                        "lodash._shimkeys": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash._getarray": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash._getarray/-/lodash._getarray-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._getarray/-/lodash._getarray-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._arraypool": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.isarray": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.isobject": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash._releasearray": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash._releasearray/-/lodash._releasearray-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._releasearray/-/lodash._releasearray-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._arraypool": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz"
+                    },
+                    "lodash._maxpoolsize": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash._slice": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
+                }
+              }
+            },
+            "lodash._basecreatecallback": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+              "dependencies": {
+                "lodash.bind": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._createwrapper": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._basebind": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._basecreate": {
+                              "version": "2.4.1",
+                              "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._isnative": {
+                                  "version": "2.4.1",
+                                  "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                },
+                                "lodash.noop": {
+                                  "version": "2.4.1",
+                                  "from": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash.isobject": {
+                              "version": "2.4.1",
+                              "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._objecttypes": {
+                                  "version": "2.4.1",
+                                  "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash._basecreatewrapper": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._basecreate": {
+                              "version": "2.4.1",
+                              "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._isnative": {
+                                  "version": "2.4.1",
+                                  "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                },
+                                "lodash.noop": {
+                                  "version": "2.4.1",
+                                  "from": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash.isobject": {
+                              "version": "2.4.1",
+                              "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._objecttypes": {
+                                  "version": "2.4.1",
+                                  "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.isfunction": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._slice": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.identity": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
+                },
+                "lodash._setbinddata": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    },
+                    "lodash.noop": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.support": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "jasmine-node": {
+      "version": "1.11.0",
+      "from": "https://registry.npmjs.org/jasmine-node/-/jasmine-node-1.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/jasmine-node/-/jasmine-node-1.11.0.tgz",
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.7.1",
+          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz"
+        },
+        "jasmine-growl-reporter": {
+          "version": "0.0.2",
+          "from": "https://registry.npmjs.org/jasmine-growl-reporter/-/jasmine-growl-reporter-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/jasmine-growl-reporter/-/jasmine-growl-reporter-0.0.2.tgz",
+          "dependencies": {
+            "growl": {
+              "version": "1.7.0",
+              "from": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
+            }
+          }
+        },
+        "requirejs": {
+          "version": "2.1.11",
+          "from": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.11.tgz",
+          "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.11.tgz"
+        },
+        "walkdir": {
+          "version": "0.0.7",
+          "from": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.7.tgz",
+          "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.7.tgz"
+        },
+        "underscore": {
+          "version": "1.6.0",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+        },
+        "gaze": {
+          "version": "0.3.4",
+          "from": "https://registry.npmjs.org/gaze/-/gaze-0.3.4.tgz",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.3.4.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2.5.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "fileset": {
+              "version": "0.1.5",
+              "from": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.9",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+        }
+      }
+    },
+    "jasmine-reporters": {
+      "version": "0.2.1",
+      "from": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-0.2.1.tgz"
+    },
+    "jshint-stylish": {
+      "version": "0.1.5",
+      "from": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-0.1.5.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "0.4.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "dependencies": {
+            "has-color": {
+              "version": "0.1.4",
+              "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.4.tgz"
+            },
+            "ansi-styles": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+            },
+            "strip-ansi": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        }
+      }
+    },
+    "karma": {
+      "version": "0.11.12",
+      "from": "https://registry.npmjs.org/karma/-/karma-0.11.12.tgz",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-0.11.12.tgz",
+      "dependencies": {
+        "di": {
+          "version": "0.0.1",
+          "from": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
+        },
+        "socket.io": {
+          "version": "0.9.16",
+          "from": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
+          "dependencies": {
+            "socket.io-client": {
+              "version": "0.9.16",
+              "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
+              "dependencies": {
+                "uglify-js": {
+                  "version": "1.2.5",
+                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
+                },
+                "ws": {
+                  "version": "0.4.31",
+                  "from": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "0.6.1",
+                      "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                    },
+                    "nan": {
+                      "version": "0.3.2",
+                      "from": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
+                    },
+                    "tinycolor": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                    },
+                    "options": {
+                      "version": "0.0.5",
+                      "from": "https://registry.npmjs.org/options/-/options-0.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.5.tgz"
+                    }
+                  }
+                },
+                "xmlhttprequest": {
+                  "version": "1.4.2",
+                  "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
+                },
+                "active-x-obfuscator": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
+                  "dependencies": {
+                    "zeparser": {
+                      "version": "0.0.5",
+                      "from": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "policyfile": {
+              "version": "0.0.4",
+              "from": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
+            },
+            "base64id": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
+            },
+            "redis": {
+              "version": "0.7.3",
+              "from": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz",
+              "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
+            }
+          }
+        },
+        "chokidar": {
+          "version": "0.8.1",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-0.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.8.1.tgz"
+        },
+        "glob": {
+          "version": "3.2.9",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@2.5.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@1.0.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+            }
+          }
+        },
+        "http-proxy": {
+          "version": "0.10.4",
+          "from": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
+          "dependencies": {
+            "pkginfo": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
+            },
+            "utile": {
+              "version": "0.2.1",
+              "from": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "deep-equal": {
+                  "version": "0.2.1",
+                  "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz"
+                },
+                "i": {
+                  "version": "0.3.2",
+                  "from": "https://registry.npmjs.org/i/-/i-0.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.2.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                },
+                "ncp": {
+                  "version": "0.4.2",
+                  "from": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "coffee-script": {
+          "version": "1.6.3",
+          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz"
+        },
+        "rimraf": {
+          "version": "2.2.6",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz"
+        },
+        "q": {
+          "version": "0.9.7",
+          "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+        },
+        "log4js": {
+          "version": "0.6.10",
+          "from": "https://registry.npmjs.org/log4js/-/log4js-0.6.10.tgz",
+          "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.10.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.1.15",
+              "from": "https://registry.npmjs.org/async/-/async-0.1.15.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.1.15.tgz"
+            },
+            "semver": {
+              "version": "1.1.4",
+              "from": "semver@1.1.4",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz"
+            },
+            "readable-stream": {
+              "version": "1.0.26",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+              "dependencies": {
+                "string_decoder": {
+                  "version": "0.10.25-1",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "useragent": {
+          "version": "2.0.7",
+          "from": "https://registry.npmjs.org/useragent/-/useragent-2.0.7.tgz",
+          "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.0.7.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.2.4",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "2.0.2",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz"
+        },
+        "connect": {
+          "version": "2.12.0",
+          "from": "https://registry.npmjs.org/connect/-/connect-2.12.0.tgz",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-2.12.0.tgz",
+          "dependencies": {
+            "batch": {
+              "version": "0.5.0",
+              "from": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz"
+            },
+            "qs": {
+              "version": "0.6.6",
+              "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+            },
+            "cookie-signature": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz"
+            },
+            "buffer-crc32": {
+              "version": "0.2.1",
+              "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
+            },
+            "cookie": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
+            },
+            "send": {
+              "version": "0.1.4",
+              "from": "https://registry.npmjs.org/send/-/send-0.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.1.4.tgz",
+              "dependencies": {
+                "range-parser": {
+                  "version": "0.0.4",
+                  "from": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz"
+                }
+              }
+            },
+            "bytes": {
+              "version": "0.2.1",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz"
+            },
+            "fresh": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz"
+            },
+            "pause": {
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
+            },
+            "uid2": {
+              "version": "0.0.3",
+              "from": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz"
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            },
+            "methods": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz"
+            },
+            "raw-body": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.2.tgz"
+            },
+            "negotiator": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz"
+            },
+            "multiparty": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.11",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.11.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.25-1",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                    },
+                    "debuglog": {
+                      "version": "0.0.2",
+                      "from": "https://registry.npmjs.org/debuglog/-/debuglog-0.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-0.0.2.tgz"
+                    }
+                  }
+                },
+                "stream-counter": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.1.32",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "karma-browserstack-launcher": {
+      "version": "0.0.7",
+      "from": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-0.0.7.tgz",
+      "dependencies": {
+        "browserstack": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/browserstack/-/browserstack-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.0.1.tgz"
+        },
+        "q": {
+          "version": "0.9.7",
+          "from": "q@0.9.7",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+        }
+      }
+    },
+    "karma-chrome-launcher": {
+      "version": "0.1.2",
+      "from": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.2.tgz"
+    },
+    "karma-firefox-launcher": {
+      "version": "0.1.3",
+      "from": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-0.1.3.tgz"
+    },
+    "karma-jasmine": {
+      "version": "0.1.5",
+      "from": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.1.5.tgz"
+    },
+    "karma-junit-reporter": {
+      "version": "0.2.1",
+      "from": "https://registry.npmjs.org/karma-junit-reporter/-/karma-junit-reporter-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/karma-junit-reporter/-/karma-junit-reporter-0.2.1.tgz",
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "0.4.2",
+          "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
+        }
+      }
+    },
+    "karma-ng-scenario": {
+      "version": "0.1.0",
+      "from": "https://registry.npmjs.org/karma-ng-scenario/-/karma-ng-scenario-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/karma-ng-scenario/-/karma-ng-scenario-0.1.0.tgz"
+    },
+    "karma-sauce-launcher": {
+      "version": "0.2.0",
+      "from": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.2.0.tgz",
+      "dependencies": {
+        "wd": {
+          "version": "0.2.10",
+          "from": "https://registry.npmjs.org/wd/-/wd-0.2.10.tgz",
+          "resolved": "https://registry.npmjs.org/wd/-/wd-0.2.10.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "vargs": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz"
+            },
+            "q": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/q/-/q-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/q/-/q-1.0.0.tgz"
+            },
+            "request": {
+              "version": "2.33.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.33.0.tgz",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.33.0.tgz",
+              "dependencies": {
+                "qs": {
+                  "version": "0.6.6",
+                  "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.1",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.2.4",
+                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+                    }
+                  }
+                },
+                "form-data": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.4",
+                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
+                },
+                "http-signature": {
+                  "version": "0.10.0",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.2",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.2",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                }
+              }
+            },
+            "archiver": {
+              "version": "0.5.2",
+              "from": "https://registry.npmjs.org/archiver/-/archiver-0.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.5.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.26",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26.tgz",
+                  "dependencies": {
+                    "string_decoder": {
+                      "version": "0.10.25-1",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                    }
+                  }
+                },
+                "zip-stream": {
+                  "version": "0.1.4",
+                  "from": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.1.4.tgz",
+                  "dependencies": {
+                    "lodash.defaults": {
+                      "version": "2.4.1",
+                      "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash.keys": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._isnative": {
+                              "version": "2.4.1",
+                              "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                            },
+                            "lodash.isobject": {
+                              "version": "2.4.1",
+                              "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+                            },
+                            "lodash._shimkeys": {
+                              "version": "2.4.1",
+                              "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lazystream": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz"
+                },
+                "file-utils": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/file-utils/-/file-utils-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/file-utils/-/file-utils-0.1.5.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "2.1.0",
+                      "from": "lodash@2.1.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.1.0.tgz"
+                    },
+                    "iconv-lite": {
+                      "version": "0.2.11",
+                      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+                    },
+                    "rimraf": {
+                      "version": "2.2.6",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz"
+                    },
+                    "glob": {
+                      "version": "3.2.9",
+                      "from": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "minimatch@0.2.14",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2.5.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "findup-sync": {
+                      "version": "0.1.2",
+                      "from": "findup-sync@0.1.2",
+                      "dependencies": {
+                        "glob": {
+                          "version": "3.1.21",
+                          "from": "glob@3.1.21",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@1.2.3",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            },
+                            "inherits": {
+                              "version": "1.0.0",
+                              "from": "inherits@1.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "lodash": {
+                          "version": "1.0.1",
+                          "from": "lodash@1.0.1"
+                        }
+                      }
+                    },
+                    "isbinaryfile": {
+                      "version": "0.1.9",
+                      "from": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-0.1.9.tgz",
+                      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-0.1.9.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+            }
+          }
+        },
+        "sauce-connect-launcher": {
+          "version": "0.2.2",
+          "from": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.2.2.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "1.3.1",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz"
+            },
+            "async": {
+              "version": "0.2.10",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "adm-zip": {
+              "version": "0.4.4",
+              "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
+              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+            }
+          }
+        },
+        "q": {
+          "version": "0.9.7",
+          "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+        },
+        "saucelabs": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz"
+        }
+      }
+    },
+    "karma-script-launcher": {
+      "version": "0.1.0",
+      "from": "https://registry.npmjs.org/karma-script-launcher/-/karma-script-launcher-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/karma-script-launcher/-/karma-script-launcher-0.1.0.tgz"
+    },
+    "load-grunt-tasks": {
+      "version": "0.3.0",
+      "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.3.0.tgz",
+      "dependencies": {
+        "globule": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            },
+            "glob": {
+              "version": "3.2.9",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2.5.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "findup-sync": {
+          "version": "0.1.2",
+          "from": "findup-sync@0.1.2",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.2.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.1.21",
+              "from": "glob@3.1.21",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@0.2.14",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "1.2.3",
+                  "from": "graceful-fs@1.2.3",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                },
+                "inherits": {
+                  "version": "1.0.0",
+                  "from": "inherits@1.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                }
+              }
+            },
+            "lodash": {
+              "version": "1.0.1",
+              "from": "lodash@1.0.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "lodash": {
+      "version": "2.1.0",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.1.0.tgz"
+    },
+    "marked": {
+      "version": "0.3.1",
+      "from": "https://registry.npmjs.org/marked/-/marked-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.1.tgz"
+    },
+    "node-html-encoder": {
+      "version": "0.0.2",
+      "from": "node-html-encoder@0.0.2",
+      "resolved": "https://registry.npmjs.org/node-html-encoder/-/node-html-encoder-0.0.2.tgz"
+    },
+    "promises-aplus-tests": {
+      "version": "1.3.2",
+      "from": "https://registry.npmjs.org/promises-aplus-tests/-/promises-aplus-tests-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/promises-aplus-tests/-/promises-aplus-tests-1.3.2.tgz",
+      "dependencies": {
+        "mocha": {
+          "version": "1.11.0",
+          "from": "https://registry.npmjs.org/mocha/-/mocha-1.11.0.tgz",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.11.0.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+            },
+            "growl": {
+              "version": "1.7.0",
+              "from": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
+            },
+            "jade": {
+              "version": "0.26.3",
+              "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+              "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+                }
+              }
+            },
+            "diff": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/diff/-/diff-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.2.tgz"
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "ms": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.3.0.tgz"
+            },
+            "glob": {
+              "version": "3.2.1",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.1.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@0.2.14",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "1.2.3",
+                  "from": "graceful-fs@1.2.3",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                },
+                "inherits": {
+                  "version": "1.0.0",
+                  "from": "inherits@1.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "sinon": {
+          "version": "1.7.3",
+          "from": "https://registry.npmjs.org/sinon/-/sinon-1.7.3.tgz",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.7.3.tgz",
+          "dependencies": {
+            "buster-format": {
+              "version": "0.5.6",
+              "from": "https://registry.npmjs.org/buster-format/-/buster-format-0.5.6.tgz",
+              "resolved": "https://registry.npmjs.org/buster-format/-/buster-format-0.5.6.tgz",
+              "dependencies": {
+                "buster-core": {
+                  "version": "0.6.4",
+                  "from": "https://registry.npmjs.org/buster-core/-/buster-core-0.6.4.tgz",
+                  "resolved": "https://registry.npmjs.org/buster-core/-/buster-core-0.6.4.tgz"
+                }
+              }
+            }
+          }
+        },
+        "underscore": {
+          "version": "1.4.4",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+        }
+      }
+    },
+    "protractor": {
+      "version": "0.19.0",
+      "from": "https://registry.npmjs.org/protractor/-/protractor-0.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/protractor/-/protractor-0.19.0.tgz",
+      "dependencies": {
+        "selenium-webdriver": {
+          "version": "2.39.0",
+          "from": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.39.0.tgz",
+          "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.39.0.tgz"
+        },
+        "minijasminenode": {
+          "version": "0.2.7",
+          "from": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-0.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-0.2.7.tgz"
+        },
+        "saucelabs": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz"
+        },
+        "glob": {
+          "version": "3.2.9",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2.5.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "adm-zip": {
+          "version": "0.4.4",
+          "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        }
+      }
+    },
+    "q": {
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/q/-/q-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.0.0.tgz"
+    },
+    "q-io": {
+      "version": "1.10.9",
+      "from": "https://registry.npmjs.org/q-io/-/q-io-1.10.9.tgz",
+      "resolved": "https://registry.npmjs.org/q-io/-/q-io-1.10.9.tgz",
+      "dependencies": {
+        "q": {
+          "version": "0.9.7",
+          "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+        },
+        "qs": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.1.0.tgz"
+        },
+        "url2": {
+          "version": "0.0.0",
+          "from": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+        },
+        "mimeparse": {
+          "version": "0.1.4",
+          "from": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz"
+        },
+        "collections": {
+          "version": "0.2.2",
+          "from": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
+          "dependencies": {
+            "weak-map": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "qq": {
+      "version": "0.3.5",
+      "from": "https://registry.npmjs.org/qq/-/qq-0.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/qq/-/qq-0.3.5.tgz",
+      "dependencies": {
+        "q": {
+          "version": "0.8.4",
+          "from": "https://registry.npmjs.org/q/-/q-0.8.4.tgz",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.8.4.tgz"
+        }
+      }
+    },
+    "rewire": {
+      "version": "1.1.3",
+      "from": "https://registry.npmjs.org/rewire/-/rewire-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-1.1.3.tgz"
+    },
+    "semver": {
+      "version": "2.1.0",
+      "from": "https://registry.npmjs.org/semver/-/semver-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-2.1.0.tgz"
+    },
+    "shelljs": {
+      "version": "0.2.6",
+      "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.2.6.tgz"
+    },
+    "winston": {
+      "version": "0.7.2",
+      "from": "https://registry.npmjs.org/winston/-/winston-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.7.2.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "cycle": {
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+        },
+        "eyes": {
+          "version": "0.1.8",
+          "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+        },
+        "pkginfo": {
+          "version": "0.3.0",
+          "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
+        },
+        "request": {
+          "version": "2.16.6",
+          "from": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
+          "dependencies": {
+            "form-data": {
+              "version": "0.0.10",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
+              "dependencies": {
+                "combined-stream": {
+                  "version": "0.0.4",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mime": {
+              "version": "1.2.11",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            },
+            "hawk": {
+              "version": "0.10.2",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.7.6",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz"
+                },
+                "boom": {
+                  "version": "0.3.8",
+                  "from": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz"
+                },
+                "cryptiles": {
+                  "version": "0.1.3",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz"
+                },
+                "sntp": {
+                  "version": "0.1.4",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.1",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+            },
+            "cookie-jar": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz"
+            },
+            "aws-sign": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz"
+            },
+            "oauth-sign": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz"
+            },
+            "qs": {
+              "version": "0.5.6",
+              "from": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
+            }
+          }
+        },
+        "stack-trace": {
+          "version": "0.0.9",
+          "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+        }
+      }
+    },
+    "yaml-js": {
+      "version": "0.0.8",
+      "from": "https://registry.npmjs.org/yaml-js/-/yaml-js-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/yaml-js/-/yaml-js-0.0.8.tgz"
+    }
+  }
+}


### PR DESCRIPTION
We need to be able to build angular at older shas, without the lock file / shrinkwrap file
the dependencies will resolve differently on different machines and at different times.

This will help us avoid broken builds and hard to track down issues.

I had to manually edit this file after it was generated because `npm shrinkwrap` will install
optional dependencies as if they were hard dependencies.

See: https://github.com/npm/npm/issues/2679#issuecomment-37361236

My manual edit:

```
diff --git a/npm-shrinkwrap.json b/npm-shrinkwrap.json
index 756df44..dc157eb 100644
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3110,19 +3110,7 @@
         "chokidar": {
           "version": "0.8.1",
           "from": "https://registry.npmjs.org/chokidar/-/chokidar-0.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.8.1.tgz",
-          "dependencies": {
-            "fsevents": {
-              "version": "0.1.6",
-              "from": "fsevents@0.1.6",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.1.6.tgz"
-            },
-            "recursive-readdir": {
-              "version": "0.0.2",
-              "from": "recursive-readdir@0.0.2",
-              "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-0.0.2.tgz"
-            }
-          }
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.8.1.tgz"
         },
         "glob": {
           "version": "3.2.9",
```
