### PR TITLE
feat(angular): Add 'isPromise' reference check

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -65,6 +65,7 @@
     "isScope": false,
     "isFile": false,
     "isBlob": false,
+    "isPromise": false,
     "isBoolean": false,
     "trim": false,
     "isElement": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -46,6 +46,7 @@
     -isFile,
     -isBlob,
     -isBoolean,
+    -isPromise,
     -trim,
     -isElement,
     -makeMap,
@@ -573,6 +574,22 @@ function isBoolean(value) {
   return typeof value === 'boolean';
 }
 
+/**
+ * @ngdoc function
+ * @name angular.isPromise
+ * @module ng
+ * @function
+ *
+ * @description
+ * Determines if a reference is a promise.
+ *
+ *
+ * @param {*} value Reference to check.
+ * @returns {boolean} True if `value` is a promise.
+ */
+function isPromise(value) {
+  return isObject(value) && isFunction(value['then']) && isFunction(value['catch']) && isFunction(value['finally']);
+}
 
 var trim = (function() {
   // native trim is way faster: http://jsperf.com/angular-trim-test

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -121,6 +121,7 @@ function publishExternalAPI(angular){
     'isString': isString,
     'isFunction': isFunction,
     'isObject': isObject,
+    'isPromise': isPromise,
     'isNumber': isNumber,
     'isElement': isElement,
     'isArray': isArray,

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -65,6 +65,7 @@
     "isScope": false,
     "isFile": false,
     "isBlob": false,
+    "isPromise": false,
     "isBoolean": false,
     "trim": false,
     "isElement": false,

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1170,4 +1170,21 @@ describe('angular', function() {
       expect(isElement(array)).toBe(false);
     });
   });
+
+  describe('isPromise', function () {
+    it('should return a boolean value', inject(function($q) {
+      var promise = $q.when(1),
+        notPromiseCollection = [
+          true,
+          [1,2,3],
+          { some: 'object' },
+          undefined,
+          42
+        ];
+      angular.forEach(notPromiseCollection, function(np) {
+        expect(isPromise(np)).toEqual(false);
+      });
+      expect(isPromise(promise)).toEqual(true);
+    }));
+  });
 });


### PR DESCRIPTION
Adds a check for whether an input is a promise/deferred object. 
I've found this useful when I want my functions capable of accepting either X or a promise of X.

Example usage:

``` javascript
var promise = $q.when({ some: 'object' });
angular.isPromise(promise); // => true

var notPromise = { some: 'object' };
angular.isPromise(notPromise); // => false
```
