### PR TITLE
docs(ngTouch): define module depending on ngTouch in ngTouch examples

### DIFF
--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -25,12 +25,15 @@
  * upon tap. (Event object is available as `$event`)
  *
  * @example
-    <example deps="angular-touch.js">
+    <example module="ngClickExample" deps="angular-touch.js">
       <file name="index.html">
         <button ng-click="count = count + 1" ng-init="count=0">
           Increment
         </button>
         count: {{ count }}
+      </file>
+      <file name="script.js">
+        angular.module('ngClickExample', ['ngTouch']);
       </file>
     </example>
  */

--- a/src/ngTouch/directive/ngSwipe.js
+++ b/src/ngTouch/directive/ngSwipe.js
@@ -19,7 +19,7 @@
  * upon left swipe. (Event object is available as `$event`)
  *
  * @example
-    <example deps="angular-touch.js">
+    <example module="ngSwipeLeftExample" deps="angular-touch.js">
       <file name="index.html">
         <div ng-show="!showActions" ng-swipe-left="showActions = true">
           Some list content, like an email in the inbox
@@ -28,6 +28,9 @@
           <button ng-click="reply()">Reply</button>
           <button ng-click="delete()">Delete</button>
         </div>
+      </file>
+      <file name="script.js">
+        angular.module('ngSwipeLeftExample', ['ngTouch']);
       </file>
     </example>
  */
@@ -49,7 +52,7 @@
  * upon right swipe. (Event object is available as `$event`)
  *
  * @example
-    <example deps="angular-touch.js">
+    <example module="ngSwipeRightExample" deps="angular-touch.js">
       <file name="index.html">
         <div ng-show="!showActions" ng-swipe-left="showActions = true">
           Some list content, like an email in the inbox
@@ -58,6 +61,9 @@
           <button ng-click="reply()">Reply</button>
           <button ng-click="delete()">Delete</button>
         </div>
+      </file>
+      <file name="script.js">
+        angular.module('ngSwipeRightExample', ['ngTouch']);
       </file>
     </example>
  */


### PR DESCRIPTION
In addition to requiring that the file is loaded, it's also necessary to
depend on the ngTouch module when creating the injector.
