### PR TITLE
fixed indentation of input.js comment

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1414,14 +1414,14 @@ var VALID_CLASS = 'ng-valid',
  * @property {Array.<Function>} $formatters Array of functions to execute, as a pipeline, whenever
        the model value changes. Each function is called, in turn, passing the value through to the
        next. Used to format / convert values for display in the control and validation.
- *      ```js
- *      function formatter(value) {
- *        if (value) {
- *          return value.toUpperCase();
- *        }
- *      }
- *      ngModel.$formatters.push(formatter);
- *      ```
+ * ```js
+ *   function formatter(value) {
+ *     if (value) {
+ *       return value.toUpperCase();
+ *     }
+ *   }
+ *   ngModel.$formatters.push(formatter);
+ * ```
  *
  * @property {Array.<Function>} $viewChangeListeners Array of functions to execute whenever the
  *     view value has changed. It is called with no arguments, and its return value is ignored.


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

the doc's code block of `$formatter` in [http://docs.angularjs.org/api/ng/type/ngModel.NgModelController](http://docs.angularjs.org/api/ng/type/ngModel.NgModelController) looks like

![2014-03-12 21 17 53](https://f.cloud.github.com/assets/1506738/2397075/99dc7492-a9e4-11e3-9e42-77a54a2bd616.png)

So I fixed indentation of code block in `input.js` 

**Other Comments:**
