### PR TITLE
Fixing expression parameters for orderBy.

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -9,7 +9,7 @@
  * Orders a specified `array` by the `expression` predicate.
  *
  * @param {Array} array The array to sort.
- * @param {function(*)|string|Array.<(function(*)|string)>} expression A predicate to be
+ * @param {function()|string|Object} expression A predicate to be
  *    used by the comparator to determine the order of elements.
  *
  *    Can be one of:


### PR DESCRIPTION
This seems to be a typo, unless I'm missing something - generated Usage example is wrong.

See http://stackoverflow.com/questions/23093953/is-the-angular-orderby-documentation-wrong-or-am-i-confused
