### PR TITLE
Check if "input" variable is defined

### DIFF
--- a/docs/content/guide/filter.ngdoc
+++ b/docs/content/guide/filter.ngdoc
@@ -103,6 +103,10 @@ text upper-case.
     angular.module('MyReverseModule', []).
       filter('reverse', function() {
         return function(input, uppercase) {
+          // if nothing was entered yet
+          if(!(input)){
+            return;
+          }
           var out = "";
           for (var i = 0; i < input.length; i++) {
             out = input.charAt(i) + out;


### PR DESCRIPTION
By default, "greeting" textfield in this example is prepopulated with "hello" text, but it's pretty easy to copy just filter code to use it in your app. If your textfield is empty while app loads, you'll get an error: "Error: [$interpolate:interr] Can't interpolate: Reverse: {{greeting|reverse}} TypeError: Cannot read property 'length' of undefined". To prevent this, we should check "input" variable, and proceed only in case it is defined.
