### PR TITLE
fix($compile): set $isolateScope correctly for sync template directives

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1425,7 +1425,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
           isolateScope = scope.$new(true);
 
-          if (templateDirective && (templateDirective === newIsolateScopeDirective.$$originalDirective)) {
+          if (templateDirective && (templateDirective === newIsolateScopeDirective ||
+              templateDirective === newIsolateScopeDirective.$$originalDirective)) {
             $linkNode.data('$isolateScope', isolateScope) ;
           } else {
             $linkNode.data('$isolateScopeNoTemplate', isolateScope);

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1797,6 +1797,19 @@ describe('$compile', function() {
                 }
               };
             });
+            directive('stscope' + uppercase(name), function(log) {
+              return {
+                scope: true,
+                restrict: 'CA',
+                template: '<span></span>',
+                compile: function() {
+                  return function (scope, element) {
+                    log(scope.$id);
+                    expect(element.data('$scope')).toBe(scope);
+                  };
+                }
+              };
+            });
             directive('trscope' + uppercase(name), function(log) {
               return {
                 scope: true,
@@ -1816,6 +1829,20 @@ describe('$compile', function() {
                 scope: {},
                 restrict: 'CA',
                 templateUrl: 'tiscope.html',
+                compile: function() {
+                  return function (scope, element) {
+                    iscope = scope;
+                    log(scope.$id);
+                    expect(element.data('$isolateScope')).toBe(scope);
+                  };
+                }
+              };
+            });
+            directive('stiscope' + uppercase(name), function(log) {
+              return {
+                scope: {},
+                restrict: 'CA',
+                template: '<span></span>',
                 compile: function() {
                   return function (scope, element) {
                     iscope = scope;
@@ -1999,6 +2026,13 @@ describe('$compile', function() {
                 expect(element.find('a').scope().$parent).toBe($rootScope);
               })
             );
+
+            it('should return the new scope for children in the directive sync template', inject(
+              function($rootScope, $compile) {
+                element = $compile('<div stscope></div>')($rootScope);
+                expect(element.find('span').scope().$parent).toBe($rootScope);
+              })
+            );
           });
 
 
@@ -2041,6 +2075,14 @@ describe('$compile', function() {
                 expect(element.isolateScope()).not.toBe($rootScope);
               })
             );
+
+            it('should return the isolate scope for children in directive sync template', inject(
+              function($rootScope, $compile) {
+                element = $compile('<div stiscope></div>')($rootScope);
+                expect(element.find('span').scope()).toBe(element.isolateScope());
+                expect(element.isolateScope()).not.toBe($rootScope);
+              })
+            );
           });
 
 
@@ -2065,6 +2107,17 @@ describe('$compile', function() {
                 element = $compile('<div><a ng-if="true" tiscope></a></div>')($rootScope);
                 $rootScope.$apply();
                 $httpBackend.flush();
+                directiveElement = element.find('a');
+                child = directiveElement.find('span');
+                expect(child.scope()).toBe(directiveElement.isolateScope());
+              })
+            );
+
+            it('should return the isolate scope for child elements in directive sync template', inject(
+              function($rootScope, $compile) {
+                var directiveElement, child;
+                element = $compile('<div><a ng-if="true" stiscope></a></div>')($rootScope);
+                $rootScope.$apply();
                 directiveElement = element.find('a');
                 child = directiveElement.find('span');
                 expect(child.scope()).toBe(directiveElement.isolateScope());


### PR DESCRIPTION
Request Type: bug

How to reproduce: http://plnkr.co/edit/nxtZGWarSPKHbtuBSiST?p=preview

The directive with 'templateUrl' is marked correctly as $isolateScope, while the directive with 'template' is marked as $isolateScopeNoTemplate and causes jqLite#scope() to return the incorrect scope for children elements

Component(s): $compile

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

all isolated scope directives that do not have 'templateUrl' where marked as $isolateScopeNoTemplate even if they did have a 'template' attribute. this caused jqLite#scope() to return a different value for child elements in the directive template just because the template loaded synchronously via 'template' and not 'templateUrl'.

**Other Comments:**
