### PR TITLE
fix(version-info): explicitly specify the remote

### DIFF
--- a/lib/versions/version-info.js
+++ b/lib/versions/version-info.js
@@ -103,7 +103,9 @@ var getPreviousVersions =  function() {
   // always use the remote tags as the local clone might
   // not contain all commits when cloned with git clone --depth=...
   // Needed e.g. for Travis
-  var tagResults = shell.exec('git ls-remote --tags | grep -o -e "v[0-9].*[0-9]$"', {silent: true});
+  var repo_url = currentPackage.repository.url;
+  var tagResults = shell.exec('git ls-remote --tags ' + repo_url + ' | grep -o -e "v[0-9].*[0-9]$"',
+                              {silent: true});
   if ( tagResults.code === 0 ) {
     return _(tagResults.output.trim().split('\n'))
       .map(function(tag) {
@@ -172,6 +174,6 @@ var getSnapshotVersion = function() {
 
 
 exports.currentPackage = currentPackage = getPackage();
+exports.gitRepoInfo = gitRepoInfo = getGitRepoInfo();
 exports.previousVersions = previousVersions = getPreviousVersions();
 exports.currentVersion = getTaggedVersion() || getSnapshotVersion();
-exports.gitRepoInfo = getGitRepoInfo();


### PR DESCRIPTION
`git ls-remote --tags` assumes that you have a remote set up for your
current branch.  That isn't the case, at least for me, when I'm working
on local branches.  `grunt write` doesn't do the right thing in that
case (`git ls-remote --tags` bails out and the silent: true param makes
this a pain to debug.)  Prefer explicit to implicit.
