### PR TITLE
fix($location): parse query parameters which precede hash in hashbang mode

### DIFF
--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1572,5 +1572,50 @@ describe('$location', function() {
       expect(locationIndex.$$rewrite('http://server/pre/')).toEqual(undefined);
       expect(locationIndex.$$rewrite('http://server/pre/otherPath')).toEqual('http://server/pre/index.html#!otherPath');
     });
+
+    it('search() should parse query parameters preceding hash prefix', function() {
+      url = new LocationHashbangInHtml5Url('http://server/base', '#!');
+      url.$$parse(url.$$rewrite('http://server/base?a=b#!?c=d#foo'));
+      expect(url.search()).toEqual({
+        'a': 'b',
+        'c': 'd'
+      });
+      expect(url.hash()).toBe('foo');
+    });
+
+
+    it('search() should parse query parameters without hash prefix', function() {
+      url = new LocationHashbangInHtml5Url('http://server/base', '#!');
+      url.$$parse(url.$$rewrite('http://server/base?a=b&c=d#foo'));
+      expect(url.search()).toEqual({
+        'a': 'b',
+        'c': 'd'
+      });
+      expect(url.hash()).toBe('foo');
+    });
+
+
+    // A question mark following the hash fragment is just part of the hash fragment, and
+    // should behave this way.
+    it('search() should ignore parse query parameters following hash fragment', function() {
+      url = new LocationHashbangInHtml5Url('http://server/base', '#!');
+      url.$$parse(url.$$rewrite('http://server/base?a=b&c=d#foo?!biz'));
+      expect(url.search()).toEqual({
+        'a': 'b',
+        'c': 'd'
+      });
+      expect(url.hash()).toBe('foo?!biz');
+    });
+
+
+    it('should keep query parameters without hash from initial url', function() {
+      url = new LocationHashbangInHtml5Url('http://server/base?a=b&c=d', '#!');
+      url.$$parse(url.$$rewrite('http://server/base?a=b&c=d#foo'));
+      expect(url.search()).toEqual({
+        'a': 'b',
+        'c': 'd'
+      });
+      expect(url.hash()).toBe('foo');
+    });
   });
 });


### PR DESCRIPTION
This fix causes `LocationHashbangUrl#$$rewrite()` to move a pre-hash query
string to after the hash.

This, in turn, causes urlResolve() to correctly parse the query string, and 
report the correct dictionary.

Closes #7239
