### PR TITLE
Don't create history state when adding leading slash to hash

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -45,6 +45,7 @@ function parseAppUrl(relativeUrl, locationObj, appBase) {
   // make sure path starts with '/';
   if (locationObj.$$path && locationObj.$$path.charAt(0) != '/') {
     locationObj.$$path = '/' + locationObj.$$path;
+    locationObj.replace();
   }
 }
 


### PR DESCRIPTION
Request Type: bug

How to reproduce: 

Component(s): $location

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

When hash doesn't starts with '/' Angular adds it. This creates new history state in browser. After this window.history.back() and so the back button of browser don't work as expected.

**Other Comments:**
