### PR TITLE
feat(ngTouch): add optional `ngSwipeDisableMouse` attribute to `ngSwipe`...

### DIFF
--- a/src/ngTouch/directive/ngSwipe.js
+++ b/src/ngTouch/directive/ngSwipe.js
@@ -12,6 +12,9 @@
  * Though ngSwipeLeft is designed for touch-based devices, it will work with a mouse click and drag
  * too.
  *
+ * To disable the mouse click and drag functionality, add `ng-swipe-disable-mouse` to
+ * the `ng-swipe-left` or `ng-swipe-right` DOM Element.
+ *
  * Requires the {@link ngTouch `ngTouch`} module to be installed.
  *
  * @element ANY
@@ -101,6 +104,10 @@ function makeSwipeDirective(directiveName, direction, eventName) {
             deltaY / deltaX < MAX_VERTICAL_RATIO;
       }
 
+      var pointerTypes = ['touch'];
+      if (!angular.isDefined(attr['ngSwipeDisableMouse'])) {
+        pointerTypes.push('mouse');
+      }
       $swipe.bind(element, {
         'start': function(coords, event) {
           startCoords = coords;
@@ -117,7 +124,7 @@ function makeSwipeDirective(directiveName, direction, eventName) {
             });
           }
         }
-      });
+      }, pointerTypes);
     };
   }]);
 }

--- a/test/ngTouch/directive/ngSwipeSpec.js
+++ b/test/ngTouch/directive/ngSwipeSpec.js
@@ -66,6 +66,24 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBe(true);
     }));
 
