### PR TITLE
fix(ngSrc, ngSrcset): only interpolate if all expressions are defined

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -513,7 +513,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
   var hasDirectives = {},
       Suffix = 'Directive',
       COMMENT_DIRECTIVE_REGEXP = /^\s*directive\:\s*([\d\w\-_]+)\s+(.*)$/,
-      CLASS_DIRECTIVE_REGEXP = /(([\d\w\-_]+)(?:\:([^;]+))?;?)/;
+      CLASS_DIRECTIVE_REGEXP = /(([\d\w\-_]+)(?:\:([^;]+))?;?)/,
+      ALL_OR_NOTHING_ATTRS = makeMap('ngSrc,ngSrcset,src,srcset');
 
   // Ref: http://developers.whatwg.org/webappapis.html#event-handler-idl-attributes
   // The assumption is that future DOM event attribute names will begin with
@@ -1856,7 +1857,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
                 // we need to interpolate again, in case the attribute value has been updated
                 // (e.g. by another directive's compile function)
-                interpolateFn = $interpolate(attr[name], true, getTrustedContext(node, name));
+                interpolateFn = $interpolate(attr[name], true, getTrustedContext(node, name),
+                    ALL_OR_NOTHING_ATTRS[name]);
 
                 // if attribute was updated so that there is no interpolation going on we don't want to
                 // register any observers

--- a/test/ng/directive/booleanAttrsSpec.js
+++ b/test/ng/directive/booleanAttrsSpec.js
@@ -204,7 +204,7 @@ describe('ngSrcset', function() {
     var element = $compile('<div ng-srcset="some/{{id}} 2x"></div>')($rootScope);
 
     $rootScope.$digest();
-    expect(element.attr('srcset')).toEqual('some/ 2x');
+    expect(element.attr('srcset')).toBeUndefined();
 
     $rootScope.$apply(function() {
       $rootScope.id = 1;

--- a/test/ng/directive/ngSrcsetSpec.js
+++ b/test/ng/directive/ngSrcsetSpec.js
@@ -11,6 +11,6 @@ describe('ngSrcset', function() {
     $rootScope.image = {};
     element = $compile('<img ng-srcset="{{image.url}} 2x">')($rootScope);
     $rootScope.$digest();
-    expect(element.attr('srcset')).toEqual(' 2x');
+    expect(element.attr('srcset')).toBeUndefined();
   }));
 });

--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -19,6 +19,11 @@ describe('$interpolate', function() {
     expect($interpolate('some text', true)).toBeUndefined();
   }));
 
+  it('should return undefined when there are bindings and strict is set to true',
+      inject(function($interpolate) {
+    expect($interpolate('test {{foo}}', false, null, true)({})).toBeUndefined();
+  }));
+
   it('should suppress falsy objects', inject(function($interpolate) {
     expect($interpolate('{{undefined}}')({})).toEqual('');
     expect($interpolate('{{null}}')({})).toEqual('');


### PR DESCRIPTION
**BREAKING CHANGE**

If `bar` is `undefined`, before `<img src="foo/{{bar}}.jpg">` yields
`<img src="foo/.jpg">`. With this change, the binding will not set `src`.

If you want the old behavior, you can do this: `<img src="foo/{{bar || ''}}.jpg">`.

The same applies for `srcset` and `href`.

Closes #6984 
