### PR TITLE
Do not merge attributes that are the same

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1652,7 +1652,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       // reapply the old attributes to the new element
       forEach(dst, function(value, key) {
         if (key.charAt(0) != '$') {
-          if (src[key]) {
+          if (src[key] && src[key] !== value) {
             value += (key === 'style' ? ';' : ' ') + src[key];
           }
           dst.$set(key, value, true, srcAttr[key]);

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -492,6 +492,15 @@ describe('$compile', function() {
               expect(element).toBe(attr.$$element);
             }
           }));
+          directive('nomerge', valueFn({
+            restrict: 'CAM',
+            replace: true,
+            template: '<div class="log" id="myid" high-log>No Merge!</div>',
+            compile: function(element, attr) {
+              attr.$set('compiled', 'COMPILED');
+              expect(element).toBe(attr.$$element);
+            }
+          }));
           directive('append', valueFn({
             restrict: 'CAM',
             template: '<div class="log" style="width: 10px" high-log>Append!</div>',
@@ -594,6 +603,16 @@ describe('$compile', function() {
           expect(div.css('height')).toBe('20px');
           expect(div.attr('replace')).toEqual('');
           expect(div.attr('high-log')).toEqual('');
+        }));
+
+        it('should not merge attributes if they are the same', inject(function($compile, $rootScope) {
+          element = $compile(
+            '<div><div nomerge class="medium-log" id="myid"></div><div>')
+            ($rootScope);
+          var div = element.find('div');
+          expect(div.hasClass('medium-log')).toBe(true);
+          expect(div.hasClass('log')).toBe(true);
+          expect(div.attr('id')).toEqual('myid');
         }));
 
         it('should prevent multiple templates per element', inject(function($compile) {


### PR DESCRIPTION
Request Type: bug

How to reproduce: 1. have a replace directive with 'id' attribute in the main wrapping element
2. have an element that references the directive and has an 'id' attribute with a value that exactly matches the 'id' attribute from the main wrapping element in the directive
3. when you view this html, you will see that the id attribute was duplicated (i.e. id="myid" becomes id="myid myid")

Component(s): $compile

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The is a very simple issue. The logic for merging attributes should not concatenate if the attribute values are the same. I would imagine that not a lot of people run into this because 

1) there are many attributes where concatenation would not cause errors (ex. styles, class, etc.)
2) for replace directives, especially for single page apps, there is no reason to put attributes on both the directive partial element and the element that references the directive.

The use case where this starts to be a problem is when you are trying to have a nicer initial page load experience. Basically, for various situations, I will have the server side render default html that is displayed by the browser before angular is fully downloaded and bootstrapped. So, this type of issue would only affect people concerned with server side rendering (either for SEO purposes or for UX so user sees something very quickly before Angular bootstraps). It only affects the initial page load. For people like me that are concerned about these types of things, it is a significant issue and this very minor change will help tremendously.

**Other Comments:**

The logic for merging attributes will essentially concatenate values if an attribute is in the DOM element and is in the partial that will be replacing the DOM element.  This doesn't make sense in some use cases, but the most clear one is where there is something like an ID which is the exact same in both. The current logic will concatenate `<div id="myid" my-directive>` and `<div id="myid">` (for the directive template) into `<div id="myid myid">`.

This pull request is to add one very simple condition that will just ensure that when the values are exactly the same, they are not concatenated.
