### PR TITLE
Place phoneId binding in a proper HTML node

### DIFF
--- a/docs/content/tutorial/step_07.ngdoc
+++ b/docs/content/tutorial/step_07.ngdoc
@@ -185,7 +185,7 @@ We also added a placeholder template for the phone details view:
 __`app/partials/phone-detail.html`:__
 
 ```html
-TBD: detail view for {{phoneId}}
+TBD: detail view for <span>{{phoneId}}</span>
 ```
 
 Note how we are using the `phoneId` expression which will be defined in the `PhoneDetailCtrl` controller.


### PR DESCRIPTION
The code where the phoneId binding in the phone-detail.html template is first explained in step 7 of the tutorial doesn't make it a child of a proper HTML node, which makes the end-to-end test against the view (also introduced in step 7) fail.

The test acquires the binding right from the view (by.binding('phoneId')), and apparently this operation fails when the binding is not a child of an HTML node, and therefore the entire test also fails. As soon as the binding is placed inside a <span></span> tag pair, the binding is found and the test passes. The code on github for step 7 has it right, the binding is within the span tags, but in the documentation I'm patching here the span's are missing.
