### PR TITLE
adding enable/disable to cacheFactory

### DIFF
--- a/src/ng/cacheFactory.js
+++ b/src/ng/cacheFactory.js
@@ -95,7 +95,8 @@ function $CacheFactoryProvider() {
           capacity = (options && options.capacity) || Number.MAX_VALUE,
           lruHash = {},
           freshEnd = null,
-          staleEnd = null;
+          staleEnd = null,
+          disabled = false;
 
       /**
        * @ngdoc type
@@ -157,6 +158,8 @@ function $CacheFactoryProvider() {
          * @returns {*} the value stored.
          */
         put: function(key, value) {
+          if (disabled) return;
+
           if (capacity < Number.MAX_VALUE) {
             var lruEntry = lruHash[key] || (lruHash[key] = {key: key});
 
@@ -186,6 +189,8 @@ function $CacheFactoryProvider() {
          * @returns {*} the value stored.
          */
         get: function(key) {
+          if (disabled) return;
+
           if (capacity < Number.MAX_VALUE) {
             var lruEntry = lruHash[key];
 
@@ -277,6 +282,32 @@ function $CacheFactoryProvider() {
          */
         info: function() {
           return extend({}, stats, {size: size});
+        },
+
+        /**
+         * @ngdoc method
+         * @name $cacheFactory.Cache#disable
+         * @function
+         *
+         * @description
+         * Disables cache programatially, you can enable it later calling {@link $cacheFactory.Cache#enable}.
+         *
+         */
+        disable: function() {
+          disabled = true;
+        },
+
+        /**
+         * @ngdoc method
+         * @name $cacheFactory.Cache#enable
+         * @function
+         *
+         * @description
+         * Enables cache programatially, you can disable it later calling {@link $cacheFactory.Cache#disable}.
+         *
+         */
+        enable: function() {
+          disabled = false;
         }
       };
 

--- a/test/ng/cacheFactorySpec.js
+++ b/test/ng/cacheFactorySpec.js
@@ -114,6 +114,49 @@ describe('$cacheFactory', function() {
       }));
     });
 
+    describe('disable, enable', function (){
+      it('should disable cache', inject(function($cacheFactory) {
+        cache.put('key1', 'bar');
+        expect(cache.get('key1')).toBe('bar');
+
+        cache.disable();
+
+        cache.put('key1', 'bar');
+        expect(cache.get('key1')).toBeUndefined();
+      }));
+
+      it('should enable cache', inject(function($cacheFactory) {
+        cache.disable();
+        cache.enable();
+
+        cache.put('key1', 'bar');
+        expect(cache.get('key1')).toBe('bar');
+      }));
+
+      it('should always miss cache with get', inject(function($cacheFactory) {
+        cache.put('key1', 'bar');
+
+        cache.disable();
+
+        expect(cache.get('key1')).toBeUndefined();
+      }));
+
+      it('should always return undefined with put', inject(function($cacheFactory) {
+        var result;
+        cache.disable();
+
+        result = cache.put('key1', 'bar');
+        expect(result).toBeUndefined();
+      }));
+
+      it('should act per cacheFactory instance', inject(function($cacheFactory) {
+        var cache2 = $cacheFactory('test2');
+        cache.disable();
+        cache2.put('key1', 'bar');
+
+        expect(cache2.get('key1')).toBe('bar');
+      }));
+    });
 
     describe('info', function() {
 


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

This functionality to `$cacheFactory` instances, allow us to disable/enable the cache programatically.

```
cache = $cacheFactory('test');
cache.put('foo', 'bar');

cache.disable();

cache.get('foo') => undefined
```

My use case is that I want to cache everything, and then I send SSE to notify clients about changes and expire cache for certain Resources (this is handled by another class).

In case the client can not receive events (connection problems with the socket), then I want to disable cache, and later when the connection is restored, enable it again.

I think a enable/disable method in the `$cacheFactory` class will be a good idea, if you guys considerer this approach can be merged, then I'll implement the class method to enable/disable all the cache instances with one method call.
