### PR TITLE
feat(http): add config parameter to headers functions

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -487,7 +487,7 @@ function $HttpProvider() {
      *    - **data** – `{string|Object}` – Data to be sent as the request message data.
      *    - **headers** – `{Object}` – Map of strings or functions which return strings representing
      *      HTTP headers to send to the server. If the return value of a function is null, the
-     *      header will not be sent.
+     *      header will not be sent. Functions take the config object as argument.
      *    - **xsrfHeaderName** – `{string}` – Name of HTTP header to populate with the XSRF token.
      *    - **xsrfCookieName** – `{string}` – Name of cookie containing the XSRF token.
      *    - **transformRequest** –
@@ -717,15 +717,15 @@ function $HttpProvider() {
         }
 
         // execute if header value is a function for merged headers
-        execHeaders(reqHeaders);
+        execHeaders(reqHeaders, config);
         return reqHeaders;
 
-        function execHeaders(headers) {
+        function execHeaders(headers, data) {
           var headerContent;
 
           forEach(headers, function(headerFn, header) {
             if (isFunction(headerFn)) {
-              headerContent = headerFn();
+              headerContent = headerFn(data);
               if (headerContent != null) {
                 headers[header] = headerContent;
               } else {

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -755,17 +755,19 @@ describe('$http', function() {
       }));
 
       it('should send execute result if header value is function', inject(function() {
-        var headerConfig = {'Accept': function() { return 'Rewritten'; }};
+        var headerConfig = {'Accept': function(config) { return 'Rewritten-' + config.method; }};
 
-        function checkHeaders(headers) {
-          return headers['Accept'] == 'Rewritten';
+        function checkHeaders(method) {
+          return function(headers) {
+            return headers['Accept'] == 'Rewritten-' + method;
+          };
         }
 
-        $httpBackend.expect('GET', '/url', undefined, checkHeaders).respond('');
-        $httpBackend.expect('POST', '/url', undefined, checkHeaders).respond('');
-        $httpBackend.expect('PUT', '/url', undefined, checkHeaders).respond('');
-        $httpBackend.expect('PATCH', '/url', undefined, checkHeaders).respond('');
-        $httpBackend.expect('DELETE', '/url', undefined, checkHeaders).respond('');
+        $httpBackend.expect('GET', '/url', undefined, checkHeaders('GET')).respond('');
+        $httpBackend.expect('POST', '/url', undefined, checkHeaders('POST')).respond('');
+        $httpBackend.expect('PUT', '/url', undefined, checkHeaders('PUT')).respond('');
+        $httpBackend.expect('PATCH', '/url', undefined, checkHeaders('PATCH')).respond('');
+        $httpBackend.expect('DELETE', '/url', undefined, checkHeaders('DELETE')).respond('');
 
         $http({url: '/url', method: 'GET', headers: headerConfig});
         $http({url: '/url', method: 'POST', headers: headerConfig});


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): $http

Impact: 

Complexity: small

This issue is related to: 

**Detailed Description:**

Adds 'data' parameter in $http's header property when headers defined as functions

**Other Comments:**

This pull request adds to $http header functions a data parameter, so headers can use object properties to be built:

Example (in a $resource) :

<pre>
...
                  login: {
                    url: './api/login.json',
                    method: 'POST',
                    headers : {
                        'Authorization': function(data) {
                          return 'Basic ' + btoa(data.user + ':' + data.pass);
                        }
                    },
...
</pre>
