### PR TITLE
Adding .resolve() function to $q

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -347,6 +347,32 @@ function qFactory(nextTick, exceptionHandler) {
 
   /**
    * @ngdoc method
+   * @name $q#resolve
+   * @function
+   *
+   * @description
+   * Creates a promise that is immediately resolved with the specified value. This api is useful
+   * when you have an interface that expects a promise to be returned but the underlying function
+   * implemention is not asychronous. Instead of creating a deferred, resolving that and then
+   * returning the deferred promise, you can simply wrap your return object with a resolve promise.
+   *
+   * ```js
+   *   var fn = function (input) {
+   *     return $q.resolve(input + 2);
+   *   }
+   * ```
+   *
+   * @param {*} value Object for the resolve promise.
+   * @returns {Promise} Returns a resolved promise with the provided value.
+   */
+  var resolve = function(value) {
+    var result = defer();
+    result.resolve(value);
+    return result.promise;
+  };
+
+  /**
+   * @ngdoc method
    * @name $q#reject
    * @function
    *
@@ -518,6 +544,7 @@ function qFactory(nextTick, exceptionHandler) {
 
   return {
     defer: defer,
+    resolve: resolve,
     reject: reject,
     when: when,
     all: all

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -926,6 +926,21 @@ describe('q', function() {
     });
   });
 
+  describe('resolve', function() {
+    it('should package a string into a resolved promise', function() {
+      var resolvedPromise = q.resolve('gonna happen');
+      promise.then(success(), error());
+      syncResolve(deferred, resolvedPromise);
+      expect(log).toEqual(['success(gonna happen)->gonna happen']);
+    });
+
+    it('should package an object into a resolved promise', function() {
+      var resolvedPromise = q.resolve({ foo: 'choo' });
+      promise.then(success(), error());
+      syncResolve(deferred, resolvedPromise);
+      expect(log).toEqual(['success({"foo":"choo"})->{"foo":"choo"}']);
+    });
+  });
 
   describe('reject', function() {
     it('should package a string into a rejected promise', function() {


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): $q

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Just like how $q.reject() returns a rejected promise, this returns a resolved promise.

**Other Comments:**

This is a simple, but very useful function missing from the $q library that exists in Q. The typical use case is when you create abstractions where calling code expects a promise to be returned from a given interface. Some implementations of the interface may be asynch (thus why promises are needed), but certain implementations may also be synchronous. You can of course create a deferred, resolve it and return the deferred promise, but simply doing $q.resolve() is much more simple and beautiful. Even if all your existing implementations are asych, this is still useful for a default interface implementation where you just return null, {}, etc.
