### PR TITLE
Correct example for filter date/'fullDate' in documentation

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -338,7 +338,7 @@ var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZEw']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d
  *   * `'medium'`: equivalent to `'MMM d, y h:mm:ss a'` for en_US locale
  *     (e.g. Sep 3, 2010 12:05:08 pm)
  *   * `'short'`: equivalent to `'M/d/yy h:mm a'` for en_US  locale (e.g. 9/3/10 12:05 pm)
- *   * `'fullDate'`: equivalent to `'EEEE, MMMM d,y'` for en_US  locale
+ *   * `'fullDate'`: equivalent to `'EEEE, MMMM d, y'` for en_US  locale
  *     (e.g. Friday, September 3, 2010)
  *   * `'longDate'`: equivalent to `'MMMM d, y'` for en_US  locale (e.g. September 3, 2010)
  *   * `'mediumDate'`: equivalent to `'MMM d, y'` for en_US  locale (e.g. Sep 3, 2010)


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: 

Complexity: 

This issue is related to: 

**Detailed Description:**

On the following docs page there is a missing space in giving the equivalent expanded filter for the shortform 'fullDate' filter.

https://docs.angularjs.org/api/ng/filter/date

It gives the equivalent as this:
`'fullDate': equivalent to 'EEEE, MMMM d,y' for en_US locale (e.g. Friday, September 3, 2010)`
Whereas it should be:
`'fullDate': equivalent to 'EEEE, MMMM d, y' for en_US locale (e.g. Friday, September 3, 2010)`

Notice the space between the `d,` and `y`. A very small issue, but probably worth fixing!

**Other Comments:**

The equivalent expanded example for 'fullDate' is given as 'EEEE, MMMM d,y' whereas it should be 'EEEE, MMMM d, y' e.g. I added the correct whitespace to the expanded example.
