### PR TITLE
fix(addStyle): reference window.angular instead of just angular

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -136,7 +136,7 @@ module.exports = {
         .replace(/\\/g, '\\\\')
         .replace(/'/g, "\\'")
         .replace(/\r?\n/g, '\\n');
-      js = "!angular.$$csp() && angular.element(document).find('head').prepend('<style type=\"text/css\">" + css + "</style>');";
+      js = "!window.angular.$$csp() && window.angular.element(document).find('head').prepend('<style type=\"text/css\">" + css + "</style>');";
       state.js.push(js);
 
       return state;


### PR DESCRIPTION
Reference window.angular instead of just angular because when running angular under an environment
where the top-level scope is not the window (nodejs for example), we have to specifically
reference window.angular.

The main reason for this fix is making running angular under nodejs easier.
Some use cases for this:
- Angular package on npm https://github.com/bclinkinbeard/angular
- angular's DI for node https://github.com/jmendiara/ng-di

Signed CLA as Tom Yam
