### PR TITLE
fix(input): format numeric string model values correctly

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1160,6 +1160,9 @@ function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   }
 
   ctrl.$formatters.push(function(value) {
+    if (isString(value) && !isNaN(value)) {
+      value = Number(value);
+    }
     return validate(ctrl, 'number', ctrl.$isEmpty(value) || isNumber(value), value);
   });
 }

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1538,6 +1538,54 @@ describe('input', function() {
     });
 
 
+    it('should translate numeric base-10 strings in model to numbers', function() {
+      compileInput('<input type="number" ng-model="age" />');
+
+      scope.$apply(function() {
+        scope.age = '10';
+      });
+
+      expect(scope.age).toBe('10');
+      expect(inputElm.val()).toBe('10');
+    });
+
+
+    it('should translate numeric base-16 strings in model to numbers', function() {
+      compileInput('<input type="number" ng-model="age" />');
+
+      scope.$apply(function() {
+        scope.age = '0xFf';
+      });
+
+      expect(scope.age).toBe('0xFf');
+      expect(inputElm.val()).toBe('255');
+    });
+
+
+    it('should translate scientific notation from numeric strings in model to numbers', function() {
+      compileInput('<input type="number" ng-model="age" />');
+
+      scope.$apply(function() {
+        scope.age = '0.1e6';
+      });
+
+      expect(scope.age).toBe('0.1e6');
+      expect(inputElm.val()).toBe('100000');
+    });
+
+
+    it('should remove leading zeros from numeric strings in model', function() {
+      compileInput('<input type="number" ng-model="age" />');
+
+      scope.$apply(function() {
+        scope.age = '010';
+      });
+
+      expect(scope.age).toBe('010');
+      expect(inputElm.val()).toBe('10');
+    });
+
+
     describe('min', function() {
 
       it('should validate', function() {


### PR DESCRIPTION
Previously, when a numeric string is used as a model value, the number input
type would not format the value. This patch corrects this behaviour by
converting to a number before performing validation, if the value is a string
and not NaN.

Closes #6683
