### PR TITLE
ngAnimate: a requestAnimationFrame callback is created for each non-animated animatable child of a structurally animated element

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -858,7 +858,7 @@ angular.module('ngAnimate', ['ng'])
           fireDOMOperation();
           fireBeforeCallbackAsync();
           fireAfterCallbackAsync();
-          closeAnimation();
+          closeAnimation(true);
           return;
         }
 
@@ -889,7 +889,7 @@ angular.module('ngAnimate', ['ng'])
           fireDOMOperation();
           fireBeforeCallbackAsync();
           fireAfterCallbackAsync();
-          closeAnimation();
+          closeAnimation(true);
           return;
         }
 
@@ -1028,16 +1028,18 @@ angular.module('ngAnimate', ['ng'])
           }
         }
 
-        function closeAnimation() {
+        function closeAnimation(immediate) {
           if(!closeAnimation.hasBeenRun) {
             closeAnimation.hasBeenRun = true;
             var data = element.data(NG_ANIMATE_STATE);
             if(data) {
-              /* only structural animations wait for reflow before removing an
+              /* Only structural animations wait for reflow before removing an
                  animation, but class-based animations don't. An example of this
                  failing would be when a parent HTML tag has a ng-class attribute
-                 causing ALL directives below to skip animations during the digest */
-              if(runner && runner.isClassBased) {
+                 causing ALL directives below to skip animations during the digest.
+                 The 'immediate' flag is passed in when there definitely was no
+                 animation and we can skip the cost of the closure and the rAF.*/
+              if((runner && runner.isClassBased) || immediate) {
                 cleanup(element, className);
               } else {
                 $$asyncCallback(function() {


### PR DESCRIPTION
Request Type: perf

How to reproduce: Enter an ng-view with ng-repeat items inside, check Developer Tools' timeline.

Component(s): ngAnimate

Impact: medium

Complexity: small

This issue is related to: 

**Detailed Description:**

When a view with animatable (e.g., ng-repeat) children is entered, the children don't get a structural animation since the parent is being animated. This is noticed in performAnimation with a call to animationsDisabled(...) and the code calls closeAnimation. closeAnimation is asynchronous when the animation that could have been run is structural, but this is unnecessary in this case as nothing has been done. One such callback costs 0.2 - 0.5ms on an iPhone5, a view with 100 items will cost 20ms of javascript execution.

**Other Comments:**
