### PR TITLE
extending resources with response data and support for instance's array actions

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -457,8 +457,14 @@ angular.module('ngResource', ['ng']).
               "Expected up to 4 arguments [params, data, success, error], got {0} arguments", arguments.length);
           }
 
-          var isInstanceCall = data instanceof Resource;
-          var value = isInstanceCall ? data : (action.isArray ? [] : new Resource(data));
+          var isInstanceCall = this instanceof Resource, value;
+
+          if (action.isArray) {
+              value = [];
+          } else {
+              value = isInstanceCall ? data : new Resource(data);
+          }
+
           var httpConfig = {};
           var responseInterceptor = action.interceptor && action.interceptor.response || defaultResponseInterceptor;
           var responseErrorInterceptor = action.interceptor && action.interceptor.responseError || undefined;
@@ -508,7 +514,7 @@ angular.module('ngResource', ['ng']).
 
           promise = promise.then(
               function(response) {
-                var value = responseInterceptor(response);
+                var value = responseInterceptor.call(data, response);
                 (success||noop)(value, response.headers);
                 return value;
               },


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): ngResource

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

A suggested solution for #4565

When calling a Resource instance's `GET` actions such as `$get` and `$query` but mostly custom ones, it is sometimes needed to be able to extend the resource with the response data e.g:

``` javascript
entity.$children()
.then(function(){
    console.log(entity.children) //undefined
});
//the response did not become a part of the resource
```

Automatically setting the response on the resource with the property name is a bad idea since it can lead to unexpected overrides (the resource might have had a property named children) and generally it should be up to the user to decide whether to extend or not and how.

My approach involves leveraging the Resource's interceptor to achieve a both flexible and clean way to extend instances. By calling the interceptor's response function with the instance as it's context (this) it is possible to reference it and set the desired properties:

``` javascript
$resource('[...]/entity/:id', {}, {
    'children': {
        method: 'GET',
        url:'[...]/entity/:id/children',
        params:{id:'@id'},
        isArray:true,
        interceptor:{
            response: function(response){
                var data = response.data;
                this.children = data; //"this" references the entity resource
                return data;
            }
        }
    }
});
```

**Other Comments:**
