### PR TITLE
docs($http): update shortcut method description

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -236,9 +236,8 @@ function $HttpProvider() {
      *
      * # Shortcut methods
      *
-     * Since all invocations of the $http service require passing in an HTTP method and URL, and
-     * POST/PUT requests require request data to be provided as well, shortcut methods
-     * were created:
+     * Shortcut methods are also available. All shortcut methods require passing in the URL, and
+     * request data must be passed in for POST/PUT requests.
      *
      * ```js
      *   $http.get('/someUrl').success(successCallback);


### PR DESCRIPTION
Update docs to reflect that $http no longer requires passing in an HTTP method, as changed in #6401.
