### PR TITLE
fix(injector): allow multiple loading of function modules

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -611,7 +611,7 @@ function createInjector(modulesToLoad, strictDi) {
   var INSTANTIATING = {},
       providerSuffix = 'Provider',
       path = [],
-      loadedModules = new HashMap(),
+      loadedModules = new HashMap([], true),
       providerCache = {
         $provide: {
             provider: supportObject(provider),

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1983,6 +1983,12 @@ if(window.jasmine || window.mocha) {
   (window.afterEach || window.teardown)(function() {
     var injector = currentSpec.$injector;
 
+    angular.forEach(currentSpec.$modules, function(module) {
+      if (module && module.$$hashKey) {
+        module.$$hashKey = undefined;
+      }
+    });
+
     currentSpec.$injector = null;
     currentSpec.$modules = null;
     currentSpec = null;

--- a/test/ApiSpecs.js
+++ b/test/ApiSpecs.js
@@ -22,6 +22,36 @@ describe('api', function() {
       expect(map.get('b')).toBe(1);
       expect(map.get('c')).toBe(undefined);
     });
+
+    it('should maintain hashKey for object keys', function() {
+      var map = new HashMap();
+      var key = {};
+      map.get(key);
+      expect(key.$$hashKey).toBeDefined();
+    });
+
+    it('should maintain hashKey for function keys', function() {
+      var map = new HashMap();
+      var key = function() {};
+      map.get(key);
+      expect(key.$$hashKey).toBeDefined();
+    });
+
+    it('should share hashKey between HashMap by default', function() {
+      var map1 = new HashMap(), map2 = new HashMap();
+      var key1 = {}, key2 = {};
+      map1.get(key1);
+      map2.get(key2);
+      expect(key1.$$hashKey).not.toEqual(key2.$$hashKey);
+    });
+
+    it('should maintain hashKey per HashMap if flag is passed', function() {
+      var map1 = new HashMap([], true), map2 = new HashMap([], true);
+      var key1 = {}, key2 = {};
+      map1.get(key1);
+      map2.get(key2);
+      expect(key1.$$hashKey).toEqual(key2.$$hashKey);
+    });
   });
 });
 

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -296,6 +296,29 @@ describe('injector', function() {
       expect(log).toEqual('abc');
     });
 
+    it('should load different instances of dependent functions', function() {
+      function  generateValueModule(name, value) {
+        return function ($provide) {
+          $provide.value(name, value);
+        };
+      }
+      var injector = createInjector([generateValueModule('name1', 'value1'),
+                                     generateValueModule('name2', 'value2')]);
+      expect(injector.get('name2')).toBe('value2');
+    });
+
+    it('should load same instance of dependent function only once', function() {
+      var count = 0;
+      function valueModule($provide) {
+        count++;
+        $provide.value('name', 'value');
+      }
+
+      var injector = createInjector([valueModule, valueModule]);
+      expect(injector.get('name')).toBe('value');
+      expect(count).toBe(1);
+    });
+
     it('should execute runBlocks after injector creation', function() {
       var log = '';
       angular.module('a', [], function(){ log += 'a'; }).run(function() { log += 'A'; });

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -808,6 +808,23 @@ describe('ngMock', function() {
             expect(example).toEqual('win');
           });
         });
+
+        describe('module cleanup', function() {
+          function testFn() {
+
+          }
+
+          it('should add hashKey to module function', function() {
+            module(testFn);
+            inject(function () {
+              expect(testFn.$$hashKey).toBeDefined();
+            });
+          });
+
+          it('should cleanup hashKey after previous test', function() {
+            expect(testFn.$$hashKey).toBeUndefined();
+          });
+        });
       });
 
       describe('in DSL', function() {


### PR DESCRIPTION
move the loadedModules lookup to be performed only on strings in order to allow loading functions that look the same. this issue caused only the first `angular.mock.module(object)` invocation to work since the loadModules lookup blocked all following invocations.

closes #7254
