### PR TITLE
Changed arguments in $cookieStore example.

### DIFF
--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -137,7 +137,7 @@ angular.module('ngCookies', ['ng']).
    * @example
    *
    * ```js
-   * function ExampleController($cookies) {
+   * function ExampleController($cookieStore) {
    *   // Put cookie
    *   $cookieStore.put('myFavorite','oatmeal');
    *   // Get cookie


### PR DESCRIPTION
In the example code for $cookieStore, $cookies was passed in, but this seem to cause an error for me. When I passed in $cookieStore instead, everything worked.
