### PR TITLE
Fixed typo and add missing semicolon

### DIFF
--- a/changelog.js
+++ b/changelog.js
@@ -172,7 +172,7 @@ var writeChangelog = function(stream, commits, version) {
   printSection(stream, 'Features', sections.feat);
   printSection(stream, 'Performance Improvements', sections.perf);
   printSection(stream, 'Breaking Changes', sections.breaks, false);
-}
+};
 
 
 var getPreviousTag = function() {

--- a/changelog.spec.js
+++ b/changelog.spec.js
@@ -13,7 +13,7 @@ describe('changelog.js', function() {
       expect(msg.hash).toBe('9b1aff905b638aa274a5fc8f88662df446d374bd');
       expect(msg.subject).toBe('broadcast $destroy event on scope destruction');
       expect(msg.body).toBe('perf testing shows that in chrome this change adds 5-15% overhead\n' +
-          'when destroying 10k nested scopes where each scope has a $destroy listener\n')
+          'when destroying 10k nested scopes where each scope has a $destroy listener\n');
       expect(msg.component).toBe('scope');
     });
 

--- a/docs/app/assets/css/docs.css
+++ b/docs/app/assets/css/docs.css
@@ -54,7 +54,7 @@ h1,h2,h3,h4,h5,h6 {
 
 .header .brand {
   padding-top: 6px;
-  padding-bottom: 0px;
+  padding-bottom: 0;
 }
 
 .header .brand img {
@@ -124,7 +124,7 @@ h1,h2,h3,h4,h5,h6 {
   font-size:1.2em;
   padding:0;
   margin:0;
-  border-bottom:1px soild #aaa;
+  border-bottom:1px solid #aaa;
   margin-bottom:5px;
 }
 
@@ -681,6 +681,6 @@ ul.events > li {
     content:", ";
   }
   #wrapper {
-    padding-bottom:0px;
+    padding-bottom:0;
   }
 }

--- a/docs/app/assets/js/angular-bootstrap/bootstrap-prettify.js
+++ b/docs/app/assets/js/angular-bootstrap/bootstrap-prettify.js
@@ -98,7 +98,7 @@ directive.ngSetText = ['getEmbeddedTemplate', function(getEmbeddedTemplate) {
       setHtmlIe8SafeWay(element, escape(getEmbeddedTemplate(attr.ngSetText)));
     }
   }
-}]
+}];
 
 
 directive.ngHtmlWrap = ['reindentCode', 'templateMerge', function(reindentCode, templateMerge) {

--- a/docs/app/assets/js/angular-bootstrap/bootstrap.js
+++ b/docs/app/assets/js/angular-bootstrap/bootstrap.js
@@ -89,7 +89,7 @@ directive.dropdownToggle =
               element.parent().removeClass('open');
               close = null;
               openElement = null;
-            }
+            };
 
             $document.on('click', close);
           }
@@ -143,7 +143,7 @@ directive.syntax = function() {
       par.insertBefore(nav, node);
     }
   }
-}
+};
 
 directive.tabbable = function() {
   return {

--- a/i18n/src/closureSlurper.js
+++ b/i18n/src/closureSlurper.js
@@ -72,7 +72,7 @@ function writeLocaleFiles() {
     var content = closureI18nExtractor.outputLocale(localeInfo, localeID);
     if (!content) return;
     var correctedLocaleId = closureI18nExtractor.correctedLocaleId(localeID);
-    var filename = NG_LOCALE_DIR + 'angular-locale_' + correctedLocaleId + '.js'
+    var filename = NG_LOCALE_DIR + 'angular-locale_' + correctedLocaleId + '.js';
     console.log('Writing ' + filename);
     return qfs.write(filename, content)
         .then(function () {

--- a/i18n/src/converter.js
+++ b/i18n/src/converter.js
@@ -17,7 +17,7 @@ function convertNumberData(dataObj, currencySymbols) {
     GROUP_SEP: dataObj.GROUP_SEP,
     PATTERNS: [parsePattern(dataObj.DECIMAL_PATTERN),
                parsePattern(dataObj.CURRENCY_PATTERN)]
-  }
+  };
 
   if (currencySymbols[dataObj.DEF_CURRENCY_CODE]) {
     numberFormats.CURRENCY_SYM = currencySymbols[dataObj.DEF_CURRENCY_CODE][1];

--- a/i18n/src/util.js
+++ b/i18n/src/util.js
@@ -4,4 +4,4 @@ exports.findLocaleId = function findLocaleId(str, type) {
   } else if (type == 'datetime') {
     return (str.match(/^DateTimeSymbols_(.+)$/) || [])[1];
   }
-}
+};

--- a/lib/promises-aplus/promises-aplus-test-adapter.js
+++ b/lib/promises-aplus/promises-aplus-test-adapter.js
@@ -1,4 +1,4 @@
-var isFunction = function isFunction(value){return typeof value == 'function';}
+var isFunction = function isFunction(value){return typeof value == 'function';};
 
 var $q = qFactory(process.nextTick, function noopExceptionHandler() {});
 

--- a/lib/versions/version-info.js
+++ b/lib/versions/version-info.js
@@ -154,7 +154,7 @@ var getCdnVersion = function() {
       }
       return cdnVersion;
     }, null);
-}
+};
 
 /**
  * Get the unstable snapshot version


### PR DESCRIPTION
Request Type: bug

Impact: small

Complexity: small

**Detailed Description:**
- `soild` to `solid`.
- `0px` to `0` in css.
- Add missed semicolon to end of line.
