### PR TITLE
Update step_07.ngdoc to fix typo in route pattern

### DIFF
--- a/docs/content/tutorial/step_07.ngdoc
+++ b/docs/content/tutorial/step_07.ngdoc
@@ -247,7 +247,7 @@ Our application routes are defined as follows:
   controller.
 
 * `when('/phones/:phoneId')`: The phone details view will be shown when the URL hash fragment
-  matches '/phone/:phoneId', where `:phoneId` is a variable part of the URL. To construct the phone
+  matches '/phones/:phoneId', where `:phoneId` is a variable part of the URL. To construct the phone
   details view, Angular will use the `phone-detail.html` template and the `PhoneDetailCtrl`
   controller.
 


### PR DESCRIPTION
One instance of `/phones/:phoneId` erroneously had a singular version, `/phone/:phoneId`, which does not match what was actually used in the code.
