### PR TITLE
fix($compile): call `normalize` on nodes for cases when browser creates ...

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -843,7 +843,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       }
       // We can not compile top level text elements since text nodes can be merged and we will
       // not be able to attach scope data to them, so we will wrap them in <span>
+      // We also need to call `normalize` on the nodes, because in some cases
+      // browsers (like IE11) allocate multiple text nodes when parsing a single block of HTML.
       forEach($compileNodes, function(node, index){
+        node.normalize();
+
         if (node.nodeType == 3 /* text node */ && node.nodeValue.match(/\S+/) /* non-empty */ ) {
           $compileNodes[index] = node = jqLite(node).wrap('<span></span>').parent()[0];
         }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2317,6 +2317,20 @@ describe('$compile', function() {
     }));
 
 
+    it('should support interpolating text spread across multiple text nodes', inject(function($rootScope, $compile) {
+      var rawElement = document.createElement("div");
+      var textNode1 = document.createTextNode("{{foo");
+      var textNode2 = document.createTextNode("bar}}");
+      rawElement.appendChild(textNode1);
+      rawElement.appendChild(textNode2);
+
+      var element = $compile(rawElement)($rootScope);
+      $rootScope.foobar = "spam eggs";
+      $rootScope.$digest();
+      expect(element.text()).toBe("spam eggs");
+    }));
+
+
     it('should support custom start/end interpolation symbols in template and directive template',
         function() {
       module(function($interpolateProvider, $compileProvider) {


### PR DESCRIPTION
Request Type: bug

How to reproduce: Occurs sporadically in the wild, but the included test synthesizes exactly what happens when it does.

Component(s): $compile

Impact: small

Complexity: small

This issue is related to:

Detailed Description:

Other Comments:

...multiple text nodes when parsing HTML

When IE 11 parses HTML, it occasionally splits text into adjacent sibling text nodes. It's difficult to reproduce, but we have some screenshots of it happening: https://dl.dropboxusercontent.com/spa/4slnjubp16y5phq/3f-ld80p.png

While this is illegal according to the DOM spec, it happens anyways and should be dealt with. Angular currently can't deal with this.

Calling normalize when compiling a node addresses this issue. Test included.
