### PR TITLE
docs($resource): change "request" to "response"

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -599,4 +599,4 @@ angular.module('ngResource', ['ng']).
     }
 
     return resourceFactory;
-  }
+  }]);

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -121,7 +121,7 @@ function shallowClearAndCopy(src, dst) {
  *   - **`transformRequest`** –
  *     `{function(data, headersGetter)|Array.<function(data, headersGetter)>}` –
  *     transform function or an array of such functions. The transform function takes the http
- *     request body and headers and returns its transformed (typically serialized) version.
+ *     response body and headers and returns its transformed (typically serialized) version.
  *   - **`transformResponse`** –
  *     `{function(data, headersGetter)|Array.<function(data, headersGetter)>}` –
  *     transform function or an array of such functions. The transform function takes the http
@@ -599,4 +599,4 @@ angular.module('ngResource', ['ng']).
     }
 
     return resourceFactory;
-  }]);
+  }


### PR DESCRIPTION
docs($resource): change "request" to "response"

This was confusing me a bit when I first read it. It clearly is meant to refer to response.
