### PR TITLE
docs(ngMock/angular-mocks) added response to whenPOST mock

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1806,7 +1806,9 @@ angular.module('ngMockE2E', ['ng']).config(['$provide', function($provide) {
  *
  *     // adds a new phone to the phones array
  *     $httpBackend.whenPOST('/phones').respond(function(method, url, data) {
- *       phones.push(angular.fromJson(data));
+ *       var phone = angular.fromJson(data);
+ *       phones.push(phone);
+ *       return [200, phone, {}];
  *     });
  *     $httpBackend.whenGET(/^\/templates\//).passThrough();
  *     //...


### PR DESCRIPTION
**Request Type**: docs

**How to reproduce:** Use whenPOST without returning a response

**Component(s):** ngMocks

**Impact:** small

**Complexity:** small

**This issue is related to:** whenPOST (mocking)

**Detailed Description:** The  `whenPOST` method should return a response containing status, response body and headers. If omitted the following error will be thrown:

`Uncaught TypeError: Cannot read property '2' of undefined`

The documentation doesn't make it very clear, so I think it will be appropriate to add.
