### PR TITLE
fix($parse): mark constant unary minus expressions as constant

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -393,7 +393,11 @@ var Parser = function (lexer, $filter, options) {
   this.options = options;
 };
 
-Parser.ZERO = function () { return 0; };
+Parser.ZERO = extend(function () {
+  return 0;
+}, {
+  constant: true
+});
 
 Parser.prototype = {
   constructor: Parser,

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1031,6 +1031,7 @@ describe('parser', function() {
 
           it('should mark complex expressions involving constant values as constant', inject(function($parse) {
             expect($parse('!true').constant).toBe(true);
+            expect($parse('-42').constant).toBe(true);
             expect($parse('1 - 1').constant).toBe(true);
             expect($parse('"foo" + "bar"').constant).toBe(true);
             expect($parse('5 != null').constant).toBe(true);


### PR DESCRIPTION
Request Type: bug

How to reproduce: Parse an expression like `-42`. Check its `constant` flag. Expected: `true`. Actual: `false`.

Component(s): $parse

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Expressions that use the unary `-` operator are currently never marked as constants.

Make `Parser.ZERO` a constant expression function, so that unary minus
expressions that use it may be marked constant.

**Other Comments:**
