### PR TITLE
refactor($rootScope): add warnings when emitting/broadcasting on a destroyed scope

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -79,8 +79,8 @@ function $RootScopeProvider(){
     return TTL;
   };
 
-  this.$get = ['$injector', '$exceptionHandler', '$parse', '$browser',
-      function( $injector,   $exceptionHandler,   $parse,   $browser) {
+  this.$get = ['$injector', '$exceptionHandler', '$parse', '$browser', '$log',
+      function( $injector,   $exceptionHandler,   $parse,   $browser,   $log) {
 
     /**
      * @ngdoc type
@@ -970,6 +970,11 @@ function $RootScopeProvider(){
             listenerArgs = concat([event], arguments, 1),
             i, length;
 
+        if (this.$$destroyed) {
+          $log.warn("Trying to emit '" + name + "' on a destroyed scope");
+          return event;
+        }
+
         do {
           namedListeners = scope.$$listeners[name] || empty;
           event.currentScope = scope;
@@ -1034,6 +1039,11 @@ function $RootScopeProvider(){
             },
             listenerArgs = concat([event], arguments, 1),
             listeners, i, length;
+
+        if (this.$$destroyed) {
+          $log.warn("Trying to broadcast '" + name + "' on a destroyed scope");
+          return event;
+        }
 
         //down while you can, then up and next sibling or up and next sibling until back at root
         while ((current = next)) {

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -874,6 +874,43 @@ describe('Scope', function() {
       $rootScope.$broadcast(EVENT);
       expect(spy.callCount).toBe(1);
     }));
+
+
+    it('should warn when emitting on a destroyed scope', inject(function($rootScope, $log) {
+      var EVENTNAME = 'barEvent',
+          child = $rootScope.$new(),
+          warning,
+          event;
+
+      child.$destroy();
+
+      expect($log.warn.logs).toEqual([]);
+      event = child.$emit(EVENTNAME);
+      expect(event.name).toEqual(EVENTNAME);
+
+      warning = $log.warn.logs.shift();
+
+      expect(warning[0]).toContain(EVENTNAME);
+      expect(warning[0]).toContain('emit');
+    }));
+
+
+    it('should warn when broadcasting on a destroyed scope', inject(function($rootScope, $log) {
+      var EVENTNAME = 'bazEvent',
+          warning,
+          event;
+
+      $rootScope.$destroy();
+
+      expect($log.warn.logs).toEqual([]);
+      event = $rootScope.$broadcast(EVENTNAME);
+      expect(event.name).toEqual(EVENTNAME);
+
+      warning = $log.warn.logs.shift();
+
+      expect(warning[0]).toContain(EVENTNAME);
+      expect(warning[0]).toContain('broadcast');
+    }));
   });
 
 


### PR DESCRIPTION
When a scope is destroyed, all event listeners gets unregistered, and the connection to
the parent/child scopes are removed. Because of this, no one is noticed of the event.
$emit and $broadcast now logs a warning when trying to emit or broadcast an event on
a destroyed scope.

Closes #6768
