### PR TITLE
feat(ng/filter): support ASP.NET JSON dates

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -295,7 +295,8 @@ var DATE_FORMATS = {
 };
 
 var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZEw']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|Z|w+))(.*)/,
-    NUMBER_STRING = /^\-?\d+$/;
+    NUMBER_STRING = /^\-?\d+$/,
+    ASP_JSON_STRING = /^\/?Date\((\-?\d+)/i; // https://github.com/moment/moment/blob/develop/moment.js#L49
 
 /**
  * @ngdoc filter
@@ -351,9 +352,10 @@ var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZEw']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d
  *   (e.g. `"h 'o''clock'"`).
  *
  * @param {(Date|number|string)} date Date to format either as Date object, milliseconds (string or
- *    number) or various ISO 8601 datetime string formats (e.g. yyyy-MM-ddTHH:mm:ss.SSSZ and its
- *    shorter versions like yyyy-MM-ddTHH:mmZ, yyyy-MM-dd or yyyyMMddTHHmmssZ). If no timezone is
- *    specified in the string input, the time is considered to be in the local timezone.
+ *    number), various ISO 8601 datetime string formats (e.g. yyyy-MM-ddTHH:mm:ss.SSSZ and its
+ *    shorter versions like yyyy-MM-ddTHH:mmZ, yyyy-MM-dd or yyyyMMddTHHmmssZ) or ASP.NET JSON dates
+ *    such as /Date(milliseconds)/. If no timezone is specified in the string input, the time is
+ *    considered to be in the local timezone.
  * @param {string=} format Formatting rules (see Description). If not specified,
  *    `mediumDate` is used.
  * @returns {string} Formatted string or the input if input is not recognized as date/millis.
@@ -421,6 +423,8 @@ function dateFilter($locale) {
     if (isString(date)) {
       if (NUMBER_STRING.test(date)) {
         date = int(date);
+      } else if (match = date.match(ASP_JSON_STRING)) {
+        date = int(match[1]);
       } else {
         date = jsonStringToDate(date);
       }

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -381,5 +381,15 @@ describe('filters', function() {
       expect(date('2003-09-10T13:02:03.12Z', format)).toEqual('2003-09-' + localDay + ' 03');
       expect(date('2003-09-10T13:02:03.1Z', format)).toEqual('2003-09-' + localDay + ' 03');
     });
+    
+    it('should support ASP.NET JSON dates', function () {
+      var format = 'yyyy-MM-d H:m:s';
+      
+      var ed = new Date(1198908717000),
+          es = '2007-12-' + ed.getDate() + ' ' + ed.getHours() + ':' + ed.getMinutes() + ':' + ed.getSeconds();
+      
+      expect(date('/Date(1198908717000)/', format)).toEqual(es);
+      expect(date('/Date(1198908717056-0700)/', format)).toEqual(es);
+    });
   });
 });

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -381,13 +381,13 @@ describe('filters', function() {
       expect(date('2003-09-10T13:02:03.12Z', format)).toEqual('2003-09-' + localDay + ' 03');
       expect(date('2003-09-10T13:02:03.1Z', format)).toEqual('2003-09-' + localDay + ' 03');
     });
-    
+
     it('should support ASP.NET JSON dates', function () {
       var format = 'yyyy-MM-d H:m:s';
-      
+
       var ed = new Date(1198908717000),
           es = '2007-12-' + ed.getDate() + ' ' + ed.getHours() + ':' + ed.getMinutes() + ':' + ed.getSeconds();
-      
+
       expect(date('/Date(1198908717000)/', format)).toEqual(es);
       expect(date('/Date(1198908717056-0700)/', format)).toEqual(es);
     });


### PR DESCRIPTION
```
Add support for ASP.NET JSON dates. The default JSON serializer
in the ASP.NET framework serializes dates in the following way:
    "/Date(1198908717056)/"
This PR allows the date filter to properly format and display
these dates. A test case and documentation were also added.

This PR should not break anything, only add additional features.
```

I also changed the timezone of my computer to make sure that the test
runs properly in different time zones, and it seems to be the case.
