### PR TITLE
fix($sniffer) & fix(ng-input): add check for older webkit browsers and extra milliseconds for iOS7

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -933,7 +933,7 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
         timeout = $browser.defer(function() {
           listener();
           timeout = null;
-        });
+        },5); // Adding 5 milliseconds for iOS7
       }
     };
 

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -21,6 +21,9 @@ function $SnifferProvider() {
         android =
           int((/android (\d+)/.exec(lowercase(($window.navigator || {}).userAgent)) || [])[1]),
         boxee = /Boxee/i.test(($window.navigator || {}).userAgent),
+        webkit =
+            int((/[a-z]*?webkit\/(\d+)/i.exec(lowercase(($window.navigator || {}).userAgent))
+                || [])[1]),
         document = $document[0] || {},
         documentMode = document.documentMode,
         vendorPrefix,
@@ -63,7 +66,8 @@ function $SnifferProvider() {
       // so let's not use the history API also
       // We are purposefully using `!(android < 4)` to cover the case when `android` is undefined
       // jshint -W018
-      history: !!($window.history && $window.history.pushState && !(android < 4) && !boxee),
+      history : !!($window.history && $window.history.pushState && !(android < 4) && !boxee
+          && !(webkit < 534)),
       // jshint +W018
       hashchange: 'onhashchange' in $window &&
                   // IE8 compatible mode lies

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -332,6 +332,29 @@ describe('$sniffer', function() {
         expect($sniffer.history).toBe(false);
       });
     });
+
+    it('should be false on Webkit versions older then 534.x.x', function() {
+      module(function($provide) {
+        var doc = {
+          body : {
+            style : {}
+          }
+        };
+        var win = {
+          history : {
+            pushState : noop
+          },
+          navigator : {
+            userAgent : 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_8; nl-nl) AppleWebkit/533.18.1 (KHTML, like Gecko) Version/5.0.2 Safari/533.18.5'
+          }
+        };
+        $provide.value('$document', jqLite(doc));
+        $provide.value('$window', win);
+      });
+      inject(function($sniffer) {
+        expect($sniffer.history).toBe(false);
+      });
+    });
   });
 
   it('should provide the android version', function() {


### PR DESCRIPTION
**Request Type**: bug
#### How to reproduce:
- $sniffer: Create a multipage app with redirects in angular and test it in Android or Safari 5 or lower, the app will end up in an endless loop and eventually crash the browser.
- ng-input: Create a form with validation and try to submit on an iOS7 device, the last character never gets sent, so the form always returns invalid.

**Component(s)**: misc core

**Impact**: medium

**Complexity**: small

**This issue is related to**: [#6733](https://github.com/angular/angular.js/pull/6733)
#### Detailed Description:

We created a responsive web app in angular, but ran into two issues:
- older webkit engines (< 534) have problem with pushState, these are used in Safari 5 and lower and the Android default browser (not Chrome)
- iOS7 the change event is fired before the value is updated
