### PR TITLE
feat(ngRoute): add named routes

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -89,7 +89,8 @@ angularFiles = {
     'ngRoute': [
       'src/ngRoute/route.js',
       'src/ngRoute/routeParams.js',
-      'src/ngRoute/directive/ngView.js'
+      'src/ngRoute/directive/ngView.js',
+      'src/ngRoute/directive/ngGoto.js'
     ],
     'ngSanitize': [
       'src/ngSanitize/sanitize.js',

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -114,6 +114,7 @@ function publishExternalAPI(angular){
     'noop':noop,
     'bind':bind,
     'toJson': toJson,
+    'toKeyValue': toKeyValue,
     'fromJson': fromJson,
     'identity':identity,
     'isUndefined': isUndefined,

--- a/src/ngRoute/directive/ngGoto.js
+++ b/src/ngRoute/directive/ngGoto.js
@@ -1,0 +1,123 @@
+'use strict';
+
+
+ngRouteModule.config(['$locationProvider', function ($locationProvider) {
+  ngRouteModule.tmpHashPrefix = '#' + $locationProvider.hashPrefix();
+}]).
+
+/**
+ * @ngdoc directive
+ * @name ngGoto
+ *
+ * @description
+ * A more powerful replacement for ngHref when using route names.
+ * By defining the alias of a path instead of writing out the full path it is possible to
+ * cherry pick individual components of a path without effecting others.
+ *
+ * Requires the {@link ngRoute `ngRoute`} module to be installed.
+ *
+ * This directive also sets the CSS class `ng-route-active` on elements when the route is
+ * active so you can restyle the element if you wish.
+ *
+ * @element ANY
+ * @param {string} ngGoto with the route to navigate to on click (or touch if using ngMobile)
+ *
+ * @example
+    <example module="ngGotoExample" deps="angular-route.js">
+      <file name="index.html">
+        <a ng-goto="home">Home -> /home</a><br />
+        <a ng-goto="many">Many -> /:userId/items</a><br />
+        <a ng-goto="single" item-id="item-1234">One -> /:userId/item/:itemId</a><br />
+        <span>Route name: {{ $route.current.name }}</span><br />
+        <span>User param: {{ $routeParams.userId }}</span><br />
+        <span>Item param: {{ $routeParams.itemId }}</span>
+      </file>
+      <file name="script.js">
+        angular.module('ngGotoExample', ['ngRoute']).
+          config(function ($routeProvider) {
+            $routeProvider.
+              when('/home', {
+                  name: 'home'
+              }).
+              when('/:userId/items', {
+                  name: 'many'
+              }).
+              when('/:userId/item/:itemId', {
+                  name: 'single'
+              }).
+              otherwise({
+                  redirectTo: '/home'
+              });
+          });
+      </file>
+    </example>
+ */
+directive('ngGoto', ['$route', '$location', '$parse', function ($route, $location, $parse) {
+  var hashPrefix = $location.$$html5 ? '' : ngRouteModule.tmpHashPrefix;
+  delete ngRouteModule.tmpHashPrefix;
+
+  return {
+    scope: true,
+    restrict: 'A',
+    compile: function compile(tElement, tAttrs, transclude) {
+      tElement.attr('ngClick', 'ngGotoHandler($event)');
+
+      return function (scope, element, attrs) {
+        var isLink = element[0].tagName === 'A',
+            isActive = false,
+            searchParams,
+            updateActive = function () {
+              if ($route.current && attrs.ngGoto === $route.current.name) {
+                  element.addClass('ng-route-active');
+                  isActive = true;
+              } else if (isActive) {
+                  element.removeClass('ng-route-active');
+                  isActive = false;
+              }
+
+              if (isLink) {
+                var url = $route.pathTo[attrs.ngGoto](attrs),
+                    search = searchParams(scope, {});
+
+                // set the href
+                if (search) {
+                  if (search === true) {
+                    search = '?' + angular.toKeyValue($location.search());
+                  } else if (angular.isObject(search)) {
+                    search = '?' + angular.toKeyValue(search);
+                  } else {
+                    search = '?' + search;
+                  }
+                  if (search === '?') { search = ''; }
+                  element.attr('href', hashPrefix + url + search);
+                } else {
+                  element.attr('href', hashPrefix + url);
+                }
+              }
+            };
+
+        // Process search attribute if defined
+        if (attrs.search) {
+          searchParams = $parse(attrs.search);
+          delete attrs.search;
+        } else {
+          // no-op function unless search exists
+          searchParams = angular.noop;
+        }
+
+        // Keep the element up to date
+        updateActive();
+        scope.$on('$routeChangeSuccess', updateActive);
+
+        // Follow clicks using mobile events where available
+        scope.ngGotoHandler = function($event) {
+          $route.to[attrs.ngGoto](attrs, searchParams(scope, {}));
+
+          if (isLink) {
+            $event.preventDefault();
+          }
+        };
+      };
+    }
+  };
+}]);

--- a/test/ngRoute/directive/ngGotoSpec.js
+++ b/test/ngRoute/directive/ngGotoSpec.js
@@ -1,0 +1,146 @@
+'use strict';
+
+describe('ngGoto', function() {
+  var element,
+      $httpBackend;
+
+  beforeEach(module('ngRoute'));
+
+  beforeEach(module(function() {
+    return function(_$httpBackend_) {
+      $httpBackend = _$httpBackend_;
+      $httpBackend.when('GET', 'Chapter.html').respond('chapter');
+    };
+  }));
+
+  afterEach(function() {
+    dealoc(element);
+  });
+
+  it('should maintain a links href attribute and assign an active class', function() {
+    module(function($routeProvider) {
+      $routeProvider.when('/Book/:book/Chapter/:chapter',
+          {controller: angular.noop, templateUrl: 'Chapter.html', name: 'chapter'});
+    });
+    inject(function($route, $location, $rootScope, $compile) {
+      element = $compile('<a ng-goto="chapter"></a>')($rootScope);
+      $rootScope.$digest();
+
+      expect(element.hasClass('ng-route-active')).toEqual(false);
+      expect(element.attr('href')).toEqual('#/Book//Chapter/');
+
+      $route.to.chapter({book: 'Moby', chapter: 'Intro'}, 'p=123');
+      $rootScope.$digest();
+      $httpBackend.flush();
+
+      expect(element.hasClass('ng-route-active')).toEqual(true);
+      expect(element.attr('href')).toEqual('#/Book/Moby/Chapter/Intro');
+    });
+  });
+
+  it('should maintain a links href attribute and respect html5 mode routing', function() {
+    module(function($routeProvider, $locationProvider) {
+      $locationProvider.html5Mode(true);
+
+      $routeProvider.when('/Book/:book/Chapter/:chapter',
+          {controller: angular.noop, templateUrl: 'Chapter.html', name: 'chapter'});
+    });
+    inject(function($route, $location, $rootScope, $compile) {
+      element = $compile('<a ng-goto="chapter"></a>')($rootScope);
+      $rootScope.$digest();
+
+      expect(element.hasClass('ng-route-active')).toEqual(false);
+      expect(element.attr('href')).toEqual('/Book//Chapter/');
+
+      $route.to.chapter({book: 'Moby', chapter: 'Intro'}, 'p=123');
+      $rootScope.$digest();
+      $httpBackend.flush();
+
+      expect(element.hasClass('ng-route-active')).toEqual(true);
+      expect(element.attr('href')).toEqual('/Book/Moby/Chapter/Intro');
+    });
+  });
+
+  it('should maintain a links href attribute and update requested params without search', function() {
+    module(function($routeProvider, $locationProvider) {
+      $routeProvider.when('/Book/:book/Chapter/:chapter',
+          {controller: angular.noop, templateUrl: 'Chapter.html', name: 'chapter'});
+    });
+    inject(function($route, $location, $rootScope, $compile) {
+      element = $compile('<a ng-goto="chapter" chapter="Lord"></a>')($rootScope);
+      $rootScope.$digest();
+
+      expect(element.hasClass('ng-route-active')).toEqual(false);
+      expect(element.attr('href')).toEqual('#/Book//Chapter/Lord');
+
+      $route.to.chapter({book: 'Moby', chapter: 'Intro'}, 'p=123');
+      $rootScope.$digest();
+      $httpBackend.flush();
+
+      expect(element.hasClass('ng-route-active')).toEqual(true);
+      expect(element.attr('href')).toEqual('#/Book/Moby/Chapter/Lord');
+    });
+  });
+
+  it('should maintain a links href attribute and update requested params with search', function() {
+    module(function($routeProvider, $locationProvider) {
+      $routeProvider.when('/Book/:book/Chapter/:chapter',
+          {controller: angular.noop, templateUrl: 'Chapter.html', name: 'chapter'});
+    });
+    inject(function($route, $location, $rootScope, $compile) {
+      element = $compile('<a ng-goto="chapter" search="true" chapter="Lord"></a>')($rootScope);
+      $rootScope.$digest();
+
+      expect(element.hasClass('ng-route-active')).toEqual(false);
+      expect(element.attr('href')).toEqual('#/Book//Chapter/Lord');
+
+      $route.to.chapter({book: 'Moby', chapter: 'Intro'}, 'p=123');
+      $rootScope.$digest();
+      $httpBackend.flush();
+
+      expect(element.hasClass('ng-route-active')).toEqual(true);
+      expect(element.attr('href')).toEqual('#/Book/Moby/Chapter/Lord?p=123');
+    });
+  });
+
+  it('should not add href unless a link', function() {
+    module(function($routeProvider, $locationProvider) {
+      $routeProvider.when('/Book/:book/Chapter/:chapter',
+          {controller: angular.noop, templateUrl: 'Chapter.html', name: 'chapter'});
+    });
+    inject(function($route, $location, $rootScope, $compile) {
+      element = $compile('<div ng-goto="chapter" chapter="Lord"></div>')($rootScope);
+      $rootScope.$digest();
+
+      expect(element.hasClass('ng-route-active')).toEqual(false);
+      expect(element.attr('href')).toEqual(undefined);
+
+      $route.to.chapter({book: 'Moby', chapter: 'Intro'}, 'p=123');
+      $rootScope.$digest();
+      $httpBackend.flush();
+
+      expect(element.hasClass('ng-route-active')).toEqual(true);
+      expect(element.attr('href')).toEqual(undefined);
+    });
+  });
+
+  it('should update route on click', function() {
+    module(function($routeProvider, $locationProvider) {
+      $routeProvider.when('/Book/:book/Chapter/:chapter',
+          {controller: angular.noop, templateUrl: 'Chapter.html', name: 'chapter'});
+    });
+    inject(function($route, $location, $rootScope, $compile) {
+      element = $compile('<div ng-goto="chapter" book="Moby" chapter="Lord"></div>')($rootScope);
+      $rootScope.$digest();
+
+      expect(element.hasClass('ng-route-active')).toEqual(false);
+
+      element.scope().ngGotoHandler();
+      $rootScope.$digest();
+      $httpBackend.flush();
+
+      expect(element.hasClass('ng-route-active')).toEqual(true);
+      expect($location.url()).toEqual('/Book/Moby/Chapter/Lord');
+    });
+  });
+});


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): ngRoute

Impact: medium

Complexity: medium

This issue is related to: 

**Detailed Description:**

Routes are defined in the same way as regular AngularJS routes except it is possible to supply a name for a route.
If a route is requested it provides a promise that is resolved once navigation is complete, or rejected if another route was navigated to in the same digest.

Links can be defined using the ngGoto directive and should be used instead of ngHref as only name need be used instead of the entire path. It is also possible to effect only a particular named group in the path without updating the rest. For instance:

if you had two routes: `/:user/links` and `/:user/pictures` you could link to pictures like: `<a ng-goto="pictures">pictures</a>` and it would automatically pick up the user you are looking at and link to their pictures (if the current path was `/steve/links` then the href of the link above would be generated `/steve/pictures`)

Links or other DOM elements that define ng-goto also use the ng-click directive to enact the route change, thus supporting ngTouch if it is included and also filling out the href if a link element.

Would resolve:
- angular/angular.js#1791
- angular/angular.js#7091

**Other Comments:**

Named routes provide helper functions for scripted route changes and partial route updating,
components may update specified named groups in a route without knowing the semantics of a
route. A directive, ngGoto, is provided for binding routes to DOM elements such as the A tag.

It is 100% backwards compatible with the existing routing system so could be added in a point release.
