### PR TITLE
fix(docs) Update angular-mocks.js

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1821,8 +1821,8 @@ angular.module('ngMockE2E', ['ng']).config(['$provide', function($provide) {
  *    an array containing response status (number), response data (string) and response headers
  *    (Object).
  *  - passThrough – `{function()}` – Any request matching a backend definition with `passThrough`
- *    handler, will be pass through to the real backend (an XHR request will be made to the
- *    server.
+ *    handler will be passed through to the real backend (an XHR request will be made to the
+ *    server.)
  */
 
 /**


### PR DESCRIPTION
Grammar nitpick - I got here by clicking the "improve this doc" feature on the website. That's neat.
