### PR TITLE
solved issue with the 'show' transition never working

### DIFF
--- a/docs/content/guide/animations.ngdoc
+++ b/docs/content/guide/animations.ngdoc
@@ -42,12 +42,14 @@ Below is a quick example of animations being enabled for `ngShow` and `ngHide`:
     }
 
     .sample-show-hide.ng-hide-add.ng-hide-add-active,
-    .sample-show-hide.ng-hide-remove {
+    .sample-show-hide.ng-hide-remove,
+    .sample-show-hide.ng-hide {
       opacity:0;
     }
 
     .sample-show-hide.ng-hide-add,
-    .sample-show-hide.ng-hide-remove.ng-hide-remove-active {
+    .sample-show-hide.ng-hide-remove.ng-hide-remove-active,
+    .sample-show-hide {
       opacity:1;
     }
   </file>


### PR DESCRIPTION
I kept having problems where the 'hide' fade animation worked fine but the 'show' fade animation didn't. I narrowed it down to `.ng-hide` not having `opacity: 0`. Sticking this in has fixed the 'show' fade animation for me.
