### PR TITLE
Replace valid methods list in $resource documentation

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -121,8 +121,7 @@ function shallowClearAndCopy(src, dst) {
  *
  *   - **`action`** – {string} – The name of action. This name becomes the name of the method on
  *     your resource object.
- *   - **`method`** – {string} – HTTP request method. Valid methods are: `GET`, `POST`, `PUT`,
- *     `DELETE`, and `JSONP`.
+ *   - **`method`** – {string} – Case insensitive HTTP method (e.g. 'GET', 'POST', etc)
  *   - **`params`** – {Object=} – Optional set of pre-bound parameters for this action. If any of
  *     the parameter value is a function, it will be executed every time when a param value needs to
  *     be obtained for a request (unless the param was overridden).


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): ngResource

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The existing documentation places includes a small list of valid methods for custom resource actions.  As any method will be passed through to $http, I see no reason to state that $resource has a more restrictive list of valid methods.

**Other Comments:**
