### PR TITLE
feat(compile): post-t'clusion linking now optional

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -859,8 +859,13 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           }
         }
 
-        if (cloneConnectFn) cloneConnectFn($linkNode, scope);
-        if (compositeLinkFn) compositeLinkFn(scope, $linkNode, $linkNode);
+        var overrides = {};
+        if (cloneConnectFn) {
+          angular.extend(overrides, cloneConnectFn($linkNode, scope));
+        }
+        if (compositeLinkFn && !overrides.alreadyLinked) {
+          compositeLinkFn(scope, $linkNode, $linkNode);
+        }
         return $linkNode;
       };
     }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3898,6 +3898,28 @@ describe('$compile', function() {
 
       });
 
+      it('should skip automatic linking if the user indicates they want to take care of it themselves', function() {
+        module(function() {
+          directive('transclude', valueFn({
+            transclude: 'content',
+            link: function(scope, element, attr, ctrl, $transclude) {
+              $transclude(function(clone) {
+                $compile(clone)(scope);
+                return {
+                  alreadyLinked: true
+                };
+              });
+            }
+          }));
+        });
+        inject(function($compile) {
+          $rootScope.list = ['Initial'];
+          element = $compile('<div transclude><div ng-init="list.push(\'Compiled\')"></div></div>')($rootScope);
+          $rootScope.$apply();
+          expect($rootScope.list).toEqual(['Initial', 'Compiled']);
+        });
+      });
+
       it('should expose the directive controller to transcluded children', function() {
         var capturedChildCtrl;
         module(function() {


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): $compile

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Can be controlled by returning an object with `{alreadyLinked: true}`
from $transclude.

Can you come up with a better name than `alreadyLinked`?

Related to #7270: While not a complete (automatic) solution to that issue, with this new feature the bug can at least be avoided.

Also, this is meant to be an advanced feature for those who want to do some more ninja-esqe stuff with transclusion. It is not meant to be used regularly or by novices who are new to $compile.

**Other Comments:**
