### PR TITLE
feat($http): pass success flag to transformResponse

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -64,14 +64,15 @@ function headersGetter(headers) {
  * @param {*} data Data to transform.
  * @param {function(string=)} headers Http headers getter fn.
  * @param {(Function|Array.<Function>)} fns Function or an array of functions.
+ * @param {boolean} success True when this is response and it is success
  * @returns {*} Transformed data.
  */
-function transformData(data, headers, fns) {
+function transformData(data, headers, fns, success) {
   if (isFunction(fns))
-    return fns(data, headers);
+    return fns(data, headers, success);
 
   forEach(fns, function(fn) {
-    data = fn(data, headers);
+    data = fn(data, headers, success);
   });
 
   return data;
@@ -739,13 +740,12 @@ function $HttpProvider() {
       return promise;
 
       function transformResponse(response) {
-        // make a copy since the response must be cacheable
-        var resp = extend({}, response, {
-          data: transformData(response.data, response.headers, config.transformResponse)
-        });
-        return (isSuccess(response.status))
-          ? resp
-          : $q.reject(resp);
+        var success = isSuccess(response.status),
+          // make a copy since the response must be cacheable
+          resp = extend({}, response, {
+            data: transformData(response.data, response.headers, config.transformResponse, success)
+          });
+        return success ? resp : $q.reject(resp);
       }
 
       function mergeHeaders(config) {

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1097,6 +1097,19 @@ describe('$http', function() {
           expect(callback.mostRecentCall.args[0]).toBe('header1');
         });
 
+        it('should know when response is failed', function() {
+          $httpBackend.expect('GET', '/url').respond(404, 'Not found');
+          $http.get('/url', {
+            transformResponse: function(data, headers, success) {
+              return success;
+            }
+          }).error(callback);
+          $httpBackend.flush();
+
+          expect(callback).toHaveBeenCalledOnce();
+          expect(callback.mostRecentCall.args[0]).toBe(false);
+        });
+
 
         it('should pipeline more functions', function() {
           function first(d, h) {return d + '-first' + ':' + h('h1')}


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): $http

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

Now `transformResponse` doesn't know about request is successful or not.
So, it is impossible to make some transformation only on success response. For example, I wrap response into object for easier handling:

``` javascript
function Post(data) {
  this.author = data.user.name;
  this.annotation = data.content.split('\n')[0];
}

$http.get('/posts', {
  transformResponse: function transformResponse(data) {
    return new Post(data)
  }
});
```

When request has failed, response doesn't contain a fields required by the post and it causes an Exeption.
With this fix I will can create the post only from success responses

``` javascript
$http.get('/posts', {
  transformResponse: function transformResponse(data, headers, success) {
    return success ? new Post(data) : data
  }
});
```
