### PR TITLE
Updating to reflect ACTUAL default $resource actions

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -168,7 +168,7 @@ function shallowClearAndCopy(src, dst) {
  *   { 'get':    {method:'GET'},
  *     'save':   {method:'POST'},
  *     'query':  {method:'GET', isArray:true},
- *     'remove': {method:'DELETE'},
+ *     'update': {method:'PUT'},
  *     'delete': {method:'DELETE'} };
  *   ```
  *


### PR DESCRIPTION
Request Type: docs

How to reproduce: Look at the docs for $resource

Component(s): ngResource

Impact: large

Complexity: small

This issue is related to: 

**Detailed Description:**

The docs seemed to be off. I can't imagine that the default $resource would create 2 DELETE actions.

**Other Comments:**

I updated the documentation for what looks to be some incorrect documentation. I updated it with what I'm guessing is correct, but that doesn't mean it is. Please review and tweak as necessary.