+    it('should only swipe given ng-swipe-disable-mouse attribute for touch events', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-swipe-left="swiped = true" ng-swipe-disable-mouse></div>')($rootScope);
+      $rootScope.$digest();
+      expect($rootScope.swiped).toBeUndefined();
+
+      browserTrigger(element, startEvent, {
+        keys : [],
+        x : 100,
+        y : 20
+      });
+      browserTrigger(element, endEvent,{
+        keys: [],
+        x: 20,
+        y: 20
+      });
+      expect(!!$rootScope.swiped).toBe(description !== 'mouse');
+    }));
+
     it('should pass event object', inject(function($rootScope, $compile) {
       element = $compile('<div ng-swipe-left="event = $event"></div>')($rootScope);
       $rootScope.$digest();

--- a/test/ngTouch/swipeSpec.js
+++ b/test/ngTouch/swipeSpec.js
@@ -1,392 +1,385 @@
 'use strict';
 
-// Wrapper to abstract over using touch events or mouse events.
-var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, endEvent) {
-  describe('$swipe with ' + description + ' events', function() {
-    var element;
+describe('$swipe', function() {
+  var element;
+  var events;
 
-    if (restrictBrowsers) {
-      // TODO(braden): Once we have other touch-friendly browsers on CI, allow them here.
-      // Currently Firefox and IE refuse to fire touch events.
-      var chrome = /chrome/.test(navigator.userAgent.toLowerCase());
-      if (!chrome) {
-        return;
-      }
-    }
+  // Skip tests on IE < 9. These versions of IE don't support createEvent(), and so
+  // we cannot control the (x,y) position of events.
+  // It works fine in IE 8 under manual testing.
+  var msie = +((/msie (\d+)/.exec(navigator.userAgent.toLowerCase()) || [])[1]);
+  if (msie < 9) {
+    return;
+  }
 
-    // Skip tests on IE < 9. These versions of IE don't support createEvent(), and so
-    // we cannot control the (x,y) position of events.
-    // It works fine in IE 8 under manual testing.
-    var msie = +((/msie (\d+)/.exec(navigator.userAgent.toLowerCase()) || [])[1]);
-    if (msie < 9) {
-      return;
-    }
+  beforeEach(function() {
+    module('ngTouch');
+    inject(function($compile, $rootScope) {
+      element = $compile('<div></div>')($rootScope);
+    });
+    events = {
+      start: jasmine.createSpy('startSpy'),
+      move: jasmine.createSpy('moveSpy'),
+      cancel: jasmine.createSpy('cancelSpy'),
+      end: jasmine.createSpy('endSpy')
+    };
+  });
+
+  afterEach(function() {
+    dealoc(element);
+  });
+
+  describe('pointerTypes', function() {
+    var usedEvents;
+    var MOUSE_EVENTS = ['mousedown','mousemove','mouseup'].sort();
+    var TOUCH_EVENTS = ['touchcancel','touchend','touchmove','touchstart'].sort();
+    var ALL_EVENTS = MOUSE_EVENTS.concat(TOUCH_EVENTS).sort();
 
     beforeEach(function() {
-      module('ngTouch');
+      usedEvents = [];
+      spyOn(element, 'on').andCallFake(function(events) {
+        angular.forEach(events.split(/\s+/), function(eventName) {
+          usedEvents.push(eventName);
+        });
+      });
     });
 
-    afterEach(function() {
-      dealoc(element);
-    });
-
-    it('should trigger the "start" event', inject(function($rootScope, $swipe, $compile) {
-      element = $compile('<div></div>')($rootScope);
-      var events = {
-        start: jasmine.createSpy('startSpy'),
-        move: jasmine.createSpy('moveSpy'),
-        cancel: jasmine.createSpy('cancelSpy'),
-        end: jasmine.createSpy('endSpy')
-      };
-
+    it('should use mouse and touch by default', inject(function($swipe) {
       $swipe.bind(element, events);
-
-      expect(events.start).not.toHaveBeenCalled();
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-
-      browserTrigger(element, startEvent,{
-        keys: [],
-        x: 100,
-        y: 20
-      });
-
-      expect(events.start).toHaveBeenCalled();
-
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
+      expect(usedEvents.sort()).toEqual(ALL_EVENTS);
     }));
 
-    it('should trigger the "move" event after a "start"', inject(function($rootScope, $swipe, $compile) {
-      element = $compile('<div></div>')($rootScope);
-      var events = {
-        start: jasmine.createSpy('startSpy'),
-        move: jasmine.createSpy('moveSpy'),
-        cancel: jasmine.createSpy('cancelSpy'),
-        end: jasmine.createSpy('endSpy')
-      };
-
-      $swipe.bind(element, events);
-
-      expect(events.start).not.toHaveBeenCalled();
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-
-      browserTrigger(element, startEvent,{
-        keys: [],
-        x: 100,
-        y: 20
-      });
-
-      expect(events.start).toHaveBeenCalled();
-
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 140,
-        y: 20
-      });
-
-      expect(events.start).toHaveBeenCalled();
-      expect(events.move).toHaveBeenCalled();
-
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
+    it('should only use mouse events for pointerType "mouse"', inject(function($swipe) {
+      $swipe.bind(element, events, ['mouse']);
+      expect(usedEvents.sort()).toEqual(MOUSE_EVENTS);
     }));
 
-    it('should not trigger a "move" without a "start"', inject(function($rootScope, $swipe, $compile) {
-      element = $compile('<div></div>')($rootScope);
-      var events = {
-        start: jasmine.createSpy('startSpy'),
-        move: jasmine.createSpy('moveSpy'),
-        cancel: jasmine.createSpy('cancelSpy'),
-        end: jasmine.createSpy('endSpy')
-      };
-
-      $swipe.bind(element, events);
-
-      expect(events.start).not.toHaveBeenCalled();
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 100,
-        y: 40
-      });
-
-      expect(events.start).not.toHaveBeenCalled();
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
+    it('should only use touch events for pointerType "touch"', inject(function($swipe) {
+      $swipe.bind(element, events, ['touch']);
+      expect(usedEvents.sort()).toEqual(TOUCH_EVENTS);
     }));
 
-    it('should not trigger an "end" without a "start"', inject(function($rootScope, $swipe, $compile) {
-      element = $compile('<div></div>')($rootScope);
-      var events = {
-        start: jasmine.createSpy('startSpy'),
-        move: jasmine.createSpy('moveSpy'),
-        cancel: jasmine.createSpy('cancelSpy'),
-        end: jasmine.createSpy('endSpy')
-      };
-
-      $swipe.bind(element, events);
-
-      expect(events.start).not.toHaveBeenCalled();
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-
-      browserTrigger(element, endEvent,{
-        keys: [],
-        x: 100,
-        y: 40
-      });
-
-      expect(events.start).not.toHaveBeenCalled();
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
+    it('should use mouse and touch if both are specified', inject(function($swipe) {
+      $swipe.bind(element, events, ['touch', 'mouse']);
+      expect(usedEvents.sort()).toEqual(ALL_EVENTS);
     }));
 
-    it('should trigger a "start", many "move"s and an "end"', inject(function($rootScope, $swipe, $compile) {
-      element = $compile('<div></div>')($rootScope);
-      var events = {
-        start: jasmine.createSpy('startSpy'),
-        move: jasmine.createSpy('moveSpy'),
-        cancel: jasmine.createSpy('cancelSpy'),
-        end: jasmine.createSpy('endSpy')
-      };
-
-      $swipe.bind(element, events);
-
-      expect(events.start).not.toHaveBeenCalled();
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-
-      browserTrigger(element, startEvent,{
-        keys: [],
-        x: 100,
-        y: 40
-      });
-
-      expect(events.start).toHaveBeenCalled();
-
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 120,
-        y: 40
-      });
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 130,
-        y: 40
-      });
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 140,
-        y: 40
-      });
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 150,
-        y: 40
-      });
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 160,
-        y: 40
-      });
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 170,
-        y: 40
-      });
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 180,
-        y: 40
-      });
-
-      expect(events.start).toHaveBeenCalled();
-      expect(events.move.calls.length).toBe(7);
-
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-
-      browserTrigger(element, endEvent,{
-        keys: [],
-        x: 200,
-        y: 40
-      });
-
-      expect(events.start).toHaveBeenCalled();
-      expect(events.move.calls.length).toBe(7);
-      expect(events.end).toHaveBeenCalled();
-
-      expect(events.cancel).not.toHaveBeenCalled();
-    }));
-
-    it('should not start sending "move"s until enough horizontal motion is accumulated', inject(function($rootScope, $swipe, $compile) {
-      element = $compile('<div></div>')($rootScope);
-      var events = {
-        start: jasmine.createSpy('startSpy'),
-        move: jasmine.createSpy('moveSpy'),
-        cancel: jasmine.createSpy('cancelSpy'),
-        end: jasmine.createSpy('endSpy')
-      };
-
-      $swipe.bind(element, events);
-
-      expect(events.start).not.toHaveBeenCalled();
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-
-      browserTrigger(element, startEvent,{
-        keys: [],
-        x: 100,
-        y: 40
-      });
-
-      expect(events.start).toHaveBeenCalled();
-
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 101,
-        y: 40
-      });
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 105,
-        y: 40
-      });
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 110,
-        y: 40
-      });
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 115,
-        y: 40
-      });
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 120,
-        y: 40
-      });
-
-      expect(events.start).toHaveBeenCalled();
-      expect(events.move.calls.length).toBe(3);
-
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-
-      browserTrigger(element, endEvent,{
-        keys: [],
-        x: 200,
-        y: 40
-      });
-
-      expect(events.start).toHaveBeenCalled();
-      expect(events.move.calls.length).toBe(3);
-      expect(events.end).toHaveBeenCalled();
-
-      expect(events.cancel).not.toHaveBeenCalled();
-    }));
-
-    it('should stop sending anything after vertical motion dominates', inject(function($rootScope, $swipe, $compile) {
-      element = $compile('<div></div>')($rootScope);
-      var events = {
-        start: jasmine.createSpy('startSpy'),
-        move: jasmine.createSpy('moveSpy'),
-        cancel: jasmine.createSpy('cancelSpy'),
-        end: jasmine.createSpy('endSpy')
-      };
-
-      $swipe.bind(element, events);
-
-      expect(events.start).not.toHaveBeenCalled();
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-
-      browserTrigger(element, startEvent,{
-        keys: [],
-        x: 100,
-        y: 40
-      });
-
-      expect(events.start).toHaveBeenCalled();
-
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.cancel).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 101,
-        y: 41
-      });
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 105,
-        y: 55
-      });
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 110,
-        y: 60
-      });
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 115,
-        y: 70
-      });
-      browserTrigger(element, moveEvent,{
-        keys: [],
-        x: 120,
-        y: 80
-      });
-
-      expect(events.start).toHaveBeenCalled();
-      expect(events.cancel).toHaveBeenCalled();
-
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-
-      browserTrigger(element, endEvent,{
-        keys: [],
-        x: 200,
-        y: 40
-      });
-
-      expect(events.start).toHaveBeenCalled();
-      expect(events.cancel).toHaveBeenCalled();
-
-      expect(events.move).not.toHaveBeenCalled();
-      expect(events.end).not.toHaveBeenCalled();
-    }));
   });
