### PR TITLE
fix(select): ensure the correct option is selected in IE 10/11

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -538,6 +538,9 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
                 }
                 // lastElement.prop('selected') provided by jQuery has side-effects
                 if (existingOption.selected !== option.selected) {
+                  // IE 10/11 bug: selecting non-first option will show wrong option selected.
+                  // https://github.com/angular/angular.js/issues/2828
+                  selectElement.prop('selectedIndex');
                   lastElement.prop('selected', (existingOption.selected = option.selected));
                 }
               } else {

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -986,9 +986,25 @@ describe('select', function() {
         expect(element.val()).toEqual('0');
         expect(element.find('option').eq(0).prop('selected')).toBeTruthy();
         expect(element.find('option').length).toEqual(2);
+
+
+        // reset and test 2nd data element selection.  this was known to fail in IE 10/11.
+        scope.$apply(function() {
+          scope.values = [{name: 'A'}, {name: 'B'}];
+          scope.selected = {};
+        });
+
+        // verify empty option exist
+        expect(element.find('option').length).toEqual(3);
+        expect(element.val()).toEqual('?');
+        expect(element.find('option').eq(0).val()).toEqual('?');
+
+        browserTrigger(element.find('option').eq(2));
+        expect(element.val()).toEqual('1');
+        expect(element.find('option').eq(1).prop('selected')).toBeTruthy();
+        expect(element.find('option').length).toEqual(2);
       });
     });
-
 
     describe('blank option', function () {
 


### PR DESCRIPTION
Request Type: bug

How to reproduce: 1.  go here: http://plnkr.co/edit/zLwCvV2TgELcWiHwxn25?p=preview
2.  select foo bar from drop down in IE 10/11.  foo bar will not be shown as selected in the dropdown

Component(s): forms

Impact: 

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

fixes issue #2828
