### PR TITLE
Documentation: Add missing argument to npm install

### DIFF
--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -80,7 +80,7 @@ and follow the instructions for setting up your computer.
       <p>Additionally install <a href="http://karma-runner.github.io/" title="Karma site">Karma</a> and
       its plugins if you don't have it already:</p>
       <pre>
-      npm install
+      npm install karma
       </pre></li>
       <li><p>You will need an http server running on your system. Mac and Linux machines typically
       have Apache pre-installed, but If you don't already have one installed, you can use <code>node</code>


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The argument `karma` was missing in the command `npm install` given for the installation of [Karma](http://karma-runner.github.io/0.12/index.html).

**Other Comments:**
