### PR TITLE
feat(ngResource): support extending resources

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -536,8 +536,14 @@ angular.module('ngResource', ['ng']).
             }
             /* jshint +W086 */ /* (purposefully fall through case statements) */
 
-            var isInstanceCall = this instanceof Resource;
-            var value = isInstanceCall ? data : (action.isArray ? [] : new Resource(data));
+            var isInstanceCall = this instanceof Resource, value;
+
+            if (action.isArray) {
+              value = [];
+            } else {
+              value = isInstanceCall ? data : new Resource(data);
+            }
+
             var httpConfig = {};
             var responseInterceptor = action.interceptor && action.interceptor.response ||
               defaultResponseInterceptor;

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -603,6 +603,9 @@ angular.module('ngResource', ['ng']).
             promise = promise.then(
               function (response) {
                 var value = responseInterceptor(response);
+                if(action.saveAs){
+                  data[action.saveAs] = value;
+                }
                 (success || noop)(value, response.headers);
                 return value;
               },


### PR DESCRIPTION
### A suggested solution for #4565

Request Type: feature

How to reproduce: 
-   **Array type action bug**: create a resource with a custom action from type array, call that action on an instance of your     custom resource. Exception is thrown.
-   **Extending resource feature**: You want the response of your action call to become a part of your resource instance. There is currently no straight forward way of doing this.

Component(s): ngResource

Impact: small

Complexity: small

This issue is related to: 

When calling a Resource instance's `GET` actions such as `$get` and `$query` but mostly custom ones, it is sometimes needed to be able to extend the resource with the response data e.g:

``` javascript
entity.$children()
.then(function(){
    console.log(entity.children) //undefined
});
//the response did not become a part of the resource
```

Automatically setting the response on the resource with the property name is a bad idea since it can lead to unexpected overrides (the resource might have had a property named children) and generally it should be up to the user to decide whether to extend or not and how.

My approach involves leveraging the Resource's interceptor to achieve a both flexible and clean way to extend instances. By calling the interceptor's response function with the instance as it's context (this) it is possible to reference it and set the desired properties:

``` javascript
$resource('[...]/entity/:id', {}, {
    'children': {
        method: 'GET',
        url:'[...]/entity/:id/children',
        params:{id:'@id'},
        isArray:true,
        interceptor:{
            response: function(response){
                var data = response.data;
                this.children = data; //"this" references the entity resource
                return data;
            }
        }
    }
});
```
### Update

As @dadleyy suggested,
I have added an optional param on actions called _saveAs_ to give the user control over whether to save the response on the resource's instance and under what property name.

``` javascript
var Entity = $resource('[...]/entity/:id', {}, {
    'children': {
        method: 'GET',
        url:'[...]/children',
        params:{entityId:'@id'},
        saveAs:'children', //new optional property, value can be any string.
        isArray:true,
    }

var entity = Entity.get({id:123});
entity.$children(function(){
  //property name is the one defined in the *saveAs* param on the $children action.
  console.log(entity.children) //[child1, child2...]
});
```
