### PR TITLE
fix(injector): conditionally create $delegate

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -592,7 +592,7 @@ function annotate(fn, strictDi, name) {
  *    Local injection arguments:
  *
  *    * `$delegate` - The original service instance, which can be monkey patched, configured,
- *      decorated or delegated to.
+ *      decorated or delegated to. (Without explicit dependency in $delegate this instance will not be created)
  *
  * @example
  * Here we decorate the {@link ng.$log $log} service to convert warnings to errors by intercepting
@@ -684,8 +684,11 @@ function createInjector(modulesToLoad, strictDi) {
         orig$get = origProvider.$get;
 
     origProvider.$get = function() {
-      var origInstance = instanceInjector.invoke(orig$get, origProvider);
-      return instanceInjector.invoke(decorFn, null, {$delegate: origInstance});
+      var locals;
+      if (includes(annotate(decorFn), '$delegate')) {
+        locals = {$delegate: instanceInjector.invoke(orig$get, origProvider)};
+      }
+      return instanceInjector.invoke(decorFn, null, locals);
     };
   }
 

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -574,6 +574,27 @@ describe('injector', function() {
           expect(log.join('; ')).
             toBe('myDecoratedService:input,dependency1; myService:decInput; dec+origReturn');
         });
+
+        it('should not generate original instance when not dependant', function() {
+          injector = createInjector([function($provide) {
+              $provide.factory('myService', function() {
+                log.push('myService:original');
+
+                return 'original';
+              });
+
+              $provide.decorator('myService', function() {
+                log.push('myService:decorated');
+
+                return 'decorated';
+              });
+            }]);
+
+          var out = injector.get('myService');
+          log.push(out);
+          expect(log.join('; ')).
+            toBe('myService:decorated; decorated');
+        });
       });
     });
 


### PR DESCRIPTION
Request Type: bug

How to reproduce: http://embed.plnkr.co/ywgTsC/preview

Component(s): di

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

On decorator instantiation, only create $delegate instance if the dependancy exists.
This allows decorators that completely replace the decorated service to be independant of the original service.

fix for https://github.com/angular/angular.js/issues/6961
