### PR TITLE
docs(css): Add background to .type-hint-domelement

### DIFF
--- a/docs/app/assets/css/docs.css
+++ b/docs/app/assets/css/docs.css
@@ -470,6 +470,10 @@ iframe.example {
   background: rgb(90, 84, 189);
 }
 
+.type-hint-domelement {
+  background: rgb(95, 158, 160);
+}
+
 .runnable-example-frame {
   width:100%;
   height:300px;


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

.type-hint-domelement does not have a background color assigned to it. DOM element type hint's are now proudly displayed with CadetBlue.
