### PR TITLE
 docs(tutorial/step_12): fix missing URL for Bower

### DIFF
--- a/docs/content/tutorial/step_12.ngdoc
+++ b/docs/content/tutorial/step_12.ngdoc
@@ -523,3 +523,5 @@ There you have it!  We have created a web app in a relatively short amount of ti
 the_end closing notes} we'll cover where to go from here.
 
 <ul doc-tutorial-nav="12"></ul>
+
+[bower]: http://bower.io


### PR DESCRIPTION
Request Type: docs

How to reproduce: 
1. Go to https://docs.angularjs.org/tutorial/step_12
2. Scroll down to the Dependencies section
3. Read the second paragraph

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

A `[Bower][bower]` link is used without a URL definition so an `<a>` tag is never generated.

**Other Comments:**
