### PR TITLE
fix(ngRepeat): ensure expected order of execution for directive lifecycle functions is maintained when they are nested along with ngRepeat

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -219,7 +219,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
         }
 
         lhs = match[1];
-        rhs = match[2];
+        rhs = $parse(match[2]);
         trackByExp = match[3];
 
         if (trackByExp) {
@@ -255,8 +255,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
         //   - index: position
         var lastBlockMap = {};
 
-        //watch props
-        $scope.$watchCollection(rhs, function ngRepeatAction(collection){
+        var ngRepeatAction = function(collection){
           var index, length,
               previousNode = $element[0],     // current position of the node
               nextNode,
@@ -382,7 +381,11 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
             }
           }
           lastBlockMap = nextBlockMap;
-        });
+        };
+
+        ngRepeatAction(rhs($scope));
+        //watch props
+        $scope.$watchCollection(rhs, ngRepeatAction);
     }
   };
 


### PR DESCRIPTION
Request Type: bug

How to reproduce: http://plnkr.co/edit/k09gvqao2oHfIaQfktkd

Component(s): ngRepeat

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

When using directives that are siblings with nested ngRepeat, their lifecycle functions are called out of order ('outer' ones are called before the 'inner' ones) e.g.:

```
<div foo ng-repeat="...">
  <div bar ng-repeat="..."></div>
<div>
```

results in the following call order:

```
foo.compile
bar.compile
foo.controller
foo.preLink
foo.postLink
bar.controller
bar.preLink
bar.postLink
```

when the expected would be:

```
foo.compile
bar.compile
foo.controller
foo.preLink
bar.controller
bar.preLink
bar.postLink
foo.postLink
```

**Other Comments:**

Ensure that lifecycle functions of directives are called in the expected
order (i.e. compile, controller, preLink, postLink) when using them along
ngRepeat on nested elements.

Previous to this change, lifecycle functions for 'outer' directives were
called before the ones for the 'inner' directives, when ngRepeat was used
on both the 'outer' and the 'inner' elements e.g.:

```
<div foo ng-repeat="...">
  <div bar ng-repeat="..."></div>
<div>
```

resulted in the following call order:

```
foo.compile
bar.compile
foo.controller
foo.preLink
foo.postLink
bar.controller
bar.preLink
bar.postLink
```

while after applying this change, the order will be:

```
foo.compile
bar.compile
foo.controller
foo.preLink
bar.controller
bar.preLink
bar.postLink
foo.postLink
```

Motivation for the change was a means to provide a communication channel
between parent and child directives where both need to be places as a
sibling of ngRepeat.
