### PR TITLE
Update step_00.ngdoc

### DIFF
--- a/docs/content/tutorial/step_00.ngdoc
+++ b/docs/content/tutorial/step_00.ngdoc
@@ -25,7 +25,7 @@ angular-seed, and run the application in the browser.
         <ul>
           <li><b>For node.js users:</b>
             <ol>
-              <li>In a <i>separate</i> terminal tab or window, run <code>node ./scripts/web-server.js</code> to start the web server.</li>
+              <li>In a <i>separate</i> terminal tab or window, run <code>npm start</code> to start the web server.</li>
               <li>Open a browser window for the app and navigate to <a
               href="http://localhost:8000/app/index.html" target="_blank">`http://localhost:8000/app/index.html`</a></li>
             </ol>


### PR DESCRIPTION
script/web-server.js is not present anymore. This doc might be referencing a previous version of the code. Currently the only way to start the server seems to be using "npm start".
