### PR TITLE
Update nonassign.ngdoc

### DIFF
--- a/docs/content/error/$compile/nonassign.ngdoc
+++ b/docs/content/error/$compile/nonassign.ngdoc
@@ -30,6 +30,9 @@ Following are invalid uses of this directive:
 
 <!-- ERROR because `myFn()=localValue` is an invalid statement -->
 <my-directive bind="myFn()">
+
+<!-- ERROR because attribute bind wasn't provided -->
+<my-directive>
 ```
 
 


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): $compile

Impact: medium

Complexity: small

This issue is related to: 

**Detailed Description:**

It might seem obvious that if you don't supply "bind" attribute in this case, you'll get an error, but I feel this is worth adding to the doc, because this was my error, and the documentation led me to try every permutation of attribute values on <my-directive>1, and completely missed the fact that <my-directive>2 in my code didn't have ANY attribute.  If my proposed edit had been there, I might have found my problem earlier.

**Other Comments:**
