### PR TITLE
optimize sortedKeys function

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -166,8 +166,8 @@ var sortedKeys = Object.keys ?
   function sortedKeys(obj){
     var keys = [];
     var key;
-    for(key in obj){
-      if(obj.hasOwnProperty(key)){
+    for (key in obj){
+      if (obj.hasOwnProperty(key)){
         keys.push(key);
       }
     }

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -159,15 +159,20 @@ function forEach(obj, iterator, context) {
   return obj;
 }
 
-function sortedKeys(obj) {
-  var keys = [];
-  for (var key in obj) {
-    if (obj.hasOwnProperty(key)) {
-      keys.push(key);
+var sortedKeys = Object.keys ?
+  function(obj){
+    return Object.keys(obj).sort();
+  } :
+  function sortedKeys(obj){
+    var keys = [];
+    var key;
+    for(key in obj){
+      if(obj.hasOwnProperty(key)){
+        keys.push(key);
+      }
     }
-  }
-  return keys.sort();
-}
+    return keys.sort();
+  };
 
 function forEachSorted(obj, iterator, context) {
   var keys = sortedKeys(obj);


### PR DESCRIPTION
Request Type: refactor

How to reproduce: 

Component(s): 

Impact: medium

Complexity: small

This issue is related to: performance regression

**Detailed Description:**

native function Object.keys is much more faster than for loop when getting the array of keys.

**Other Comments:**

if there is Object.keys, it's much faster than for loop .
This is a test example:
http://jsperf.com/angular-object-keys-vs-for-loop
