### PR TITLE
docs(ngCookies): use GFM code-snippet rather than example tag

### DIFF
--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -32,18 +32,15 @@ angular.module('ngCookies', ['ng']).
    * Requires the {@link ngCookies `ngCookies`} module to be installed.
    *
    * @example
-   <example>
-     <file name="index.html">
-       <script>
-         function ExampleController($cookies) {
-           // Retrieving a cookie
-           var favoriteCookie = $cookies.myFavorite;
-           // Setting a cookie
-           $cookies.myFavorite = 'oatmeal';
-         }
-       </script>
-     </file>
-   </example>
+   *
+   * ```js
+   * function ExampleController($cookies) {
+   *   // Retrieving a cookie
+   *   var favoriteCookie = $cookies.myFavorite;
+   *   // Setting a cookie
+   *   $cookies.myFavorite = 'oatmeal';
+   * }
+   * ```
    */
    factory('$cookies', ['$rootScope', '$browser', function ($rootScope, $browser) {
       var cookies = {},
@@ -136,8 +133,6 @@ angular.module('ngCookies', ['ng']).
    * deserialized by angular's toJson/fromJson.
    *
    * Requires the {@link ngCookies `ngCookies`} module to be installed.
-   *
-   * @example
    */
    factory('$cookieStore', ['$cookies', function($cookies) {
 


### PR DESCRIPTION
The example tag creates a big ugly white rectangle on the docs page, and this
is not very helpful and kind of looks bad. So GFM snippets are a better way to
go.

This fix also removes the unnecessary example heading from the $cookieStore
page, as there has not been an example use of $cookieStore for 2 years now.
