### PR TITLE
chore($rootScope): Scope.prototype.constructor property

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -145,7 +145,6 @@ function $RootScopeProvider(){
 
 
     Scope.prototype = {
-      constructor: Scope,
       /**
        * @ngdoc method
        * @name $rootScope.Scope#$new
@@ -1152,6 +1151,18 @@ function $RootScopeProvider(){
         return event;
       }
     };
+
+    if(Object.defineProperty){ // the browser supports 'defineProperty'
+      Object.defineProperty(Scope.prototype, 'constructor', {
+        writable: true,
+        configurable: true,
+        enumerable: false,
+        value: Scope
+      });
+    }
+    else{
+      Scope.prototype.constructor = Scope;
+    }
 
     var $rootScope = new Scope();
 


### PR DESCRIPTION
This PR makes `Scope.prototype.constructor` property a non-enumerable property as every default `prototype.constructor` property is. The `Object.defineProperty` function is supported by IE 9+ and other browsers, but it that function is not present on `Object` the default assignment of that property is executed, so the code will still work in IE 8-.
