### PR TITLE
fix(ngModelOptions): introduce $cancelUpdate to cancel pending updates

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1659,20 +1659,20 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
       if ($error[validationErrorKey]) invalidCount--;
       if (!invalidCount) {
         toggleValidCss(true);
-        this.$valid = true;
-        this.$invalid = false;
+        ctrl.$valid = true;
+        ctrl.$invalid = false;
       }
     } else {
       toggleValidCss(false);
-      this.$invalid = true;
-      this.$valid = false;
+      ctrl.$invalid = true;
+      ctrl.$valid = false;
       invalidCount++;
     }
 
     $error[validationErrorKey] = !isValid;
     toggleValidCss(isValid, validationErrorKey);
 
-    parentForm.$setValidity(validationErrorKey, isValid, this);
+    parentForm.$setValidity(validationErrorKey, isValid, ctrl);
   };
 
   /**
@@ -1686,8 +1686,8 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
    * state (ng-pristine class).
    */
   this.$setPristine = function () {
-    this.$dirty = false;
-    this.$pristine = true;
+    ctrl.$dirty = false;
+    ctrl.$pristine = true;
     $animate.removeClass($element, DIRTY_CLASS);
     $animate.addClass($element, PRISTINE_CLASS);
   };
@@ -1713,30 +1713,30 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
    */
   this.$cancelUpdate = function() {
     $timeout.cancel(pendingDebounce);
-    this.$render();
+    ctrl.$render();
   };
 
   // update the view value
   this.$$realSetViewValue = function(value) {
-    this.$viewValue = value;
+    ctrl.$viewValue = value;
 
     // change to dirty
-    if (this.$pristine) {
-      this.$dirty = true;
-      this.$pristine = false;
+    if (ctrl.$pristine) {
+      ctrl.$dirty = true;
+      ctrl.$pristine = false;
       $animate.removeClass($element, PRISTINE_CLASS);
       $animate.addClass($element, DIRTY_CLASS);
       parentForm.$setDirty();
     }
 
-    forEach(this.$parsers, function(fn) {
+    forEach(ctrl.$parsers, function(fn) {
       value = fn(value);
     });
 
-    if (this.$modelValue !== value) {
-      this.$modelValue = value;
+    if (ctrl.$modelValue !== value) {
+      ctrl.$modelValue = value;
       ngModelSet($scope, value);
-      forEach(this.$viewChangeListeners, function(listener) {
+      forEach(ctrl.$viewChangeListeners, function(listener) {
         try {
           listener();
         } catch(e) {
@@ -1772,9 +1772,9 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
    * @param {string} trigger Event that triggered the update.
    */
   this.$setViewValue = function(value, trigger) {
-    var debounceDelay = this.$options && (isObject(this.$options.debounce)
-        ? (this.$options.debounce[trigger] || this.$options.debounce['default'] || 0)
-        : this.$options.debounce) || 0;
+    var debounceDelay = ctrl.$options && (isObject(ctrl.$options.debounce)
+        ? (ctrl.$options.debounce[trigger] || ctrl.$options.debounce['default'] || 0)
+        : ctrl.$options.debounce) || 0;
 
     $timeout.cancel(pendingDebounce);
     if (debounceDelay) {
@@ -1782,7 +1782,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
         ctrl.$$realSetViewValue(value);
       }, debounceDelay);
     } else {
-      this.$$realSetViewValue(value);
+      ctrl.$$realSetViewValue(value);
     }
   };
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -847,20 +847,46 @@ describe('input', function() {
       dealoc(doc);
     }));
 
-
-    it('should allow cancelling pending updates', inject(function($timeout) {
+    it('should allow canceling pending updates', inject(function($timeout) {
       compileInput(
-          '<form name="test">'+
-            '<input type="text" ng-model="name" name="alias" '+
-              'ng-model-options="{ debounce: 10000 }" />'+
-            '</form>');
+        '<input type="text" ng-model="name" name="alias" '+
+          'ng-model-options="{ debounce: 10000 }" />');
+
       changeInputValueTo('a');
       expect(scope.name).toEqual(undefined);
       $timeout.flush(2000);
-      scope.test.alias.$cancelDebounce();
+      scope.form.alias.$cancelUpdate();
       expect(scope.name).toEqual(undefined);
       $timeout.flush(10000);
       expect(scope.name).toEqual(undefined);
+    }));
+
+    it('should reset input val if cancelUpdate called during pending update', function() {
+      compileInput(
+        '<input type="text" ng-model="name" name="alias" '+
+          'ng-model-options="{ updateOn: \'blur\' }" />');
+      scope.$digest();
+
+      changeInputValueTo('a');
+      expect(inputElm.val()).toBe('a');
+      scope.form.alias.$cancelUpdate();
+      expect(inputElm.val()).toBe('');
+      browserTrigger(inputElm, 'blur');
+      expect(inputElm.val()).toBe('');
+    });
+
+    it('should reset input val if cancelUpdate called during debounce', inject(function($timeout) {
+      compileInput(
+        '<input type="text" ng-model="name" name="alias" '+
+          'ng-model-options="{ debounce: 2000 }" />');
+      scope.$digest();
+
+      changeInputValueTo('a');
+      expect(inputElm.val()).toBe('a');
+      scope.form.alias.$cancelUpdate();
+      expect(inputElm.val()).toBe('');
+      $timeout.flush(3000);
+      expect(inputElm.val()).toBe('');
     }));
 
   });


### PR DESCRIPTION
$cancelUpdate cancels any debounce action and resets the view value by invoking $render. this method should be invoked before programmatic update to the model of input that might have pending updates due to updateOn or debounced actions. Fixes https://github.com/angular/angular.js/issues/6994
