### PR TITLE
Update tutorial documentation step_00.ngdoc

### DIFF
--- a/docs/content/tutorial/step_00.ngdoc
+++ b/docs/content/tutorial/step_00.ngdoc
@@ -84,9 +84,9 @@ __`app/index.html`:__
 <head>
   <meta charset="utf-8">
   <title>My HTML File</title>
+  <link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css">
   <link rel="stylesheet" href="css/app.css">
-  <link rel="stylesheet" href="css/bootstrap.css">
-  <script src="lib/angular/angular.js"></script>
+  <script src="../bower_components/angular/angular.js"></script>
 </head>
 <body>
 
@@ -114,7 +114,7 @@ __`app/index.html`:__
 
 * AngularJS script tag:
 
-          <script src="lib/angular/angular.js">
+          <script src="../bower_components/angular/angular.js"></script>
 
   This code downloads the `angular.js` script and registers a callback that will be executed by the
 browser when the containing HTML page is fully downloaded. When the callback is executed, Angular


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

As a developer learning AngularJS through `PhoneCat Tutorial App` on page `0 - Bootstrapping`, I'd like to see a code in tutorial's page in the same way like is coded within demo project. Tutorial uses `lib` and `css` folders for linking plugins instead of `bower_components`.

In Pull Request #6960 I fixed this small issue ;)

Cheers, Martin
### angular-phonecat/app/index.html

``` html
  <link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css">
  <link rel="stylesheet" href="css/app.css">
  <script src="../bower_components/angular/angular.js"></script>
```
### AngularJS: Tutorial: 0 - Bootstrapping
- Link: http://docs.angularjs.org/tutorial/step_00
- File: step_00.ngdoc

``` html
  <link rel="stylesheet" href="css/app.css">
  <link rel="stylesheet" href="css/bootstrap.css">
  <script src="lib/angular/angular.js"></script>
```

and

``` html
  <script src="lib/angular/angular.js">
```

**Other Comments:**

This change/branch was created directly through `improve this doc` button
