### PR TITLE
fix(currencyFilter): Remove hardcoded fractionSize in currency

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -52,7 +52,7 @@ function currencyFilter($locale) {
   var formats = $locale.NUMBER_FORMATS;
   return function(amount, currencySymbol){
     if (isUndefined(currencySymbol)) currencySymbol = formats.CURRENCY_SYM;
-    return formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP, 2).
+    return formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP).
                 replace(/\u00A4/g, currencySymbol);
   };
 }
@@ -179,6 +179,9 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
 
     if (fractionSize && fractionSize !== "0") formatedText += decimalSep + fraction.substr(0, fractionSize);
   } else {
+    if (isUndefined(fractionSize)) {
+      fractionSize = pattern.minFrac;
+    }
 
     if (fractionSize > 0 && number > -1 && number < 1) {
       formatedText = number.toFixed(fractionSize);


### PR DESCRIPTION
Request Type: bug

How to reproduce: _
- In a config block, update the minFrac and maxFrac values in $locale for the currency pattern
- Run a value through the currency filter

**Expected behaviour:**

The string outputted follows the pattern rules set in $locale

**Actual behaviour:**

The minFrac and maxFrac properties are ignored

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The hardcoded fractionSize in the `currencyFilter` makes the minFrac and maxFrac options in $locale redundant.

The default minFrac and maxFrac options in $locale are functionally equivalent and removing the hardcoded value would allow the behaviour of the currencyFilter to be customisable.

**Other Comments:**

The motivation behind this change is to make i18n of currencies slightly easier.

Currencies such as the Yen typically are rendered with no decimal places, and the Dinar is usually rendered with 3 decimal places. Please refer to http://en.wikipedia.org/wiki/ISO_4217#cite_note-ReferenceA-6 for a full list of currencies and their decimal places.
