### PR TITLE
fix(ngResource): resource instances should be instantiated with the corr...

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -501,7 +501,8 @@ angular.module('ngResource', ['ng']).
           /* jshint +W086 */ /* (purposefully fall through case statements) */
 
           var isInstanceCall = this instanceof Resource;
-          var value = isInstanceCall ? data : (action.isArray ? [] : new Resource(data));
+          var ResourceConstructor = this;
+          var value = isInstanceCall ? data : (action.isArray ? [] : new ResourceConstructor(data));
           var httpConfig = {};
           var responseInterceptor = action.interceptor && action.interceptor.response ||
                                     defaultResponseInterceptor;
@@ -535,7 +536,7 @@ angular.module('ngResource', ['ng']).
               if (action.isArray) {
                 value.length = 0;
                 forEach(data, function(item) {
-                  value.push(new Resource(item));
+                  value.push(new ResourceConstructor(item));
                 });
               } else {
                 shallowClearAndCopy(data, value);

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -798,6 +798,18 @@ describe("resource", function() {
         expect(promiseValue).toEqual({ value: 'transformed' });
         expect(successValue).toBe(promiseValue);
       });
+
+      it('should get instantiated with the correct constructor function', function(){
+	$httpBackend.expect('GET', '/CreditCard/123').respond({id: 123, number: '9876'});
+
+	CreditCard.prototype.someCustomMethod = function(){ return 'hello'; };
+
+	var cc = CreditCard.get({id: 123});
+
+	expect(cc.someCustomMethod).toBe(CreditCard.prototype.someCustomMethod);
+	expect(cc.someCustomMethod()).toEqual('hello');
+      });
+
     });
 
 
@@ -938,6 +950,21 @@ describe("resource", function() {
       var response = callback.mostRecentCall.args[0];
       expect(response.status).toBe(404);
       expect(response.config).toBeDefined();
+    });
+
+    it('should return a collection of objects instantiated with the correct constructor function', function(){
+      $httpBackend.expect('GET', '/CreditCard?key=value').respond([{id: 1}, {id: 2}]);
+
+      CreditCard.prototype.someCustomMethod = function(){ return 'hello'; };
+
+      var ccs = CreditCard.query({key: 'value'});
+
+      $httpBackend.flush();
+
+      expect(ccs[0].someCustomMethod).toBe(CreditCard.prototype.someCustomMethod);
+      expect(ccs[0].someCustomMethod()).toEqual('hello');
+      expect(ccs[1].someCustomMethod).toBe(CreditCard.prototype.someCustomMethod);
+      expect(ccs[1].someCustomMethod()).toEqual('hello');
     });
   });
 


### PR DESCRIPTION
### The problem

Consider a simple Resource 'class' with a custom method added to the prototype:

``` js
var User = $resource('/user/:userId', {userId:'@id'});
User.prototype.sayHello = function(){};
```

Then this will work:

``` js
var user = new User();
user.sayHi();
```

But when one or more instances are retrieved using `.get()` or `.query()`, the wrong constructor is used, causing this functionality to break:

``` js
// When using .get()
var user = User.get({userId:123}, function() {
    user.sayHi(); // This will not work
});

// When using .query()
users = User.query(function(){
    var user = users[0];
    user.sayHi(); // This will not work
});
```

This is a result of instantiating the new resource instances directly from the `Resource` constructor defined in the `resourceFactory()` function and not the constructor of the current Resource 'class'.
### The fix

This PR makes sure the correct constructor is used and the prototype is chained correctly if resource instances are created by `.get()` or `.query()`.

``` js
// When using .get()
var user = User.get({userId:123}, function() {
    user.sayHi(); // This will now work as expected
});

// When using .query()
users = User.query(function(){
    var user = users[0];
    user.sayHi(); // This will now work as expected
});
```

This PR replaces and extends #5168 in that it now also includes support for objects instantiated by `query()` and is using a newer version of `ngResource`.
