### PR TITLE
package.json is missing the version field, which breaks npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "angularjs",
+  "version": "1.3.0-beta.2",
   "branchVersion": "1.3.*",
   "cdnVersion": "1.3.0-beta.2",
   "repository": {


### PR DESCRIPTION
Request Type: bug

How to reproduce: Try to do:

```
npm install --save-dev https://github.com/angular/angular.js/tarball/master
```

Note that it won't succeed because there's no version in the package.json.

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

This is fixed with pull request https://github.com/angular/angular.js/pull/6752

**Other Comments:**

In order to be able to support `npm install --save-dev https://github.com/angular/angular.js/tarball/master`, repositories need to have a version field in their package.json.
