### PR TITLE
fix(ng-model-options): Canceling debounces now forces a view reset

### DIFF
--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -863,6 +863,21 @@ describe('input', function() {
       expect(scope.name).toEqual(undefined);
     }));
 
+
+    it("should reset the input value when cancelDebounce is called", inject(function($timeout) {
+      compileInput(
+          '<form name="test">'+
+            '<input type="text" ng-model="name" name="alias" '+
+              'ng-model-options="{ debounce: 2000 }" />'+
+            '</form>');
+      
+      inputElm.val('a');
+      scope.test.alias.$cancelDebounce();
+      expect(inputElm.val()).toBe('');
+      $timeout.flush(3000);
+      expect(inputElm.val()).toBe('');
+    }));
+
   });
 
   it('should allow complex reference binding', function() {


### PR DESCRIPTION
This PR forces a view reset when canceling a pending debounce in order to fix some unexpected behaviors.

Closes #6994
