### PR TITLE
fix(ngOptions): don't change user selections while <select> open in fire...

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -531,7 +531,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
                   lastElement.val(existingOption.id = option.id);
                 }
                 // lastElement.prop('selected') provided by jQuery has side-effects
-                if (lastElement[0].selected !== option.selected) {
+                if (existingOption.selected !== option.selected) {
                   lastElement.prop('selected', (existingOption.selected = option.selected));
                 }
               } else {


### PR DESCRIPTION
Sample patch that fixes issue #6679 but may regress parts of the code base.

I'm finding it difficult to verify the test suite because these unit tests are failing for me in New Zealand (see issue #5017). But time zone errors aside, I believe my patch breaks subtly with this output: 

```
Chrome 33.0.1750 (Linux) select ngOptions binding should select correct input if previously selected option was "?" FAILED
  Expected '1' to equal '0'.
  Error: Expected '1' to equal '0'.
      at null.<anonymous> (/home/mbgray/workspace/angular.js/test/ng/directive/selectSpec.js:965:31)
  Expected false to be truthy.
  Error: Expected false to be truthy.
      at null.<anonymous> (/home/mbgray/workspace/angular.js/test/ng/directive/selectSpec.js:966:63)
```

I'm submitting it anyway because it might be a starting point for conversation and other fixes. I'm not as comfortable this deep in the framework and didn't know how to take this further.
