### PR TITLE
perf(*): Small performance changes for one-time binding interpolation

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1814,9 +1814,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           compile: valueFn(function textInterpolateLinkFn(scope, node) {
             var parent = node.parent(),
                 bindings = parent.data('$binding') || [];
-            // Need to interpolate again in case this is using one-time bindings in multiple clones
+            // Need a clone in case this is using one-time bindings in multiple clones
             // of transcluded templates.
-            interpolateFn = $interpolate(text);
+            interpolateFn = interpolateFn.clone();
             bindings.push(interpolateFn);
             safeAddClass(parent.data('$binding', bindings), 'ng-binding');
             scope.$watch(interpolateFn, function interpolateFnWatchAction(value) {

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1068,17 +1068,21 @@ function $ParseProvider() {
           if (!stable) {
             lastValue = expression(self, locals);
             oneTimeParseFn.$$unwatch = isDefined(lastValue);
-            if (oneTimeParseFn.$$unwatch && self && self.$$postDigestQueue) {
-              self.$$postDigestQueue.push(function () {
-                // create a copy if the value is defined and it is not a $sce value
-                if ((stable = isDefined(lastValue)) && !lastValue.$$unwrapTrustedValue) {
-                  lastValue = copy(lastValue);
-                }
-              });
+            if (oneTimeParseFn.$$unwatch && self && self.$$postDigestQueue && !oneTimeParseFn.$$postDigest) {
+              oneTimeParseFn.$$postDigest = true;
+              self.$$postDigestQueue.push(oneTimeParseCheckFn);
             }
           }
           return lastValue;
         }
+
+        function oneTimeParseCheckFn() {
+          // create a copy if the value is defined and it is not a $sce value
+          oneTimeParseFn.$$postDigest = false;
+          if ((stable = isDefined(lastValue)) && !lastValue.$$unwrapTrustedValue) {
+            lastValue = copy(lastValue);
+          }
+        }      
       }
     };
   }];


### PR DESCRIPTION
Add a `clone` function to the interpolate function. Use `clone` when interpolating text

Do not add multiple times the same post digest function on one-time binding

The benchmark was done using http://plnkr.co/edit/rJOqa0oh35Y0xBhTYZ6w
Without this patch, the initial digest is ~40% slower for expressions using one-time binding. With this patch, the initial digest is ~20% slower
