### PR TITLE
fix($sniffer): IE9 backspace bug in compatibility mode

### DIFF
--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -69,10 +69,10 @@ function $SnifferProvider() {
                   // IE8 compatible mode lies
                   (!documentMode || documentMode > 7),
       hasEvent: function(event) {
-        // IE9 implements 'input' event it's so fubared that we rather pretend that it doesn't have
-        // it. In particular the event is not fired when backspace or delete key are pressed or
-        // when cut operation is performed.
-        if (event == 'input' && msie == 9) return false;
+        // IE9 (and some other versions in compatiblity mode) implements 'input' event but it's so
+        // fubared that we rather pretend that it doesn't have it. In particular the event is not fired
+        // when backspace or delete key are pressed or when cut operation is performed.
+        if (event == 'input' && msie <= 9) return false;
 
         if (isUndefined(eventSupport[event])) {
           var divElm = document.createElement('div');

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -80,7 +80,7 @@ describe('$sniffer', function() {
       // IE9 implementation is fubared, so it's better to pretend that it doesn't have the support
       mockDivElement = {oninput: noop};
 
-      expect($sniffer.hasEvent('input')).toBe((msie == 9) ? false : true);
+      expect($sniffer.hasEvent('input')).toBe((msie <= 9) ? false : true);
     });
   });
 


### PR DESCRIPTION
Change IE9 input event workaround in $sniffer to
work in compatibility mode (msie can be less than 9)

Closes #3110
