### PR TITLE
fix($interpolate): don't ReferenceError when context is undefined

### DIFF
--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -199,7 +199,7 @@ function $InterpolateProvider() {
         };
 
         return extend(function interpolationFn(context) {
-            var scopeId = context.$id || 'notAScope';
+            var scopeId = (context && context.$id) || 'notAScope';
             var lastValues = lastValuesCache.values[scopeId];
             var lastResult = lastValuesCache.results[scopeId];
             var i = 0;
@@ -214,7 +214,7 @@ function $InterpolateProvider() {
             if (!lastValues) {
               lastValues = [];
               inputsChanged = true;
-              if (context.$on) {
+              if (context && context.$on) {
                 context.$on('$destroy', function() {
                   lastValuesCache.values[scopeId] = null;
                   lastValuesCache.results[scopeId] = null;

--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -51,6 +51,11 @@ describe('$interpolate', function() {
   }));
 
 
+  it('should interpolate with undefined context', inject(function($interpolate) {
+    expect($interpolate("Hello, world!{{bloop}}")()).toBe("Hello, world!");
+  }));
+
+
   describe('interpolating in a trusted context', function() {
     var sce;
     beforeEach(function() {


### PR DESCRIPTION
546cb42 introduced a regression, which would cause the function returned from
$interpolate to throw a ReferenceError if `context` is undefined. This change 
prevents the error from being thrown.

Closes #7230
