### PR TITLE
docs(CONTRIBUTING.md): anchor fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Before you submit your pull request consider the following guidelines:
      ```
 
 * Create your patch, **including appropriate test cases**.
-* Follow our [Coding Rules](#coding-rules).
+* Follow our [Coding Rules](#rules).
 * Run the full Angular test suite, as described in the [developer documentation][dev-doc],
   and ensure that all tests pass.
 * Commit your changes using a descriptive commit message that follows our


### PR DESCRIPTION
Request Type: docs

How to reproduce: 1) Open https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md

2) search for the text "Follow our Coding Rules"

3) Click on the "Coding Rules" anchor

4) It doesn't take you to coding rule section.

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

"Follow our Coding Rules" should link to "#rules" and not "#coding-rules"
