### PR TITLE
Use the full list of google closure locales

### DIFF
--- a/i18n/src/closureSlurper.js
+++ b/i18n/src/closureSlurper.js
@@ -23,7 +23,11 @@ function readSymbols() {
       var currencySymbols = closureI18nExtractor.extractCurrencySymbols(content);
       return qfs.read(__dirname + '/../closure/numberSymbols.js', 'b').then(function(content) {
           closureI18nExtractor.extractNumberSymbols(content, localeInfo, currencySymbols);
-        });
+        }).then(function(mainContent) {
+            return qfs.read(__dirname + '/../closure/numberSymbolsExt.js', 'b').then(function(content) {
+                closureI18nExtractor.extractNumberSymbols(content, localeInfo, currencySymbols);
+              });
+          });
       });
 
   console.log("Processing datetime symbols ...");

--- a/i18n/update-closure.sh
+++ b/i18n/update-closure.sh
@@ -12,4 +12,5 @@ curl https://closure-library.googlecode.com/git/closure/goog/i18n/currency.js > 
 curl https://closure-library.googlecode.com/git/closure/goog/i18n/datetimesymbols.js > closure/datetimeSymbols.js
 curl https://closure-library.googlecode.com/git/closure/goog/i18n/datetimesymbolsext.js > closure/datetimeSymbolsExt.js
 curl https://closure-library.googlecode.com/git/closure/goog/i18n/numberformatsymbols.js > closure/numberSymbols.js
+curl https://closure-library.googlecode.com/git/closure/goog/i18n/numberformatsymbolsext.js > closure/numberSymbolsExt.js
 curl https://closure-library.googlecode.com/git/closure/goog/i18n/pluralrules.js > closure/pluralRules.js

--- a/src/ngLocale/.jshintrc
+++ b/src/ngLocale/.jshintrc
@@ -19,5 +19,7 @@
   "globals": {
     "angular": false
   },
-  "-W041": false
+  "-W041": false,
+  "shadow": true, /* locale files are generated from a 3rd party library that redeclares vars */
+  "funcscope": true /* locale files are generated from a 3rd party library that uses vars outside the definition scope */
 }


### PR DESCRIPTION
The current list of locales is not complete and partly wrong.

I adjusted the locale generation to use the full list of the locales in the google closure library in order to have 
a) a correct generated list e.g. Peru had the currency euro because the fallback of Spanish as currency was euro 
b) a complete list of locales (why were they missing anyway?)

BTW: in the currently used numberformatsymbols.js from Closure it says:

```
* To reduce the file size (which may cause issues in some JS
* developing environments), this file will only contain locales
* that are frequently used by web applications.
```

I think all possible locale files should be generated.
