### PR TITLE
Add fraction size parameter to currencyFilter

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -50,9 +50,9 @@
 currencyFilter.$inject = ['$locale'];
 function currencyFilter($locale) {
   var formats = $locale.NUMBER_FORMATS;
-  return function(amount, currencySymbol){
+  return function(amount, currencySymbol, fractionSize){
     if (isUndefined(currencySymbol)) currencySymbol = formats.CURRENCY_SYM;
-    return formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP, 2).
+    return formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP, fractionSize).
                 replace(/\u00A4/g, currencySymbol);
   };
 }


### PR DESCRIPTION
feat(filter): currencyFilter and numberFilter should have same fraction behavior

currencyFilter now accepts fractionSize so it behaves "similar" to a numberFilter, it even uses locale patterns by default.
