### PR TITLE
input[type=radio] with object behind ng-model

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1202,7 +1202,7 @@ function radioInputType(scope, element, attr, ctrl) {
 
   ctrl.$render = function() {
     var value = attr.value;
-    element[0].checked = (value == ctrl.$viewValue);
+    element[0].checked = angular.equals(value, ctrl.$viewValue);
   };
 
   attr.$observe('value', ctrl.$render);


### PR DESCRIPTION
Request Type: bug

How to reproduce: Use object for ng-model for input[radio]

Component(s): misc core

Impact: medium

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

If you use object as models with radio, then the `$render` method won't be ever called, because of `{} == {}` is always `false`. So we should use angular.equals instead of ==.
