### PR TITLE
testing fail tutorial step_08.ngdoc

### DIFF
--- a/docs/content/tutorial/step_08.ngdoc
+++ b/docs/content/tutorial/step_08.ngdoc
@@ -130,6 +130,8 @@ __`test/unit/controllersSpec.js`:__
 ...
   describe('PhoneDetailCtrl', function(){
     var scope, $httpBackend, ctrl;
+    
+    beforeEach(module('phonecatApp'));
 
     beforeEach(inject(function(_$httpBackend_, $rootScope, $routeParams, $controller) {
       $httpBackend = _$httpBackend_;


### PR DESCRIPTION
Request Type: docs

How to reproduce: angular-phonecat tutorial moved to step_08
and running controllerSpec.js to karma testing

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Users test angularjs tutorial. and finally reach to the 08 step.
karma testing is fail.
fore documents(step_05.ngdoc) not describe that Global Module Loaded.

**Other Comments:**

fore documents(step_05.ngdoc) not describe that Global Module Loaded
