### PR TITLE
Fix typo on angular-mocks.js

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2019,7 +2019,7 @@ if(window.jasmine || window.mocha) {
    * @param {...(string|Function|Object)} fns any number of modules which are represented as string
    *        aliases or as anonymous module initialization functions. The modules are used to
    *        configure the injector. The 'ng' and 'ngMock' modules are automatically loaded. If an
-   *        object literal is passed they will be register as values in the module, the key being
+   *        object literal is passed they will be registered as values in the module, the key being
    *        the module name and the value being what is returned.
    */
   window.module = angular.mock.module = function() {


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): ngMock

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**
