### PR TITLE
test($rootScope): add assertion to test ensuring that NaN -> NaN does not throw

### DIFF
--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -605,7 +605,9 @@ describe('Scope', function() {
 
         it('should not infinitely digest when current value is NaN', function() {
           $rootScope.obj = [NaN];
-          $rootScope.$digest();
+          expect(function() {
+            $rootScope.$digest();
+          }).not.toThrow();
         });
 
         it('should watch array-like objects like arrays', function () {


### PR DESCRIPTION
https://github.com/angular/angular.js/commit/fb6062fb9d83545730b993e94ac7482ffd43a62c implements a fix for NaN values causing $watchCollection to throw an infdig error. This change updates the test by adding an assertion which explains what is actually being tested a bit better, and may also provide better information in the event that the test ever fails.
