### PR TITLE
fix(input): Allow ng-true-value and ng-required on a checkbox

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1229,11 +1229,11 @@ function checkboxInputType(scope, element, attr, ctrl) {
     return value !== trueValue;
   };
 
-  ctrl.$formatters.push(function(value) {
+  ctrl.$formatters.unshift(function(value) {
     return value === trueValue;
   });
 
-  ctrl.$parsers.push(function(value) {
+  ctrl.$parsers.unshift(function(value) {
     return value ? trueValue : falseValue;
   });
 }

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1822,6 +1822,33 @@ describe('input', function() {
     });
 
 
+    it('should allow custom enumeration and ng-required', function() {
+      compileInput('<input type="checkbox" ng-model="name" ng-true-value="y" ' +
+          'ng-false-value="n" ng-required="true">');
+
+      scope.$apply(function() {
+        scope.name = 'y';
+      });
+      expect(inputElm[0].checked).toBe(true);
+
+      scope.$apply(function() {
+        scope.name = 'n';
+      });
+      expect(inputElm[0].checked).toBe(false);
+
+      scope.$apply(function() {
+        scope.name = 'something else';
+      });
+      expect(inputElm[0].checked).toBe(false);
+
+      browserTrigger(inputElm, 'click');
+      expect(scope.name).toEqual('y');
+
+      browserTrigger(inputElm, 'click');
+      expect(scope.name).toBeUndefined();
+    });
+
+
     it('should be required if false', function() {
       compileInput('<input type="checkbox" ng:model="value" required />');
 


### PR DESCRIPTION
Put the input[checkbox] formatter and parser first in the `$formatters` and `$parsers` queue so they are the first being called when formatting and the last when parsing. This allows the existing logic at `ng-required` (that uses `$isEmpty`) to work on the `ng-true-value` value

Closes #6875
