### PR TITLE
Fix link to Closure Library

### DIFF
--- a/docs/content/misc/faq.ngdoc
+++ b/docs/content/misc/faq.ngdoc
@@ -72,7 +72,7 @@ The size of the file is < 36KB compressed and minified.
 
 ### Can I use the open-source Closure Library with Angular?
 
-Yes, you can use widgets from the [Closure Library](http://code.google.com/closure/library)
+Yes, you can use widgets from the [Closure Library](https://developers.google.com/closure/library/)
 in Angular.
 
 ### Does Angular use the jQuery library?


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: medium

Complexity: small

This issue is related to: 

**Detailed Description:**

The link (http://code.google.com/closure/library) throws a 404. The correct link seems to be https://developers.google.com/closure/library/

**Other Comments:**
