### PR TITLE
docs(API): There must be an Oxford comma after "globalAPIs"

### DIFF
--- a/docs/content/api/index.ngdoc
+++ b/docs/content/api/index.ngdoc
@@ -6,7 +6,7 @@
 Welcome to the AngularJS API docs page. These pages contain the AngularJS reference materials for version <strong ng-bind="version"></strong>.
 
 The documentation is organized into **{@link guide/module modules}** which contain various components of an AngularJS application.
-These components are {@link guide/directive directives}, {@link guide/services services}, {@link guide/filter filters}, {@link guide/providers providers}, {@link guide/templates types}, global APIs and testing mocks.
+These components are {@link guide/directive directives}, {@link guide/services services}, {@link guide/filter filters}, {@link guide/providers providers}, {@link guide/templates types}, global APIs, and testing mocks.
 
 <div class="alert alert-info">
 **Angular Namespaces `$` and `$$`**


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: medium

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

Request Type: docs

Impact: medium

Complexity: small

This issue is related to: API Docs

**Detailed Description:**

Verified necessity of Oxford comma after "globalAPIs" to clarify that "global APIs and testing mocks" are two separate objects.  (Source: https://owl.english.purdue.edu/owl/resource/607/01/)

Location of insertion:
![angular](https://cloud.githubusercontent.com/assets/5858247/3073888/f9e45100-e311-11e3-9f5c-748707bd147d.jpeg)
