### PR TITLE
Outdated? start up instructions for web-server

### DIFF
--- a/docs/content/tutorial/step_00.ngdoc
+++ b/docs/content/tutorial/step_00.ngdoc
@@ -25,7 +25,7 @@ angular-seed, and run the application in the browser.
         <ul>
           <li><b>For node.js users:</b>
             <ol>
-              <li>In a <i>separate</i> terminal tab or window, run <code>node ./scripts/web-server.js</code> to start the web server.</li>
+              <li>In a <i>separate</i> terminal tab or window, run <code>npm start</code> to start the web server.</li>
               <li>Open a browser window for the app and navigate to <a
               href="http://localhost:8000/app/index.html" target="_blank">`http://localhost:8000/app/index.html`</a></li>
             </ol>


### PR DESCRIPTION
Doesn't look like there is a scripts/web-server.js script, so doing "node scripts/web-server.js" doesn't work. On the other hand, "npm start" from the root project directory seems to start things up. No idea if this is still true in windows, but it probably is. Somebody should check that and make relevant changes to the windows tab of the instructions if needed. Similar changes will need to be made on the root tutorial page as well. Tested from Ubuntu 13.10
