### PR TITLE
fix(ngHref): allow setting href to empty string

### DIFF
--- a/src/ng/directive/booleanAttrs.js
+++ b/src/ng/directive/booleanAttrs.js
@@ -380,7 +380,7 @@ forEach(['src', 'srcset', 'href'], function(attrName) {
         }
 
         attr.$observe(normalized, function(value) {
-          if (!value)
+          if (!value && attrName === 'src')
              return;
 
           attr.$set(name, value);

--- a/test/ng/directive/booleanAttrsSpec.js
+++ b/test/ng/directive/booleanAttrsSpec.js
@@ -246,6 +246,18 @@ describe('ngHref', function() {
   }));
 
 
+  it('should remote href value when interpolated value is empty', inject(function($compile, $rootScope) {
+    element = $compile('<div ng-href="{{id}}"></div>')($rootScope);
+    $rootScope.$digest();
+    expect(element.attr('href')).toEqual('');
+
+    $rootScope.$apply(function() {
+      $rootScope.id = 1;
+    });
+    expect(element.attr('href')).toEqual('1');
+  }));
+
+
   it('should bind href even if no interpolation', inject(function($rootScope, $compile) {
     element = $compile('<a ng-href="http://server"></a>')($rootScope)
     $rootScope.$digest();


### PR DESCRIPTION
Fixed issue 2755:
https://github.com/angular/angular.js/issues/2755

ngHref should now allow empty strings, and ngSrc will not accept empty strings as intended: https://github.com/angular/angular.js/commit/b6e4a71166c7f00f4140fd7ea8f0cd81b4487a3f
