### PR TITLE
fix(ngModelOptions): add textarea support

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1973,22 +1973,25 @@ var ngModelDirective = function() {
   return {
     require: ['ngModel', '^?form', '^?ngModelOptions'],
     controller: NgModelController,
-    link: function(scope, element, attr, ctrls) {
-      // notify others, especially parent forms
+    link: {
+      pre: function(scope, element, attr, ctrls) {
+        // Pass the ng-model-options to the ng-model controller
+        if (ctrls[2]) {
+          ctrls[0].$options = ctrls[2].$options;
+        }
+      },
+      post: function(scope, element, attr, ctrls) {
+        // notify others, especially parent forms
 
-      var modelCtrl = ctrls[0],
-          formCtrl = ctrls[1] || nullFormCtrl;
+        var modelCtrl = ctrls[0],
+            formCtrl = ctrls[1] || nullFormCtrl;
 
-      formCtrl.$addControl(modelCtrl);
+        formCtrl.$addControl(modelCtrl);
 
-      // Pass the ng-model-options to the ng-model controller
-      if ( ctrls[2] ) {
-        modelCtrl.$options = ctrls[2].$options;
+        scope.$on('$destroy', function() {
+          formCtrl.$removeControl(modelCtrl);
+        });
       }
-
-      scope.$on('$destroy', function() {
-        formCtrl.$removeControl(modelCtrl);
-      });
     }
   };
 };

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -642,6 +642,17 @@ describe('input', function() {
       expect(scope.name).toEqual('a');
     });
 
+    it('should allow overriding the model update trigger event on text areas', function() {
+      compileInput(
+          '<textarea ng-model="name" name="alias" '+
+            'ng-model-options="{ updateOn: \'blur\' }"'+
+          '/>');
+
+      changeInputValueTo('a');
+      expect(scope.name).toBeUndefined();
+      browserTrigger(inputElm, 'blur');
+      expect(scope.name).toEqual('a');
+    });
 
     it('should bind the element to a list of events', function() {
       compileInput(


### PR DESCRIPTION
since directives are sorted by priority and name and `ngModel` & `textarea` have the same priority and 'textarea'>'ngModel' (unlike 'input'), textarea in linked first. this is a problem since textarea expect ngModelController.$options to exist and it is created only when ngModel is linked. this is solved easily by moving the creation of $options to pre-link.

fixes #7281
