### PR TITLE
fix(input): allow use of integers in ng-true-value

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1236,6 +1236,12 @@ function checkboxInputType(scope, element, attr, ctrl) {
   if (!isString(trueValue)) trueValue = true;
   if (!isString(falseValue)) falseValue = false;
 
+  var intTrueValue = parseInt(trueValue, 10),
+      intFalseValue = parseInt(falseValue, 10);
+
+  if(!equals(intTrueValue, NaN)) trueValue = intTrueValue;
+  if(!equals(intFalseValue, NaN)) falseValue = intFalseValue;
+
   var listener = function(ev) {
     scope.$apply(function() {
       ctrl.$setViewValue(element[0].checked, ev && ev.type);

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2104,6 +2104,32 @@ describe('input', function() {
       expect(scope.name).toEqual('n');
     });
 
+    it('should allow custom enumeration with integers', function() {
+      compileInput('<input type="checkbox" ng-model="name" ng-true-value="1" ' +
+        'ng-false-value="0">');
+
+      scope.$apply(function() {
+        scope.name = 1;
+      });
+      expect(inputElm[0].checked).toBe(true);
+
+      scope.$apply(function() {
+        scope.name = 0;
+      });
+      expect(inputElm[0].checked).toBe(false);
+
+      scope.$apply(function() {
+        scope.name = 'something else';
+      });
+      expect(inputElm[0].checked).toBe(false);
+
+      browserTrigger(inputElm, 'click');
+      expect(scope.name).toEqual(1);
+
+      browserTrigger(inputElm, 'click');
+      expect(scope.name).toEqual(0);
+    });
+
 
     it('should be required if false', function() {
       compileInput('<input type="checkbox" ng:model="value" required />');


### PR DESCRIPTION
Request Type: bug

How to reproduce: PR for: https://github.com/angular/angular.js/issues/7109

Plunker from that issue: http://plnkr.co/edit/VxJVpbRV4vkbivKpAUUn?p=preview

Component(s): forms

Impact: medium

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

Resolves an issue where values of '1' in ng-true-value would not set the
checkbox to a checked state when the scope's value was 1.

Closes #7109
