### PR TITLE
Update concepts.ngdoc  - ng-repeat examples NEVER SHOW UP

### DIFF
--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -2,6 +2,15 @@
 @name Conceptual Overview
 @description
 
+
+============================================================================
+
+SEE "Propose file change" FOR DISPLAY PROBLEMS (DON'T KNOW WHY THIS OCCURS!).
+
+============================================================================
+
+
+
 # Conceptual Overview
 
 This section briefly touches on all of the important parts of AngularJS using a simple example.


### PR DESCRIPTION
NOTE:  These examples never show up in the presentation... this made it difficult to understand what was meant by using ng-repeat (only occurs in writing NOT in your "fork" copy or anywhere in the Guide). Search only finds one ng-repeat in the "Developer Guide" document(not in the comment version. Examples do not show up in "Developer Guide" version.
