### PR TITLE
fix($sniffer): force $sniffer.history to be false when inside ff addon

### DIFF
--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -28,6 +28,7 @@ function $SnifferProvider() {
         bodyStyle = document.body && document.body.style,
         transitions = false,
         animations = false,
+        ffPlugin = $window.XPCNativeWrapper !== undefined,
         match;
 
     if (bodyStyle) {
@@ -62,8 +63,14 @@ function $SnifferProvider() {
       // older webkit browser (533.9) on Boxee box has exactly the same problem as Android has
       // so let's not use the history API also
       // We are purposefully using `!(android < 4)` to cover the case when `android` is undefined
+
+      // XPCNativeWrapper is a global available only for scripts running
+      // as FF addon "content script". It's the simplest way to check if
+      // we're running in context of an addon. If yes, ffPlugin is true and
+      // we force oldschool use of `location.href` instead of HTML5 API.
       // jshint -W018
-      history: !!($window.history && $window.history.pushState && !(android < 4) && !boxee),
+      history: !!($window.history && $window.history.pushState && !(android < 4) && !boxee &&
+                  !ffPlugin),
       // jshint +W018
       hashchange: 'onhashchange' in $window &&
                   // IE8 compatible mode lies

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -20,6 +20,11 @@ describe('$sniffer', function() {
       expect(sniffer({history: {}}).history).toBe(false);
       expect(sniffer({}).history).toBe(false);
     });
+
+    it('should be false XPCNativeWrapper is defined', function() {
+      var h = {pushState: noop, replaceState: noop};
+      expect(sniffer({history: h, XPCNativeWrapper: {}}).history).toBe(false);
+    });
   });
 
   describe('hashchange', function() {


### PR DESCRIPTION
Request Type: bug

How to reproduce: Described precisely in reported issue #7241

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

`history.pushState` and `history.replaceState` seem broken when
executed in scope of firefox's addon contentscript. This causes angular
to behave unpredictably as described in issue #7241. This commit
adds extra check for presence of `XPCNativeWrapper` object and makes
`$sniffer.history` depend on it too.

**Other Comments:**

Closes #7241
