### PR TITLE
fix(injector): invoke config blocks for module after all providers

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -100,14 +100,18 @@ function setupModuleLoader(window) {
         var invokeQueue = [];
 
         /** @type {!Array.<Function>} */
+        var configBlocks = [];
+
+        /** @type {!Array.<Function>} */
         var runBlocks = [];
 
-        var config = invokeLater('$injector', 'invoke');
+        var config = invokeLater('$injector', 'invoke', 'push', configBlocks);
 
         /** @type {angular.Module} */
         var moduleInstance = {
           // Private state
           _invokeQueue: invokeQueue,
+          _configBlocks: configBlocks,
           _runBlocks: runBlocks,
 
           /**
@@ -297,9 +301,10 @@ function setupModuleLoader(window) {
          * @param {String=} insertMethod
          * @returns {angular.Module}
          */
-        function invokeLater(provider, method, insertMethod) {
+        function invokeLater(provider, method, insertMethod, queue) {
+          if (!queue) queue = invokeQueue;
           return function() {
-            invokeQueue[insertMethod || 'push']([provider, method, arguments]);
+            queue[insertMethod || 'push']([provider, method, arguments]);
             return moduleInstance;
           };
         }

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -305,6 +305,29 @@ describe('injector', function() {
       expect(log).toEqual('abABCD');
     });
 
+    it('should execute own config blocks after all own providers are invoked', function() {
+      var log = '';
+      angular.module('a', ['b'])
+      .config(function($aProvider) {
+        log += 'aConfig;';
+      })
+      .provider('$a', function() {
+        log += '$aProvider;';
+        this.$get = function() {};
+      });
+      angular.module('b', [])
+      .config(function($bProvider) {
+        log += 'bConfig;';
+      })
+      .provider('$b', function() {
+        log += '$bProvider;';
+        this.$get = function() {};
+      });
+
+      createInjector(['a']);
+      expect(log).toBe('$bProvider;bConfig;$aProvider;aConfig;');
+    });
+
     describe('$provide', function() {
 
       it('should throw an exception if we try to register a service called "hasOwnProperty"', function() {

--- a/test/loaderSpec.js
+++ b/test/loaderSpec.js
@@ -46,7 +46,6 @@ describe('module loader', function() {
     expect(myModule.requires).toEqual(['other']);
     expect(myModule._invokeQueue).toEqual([
       ['$provide', 'constant', ['abc', 123] ],
-      ['$injector', 'invoke', ['config'] ],
       ['$provide', 'provider', ['sk', 'sv'] ],
       ['$provide', 'factory', ['fk', 'fv'] ],
       ['$provide', 'service', ['a', 'aa'] ],
@@ -54,6 +53,9 @@ describe('module loader', function() {
       ['$filterProvider', 'register', ['f', 'ff'] ],
       ['$compileProvider', 'directive', ['d', 'dd'] ],
       ['$controllerProvider', 'register', ['ctrl', 'ccc']],
+    ]);
+    expect(myModule._configBlocks).toEqual([
+      ['$injector', 'invoke', ['config'] ],
       ['$injector', 'invoke', ['init2'] ]
     ]);
     expect(myModule._runBlocks).toEqual(['runBlock']);


### PR DESCRIPTION
This change ensures that a module's config blocks are always invoked after all of its providers are registered.

NOTE: I'm not entirely sure if this is desirable yet, because the point mentioned in the BREAKING CHANGE section below may actually be something which is desirable. However, I do feel it is probably better to always invoke config blocks for a single module after all of its providers. The config blocks should not play a role in how providers are registered, in my own opinion.

BREAKING CHANGE:

Previously, config blocks would be able to control behaviour of provider registration, due to being invoked prior to provider registration. Now, provider registration always occurs prior to configuration for a given module, and therefore config blocks are not able to have any control over a providers 
registration.

Example:

Previously, the following:

``` js
   angular.module('foo', [])
    .provider('$rootProvider', function() {
      this.$get = function() { ... }
    })
    .config(function($rootProvider) {
      $rootProvider.dependentMode = "B";
    })
    .provider('$dependentProvider', function($rootProvider) {
      if ($rootProvider.dependentMode === "A") {
        this.$get = function() {
          // Special mode!
        }
      } else {
        this.$get = function() {
          // something else
        }
      }
    });
```

would have "worked", meaning behaviour of the config block between the registration of "$rootProvider" and "$dependentProvider" would have actually accomplished something and changed the behaviour of the app. This is no longer possible within a single module.

Fixes #7139
