### PR TITLE
Removed ng-init from inner loop

### DIFF
--- a/src/ng/directive/ngInit.js
+++ b/src/ng/directive/ngInit.js
@@ -38,8 +38,8 @@
    </script>
    <div ng-controller="Ctrl">
      <div ng-repeat="innerList in list" ng-init="outerIndex = $index">
-       <div ng-repeat="value in innerList" ng-init="innerIndex = $index">
-          <span class="example-init">list[ {{outerIndex}} ][ {{innerIndex}} ] = {{value}};</span>
+       <div ng-repeat="value in innerList">
+          <span class="example-init">list[ {{outerIndex}} ][ {{$index}} ] = {{value}};</span>
        </div>
      </div>
    </div>


### PR DESCRIPTION
This is unnecessary. $index should be used instead.
