### PR TITLE
fix(ngIf): use the correct scope for transclusion

### DIFF
--- a/src/ng/directive/ngIf.js
+++ b/src/ng/directive/ngIf.js
@@ -88,15 +88,15 @@ var ngIfDirective = ['$animate', function($animate) {
         $scope.$watch($attr.ngIf, function ngIfWatchAction(value) {
 
           if (toBoolean(value)) {
-            if (!childScope) {
-              childScope = $scope.$new();
-              $transclude(childScope, function (clone) {
+            if (!block) {
+              $transclude(function (clone, childScope) {
                 clone[clone.length++] = document.createComment(' end ngIf: ' + $attr.ngIf + ' ');
                 // Note: We only need the first/last node of the cloned nodes.
                 // However, we need to keep the reference to the jqlite wrapper as it might be changed later
                 // by a directive with templateUrl when it's template arrives.
                 block = {
-                  clone: clone
+                  clone: clone,
+                  scope: childScope
                 };
                 $animate.enter(clone, $element.parent(), $element);
               });
@@ -105,10 +105,6 @@ var ngIfDirective = ['$animate', function($animate) {
             if(previousElements) {
               previousElements.remove();
               previousElements = null;
-            }
-            if(childScope) {
-              childScope.$destroy();
-              childScope = null;
             }
             if(block) {
               previousElements = getBlockElements(block.clone);

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1567,6 +1567,40 @@ describe('$compile', function() {
           }));
         });
 
+        describe('transclude and children', function() {
+          beforeEach(module(function($compileProvider) {
+
+            $compileProvider.directive('myExample', valueFn({
+              scope: {},
+              link: function link(scope, element, attrs) {
+                var foo = element[0].querySelector('.foo');
+                scope.children = angular.element(foo).children().length;
+              },
+              template: '<div>' +
+                '<div>myExample {{children}}!</div>' +
+                '<div class="foo" ng-transclude></div>' +
+                '<div ng-if="children">has children</div>' +
+              '</div>',
+              transclude: true
+
+            }));
+
+          }));
+
+          it("should not pick up too many children when transcluding", inject(function($compile, $rootScope) {
+            var element = $compile('<div my-example></div>')($rootScope);
+            $rootScope.$digest();
+            expect(element.text()).toEqual('myExample 0!');
+            dealoc(element);
+
+            element = $compile('<div my-example><p></p></div>')($rootScope);
+            $rootScope.$digest();
+            expect(element.text()).toEqual('myExample 1!has children');
+            dealoc(element);
+          }));
+
+        });
+
 
 
         it("should fail if replacing and template doesn't have a single root element", function() {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -379,6 +379,11 @@ describe('ngModel', function() {
       $rootScope.inputPresent = false;
       $rootScope.$apply();
 
+      // This double apply is needed because ngAnimate destroys the ng-if element
+      // in a post-digest block which means that the update to $rootScope.myForm.$valid
+      // is done outside an apply block.
+      $rootScope.$apply();
+
       expect($rootScope.myForm.$valid).toBe(true);
       expect(isFormValid).toBe(true);
       expect($rootScope.myForm.myControl).toBeUndefined();


### PR DESCRIPTION
ngIf was creating its own scopes to use for the transclusion but these were not the correct scopes.
We should let the boundTransclusionFn deal with this for us.

Fixes the regression identified in e994259739821094e77a3d2c1f30c28713b7ab3a
