### PR TITLE
Fix explanation of script tag change

### DIFF
--- a/docs/content/tutorial/step_07.ngdoc
+++ b/docs/content/tutorial/step_07.ngdoc
@@ -129,10 +129,13 @@ __`app/index.html`:__
 </html>
 ```
 
-We have added to extra `<script>` tags in our index file to load up extra JavaScript files into our
+We have added an extra `<script>` tag to our index file to load up an extra JavaScript file into our
 application:
 
 - `angular-route.js` : defines the `ngRoute` module.
+
+This is in addition to the previously specified `<script>` tag:
+
 - `controllers.js` : defines a new `phonecatControllers` module.
 
 Note that we removed most of the code in the `index.html` template and replaced it with a single


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): ngRoute

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

The description says we added "to new tags" which probably was supposed to be "two new tags". But even with that it's a bit confusing because there is one tag added compared to the previous step, that is the tag for `angular-route.js`. I just updated the doc to say this more clearly.
