### PR TITLE
feat($compile): support transcluding SVG nodes when there is no root <svg> node

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -70,6 +70,7 @@
     "isElement": false,
     "makeMap": false,
     "map": false,
+    "reduce": false,
     "size": false,
     "includes": false,
     "indexOf": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -50,6 +50,7 @@
     -isElement,
     -makeMap,
     -map,
+    -reduce,
     -size,
     -includes,
     -indexOf,
@@ -638,6 +639,39 @@ function map(obj, iterator, context) {
     results.push(iterator.call(context, value, index, list));
   });
   return results;
+}
+
+
+/**
+ * @description
+ * Reduces a collection into a single accumulated value. Based on ES5 Array#reduce
+ *
+ * This is useful for performing operations on a collection, which should result in
+ * a single value, such as concatenating the outerHTML of a collection of DOM nodes
+ * into a single string.
+ *
+ * @param {Array} array The array to operate on.
+ * @param {Function(*, *, i, Array)} callback Count function to operate on each value in the
+ *    collection. The parameters are as follows:
+ *    - previousValue The previous accumulated value
+ *    - currentValue  The value from the current index in the collection
+ *    - index         The index of the current value
+ *    - array         A reference to the array being operated on
+ *
+ *    The callback should return the accumulated value.
+ * @param {*} initialValue The initial value for the accumulator
+ *
+ * @returns {*} The accumulated value, resulting from callback being called on each element
+ *    in the collection. See http://goo.gl/YwhaCh for more details.
+ */
+function reduce(array, callback, initialValue) {
+  var i;
+  var ii;
+  var previousValue = initialValue;
+  for (i = 0, ii = array.length; i < ii; ++i) {
+    previousValue = callback(previousValue, array[i], i, array);
+  }
+  return previousValue;
 }
 
 

--- a/test/helpers/matchers.js
+++ b/test/helpers/matchers.js
@@ -167,6 +167,14 @@ beforeEach(function() {
       this.message = function() {
         return "Expected '" + angular.mock.dump(this.actual) + "' to have class '" + clazz + "'.";
       };
+      var node = this.actual;
+      if (node.hasClass) node = node[0];
+      if (window.SVGElement && node instanceof window.SVGElement
+          && typeof node.className === "object") {
+        var tmp = document.createElement('div');
+        tmp.className = node.className.animVal;
+        return jqLite(tmp).hasClass(clazz);
+      }
       return this.actual.hasClass ?
               this.actual.hasClass(clazz) :
               angular.element(this.actual).hasClass(clazz);

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4040,6 +4040,37 @@ describe('$compile', function() {
         });
 
       });
+
+
+      it('should transclude SVG content into SVG templates', function() {
+        if (!window.SVGCircleElement) return;
+        module(function() {
+          directive('svgRoot', valueFn({
+            restrict: 'A',
+            template: '<svg><g></g></svg>',
+            replace: true,
+            transclude: true,
+            link: function(scope, elem, attr, ctrl, transclude) {
+              transclude(scope, function(nodes) {
+                jqLite(nodes).addClass('test');
+                elem.children(0).append(nodes);
+              });
+            }
+          }));
+        });
+        inject(function($compile, $rootScope) {
+          element = $compile('<div svg-root><circle cx="10" cy="10" r="10" ng-click="foo=88"/></div>')($rootScope);
+          $rootScope.$digest();
+          var circle = element.find('circle');
+          expect(circle.length).toBe(1);
+          expect(circle[0].constructor).toBe(window.SVGCircleElement);
+
+          // Ensure that the directives are still compiled
+          browserTrigger(circle, 'click');
+          expect($rootScope.foo).toBe(88);
+          expect(circle).toHaveClass('test');
+        });
+      });
     });
 
 


### PR DESCRIPTION
# This CL is a work in progress, and is not meant to be committed in this state.

Due to https://github.com/angular/angular.js/commit/f0e12ea7fea853192e4eead00b40d6041c5f914a, it is now possible to have a directive whose template content is SVG.

However, the following issue arises:

A template like

``` html
<replaces-with-svg-and-transcludes>
  <g>
    <circle r=50 cx=0 cy=0 />
    <text>My circle!</text>
  </g>
</replaces-with-svg-and-transcludes>
```

Would not work as expected, due to the group, circle and text nodes being
parsed as HTMLUnknownElements, for not being parsed in an SVG context.

This change enables transcluded SVG content to work when parsed as non-HTML
content, with the cost of linking the transcluded elements again.

Fixes #7383
