### PR TITLE
fix(filterFilter) deeply-nested predicate objects + multiple conditions were not giving expected results

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -137,13 +137,12 @@ function filterFilter() {
       } else {
         comparator = function(obj, text) {
           if (obj && text && typeof obj === 'object' && typeof text === 'object') {
-            for (var objKey in obj) {
-              if (objKey.charAt(0) !== '$' && hasOwnProperty.call(obj, objKey) &&
-                  comparator(obj[objKey], text[objKey])) {
-                return true;
+            for (var textKey in text) {
+              if (textKey.charAt(0) === '$' || !hasOwnProperty.call(text, textKey) ||
+                  !comparator(obj[textKey], text[textKey])) {
+                return false;
               }
             }
-            return false;
           }
           text = (''+text).toLowerCase();
           return (''+obj).toLowerCase().indexOf(text) > -1;

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -74,23 +74,31 @@ describe('Filter: filter', function() {
     var items = [{person: {name: 'John'}},
                  {person: {name: 'Rita'}},
                  {person: {name: 'Billy'}},
-                 {person: {name: 'Joan'}}];
+                 {person: {name: 'Joan'}},
+                 {person: {name: 'Albert', surname: 'Boada', contact: {country: 'Catalunya'}}}];
     expect(filter(items, {person: {name: 'Jo'}}).length).toBe(2);
     expect(filter(items, {person: {name: 'Jo'}})).toEqual([
       {person: {name: 'John'}}, {person: {name: 'Joan'}}
     ]);
+    expect(filter(items, {person: {name: 'Al',  surname: 'Bo'}})).toEqual([items[4]]);
+    expect(filter(items, {person: {name: 'foo', surname: 'Bo'}}).length).toBe(0);
+    expect(filter(items, {person: {name: 'Al',  surname: 'foo'}}).length).toBe(0);
+    expect(filter(items, {person: {name: 'Al',  contact: {country: 'cat'}}})).toEqual([items[4]]);
+    expect(filter(items, {person: {name: 'Al',  contact: {country: 'foo'}}}).length).toBe(0);
   });
 
 
   it('should match any properties for given "$" property', function() {
     var items = [{first: 'tom', last: 'hevery'},
                  {first: 'adam', last: 'hevery', alias: 'tom', done: false},
-                 {first: 'john', last: 'clark', middle: 'tommy'}];
+                 {first: 'john', last: 'clark', middle: 'tommy'},
+                 {first: 'Albert', contact: {country: 'Catalunya'}}];
     expect(filter(items, {$: 'tom'}).length).toBe(3);
-    expect(filter(items, {$: 'a'}).length).toBe(2);
+    expect(filter(items, {$: 'a'}).length).toBe(3);
     expect(filter(items, {$: false}).length).toBe(1);
     expect(filter(items, {$: 10}).length).toBe(0);
     expect(filter(items, {$: 'hevery'})[0]).toEqual(items[0]);
+    expect(filter(items, {$: 'Cat'})[0]).toEqual(items[3]);
   });
 
   it('should support boolean properties', function() {


### PR DESCRIPTION
Request Type: bug

How to reproduce: 

http://plnkr.co/edit/Yd705mYbqKJ3n79TXLmx?p=preview

Component(s): misc core

Impact: medium

Complexity: small

**Detailed Description:**

Fixes current `filterFilter`'s implementation (introduced in 1.2.13 as a result of #6215) for **deeply-nested predicate objects** + **multiple conditions** scenarios.

Problem: when using deeply nested predicate objects, `filterFilter` is currently behaving as if it was using _OR_ operators (i.e. it doesn't matter if some conditions don't match as long as one does), and should be behaving as if it used _AND_ operators in order to be consistent with the original implementation for non-deeply-nested predicate objects.
