### PR TITLE
fix($location): make behaviour of relative links consistent in html5Mode

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -655,7 +655,11 @@ function $LocationProvider(){
       // Make relative links work in HTML5 mode for legacy browsers (or at least IE8 & 9)
       // The href should be a regular url e.g. /link/somewhere or link/somewhere or ../somewhere or
       // somewhere#anchor or http://example.com/somewhere
-      if (LocationMode === LocationHashbangInHtml5Url) {
+      //
+      // For whatever reason, relative urls in angular apps with a router seem to not work
+      // correctly, and so similar work is also necessary for plain html5Mode. It may be desirable,
+      // down the line, to perform this work for all location modes.
+      if (LocationMode === LocationHashbangInHtml5Url || LocationMode === LocationHtml5Url) {
         // get the actual href attribute - see
         // http://msdn.microsoft.com/en-us/library/ie/dd347148(v=vs.85).aspx
         var href = elm.attr('href') || elm.attr('xlink:href');

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -91,6 +91,7 @@ function LocationHtml5Url(appBase, basePrefix) {
   this.$$html5 = true;
   basePrefix = basePrefix || '';
   var appBaseNoFile = stripFile(appBase);
+  var baseFile = appBase.slice(appBaseNoFile.length);
   parseAbsoluteUrl(appBase, this, appBase);
 
 
@@ -133,7 +134,12 @@ function LocationHtml5Url(appBase, basePrefix) {
     if ( (appUrl = beginsWith(appBase, url)) !== undefined ) {
       prevAppUrl = appUrl;
       if ( (appUrl = beginsWith(basePrefix, appUrl)) !== undefined ) {
-        return appBaseNoFile + (beginsWith('/', appUrl) || appUrl);
+        var rewritten = beginsWith('/', appUrl) || appUrl;
+        if (rewritten.indexOf(baseFile) === 0) {
+          rewritten = rewritten.slice(baseFile.length);
+          rewritten = beginsWith('/', rewritten) || rewritten;
+        }
+        return appBaseNoFile + rewritten;
       } else {
         return appBase + prevAppUrl;
       }
@@ -618,7 +624,8 @@ function $LocationProvider(){
         LocationMode,
         baseHref = $browser.baseHref(), // if base[href] is undefined, it defaults to ''
         initialUrl = $browser.url(),
-        appBase;
+        appBase,
+        baseFile;
 
     if (html5Mode) {
       appBase = serverBase(initialUrl) + (baseHref || '/');

--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -42,11 +42,11 @@ ngRouteModule.directive('ngView', ngViewFillContentFactory);
       <file name="index.html">
         <div ng-controller="MainCtrl as main">
           Choose:
-          <a href="Book/Moby">Moby</a> |
-          <a href="Book/Moby/ch/1">Moby: Ch1</a> |
-          <a href="Book/Gatsby">Gatsby</a> |
-          <a href="Book/Gatsby/ch/4?key=value">Gatsby: Ch4</a> |
-          <a href="Book/Scarlet">Scarlet Letter</a><br/>
+          <a href="/Book/Moby">Moby</a> |
+          <a href="/Book/Moby/ch/1">Moby: Ch1</a> |
+          <a href="/Book/Gatsby">Gatsby</a> |
+          <a href="/Book/Gatsby/ch/4?key=value">Gatsby: Ch4</a> |
+          <a href="/Book/Scarlet">Scarlet Letter</a><br/>
 
           <div class="view-animate-container">
             <div ng-view class="view-animate"></div>

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -273,11 +273,11 @@ function $RouteProvider(){
      *   <file name="index.html">
      *     <div ng-controller="MainController">
      *       Choose:
-     *       <a href="Book/Moby">Moby</a> |
-     *       <a href="Book/Moby/ch/1">Moby: Ch1</a> |
-     *       <a href="Book/Gatsby">Gatsby</a> |
-     *       <a href="Book/Gatsby/ch/4?key=value">Gatsby: Ch4</a> |
-     *       <a href="Book/Scarlet">Scarlet Letter</a><br/>
+     *       <a href="/Book/Moby">Moby</a> |
+     *       <a href="/Book/Moby/ch/1">Moby: Ch1</a> |
+     *       <a href="/Book/Gatsby">Gatsby</a> |
+     *       <a href="/Book/Gatsby/ch/4?key=value">Gatsby: Ch4</a> |
+     *       <a href="/Book/Scarlet">Scarlet Letter</a><br/>
      *
      *       <div ng-view></div>
      *

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1119,6 +1119,51 @@ describe('$location', function() {
     });
 
 
+    it('should rewrite relative links relative to current path when history enabled', function() {
+      configureService('link', true, true, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser, $location) {
+          $location.path('/some');
+          browserTrigger(link, 'click');
+          expectRewriteTo($browser, 'http://host.com/base/some/link');
+        }
+      );
+    });
+
+
+    it('should replace current path when link begins with "/" and history enabled', function() {
+      configureService('/link', true, true, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser, $location) {
+          $location.path('/some');
+          browserTrigger(link, 'click');
+          expectRewriteTo($browser, 'http://host.com/base/link');
+        }
+      );
+    });
+
+
+    it('should replace current hash fragment when link begins with "#" history enabled', function() {
+      configureService('#link', true, true, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser, $location) {
+          // Initialize browser URL
+          $location.path('/some');
+          $location.hash('foo');
+          browserTrigger(link, 'click');
+          expect($location.hash()).toBe('link');
+          expectRewriteTo($browser, 'http://host.com/base/some#link');
+        }
+      );
+    });
+
+
     // don't run next tests on IE<9, as browserTrigger does not simulate pressed keys
     if (!(msie < 9)) {
 


### PR DESCRIPTION
3f047704c70a957596371fec554d3e1fb066a29d supposedly made html5Mode work consistently for both legacy browsers and modern browsers. However, Chrome 34 and Firefox 31 both fail to handle relative links with the default base URL, at least within an Angular app. This patch allows the URL processing which occurs for legacy browsers to also occur in modern browsers when html5Mode is enabled, and corrects this behaviour.

Closes #7151
