### PR TITLE
scope.$watchGroup + $interpolation speedup

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1804,9 +1804,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 bindings = parent.data('$binding') || [];
             bindings.push(interpolateFn);
             safeAddClass(parent.data('$binding', bindings), 'ng-binding');
-            scope.$watch(interpolateFn, function interpolateFnWatchAction(value) {
+            scope.$watchGroup(interpolateFn.expressions, interpolateFn.$$invoke(function(value) {
               node[0].nodeValue = value;
-            });
+            }));
           })
         });
       }
@@ -1867,7 +1867,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 attr[name] = interpolateFn(scope);
                 ($$observers[name] || ($$observers[name] = [])).$$inter = true;
                 (attr.$$observers && attr.$$observers[name].$$scope || scope).
-                  $watch(interpolateFn, function interpolateFnWatchAction(newValue, oldValue) {
+                  $watchGroup(interpolateFn.expressions, interpolateFn.$$invoke(function (newValue, oldValue) {
                     //special case for class attribute addition + removal
                     //so that class changes can tap into the animation
                     //hooks provided by the $animate service. Be sure to
@@ -1879,7 +1879,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                     } else {
                       attr.$set(name, newValue);
                     }
-                  });
+                  }));
               }
             };
           }

--- a/src/ng/directive/ngPluralize.js
+++ b/src/ng/directive/ngPluralize.js
@@ -204,7 +204,7 @@ var ngPluralizeDirective = ['$locale', '$interpolate', function($locale, $interp
           //if explicit number rule such as 1, 2, 3... is defined, just use it. Otherwise,
           //check it against pluralization rules in $locale service
           if (!(value in whens)) value = $locale.pluralCat(value - offset);
-           return whensExpFns[value](scope, element, true);
+           return whensExpFns[value](scope);
         } else {
           return '';
         }

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -609,6 +609,8 @@ var optionDirective = ['$interpolate', function($interpolate) {
             parent = element.parent(),
             selectCtrl = parent.data(selectCtrlName) ||
               parent.parent().data(selectCtrlName); // in case we are in optgroup
+        var newString;
+        var oldString;
 
         if (selectCtrl && selectCtrl.databound) {
           // For some reason Opera defaults to true and if not overridden this messes up the repeater.
@@ -619,10 +621,12 @@ var optionDirective = ['$interpolate', function($interpolate) {
         }
 
         if (interpolateFn) {
-          scope.$watch(interpolateFn, function interpolateWatchAction(newVal, oldVal) {
-            attr.$set('value', newVal);
-            if (newVal !== oldVal) selectCtrl.removeOption(oldVal);
-            selectCtrl.addOption(newVal);
+          scope.$watchGroup(interpolateFn.expressions, function interpolateWatchAction(newVals, oldVals) {
+            oldString = newString;
+            newString = interpolateFn.compute(newVals);
+            attr.$set('value', newString);
+            if (oldString) selectCtrl.removeOption(oldString);
+            selectCtrl.addOption(newString);
           });
         } else {
           selectCtrl.addOption(attr.value);

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -609,8 +609,6 @@ var optionDirective = ['$interpolate', function($interpolate) {
             parent = element.parent(),
             selectCtrl = parent.data(selectCtrlName) ||
               parent.parent().data(selectCtrlName); // in case we are in optgroup
-        var newString;
-        var oldString;
 
         if (selectCtrl && selectCtrl.databound) {
           // For some reason Opera defaults to true and if not overridden this messes up the repeater.
@@ -621,12 +619,12 @@ var optionDirective = ['$interpolate', function($interpolate) {
         }
 
         if (interpolateFn) {
-          scope.$watchGroup(interpolateFn.expressions, function interpolateWatchAction(newVals, oldVals) {
-            oldString = newString;
-            newString = interpolateFn.compute(newVals);
-            attr.$set('value', newString);
-            if (oldString) selectCtrl.removeOption(oldString);
-            selectCtrl.addOption(newString);
+          scope.$watch(interpolateFn, function interpolateWatchAction(newVal, oldVal) {
+            attr.$set('value', newVal);
+            if (oldVal !== newVal) {
+              selectCtrl.removeOption(oldVal);
+            }
+            selectCtrl.addOption(newVal);
           });
         } else {
           selectCtrl.addOption(attr.value);

--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -125,32 +125,36 @@ function $InterpolateProvider() {
       var startIndex,
           endIndex,
           index = 0,
-          parts = [],
-          length = text.length,
+          separators = [],
+          expressions = [],
+          textLength = text.length,
           hasInterpolation = false,
+          hasText = false,
           fn,
           exp,
           concat = [];
 
-      while(index < length) {
+      while(index < textLength) {
         if ( ((startIndex = text.indexOf(startSymbol, index)) != -1) &&
              ((endIndex = text.indexOf(endSymbol, startIndex + startSymbolLength)) != -1) ) {
-          (index != startIndex) && parts.push(text.substring(index, startIndex));
-          parts.push(fn = $parse(exp = text.substring(startIndex + startSymbolLength, endIndex)));
+          if (index !== startIndex) hasText = true;
+          separators.push(text.substring(index, startIndex));
+          expressions.push(fn = interpolateParse(exp = text.substring(startIndex + startSymbolLength, endIndex)));
           fn.exp = exp;
           index = endIndex + endSymbolLength;
           hasInterpolation = true;
         } else {
-          // we did not find anything, so we have to add the remainder to the parts array
-          (index != length) && parts.push(text.substring(index));
-          index = length;
+          // we did not find an interpolation, so we have to add the remainder to the separators array
+          if (index !== textLength) {
+            hasText = true;
+            separators.push(text.substring(index));
+          }
+          break;
         }
       }
 
-      if (!(length = parts.length)) {
-        // we added, nothing, must have been an empty string.
-        parts.push('');
-        length = 1;
+      if (separators.length === expressions.length) {
+        separators.push('');
       }
 
       // Concatenating expressions makes it hard to reason about whether some combination of
@@ -159,44 +163,64 @@ function $InterpolateProvider() {
       // that's used is assigned or constructed by some JS code somewhere that is more testable or
       // make it obvious that you bound the value to some user controlled value.  This helps reduce
       // the load when auditing for XSS issues.
-      if (trustedContext && parts.length > 1) {
+      if (trustedContext && hasInterpolation && (hasText || expressions.length > 1)) {
           throw $interpolateMinErr('noconcat',
               "Error while interpolating: {0}\nStrict Contextual Escaping disallows " +
               "interpolations that concatenate multiple expressions when a trusted value is " +
               "required.  See http://docs.angularjs.org/api/ng.$sce", text);
       }
 
-      if (!mustHaveExpression  || hasInterpolation) {
-        concat.length = length;
-        fn = function(context) {
-          try {
-            for(var i = 0, ii = length, part; i<ii; i++) {
-              if (typeof (part = parts[i]) == 'function') {
-                part = part(context);
-                if (trustedContext) {
-                  part = $sce.getTrusted(trustedContext, part);
-                } else {
-                  part = $sce.valueOf(part);
-                }
-                if (part === null || isUndefined(part)) {
-                  part = '';
-                } else if (typeof part != 'string') {
-                  part = toJson(part);
-                }
-              }
-              concat[i] = part;
-            }
-            return concat.join('');
+      if (!mustHaveExpression || hasInterpolation) {
+        concat.length = separators.length + expressions.length;
+        var computeFn = function (values, context) {
+          for(var i = 0, ii = expressions.length; i < ii; i++) {
+            concat[2*i] = separators[i];
+            concat[(2*i)+1] = values ? values[i] : expressions[i](context);
           }
-          catch(err) {
+          concat[2*ii] = separators[ii];
+          return concat.join('');
+        };
+
+        fn = function(context) {
+          return computeFn(null, context);
+        };
+        fn.exp = text;
+
+        // hack in order to preserve existing api
+        fn.$$invoke = function (listener) {
+          return function (values, oldValues, scope) {
+            var current = computeFn(values, scope);
+            listener(current, this.$$lastInter == null ? current : this.$$lastInter, scope);
+            this.$$lastInter = current;
+          };
+        };
+        fn.separators = separators;
+        fn.expressions = expressions;
+        return fn;
+      }
+
+      function interpolateParse(expression) {
+        var exp = $parse(expression);
+        return function (scope) {
+          try {
+            var value = exp(scope);
+            if (trustedContext) {
+              value = $sce.getTrusted(trustedContext, value);
+            } else {
+              value = $sce.valueOf(value);
+            }
+            if (value === null || isUndefined(value)) {
+              value = '';
+            } else if (typeof value != 'string') {
+              value = toJson(value);
+            }
+            return value;
+          } catch(err) {
             var newErr = $interpolateMinErr('interr', "Can't interpolate: {0}\n{1}", text,
-                err.toString());
+              err.toString());
             $exceptionHandler(newErr);
           }
         };
-        fn.exp = text;
-        fn.parts = parts;
-        return fn;
       }
     }
 

--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -174,13 +174,30 @@ function $InterpolateProvider() {
 
         var lastValues = [];
         var lastResult;
+
         var compute = function(values) {
           for(var i = 0, ii = expressions.length; i < ii; i++) {
             concat[2*i] = separators[i];
-            concat[(2*i)+1] = stringify(values[i]);
+            concat[(2*i)+1] = values[i];
           }
           concat[2*ii] = separators[ii];
           return concat.join('');
+        };
+
+        var stringify = function (value) {
+          if (trustedContext) {
+            value = $sce.getTrusted(trustedContext, value);
+          } else {
+            value = $sce.valueOf(value);
+          }
+
+          if (value === null || isUndefined(value)) {
+            value = '';
+          } else if (typeof value != 'string') {
+            value = toJson(value);
+          }
+
+          return value;
         };
 
         return extend(function interpolationFn(context) {
@@ -192,7 +209,7 @@ function $InterpolateProvider() {
 
             try {
               for (; i < ii; i++) {
-                val = parseFns[i](context);
+                val = stringify(parseFns[i](context));
                 if (val !== lastValues[i]) {
                   inputsChanged = true;
                 }
@@ -216,22 +233,6 @@ function $InterpolateProvider() {
           separators: separators,
           expressions: expressions
         });
-      }
-
-      function stringify(value) {
-        if (trustedContext) {
-          value = $sce.getTrusted(trustedContext, value);
-        } else {
-          value = $sce.valueOf(value);
-        }
-
-        if (value === null || isUndefined(value)) {
-          value = '';
-        } else if (typeof value != 'string') {
-          value = toJson(value);
-        }
-
-        return value;
       }
     }
 

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -354,6 +354,66 @@ function $RootScopeProvider(){
         };
       },
 
+      /**
+       * @ngdoc method
+       * @name $rootScope.Scope#$watchGroup
+       * @function
+       *
+       * @description
+       * A variant of {@link ng.$rootScope.Scope#$watch $watch()} where it watches an array of `watchExpressions`.
+       * If any one expression in the collection changes the `listener` is executed.
+       *
+       * - The items in the `watchCollection` array are observed via standard $watch operation and are examined on every
+       *   call to $digest() to see if any items changes.
+       * - The `listener` is called whenever any expression in the `watchExpressions` array changes.
+       *
+       * @param {Array.<string|Function(scope)>} watchExpressions Array of expressions that will be individually
+       * watched using {@link ng.$rootScope.Scope#$watch $watch()}
+       *
+       * @param {function(newValues, oldValues, scope)} listener Callback called whenever the return value of any
+       *    expression in `watchExpressions` changes
+       *    The `newValues` array contains the current values of the `watchExpressions`, with the indexes matching
+       *    those of `watchExpression`
+       *    and the `oldValues` array contains the previous values of the `watchExpressions`, with the indexes matching
+       *    those of `watchExpression`
+       *    The `scope` refers to the current scope.
+       *
+       * @returns {function()} Returns a de-registration function for all listeners.
+       */
+      $watchGroup: function(watchExpressions, listener) {
+        var oldValues = new Array(watchExpressions.length),
+            newValues = new Array(watchExpressions.length);
+
+        if (watchExpressions.length === 1) {
+          // Special case size of one
+          return this.$watch(watchExpressions[0], function (value, oldValue, scope) {
+            newValues[0] = value;
+            oldValues[0] = oldValue;
+            listener.call(this, newValues, oldValues, scope);
+          });
+        }
+        var deregisterFns = [],
+            changeCount = 0;
+
+        forEach(watchExpressions, function (expr, i) {
+          deregisterFns.push(this.$watch(expr, function (value, oldValue) {
+            newValues[i] = value;
+            oldValues[i] = oldValue;
+            changeCount++;
+          }));
+        }, this);
+
+        deregisterFns.push(this.$watch(function () {return changeCount;}, function (c, o, scope) {
+          listener.call(this, newValues, oldValues, scope);
+        }));
+
+        return function deregisterWatchGroup() {
+          forEach(deregisterFns, function (fn) {
+            fn();
+          });
+        };
+      },
+
 
       /**
        * @ngdoc method
@@ -756,7 +816,7 @@ function $RootScopeProvider(){
 
         // prevent NPEs since these methods have references to properties we nulled out
         this.$destroy = this.$digest = this.$apply = noop;
-        this.$on = this.$watch = function() { return noop; };
+        this.$on = this.$watch = this.$watchGroup = function() { return noop; };
       },
 
       /**

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -381,30 +381,22 @@ function $RootScopeProvider(){
        * @returns {function()} Returns a de-registration function for all listeners.
        */
       $watchGroup: function(watchExpressions, listener) {
-        var oldValues = new Array(watchExpressions.length),
-            newValues = new Array(watchExpressions.length);
-
-        if (watchExpressions.length === 1) {
-          // Special case size of one
-          return this.$watch(watchExpressions[0], function (value, oldValue, scope) {
-            newValues[0] = value;
-            oldValues[0] = oldValue;
-            listener.call(this, newValues, oldValues, scope);
-          });
-        }
-        var deregisterFns = [],
-            changeCount = 0;
+        var oldValues = new Array(watchExpressions.length);
+        var newValues = new Array(watchExpressions.length);
+        var deregisterFns = [];
+        var changeCount = 0;
+        var self = this;
 
         forEach(watchExpressions, function (expr, i) {
-          deregisterFns.push(this.$watch(expr, function (value, oldValue) {
+          deregisterFns.push(self.$watch(expr, function (value, oldValue) {
             newValues[i] = value;
             oldValues[i] = oldValue;
             changeCount++;
           }));
         }, this);
 
-        deregisterFns.push(this.$watch(function () {return changeCount;}, function (c, o, scope) {
-          listener.call(this, newValues, oldValues, scope);
+        deregisterFns.push(self.$watch(function () {return changeCount;}, function () {
+          listener(newValues, oldValues, self);
         }));
 
         return function deregisterWatchGroup() {

--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -302,27 +302,24 @@ _jQuery.fn.bindings = function(windowJquery, bindExp) {
 
   selection.each(function() {
     var element = windowJquery(this),
-        binding;
-    if (binding = element.data('$binding')) {
-      if (typeof binding == 'string') {
-        if (match(binding)) {
-          push(element.scope().$eval(binding));
+        bindings;
+    if (bindings = element.data('$binding')) {
+      if (!angular.isArray(bindings)) {
+        bindings = [bindings];
+      }
+      for(var expressions = [], binding, j=0, jj=bindings.length;  j<jj; j++) {
+        binding = bindings[j];
+
+        if (binding.expressions) {
+          expressions = binding.expressions;
+        } else {
+          expressions = [binding];
         }
-      } else {
-        if (!angular.isArray(binding)) {
-          binding = [binding];
-        }
-        for(var fns, j=0, jj=binding.length;  j<jj; j++) {
-          fns = binding[j];
-          if (fns.expressions) {
-            fns = fns.expressions;
-          } else {
-            fns = [fns];
-          }
-          for (var scope, fn, i = 0, ii = fns.length; i < ii; i++) {
-            if(match((fn = fns[i]).exp)) {
-              push(fn(scope = scope || element.scope()));
-            }
+        for (var scope, expression, i = 0, ii = expressions.length; i < ii; i++) {
+          expression = expressions[i];
+          if(match(expression)) {
+            scope = scope || element.scope();
+            push(scope.$eval(expression));
           }
         }
       }

--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -314,8 +314,8 @@ _jQuery.fn.bindings = function(windowJquery, bindExp) {
         }
         for(var fns, j=0, jj=binding.length;  j<jj; j++) {
           fns = binding[j];
-          if (fns.parts) {
-            fns = fns.parts;
+          if (fns.expressions) {
+            fns = fns.expressions;
           } else {
             fns = [fns];
           }

--- a/test/BinderSpec.js
+++ b/test/BinderSpec.js
@@ -167,30 +167,6 @@ describe('Binder', function() {
     expect(element[0].childNodes.length).toEqual(1);
   }));
 
-  it('IfTextBindingThrowsErrorDecorateTheSpan', function() {
-    module(function($exceptionHandlerProvider){
-      $exceptionHandlerProvider.mode('log');
-    });
-    inject(function($rootScope, $exceptionHandler, $compile) {
-      element = $compile('<div>{{error.throw()}}</div>', null, true)($rootScope);
-      var errorLogs = $exceptionHandler.errors;
-
-      $rootScope.error = {
-          'throw': function() {throw 'ErrorMsg1';}
-      };
-      $rootScope.$apply();
-
-      $rootScope.error['throw'] = function() {throw 'MyError';};
-      errorLogs.length = 0;
-      $rootScope.$apply();
-      expect(errorLogs.shift().message).toMatch(/^\[\$interpolate:interr\] Can't interpolate: \{\{error.throw\(\)\}\}\nMyError/);
-
-      $rootScope.error['throw'] = function() {return 'ok';};
-      $rootScope.$apply();
-      expect(errorLogs.length).toBe(0);
-    });
-  });
-
   it('IfAttrBindingThrowsErrorDecorateTheAttribute', function() {
     module(function($exceptionHandlerProvider){
       $exceptionHandlerProvider.mode('log');

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2080,6 +2080,8 @@ describe('$compile', function() {
 
 
     it('should set interpolated attrs to initial interpolation value', inject(function($rootScope, $compile) {
+      // we need the interpolated attributes to be initialized so that linking fn in a component
+      // can access the value during link
       $rootScope.whatever = 'test value';
       $compile('<div some-attr="{{whatever}}" observer></div>')($rootScope);
       expect(directiveAttrs.someAttr).toBe($rootScope.whatever);

--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -7,7 +7,6 @@ describe('$interpolate', function() {
     var interpolateFn = $interpolate('some text');
 
     expect(interpolateFn.exp).toBe('some text');
-    expect(interpolateFn.template).toBe('some text');
     expect(interpolateFn.separators).toEqual(['some text']);
     expect(interpolateFn.expressions).toEqual([]);
 
@@ -38,7 +37,6 @@ describe('$interpolate', function() {
     var interpolateFn = $interpolate('Hello {{name}}!');
 
     expect(interpolateFn.exp).toBe('Hello {{name}}!');
-    expect(interpolateFn.template).toBe('Hello {{name}}!');
     expect(interpolateFn.separators).toEqual(['Hello ', '!']);
     expect(interpolateFn.expressions).toEqual(['name']);
 
@@ -67,17 +65,21 @@ describe('$interpolate', function() {
       inject(['$sce', function($sce) { sce = $sce; }]);
     });
 
-    it('should NOT interpolate non-trusted expressions', inject(function($interpolate) {
-      var foo = "foo";
+    it('should NOT interpolate non-trusted expressions', inject(function($interpolate, $rootScope) {
+      var scope = $rootScope.$new();
+      scope.foo = "foo";
+
       expect(function() {
-        $interpolate('{{foo}}', true, sce.CSS).compute([foo]);
+        $interpolate('{{foo}}', true, sce.CSS)(scope);
       }).toThrowMinErr('$interpolate', 'interr');
     }));
 
-    it('should NOT interpolate mistyped expressions', inject(function($interpolate) {
-      var foo = sce.trustAsCss("foo");
+    it('should NOT interpolate mistyped expressions', inject(function($interpolate, $rootScope) {
+      var scope = $rootScope.$new();
+      scope.foo = sce.trustAsCss("foo");
+
       expect(function() {
-        $interpolate('{{foo}}', true, sce.HTML).compute([foo]);
+        $interpolate('{{foo}}', true, sce.HTML)(scope);
       }).toThrowMinErr('$interpolate', 'interr');
     }));
 

--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -3,7 +3,7 @@
 describe('$interpolate', function() {
 
   it('should return the interpolation object when there are no bindings and textOnly is undefined',
-      inject(function($interpolate, $rootScope) {
+      inject(function($interpolate) {
     var interpolateFn = $interpolate('some text');
 
     expect(interpolateFn.exp).toBe('some text');
@@ -11,7 +11,6 @@ describe('$interpolate', function() {
     expect(interpolateFn.expressions).toEqual([]);
 
     expect(interpolateFn({})).toBe('some text');
-    expect(interpolateFn.compute([])).toBe('some text');
   }));
 
 
@@ -21,15 +20,15 @@ describe('$interpolate', function() {
   }));
 
   it('should suppress falsy objects', inject(function($interpolate) {
-    expect($interpolate('{{undefined}}').compute([undefined])).toEqual('');
-    expect($interpolate('{{null}}').compute([null])).toEqual('');
-    expect($interpolate('{{a.b}}').compute([undefined])).toEqual('');
+    expect($interpolate('{{undefined}}')({})).toEqual('');
+    expect($interpolate('{{null}}')({})).toEqual('');
+    expect($interpolate('{{a.b}}')({})).toEqual('');
   }));
 
   it('should jsonify objects', inject(function($interpolate) {
-    expect($interpolate('{{ {} }}').compute([{}])).toEqual('{}');
-    expect($interpolate('{{ true }}').compute([true])).toEqual('true');
-    expect($interpolate('{{ false }}').compute([false])).toEqual('false');
+    expect($interpolate('{{ {} }}')({})).toEqual('{}');
+    expect($interpolate('{{ true }}')({})).toEqual('true');
+    expect($interpolate('{{ false }}')({})).toEqual('false');
   }));
 
 
@@ -44,12 +43,11 @@ describe('$interpolate', function() {
     scope.name = 'Bubu';
 
     expect(interpolateFn(scope)).toBe('Hello Bubu!');
-    expect(interpolateFn.compute(['Bubu'])).toBe('Hello Bubu!');
   }));
 
 
   it('should ignore undefined model', inject(function($interpolate) {
-    expect($interpolate("Hello {{'World'}}{{foo}}").compute(['World'])).toBe('Hello World');
+    expect($interpolate("Hello {{'World'}}{{foo}}")({})).toBe('Hello World');
   }));
 
 
@@ -85,12 +83,12 @@ describe('$interpolate', function() {
 
     it('should interpolate trusted expressions in a regular context', inject(function($interpolate) {
       var foo = sce.trustAsCss("foo");
-      expect($interpolate('{{foo}}', true).compute([foo])).toEqual('foo');
+      expect($interpolate('{{foo}}', true)({foo: foo})).toBe('foo');
     }));
 
     it('should interpolate trusted expressions in a specific trustedContext', inject(function($interpolate) {
       var foo = sce.trustAsCss("foo");
-      expect($interpolate('{{foo}}', true, sce.CSS).compute([foo])).toEqual('foo');
+      expect($interpolate('{{foo}}', true, sce.CSS)({foo: foo})).toBe('foo');
     }));
 
     // The concatenation of trusted values does not necessarily result in a trusted value.  (For
@@ -100,7 +98,7 @@ describe('$interpolate', function() {
       var foo = sce.trustAsCss("foo");
       var bar = sce.trustAsCss("bar");
       expect(function() {
-        return $interpolate('{{foo}}{{bar}}', true, sce.CSS).compute([foo, bar]);
+        return $interpolate('{{foo}}{{bar}}', true, sce.CSS)({foo: foo, bar: bar});
       }).toThrowMinErr(
                 "$interpolate", "noconcat", "Error while interpolating: {{foo}}{{bar}}\n" +
                 "Strict Contextual Escaping disallows interpolations that concatenate multiple " +
@@ -119,8 +117,8 @@ describe('$interpolate', function() {
     it('should not get confused with same markers', inject(function($interpolate) {
       expect($interpolate('---').separators).toEqual(['---']);
       expect($interpolate('---').expressions).toEqual([]);
-      expect($interpolate('----').compute([])).toEqual('');
-      expect($interpolate('--1--').compute([1])).toEqual('1');
+      expect($interpolate('----')({})).toEqual('');
+      expect($interpolate('--1--')({})).toEqual('1');
     }));
   });
 
@@ -140,7 +138,7 @@ describe('$interpolate', function() {
           separators = interpolateFn.separators, expressions = interpolateFn.expressions;
       expect(separators).toEqual(['a', 'C']);
       expect(expressions).toEqual(['b']);
-      expect(interpolateFn.compute([123])).toEqual('a123C');
+      expect(interpolateFn({b: 123})).toEqual('a123C');
     }));
 
     it('should Parse Ending Binding', inject(function($interpolate) {
@@ -148,7 +146,7 @@ describe('$interpolate', function() {
         separators = interpolateFn.separators, expressions = interpolateFn.expressions;
       expect(separators).toEqual(['a', '']);
       expect(expressions).toEqual(['b']);
-      expect(interpolateFn.compute([123])).toEqual('a123');
+      expect(interpolateFn({b: 123})).toEqual('a123');
     }));
 
     it('should Parse Begging Binding', inject(function($interpolate) {
@@ -156,7 +154,7 @@ describe('$interpolate', function() {
         separators = interpolateFn.separators, expressions = interpolateFn.expressions;
       expect(separators).toEqual(['', 'c']);
       expect(expressions).toEqual(['b']);
-      expect(interpolateFn.compute([123])).toEqual('123c');
+      expect(interpolateFn({b: 123})).toEqual('123c');
     }));
 
     it('should Parse Loan Binding', inject(function($interpolate) {
@@ -164,7 +162,7 @@ describe('$interpolate', function() {
         separators = interpolateFn.separators, expressions = interpolateFn.expressions;
       expect(separators).toEqual(['', '']);
       expect(expressions).toEqual(['b']);
-      expect(interpolateFn.compute([123])).toEqual('123');
+      expect(interpolateFn({b: 123})).toEqual('123');
     }));
 
     it('should Parse Two Bindings', inject(function($interpolate) {
@@ -172,7 +170,7 @@ describe('$interpolate', function() {
         separators = interpolateFn.separators, expressions = interpolateFn.expressions;
       expect(separators).toEqual(['', '', '']);
       expect(expressions).toEqual(['b', 'c']);
-      expect(interpolateFn.compute([111, 222])).toEqual('111222');
+      expect(interpolateFn({b: 111, c: 222})).toEqual('111222');
     }));
 
     it('should Parse Two Bindings With Text In Middle', inject(function($interpolate) {
@@ -180,7 +178,7 @@ describe('$interpolate', function() {
         separators = interpolateFn.separators, expressions = interpolateFn.expressions;
       expect(separators).toEqual(['', 'x', '']);
       expect(expressions).toEqual(['b', 'c']);
-      expect(interpolateFn.compute([111, 222])).toEqual('111x222');
+      expect(interpolateFn({b: 111, c: 222})).toEqual('111x222');
     }));
 
     it('should Parse Multiline', inject(function($interpolate) {
@@ -188,7 +186,7 @@ describe('$interpolate', function() {
         separators = interpolateFn.separators, expressions = interpolateFn.expressions;
       expect(separators).toEqual(['"X\nY', 'C\nD"']);
       expect(expressions).toEqual(['A\n+B']);
-      expect(interpolateFn.compute([123])).toEqual('"X\nY123C\nD"');
+      expect(interpolateFn({'A': 'aa', 'B': 'bb'})).toEqual('"X\nYaabbC\nD"');
     }));
   });
 
@@ -217,9 +215,9 @@ describe('$interpolate', function() {
     }));
 
     it('should interpolate a multi-part expression when isTrustedContext is false', inject(function($interpolate) {
-      expect($interpolate('some/{{id}}').compute([undefined])).toEqual('some/');
-      expect($interpolate('some/{{id}}').compute([1])).toEqual('some/1');
-      expect($interpolate('{{foo}}{{bar}}').compute([1, 2])).toEqual('12');
+      expect($interpolate('some/{{id}}')({})).toEqual('some/');
+      expect($interpolate('some/{{id}}')({id: 1})).toEqual('some/1');
+      expect($interpolate('{{foo}}{{bar}}')({foo: 1, bar: 2})).toEqual('12');
     }));
   });
 
@@ -251,8 +249,8 @@ describe('$interpolate', function() {
       inject(function($interpolate) {
         expect($interpolate('---').separators).toEqual(['---']);
         expect($interpolate('---').expressions).toEqual([]);
-        expect($interpolate('----').compute([])).toEqual('');
-        expect($interpolate('--1--').compute([1])).toEqual('1');
+        expect($interpolate('----')({})).toEqual('');
+        expect($interpolate('--1--')({})).toEqual('1');
       });
     });
   });

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1045,7 +1045,7 @@ describe('parser', function() {
           }));
         });
 
-        describe('nulls in expressions', function() {
+        describe('null/undefined in expressions', function() {
           // simpleGetterFn1
           it('should return null for `a` where `a` is null', inject(function($rootScope) {
             $rootScope.a = null;
@@ -1091,6 +1091,19 @@ describe('parser', function() {
           it('should return undefined for `a.b.c.d.e.f.g` where `f` is null', inject(function($rootScope) {
             $rootScope.a = { b: { c: { d: { e: { f: null } } } } };
             expect($rootScope.$eval('a.b.c.d.e.f.g')).toBeUndefined();
+          }));
+
+
+          it('should return undefined if the return value of a function invocation is undefined',
+              inject(function($rootScope) {
+            $rootScope.fn = function() {};
+            expect($rootScope.$eval('fn()')).toBeUndefined();
+          }));
+
+          it('should ignore undefined values when doing addition/concatenation',
+              inject(function($rootScope) {
+            $rootScope.fn = function() {};
+            expect($rootScope.$eval('foo + "bar" + fn()')).toBe('bar');
           }));
         });
       });

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -777,6 +777,89 @@ describe('Scope', function() {
     });
   });
 
+  describe('$watchGroup', function() {
+    var scope;
+    beforeEach(inject(function($rootScope) {
+      scope = $rootScope.$new();
+    }));
+
+
+    it('should treat set of 1 as direct watch', function() {
+      var lastValues = ['foo'];
+      var log = '';
+      var clean = scope.$watchGroup(['a'], function(values, oldValues, s) {
+        log += values.join(',') + ';';
+        expect(s).toBe(scope);
+        expect(oldValues).toEqual(lastValues);
+        lastValues = values.slice();
+      });
+
+      scope.a = 'foo';
+      scope.$digest();
+      expect(log).toEqual('foo;');
+
+      scope.$digest();
+      expect(log).toEqual('foo;');
+
+      scope.a = 'bar';
+      scope.$digest();
+      expect(log).toEqual('foo;bar;');
+
+      clean();
+      scope.a = 'xxx';
+      scope.$digest();
+      expect(log).toEqual('foo;bar;');
+    });
+
+
+    it('should detect a change to any one in a set', function() {
+      var lastValues = ['foo', 'bar'];
+      var log = '';
+
+      scope.$watchGroup(['a', 'b'], function(values, oldValues, s) {
+        log += values.join(',') + ';';
+        expect(s).toBe(scope);
+        expect(oldValues).toEqual(lastValues);
+        lastValues = values.slice();
+      });
+
+      scope.a = 'foo';
+      scope.b = 'bar';
+      scope.$digest();
+      expect(log).toEqual('foo,bar;');
+
+      log = '';
+      scope.$digest();
+      expect(log).toEqual('');
+
+      scope.a = 'a';
+      scope.$digest();
+      expect(log).toEqual('a,bar;');
+
+      log = '';
+      scope.a = 'A';
+      scope.b = 'B';
+      scope.$digest();
+      expect(log).toEqual('A,B;');
+    });
+
+
+    it('should not call watch action fn when watchGroup was deregistered', function() {
+      var lastValues = ['foo', 'bar'];
+      var log = '';
+      var deregister = scope.$watchGroup(['a', 'b'], function(values, oldValues, s) {
+        log += values.join(',') + ';';
+        expect(s).toBe(scope);
+        expect(oldValues).toEqual(lastValues);
+        lastValues = values.slice();
+      });
+
+      deregister();
+      scope.a = 'xxx';
+      scope.$digest();
+      expect(log).toEqual('');
+    });
+  });
 
   describe('$destroy', function() {
     var first = null, middle = null, last = null, log = null;

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -779,83 +779,69 @@ describe('Scope', function() {
 
   describe('$watchGroup', function() {
     var scope;
-    beforeEach(inject(function($rootScope) {
+    var log;
+
+    beforeEach(inject(function($rootScope, _log_) {
       scope = $rootScope.$new();
+      log = _log_;
     }));
 
 
     it('should work for a group with just a single expression', function() {
-      var lastValues = ['foo'];
-      var log = '';
-      var clean = scope.$watchGroup(['a'], function(values, oldValues, s) {
-        log += values.join(',') + ';';
+      scope.$watchGroup(['a'], function(values, oldValues, s) {
         expect(s).toBe(scope);
-        expect(oldValues).toEqual(lastValues);
-        lastValues = values.slice();
+        log(oldValues + ' >>> ' + values);
       });
 
       scope.a = 'foo';
       scope.$digest();
-      expect(log).toEqual('foo;');
+      expect(log).toEqual('foo >>> foo');
 
+      log.reset();
       scope.$digest();
-      expect(log).toEqual('foo;');
+      expect(log).toEqual('');
 
       scope.a = 'bar';
       scope.$digest();
-      expect(log).toEqual('foo;bar;');
-
-      clean();
-      scope.a = 'xxx';
-      scope.$digest();
-      expect(log).toEqual('foo;bar;');
+      expect(log).toEqual('foo >>> bar');
     });
 
 
     it('should detect a change to any one expression in the group', function() {
-      var lastValues = ['foo', 'bar'];
-      var log = '';
-
       scope.$watchGroup(['a', 'b'], function(values, oldValues, s) {
-        log += values.join(',') + ';';
         expect(s).toBe(scope);
-        expect(oldValues).toEqual(lastValues);
-        lastValues = values.slice();
+        log(oldValues + ' >>> ' + values);
       });
 
       scope.a = 'foo';
       scope.b = 'bar';
       scope.$digest();
-      expect(log).toEqual('foo,bar;');
+      expect(log).toEqual('foo,bar >>> foo,bar');
 
-      log = '';
+      log.reset();
       scope.$digest();
       expect(log).toEqual('');
 
       scope.a = 'a';
       scope.$digest();
-      expect(log).toEqual('a,bar;');
+      expect(log).toEqual('foo,bar >>> a,bar');
 
-      log = '';
+      log.reset();
       scope.a = 'A';
       scope.b = 'B';
       scope.$digest();
-      expect(log).toEqual('A,B;');
+      expect(log).toEqual('a,bar >>> A,B');
     });
 
 
     it('should not call watch action fn when watchGroup was deregistered', function() {
-      var lastValues = ['foo', 'bar'];
-      var log = '';
-      var deregister = scope.$watchGroup(['a', 'b'], function(values, oldValues, s) {
-        log += values.join(',') + ';';
-        expect(s).toBe(scope);
-        expect(oldValues).toEqual(lastValues);
-        lastValues = values.slice();
+      var deregister = scope.$watchGroup(['a', 'b'], function(values, oldValues) {
+        log(oldValues + ' >>> ' + values);
       });
 
       deregister();
       scope.a = 'xxx';
+      scope.b = 'yyy';
       scope.$digest();
       expect(log).toEqual('');
     });

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -784,7 +784,7 @@ describe('Scope', function() {
     }));
 
 
-    it('should treat set of 1 as direct watch', function() {
+    it('should work for a group with just a single expression', function() {
       var lastValues = ['foo'];
       var log = '';
       var clean = scope.$watchGroup(['a'], function(values, oldValues, s) {
@@ -812,7 +812,7 @@ describe('Scope', function() {
     });
 
 
-    it('should detect a change to any one in a set', function() {
+    it('should detect a change to any one expression in the group', function() {
       var lastValues = ['foo', 'bar'];
       var log = '';
 


### PR DESCRIPTION
This is my refactoring of @rodyhaddad's PR #6598

I tried several approaches to clean it up and ended up doing a full circle by keeping the $interpolate optimization that Rody did for parsing but then reimplementing the `$watchGroup` logic inside of the function returned by $interpolate. This resulted in almost no breaking change (the only difference is that fn returned by $interpolate now expects a proper Scope instance rather than an object), removal of all hacks and still preserving the performance boost.

There are three minor todos left before this can be merged, but I'm throwing it out here so that others can start reviewing.

Todos left:
- [x] remove the single expression optimization from watchGroup, we don't need it any more
- [x] hide the `compute` fn currently exposed as a property of the fn returned by `$interpolate`. this requires changes to 17 tests.
- [ ] squash
