### PR TITLE
test(ngMessages): use strict-di for ngMessages tests

### DIFF
--- a/test/ngMessages/messagesSpec.js
+++ b/test/ngMessages/messagesSpec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 describe('ngMessages', function() {
-
+  beforeEach(inject.strictDi());
   beforeEach(module('ngMessages'));
 
   function they(msg, vals, spec, focus) {


### PR DESCRIPTION
This will hopefully prevent issues similar to the one fixed by 63b100c0
