### PR TITLE
avoid bypassing xss protection

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1481,7 +1481,7 @@ var VALID_CLASS = 'ng-valid',
     </file>
     <file name="script.js">
       angular.module('customControl', []).
-        directive('contenteditable', function() {
+        directive('contenteditable', ['$sce', function($sce) {
           return {
             restrict: 'A', // only activate on element attribute
             require: '?ngModel', // get a hold of NgModelController
@@ -1490,7 +1490,7 @@ var VALID_CLASS = 'ng-valid',
 
               // Specify how UI should be updated
               ngModel.$render = function() {
-                element.html(ngModel.$viewValue || '');
+                element.html($sce.getTrustedHtml(ngModel.$viewValue || ''));
               };
 
               // Listen for change events to enable binding
@@ -1511,7 +1511,7 @@ var VALID_CLASS = 'ng-valid',
               }
             }
           };
-        });
+        }]);
     </file>
     <file name="index.html">
       <form name="myForm">


### PR DESCRIPTION
Request Type: docs

How to reproduce: If binding database data to a contentEditable that contains raw HTML the example in these docs binds it directly. Shouldn't it use the $sce service?

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: security

**Detailed Description:**

element.html() sets the raw value directly in the dom which seems to bypass the built-in $sce protection one would normally get with a built-in directive. This seems dangerous to promote as an example. element.html() seems inherently dangerous to use in a directive. Could it alternatively be overridden to only accept safe strings? Perhaps with a safeHtml() alternative.

**Other Comments:**

element.html() sets the raw value directly in the dom which seems to bypass the built-in $sce protection one would normally get with a built-in directive. This seems dangerous to promote as an example. element.html() seems inherently dangerous to use in a directive. Could it alternatively be overridden to only accept safe strings? Perhaps with a safeHtml() alternative.
