### PR TITLE
docs(ngRoute): ngRoute does not parseInt possible integer route parts in $routeParams

### DIFF
--- a/src/ngRoute/routeParams.js
+++ b/src/ngRoute/routeParams.js
@@ -33,7 +33,7 @@ ngRouteModule.provider('$routeParams', $RouteParamsProvider);
  *  // Route: /Chapter/:chapterId/Section/:sectionId
  *  //
  *  // Then
- *  $routeParams ==> {chapterId:1, sectionId:2, search:'moby'}
+ *  $routeParams ==> {chapterId:'1', sectionId:'2', search:'moby'}
  * ```
  */
 function $RouteParamsProvider() {


### PR DESCRIPTION
Request Type: docs

How to reproduce: View docs for $routeParams

Component(s): ngRoute

Impact: small

Complexity: small

Detailed Description:

Bad documented type for $routeParams. It should be an Object.<string, string>
Integers are not parsed for the user. They must be parsed from the string pulled from the URL.
