### PR TITLE
fix(limitTo): do not convert Infinity to NaN

### DIFF
--- a/src/ng/filter/limitTo.js
+++ b/src/ng/filter/limitTo.js
@@ -73,7 +73,8 @@ function limitToFilter(){
   return function(input, limit) {
     if (!isArray(input) && !isString(input)) return input;
 
-    limit = int(limit);
+    if (Math.abs(Number(limit)) === Infinity) limit = Number(limit);
+    else limit = int(limit);
 
     if (isString(input)) {
       //NaN check on limit

--- a/test/ng/filter/limitToSpec.js
+++ b/test/ng/filter/limitToSpec.js
@@ -68,4 +68,18 @@ describe('Filter: limitTo', function() {
     expect(limitTo(str, -9)).toEqual(str);
     expect(limitTo(str, '-9')).toEqual(str);
   })
+
+  it('should return entire input array when limited by Infinity', function() {
+    expect(limitTo(items, Infinity)).toEqual(items);
+    expect(limitTo(items, 'Infinity')).toEqual(items);
+    expect(limitTo(items, -Infinity)).toEqual(items);
+    expect(limitTo(items, '-Infinity')).toEqual(items);
+  });
+
+  it('should return the entire string when limited by Infinity', function() {
+    expect(limitTo(str, Infinity)).toEqual(str);
+    expect(limitTo(str, 'Infinity')).toEqual(str);
+    expect(limitTo(str, -Infinity)).toEqual(str);
+    expect(limitTo(str, '-Infinity')).toEqual(str);
+  });
 });


### PR DESCRIPTION
`parseInt(Infinity, 10)` will result in `NaN`, which becomes undesirable when the
expected behaviour is to return the entire input.

I believe this is possibly useful as a way to toggle input limiting based on
certain factors.

Closes #6771
