### PR TITLE
fix(Angular.js): not serializing null values

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1062,14 +1062,16 @@ function parseKeyValue(/**string*/keyValue) {
 function toKeyValue(obj) {
   var parts = [];
   forEach(obj, function(value, key) {
-    if (isArray(value)) {
-      forEach(value, function(arrayValue) {
+    if (value !== null) {
+      if (isArray(value)) {
+        forEach(value, function(arrayValue) {
+          parts.push(encodeUriQuery(key, true) +
+                     (arrayValue === true ? '' : '=' + encodeUriQuery(arrayValue, true)));
+        });
+      } else {
         parts.push(encodeUriQuery(key, true) +
-                   (arrayValue === true ? '' : '=' + encodeUriQuery(arrayValue, true)));
-      });
-    } else {
-    parts.push(encodeUriQuery(key, true) +
-               (value === true ? '' : '=' + encodeUriQuery(value, true)));
+                   (value === true ? '' : '=' + encodeUriQuery(value, true)));
+      }
     }
   });
   return parts.length ? parts.join('&') : '';

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -491,6 +491,14 @@ describe('angular', function() {
       expect(toKeyValue({key: [323,'value',true, 1234]})).
       toEqual('key=323&key=value&key&key=1234');
     });
+
+    it('should not serialize null values', function() {
+      expect(toKeyValue({nullKey: null, key: 'value'})).toEqual('key=value');
+    });
+
+    it('should not serialize undefined', function() {
+      expect(toKeyValue({undefinedKey: undefined, key: 'value'})).toEqual('key=value');
+    });
   });
 
 


### PR DESCRIPTION
toKeyValue should not serialize a value if that value is set as null. 
