### PR TITLE
docs(ngAnimate): change "&#64" to "@" symbol

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -106,11 +106,11 @@
  *   -webkit-animation: enter_sequence 1s linear; /&#42; Safari/Chrome &#42;/
  *   animation: enter_sequence 1s linear; /&#42; IE10+ and Future Browsers &#42;/
  * }
- * &#64-webkit-keyframes enter_sequence {
+ * @-webkit-keyframes enter_sequence {
  *   from { opacity:0; }
  *   to { opacity:1; }
  * }
- * &#64keyframes enter_sequence {
+ * @keyframes enter_sequence {
  *   from { opacity:0; }
  *   to { opacity:1; }
  * }


### PR DESCRIPTION
Request Type: docs

How to reproduce:
See http://docs.angularjs.org/api/ngAnimate

Component(s): ngAnimate

Impact: small

Complexity: small

This issue is related to:

**Detailed Description:**

&#64 was not rendered as an "@" symbol (even after adding the missing semicolon). Replacing this with an actual "@" symbol.
Closes #6822.
