### PR TITLE
Added controllerAs example

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -64,6 +64,7 @@
  *       restrict: 'A',
  *       scope: false,
  *       controller: function($scope, $element, $attrs, $transclude, otherInjectables) { ... },
+ *       controllerAs: 'stringAlias',
  *       require: 'siblingDirectiveName', // or // ['^parentDirectiveName', '?optionalDirectiveName', '?^optionalParent'],
  *       compile: function compile(tElement, tAttrs, transclude) {
  *         return {


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): $compile

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

This documents the new `controllerAs` syntax in the example directive.
