### PR TITLE
$Document Example

### DIFF
--- a/src/ng/document.js
+++ b/src/ng/document.js
@@ -7,6 +7,22 @@
  *
  * @description
  * A {@link angular.element jQuery or jqLite} wrapper for the browser's `window.document` object.
+ *
+ * @example
+   <example>
+     <file name="index.html">
+       <div ng-controller="MainCtrl">
+         <p>$document title: <b ng-bind="title"></b></p>
+         <p>window.document title: <b ng-bind="windowTitle"></b></p>
+       </div>
+     </file>
+     <file name="script.js">
+       function MainCtrl($scope, $document) {
+         $scope.title = $document[0].title;
+         $scope.windowTitle = angular.element(window.document)[0].title;
+       }
+     </file>
+   </example>
  */
 function $DocumentProvider(){
   this.$get = ['$window', function(window){


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

An example to show how $document is essentially the same as the window.document wrapped in an angular.element expression.

**Other Comments:**
