### PR TITLE
fix($rootScope): avoid unstable reference in $broadcast event

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -1029,25 +1029,33 @@ function $RootScopeProvider(){
        * @return {Object} Event object (see {@link ng.$rootScope.Scope#$on}).
        */
       $emit: function(name, args) {
+        function Event(currentScope) {
+          this.name = name;
+          this.currentScope = currentScope;
+          this.targetScope = target;
+          this.defaultPrevented = globalDefaultPrevented;
+        }
+        Event.prototype.preventDefault = function() {
+          // Deals with the current instance (this) and also the next ones with globalDefaultPrevented.
+          this.defaultPrevented = true;
+          globalDefaultPrevented = true;
+        };
+        Event.prototype.stopPropagation = function() {
+          stopPropagation = true;
+        };
+
         var empty = [],
             namedListeners,
+            target = this,
             scope = this,
             stopPropagation = false,
-            event = {
-              name: name,
-              targetScope: scope,
-              stopPropagation: function() {stopPropagation = true;},
-              preventDefault: function() {
-                event.defaultPrevented = true;
-              },
-              defaultPrevented: false
-            },
-            listenerArgs = concat([event], arguments, 1),
+            globalDefaultPrevented = false,
+            event = new Event(scope),
+            listenerArgs,
             i, length;
 
         do {
           namedListeners = scope.$$listeners[name] || empty;
-          event.currentScope = scope;
           for (i=0, length=namedListeners.length; i<length; i++) {
 
             // if listeners were deregistered, defragment the array
@@ -1059,6 +1067,8 @@ function $RootScopeProvider(){
             }
             try {
               //allow all listeners attached to the current scope to run
+              event = new Event(scope);
+              listenerArgs = concat([event], arguments, 1);
               namedListeners[i].apply(null, listenerArgs);
             } catch (e) {
               $exceptionHandler(e);
@@ -1069,7 +1079,6 @@ function $RootScopeProvider(){
           //traverse upwards
           scope = scope.$parent;
         } while (scope);
-
         return event;
       },
 
@@ -1100,16 +1109,19 @@ function $RootScopeProvider(){
           this.name = name;
           this.currentScope = currentScope;
           this.targetScope = target;
-          this.defaultPrevented = false;
+          this.defaultPrevented = globalDefaultPrevented;
         }
         Event.prototype.preventDefault = function() {
+          // Deals with the current instance (this) and also the next ones with globalDefaultPrevented.
           this.defaultPrevented = true;
+          globalDefaultPrevented = true;
         };
 
         var target = this,
             current = target,
             next = target,
             listenerArgs,
+            globalDefaultPrevented = false,
             event = new Event(current),
             listeners, i, length;
 

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -1104,7 +1104,7 @@ function $RootScopeProvider(){
         }
         Event.prototype.preventDefault = function() {
           this.defaultPrevented = true;
-        }
+        };
 
         var target = this,
             current = target,

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1572,6 +1572,10 @@ describe('Scope', function() {
           });
           grandChild.$emit('myEvent');
           expect(event).toBeDefined();
+
+          // Asynchronous expectation : current & target should be the same as above
+          expect(event.targetScope).toBe(grandChild);
+          expect(event.currentScope).toBe(child);
         });
 
 
@@ -1693,6 +1697,18 @@ describe('Scope', function() {
           expect(result.name).toBe('some');
           expect(result.targetScope).toBe(child1);
         });
+
+        it('should have preventDefault method and defaultPrevented property', function() {
+          var event = child2.$broadcast('myEvent');
+          expect(event.defaultPrevented).toBe(false);
+
+          grandChild21.$on('myEvent', function(event) {
+            event.preventDefault();
+          });
+          event = child2.$broadcast('myEvent');
+          expect(event.defaultPrevented).toBe(true);
+        });
+
       });
 
 
@@ -1704,15 +1720,17 @@ describe('Scope', function() {
               event;
 
           child.$on('fooEvent', function(e) {
+            expect(e.targetScope).toBe(scope);
+            expect(e.currentScope).toBe(child);
+            expect(e.name).toBe('fooEvent');
             event = e;
           });
           scope.$broadcast('fooEvent');
 
-          expect(event.name).toBe('fooEvent');
+          // Asynchronous expectation : current & target should be the same as above
           expect(event.targetScope).toBe(scope);
           expect(event.currentScope).toBe(child);
         }));
-
 
         it('should support passing messages as varargs', inject(function($rootScope) {
           var scope = $rootScope,

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1700,6 +1700,7 @@ describe('Scope', function() {
         it('should receive event object', inject(function($rootScope) {
           var scope = $rootScope,
               child = scope.$new(),
+              grandChild = child.$new(),
               event;
 
           child.$on('fooEvent', function(e) {


### PR DESCRIPTION
Request Type: bug

How to reproduce: Any case of asynchronous access to `event.currentScope` :
- `console.log(event)` then expand the object in console (Chrome / Firefox)
- Via `$timeout`
- In Jasmine expectation

[Plunker](http://plnkr.co/edit/YbsyEhzz81Mcd9TZdBwt?p=preview)

Note : The tree of scopes must have a depth greater than 2 (see commit diff for rootScopeSpec.js).

Component(s): scope

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

In the $broadcast method, the `event.currentScope` is initialized with `current` which is the iterator used by the scope traversal's loop.

It caused problems when using asynchonously the event object : the `event.currentScope` is not the scope which listen the event. It's the last scope crossed by the traversal which has nothing to do with the event (or coincidentally has).

**Other Comments:**
