### PR TITLE
feat(ngTouch's ngClick): add 'ng-touch' attribute to prevent bluring

### DIFF
--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -157,8 +157,15 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     event.stopPropagation();
     event.preventDefault();
 
-    // Blur focused form elements
-    event.target && event.target.blur();
+    // Blur focused form elements only if the user did not specify to keep it.
+    // Specified by adding the attribute 'ng-touch' with the value 'keep-focus'.
+    if (!event.target.attributes['ng-touch']) {
+        event.target && event.target.blur();
+    } else {
+      if (event.target.attributes['ng-touch'].nodeValue !== 'keep-focus') {
+        event.target && event.target.blur();
+      }
+    }
   }
 
 

--- a/test/ngTouch/directive/ngClickSpec.js
+++ b/test/ngTouch/directive/ngClickSpec.js
@@ -600,5 +600,91 @@ describe('ngClick (touch)', function() {
 
       expect(called).toEqual(true);
     }));
+
+    it('should remove focus by default', inject(function($rootScope, $compile, $rootElement, $document) {
+      $document.find('body').append($rootElement);
+      $rootElement.append(
+          '<input ng-click="count = count + 1" type="text" >'
+      );
+      $compile($rootElement)($rootScope);
+
+      element = $rootElement.find('input').eq(0);
+
+      $rootScope.count = 0;
+
+      $rootScope.$digest();
+
+      expect($rootScope.count).toBe(0);
+
+      time = 10;
+      browserTrigger(element, 'touchstart',{
+        keys: [],
+        x: 10,
+        y: 10
+      });
+
+      time = 50;
+      browserTrigger(element, 'touchend',{
+        keys: [],
+        x: 10,
+        y: 10
+      });
+
+      expect($rootScope.count).toBe(1);
+
+      time = 90;
+      // Verify that it is blured so we don't get soft-keyboard
+      element[0].blur = jasmine.createSpy('blur');
+      browserTrigger(element, 'click',{
+        keys: [],
+        x: 10,
+        y: 10
+      });
+      expect(element[0].blur).toHaveBeenCalled();
+      $document.find('body').empty();
+    }));
+
+    it('should keep focus if it is specified', inject(function($rootScope, $compile, $rootElement, $document) {
+      $document.find('body').append($rootElement);
+      $rootElement.append(
+          '<input ng-click="count = count + 1" type="text" ng-touch="keep-focus" >'
+      );
+      $compile($rootElement)($rootScope);
+
+      element = $rootElement.find('input').eq(0);
+
+      $rootScope.count = 0;
+
+      $rootScope.$digest();
+
+      expect($rootScope.count).toBe(0);
+
+      time = 10;
+      browserTrigger(element, 'touchstart',{
+        keys: [],
+        x: 10,
+        y: 10
+      });
+
+      time = 50;
+      browserTrigger(element, 'touchend',{
+        keys: [],
+        x: 10,
+        y: 10
+      });
+
+      expect($rootScope.count).toBe(1);
+
+      time = 90;
+      // Verify that it is not blured so we do get soft-keyboard
+      element[0].blur = jasmine.createSpy('blur');
+      browserTrigger(element, 'click',{
+        keys: [],
+        x: 10,
+        y: 10
+      });
+      expect(element[0].blur).not.toHaveBeenCalled();
+      $document.find('body').empty();
+    }));
   });
 });


### PR DESCRIPTION
Request Type: 

How to reproduce: 

Component(s): 

Impact: 

Complexity: 

This issue is related to: 

**Detailed Description:**

**Other Comments:**

Can now add 'ng-touch=keep-focus' to any element to prevent the focus from being blured.
Primarily useful for input elements in a modal where one needs the soft keyboard to remain open or
for select elements.  Without the new attribute, select elements are difficult to use under iOS when
the element is on a modal and input elements that depend on the soft keyboard were unusable.  Now with the new attribute, they are fully usable.  If the new attribute is not used, old behavior is
mantained.
