### PR TITLE
docs(ngForm): remove duplicate @param annotation

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -360,8 +360,6 @@ function FormController(element, attrs, $scope, $animate) {
       </file>
     </example>
  *
- * @param {string=} name Name of the form. If specified, the form controller will be published into
- *                       related scope, under this name.
  */
 var formDirectiveFactory = function(isNgForm) {
   return ['$timeout', function($timeout) {


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): forms

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

When the example for `ngAnimate` was added in commit:3344396, the `@param name` annotation was unintentionally duplicated. Remove this duplicate.

**Other Comments:**
