### PR TITLE
Bug on step 12

### DIFF
--- a/docs/content/tutorial/step_12.ngdoc
+++ b/docs/content/tutorial/step_12.ngdoc
@@ -58,7 +58,7 @@ We must ask bower to download and install this dependency. We can do this by run
 ```
 npm install
 ```
-
+FIXME
 <div class="alert alert-info">
   If you have bower installed globally then you can run `bower install` but for this project we have
   preconfigured `npm install` to run bower for us.


### PR DESCRIPTION
"npm install" on this steps, puts jquery.js in app/bower_components/jquery/dist/jquery.js but index.html is looking for bower_components/jquery/jquery.js

I've added a FIXME in the doc because I couldn't submit otherwise, but I guess the index.html file need to be changed, or bower's config?
