### PR TITLE
Webstorm IDE complains about Regex Range

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -512,8 +512,8 @@ $CompileProvider.$inject = ['$provide', '$$sanitizeUriProvider'];
 function $CompileProvider($provide, $$sanitizeUriProvider) {
   var hasDirectives = {},
       Suffix = 'Directive',
-      COMMENT_DIRECTIVE_REGEXP = /^\s*directive\:\s*([\d\w\-_]+)\s+(.*)$/,
-      CLASS_DIRECTIVE_REGEXP = /(([\d\w\-_]+)(?:\:([^;]+))?;?)/;
+      COMMENT_DIRECTIVE_REGEXP = /^\s*directive\:\s*([\d\w_\-]+)\s+(.*)$/,
+      CLASS_DIRECTIVE_REGEXP = /(([\d\w_\-]+)(?:\:([^;]+))?;?)/;
 
   // Ref: http://developers.whatwg.org/webappapis.html#event-handler-idl-attributes
   // The assumption is that future DOM event attribute names will begin with


### PR DESCRIPTION
Request Type: bug

How to reproduce: Open angular.js in WebStorm 8, complains that character class may not be used inside character range

Component(s): $compile

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

In CLASS_DIRECTIVE_REGEXP and COMMENT_DIRECTIVE_REGEXP, putting the - character at the end of the character patter speeds up many IDE parsers and alleviates some errors in certain IDE's. (WebStorm 8)
Functionally absolutely equivalent. No test change needed.

**Other Comments:**
