### PR TITLE
Update ngClass.js

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -19,7 +19,7 @@ function classDirective(name, selector) {
           scope.$watch('$index', function($index, old$index) {
             // jshint bitwise: false
             var mod = $index & 1;
-            if (mod !== old$index & 1) {
+            if (mod !== (old$index & 1)) {
               var classes = arrayClasses(scope.$eval(attr[name]));
               mod === selector ?
                 addClasses(classes) :


### PR DESCRIPTION
I don't know if this was intended, but I don't think the code was comparing the indexes correctly and it was causing some weird behavior when using the ng-class-even and ng-class-odd directives.

See the following plunkr for an example of the bug.  http://plnkr.co/edit/VAi6DB0QdWRutNGnVdSL?p=preview

Select the Red Radio button option to see that when switching classes on rows the classes are not always switched properly.
