### PR TITLE
`_angular` is redundant

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -10,7 +10,6 @@
     -push,
     -toString,
     -ngMinErr,
-    -_angular,
     -angularModule,
     -nodeName_,
     -uid,
@@ -161,8 +160,6 @@ var /** holds major version number for IE or NaN for real browsers */
     toString          = Object.prototype.toString,
     ngMinErr          = minErr('ng'),
 
-
-    _angular          = window.angular,
     /** @name angular */
     angular           = window.angular || (window.angular = {}),
     angularModule,


### PR DESCRIPTION
Request Type: bug

How to reproduce: _angular variable is redundant in the source

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

Going through the commit history on GitHub, the `_angular` is for noConflict mode, the case where you have an old reference to a variable called Angular you want to preserve.

Here is the commit that added _angular in : https://github.com/angular/angular.js/commit/12ba6cec4fb79521101744e02a7e09f9fbb591c4

This feature was later removed here: 
https://github.com/angular/angular.js/commit/9faabd1ba0b1929785bcf166dc0ff60008e7c442

The variable 'made it through', it's redundant now.
