### PR TITLE
feat($parse): Support for typeof, instanceof, void, in operators

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -101,7 +101,11 @@ var OPERATORS = {
     '&':function(self, locals, a,b){return a(self, locals)&b(self, locals);},
 //    '|':function(self, locals, a,b){return a|b;},
     '|':function(self, locals, a,b){return b(self, locals)(self, locals, a(self, locals));},
-    '!':function(self, locals, a){return !a(self, locals);}
+    '!':function(self, locals, a){return !a(self, locals);},
+    'typeof':function(self, locals, a){return typeof a(self, locals);},
+    'void':function(self, locals, a){return void a(self, locals);},
+    'instanceof':function(self, locals, a, b, globalFn){return a(self, locals) instanceof (b(self, locals) || window[globalFn]);},
+    'in':function(self, locals, a, b){return a(self, locals) in b(self, locals);}
 };
 /* jshint bitwise: true */
 var ESCAPE = {"n":"\n", "f":"\f", "r":"\r", "t":"\t", "v":"\v", "'":"'", '"':'"'};
@@ -131,6 +135,7 @@ Lexer.prototype = {
 
     var token;
     var json = [];
+    var operator;
 
     while (this.index < this.text.length) {
       this.ch = this.text.charAt(this.index);
@@ -138,6 +143,10 @@ Lexer.prototype = {
         this.readString(this.ch);
       } else if (this.isNumber(this.ch) || this.is('.') && this.isNumber(this.peek())) {
         this.readNumber();
+      } else if (operator = this.isOperator()){
+        var operatorFn = OPERATORS[operator];
+        this.tokens.push({index: this.index, text: operator, fn: operatorFn});
+        this.index += operator.length + 1;
       } else if (this.isIdent(this.ch)) {
         this.readIdent();
         // identifiers can only be if the preceding char was a { or ,
@@ -213,6 +222,13 @@ Lexer.prototype = {
     return ('a' <= ch && ch <= 'z' ||
             'A' <= ch && ch <= 'Z' ||
             '_' === ch || ch === '$');
+  },
+
+  isOperator: function(){
+    if(this.text.substr(this.index, this.index + 7) === 'typeof ') return 'typeof';
+    if(this.text.substr(this.index, this.index + 5) === 'void ') return 'void';
+    if(this.text.substr(this.index, this.index + 11) === 'instanceof ') return 'instanceof';
+    if(this.text.substr(this.index, this.index + 3) === 'in ') return 'in';
   },
 
   isExpOperator: function(ch) {
@@ -528,9 +544,9 @@ Parser.prototype = {
     });
   },
 
-  binaryFn: function(left, fn, right) {
+  binaryFn: function(left, fn, right, globalRight) {
     return extend(function(self, locals) {
-      return fn(self, locals, left, right);
+      return fn(self, locals, left, right, globalRight);
     }, {
       constant:left.constant && right.constant
     });
@@ -680,10 +696,29 @@ Parser.prototype = {
   },
 
   multiplicative: function() {
-    var left = this.unary();
+    var left = this.inOperator();
     var token;
     while ((token = this.expect('*','/','%'))) {
-      left = this.binaryFn(left, token.fn, this.unary());
+      left = this.binaryFn(left, token.fn, this.inOperator());
+    }
+    return left;
+  },
+
+  inOperator: function() {
+    var left = this.instance();
+    var token;
+    while ((token = this.expect('in'))) {
+      left = this.binaryFn(left, token.fn, this.instance());
+    }
+    return left;
+  },
+
+  instance: function() {
+    var left = this.unary();
+    var token;
+    while ((token = this.expect('instanceof'))) {
+      var globalFn = this.tokens[0].text;
+      left = this.binaryFn(left, token.fn, this.unary(), globalFn);
     }
     return left;
   },
@@ -694,7 +729,7 @@ Parser.prototype = {
       return this.primary();
     } else if ((token = this.expect('-'))) {
       return this.binaryFn(Parser.ZERO, token.fn, this.unary());
-    } else if ((token = this.expect('!'))) {
+    } else if ((token = this.expect('!', 'typeof', 'void'))) {
       return this.unaryFn(token.fn, this.unary());
     } else {
       return this.primary();

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -129,6 +129,18 @@ describe('parser', function() {
       expect(tokens[3].text).toEqual(':');
     });
 
+    it('should tokenize typeof, void, in and instanceof operators', function() {
+      var tokens = lex("typeof void instanceof in");
+      expect(tokens[0].text).toEqual('typeof');
+      expect(tokens[0].fn.toString().indexOf('typeof')).toNotEqual(-1);
+      expect(tokens[1].text).toEqual('void');
+      expect(tokens[1].fn.toString().indexOf('void')).toNotEqual(-1);
+      expect(tokens[2].text).toEqual('instanceof');
+      expect(tokens[2].fn.toString().indexOf('instanceof')).toNotEqual(-1);
+      expect(tokens[3].text).toEqual('in');
+      expect(tokens[3].fn.toString().indexOf('in')).toNotEqual(-1);
+    });
+
     it('should tokenize statements', function() {
       var tokens = lex("a;b;");
       expect(tokens[0].text).toEqual('a');
@@ -635,6 +647,44 @@ describe('parser', function() {
           scope.a = "a";
           scope.b = {c: "bc"};
           expect(scope.$eval('a + \n b.c + \r "\td" + \t \r\n\r "\r\n\n"')).toEqual("abc\td\r\n\n");
+        });
+
+        it('should support "typeof" operator', function() {
+          scope.str = 'str';
+          scope.obj = {};
+          expect(scope.$eval('typeof 1')).toBe('number');
+          expect(scope.$eval('typeof str')).toBe('string');
+          expect(scope.$eval('typeof obj')).toBe('object');
+          expect(scope.$eval('typeof "string literal" === "string"')).toBe(true);
+        });
+
+        it('should support "void" operator', function() {
+          scope.obj = {
+            num: 5,
+            increment: function() { return ++this.num; }
+          };
+          expect(scope.$eval('void 0')).toBe(undefined);
+          expect(scope.$eval('void obj.increment()')).toBe(undefined);
+          expect(scope.obj.num).toBe(6);
+        });
+
+        it('should support "instanceof" operator', function() {
+          scope.Fn = function(){};
+          scope.obj = new scope.Fn();
+          scope.date = new Date();
+          scope.arr = [1, 2, 3];
+          expect(scope.$eval('obj instanceof Fn')).toBe(true);
+          expect(scope.$eval('obj instanceof Fn === false')).toBe(false);
+          expect(scope.$eval('date instanceof Date')).toBe(true);
+          expect(scope.$eval('arr instanceof Array')).toBe(true);
+        });
+
+        it('should support "in" operator', function() {
+          scope.obj = { key: 'value' };
+          scope.prop = 'key';
+          expect(scope.$eval('"key" in obj')).toBe(true);
+          expect(scope.$eval('prop in obj')).toBe(true);
+          expect(scope.$eval('key in obj')).toBe(false);
         });
 
         describe('sandboxing', function() {


### PR DESCRIPTION
This PR is a solution to Issue #6765.

The `$parse` service not supports `typeof`, `instanceof`, `void`, and `in` operators.
Furthermore in case of `instanceof` we can check whether some object is an instance created by a constructor defined on scope:

``` javascript
scope.Fn = function(){};
scope.obj = new scope.Fn();
$parse('obj instanceof Fn')(scope); //yields 'true'
```

as well as check whether some object is an instance of a global 'class' like `Date` or `Array`:

``` javascript
scope.arr = [1, 2, 3];
$parse('arr instanceof Array')(scope); //yields 'true'
```
