### PR TITLE
fix(ngView): remove reference to scope

### DIFF
--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -56,7 +56,6 @@ ngRouteModule.directive('ngView', ngViewFillContentFactory);
           <pre>$location.path() = {{main.$location.path()}}</pre>
           <pre>$route.current.templateUrl = {{main.$route.current.templateUrl}}</pre>
           <pre>$route.current.params = {{main.$route.current.params}}</pre>
-          <pre>$route.current.scope.name = {{main.$route.current.scope.name}}</pre>
           <pre>$routeParams = {{main.$routeParams}}</pre>
         </div>
       </file>


### PR DESCRIPTION
$route.name.scope.current returns undefined in the docs example,
as scope is never injected into the relevant controller.
Scope doesn't need to be there, so it's best to just remove it.

Suggested in #5076.
