### PR TITLE
Clarify behaviour of $promise in ngResource when using an interceptor

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -198,6 +198,9 @@ function shallowClearAndCopy(src, dst) {
  *
  *     On failure, the promise is resolved with the {@link ng.$http http response} object, without
  *     the `resource` property.
+ * 
+ *     If an interceptor object was provided, the promise will instead be resolved with the value
+ *     returned by the interceptor.
  *
  *   - `$resolved`: `true` after first server interaction is completed (either with success or
  *      rejection), `false` before that. Knowing if the Resource has been resolved is useful in


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): ngResource

Impact: 

Complexity: 

This issue is related to: 

**Detailed Description:**

When an interceptor is used in ngResource, the $promise is no longer resolved with the resource object, but instead with the value returned by the interceptor. This is now specified in the docs.

**Other Comments:**
