### PR TITLE
docs(guide/services): fix link to minify Wikipedia page

### DIFF
--- a/docs/content/guide/services.ngdoc
+++ b/docs/content/guide/services.ngdoc
@@ -130,7 +130,7 @@ injection of `$window`, `$scope`, and our `notify` service:
 </example>
 
 <div class="alert alert-danger">
-**Careful:** If you plan to [minify](http://en.wikipedia.org/wiki/Minification_(programming) your
+**Careful:** If you plan to [minify](http://en.wikipedia.org/wiki/Minification_(programming)) your
 code, your variable names will get renamed unless you use one of the annotation techniques above.
 </div>
 


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

Missing parenthesis is causing docs to link to a non-existent page.
