### PR TITLE
fix($compile): fix memory leak

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1465,9 +1465,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
               case '&':
                 parentGet = $parse(attrs[attrName]);
-                isolateScope[scopeName] = function(locals) {
-                  return parentGet(scope, locals);
-                };
+                isolateScope[scopeName] = parentGetFn(parentGet, scope);
                 break;
 
               default:
@@ -1813,6 +1811,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       }
     }
 
+   function parentGetFn(parentGet, scope) {
+     return function(locals) {
+       return parentGet(scope, locals);
+     };
+   }
 
     function getTrustedContext(node, attrNormalizedName) {
       if (attrNormalizedName == "srcdoc") {


### PR DESCRIPTION
For functions that have a '&' binding on the scope, change the function from an inline definition to an external definition so the function closure has no access to the parent scope.

Closes #6794

Note: I am not sure this if this is a Chrome GC bug (as the function never uses the parent scope), but for the scenario from the issue, the patch fixes the leak
