### PR TITLE
fix(ngSanitize): update to exclude smart quotes

### DIFF
--- a/src/ngSanitize/filter/linky.js
+++ b/src/ngSanitize/filter/linky.js
@@ -104,7 +104,7 @@
  */
 angular.module('ngSanitize').filter('linky', ['$sanitize', function($sanitize) {
   var LINKY_URL_REGEXP =
-        /((ftp|https?):\/\/|(mailto:)?[A-Za-z0-9._%+-]+@)\S*[^\s.;,(){}<>"]/,
+        /((ftp|https?):\/\/|(mailto:)?[A-Za-z0-9._%+-]+@)\S*[^\s.;,(){}<>"”’]/,
       MAILTO_REGEXP = /^mailto:/;
 
   return function(text, target) {

--- a/test/ngSanitize/filter/linkySpec.js
+++ b/test/ngSanitize/filter/linkySpec.js
@@ -10,11 +10,13 @@ describe('linky', function() {
   }));
 
   it('should do basic filter', function() {
-    expect(linky("http://ab/ (http://a/) <http://a/> http://1.2/v:~-123. c")).
+    expect(linky("http://ab/ (http://a/) <http://a/> http://1.2/v:~-123. c “http://example.com” ‘http://me.com’")).
       toEqual('<a href="http://ab/">http://ab/</a> ' +
               '(<a href="http://a/">http://a/</a>) ' +
               '&lt;<a href="http://a/">http://a/</a>&gt; ' +
-              '<a href="http://1.2/v:~-123">http://1.2/v:~-123</a>. c');
+              '<a href="http://1.2/v:~-123">http://1.2/v:~-123</a>. c ' +
+              '&#8220;<a href="http://example.com">http://example.com</a>&#8221; ' +
+              '&#8216;<a href="http://me.com">http://me.com</a>&#8217;');
     expect(linky(undefined)).not.toBeDefined();
   });
 


### PR DESCRIPTION
Request Type: bug

How to reproduce: Add a smart quote (single or double) at the end of a
url string and filter the string with linky. Example plunker:
http://plnkr.co/edit/CeB5x48U0D1eXq4yXkvk?p=preview

Component(s): ngSanitize

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

When smart quotes are included in content filtered through linky, any
smart quote at the end of a URL string will be included in the link
text and the href.

**Other Comments:**
