### PR TITLE
fix(foreach): change foreach to support NamedNodeMap

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -243,8 +243,13 @@ function forEach(obj, iterator, context) {
     } else if (obj.forEach && obj.forEach !== forEach) {
       obj.forEach(iterator, context);
     } else if (isArrayLike(obj)) {
-      for (key = 0; key < obj.length; key++)
+      for (key = 0; key < obj.length; key++) {
         iterator.call(context, obj[key], key);
+      }
+    } else if (isNumber(obj.length) && isFunction(obj.item)) {
+      for (key = 0; key < obj.length; key++) {
+        iterator.call(context, obj.item(key), key);
+      }
     } else {
       for (key in obj) {
         if (obj.hasOwnProperty(key)) {


### PR DESCRIPTION
Request Type: bug

How to reproduce: The Caja browser does not expose numeric accessors on Element.attributes, only the NamedNodeMap interface, so Element.attributes fails to pass isArrayLike and thus no appElement is ever set.

https://code.google.com/p/google-caja/issues/detail?id=1905

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Most but not all browsers (e.g. Caja) make Element.attributes pass the isArrayLike() test, which is why this bug was not caught earlier.

**Other Comments:**
