### PR TITLE
feat($q): Adds a context object to the promise chain callbacks.

### DIFF
--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -526,6 +526,96 @@ describe('q', function() {
       });
 
 
+      describe('context', function() {
+        it('should add context to resolve callback', function() {
+          var self = {};
+          var actual;
+          promise.context(self).then(function() {
+            actual = this;
+          });
+          syncResolve(deferred, 'foo');
+          expect(actual).toBe(self);
+        });
+
+
+        it('should add context to reject callback', function() {
+          var self = {};
+          var actual;
+          promise.context(self).catch(function() {
+            actual = this;
+          });
+          syncReject(deferred, 'foo');
+          expect(actual).toBe(self);
+        });
+
+
+        it('should add context to progress callback', function() {
+          var self = {};
+          var actual;
+          promise.context(self).then(null, null, function() {
+            actual = this;
+          });
+          deferred.notify();
+          syncResolve(deferred, 'foo');
+          expect(actual).toBe(self);
+        });
+
+
+        it('should add context to catch callback', function() {
+          var self = {};
+          var actual;
+          promise.context(self).catch(function() {
+            actual = this;
+          });
+          syncReject(deferred, 'foo');
+          expect(actual).toBe(self);
+        });
+
+
+        it('should add context to finally callback', function() {
+          var self = {};
+          var actual;
+          promise.context(self).finally(function() {
+            actual = this;
+          });
+          syncResolve(deferred, 'foo');
+          expect(actual).toBe(self);
+        });
+
+
+        it('should propogate the context down the chain', function() {
+          var self = {};
+          var actual;
+          promise.context(self).
+            then(function() {
+              actual = this;
+            }).
+            then(function() {
+              expect(this).toBe(actual);
+            });
+          syncResolve(deferred, 'foo');
+          expect(actual).toBe(self);
+        });
+
+
+        it('should only propogate the context down the chain', function() {
+          var self = {};
+          var actual;
+          var actualNotSelf;
+          promise.context(self).then(function() {
+            actual = this;
+          });
+          promise.then(function() {
+            actualNotSelf = this;
+          });
+          syncResolve(deferred, 'foo');
+          expect(actual).toBe(self);
+          expect(actualNotSelf).not.toBe(self);
+        });
+
+      });
+
+
       describe('then', function() {
         it('should allow registration of a success callback without an errback or progressback ' +
           'and resolve', function() {


### PR DESCRIPTION
Request Type: feature

Component(s): $q

Impact: medium

Complexity: small

**Detailed Description:**

Too many times I'm forced to write code like this:

``` javascript
return myThing.go().then(
    angular.bind(this, this.success_),
    angular.bind(this, this.error_),
    angular.bind(this, this.progress_)).
  catch(angular.bind(this, this.catch_)).
  finally(angular.bind(this, this.finally_));
```

Instead, it would be nice if a context could be added to the promise chain, resulting in:

``` javascript
return myThing.go().context(this).
  then(this.success_, this.error_, this.progress_).
  catch(this.catch_).
  finally(this.finally_);
```

Removing the context (if returning a promise as above) would just be:

``` javascript
return myThing.go().context(this).
  then(this.success_, this.error_, this.progress_).context();
```
