### PR TITLE
Update ngStyle.js

### DIFF
--- a/src/ng/directive/ngStyle.js
+++ b/src/ng/directive/ngStyle.js
@@ -12,11 +12,15 @@
  * @param {expression} ngStyle {@link guide/expression Expression} which evals to an
  *      object whose keys are CSS style names and values are corresponding values for those CSS
  *      keys.
- *
+ * For some CSS elements, they must be surounded with single quotes('). The single quote must be used for AngularJS 
+ * to recognize the property and the value. They should each be surrounded in there own set of quotes as shown in the
+ * example with 'background-color' below.
+ * 
  * @example
    <example>
      <file name="index.html">
         <input type="button" value="set" ng-click="myStyle={color:'red'}">
+        <input type="button" vlaue="Background" ng-click="myStyle={'background-color':'blue'}">
         <input type="button" value="clear" ng-click="myStyle={}">
         <br/>
         <span ng-style="myStyle">Sample Text</span>


### PR DESCRIPTION
Explaining that single quotes are needed for property/value pairs. Feel free to improve on this but it is something that is needed in the documentation.
