### PR TITLE
fix($compile): Major Memory Leak in Directive '&' attribute

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1462,9 +1462,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
               case '&':
                 parentGet = $parse(attrs[attrName]);
-                isolateScope[scopeName] = function(locals) {
-                  return parentGet(scope, locals);
-                };
+                isolateScope[scopeName] = parentGetFn(parentGet, scope);
                 break;
 
               default:
@@ -1809,8 +1807,19 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         });
       }
     }
-
-
+	/**
+	 * Wrapper for '&' One-way binding to prevent memory leak.
+	 * Backport from 1.3.x fix for bug #6794.
+	 * @param {function} parentGet Gets value from parent
+	 * @param {ng.$rootScope.Scope} scope Target Scope
+	 * @return {function} & Binding Fn
+	 */
+	function parentGetFn(parentGet, scope) {
+      return function (locals) {
+        return parentGet(scope, locals);
+      };
+    }
+	
     function getTrustedContext(node, attrNormalizedName) {
       if (attrNormalizedName == "srcdoc") {
         return $sce.HTML;

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1462,9 +1462,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
               case '&':
                 parentGet = $parse(attrs[attrName]);
-                isolateScope[scopeName] = function(locals) {
-                  return parentGet(scope, locals);
-                };
+                isolateScope[scopeName] = parentGetFn(parentGet, scope);
                 break;
 
               default:
@@ -1809,7 +1807,18 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         });
       }
     }
-
+	/**
+	 * Wrapper for '&' One-way binding to prevent memory leak.
+	 * Backport from 1.3.x fix for bug #6794.
+	 * @param {function} parentGet Gets value from parent
+	 * @param {ng.$rootScope.Scope} scope Target Scope
+	 * @return {function} & Binding Fn
+	 */
+	function parentGetFn(parentGet, scope) {
+      return function (locals) {
+        return parentGet(scope, locals);
+      };
+    }
 
     function getTrustedContext(node, attrNormalizedName) {
       if (attrNormalizedName == "srcdoc") {


### PR DESCRIPTION
Request Type: bug

How to reproduce: http://plnkr.co/edit/TW2TjC8JkxlDyQRCLcRg
Start on Home, click link for Leak directive, click link for Home page.
In chrome timeline force garbage collection.
Take heap snapshot. Despite being entirely gone from the page and no external references, directive is not GC'ed and because it contains a reference to it's parent, the parent is not collected either.

Component(s): $compile

Impact: large

Complexity: small

This issue is related to: a memory leak

**Detailed Description:**

When a directive is written using '&' reverse one way binding there is a major memory leak. 
when & attribute removed, leak is gone.

**Other Comments:**

For functions that have a '&' binding on the scope, change the function
from an inline definition to an external definition so the function
closure has no access to the parent scope.
Backport of fix on 1.3.x

Closes #6794
