### PR TITLE
style(everything): use parentheses next to a function name and a space before braces

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function(grunt) {
           hostname: '0.0.0.0',
           base: '.',
           keepalive: true,
-          middleware: function(connect, options){
+          middleware: function(connect, options) {
             return [
               //uncomment to enable CSP
               // util.csp(),
@@ -56,7 +56,7 @@ module.exports = function(grunt) {
           // to avoid https://github.com/joyent/libuv/issues/826
           port: 8000,
           hostname: '0.0.0.0',
-          middleware: function(connect, options){
+          middleware: function(connect, options) {
             return [
               function(req, resp, next) {
                 // cache get requests to speed up tests on travis

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -113,7 +113,7 @@
  * @param {string} string String to be converted to lowercase.
  * @returns {string} Lowercased string.
  */
-var lowercase = function(string){return isString(string) ? string.toLowerCase() : string;};
+var lowercase = function(string) { return isString(string) ? string.toLowerCase() : string; };
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 /**
@@ -126,19 +126,19 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
  * @param {string} string String to be converted to uppercase.
  * @returns {string} Uppercased string.
  */
-var uppercase = function(string){return isString(string) ? string.toUpperCase() : string;};
+var uppercase = function(string) { return isString(string) ? string.toUpperCase() : string; };
 
 
 var manualLowercase = function(s) {
   /* jshint bitwise: false */
   return isString(s)
-      ? s.replace(/[A-Z]/g, function(ch) {return String.fromCharCode(ch.charCodeAt(0) | 32);})
+      ? s.replace(/[A-Z]/g, function(ch) { return String.fromCharCode(ch.charCodeAt(0) | 32); })
       : s;
 };
 var manualUppercase = function(s) {
   /* jshint bitwise: false */
   return isString(s)
-      ? s.replace(/[a-z]/g, function(ch) {return String.fromCharCode(ch.charCodeAt(0) & ~32);})
+      ? s.replace(/[a-z]/g, function(ch) { return String.fromCharCode(ch.charCodeAt(0) & ~32); })
       : s;
 };
 
@@ -402,11 +402,11 @@ noop.$inject = [];
      };
    ```
  */
-function identity($) {return $;}
+function identity($) { return $; }
 identity.$inject = [];
 
 
-function valueFn(value) {return function() {return value;};}
+function valueFn(value) { return function() {return value; }; }
 
 /**
  * @ngdoc function
@@ -420,7 +420,7 @@ function valueFn(value) {return function() {return value;};}
  * @param {*} value Reference to check.
  * @returns {boolean} True if `value` is undefined.
  */
-function isUndefined(value){return typeof value === 'undefined';}
+function isUndefined(value) { return typeof value === 'undefined'; }
 
 
 /**
@@ -435,7 +435,7 @@ function isUndefined(value){return typeof value === 'undefined';}
  * @param {*} value Reference to check.
  * @returns {boolean} True if `value` is defined.
  */
-function isDefined(value){return typeof value !== 'undefined';}
+function isDefined(value) { return typeof value !== 'undefined'; }
 
 
 /**
@@ -451,7 +451,7 @@ function isDefined(value){return typeof value !== 'undefined';}
  * @param {*} value Reference to check.
  * @returns {boolean} True if `value` is an `Object` but not `null`.
  */
-function isObject(value){return value != null && typeof value === 'object';}
+function isObject(value) { return value != null && typeof value === 'object'; }
 
 
 /**
@@ -466,7 +466,7 @@ function isObject(value){return value != null && typeof value === 'object';}
  * @param {*} value Reference to check.
  * @returns {boolean} True if `value` is a `String`.
  */
-function isString(value){return typeof value === 'string';}
+function isString(value) { return typeof value === 'string'; }
 
 
 /**
@@ -481,7 +481,7 @@ function isString(value){return typeof value === 'string';}
  * @param {*} value Reference to check.
  * @returns {boolean} True if `value` is a `Number`.
  */
-function isNumber(value){return typeof value === 'number';}
+function isNumber(value) { return typeof value === 'number'; }
 
 
 /**
@@ -496,7 +496,7 @@ function isNumber(value){return typeof value === 'number';}
  * @param {*} value Reference to check.
  * @returns {boolean} True if `value` is a `Date`.
  */
-function isDate(value){
+function isDate(value) {
   return toString.call(value) === '[object Date]';
 }
 
@@ -530,7 +530,7 @@ function isArray(value) {
  * @param {*} value Reference to check.
  * @returns {boolean} True if `value` is a `Function`.
  */
-function isFunction(value){return typeof value === 'function';}
+function isFunction(value) { return typeof value === 'function'; }
 
 
 /**
@@ -614,7 +614,7 @@ function isElement(node) {
  * @param str 'key1,key2,...'
  * @returns {object} in the form of {key1:true, key2:true, ...}
  */
-function makeMap(str){
+function makeMap(str) {
   var obj = {}, items = str.split(","), i;
   for ( i = 0; i < items.length; i++ )
     obj[ items[i] ] = true;
@@ -760,7 +760,7 @@ function isLeafNode (node) {
  </file>
  </example>
  */
-function copy(source, destination){
+function copy(source, destination) {
   if (isWindow(source) || isScope(source)) {
     throw ngMinErr('cpws',
       "Can't copy! Making copies of Window or Scope instances is not supported.");
@@ -1425,7 +1425,7 @@ function bootstrap(element, modules, config) {
 }
 
 var SNAKE_CASE_REGEXP = /[A-Z]/g;
-function snake_case(name, separator){
+function snake_case(name, separator) {
   separator = separator || '_';
   return name.replace(SNAKE_CASE_REGEXP, function(letter, pos) {
     return (pos ? separator : '') + letter.toLowerCase();

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -102,7 +102,7 @@ var version = {
 };
 
 
-function publishExternalAPI(angular){
+function publishExternalAPI(angular) {
   extend(angular, {
     'bootstrap': bootstrap,
     'copy': copy,

--- a/src/apis.js
+++ b/src/apis.js
@@ -34,7 +34,7 @@ function hashKey(obj) {
 /**
  * HashMap which can use objects as keys
  */
-function HashMap(array){
+function HashMap(array) {
   forEach(array, this.put, this);
 }
 HashMap.prototype = {

--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -97,8 +97,8 @@ function annotate(fn, strictDi, name) {
         }
         fnText = fn.toString().replace(STRIP_COMMENTS, '');
         argDecl = fnText.match(FN_ARGS);
-        forEach(argDecl[1].split(FN_ARG_SPLIT), function(arg){
-          arg.replace(FN_ARG, function(all, underscore, name){
+        forEach(argDecl[1].split(FN_ARG_SPLIT), function(arg) {
+          arg.replace(FN_ARG, function(all, underscore, name) {
             $inject.push(name);
           });
         });
@@ -692,7 +692,7 @@ function createInjector(modulesToLoad, strictDi) {
   ////////////////////////////////////
   // Module Loading
   ////////////////////////////////////
-  function loadModules(modulesToLoad){
+  function loadModules(modulesToLoad) {
     var runBlocks = [], moduleFn, invokeQueue, i, ii;
     forEach(modulesToLoad, function(module) {
       if (loadedModules.get(module)) return;
@@ -763,7 +763,7 @@ function createInjector(modulesToLoad, strictDi) {
       }
     }
 
-    function invoke(fn, self, locals, serviceName){
+    function invoke(fn, self, locals, serviceName) {
       if (typeof locals === 'string') {
         serviceName = locals;
         locals = null;

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -280,7 +280,7 @@ function jqLiteClone(element) {
   return element.cloneNode(true);
 }
 
-function jqLiteDealoc(element){
+function jqLiteDealoc(element) {
   jqLiteRemoveData(element);
   for ( var i = 0, children = element.childNodes || []; i < children.length; i++) {
     jqLiteDealoc(children[i]);
@@ -566,7 +566,7 @@ forEach({
     }
   },
 
-  attr: function(element, name, value){
+  attr: function(element, name, value) {
     var lowercasedName = lowercase(name);
     if (BOOLEAN_ATTR[lowercasedName]) {
       if (isDefined(value)) {
@@ -765,7 +765,7 @@ forEach({
 
   dealoc: jqLiteDealoc,
 
-  on: function onFn(element, type, fn, unsupported){
+  on: function onFn(element, type, fn, unsupported) {
     if (isDefined(unsupported)) throw jqLiteMinErr('onargs', 'jqLite#on() does not support the `selector` or `eventData` parameters');
 
     var events = jqLiteExpandoStore(element, 'events'),

--- a/src/minErr.js
+++ b/src/minErr.js
@@ -29,7 +29,7 @@
  */
 
 function minErr(module) {
-  return function () {
+  return function() {
     var code = arguments[0],
       prefix = '[' + (module ? module + ':' : '') + code + '] ',
       template = arguments[1],

--- a/src/ng/anchorScroll.js
+++ b/src/ng/anchorScroll.js
@@ -26,7 +26,7 @@
      </file>
      <file name="script.js">
        function ScrollCtrl($scope, $location, $anchorScroll) {
-         $scope.gotoBottom = function (){
+         $scope.gotoBottom = function() {
            // set the location.hash to the id of
            // the element you wish to scroll to.
            $location.hash('bottom');

--- a/src/ng/asyncCallback.js
+++ b/src/ng/asyncCallback.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function $$AsyncCallbackProvider(){
+function $$AsyncCallbackProvider() {
   this.$get = ['$$rAF', '$timeout', function($$rAF, $timeout) {
     return $$rAF.supported
       ? function(fn) { return $$rAF(fn); }

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -376,7 +376,7 @@ function Browser(window, document, $log, $sniffer) {
 
 }
 
-function $BrowserProvider(){
+function $BrowserProvider() {
   this.$get = ['$window', '$log', '$sniffer', '$document',
       function( $window,   $log,   $sniffer,   $document){
         return new Browser($window, $document, $log, $sniffer);

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -838,7 +838,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               compileNodes($compileNodes, transcludeFn, $compileNodes,
                            maxPriority, ignoreDirective, previousCompileContext);
       safeAddClass($compileNodes, 'ng-scope');
-      return function publicLinkFn(scope, cloneConnectFn, transcludeControllers){
+      return function publicLinkFn(scope, cloneConnectFn, transcludeControllers) {
         assertArg(scope, 'scope');
         // important!!: we must call our jqLite.clone() since the jQuery one is trying to be smart
         // and sometimes changes the structure of the DOM.

--- a/src/ng/directive/a.js
+++ b/src/ng/directive/a.js
@@ -37,7 +37,7 @@ var htmlAnchorDirective = valueFn({
         // SVGAElement does not use the href attribute, but rather the 'xlinkHref' attribute.
         var href = toString.call(element.prop('href')) === '[object SVGAnimatedString]' ?
                    'xlink:href' : 'href';
-        element.on('click', function(event){
+        element.on('click', function(event) {
           // if we have no href url, then don't navigate anywhere.
           if (!element.attr(href)) {
             event.preventDefault();

--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -193,7 +193,7 @@ function FormController(element, attrs, $scope, $animate) {
    * Setting a form back to a pristine state is often useful when we want to 'reuse' a form after
    * saving or resetting it.
    */
-  form.$setPristine = function () {
+  form.$setPristine = function() {
     $animate.removeClass(element, DIRTY_CLASS);
     $animate.addClass(element, PRISTINE_CLASS);
     form.$dirty = false;

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -855,7 +855,7 @@ var inputType = {
 
 // A helper function to call $setValidity and return the value / undefined,
 // a pattern that is repeated a lot in the input validation logic.
-function validate(ctrl, validatorName, validity, value){
+function validate(ctrl, validatorName, validity, value) {
   ctrl.$setValidity(validatorName, validity);
   return validity ? value : undefined;
 }

--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -256,7 +256,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
         var lastBlockMap = {};
 
         //watch props
-        $scope.$watchCollection(rhs, function ngRepeatAction(collection){
+        $scope.$watchCollection(rhs, function ngRepeatAction(collection) {
           var index, length,
               previousNode = $element[0],     // current position of the node
               nextNode,

--- a/src/ng/directive/ngShowHide.js
+++ b/src/ng/directive/ngShowHide.js
@@ -167,7 +167,7 @@
  */
 var ngShowDirective = ['$animate', function($animate) {
   return function(scope, element, attr) {
-    scope.$watch(attr.ngShow, function ngShowWatchAction(value){
+    scope.$watch(attr.ngShow, function ngShowWatchAction(value) {
       $animate[toBoolean(value) ? 'removeClass' : 'addClass'](element, 'ng-hide');
     });
   };
@@ -327,7 +327,7 @@ var ngShowDirective = ['$animate', function($animate) {
  */
 var ngHideDirective = ['$animate', function($animate) {
   return function(scope, element, attr) {
-    scope.$watch(attr.ngHide, function ngHideWatchAction(value){
+    scope.$watch(attr.ngHide, function ngHideWatchAction(value) {
       $animate[toBoolean(value) ? 'addClass' : 'removeClass'](element, 'ng-hide');
     });
   };

--- a/src/ng/document.js
+++ b/src/ng/document.js
@@ -24,7 +24,7 @@
      </file>
    </example>
  */
-function $DocumentProvider(){
+function $DocumentProvider() {
   this.$get = ['$window', function(window){
     return jqLite(window.document);
   }];

--- a/src/ng/exceptionHandler.js
+++ b/src/ng/exceptionHandler.js
@@ -16,7 +16,7 @@
  * ## Example:
  *
  * ```js
- *   angular.module('exceptionOverride', []).factory('$exceptionHandler', function () {
+ *   angular.module('exceptionOverride', []).factory('$exceptionHandler', function() {
  *     return function (exception, cause) {
  *       exception.message += ' (caused by "' + cause + '")';
  *       throw exception;

--- a/src/ng/filter/limitTo.js
+++ b/src/ng/filter/limitTo.js
@@ -69,7 +69,7 @@
      </file>
    </example>
  */
-function limitToFilter(){
+function limitToFilter() {
   return function(input, limit) {
     if (!isArray(input) && !isString(input)) return input;
 

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -61,7 +61,7 @@
    </example>
  */
 orderByFilter.$inject = ['$parse'];
-function orderByFilter($parse){
+function orderByFilter($parse) {
   return function(array, sortPredicate, reverseOrder) {
     if (!isArray(array)) return array;
     if (!sortPredicate) return array;
@@ -89,7 +89,7 @@ function orderByFilter($parse){
     for ( var i = 0; i < array.length; i++) { arrayCopy.push(array[i]); }
     return arrayCopy.sort(reverseComparator(comparator, reverseOrder));
 
-    function comparator(o1, o2){
+    function comparator(o1, o2) {
       for ( var i = 0; i < sortPredicate.length; i++) {
         var comp = sortPredicate[i](o1, o2);
         if (comp !== 0) return comp;
@@ -101,7 +101,7 @@ function orderByFilter($parse){
           ? function(a,b){return comp(b,a);}
           : comp;
     }
-    function compare(v1, v2){
+    function compare(v1, v2) {
       var t1 = typeof v1;
       var t2 = typeof v2;
       if (t1 == t2) {

--- a/src/ng/locale.js
+++ b/src/ng/locale.js
@@ -10,7 +10,7 @@
  *
  * * `id` – `{string}` – locale id formatted as `languageId-countryId` (e.g. `en-us`)
  */
-function $LocaleProvider(){
+function $LocaleProvider() {
   this.$get = function() {
     return {
       id: 'en-us',

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -539,7 +539,7 @@ function locationGetterSetter(property, preprocess) {
  * @description
  * Use the `$locationProvider` to configure how the application deep linking paths are stored.
  */
-function $LocationProvider(){
+function $LocationProvider() {
   var hashPrefix = '',
       html5Mode = false;
 

--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -42,7 +42,7 @@
  * @description
  * Use the `$logProvider` to configure how the application logs messages
  */
-function $LogProvider(){
+function $LogProvider() {
   var debug = true,
       self = this;
 
@@ -107,7 +107,7 @@ function $LogProvider(){
        * @description
        * Write a debug message
        */
-      debug: (function () {
+      debug: (function() {
         var fn = consoleLog('debug');
 
         return function() {

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -393,7 +393,7 @@ var Parser = function (lexer, $filter, options) {
   this.options = options;
 };
 
-Parser.ZERO = extend(function () {
+Parser.ZERO = extend(function() {
   return 0;
 }, {
   constant: true
@@ -435,7 +435,7 @@ Parser.prototype = {
     return value;
   },
 
-  primary: function () {
+  primary: function() {
     var primary;
     if (this.expect('(')) {
       primary = this.filterChain();
@@ -784,7 +784,7 @@ Parser.prototype = {
   },
 
   // This is used with json array declaration
-  arrayDeclaration: function () {
+  arrayDeclaration: function() {
     var elementFns = [];
     var allConstant = true;
     if (this.peekToken().text !== ']') {
@@ -814,7 +814,7 @@ Parser.prototype = {
     });
   },
 
-  object: function () {
+  object: function() {
     var keyValues = [];
     var allConstant = true;
     if (this.peekToken().text !== '}') {

--- a/src/ng/raf.js
+++ b/src/ng/raf.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function $$RAFProvider(){ //rAF
+function $$RAFProvider() { //rAF
   this.$get = ['$window', '$timeout', function($window, $timeout) {
     var requestAnimationFrame = $window.requestAnimationFrame ||
                                 $window.webkitRequestAnimationFrame ||

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -67,7 +67,7 @@
  * They also provide an event emission/broadcast and subscription facility. See the
  * {@link guide/scope developer guide on scopes}.
  */
-function $RootScopeProvider(){
+function $RootScopeProvider() {
   var TTL = 10;
   var $rootScopeMinErr = minErr('$rootScope');
   var lastDirtyWatch = null;

--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -750,7 +750,7 @@ function $SceProvider() {
      * @description
      * Returns a boolean indicating if SCE is enabled.
      */
-    sce.isEnabled = function () {
+    sce.isEnabled = function() {
       return enabled;
     };
     sce.trustAs = $sceDelegate.trustAs;

--- a/src/ng/window.js
+++ b/src/ng/window.js
@@ -40,6 +40,6 @@
      </file>
    </example>
  */
-function $WindowProvider(){
+function $WindowProvider() {
   this.$get = valueFn(window);
 }

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -298,7 +298,7 @@ angular.mock.$LogProvider = function() {
     }
   };
 
-  this.$get = function () {
+  this.$get = function() {
     var $log = {
       log: function() { $log.log.logs.push(concat([], arguments, 0)); },
       warn: function() { $log.warn.logs.push(concat([], arguments, 0)); },
@@ -318,7 +318,7 @@ angular.mock.$LogProvider = function() {
      * @description
      * Reset all of the logging arrays to empty.
      */
-    $log.reset = function () {
+    $log.reset = function() {
       /**
        * @ngdoc property
        * @name $log#log.logs

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -337,7 +337,7 @@ function shallowClearAndCopy(src, dst) {
  * ```
  */
 angular.module('ngResource', ['ng']).
-  provider('$resource', function () {
+  provider('$resource', function() {
     var provider = this;
 
     this.defaults = {

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -34,7 +34,7 @@ var ngRouteModule = angular.module('ngRoute', ['ng']).
  * ## Dependencies
  * Requires the {@link ngRoute `ngRoute`} module to be installed.
  */
-function $RouteProvider(){
+function $RouteProvider() {
   function inherit(parent, extra) {
     return angular.extend(new (angular.extend(function() {}, {prototype:parent}))(), extra);
   }

--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -416,7 +416,7 @@ function encodeEntities(value) {
  *     comment: function(text) {}
  * }
  */
-function htmlSanitizeWriter(buf, uriValidator){
+function htmlSanitizeWriter(buf, uriValidator) {
   var ignore = false;
   var out = angular.bind(buf, buf.push);
   return {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -17,7 +17,7 @@ describe('angular', function() {
   });
 
   describe("copy", function() {
-    it("should return same object", function () {
+    it("should return same object", function() {
       var obj = {};
       var arr = [];
       expect(copy({}, obj)).toBe(obj);
@@ -755,11 +755,11 @@ describe('angular', function() {
     });
 
 
-    it('should complain if an element has already been bootstrapped', function () {
+    it('should complain if an element has already been bootstrapped', function() {
       var element = jqLite('<div>bootstrap me!</div>');
       angular.bootstrap(element);
 
-      expect(function () {
+      expect(function() {
         angular.bootstrap(element);
       }).toThrowMatching(
         /\[ng:btstrpd\] App Already Bootstrapped with this Element '<div class="?ng\-scope"?( ng\-[0-9]+="?[0-9]+"?)?>'/i
@@ -769,9 +769,9 @@ describe('angular', function() {
     });
 
 
-    it('should complain if manually bootstrapping a document whose <html> element has already been bootstrapped', function () {
+    it('should complain if manually bootstrapping a document whose <html> element has already been bootstrapped', function() {
       angular.bootstrap(document.getElementsByTagName('html')[0]);
-      expect(function () {
+      expect(function() {
         angular.bootstrap(document);
       }).toThrowMatching(
         /\[ng:btstrpd\] App Already Bootstrapped with this Element 'document'/i

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -59,7 +59,7 @@ describe('injector', function() {
 
 
   it('should allow query names', function() {
-    providers('abc', function () { return ''; });
+    providers('abc', function() { return ''; });
 
     expect(injector.has('abc')).toBe(true);
     expect(injector.has('xyz')).toBe(false);
@@ -152,7 +152,7 @@ describe('injector', function() {
       fn.$inject = ['a'];
       expect(annotate(fn)).toBe(fn.$inject);
       expect(annotate(function() {})).toEqual([]);
-      expect(annotate(function () {})).toEqual([]);
+      expect(annotate(function() {})).toEqual([]);
       expect(annotate(function  () {})).toEqual([]);
       expect(annotate(function /* */ () {})).toEqual([]);
     });
@@ -605,7 +605,7 @@ describe('injector', function() {
 
 
       it('should decorate the missing service error with module function', function() {
-        function myModule(xyzzy){}
+        function myModule(xyzzy) {}
         expect(function() {
           createInjector([myModule]);
         }).toThrowMinErr(
@@ -615,7 +615,7 @@ describe('injector', function() {
 
 
       it('should decorate the missing service error with module array function', function() {
-        function myModule(xyzzy){}
+        function myModule(xyzzy) {}
         expect(function() {
           createInjector([['xyzzy', myModule]]);
         }).toThrowMinErr(

--- a/test/e2e/docsAppE2E.js
+++ b/test/e2e/docsAppE2E.js
@@ -1,6 +1,6 @@
-describe('docs.angularjs.org', function () {
-  describe('App', function () {
-    // it('should filter the module list when searching', function () {
+describe('docs.angularjs.org', function() {
+  describe('App', function() {
+    // it('should filter the module list when searching', function() {
     //   browser.get();
     //   browser.waitForAngular();
 
@@ -13,7 +13,7 @@ describe('docs.angularjs.org', function () {
     // });
 
 
-    it('should change the page content when clicking a link to a service', function () {
+    it('should change the page content when clicking a link to a service', function() {
       browser.get('');
 
       var ngBindLink = element(by.css('.definition-table td a[href="api/ng/directive/ngClick"]'));
@@ -24,7 +24,7 @@ describe('docs.angularjs.org', function () {
     });
 
 
-    it('should show the functioning input directive example', function () {
+    it('should show the functioning input directive example', function() {
       browser.get('index-debug.html#!/api/ng/directive/input');
 
       //Wait for animation

--- a/test/helpers/matchers.js
+++ b/test/helpers/matchers.js
@@ -203,7 +203,7 @@ beforeEach(function() {
         exceptionMessage = exception.message || exception;
       }
 
-      this.message = function () {
+      this.message = function() {
         return "Expected function " + not + "to throw " +
           namespace + "MinErr('" + code + "')" +
           (regex ? " matching " + regex.toString() : "") +

--- a/test/helpers/testabilityPatch.js
+++ b/test/helpers/testabilityPatch.js
@@ -306,7 +306,7 @@ function trace(name) {
 }
 
 var karmaDump = dump;
-window.dump = function () {
+window.dump = function() {
   karmaDump.apply(undefined, map(arguments, function(arg) {
     return angular.mock.dump(arg);
   }));

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -185,7 +185,7 @@ describe('jqLite', function() {
       }
     );
 
-    it('should return null values', function () {
+    it('should return null values', function() {
       var ul = jqLite('<ul><li><p><b>deep deep</b><p></li></ul>'),
           li = ul.find('li'),
           b = li.find('b');
@@ -365,7 +365,7 @@ describe('jqLite', function() {
       expect(jqLite(c).data('prop')).toBeUndefined();
     });
 
-    it('should only remove the specified value when providing a property name to removeData', function () {
+    it('should only remove the specified value when providing a property name to removeData', function() {
       var selected = jqLite(a);
 
       expect(selected.data('prop1')).toBeUndefined();
@@ -710,7 +710,7 @@ describe('jqLite', function() {
 
       });
 
-      it('should allow toggling multiple classes without a condition', function () {
+      it('should allow toggling multiple classes without a condition', function() {
         var selector = jqLite([a, b]);
         expect(selector.toggleClass('abc cde')).toBe(selector);
         expect(jqLite(a).hasClass('abc')).toBe(true);
@@ -738,7 +738,7 @@ describe('jqLite', function() {
         expect(jqLite(b).hasClass('cde')).toBe(false);
       });
 
-      it('should allow toggling multiple classes with a condition', function () {
+      it('should allow toggling multiple classes with a condition', function() {
         var selector = jqLite([a, b]);
         selector.addClass('abc');
         expect(selector.toggleClass('abc cde', true)).toBe(selector);
@@ -755,7 +755,7 @@ describe('jqLite', function() {
         expect(jqLite(b).hasClass('cde')).toBe(false);
       });
 
-      it('should not break for null / undefined selectors', function () {
+      it('should not break for null / undefined selectors', function() {
         var selector = jqLite([a, b]);
         expect(selector.toggleClass(null)).toBe(selector);
         expect(selector.toggleClass(undefined)).toBe(selector);
@@ -890,7 +890,7 @@ describe('jqLite', function() {
       expect(input.val()).toEqual('abc');
     });
 
-    it('should get an array of selected elements from a multi select', function () {
+    it('should get an array of selected elements from a multi select', function() {
       expect(jqLite(
         '<select multiple>' +
           '<option selected>test 1</option>' +
@@ -1125,7 +1125,7 @@ describe('jqLite', function() {
       aElem.off('click', function() {});
     });
 
-    it('should do nothing when a specific listener was not registered', function () {
+    it('should do nothing when a specific listener was not registered', function() {
       var aElem = jqLite(a);
       aElem.on('click', function() {});
 
@@ -1289,10 +1289,10 @@ describe('jqLite', function() {
 
     // Only run this test for jqLite and not normal jQuery
     if ( _jqLiteMode ) {
-      it('should throw an error if a selector is passed', function () {
+      it('should throw an error if a selector is passed', function() {
         var aElem = jqLite(a);
         aElem.on('click', noop);
-        expect(function () {
+        expect(function() {
           aElem.off('click', noop, '.test');
         }).toThrowMatching(/\[jqLite:offargs\]/);
       });

--- a/test/loaderSpec.js
+++ b/test/loaderSpec.js
@@ -3,7 +3,7 @@
 describe('module loader', function() {
   var window;
 
-  beforeEach(function () {
+  beforeEach(function() {
     window = {};
     setupModuleLoader(window);
   });

--- a/test/minErrSpec.js
+++ b/test/minErrSpec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('minErr', function () {
+describe('minErr', function() {
 
   var supportStackTraces = function() {
     var e = new Error();
@@ -76,7 +76,7 @@ describe('minErr', function () {
     expect(myError.message).toMatch(/^\[test:26\] Something horrible happened!/);
   });
 
-  it('should include a namespace in the message only if it is namespaced', function () {
+  it('should include a namespace in the message only if it is namespaced', function() {
     var myError = emptyTestError('26', 'This is a {0}', 'Foo');
     var myNamespacedError = testError('26', 'That is a {0}', 'Bar');
     expect(myError.message).toMatch(/^\[26\] This is a Foo/);

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -279,12 +279,12 @@ describe('browser', function() {
       });
     });
 
-    describe('put via cookies(cookieName, string), if no <base href> ', function () {
-      beforeEach(function () {
+    describe('put via cookies(cookieName, string), if no <base href> ', function() {
+      beforeEach(function() {
         fakeDocument.basePath = undefined;
       });
 
-      it('should default path in cookie to "" (empty string)', function () {
+      it('should default path in cookie to "" (empty string)', function() {
         browser.cookies('cookie', 'bender');
         // This only fails in Safari and IE when cookiePath returns undefined
         // Where it now succeeds since baseHref return '' instead of undefined

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3343,13 +3343,13 @@ describe('$compile', function() {
     });
 
 
-    it('should instantiate the controller after the isolate scope bindings are initialized (with template)', function () {
-      module(function () {
+    it('should instantiate the controller after the isolate scope bindings are initialized (with template)', function() {
+      module(function() {
         var Ctrl = function ($scope, log) {
           log('myFoo=' + $scope.myFoo);
         };
 
-        directive('myDirective', function () {
+        directive('myDirective', function() {
           return {
             scope: {
               myFoo: "="
@@ -3370,13 +3370,13 @@ describe('$compile', function() {
     });
 
 
-    it('should instantiate the controller after the isolate scope bindings are initialized (with templateUrl)', function () {
-      module(function () {
+    it('should instantiate the controller after the isolate scope bindings are initialized (with templateUrl)', function() {
+      module(function() {
         var Ctrl = function ($scope, log) {
           log('myFoo=' + $scope.myFoo);
         };
 
-        directive('myDirective', function () {
+        directive('myDirective', function() {
           return {
             scope: {
               myFoo: "="
@@ -3447,21 +3447,21 @@ describe('$compile', function() {
     });
 
 
-    it('should allow controller usage in pre-link directive functions with templateUrl', function () {
-      module(function () {
+    it('should allow controller usage in pre-link directive functions with templateUrl', function() {
+      module(function() {
         var Ctrl = function (log) {
           log('instance');
         };
 
-        directive('myDirective', function () {
+        directive('myDirective', function() {
           return {
             scope: true,
             templateUrl: 'hello.html',
             controller: Ctrl,
-            compile: function () {
+            compile: function() {
               return {
                 pre: function (scope, template, attr, ctrl) {},
-                post: function () {}
+                post: function() {}
               };
             }
           };
@@ -3480,21 +3480,21 @@ describe('$compile', function() {
     });
 
 
-    it('should allow controller usage in pre-link directive functions with a template', function () {
-      module(function () {
+    it('should allow controller usage in pre-link directive functions with a template', function() {
+      module(function() {
         var Ctrl = function (log) {
           log('instance');
         };
 
-        directive('myDirective', function () {
+        directive('myDirective', function() {
           return {
             scope: true,
             template: '<p>Hello</p>',
             controller: Ctrl,
-            compile: function () {
+            compile: function() {
               return {
                 pre: function (scope, template, attr, ctrl) {},
-                post: function () {}
+                post: function() {}
               };
             }
           };
@@ -4564,7 +4564,7 @@ describe('$compile', function() {
       expect(element.attr('test4')).toBe('Misko');
     }));
 
-    describe('when an attribute has a dash-separated name', function () {
+    describe('when an attribute has a dash-separated name', function() {
 
       it('should work with different prefixes', inject(function($compile, $rootScope) {
         $rootScope.name = "JamieMason";
@@ -4678,7 +4678,7 @@ describe('$compile', function() {
     }));
 
 
-    it('should throw error if unterminated', function () {
+    it('should throw error if unterminated', function() {
       module(function($compileProvider) {
         $compileProvider.directive('foo', function() {
           return {
@@ -4696,7 +4696,7 @@ describe('$compile', function() {
     });
 
 
-    it('should correctly collect ranges on multiple directives on a single element', function () {
+    it('should correctly collect ranges on multiple directives on a single element', function() {
       module(function($compileProvider) {
         $compileProvider.directive('emptyDirective', function() {
           return function (scope, element) {
@@ -4728,7 +4728,7 @@ describe('$compile', function() {
     });
 
 
-    it('should throw error if unterminated (containing termination as a child)', function () {
+    it('should throw error if unterminated (containing termination as a child)', function() {
       module(function($compileProvider) {
         $compileProvider.directive('foo', function() {
           return {

--- a/test/ng/controllerSpec.js
+++ b/test/ng/controllerSpec.js
@@ -59,7 +59,7 @@ describe('$controller', function() {
     });
 
 
-    it('should throw an exception if a controller is called "hasOwnProperty"', function () {
+    it('should throw an exception if a controller is called "hasOwnProperty"', function() {
       expect(function() {
         $controllerProvider.register('hasOwnProperty', function($scope) {});
       }).toThrowMinErr('ng', 'badname', "hasOwnProperty is not a valid controller name");

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -68,7 +68,7 @@ describe('form', function() {
     expect(scope.myForm.alias).toBeDefined();
   });
 
-  it('should use ngForm value as form name when nested inside form', function () {
+  it('should use ngForm value as form name when nested inside form', function() {
     doc = $compile(
       '<form name="myForm">' +
         '<div ng-form="nestedForm"><input type="text" name="alias" ng-model="value"/></div>' +

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1045,7 +1045,7 @@ describe('input', function() {
 
 
   // INPUT TYPES
-  describe('month', function (){
+  describe('month', function() {
       it('should render blank if model is not a Date object', function() {
           compileInput('<input type="month" ng-model="january"/>');
 
@@ -1056,7 +1056,7 @@ describe('input', function() {
           expect(inputElm.val()).toBe('');
       });
 
-      it('should set the view if the model is a valid Date object', function (){
+      it('should set the view if the model is a valid Date object', function() {
           compileInput('<input type="month" ng-model="march"/>');
 
           scope.$apply(function(){
@@ -1066,7 +1066,7 @@ describe('input', function() {
           expect(inputElm.val()).toBe('2013-03');
       });
 
-      it('should set the model undefined if the input is an invalid month string', function () {
+      it('should set the model undefined if the input is an invalid month string', function() {
           compileInput('<input type="month" ng-model="value"/>');
 
           scope.$apply(function(){
@@ -1128,20 +1128,20 @@ describe('input', function() {
       });
 
 
-      describe('min', function (){
-          beforeEach(function (){
+      describe('min', function() {
+          beforeEach(function() {
               compileInput('<input type="month" ng-model="value" name="alias" min="2013-01" />');
               scope.$digest();
           });
 
-          it('should invalidate', function (){
+          it('should invalidate', function() {
               changeInputValueTo('2012-12');
               expect(inputElm).toBeInvalid();
               expect(scope.value).toBeFalsy();
               expect(scope.form.alias.$error.min).toBeTruthy();
           });
 
-          it('should validate', function (){
+          it('should validate', function() {
               changeInputValueTo('2013-07');
               expect(inputElm).toBeValid();
               expect(+scope.value).toBe(+new Date(2013, 6, 1));
@@ -1149,20 +1149,20 @@ describe('input', function() {
           });
       });
 
-      describe('max', function(){
-          beforeEach(function (){
+      describe('max', function() {
+          beforeEach(function() {
               compileInput('<input type="month" ng-model="value" name="alias" max="2013-01" />');
               scope.$digest();
           });
 
-          it('should validate', function (){
+          it('should validate', function() {
               changeInputValueTo('2012-03');
               expect(inputElm).toBeValid();
               expect(+scope.value).toBe(+new Date(2012, 2, 1));
               expect(scope.form.alias.$error.max).toBeFalsy();
           });
 
-          it('should invalidate', function (){
+          it('should invalidate', function() {
               changeInputValueTo('2013-05');
               expect(inputElm).toBeInvalid();
               expect(scope.value).toBeUndefined();
@@ -1171,18 +1171,18 @@ describe('input', function() {
       });
   });
 
-   describe('week', function (){
+   describe('week', function() {
       it('should set render blank if model is not a Date object', function() {
          compileInput('<input type="week" ng-model="secondWeek"/>');
 
-         scope.$apply(function(){
+         scope.$apply(function() {
             scope.secondWeek = '2013-W02';
          });
 
          expect(inputElm.val()).toBe('');
       });
 
-      it('should set the view if the model is a valid Date object', function (){
+      it('should set the view if the model is a valid Date object', function() {
          compileInput('<input type="week" ng-model="secondWeek"/>');
 
          scope.$apply(function(){
@@ -1192,10 +1192,10 @@ describe('input', function() {
          expect(inputElm.val()).toBe('2013-W02');
       });
 
-      it('should set the model undefined if the input is an invalid week string', function () {
+      it('should set the model undefined if the input is an invalid week string', function() {
          compileInput('<input type="week" ng-model="value"/>');
 
-         scope.$apply(function(){
+         scope.$apply(function() {
             scope.value = new Date(2013, 0, 11);
          });
 
@@ -1253,20 +1253,20 @@ describe('input', function() {
            expect(inputElm).toBeValid();
        });
 
-      describe('min', function (){
-         beforeEach(function (){
+      describe('min', function() {
+         beforeEach(function() {
             compileInput('<input type="week" ng-model="value" name="alias" min="2013-W01" />');
             scope.$digest();
          });
 
-         it('should invalidate', function (){
+         it('should invalidate', function() {
             changeInputValueTo('2012-W12');
             expect(inputElm).toBeInvalid();
             expect(scope.value).toBeFalsy();
             expect(scope.form.alias.$error.min).toBeTruthy();
          });
 
-         it('should validate', function (){
+         it('should validate', function() {
             changeInputValueTo('2013-W03');
             expect(inputElm).toBeValid();
             expect(+scope.value).toBe(+new Date(2013, 0, 17));
@@ -1274,20 +1274,20 @@ describe('input', function() {
          });
       });
 
-      describe('max', function(){
-         beforeEach(function (){
+      describe('max', function() {
+         beforeEach(function() {
             compileInput('<input type="week" ng-model="value" name="alias" max="2013-W01" />');
             scope.$digest();
          });
 
-         it('should validate', function (){
+         it('should validate', function() {
             changeInputValueTo('2012-W01');
             expect(inputElm).toBeValid();
             expect(+scope.value).toBe(+new Date(2012, 0, 5));
             expect(scope.form.alias.$error.max).toBeFalsy();
          });
 
-         it('should invalidate', function (){
+         it('should invalidate', function() {
             changeInputValueTo('2013-W03');
             expect(inputElm).toBeInvalid();
             expect(scope.value).toBeUndefined();
@@ -1296,7 +1296,7 @@ describe('input', function() {
       });
    });
 
-   describe('datetime-local', function () {
+   describe('datetime-local', function() {
       it('should render blank if model is not a Date object', function() {
          compileInput('<input type="datetime-local" ng-model="lunchtime"/>');
 
@@ -1307,20 +1307,20 @@ describe('input', function() {
          expect(inputElm.val()).toBe('');
       });
 
-      it('should set the view if the model if a valid Date object.', function(){
+      it('should set the view if the model if a valid Date object.', function() {
          compileInput('<input type="datetime-local" ng-model="tenSecondsToNextYear"/>');
 
-         scope.$apply(function (){
+         scope.$apply(function() {
             scope.tenSecondsToNextYear = new Date(2013, 11, 31, 23, 59);
          });
 
          expect(inputElm.val()).toBe('2013-12-31T23:59');
       });
 
-      it('should set the model undefined if the view is invalid', function (){
+      it('should set the model undefined if the view is invalid', function() {
          compileInput('<input type="datetime-local" ng-model="breakMe"/>');
 
-         scope.$apply(function (){
+         scope.$apply(function() {
             scope.breakMe = new Date(2009, 0, 6, 16, 25);
          });
 
@@ -1377,20 +1377,20 @@ describe('input', function() {
            expect(inputElm).toBeValid();
        });
 
-      describe('min', function (){
-         beforeEach(function (){
+      describe('min', function() {
+         beforeEach(function() {
             compileInput('<input type="datetime-local" ng-model="value" name="alias" min="2000-01-01T12:30" />');
             scope.$digest();
          });
 
-         it('should invalidate', function (){
+         it('should invalidate', function() {
             changeInputValueTo('1999-12-31T01:02');
             expect(inputElm).toBeInvalid();
             expect(scope.value).toBeFalsy();
             expect(scope.form.alias.$error.min).toBeTruthy();
          });
 
-         it('should validate', function (){
+         it('should validate', function() {
             changeInputValueTo('2000-01-01T23:02');
             expect(inputElm).toBeValid();
             expect(+scope.value).toBe(+new Date(2000, 0, 1, 23, 2));
@@ -1398,13 +1398,13 @@ describe('input', function() {
          });
       });
 
-      describe('max', function (){
-         beforeEach(function (){
+      describe('max', function() {
+         beforeEach(function() {
             compileInput('<input type="datetime-local" ng-model="value" name="alias" max="2019-01-01T01:02" />');
             scope.$digest();
          });
 
-         it('should invalidate', function (){
+         it('should invalidate', function() {
             changeInputValueTo('2019-12-31T01:02');
             expect(inputElm).toBeInvalid();
             expect(scope.value).toBeFalsy();
@@ -1428,7 +1428,7 @@ describe('input', function() {
          expect(inputElm).toBeInvalid();
 
          scope.max = '2001-01-01T01:02';
-         scope.$digest(function () {
+         scope.$digest(function() {
             expect(inputElm).toBeValid();
             done();
          });
@@ -1443,14 +1443,14 @@ describe('input', function() {
          expect(inputElm).toBeInvalid();
 
          scope.min = '2014-01-01T01:02';
-         scope.$digest(function () {
+         scope.$digest(function() {
             expect(inputElm).toBeValid();
             done();
          });
       });
    });
 
-  describe('time', function () {
+  describe('time', function() {
     it('should render blank if model is not a Date object', function() {
       compileInput('<input type="time" ng-model="lunchtime"/>');
 
@@ -1461,20 +1461,20 @@ describe('input', function() {
       expect(inputElm.val()).toBe('');
     });
 
-    it('should set the view if the model if a valid Date object.', function(){
+    it('should set the view if the model if a valid Date object.', function() {
       compileInput('<input type="time" ng-model="threeFortyOnePm"/>');
 
-      scope.$apply(function (){
+      scope.$apply(function() {
         scope.threeFortyOnePm = new Date(0, 0, 1, 15, 41);
       });
 
       expect(inputElm.val()).toBe('15:41');
     });
 
-    it('should set the model undefined if the view is invalid', function (){
+    it('should set the model undefined if the view is invalid', function() {
       compileInput('<input type="time" ng-model="breakMe"/>');
 
-      scope.$apply(function (){
+      scope.$apply(function() {
         scope.breakMe = new Date(0, 0, 1, 16, 25);
       });
 
@@ -1531,20 +1531,20 @@ describe('input', function() {
           expect(inputElm).toBeValid();
       });
 
-    describe('min', function (){
-      beforeEach(function (){
+    describe('min', function() {
+      beforeEach(function() {
         compileInput('<input type="time" ng-model="value" name="alias" min="09:30" />');
         scope.$digest();
       });
 
-      it('should invalidate', function (){
+      it('should invalidate', function() {
         changeInputValueTo('01:02');
         expect(inputElm).toBeInvalid();
         expect(scope.value).toBeFalsy();
         expect(scope.form.alias.$error.min).toBeTruthy();
       });
 
-      it('should validate', function (){
+      it('should validate', function() {
         changeInputValueTo('23:02');
         expect(inputElm).toBeValid();
         expect(+scope.value).toBe(+new Date(0, 0, 1, 23, 2));
@@ -1552,13 +1552,13 @@ describe('input', function() {
       });
     });
 
-    describe('max', function (){
-      beforeEach(function (){
+    describe('max', function() {
+      beforeEach(function() {
         compileInput('<input type="time" ng-model="value" name="alias" max="22:30" />');
         scope.$digest();
       });
 
-      it('should invalidate', function (){
+      it('should invalidate', function() {
         changeInputValueTo('23:00');
         expect(inputElm).toBeInvalid();
         expect(scope.value).toBeFalsy();
@@ -1582,7 +1582,7 @@ describe('input', function() {
       expect(inputElm).toBeInvalid();
 
       scope.max = '12:34';
-      scope.$digest(function () {
+      scope.$digest(function() {
         expect(inputElm).toBeValid();
         done();
       });
@@ -1597,14 +1597,14 @@ describe('input', function() {
       expect(inputElm).toBeInvalid();
 
       scope.min = '13:50';
-      scope.$digest(function () {
+      scope.$digest(function() {
         expect(inputElm).toBeValid();
         done();
       });
     });
   });
 
-  describe('date', function () {
+  describe('date', function() {
     it('should render blank if model is not a Date object.', function() {
         compileInput('<input type="date" ng-model="birthday"/>');
 
@@ -1615,20 +1615,20 @@ describe('input', function() {
         expect(inputElm.val()).toBe('');
     });
 
-    it('should set the view if the model if a valid Date object.', function(){
+    it('should set the view if the model if a valid Date object.', function() {
         compileInput('<input type="date" ng-model="christmas"/>');
 
-        scope.$apply(function (){
+        scope.$apply(function() {
             scope.christmas = new Date(2013, 11, 25);
         });
 
         expect(inputElm.val()).toBe('2013-12-25');
     });
 
-    it('should set the model undefined if the view is invalid', function (){
+    it('should set the model undefined if the view is invalid', function() {
         compileInput('<input type="date" ng-model="arrMatey"/>');
 
-        scope.$apply(function (){
+        scope.$apply(function() {
             scope.arrMatey = new Date(2014, 8, 14);
         });
 
@@ -1685,20 +1685,20 @@ describe('input', function() {
           expect(inputElm).toBeValid();
       });
 
-    describe('min', function (){
-        beforeEach(function (){
+    describe('min', function() {
+        beforeEach(function() {
            compileInput('<input type="date" ng-model="value" name="alias" min="2000-01-01" />');
            scope.$digest();
         });
 
-        it('should invalidate', function (){
+        it('should invalidate', function() {
            changeInputValueTo('1999-12-31');
            expect(inputElm).toBeInvalid();
            expect(scope.value).toBeFalsy();
            expect(scope.form.alias.$error.min).toBeTruthy();
         });
 
-        it('should validate', function (){
+        it('should validate', function() {
             changeInputValueTo('2000-01-01');
             expect(inputElm).toBeValid();
             expect(+scope.value).toBe(+new Date(2000, 0, 1));
@@ -1706,13 +1706,13 @@ describe('input', function() {
         });
     });
 
-    describe('max', function (){
-        beforeEach(function (){
+    describe('max', function() {
+        beforeEach(function() {
            compileInput('<input type="date" ng-model="value" name="alias" max="2019-01-01" />');
            scope.$digest();
         });
 
-        it('should invalidate', function (){
+        it('should invalidate', function() {
             changeInputValueTo('2019-12-31');
             expect(inputElm).toBeInvalid();
             expect(scope.value).toBeFalsy();
@@ -1736,7 +1736,7 @@ describe('input', function() {
       expect(inputElm).toBeInvalid();
 
       scope.max = '2001-01-01';
-      scope.$digest(function () {
+      scope.$digest(function() {
          expect(inputElm).toBeValid();
          done();
       });
@@ -1751,7 +1751,7 @@ describe('input', function() {
        expect(inputElm).toBeInvalid();
 
        scope.min = '2014-01-01';
-       scope.$digest(function () {
+       scope.$digest(function() {
           expect(inputElm).toBeValid();
           done();
        });
@@ -1847,7 +1847,7 @@ describe('input', function() {
         expect(inputElm).toBeInvalid();
 
         scope.min = 0;
-        scope.$digest(function () {
+        scope.$digest(function() {
           expect(inputElm).toBeValid();
           done();
         });
@@ -1881,7 +1881,7 @@ describe('input', function() {
         expect(inputElm).toBeValid();
 
         scope.max = 0;
-        scope.$digest(function () {
+        scope.$digest(function() {
           expect(inputElm).toBeInvalid();
           done();
         });

--- a/test/ng/directive/ngIfSpec.js
+++ b/test/ng/directive/ngIfSpec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('ngIf', function () {
+describe('ngIf', function() {
   var $scope, $compile, element, $compileProvider;
 
   beforeEach(module(function(_$compileProvider_) {
@@ -12,7 +12,7 @@ describe('ngIf', function () {
     element = $compile('<div></div>')($scope);
   }));
 
-  afterEach(function () {
+  afterEach(function() {
     dealoc(element);
   });
 
@@ -21,17 +21,17 @@ describe('ngIf', function () {
     $scope.$apply();
   }
 
-  it('should immediately remove element if condition is false', function () {
+  it('should immediately remove element if condition is false', function() {
     makeIf('false');
     expect(element.children().length).toBe(0);
   });
 
-  it('should leave the element if condition is true', function () {
+  it('should leave the element if condition is true', function() {
     makeIf('true');
     expect(element.children().length).toBe(1);
   });
 
-  it('should not add the element twice if the condition goes from true to true', function () {
+  it('should not add the element twice if the condition goes from true to true', function() {
     $scope.hello = 'true1';
     makeIf('hello');
     expect(element.children().length).toBe(1);
@@ -39,7 +39,7 @@ describe('ngIf', function () {
     expect(element.children().length).toBe(1);
   });
 
-  it('should not recreate the element if the condition goes from true to true', function () {
+  it('should not recreate the element if the condition goes from true to true', function() {
     $scope.hello = 'true1';
     makeIf('hello');
     element.children().data('flag', true);
@@ -47,7 +47,7 @@ describe('ngIf', function () {
     expect(element.children().data('flag')).toBe(true);
   });
 
-  it('should create then remove the element if condition changes', function () {
+  it('should create then remove the element if condition changes', function() {
     $scope.hello = true;
     makeIf('hello');
     expect(element.children().length).toBe(1);
@@ -55,7 +55,7 @@ describe('ngIf', function () {
     expect(element.children().length).toBe(0);
   });
 
-  it('should create a new scope every time the expression evaluates to true', function () {
+  it('should create a new scope every time the expression evaluates to true', function() {
     $scope.$apply('value = true');
     element.append($compile(
       '<div ng-if="value"><span ng-init="value=false"></span></div>'
@@ -84,7 +84,7 @@ describe('ngIf', function () {
     expect(destroyed).toBe(true);
   });
 
-  it('should play nice with other elements beside it', function () {
+  it('should play nice with other elements beside it', function() {
     $scope.values = [1, 2, 3, 4];
     element.append($compile(
       '<div ng-repeat="i in values"></div>' +
@@ -201,7 +201,7 @@ describe('ngIf and transcludes', function() {
   });
 });
 
-describe('ngIf animations', function () {
+describe('ngIf animations', function() {
   var body, element, $rootElement;
 
   function html(html) {

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -362,7 +362,7 @@ describe('ngInclude', function() {
         compileAndLink('<div><ng:include src="tpl" autoscroll></ng:include></div>'),
         function($rootScope, $animate, $timeout) {
 
-      $rootScope.$apply(function () {
+      $rootScope.$apply(function() {
         $rootScope.tpl = 'template.html';
       });
 
@@ -379,7 +379,7 @@ describe('ngInclude', function() {
 
       element = $compile('<div><ng:include src="tpl" autoscroll="value"></ng:include></div>')($rootScope);
 
-      $rootScope.$apply(function () {
+      $rootScope.$apply(function() {
         $rootScope.tpl = 'template.html';
         $rootScope.value = true;
       });
@@ -387,7 +387,7 @@ describe('ngInclude', function() {
       expect($animate.queue.shift().event).toBe('enter');
       $animate.triggerCallbacks();
 
-      $rootScope.$apply(function () {
+      $rootScope.$apply(function() {
         $rootScope.tpl = 'another.html';
         $rootScope.value = 'some-string';
       });
@@ -414,7 +414,7 @@ describe('ngInclude', function() {
         compileAndLink('<div><ng:include src="tpl"></ng:include></div>'),
         function($rootScope, $animate, $timeout) {
 
-      $rootScope.$apply(function () {
+      $rootScope.$apply(function() {
         $rootScope.tpl = 'template.html';
       });
 
@@ -429,7 +429,7 @@ describe('ngInclude', function() {
 
       element = $compile('<div><ng:include src="tpl" autoscroll="value"></ng:include></div>')($rootScope);
 
-      $rootScope.$apply(function () {
+      $rootScope.$apply(function() {
         $rootScope.tpl = 'template.html';
         $rootScope.value = false;
       });
@@ -437,12 +437,12 @@ describe('ngInclude', function() {
       expect($animate.queue.shift().event).toBe('enter');
       $animate.triggerCallbacks();
 
-      $rootScope.$apply(function () {
+      $rootScope.$apply(function() {
         $rootScope.tpl = 'template.html';
         $rootScope.value = undefined;
       });
 
-      $rootScope.$apply(function () {
+      $rootScope.$apply(function() {
         $rootScope.tpl = 'template.html';
         $rootScope.value = null;
       });

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -807,7 +807,7 @@ describe('ngRepeat', function() {
   });
 
   it('should add separator comments after each item', inject(function ($compile, $rootScope) {
-    var check = function () {
+    var check = function() {
       var children = element.find('div');
       expect(children.length).toBe(3);
 
@@ -1008,7 +1008,7 @@ describe('ngRepeat', function() {
       expect(newLis[2]).toEqual(lis[1]);
     });
 
-    it('should be stable even if the collection is initially undefined', function () {
+    it('should be stable even if the collection is initially undefined', function() {
       scope.items = undefined;
       scope.$digest();
 
@@ -1067,7 +1067,7 @@ describe('ngRepeat', function() {
   });
 
 
-  describe('ngRepeatStart', function () {
+  describe('ngRepeatStart', function() {
     it('should grow multi-node repeater', inject(function($compile, $rootScope) {
       $rootScope.show = false;
       $rootScope.books = [

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -990,9 +990,9 @@ describe('select', function() {
     });
 
 
-    describe('blank option', function () {
+    describe('blank option', function() {
 
-      it('should be compiled as template, be watched and updated', function () {
+      it('should be compiled as template, be watched and updated', function() {
         var option;
         createSingleSelect('<option value="">blank is {{blankVal}}</option>');
 
@@ -1019,7 +1019,7 @@ describe('select', function() {
       });
 
 
-      it('should support binding via ngBindTemplate directive', function () {
+      it('should support binding via ngBindTemplate directive', function() {
         var option;
         createSingleSelect('<option value="" ng-bind-template="blank is {{blankVal}}"></option>');
 
@@ -1036,7 +1036,7 @@ describe('select', function() {
       });
 
 
-      it('should support biding via ngBind attribute', function () {
+      it('should support biding via ngBind attribute', function() {
         var option;
         createSingleSelect('<option value="" ng-bind="blankVal"></option>');
 
@@ -1053,7 +1053,7 @@ describe('select', function() {
       });
 
 
-      it('should be rendered with the attributes preserved', function () {
+      it('should be rendered with the attributes preserved', function() {
         var option;
         createSingleSelect('<option value="" class="coyote" id="road-runner" ' +
           'custom-attr="custom-attr">{{blankVal}}</option>');

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -171,7 +171,7 @@ describe('filters', function() {
     });
   });
 
-  describe('json', function () {
+  describe('json', function() {
     it('should do basic filter', function() {
       expect(filter('json')({a:"b"})).toEqual(toJson({a:"b"}, true));
     });
@@ -365,7 +365,7 @@ describe('filters', function() {
       expect(date('2003-09-10', format)).toEqual('2003-09-10 00-00-00');
     });
 
-    it('should support different degrees of subsecond precision', function () {
+    it('should support different degrees of subsecond precision', function() {
       var format = 'yyyy-MM-dd ss';
 
       var localDay = new Date(Date.UTC(2003, 9-1, 10, 13, 2, 3, 123)).getDate();

--- a/test/ng/filter/limitToSpec.js
+++ b/test/ng/filter/limitToSpec.js
@@ -53,7 +53,7 @@ describe('Filter: limitTo', function() {
   });
 
 
-  it('should return a copy of input array if X is exceeds array length', function () {
+  it('should return a copy of input array if X is exceeds array length', function() {
     expect(limitTo(items, 9)).toEqual(items);
     expect(limitTo(items, '9')).toEqual(items);
     expect(limitTo(items, -9)).toEqual(items);

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -491,7 +491,7 @@ describe('$httpBackend', function() {
     });
 
 
-    it('should return original backend status code if different from 0', function () {
+    it('should return original backend status code if different from 0', function() {
       $backend = createHttpBackend($browser, createMockXhr);
 
       // request to http://

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1013,7 +1013,7 @@ describe('$http', function() {
         });
 
 
-        it('should ignore Blob objects', function () {
+        it('should ignore Blob objects', function() {
           if (!window.Blob) return;
 
           var blob = new Blob(['blob!'], { type: 'text/plain' });
@@ -1163,7 +1163,7 @@ describe('$http', function() {
         expect(callback.mostRecentCall.args[0]).toBe('content');
       }));
 
-      it('should cache request when cache is provided and no method specified', function () {
+      it('should cache request when cache is provided and no method specified', function() {
         doFirstCacheRequest();
 
         $http({url: '/url', cache: cache}).success(callback);
@@ -1301,7 +1301,7 @@ describe('$http', function() {
       });
 
 
-      it('should allow the cached value to be an empty string', function () {
+      it('should allow the cached value to be an empty string', function() {
         cache.put('/abc', '');
 
         callback.andCallFake(function (response, status, headers) {
@@ -1330,7 +1330,7 @@ describe('$http', function() {
           })
       );
 
-      describe('$http.defaults.cache', function () {
+      describe('$http.defaults.cache', function() {
 
         it('should be undefined by default', function() {
           expect($http.defaults.cache).toBeUndefined()

--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -27,21 +27,21 @@ describe('$interpolate', function() {
   }));
 
   it('should rethrow exceptions', inject(function($interpolate, $rootScope) {
-    $rootScope.err = function () {
+    $rootScope.err = function() {
       throw new Error('oops');
     };
-    expect(function () {
+    expect(function() {
       $interpolate('{{err()}}')($rootScope);
     }).toThrowMinErr("$interpolate", "interr", "Can't interpolate: {{err()}}\nError: oops");
   }));
 
   it('should stop interpolation when encountering an exception', inject(function($interpolate, $compile, $rootScope) {
-    $rootScope.err = function () {
+    $rootScope.err = function() {
       throw new Error('oops');
     };
     var dom = jqLite('<div>{{1 + 1}}</div><div>{{err()}}</div><div>{{1 + 2}}</div>');
     $compile(dom)($rootScope);
-    expect(function () {
+    expect(function() {
       $rootScope.$apply();
     }).toThrowMinErr("$interpolate", "interr", "Can't interpolate: {{err()}}\nError: oops");
     expect(dom[0].innerHTML).toEqual('2');

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -13,7 +13,7 @@ describe('$location', function() {
   });
 
 
-  describe('File Protocol', function () {
+  describe('File Protocol', function() {
     var urlParsingNodePlaceholder;
 
     beforeEach(inject(function ($sniffer) {
@@ -43,7 +43,7 @@ describe('$location', function() {
     }));
 
 
-    it('should not include the drive name in path() on WIN', function (){
+    it('should not include the drive name in path() on WIN', function() {
       //See issue #4680 for details
       url = new LocationHashbangUrl('file:///base', '#!');
       url.$$parse('file:///base#!/foo?a=b&c#hash');
@@ -52,7 +52,7 @@ describe('$location', function() {
     });
 
 
-    it('should include the drive name if it was provided in the input url', function () {
+    it('should include the drive name if it was provided in the input url', function() {
       url = new LocationHashbangUrl('file:///base', '#!');
       url.$$parse('file:///base#!/C:/foo?a=b&c#hash');
 
@@ -671,7 +671,7 @@ describe('$location', function() {
       );
     });
 
-    it('should correctly convert html5 url with path matching basepath to hashbang url', function () {
+    it('should correctly convert html5 url with path matching basepath to hashbang url', function() {
       initService(true, '!', false);
       inject(
         initBrowser('http://domain.com/base/index.html', '/base/index.html'),

--- a/test/ng/logSpec.js
+++ b/test/ng/logSpec.js
@@ -116,7 +116,7 @@ describe('$log', function() {
     );
   });
 
-  describe("$log.debug", function () {
+  describe("$log.debug", function() {
 
 	  beforeEach(initService(false));
 

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -12,8 +12,8 @@ describe('parser', function() {
   describe('lexer', function() {
     var lex;
 
-    beforeEach(function () {
-      lex = function () {
+    beforeEach(function() {
+      lex = function() {
         var lexer = new Lexer({csp: false, unwrapPromises: false});
         return lexer.lex.apply(lexer, arguments);
       };
@@ -496,7 +496,7 @@ describe('parser', function() {
         });
 
         it('should evaluate object methods in correct context (this)', function() {
-          var C = function () {
+          var C = function() {
             this.a = 123;
           };
           C.prototype.getA = function() {
@@ -509,7 +509,7 @@ describe('parser', function() {
         });
 
         it('should evaluate methods in correct context (this) in argument', function() {
-          var C = function () {
+          var C = function() {
             this.a = 123;
           };
           C.prototype.sum = function(value) {
@@ -536,7 +536,7 @@ describe('parser', function() {
           expect(scope.$eval("a().name")).toEqual("misko");
         });
 
-        it('should evaluate field access after array access', function () {
+        it('should evaluate field access after array access', function() {
           scope.items =  [{}, {name:'misko'}];
           expect(scope.$eval('items[1].name')).toEqual("misko");
         });
@@ -1102,7 +1102,7 @@ describe('parser', function() {
 
     var deferred, promise, q;
 
-    describe('unwrapPromises setting', function () {
+    describe('unwrapPromises setting', function() {
 
       beforeEach(inject(function($rootScope, $q) {
         scope = $rootScope;
@@ -1117,7 +1117,7 @@ describe('parser', function() {
       it('should not unwrap promises by default', inject(function ($parse) {
         scope.person = promise;
         scope.things = {person: promise};
-        scope.getPerson = function () { return promise; };
+        scope.getPerson = function() { return promise; };
 
         var getter = $parse('person');
         var propGetter = $parse('things.person');

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -494,7 +494,7 @@ describe('q', function() {
       });
 
 
-      it("should not save and re-emit progress notifications between ticks", function () {
+      it("should not save and re-emit progress notifications between ticks", function() {
         promise.then(success(1), error(1), progress(1));
         deferred.notify('foo');
         deferred.notify('bar');
@@ -774,7 +774,7 @@ describe('q', function() {
           expect(logStr()).toBe('finally1()');
         });
 
-        describe("when the promise is fulfilled", function () {
+        describe("when the promise is fulfilled", function() {
 
           it('should call the callback',
               function() {
@@ -816,7 +816,7 @@ describe('q', function() {
 
             describe("that is fulfilled", function() {
               it("should fulfill with the original reason after that promise resolves",
-                function () {
+                function() {
 
                 var returnedDef = defer();
                 returnedDef.resolve('bar');
@@ -832,7 +832,7 @@ describe('q', function() {
 
             describe("that is rejected", function() {
               it("should reject with this new rejection reason",
-                function () {
+                function() {
                 var returnedDef = defer()
                 returnedDef.reject('bar');
                 promise['finally'](fin(1, returnedDef.promise))
@@ -856,9 +856,9 @@ describe('q', function() {
         });
 
 
-        describe("when the promise is rejected", function () {
+        describe("when the promise is rejected", function() {
 
-          it("should call the callback", function () {
+          it("should call the callback", function() {
             promise['finally'](fin(1))
                    .then(success(2), error(1))
             syncReject(deferred, 'foo');
@@ -876,7 +876,7 @@ describe('q', function() {
 
             describe("that is fulfilled", function() {
 
-              it("should reject with the original reason after that promise resolves", function () {
+              it("should reject with the original reason after that promise resolves", function() {
                 var returnedDef = defer()
                 returnedDef.resolve('bar');
                 promise['finally'](fin(1, returnedDef.promise))
@@ -887,7 +887,7 @@ describe('q', function() {
 
             });
 
-            describe("that is rejected", function () {
+            describe("that is rejected", function() {
 
               it("should reject with the new reason", function() {
                 var returnedDef = defer()

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -266,12 +266,12 @@ describe('Scope', function() {
           var d = $q.defer();
 
           d.resolve('Hello, world.');
-          $rootScope.$watch(function () {
+          $rootScope.$watch(function() {
               var $d2 = $q.defer();
               $d2.resolve('Goodbye.');
-              $d2.promise.then(function () { });
+              $d2.promise.then(function() { });
               return d.promise;
-          }, function () { return 0; });
+          }, function() { return 0; });
 
           expect(function() {
               $rootScope.$digest();
@@ -610,10 +610,10 @@ describe('Scope', function() {
           }).not.toThrow();
         });
 
-        it('should watch array-like objects like arrays', function () {
+        it('should watch array-like objects like arrays', function() {
           var arrayLikelog = [];
           $rootScope.$watchCollection('arrayLikeObject', function logger(obj) {
-            forEach(obj, function (element){
+            forEach(obj, function (element) {
               arrayLikelog.push(element.name);
             });
           });

--- a/test/ng/sceSpecs.js
+++ b/test/ng/sceSpecs.js
@@ -151,7 +151,7 @@ describe('SCE', function() {
     it('should NOT unwrap values when the type is different', inject(function($sce) {
       var originalValue = "originalValue";
       var wrappedValue = $sce.trustAs($sce.HTML, originalValue);
-      expect(function () { $sce.getTrusted($sce.CSS, wrappedValue); }).toThrowMinErr(
+      expect(function() { $sce.getTrusted($sce.CSS, wrappedValue); }).toThrowMinErr(
           '$sce', 'unsafe', 'Attempting to use an unsafe value in a safe context.');
     }));
 

--- a/test/ng/urlUtilsSpec.js
+++ b/test/ng/urlUtilsSpec.js
@@ -2,11 +2,11 @@
 
 describe('urlUtils', function() {
   describe('urlResolve', function() {
-    it('should normalize a relative url', function () {
+    it('should normalize a relative url', function() {
       expect(urlResolve("foo").href).toMatch(/^https?:\/\/[^/]+\/foo$/);
     });
 
-    it('should parse relative URL into component pieces', function () {
+    it('should parse relative URL into component pieces', function() {
       var parsed = urlResolve("foo");
       expect(parsed.href).toMatch(/https?:\/\//);
       expect(parsed.protocol).toMatch(/^https?/);
@@ -16,7 +16,7 @@ describe('urlUtils', function() {
     });
 
 
-    it('should return pathname as / if empty path provided', function () {
+    it('should return pathname as / if empty path provided', function() {
       //IE counts / as empty, necessary to use / so that pathname is not context.html
       var parsed = urlResolve('/');
       expect(parsed.pathname).toBe('/');

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1588,7 +1588,7 @@ describe("ngAnimate", function() {
       });
 
 
-      describe('animation evaluation', function () {
+      describe('animation evaluation', function() {
 
         it('should re-evaluate the CSS classes for an animation each time',
           inject(function($animate, $rootScope, $sniffer, $rootElement, $timeout, $compile) {

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -530,7 +530,7 @@ describe('ngMock', function() {
       log = '';
     }));
 
-    function logFn(text){ return function() {
+    function logFn(text) { return function() {
         log += text +';';
       };
     }

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -302,13 +302,13 @@ describe("resource", function() {
   });
 
 
-  it('should allow relative paths in resource url', function () {
+  it('should allow relative paths in resource url', function() {
     var R = $resource(':relativePath');
     $httpBackend.expect('GET', 'data.json').respond('{}');
     R.get({ relativePath: 'data.json' });
   });
 
-  it('should handle + in url params', function () {
+  it('should handle + in url params', function() {
     var R = $resource('/api/myapp/:myresource?from=:from&to=:to&histlen=:histlen');
     $httpBackend.expect('GET', '/api/myapp/pear+apple?from=2012-04-01&to=2012-04-29&histlen=3').respond('{}');
     R.get({ myresource: 'pear+apple', from : '2012-04-01', to : '2012-04-29', histlen : 3  });

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -880,7 +880,7 @@ describe('ngView animations', function() {
     });
 
 
-  describe('autoscroll', function () {
+  describe('autoscroll', function() {
     var autoScrollSpy;
 
     function spyOnAnchorScroll() {

--- a/test/ngScenario/ScenarioSpec.js
+++ b/test/ngScenario/ScenarioSpec.js
@@ -30,12 +30,12 @@ describe("ScenarioSpec: Compilation", function() {
     }));
   });
 
-  describe('jQuery', function () {
-    it('should exist on the angular.scenario object', function () {
+  describe('jQuery', function() {
+    it('should exist on the angular.scenario object', function() {
       expect(angular.scenario.jQuery).toBeDefined();
     });
 
-    it('should have common jQuery methods', function () {
+    it('should have common jQuery methods', function() {
       var jQuery = angular.scenario.jQuery;
       expect(typeof jQuery).toEqual('function');
       expect(typeof jQuery('<div></div>').html).toEqual('function');

--- a/test/ngScenario/matchersSpec.js
+++ b/test/ngScenario/matchersSpec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('angular.scenario.matchers', function () {
+describe('angular.scenario.matchers', function() {
   var matchers;
 
   function expectMatcher(value, test) {


### PR DESCRIPTION
Request Type: chore

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

AngularJS style guide and Google JavaScript style guide uses `function() {` and `function name() {`, not `function (){` and `function name(){` style.

[AngularJS style guide](https://google-styleguide.googlecode.com/svn/trunk/angularjs-google-style.html)

[Google JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)

**Other Comments:**

This might be too trivial for a commit or too big for one pull request, I just thought about it reading through AngularJS sources for the first time and looking at "Contributing to AngularJS" document.
