### PR TITLE
fix(ngEventDirs): blur and focus use $evalAsync to prevent inprog errors

### DIFF
--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -31,7 +31,7 @@
    </example>
  */
 /*
- * A directive that allows creation of custom onclick handlers that are defined as angular
+ * A directive that allows creation of custom event handlers that are defined as angular
  * expressions and are compiled and executed within the current scope.
  *
  * Events that are handled via these handler are always configured not to propagate further.
@@ -47,9 +47,13 @@ forEach(
           var fn = $parse(attr[directiveName]);
           return function ngEventHandler(scope, element) {
             element.on(lowercase(name), function(event) {
-              scope.$apply(function() {
+              if (scope.$$phase) {
                 fn(scope, {$event:event});
-              });
+              } else {
+                scope.$apply(function() {
+                  fn(scope, {$event:event});
+                });
+              }
             });
           };
         }

--- a/test/ng/directive/ngEventDirsSpec.js
+++ b/test/ng/directive/ngEventDirsSpec.js
@@ -39,4 +39,38 @@ describe('event directives', function() {
       expect($rootScope.formSubmitted).toEqual('foo');
     }));
   });
+
+  describe('ngBlur', function() {
+    it('should get called when ngKeydown triggers blur', inject(function($rootScope, $compile) {
+      $rootScope.blur = function() {
+        browserTrigger(element, 'blur');
+      };
+
+      element = $compile('<input type="text" ng-blur="blurred = true" ng-keydown="blur()" />')($rootScope);
+
+      $rootScope.$digest();
+      expect($rootScope.blurred).not.toBeDefined();
+
+      browserTrigger(element, 'keydown');
+      expect($rootScope.blurred).toEqual(true);
+    }));
+  });
+
+  describe('ngFocus', function() {
+    it('should get called when ngClick triggers focus', inject(function($rootScope, $compile) {
+      $rootScope.focus = function() {
+        browserTrigger(element.children()[0], 'focus');
+      };
+
+      element = $compile('<div><input type="text" ng-focus="focused = true" />' +
+        '<button type="button" ng-click="focus()"></button></div>')($rootScope);
+
+      $rootScope.$digest();
+      expect($rootScope.focused).not.toBeDefined();
+
+      browserTrigger(element.children()[1], 'click');
+      expect($rootScope.focused).toEqual(true);
+    }));
+  });
+
 });


### PR DESCRIPTION
Request Type: bug

How to reproduce: 
- ng-click triggers focus() on an element that has ng-focus 
- ng-key\* triggers blur() on an element that has ng-blur 
- moving an element  in an ng-repeat  that has ng-blur before the preceding item

Component(s): 

Impact: medium

Complexity: medium

This issue is related to: 

**Detailed Description:**

**Other Comments:**

This fixes cases where ngFocus and ngBlur will throw $rootScope.inprog errors, because they have been called during an active digest. There are (at least) three scenarios where this can happen, see above

ng-click triggers focus() on an element that has ng-focus
ng-key\* triggers blur() on an element that has ng-blur
moving an element with ng-blur in an ng-repeat before the preceding item

There's some discussion about this in #5402

I'd say we give it a shot and see if it causes any problems. Using $evalAsync was suggested by @caitp in https://github.com/angular/angular.js/issues/4979#issuecomment-35659108 .

Fixes #5945
Closes #5402
