### PR TITLE
feat(ngClass): one can pass an $element variable into ngClass expression functions

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -2,16 +2,17 @@
 
 function classDirective(name, selector) {
   name = 'ngClass' + name;
-  return function() {
+  return ['$parse', function($parse) {
     return {
       restrict: 'AC',
       link: function(scope, element, attr) {
         var oldVal;
 
-        scope.$watch(attr[name], ngClassWatchAction, true);
+        var expression = $parse(attr[name]).bind(null, scope, { $element: element });
+        scope.$watch(expression, ngClassWatchAction, true);
 
         attr.$observe('class', function(value) {
-          ngClassWatchAction(scope.$eval(attr[name]));
+          ngClassWatchAction(expression());
         });
 
 
@@ -20,7 +21,7 @@ function classDirective(name, selector) {
             // jshint bitwise: false
             var mod = $index & 1;
             if (mod !== old$index & 1) {
-              var classes = flattenClasses(scope.$eval(attr[name]));
+              var classes = flattenClasses(expression());
               mod === selector ?
                 attr.$addClass(classes) :
                 attr.$removeClass(classes);
@@ -59,7 +60,7 @@ function classDirective(name, selector) {
         }
       }
     };
-  };
+  }];
 }
 
 /**

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -303,6 +303,19 @@ describe('ngClass', function() {
     expect(e2.hasClass('even')).toBeTruthy();
     expect(e2.hasClass('odd')).toBeFalsy();
   }));
+
+  it('should pass the $element variable to functions in expression', inject(function($rootScope, $compile){
+    element = $compile('<div>' +
+      '<div ng-class="{\'some-class\': fn($element)}"></div>' +
+      '</div>')($rootScope);
+    var el;
+    $rootScope.fn = function(theElement){
+      el = theElement && theElement[0];
+    };
+    $rootScope.$digest();
+
+    expect(el).toBe(element.children()[0]);
+  }));
 });
 
 describe('ngClass animations', function() {


### PR DESCRIPTION
When using directives like `ngClick`, `ngFocus`, `ngKeydown`, `ngMousemove` etc. AngularJS passes a special `$event` object to any function that basically is an event listener. 

One can then write in HTML

``` html
ng-click="someHandler($event)"
```

and in javascript:

``` javascript
$scope.someHandler = function(event){
    var element = $(event.currentTarget);
    // some other code
};
```

to get ahold of the HTML element (actually jQuery of jqLite object containing it) that the `ngClick` directive was applied to in the first place.

However in current version of AngularJS it is impossible to easily access that element using `ngClass` directive. This pull request makes it possible to pass a special `$element` object to any function in an `ngClass` expression so one can now write:

``` html
ng-class="{'some-class': someCondition($element)}"
```

``` javascript
$scope.someCondition = function(element){
    if(conditionsThatElementMustMeet(element))
        return true;
    else
        return false;
};
```

A real example might be a situation when one wants to apply a class to an element if and only if it's content is overflowing:

``` css
#my-element{
    overflow: hidden;
    width: 50px;
    display: inline-block;
    white-space: nowrap;
    text-overflow: ellipsis;
}
```

``` html
<div id="my-element" ng-class="{'it-is-overflowing': isOverflowing($element)}">
    {{modelBinding}}
</div>
```

``` javascript
$scope.modelBinding = 'some string content'; // this could be user input
$scope.isOverflowing = function(element){
    // actual check whether the element's content is overflowing
    return element[0].scrollWidth > element[0].clientWidth;
};
```

Live code example here: http://jsfiddle.net/YAWGd/