-};
 
-swipeTests('touch', /* restrictBrowers */ true, 'touchstart', 'touchmove', 'touchend');
-swipeTests('mouse', /* restrictBrowers */ false, 'mousedown',  'mousemove', 'mouseup');
+  swipeTests('touch', /* restrictBrowers */ true, 'touchstart', 'touchmove', 'touchend');
+  swipeTests('mouse', /* restrictBrowers */ false, 'mousedown',  'mousemove', 'mouseup');
 
+  // Wrapper to abstract over using touch events or mouse events.
+  function swipeTests(description, restrictBrowsers, startEvent, moveEvent, endEvent) {
+    describe('$swipe with ' + description + ' events', function() {
+      if (restrictBrowsers) {
+        // TODO(braden): Once we have other touch-friendly browsers on CI, allow them here.
+        // Currently Firefox and IE refuse to fire touch events.
+        var chrome = /chrome/.test(navigator.userAgent.toLowerCase());
+        if (!chrome) {
+          return;
+        }
+      }
+
+      it('should trigger the "start" event', inject(function($swipe) {
+        $swipe.bind(element, events);
+
+        expect(events.start).not.toHaveBeenCalled();
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, startEvent,{
+          keys: [],
+          x: 100,
+          y: 20
+        });
+
+        expect(events.start).toHaveBeenCalled();
+
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+      }));
+
+      it('should trigger the "move" event after a "start"', inject(function($swipe) {
+        $swipe.bind(element, events);
+
+        expect(events.start).not.toHaveBeenCalled();
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, startEvent,{
+          keys: [],
+          x: 100,
+          y: 20
+        });
+
+        expect(events.start).toHaveBeenCalled();
+
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 140,
+          y: 20
+        });
+
+        expect(events.start).toHaveBeenCalled();
+        expect(events.move).toHaveBeenCalled();
+
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+      }));
+
+      it('should not trigger a "move" without a "start"', inject(function($swipe) {
+        $swipe.bind(element, events);
+
+        expect(events.start).not.toHaveBeenCalled();
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 100,
+          y: 40
+        });
+
+        expect(events.start).not.toHaveBeenCalled();
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+      }));
+
+      it('should not trigger an "end" without a "start"', inject(function($swipe) {
+        $swipe.bind(element, events);
+
+        expect(events.start).not.toHaveBeenCalled();
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, endEvent,{
+          keys: [],
+          x: 100,
+          y: 40
+        });
+
+        expect(events.start).not.toHaveBeenCalled();
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+      }));
+
+      it('should trigger a "start", many "move"s and an "end"', inject(function($swipe) {
+        $swipe.bind(element, events);
+
+        expect(events.start).not.toHaveBeenCalled();
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, startEvent,{
+          keys: [],
+          x: 100,
+          y: 40
+        });
+
+        expect(events.start).toHaveBeenCalled();
+
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 120,
+          y: 40
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 130,
+          y: 40
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 140,
+          y: 40
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 150,
+          y: 40
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 160,
+          y: 40
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 170,
+          y: 40
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 180,
+          y: 40
+        });
+
+        expect(events.start).toHaveBeenCalled();
+        expect(events.move.calls.length).toBe(7);
+
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, endEvent,{
+          keys: [],
+          x: 200,
+          y: 40
+        });
+
+        expect(events.start).toHaveBeenCalled();
+        expect(events.move.calls.length).toBe(7);
+        expect(events.end).toHaveBeenCalled();
+
+        expect(events.cancel).not.toHaveBeenCalled();
+      }));
+
+      it('should not start sending "move"s until enough horizontal motion is accumulated', inject(function($swipe) {
+        $swipe.bind(element, events);
+
+        expect(events.start).not.toHaveBeenCalled();
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, startEvent,{
+          keys: [],
+          x: 100,
+          y: 40
+        });
+
+        expect(events.start).toHaveBeenCalled();
+
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 101,
+          y: 40
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 105,
+          y: 40
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 110,
+          y: 40
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 115,
+          y: 40
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 120,
+          y: 40
+        });
+
+        expect(events.start).toHaveBeenCalled();
+        expect(events.move.calls.length).toBe(3);
+
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, endEvent,{
+          keys: [],
+          x: 200,
+          y: 40
+        });
+
+        expect(events.start).toHaveBeenCalled();
+        expect(events.move.calls.length).toBe(3);
+        expect(events.end).toHaveBeenCalled();
+
+        expect(events.cancel).not.toHaveBeenCalled();
+      }));
+
+      it('should stop sending anything after vertical motion dominates', inject(function($swipe) {
+        $swipe.bind(element, events);
+
+        expect(events.start).not.toHaveBeenCalled();
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, startEvent,{
+          keys: [],
+          x: 100,
+          y: 40
+        });
+
+        expect(events.start).toHaveBeenCalled();
+
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 101,
+          y: 41
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 105,
+          y: 55
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 110,
+          y: 60
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 115,
+          y: 70
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 120,
+          y: 80
+        });
+
+        expect(events.start).toHaveBeenCalled();
+        expect(events.cancel).toHaveBeenCalled();
+
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, endEvent,{
+          keys: [],
+          x: 200,
+          y: 40
+        });
+
+        expect(events.start).toHaveBeenCalled();
+        expect(events.cancel).toHaveBeenCalled();
+
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+      }));
+    });
+  }
+
+});


### PR DESCRIPTION
... directives to ignore mouse events.

This attribute is useful for text that should still be selectable
by the mouse and not trigger the swipe action.

This also adds an optional third argument to `$swipe.bind` to define
the pointer types that should be listened to.

Adapted version of #6627.

Closes #6627
Fixes #6626
