### PR TITLE
refactor(filters): make numberFilter and currencyFilter take locale change into account

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -49,8 +49,8 @@
  */
 currencyFilter.$inject = ['$locale'];
 function currencyFilter($locale) {
-  var formats = $locale.NUMBER_FORMATS;
   return function(amount, currencySymbol){
+    var formats = $locale.NUMBER_FORMATS;
     if (isUndefined(currencySymbol)) currencySymbol = formats.CURRENCY_SYM;
     return formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP, 2).
                 replace(/\u00A4/g, currencySymbol);
@@ -109,8 +109,8 @@ function currencyFilter($locale) {
 
 numberFilter.$inject = ['$locale'];
 function numberFilter($locale) {
-  var formats = $locale.NUMBER_FORMATS;
   return function(number, fractionSize) {
+    var formats = $locale.NUMBER_FORMATS;
     return formatNumber(number, formats.PATTERNS[0], formats.GROUP_SEP, formats.DECIMAL_SEP,
       fractionSize);
   };


### PR DESCRIPTION
Request Type: refactor

How to reproduce: 

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Make numberFilter and currencyFilter filters take into account a locale change. Currently, if the locale is changed in an application, the filters will update their output without taking into account the new locale. This is because the locale NUMBER_FORMATS parameters are "cached" in those filters, unlike in dateFilter.

**Other Comments:**
