### PR TITLE
docs(docs.css): add media query fix

### DIFF
--- a/docs/app/assets/css/docs.css
+++ b/docs/app/assets/css/docs.css
@@ -576,6 +576,15 @@ ul.events > li {
   margin-bottom:40px;
 }
 
+@media only screen and (max-width : 992px) and (min-width : 768px) {
+  .main-body-grid > .grid-left {
+    top: 140px; 
+  }
+  .main-body-grid {
+    margin-top: 160px;
+  }
+}
+
 @media only screen and (max-width : 768px) {
   .picker, .picker select {
     width:auto;


### PR DESCRIPTION
Request Type: docs

How to reproduce: resize browser to between 992px and 768px

Component(s): 

Impact: 

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

show main-body content that is hidden underneath bootstrap navbar
between 992px and 768px screen width
