### PR TITLE
feat(FormController): add `$rollbackViewValue` to rollback all controls

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -76,6 +76,23 @@ function FormController(element, attrs, $scope, $animate) {
 
   /**
    * @ngdoc method
+   * @name form.FormController#$rollbackViewValue
+   *
+   * @description
+   * Rollback all form controls pending updates to the `$modelValue`.
+   *
+   * Updates may be pending by a debounced event or because the input is waiting for a some future
+   * event defined in `ng-model-options`. This method is typically needed by the reset button of
+   * a form that uses `ng-model-options` to pend updates.
+   */
+  form.$rollbackViewValue = function() {
+    forEach(controls, function(control) {
+      control.$rollbackViewValue();
+    });
+  };
+
+  /**
+   * @ngdoc method
    * @name form.FormController#$commitViewValue
    *
    * @description

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -206,6 +206,42 @@ describe('form', function() {
     });
   });
 
+  describe('rollback view value', function () {
+    it('should trigger rollback on form controls', function() {
+      var form = $compile(
+          '<form name="test" ng-model-options="{ updateOn: \'\' }" >' +
+            '<input type="text" ng-model="name" />' +
+            '<button ng-click="test.$rollbackViewValue()" />' +
+          '</form>')(scope);
+      scope.$digest();
+
+      var inputElm = form.find('input').eq(0);
+      changeInputValue(inputElm, 'a');
+      expect(inputElm.val()).toBe('a');
+      browserTrigger(form.find('button'), 'click');
+      expect(inputElm.val()).toBe('');
+      dealoc(form);
+    });
+
+    it('should trigger rollback on form controls with nested forms', function() {
+      var form = $compile(
+          '<form name="test" ng-model-options="{ updateOn: \'\' }" >' +
+            '<div class="ng-form" name="child">' +
+              '<input type="text" ng-model="name" />' +
+            '</div>' +
+            '<button ng-click="test.$rollbackViewValue()" />' +
+          '</form>')(scope);
+      scope.$digest();
+
+      var inputElm = form.find('input').eq(0);
+      changeInputValue(inputElm, 'a');
+      expect(inputElm.val()).toBe('a');
+      browserTrigger(form.find('button'), 'click');
+      expect(inputElm.val()).toBe('');
+      dealoc(form);
+    });
+  });
+
   describe('preventing default submission', function() {
 
     it('should prevent form submission', function() {


### PR DESCRIPTION
Currently it is possible to use `ngModelOptions` to pend model updates until form is submitted, but in case the user wants to reset the form back to its original values he must call `$rollbackViewValue` on each input control in the form. This commit adds a `$rollbackViewValue` on the form controller in order to make this operation easier, similarly to `$commitViewValue`.
