### PR TITLE
Update jqLite.js documentation for css() function.

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -45,7 +45,7 @@
  * - [`children()`](http://api.jquery.com/children/) - Does not support selectors
  * - [`clone()`](http://api.jquery.com/clone/)
  * - [`contents()`](http://api.jquery.com/contents/)
- * - [`css()`](http://api.jquery.com/css/)
+ * - [`css()`](http://api.jquery.com/css/) - Getter function only retrieves inline-styles
  * - [`data()`](http://api.jquery.com/data/)
  * - [`empty()`](http://api.jquery.com/empty/)
  * - [`eq()`](http://api.jquery.com/eq/)


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): jqLite

Impact: small

Complexity: small

This issue is related to: jqLite documentation

**Detailed Description:** The jQuery css() getter functionality utilises getComputedStyle() whereas jqLite only retrieves what is declared inline on an element.

**Other Comments:**
