### PR TITLE
fix(angular.copy): support circular references

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -799,20 +799,26 @@ function copy(source, destination) {
 }
 
 /**
- * Create a shallow copy of an object
+ * Creates a shallow copy of an object, an array or a primitive
  */
 function shallowCopy(src, dst) {
-  dst = dst || {};
+  if (isArray(src)) {
+    dst = dst || [];
 
-  for(var key in src) {
-    // shallowCopy is only ever called by $compile nodeLinkFn, which has control over src
-    // so we don't need to worry about using our custom hasOwnProperty here
-    if (src.hasOwnProperty(key) && !(key.charAt(0) === '$' && key.charAt(1) === '$')) {
-      dst[key] = src[key];
+    for ( var i = 0; i < src.length; i++) {
+      dst[i] = src[i];
+    }
+  } else if (isObject(src)) {
+    dst = dst || {};
+
+    for (var key in src) {
+      if (hasOwnProperty.call(src, key) && !(key.charAt(0) === '$' && key.charAt(1) === '$')) {
+        dst[key] = src[key];
+      }
     }
   }
 
-  return dst;
+  return dst || src;
 }
 
 

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -78,7 +78,7 @@ function classDirective(name, selector) {
               updateClasses(oldClasses, newClasses);
             }
           }
-          oldVal = copy(newVal);
+          oldVal = shallowCopy(newVal);
         }
       }
     };

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -283,7 +283,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
         // we need to work of an array, so we need to see if anything was inserted/removed
         scope.$watch(function selectMultipleWatch() {
           if (!equals(lastView, ctrl.$viewValue)) {
-            lastView = copy(ctrl.$viewValue);
+            lastView = shallowCopy(ctrl.$viewValue);
             ctrl.$render();
           }
         });

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -111,9 +111,9 @@ function $HttpProvider() {
       common: {
         'Accept': 'application/json, text/plain, */*'
       },
-      post:   copy(CONTENT_TYPE_APPLICATION_JSON),
-      put:    copy(CONTENT_TYPE_APPLICATION_JSON),
-      patch:  copy(CONTENT_TYPE_APPLICATION_JSON)
+      post:   shallowCopy(CONTENT_TYPE_APPLICATION_JSON),
+      put:    shallowCopy(CONTENT_TYPE_APPLICATION_JSON),
+      patch:  shallowCopy(CONTENT_TYPE_APPLICATION_JSON)
     },
 
     xsrfCookieName: 'XSRF-TOKEN',
@@ -874,7 +874,7 @@ function $HttpProvider() {
           } else {
             // serving from cache
             if (isArray(cachedResp)) {
-              resolvePromise(cachedResp[1], cachedResp[0], copy(cachedResp[2]), cachedResp[3]);
+              resolvePromise(cachedResp[1], cachedResp[0], shallowCopy(cachedResp[2]), cachedResp[3]);
             } else {
               resolvePromise(cachedResp, 200, {}, 'OK');
             }

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1072,7 +1072,7 @@ function $ParseProvider() {
               self.$$postDigestQueue.push(function () {
                 // create a copy if the value is defined and it is not a $sce value
                 if ((stable = isDefined(lastValue)) && !lastValue.$$unwrapTrustedValue) {
-                  lastValue = copy(lastValue);
+                  lastValue = copy(lastValue, null);
                 }
               });
             }

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -698,7 +698,7 @@ function $RootScopeProvider(){
                                && isNaN(value) && isNaN(last)))) {
                       dirty = true;
                       lastDirtyWatch = watch;
-                      watch.last = watch.eq ? copy(value) : value;
+                      watch.last = watch.eq ? copy(value, null) : value;
                       watch.fn(value, ((last === initWatchVal) ? value : last), current);
                       if (ttl < 5) {
                         logIdx = 4 - ttl;

--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -737,7 +737,7 @@ function $SceProvider() {
         'document.  See http://docs.angularjs.org/api/ng.$sce for more information.');
     }
 
-    var sce = copy(SCE_CONTEXTS);
+    var sce = shallowCopy(SCE_CONTEXTS);
 
     /**
      * @ngdoc method

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -218,6 +218,25 @@ describe('angular', function() {
       expect(clone.hello).toBeUndefined();
       expect(clone.goodbye).toBe("world");
     });
+
+    it('should handle arrays', function() {
+      var original = [{}, 1],
+          clone = [];
+
+      var aCopy = shallowCopy(original);
+      expect(aCopy).not.toBe(original);
+      expect(aCopy).toEqual(original);
+      expect(aCopy[0]).toBe(original[0]);
+
+      expect(shallowCopy(original, clone)).toBe(clone);
+      expect(clone).toEqual(original);
+    });
+
+    it('should handle primitives', function() {
+      expect(shallowCopy('test')).toBe('test');
+      expect(shallowCopy(3)).toBe(3);
+      expect(shallowCopy(true)).toBe(true);
+    });
   });
 
   describe('elementHTML', function() {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -146,6 +146,20 @@ describe('angular', function() {
       // make sure we retain the old key
       expect(hashKey(dst)).toEqual(h);
     });
+
+    it('should handle circular references when circularRefs is turned on', function () {
+      var a = {b: {a: null}, self: null, selfs: [null, null, [null]]};
+      a.b.a = a;
+      a.self = a;
+      a.selfs = [a, a.b, [a]];
+
+      var aCopy = copy(a, null);
+      expect(aCopy).toEqual(a);
+
+      expect(aCopy).not.toBe(a);
+      expect(aCopy).toBe(aCopy.self);
+      expect(aCopy.selfs[2]).not.toBe(a.selfs[2]);
+    });
   });
 
   describe("extend", function() {


### PR DESCRIPTION
This PR is in response of #7592

I broke it into two parts:
1. Making `angular.copy` support circular references. This is useful for [the digest loop](https://github.com/angular/angular.js/blob/4eb9522f902f31a73b762ba0222cf3ad5d6c0b32/src/ng/rootScope.js#L693) and for [$parse's bind-once feature](https://github.com/angular/angular.js/blob/4eb9522f902f31a73b762ba0222cf3ad5d6c0b32/src/ng/parse.js#L1075). We're deeply copying user defined objects, which will make `.copy` hit the maximum call stack if it can't handle circular references.
2. Since `.copy` is now _heavier_, shallowCopy can take its place in many scenarios. But it needs to handle 
   arrays and primitives to do the full job (mainly for ngClass)
