### PR TITLE
fix(ngClass): handle index change correctly

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -17,9 +17,8 @@ function classDirective(name, selector) {
 
         if (name !== 'ngClass') {
           scope.$watch('$index', function($index, old$index) {
-            // jshint bitwise: false
-            var mod = $index & 1;
-            if (mod !== old$index & 1) {
+            var mod = $index % 2;
+            if (mod !== old$index % 2) {
               var classes = arrayClasses(scope.$eval(attr[name]));
               mod === selector ?
                 addClasses(classes) :

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -276,6 +276,27 @@ describe('ngClass', function() {
   }));
 
 
+  it('should update ngClassOdd/Even when model is changed by adding', inject(function($rootScope, $compile) {
+    element = $compile('<ul>' +
+      '<li ng-repeat="i in items" ' +
+      'ng-class-odd="\'odd\'" ng-class-even="\'even\'">i</li>' +
+      '<ul>')($rootScope);
+    $rootScope.items = ['b','c','d'];
+    $rootScope.$digest();
+
+    $rootScope.items.unshift('a');
+    $rootScope.$digest();
+
+    var e1 = jqLite(element[0].childNodes[1]);
+    var e4 = jqLite(element[0].childNodes[7]);
+
+    expect(e1.hasClass('odd')).toBeTruthy();
+    expect(e1.hasClass('even')).toBeFalsy();
+
+    expect(e4.hasClass('even')).toBeTruthy();
+    expect(e4.hasClass('odd')).toBeFalsy();
+  }));
+
   it('should update ngClassOdd/Even when model is changed by filtering', inject(function($rootScope, $compile) {
     element = $compile('<ul>' +
       '<li ng-repeat="i in items track by $index" ' +


### PR DESCRIPTION
changed the odd/even calculation to be done using modulo operation instead of bitwise operation. the bitwise operation caused issues with operator precedance (`mod !== old$index & 1` is actually parsed as `(mod !== old$index) & 1` and not `mod !== (old$index & 1)` as might be expected). decided it is better to just use modulo operation for readibility instead of adding parentheses.

fixes #7256
