### PR TITLE
fix(ngModel): do not dirty the input if nothing was changed

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1755,8 +1755,11 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
    */
   this.$commitViewValue = function() {
     var value = ctrl.$viewValue;
-    ctrl.$$lastCommittedViewValue = value;
     $timeout.cancel(pendingDebounce);
+    if (ctrl.$$lastCommittedViewValue === value) {
+      return;
+    }
+    ctrl.$$lastCommittedViewValue = value;
 
     // change to dirty
     if (ctrl.$pristine) {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -170,7 +170,7 @@ describe('NgModelController', function() {
 
       // invalid
       ctrl.$parsers.push(function() {return undefined;});
-      ctrl.$setViewValue('val');
+      ctrl.$setViewValue('val2');
       expect(spy).toHaveBeenCalledOnce();
     });
 
@@ -641,6 +641,16 @@ describe('input', function() {
       expect(scope.name).toBeUndefined();
       browserTrigger(inputElm, 'blur');
       expect(scope.name).toEqual('a');
+    });
+
+    it('should not dirty the input if nothing was changed before updateOn trigger', function() {
+      compileInput(
+          '<input type="text" ng-model="name" name="alias" '+
+            'ng-model-options="{ updateOn: \'blur\' }"'+
+          '/>');
+
+      browserTrigger(inputElm, 'blur');
+      expect(scope.form.alias.$pristine).toBeTruthy();
     });
 
     it('should allow overriding the model update trigger event on text areas', function() {


### PR DESCRIPTION
This caused the input to become dirty every time `$commitViewValue` was called, even if no update to the view value was made. For example, `updateOn` triggers and form submit may call `$commitViewValue` without updating the view value.

Closes #7457
