### PR TITLE
Fix language matching in code directive

### DIFF
--- a/docs/app/src/directives.js
+++ b/docs/app/src/directives.js
@@ -22,7 +22,7 @@ angular.module('directives', [])
     terminal: true,
     compile: function(element) {
       var linenums = element.hasClass('linenum');// || element.parent()[0].nodeName === 'PRE';
-      var match = /lang-(\S)+/.exec(element.className);
+      var match = /lang-(\S+)/.exec(element[0].className);
       var lang = match && match[1];
       var html = element.html();
       element.html(window.prettyPrintOne(html, lang, linenums));

--- a/docs/app/test/directivesSpec.js
+++ b/docs/app/test/directivesSpec.js
@@ -1,0 +1,38 @@
+describe("code", function() {
+  var prettyPrintOne, oldPP;
+  var compile, scope;
+
+  var any = jasmine.any;
+
+  beforeEach(module('directives'));
+
+  beforeEach(inject(function($rootScope, $compile) {
+    // Provide stub for pretty print function
+    oldPP = window.prettyPrintOne;
+    prettyPrintOne = window.prettyPrintOne = jasmine.createSpy();
+
+    scope = $rootScope.$new();
+    compile = $compile;
+  }));
+
+  afterEach(function() {
+    window.prettyPrintOne = oldPP;
+  });
+
+
+  it('should pretty print innerHTML', function() {
+    compile('<code>var x;</code>')(scope);
+    expect(prettyPrintOne).toHaveBeenCalledWith('var x;', null, false);
+  });
+
+  it('should allow language declaration', function() {
+    compile('<code class="lang-javascript"></code>')(scope);
+    expect(prettyPrintOne).toHaveBeenCalledWith(any(String), 'javascript', false);
+  });
+
+  it('supports allow line numbers', function() {
+    compile('<code class="linenum"></code>')(scope);
+    expect(prettyPrintOne).toHaveBeenCalledWith(any(String), null, true);
+  });
+});
+


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The language matching for the `code` directive in docs app is not working.

For example, `class="lang-javascript"` should match `javascript` but it doesn't

**Other Comments:**

Includes:
- Fix for the `code` directive
- Tests for the `code` directive
