### PR TITLE
Fixing weird formatting in filter documentation

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -35,15 +35,15 @@
  *
  *   Can be one of:
  *
- *     - `function(actual, expected)`:
- *       The function will be given the object value and the predicate value to compare and
- *       should return true if the item should be included in filtered result.
+ *   - `function(actual, expected)`:
+ *     The function will be given the object value and the predicate value to compare and
+ *     should return true if the item should be included in filtered result.
  *
- *     - `true`: A shorthand for `function(actual, expected) { return angular.equals(expected, actual)}`.
- *       this is essentially strict comparison of expected and actual.
+ *   - `true`: A shorthand for `function(actual, expected) { return angular.equals(expected, actual)}`.
+ *     this is essentially strict comparison of expected and actual.
  *
- *     - `false|undefined`: A short hand for a function which will look for a substring match in case
- *       insensitive way.
+ *   - `false|undefined`: A short hand for a function which will look for a substring match in case
+ *     insensitive way.
  *
  * @example
    <example>


### PR DESCRIPTION
Request Type: docs

How to reproduce: Go to Filter documentation (http://docs.angularjs.org/api/ng/filter/filter), in the arguments table, compare the details column of `expression` with `comparator`, specifically after the line "Can be one of:"

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Minor changes in the docs: the `comparator` argument description in the filter documentation (http://docs.angularjs.org/api/ng/filter/filter) was looking really weird, as it should look like the `expression` argument doc - a simple list of possible data types.

**Other Comments:**
