### PR TITLE
docs(directive): fix misspelled HTML class for an alert

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -282,7 +282,7 @@ using `templateUrl` instead:
 Great! But what if we wanted to have our directive match the tag name `<my-customer>` instead?
 If we simply put a `<my-customer>` element into the HTML, it doesn't work.
 
-<div class="alert alert-waring">
+<div class="alert alert-warning">
 **Note:** When you create a directive, it is restricted to attribute only by default. In order to
 create directives that are triggered by element or class name, you need to use the `restrict` option.
 </div>


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

This PR fixes issue #7371.
