### PR TITLE
fix(ngResource): stop /. collapsing affecting parameter values

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -455,9 +455,8 @@ angular.module('ngResource', ['ng']).
           if (self.defaults.stripTrailingSlashes) {
             url = url.replace(/\/+$/, '') || '/';
           }
-          
-          config.url = url;
 
+          config.url = url;
 
           // set params - delegate param encoding to $http
           forEach(params, function (value, key) {

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1182,15 +1182,15 @@ describe("resource", function() {
     describe('escaping /. with /\\.', function() {
       it('should work with query()', function() {
         $httpBackend.expect('GET', '/users/.json').respond();
-        $resource('/users/\\.json').query();
+        $resource('/users/:user_id\\.json').query();
       });
       it('should work with get()', function() {
         $httpBackend.expect('GET', '/users/.json').respond();
-        $resource('/users/\\.json').get();
+        $resource('/users/:user_id\\.json').get();
       });
       it('should work with save()', function() {
         $httpBackend.expect('POST', '/users/.json').respond();
-        $resource('/users/\\.json').save({});
+        $resource('/users/:user_id\\.json').save({});
       });
     });
   });


### PR DESCRIPTION
Request Type: bug

How to reproduce: Create a resource with URL '/myservice/:myparam'.
Call the resource with '.foo' as the value for myparam.
After resolving the parameter, ngResource incorrectly collapses the URL to '/myservice.foo', while in fact collapsing '/.format' to '.format' should only happen if '.foo' is part of the original resource URL. It should not affect parameter values like '.foo'.

Component(s): ngResource

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The ngResource documentation states: "If the parameter before the suffix is empty, :resource_id in this case, then the /. will be collapsed down to a single .. If you need this sequence to appear and not collapse then you can escape it with /.."

But the resource.js implementation always replaces "./" instance with ".", regardless if these are caused by an empty parameter before the suffix. If the "." comes from the parameter value, ngResource should not touch it.

This pull request changes the ngResource behavior to match the documentation.

**Other Comments:**
