### PR TITLE
Fix confusing behaviour of ngResource callbacks

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -559,7 +559,9 @@ angular.module('ngResource', ['ng']).
           promise = promise.then(
               function(response) {
                 var value = responseInterceptor(response);
-                (success||noop)(value, response.headers);
+                $q.when(value).then(function(value) {
+                  (success||noop)(value, response.headers);
+                });
                 return value;
               },
               responseErrorInterceptor);

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -551,20 +551,36 @@ angular.module('ngResource', ['ng']).
           }, function(response) {
             value.$resolved = true;
 
-            (error||noop)(response);
-
             return $q.reject(response);
           });
 
           promise = promise.then(
               function(response) {
                 var value = responseInterceptor(response);
+
                 $q.when(value).then(function(value) {
                   (success||noop)(value, response.headers);
+                }, function(response) {
+                  (error||noop)(response);
                 });
+
                 return value;
               },
-              responseErrorInterceptor);
+              function(response) {
+                if (responseErrorInterceptor) {
+                  response = responseErrorInterceptor(response);
+                } else {
+                  response = $q.reject(response);
+                }
+
+                $q.when(response).then(function(value) {
+                  (success||noop)(value, response.headers);
+                }, function(response) {
+                  (error||noop)(response);
+                });
+
+                return response;
+              });
 
           if (!isInstanceCall) {
             // we are creating instance / collection

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -600,12 +600,11 @@ describe("resource", function() {
 
   describe('promise api', function() {
 
-    var $rootScope, $q;
+    var $rootScope;
 
 
-    beforeEach(inject(function(_$rootScope_, _$q_) {
+    beforeEach(inject(function(_$rootScope_) {
       $rootScope = _$rootScope_;
-      $q = _$q_;
     }));
 
 
@@ -941,55 +940,110 @@ describe("resource", function() {
       expect(response.config).toBeDefined();
     });
 
-    it('should call the success callback with the object returned from the interceptor, not a promise', function() {
-      CreditCard = $resource('/CreditCard', {}, {
-        query: {
-          method: 'get',
-          isArray: true,
-          interceptor: {
-            response: function(response) {
-              return $q.when(response.data);
+    describe('when the response interceptor returns a promise', function() {
+      var makeCreditCard, $q;
+
+      beforeEach(inject(function(_$q_) {
+        makeCreditCard = function(interceptor) {
+          return $resource('/CreditCard', {}, {
+            query: {
+              method: 'get',
+              isArray: true,
+              interceptor: interceptor
             }
+          });
+        };
+
+        $q = _$q_;
+
+        $httpBackend.expect('GET', '/CreditCard').respond([{id: 1}]);
+      }));
+
+      it('should call the success callback with the resolution value of the promise', function() {
+        CreditCard = makeCreditCard({
+          response: function(response) {
+            return $q.when(response.data);
           }
-        }
+        });
+
+        CreditCard.query(callback);
+        $httpBackend.flush();
+        expect(callback).toHaveBeenCalledOnce();
+
+        var response = callback.mostRecentCall.args[0];
+        expect(response.then).not.toBeDefined();
+        expect(response[0].id).toEqual(1);
       });
 
-      $httpBackend.expect('GET', '/CreditCard').respond([{id: 1}]);
+      it('should call the error callback with the rejection value of the promise', function() {
+        CreditCard = makeCreditCard({
+          response: function(response) {
+            return $q.reject(response);
+          }
+        });
 
-      CreditCard.query(callback);
+        CreditCard.query(function() {}, callback);
+        $httpBackend.flush();
+        expect(callback).toHaveBeenCalledOnce();
 
-      $httpBackend.flush();
-      expect(callback).toHaveBeenCalledOnce();
-
-      var response = callback.mostRecentCall.args[0];
-      expect(response.then).not.toBeDefined();
-      expect(response[0].id).toEqual(1);
+        var response = callback.mostRecentCall.args[0];
+        expect(response.then).not.toBeDefined();
+        expect(response.status).toEqual(200);
+        expect(response.config).toBeDefined();
+      });
     });
 
-    it('should call the failure callback with the object returned from the interceptor, not a promise', function() {
-      CreditCard = $resource('/CreditCard', {}, {
-        query: {
-          method: 'get',
-          isArray: true,
-          interceptor: {
-            responseError: function(response) {
-              return $q.when(response);
+    describe('when the responseError interceptor returns a promise', function() {
+      var makeCreditCard, $q;
+
+      beforeEach(inject(function(_$q_) {
+        makeCreditCard = function(interceptor) {
+          return $resource('/CreditCard', {}, {
+            query: {
+              method: 'get',
+              isArray: true,
+              interceptor: interceptor
             }
+          });
+        };
+
+        $q = _$q_;
+
+        $httpBackend.expect('GET', '/CreditCard').respond(404);
+      }));
+
+      it('should call the success callback with the resolution value of the promise', function() {
+        CreditCard = makeCreditCard({
+          responseError: function(response) {
+            return $q.when({id: 1});
           }
-        }
+        });
+
+        CreditCard.query(callback);
+        $httpBackend.flush();
+        expect(callback).toHaveBeenCalledOnce();
+
+        var response = callback.mostRecentCall.args[0];
+        expect(response.then).not.toBeDefined();
+        expect(response.id).toEqual(1);
       });
 
-      $httpBackend.expect('GET', '/CreditCard').respond(404);
+      it('should call the error callback with the rejection value of the promise', function() {
+        CreditCard = makeCreditCard({
+          responseError: function(response) {
+            return $q.reject(response);
+          }
+        });
 
-      CreditCard.query(function() {}, callback);
+        CreditCard.query(function() {}, callback);
+        $httpBackend.flush();
+        expect(callback).toHaveBeenCalledOnce();
 
-      $httpBackend.flush();
-      expect(callback).toHaveBeenCalledOnce();
-
-      var response = callback.mostRecentCall.args[0];
-      expect(response.then).not.toBeDefined();
-      expect(response.status).toEqual(404);
-      expect(response.config).toBeDefined();
+        var response = callback.mostRecentCall.args[0];
+        expect(response.then).not.toBeDefined();
+        expect(response.status).toEqual(404);
+        expect(response.config).toBeDefined();
+      });
     });
   });
 


### PR DESCRIPTION
Request Type: bug

How to reproduce: Create a resource and add a response interceptor to an action. Make the interceptor return a function. Call the action and check the parameter handed into the callback function. The parameter will be a promise, not the resolved value of that promise.

Component(s): ngResource

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

When using an interceptor in ngResource, if the interceptor returns a promise, this promise is given to the success callback. Instead, the object which resolves the promise should be given to the success callback.

**Other Comments:**

This fixes issue #6731
