### PR TITLE
Karma also needs to be told about ngResource

### DIFF
--- a/docs/content/tutorial/step_11.ngdoc
+++ b/docs/content/tutorial/step_11.ngdoc
@@ -251,7 +251,19 @@ describe('PhoneCat controllers', function() {
 });
 ```
 
-You should now see the following output in the Karma tab:
+For our modified tests to work, however, Karma also has to be told to load the `angular-resource.js` file,
+so that the {@link api/ngResource ngResource} module becomes available to the testing framework.
+
+__`test/karma.conf.js`:__
+```js
+...
+      'app/bower_components/angular-route/angular-route.js',
+      'app/bower_components/angular-resource/angular-resource.js',
+      'app/bower_components/angular-mocks/angular-mocks.js',
+...
+```
+
+Once Karma has been restarted through ```npm test```, you should now see the following output in the Karma tab:
 
 <pre>Chrome 22.0: Executed 4 of 4 SUCCESS (0.038 secs / 0.01 secs)</pre>
 


### PR DESCRIPTION
In step 11 the controllers' unit tests are adapted to work with the Phone service, which uses the ngResource module. But for this to work, Karma's configuration also needs to be told to load the `angular-resource.js` file through its `karma.conf.js` configuration, and any testing runs that may be happening at the time restarted for the change to take effect.

Though the diff from step 10 to step 11 does modify the Karma configuration, https://github.com/angular/angular-phonecat/compare/step-10...step-11, the explanation says nothing about it, and the tests will all fail precisely because of a failure to load ngResource for no apparent reason until the module is explicitly made available to Karma through the steps described in this pull request.

Feel free to adapt the wording to whatever may be more appropriate, but the extra instructions added in this pull request seem to be absolutely indispensable to get all tests in the green again.

An alternative, of course, is to simply ship a `karma.conf.js` with `angular-resource.js` already loaded in an updated source package, and sidestep this whole problem that arises in step 11 from the start.
