### PR TITLE
fix($filter): $orderBy filter with dates when sorting multiple fields

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -105,6 +105,10 @@ function orderByFilter($parse){
       var t1 = typeof v1;
       var t2 = typeof v2;
       if (t1 == t2) {
+        if (isDate(v1) && isDate(v2)) {
+          v1 = v1.valueOf();
+          v2 = v2.valueOf();
+        }
         if (t1 == "string") {
            v1 = v1.toLowerCase();
            v2 = v2.toLowerCase();

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -23,6 +23,36 @@ describe('Filter: orderBy', function() {
     expect(orderBy([{a:15, b:1}, {a:2, b:1}], ['+b', '-a'])).toEqualData([{a:15, b:1}, {a:2, b:1}]);
   });
 
+
+  it('should sort array by date predicate', function() {
+    // same dates
+    expect(orderBy([
+            { a:new Date('01/01/2014'), b:1 },
+            { a:new Date('01/01/2014'), b:3 },
+            { a:new Date('01/01/2014'), b:4 },
+            { a:new Date('01/01/2014'), b:2 }],
+            ['a', 'b']))
+    .toEqualData([
+            { a:new Date('01/01/2014'), b:1 },
+            { a:new Date('01/01/2014'), b:2 },
+            { a:new Date('01/01/2014'), b:3 },
+            { a:new Date('01/01/2014'), b:4 }]);
+
+    // one different date
+    expect(orderBy([
+            { a:new Date('01/01/2014'), b:1 },
+            { a:new Date('01/01/2014'), b:3 },
+            { a:new Date('01/01/2013'), b:4 },
+            { a:new Date('01/01/2014'), b:2 }],
+            ['a', 'b']))
+    .toEqualData([
+            { a:new Date('01/01/2013'), b:4 },
+            { a:new Date('01/01/2014'), b:1 },
+            { a:new Date('01/01/2014'), b:2 },
+            { a:new Date('01/01/2014'), b:3 }]);
+  });
+
+
   it('should use function', function() {
     expect(
       orderBy(


### PR DESCRIPTION
Request Type: 

How to reproduce: 

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

Request Type: 

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

extend compare method to use Date.valueOf() when comparing dates

closes #6676 
