### PR TITLE
ngModelOptions debounce was failing when on event with a value of 0

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1822,9 +1822,20 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
    * @param {string} trigger Event that triggered the update.
    */
   this.$setViewValue = function(value, trigger) {
-    var debounceDelay = ctrl.$options && (isObject(ctrl.$options.debounce)
-        ? (ctrl.$options.debounce[trigger] || ctrl.$options.debounce['default'] || 0)
-        : ctrl.$options.debounce) || 0;
+    var debounceDelay = 0,
+        options = ctrl.$options,
+        debounce;
+
+    if(options && isDefined(options.debounce)) {
+      debounce = options.debounce;
+      if(isNumber(debounce)) {
+        debounceDelay = debounce;
+      } else if(isNumber(debounce[trigger])) {
+        debounceDelay = debounce[trigger];
+      } else if (isNumber(debounce['default'])) {
+        debounceDelay = debounce['default'];
+      }
+    }
 
     $timeout.cancel(pendingDebounce);
     if (debounceDelay) {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -844,6 +844,25 @@ describe('input', function() {
       expect(scope.checkbox).toBe(false);
     }));
 
+    it('should allow selecting 0 for non-default debounce timeouts for each event on checkboxes', inject(function($timeout) {
+      compileInput('<input type="checkbox" ng-model="checkbox" '+
+        'ng-model-options="{ '+
+          'updateOn: \'default blur\', debounce: { default: 10000, blur: 0 } }"'+
+        '/>');
+
+      inputElm[0].checked = false;
+      browserTrigger(inputElm, 'click');
+      expect(scope.checkbox).toBe(undefined);
+      $timeout.flush(8000);
+      expect(scope.checkbox).toBe(undefined);
+      $timeout.flush(3000);
+      expect(scope.checkbox).toBe(true);
+      inputElm[0].checked = true;
+      browserTrigger(inputElm, 'click');
+      browserTrigger(inputElm, 'blur');
+      $timeout.flush(0);
+      expect(scope.checkbox).toBe(false);
+    }));
 
     it('should inherit model update settings from ancestor elements', inject(function($timeout) {
       var doc = $compile(


### PR DESCRIPTION
Request Type: bug

How to reproduce: [Here's a fiddle that demonstrates.](http://jsfiddle.net/joelhooks/QZ8hg/)

Component(s): misc core

Impact: medium

Complexity: small

This issue is related to: 

**Detailed Description:**

Was testing ngModelOptions, and noticed that the provided example
`ngModelOptions="{ updateOn: 'default blur', debounce: {'default': 500, 'blur':
0} }"` didn't function. With a little investigating I determined that the logic
operation was skipping debounce[trigger] if it was 0 (thanks JS falsiness!).

My first solution was to do this:

``` javascript
var debounceDelay = ctrl.$options && (
  isObject(ctrl.$options.debounce)
    ? (isNumber(ctrl.$options.debounce[trigger]) ?
    ctrl.$options.debounce[trigger]
                                                   :
                                                   (ctrl.$options.debounce['default']
                                                   || 0))
      : ctrl.$options.debounce
      ) || 0;
```

Which hopefully makes us all cringe. Instead of adding this mess (the original
logic took me about 30 minutes to understand), I decided to unroll it into
something a bit less... terse.

I added a unit test to cover this scenario.

This was found in **1.3.0-beta.6.**

[Here's a fiddle that demonstrates.](http://jsfiddle.net/joelhooks/QZ8hg/) Notice that it debounces blur, despite it being configured with 0. THis is because `(ctrl.$options.debounce[trigger] || ctrl.$options.debounce['default'] || 0)` will **always** skip to default if it exists and `debounce[trigger]` is 0. Without a default alongside the trigger, the final 0 would be the result, and I suspect that is how this slipped by.

**Other Comments:**
