### PR TITLE
Add karma config update reference to step 11 of the tutorial

### DIFF
--- a/docs/content/tutorial/step_11.ngdoc
+++ b/docs/content/tutorial/step_11.ngdoc
@@ -251,6 +251,20 @@ describe('PhoneCat controllers', function() {
 });
 ```
 
+We also need to update the Karma config file with angular-resource in order for the unit tests to work.
+__`test/karma.conf.js`:__
+
+```js
+    files : [
+      'app/bower_components/angular/angular.js',
+      'app/bower_components/angular-route/angular-route.js',
+      'app/bower_components/angular-resource/angular-resource.js',
+      'app/bower_components/angular-mocks/angular-mocks.js',
+      'app/js/**/*.js',
+      'test/unit/**/*.js'
+    ],
+```
+
 You should now see the following output in the Karma tab:
 
 <pre>Chrome 22.0: Executed 4 of 4 SUCCESS (0.038 secs / 0.01 secs)</pre>


### PR DESCRIPTION
Request Type: docs

How to reproduce: On step 11 of the tutorial if you just follow the instructions on the main page the unit tests will fail.

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

When including the ng-resource module you appear to need to add a reference to the karma config file as well or the unit tests will fail. This burned me for a while when going through the tutorial.

**Other Comments:**
