### PR TITLE
ngResource - POST parameter value prefixed with @ is not extracted from the data object.

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -94,8 +94,8 @@ function shallowClearAndCopy(src, dst) {
  *   Given a template `/path/:verb` and parameter `{verb:'greet', salutation:'Hello'}` results in
  *   URL `/path/greet?salutation=Hello`.
  *
- *   If the parameter value is prefixed with `@` then the value of that parameter is extracted from
- *   the data object (useful for non-GET operations).
+ *   If the parameter value is prefixed with `@` then the value of that parameter will be taken
+ *   from the corresponding key on the data object (useful for non-GET operations).
  *
  * @param {Object.<Object>=} actions Hash with declaration of custom action that should extend
  *   the default set of resource actions. The declaration should be created in the format of {@link


### PR DESCRIPTION
Documentation states:

If the parameter value is prefixed with @ then the value of that parameter is extracted from the data object (useful for non-GET operations).

We have the parameters prefixed with '@' but they are still present within the POST Object.
