### PR TITLE
fix($parse): allow most latin letters as identifiers

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -210,8 +210,12 @@ Lexer.prototype = {
   },
 
   isIdent: function(ch) {
+    // Check legitimate identifiers, including extended latin letters
     return ('a' <= ch && ch <= 'z' ||
             'A' <= ch && ch <= 'Z' ||
+            'À' <= ch && ch <= 'Ö' ||
+            'Ø' <= ch && ch <= 'ö' ||
+            'ø' <= ch && ch <= 'ÿ' ||
             '_' === ch || ch === '$');
   },
 

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -182,6 +182,18 @@ describe('parser', function() {
       }).toThrowMinErr('$parse', 'lexerr', 'Lexer Error: Invalid exponent at column 4 in expression [0.5E-A].');
     });
 
+    it('should not throw exception for latin letters with grave, accute, circumflex, tilde, diaeresis, ring above, cedilla', function() {
+      expect(function() {
+        lex("ÀáÊñÖåÇ");
+      }).not.toThrow();
+    });
+
+    it('should throw exception for signs among the extended characters ', function() {
+      expect(function() {
+        lex("€¿×÷");
+      }).toThrow();
+    });
+
     it('should tokenize number starting with a dot', function() {
       var tokens = lex(".5");
       expect(tokens[0].text).toEqual(0.5);


### PR DESCRIPTION
Angular will today throw an execption if binding using an expression with extended latin letters as JSON object properties. Eg if $scope.a = {"hellö": world"}, you cannot bind to {{a.hellö}} although this is valid JSON.
This fix allows most extended latin letters by adding three ranges of latin letters in the isIdent(ch) check.
It's a compromise:
- The division and multiplication sign split above ranges and are not allowed
- Some more latin letters exist, but they are spread out and hunting them one by one might be too costly
  Two tests supporting above statements are included.

Closes #2174
