### PR TITLE
docs(misc/contribute): make anchor links work properly

### DIFF
--- a/docs/content/misc/contribute.ngdoc
+++ b/docs/content/misc/contribute.ngdoc
@@ -11,12 +11,12 @@ See the [contributing guidelines](https://github.com/angular/angular.js/blob/mas
 for how to contribute your own code to AngularJS.
 
 
-1. {@link #building-and-testing-angularjs_installing-dependencies Installing Dependencies}
-2. {@link #building-and-testing-angularjs_forking-angular-on-github Forking Angular on Github}
-3. {@link #building-and-testing-angularjs_building-angularjs Building AngularJS}
-4. {@link #building-and-testing-angularjs_running-a-local-development-web-server Running a Local Development Web Server}
-5. {@link #building-and-testing-angularjs_running-the-unit-test-suite Running the Unit Test Suite}
-6. {@link #building-and-testing-angularjs_running-the-end-to-end-test-suite Running the End-to-end Test Suite}
+1. {@link misc/contribute#installing-dependencies Installing Dependencies}
+2. {@link misc/contribute#forking-angular-on-github Forking Angular on Github}
+3. {@link misc/contribute#building-angularjs Building AngularJS}
+4. {@link misc/contribute#running-a-local-development-web-server Running a Local Development Web Server}
+5. {@link misc/contribute#running-the-unit-test-suite Running the Unit Test Suite}
+6. {@link misc/contribute#running-the-end-to-end-test-suite Running the End-to-end Test Suite}
 
 ## Installing Dependencies
 


### PR DESCRIPTION
The hash links in misc/contribute were never going to hit the right target, and would cause a
404 (which, by the way, causes over 1000 errors in the console, it would be good to look into
those!).

This probably isn't the best solution for this, but it works for now, so that's nice.
