### PR TITLE
Update step_06.ngdoc

### DIFF
--- a/docs/content/tutorial/step_06.ngdoc
+++ b/docs/content/tutorial/step_06.ngdoc
@@ -61,7 +61,7 @@ ng.directive:ngSrc ngSrc} directive. That directive prevents the
 browser from treating the Angular `{{ expression }}` markup literally, and initiating a request to
 invalid url `http://localhost:8000/app/{{phone.imageUrl}}`, which it would have done if we had only
 specified an attribute binding in a regular `src` attribute (`<img src="{{phone.imageUrl}}">`).
-Using the `ngSrc` directive prevents the browser from making an http request to an invalid location.
+Using the `ng-Src` directive prevents the browser from making an http request to an invalid location.
 
 
 ## Test


### PR DESCRIPTION
In the description of adding the ng-Src to the image tag, there was a typo: 'ngSrc' instead of ng-Src.
