### PR TITLE
Fix link in location.js documentation

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -508,8 +508,7 @@ function locationGetterSetter(property, preprocess) {
  *   - Clicks on a link.
  * - Represents the URL object as a set of methods (protocol, host, port, path, search, hash).
  *
- * For more information see {@link guide/dev_guide.services.$location Developer Guide: Angular
- * Services: Using $location}
+ * For more information see {@link guide/$location Developer Guide: Using $location}
  */
 
 /**


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): $location

Impact: 

Complexity: 

This issue is related to: 

**Detailed Description:**

**Other Comments:**

See the top of http://docs.angularjs.org/api/ng/service/$location
