### PR TITLE
fix($parse): make equality and relational operators left-associative

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -659,8 +659,8 @@ Parser.prototype = {
   equality: function() {
     var left = this.relational();
     var token;
-    if ((token = this.expect('==','!=','===','!=='))) {
-      left = this.binaryFn(left, token.fn, this.equality());
+    while ((token = this.expect('==','!=','===','!=='))) {
+      left = this.binaryFn(left, token.fn, this.relational());
     }
     return left;
   },
@@ -668,8 +668,8 @@ Parser.prototype = {
   relational: function() {
     var left = this.additive();
     var token;
-    if ((token = this.expect('<', '>', '<=', '>='))) {
-      left = this.binaryFn(left, token.fn, this.relational());
+    while ((token = this.expect('<', '>', '<=', '>='))) {
+      left = this.binaryFn(left, token.fn, this.additive());
     }
     return left;
   },

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -252,6 +252,8 @@ describe('parser', function() {
           expect(scope.$eval("2>=1")).toEqual(2>=1);
           expect(scope.$eval("true==2<3")).toEqual(true == 2<3);
           expect(scope.$eval("true===2<3")).toEqual(true === 2<3);
+          expect(scope.$eval("1===1===true")).toEqual(1 === 1 === true);
+          expect(scope.$eval("1<2<=1")).toEqual(1 < 2 <= 1);
         });
 
         it('should parse logical', function() {


### PR DESCRIPTION
Request Type: bug

How to reproduce: Evaluate `"1 === 1 === true"`. Expected: `true`. Actual: `false`.

Component(s): $parse

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

This fixes an associativity issue in expressions that use multiple
equality or relational operators back to back without grouping.

Previously, these expressions were right-associative, which may
cause confusion for users who expect them to behave identically
to JavaScript expressions.

An expression like "a === b === c" was evaluated as "a === (b === c)".
Now it is evaluated as it is in JavaScript: "(a === b) === c".

Breaks expressions that have relied on right-associativity.

**Other Comments:**
