### PR TITLE
fix(ngCloak) don't show template binding braces during ng-init

### DIFF
--- a/src/ng/directive/ngCloak.js
+++ b/src/ng/directive/ngCloak.js
@@ -57,7 +57,7 @@
  *
  */
 var ngCloakDirective = ngDirective({
-  compile: function(element, attr) {
+  link: function(scope, element, attr) {
     attr.$set('ngCloak', undefined);
     element.removeClass('ng-cloak');
   }

--- a/test/ng/directive/ngCloakSpec.js
+++ b/test/ng/directive/ngCloakSpec.js
@@ -9,15 +9,16 @@ describe('ngCloak', function() {
   });
 
 
-  it('should get removed when an element is compiled', inject(function($rootScope, $compile) {
+  it('should get removed when an element is linked', inject(function($rootScope, $compile) {
     element = jqLite('<div ng-cloak></div>');
     expect(element.attr('ng-cloak')).toBe('');
-    $compile(element);
+    $compile(element)($rootScope);
+    $rootScope.$digest();
     expect(element.attr('ng-cloak')).toBeUndefined();
   }));
 
 
-  it('should remove ngCloak class from a compiled element with attribute', inject(
+  it('should remove ngCloak class from a linked element with attribute', inject(
       function($rootScope, $compile) {
     element = jqLite('<div ng-cloak class="foo ng-cloak bar"></div>');
 
@@ -25,7 +26,8 @@ describe('ngCloak', function() {
     expect(element.hasClass('ng-cloak')).toBe(true);
     expect(element.hasClass('bar')).toBe(true);
 
-    $compile(element);
+    $compile(element)($rootScope);
+    $rootScope.$digest();
 
     expect(element.hasClass('foo')).toBe(true);
     expect(element.hasClass('ng-cloak')).toBe(false);
@@ -33,14 +35,15 @@ describe('ngCloak', function() {
   }));
 
 
-  it('should remove ngCloak class from a compiled element', inject(function($rootScope, $compile) {
+  it('should remove ngCloak class from a linked element', inject(function($rootScope, $compile) {
     element = jqLite('<div class="foo ng-cloak bar"></div>');
 
     expect(element.hasClass('foo')).toBe(true);
     expect(element.hasClass('ng-cloak')).toBe(true);
     expect(element.hasClass('bar')).toBe(true);
 
-    $compile(element);
+    $compile(element)($rootScope);
+    $rootScope.$digest();
 
     expect(element.hasClass('foo')).toBe(true);
     expect(element.hasClass('ng-cloak')).toBe(false);


### PR DESCRIPTION
Request Type: 

How to reproduce: 

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

will prevent showing binding braces during ng-init.

closes #2927
