### PR TITLE
fix one build warning in `minall`

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -895,7 +895,14 @@ function $RootScopeProvider(){
             $rootScope.$digest();
           } catch (e) {
             $exceptionHandler(e);
-            throw e;
+            var ex = e; // Avoiding reassigning e
+            if (e.message && e.stack && e.stack.indexOf(e.message) == -1) {
+                // Safari & Fx's stack traces don't contain error.message content unlike those of Chrome and IE
+                // So if stack doesn't contain message, we create a new string that contains both.
+                // Since error.stack is read-only in Safari, I'm overriding e and not e.stack here.
+                ex = e.message + '\n' + e.stack;
+            }
+            throw $rootScopeMinErr('baddigest', "{0}", ex.stack || ex.message || ex);
           }
         }
       },


### PR DESCRIPTION
Request Type: bug

How to reproduce: build with `grunt`, warning shows in `minall`

Component(s): scope

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

There are several more issues like this, but I'm not sure if I know the right way to fix them.

**Other Comments:**

Used code from cironunes/angular.js, slightly modified (Firefox should be abbreviated Fx, exception variable should not be reassigned).
