### PR TITLE
Update ngInclude doc for quoted source

### DIFF
--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -52,7 +52,7 @@
        url of the template: <tt>{{template.url}}</tt>
        <hr/>
        <div class="slide-animate-container">
-         <div class="slide-animate" ng-include="template.url"></div>
+         <div class="slide-animate" ng-include="  'template.url'  "></div>
        </div>
      </div>
     </file>


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: medium

Complexity: small

This issue is related to: 

**Detailed Description:**

As noted on stackoverflow.com (http://stackoverflow.com/questions/13943471/angularjs-ng-include), the use of ngInclude requires single quotes around the template filename.  The documentation and examples should show: <div ng-include="  'template.url'  "> instead of simply "template.url" to remind users to enclose the filename in single quotes.  As a additional step ngInclude should issue some warning that the include failed.  It now fails silently and makes for a bad day at the programming chair.

**Other Comments:**

In my fork I attempted to update the document file for ngInclude.  Probably due to my lack of experience I was unable to match the document source to what I see online at docs.angularjs.org//api/ng/directive/ngInclude.  Specifically I would have liked to update the Usage section to show ng-include="  'template.html' "  on all occurrences.  I've only experienced this issue using ngInclude as an HTML attribute, so I did not know if the Element and CSS class usage examples should also be updated.  Thanks for the great product.  Angular is awesome.
