### PR TITLE
refactor($compile): allow adding directive collectors and extractors

### DIFF
--- a/test/BinderSpec.js
+++ b/test/BinderSpec.js
@@ -196,7 +196,7 @@ describe('Binder', function() {
       $exceptionHandlerProvider.mode('log');
     });
     inject(function($rootScope, $exceptionHandler, $compile) {
-      $compile('<div attr="before {{error.throw()}} after"></div>', null, true)($rootScope);
+      $compile('<div attr="before {{error.throw()}} after"></div>', null)($rootScope);
       var errorLogs = $exceptionHandler.errors;
       var count = 0;
 


### PR DESCRIPTION
Refactor `$compile` so it is able to accept directive collectors and directive extractors. Add all the current directive collectors and directive extractors that handle the current operations

This patch is to start the conversation if the refactor into directive collectors and directive extractors should be done at 1.3 or if this should wait to 2.0
