### PR TITLE
Correct size of the compressed/minified angular.js

### DIFF
--- a/docs/content/misc/faq.ngdoc
+++ b/docs/content/misc/faq.ngdoc
@@ -67,7 +67,7 @@ illustration we typically build snappy apps with hundreds or thousands of active
 
 ### How big is the angular.js file that I need to include?
 
-The size of the file is < 36KB compressed and minified.
+The size of the file is < 104KB compressed and minified.
 
 
 ### Can I use the open-source Closure Library with Angular?


### PR DESCRIPTION
Looking at angular.min.js for 1.2.16, the size has grown:

```
$ curl -s http://ajax.googleapis.com/ajax/libs/angularjs/1.2.16/angular.min.js | wc -c | numfmt --to=iec
103K
```
