### PR TITLE
Consistent capitalisation of "Angular" for step_06.ngdoc

### DIFF
--- a/docs/content/tutorial/step_06.ngdoc
+++ b/docs/content/tutorial/step_06.ngdoc
@@ -63,7 +63,7 @@ the element attribute.
 
 We also added phone images next to each record using an image tag with the {@link
 ng.directive:ngSrc ngSrc} directive. That directive prevents the
-browser from treating the angular `{{ expression }}` markup literally, and initiating a request to
+browser from treating the Angular `{{ expression }}` markup literally, and initiating a request to
 invalid url `http://localhost:8000/app/{{phone.imageUrl}}`, which it would have done if we had only
 specified an attribute binding in a regular `src` attribute (`<img src="{{phone.imageUrl}}">`).
 Using the `ngSrc` directive prevents the browser from making an http request to an invalid location.


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: large

Complexity: small

This issue is related to: 

**Detailed Description:**

Consistent capitalisation of "Angular"

**Other Comments:**
