### PR TITLE
fix($parse): fix parsing error with leading space and one time bind

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1024,6 +1024,8 @@ function $ParseProvider() {
       switch (typeof exp) {
         case 'string':
 
+          exp = trim(exp);
+
           if (exp.charAt(0) === ':' && exp.charAt(1) === ':') {
             oneTime = true;
             exp = exp.substring(2);

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2196,6 +2196,22 @@ describe('$compile', function() {
         })
     );
 
+    it('should one-time bind if the expression starts with a space and two colons', inject(
+            function($rootScope, $compile) {
+              $rootScope.name = 'angular';
+              element = $compile('<div name="attr: {{::name}}">text: {{ ::name }}</div>')($rootScope);
+              expect($rootScope.$$watchers.length).toBe(2);
+              $rootScope.$digest();
+              expect(element.text()).toEqual('text: angular');
+              expect(element.attr('name')).toEqual('attr: angular');
+              expect($rootScope.$$watchers.length).toBe(0);
+              $rootScope.name = 'not-angular';
+              $rootScope.$digest();
+              expect(element.text()).toEqual('text: angular');
+              expect(element.attr('name')).toEqual('attr: angular');
+            })
+        );
+
 
     it('should process attribute interpolation in pre-linking phase at priority 100', function() {
       module(function() {


### PR DESCRIPTION
Easy way to fix #7640 : add a simple trim when expression is parsed.
