### PR TITLE
dedupe jshint options

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -38,7 +38,6 @@
     "uppercase": false,
     "manualLowercase": false,
     "manualUppercase": false,
-    "nodeName_": false,
     "isArrayLike": false,
     "forEach": false,
     "sortedKeys": false,


### PR DESCRIPTION
The .jshintrc file in src/ had a duplicate nodeName_ option. I removed the dupe.
