### PR TITLE
Fix its vs it's typos.

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -795,7 +795,7 @@ angular.module('ngAnimate', ['ng'])
          * | 8. The animation ends and all generated CSS classes are removed from the element                                                     | class="my-animation"                                                                 |
          * | 9. The doneCallback() callback is fired (if provided)                                                                                | class="my-animation"                                                                 |
          *
-         * @param {DOMElement} element the element which will it's CSS classes changed
+         * @param {DOMElement} element the element which will its CSS classes changed
          *   removed from it
          * @param {string} add the CSS classes which will be added to the element
          * @param {string} remove the CSS class which will be removed from the element

--- a/src/ngScenario/Future.js
+++ b/src/ngScenario/Future.js
@@ -38,7 +38,7 @@ angular.scenario.Future.prototype.execute = function(doneFn) {
 };
 
 /**
- * Configures the future to convert it's final with a function fn(value)
+ * Configures the future to convert its final with a function fn(value)
  *
  * @param {function()} fn function(value) that returns the parsed value
  */
@@ -48,7 +48,7 @@ angular.scenario.Future.prototype.parsedWith = function(fn) {
 };
 
 /**
- * Configures the future to parse it's final value from JSON
+ * Configures the future to parse its final value from JSON
  * into objects.
  */
 angular.scenario.Future.prototype.fromJson = function() {
@@ -56,7 +56,7 @@ angular.scenario.Future.prototype.fromJson = function() {
 };
 
 /**
- * Configures the future to convert it's final value from objects
+ * Configures the future to convert its final value from objects
  * into JSON.
  */
 angular.scenario.Future.prototype.toJson = function() {

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -589,7 +589,7 @@ describe('ngView and transcludes', function() {
     });
   });
 
-  it("should compile it's content correctly (although we remove it later)", function() {
+  it("should compile its content correctly (although we remove it later)", function() {
     var testElement;
     module(function($compileProvider, $routeProvider) {
       $routeProvider.when('/view', {template: ' '});


### PR DESCRIPTION
Only use the apostrophe if you can expand "it's" to "it is" and
still have a grammatical phrase.
