### PR TITLE
Update step_08.ngdoc

### DIFF
--- a/docs/content/tutorial/step_08.ngdoc
+++ b/docs/content/tutorial/step_08.ngdoc
@@ -184,7 +184,7 @@ You can now rerun `npm run protractor` to see the tests run.
 
 # Experiments
 
-* Using the {@link guide/dev_guide.e2e-testing Angular's end-to-end test runner API}, write a test
+* Using the {@link https://github.com/angular/protractor/blob/master/docs/api.md Protractor API}, write a test
 that verifies that we display 4 thumbnail images on the Nexus S details page.
 
 


### PR DESCRIPTION
AngularJS test runner API has been deprecated, Protractor is advised: http://docs.angularjs.org/guide/e2e-testing
Link is updated to direct reader to Protractor API.
