### PR TITLE
docs(ngIf): add warning regarding falsy values

### DIFF
--- a/src/ng/directive/ngIf.js
+++ b/src/ng/directive/ngIf.js
@@ -32,6 +32,11 @@
  * Additionally, you can provide animations via the `ngAnimate` module to animate the `enter`
  * and `leave` effects.
  *
+ * <div class="alert alert-warning">
+ * **Note:** Here is a list of values that ngShow will consider as a falsy value (case insensitive):<br />
+ * "f" / "0" / "false" / "no" / "n" / "[]"
+ * </div>
+ *
  * @animations
  * enter - happens just after the ngIf contents change and a new DOM element is created and injected into the ngIf container
  * leave - happens just before the ngIf contents are removed from the DOM


### PR DESCRIPTION
Add warning message to ngIf's documentation regarding what values are considered falsy (similar to ngHide / ngShow).
