### PR TITLE
fix(ngAnimate): fix property name that is used to calculate cache key

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -1386,7 +1386,7 @@ angular.module('ngAnimate', ['ng'])
         });
 
         element.addClass(activeClassName);
-        var eventCacheKey = elementData.eventCacheKey + ' ' + activeClassName;
+        var eventCacheKey = elementData.cacheKey + ' ' + activeClassName;
         var timings = getElementAnimationDetails(element, eventCacheKey);
 
         var maxDuration = Math.max(timings.transitionDuration, timings.animationDuration);


### PR DESCRIPTION
Request Type: bug

How to reproduce: I met this issue in an huge screen so I cannot provide a use case.

Component(s): ngAnimate

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Problem occured when there was 2 ng-hide/ng-show on a page - one had animation assigned and other doesn't. If second item (without animation) is shown/hidden first - then due to this but it get incorrect cache key assigned and it was the same for second animation - so second animation was not animated because it used wrong cacheKey to extract cached timings for non-animated element.

**Other Comments:**
