### PR TITLE
docs($rootScope): fix incorrect docs and make them clearer

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -261,12 +261,16 @@ function $RootScopeProvider(){
            expect(scope.counter).toEqual(0);
 
            scope.$digest();
-           // no variable change
-           expect(scope.counter).toEqual(0);
+           // the listener is always called during the first $digest loop after it was registered
+           expect(scope.counter).toEqual(1);
+
+           scope.$digest();
+           // but now it will not be called unless the value changes
+           expect(scope.counter).toEqual(1);
 
            scope.name = 'adam';
            scope.$digest();
-           expect(scope.counter).toEqual(1);
+           expect(scope.counter).toEqual(2);
 
 
 
@@ -632,12 +636,16 @@ function $RootScopeProvider(){
            expect(scope.counter).toEqual(0);
 
            scope.$digest();
-           // no variable change
-           expect(scope.counter).toEqual(0);
+           // the listener is always called during the first $digest loop after it was registered
+           expect(scope.counter).toEqual(1);
+
+           scope.$digest();
+           // but now it will not be called unless the value changes
+           expect(scope.counter).toEqual(1);
 
            scope.name = 'adam';
            scope.$digest();
-           expect(scope.counter).toEqual(1);
+           expect(scope.counter).toEqual(2);
        * ```
        *
        */


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): scope

Impact: large

Complexity: small

This issue is related to: 

**Detailed Description:**

During the first digest loop after registering a $watch
the listener always run, so the example about the $digest cycles in the $rootScope docs was incorrect
(here's a plunk to prove it:
http://plnkr.co/edit/NRM4UIp9rk28VbylAtvl).
Also, we can make it clearer that if the value doesn't change,
the listener doesn't run on subsequent $digest loops.

**Other Comments:**
