### PR TITLE
feat($injector): report circularity in circular dependency error message

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -749,7 +749,8 @@ function createInjector(modulesToLoad, strictDi) {
     function getService(serviceName) {
       if (cache.hasOwnProperty(serviceName)) {
         if (cache[serviceName] === INSTANTIATING) {
-          throw $injectorMinErr('cdep', 'Circular dependency found: {0}', path.join(' <- '));
+          throw $injectorMinErr('cdep', 'Circular dependency found: {0}',
+                    serviceName + ' <- ' + path.join(' <- '));
         }
         return cache[serviceName];
       } else {

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -656,7 +656,7 @@ describe('injector', function() {
             $provide.factory('service', function(service){});
             return function(service) {};
           }]);
-        }).toThrowMinErr('$injector', 'cdep', 'Circular dependency found: service');
+        }).toThrowMinErr('$injector', 'cdep', 'Circular dependency found: service <- service');
       });
 
 
@@ -667,7 +667,7 @@ describe('injector', function() {
             $provide.factory('b', function(a){});
             return function(a) {};
           }]);
-        }).toThrowMinErr('$injector', 'cdep', 'Circular dependency found: b <- a');
+        }).toThrowMinErr('$injector', 'cdep', 'Circular dependency found: a <- b <- a');
       });
 
     });


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): di

Impact: medium

Complexity: small

This issue is related to: 

**Detailed Description:**

Change the error message for a circular dependency to display the full
circle back to the first service being instantiated, so that the problem
is obvious:

```
a <- b <- a
```

The previous message stopped one dependency short of the full
circle:

```
b <- a
```

**Other Comments:**

Changes the content of the cdep error message, which may be considered
a breaking change.
