### PR TITLE
Fix runtime error in sample code

### DIFF
--- a/docs/content/guide/bootstrap.ngdoc
+++ b/docs/content/guide/bootstrap.ngdoc
@@ -100,7 +100,6 @@ Here is an example of manually initializing Angular:
       }]);
 
     angular.element(document).ready(function() {
-      angular.module('myApp', []);
       angular.bootstrap(document, ['myApp']);
     });
   </script>


### PR DESCRIPTION
Extra angular.module('myApp', []) call wipes out previously defined myApp module
