### PR TITLE
test(ngClass): add test for ngClassOdd/Even with negative $index

### DIFF
--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -216,6 +216,17 @@ describe('ngClass', function() {
     expect(e2.hasClass('D')).toBeFalsy();
   }));
 
+  it('should calculate ngClassOdd/Even when $index is negative', inject(function($rootScope, $compile){
+    element = $compile("<ul><li ng-repeat=\"(key,value) in {'-1': '', '-2': ''}\" ng-init=\"$index = key\" ng-class-even=\"'even'\" ng-class-odd=\"'odd'\" class=\"exists\">{{ $index }}</li></ul>")($rootScope);
+    $rootScope.$digest();
+    var e1 = jqLite(element[0].childNodes[1]);
+    var e2 = jqLite(element[0].childNodes[3]);
+    expect(e1.hasClass('exists')).toBeTruthy();
+    expect(e1.hasClass('even')).toBeTruthy();
+    expect(e2.hasClass('exists')).toBeTruthy();
+    expect(e2.hasClass('odd')).toBeTruthy();
+  }));
+
 
   it('should reapply ngClass when interpolated class attribute changes', inject(function($rootScope, $compile) {
     element = $compile('<div class="one {{cls}} three" ng-class="{four: four}"></div>')($rootScope);


### PR DESCRIPTION
Request Type: test

How to reproduce: 

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

Add in a test to ensure that even/odd is calculated correctly with
negative index

Closes #5204
