### PR TITLE
docs(css): Remove Firefox select element default

### DIFF
--- a/docs/app/assets/css/docs.css
+++ b/docs/app/assets/css/docs.css
@@ -257,6 +257,9 @@ code.highlighted {
   z-index: 99;
   cursor: pointer;
   font-size: 16px;
+  -moz-appearance: none;
+  text-indent: 0.01px;
+  text-overflow: '';
 }
 
 .picker:after {


### PR DESCRIPTION
Request Type: docs

How to reproduce: View the docs from Firefox. The version picker's select elements arrow is still showing.

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

In firefox the version picker's dropdown from the default select element is still showing. This is a hack to force FF to hide the ugly default.
