### PR TITLE
fix($http): support url format variant for arrays value #fixes 7363

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -117,7 +117,9 @@ function $HttpProvider() {
     },
 
     xsrfCookieName: 'XSRF-TOKEN',
-    xsrfHeaderName: 'X-XSRF-TOKEN'
+    xsrfHeaderName: 'X-XSRF-TOKEN',
+
+    useArrayParams: false
   };
 
   /**
@@ -485,6 +487,7 @@ function $HttpProvider() {
      *      for more information.
      *    - **responseType** - `{string}` - see
      *      [requestType](https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest#responseType).
+     *    - **useArrayParams** - `{boolean}` - true if arrays should be sent as `param[]=val1&param[]=val2` instead of `param=val1&param=val2`.
      *
      * @returns {HttpPromise} Returns a {@link ng.$q promise} object with the
      *   standard `then` method and two http specific methods: `success` and `error`. The `then`
@@ -594,7 +597,8 @@ function $HttpProvider() {
       var config = {
         method: 'get',
         transformRequest: defaults.transformRequest,
-        transformResponse: defaults.transformResponse
+        transformResponse: defaults.transformResponse,
+        useArrayParams: defaults.useArrayParams
       };
       var headers = mergeHeaders(requestConfig);
 
@@ -852,7 +856,7 @@ function $HttpProvider() {
           promise = deferred.promise,
           cache,
           cachedResp,
-          url = buildUrl(config.url, config.params);
+          url = buildUrl(config.url, config.params, config.useArrayParams);
 
       $http.pendingRequests.push(config);
       promise.then(removePendingReq, removePendingReq);
@@ -939,18 +943,19 @@ function $HttpProvider() {
     }
 
 
-    function buildUrl(url, params) {
+    function buildUrl(url, params, useArrayParams) {
           if (!params) return url;
           var parts = [];
           forEachSorted(params, function(value, key) {
             if (value === null || isUndefined(value)) return;
-            if (!isArray(value)) value = [value];
+            var valueIsArray = isArray(value);
+            if (!valueIsArray) value = [value];
 
             forEach(value, function(v) {
               if (isObject(v)) {
                 v = toJson(v);
               }
-              parts.push(encodeUriQuery(key) + '=' +
+              parts.push(encodeUriQuery(key) + (valueIsArray && useArrayParams ? '[]' : '') + '=' +
                          encodeUriQuery(v));
             });
           });


### PR DESCRIPTION
$http now supports both url format `/foo?countries[]=US&countries[]=GB` and `/foo?countries=US&countries=GB`
In order to activate the first format, config.useArrayParams must be set to true.

Fixes #7363
