### PR TITLE
configure encoding (true/false) of uri parameters

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -470,7 +470,7 @@ angular.module('ngResource', ['ng']).
           });
 
           httpConfig.data = data;
-          var encoding = action.encoding ? action.encoding : true
+          var encoding = action.encoding || true;
           route.setUrlParams(httpConfig, extend({}, extractParams(data, action.params || {}), params), action.url, encoding);
 
           var promise = $http(httpConfig).then(function(response) {

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -470,7 +470,7 @@ angular.module('ngResource', ['ng']).
           });
 
           httpConfig.data = data;
-          var encoding = action.encoding ? action.encoding : false
+          var encoding = action.encoding ? action.encoding : true
           route.setUrlParams(httpConfig, extend({}, extractParams(data, action.params || {}), params), action.url, encoding);
 
           var promise = $http(httpConfig).then(function(response) {

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -358,9 +358,9 @@ angular.module('ngResource', ['ng']).
           if (angular.isDefined(val) && val !== null) {
             if(encoding) {
             	encodedVal = encodeUriSegment(val);
-		    } else {
-		    	encodedVal = val;
-		    }
+	    } else {
+	    	encodedVal = val;
+	    }
             url = url.replace(new RegExp(":" + urlParam + "(\\W|$)", "g"), encodedVal + "$1");
           } else {
             url = url.replace(new RegExp("(\/?):" + urlParam + "(\\W|$)", "g"), function(match,

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -470,7 +470,7 @@ angular.module('ngResource', ['ng']).
           });
 
           httpConfig.data = data;
-          var encoding = action.encoding || true;
+          var encoding = (action.encoding == null)? true : action.encoding;
           route.setUrlParams(httpConfig, extend({}, extractParams(data, action.params || {}), params), action.url, encoding);
 
           var promise = $http(httpConfig).then(function(response) {

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -338,7 +338,7 @@ angular.module('ngResource', ['ng']).
     }
 
     Route.prototype = {
-      setUrlParams: function(config, params, actionUrl) {
+      setUrlParams: function(config, params, actionUrl, encoding) {
         var self = this,
             url = actionUrl || self.template,
             val,
@@ -356,7 +356,11 @@ angular.module('ngResource', ['ng']).
         forEach(self.urlParams, function(_, urlParam){
           val = params.hasOwnProperty(urlParam) ? params[urlParam] : self.defaults[urlParam];
           if (angular.isDefined(val) && val !== null) {
-            encodedVal = encodeUriSegment(val);
+            if(encoding) {
+            	encodedVal = encodeUriSegment(val);
+		    } else {
+		    	encodedVal = val;
+		    }
             url = url.replace(new RegExp(":" + urlParam + "(\\W|$)", "g"), encodedVal + "$1");
           } else {
             url = url.replace(new RegExp("(\/?):" + urlParam + "(\\W|$)", "g"), function(match,
@@ -466,7 +470,8 @@ angular.module('ngResource', ['ng']).
           });
 
           httpConfig.data = data;
-          route.setUrlParams(httpConfig, extend({}, extractParams(data, action.params || {}), params), action.url);
+          var encoding = action.encoding ? action.encoding : false
+          route.setUrlParams(httpConfig, extend({}, extractParams(data, action.params || {}), params), action.url, encoding);
 
           var promise = $http(httpConfig).then(function(response) {
             var data = response.data,

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -130,13 +130,23 @@ describe("resource", function() {
 		});
 
     $httpBackend.expect('GET', '/Path/foo#1').respond('{}');
-    $httpBackend.expect('GET', '/Path/doh!@foo?bar=baz#1').respond('{}');
     $httpBackend.expect('GET', '/Path/http://localhost:8080').respond('{}');
 
     R.get({a: 'foo#1'});
-    R.get({a: 'doh!@foo', bar: 'baz#1'});
     R.get({a: 'http://localhost:8080'});
   });
+  
+  it('should still encode query params that are delegated to http', function() {
+    var R = $resource('/Path/:a', {}, {
+		  get : {method:'GET', params:{}, encoding:false}
+		});
+
+    $httpBackend.expect('GET', '/Path/doh!@foo?bar=baz%231').respond('{}');
+
+    R.get({a: 'doh!@foo', bar: 'baz#1'});
+  });
+  
+ 
 
   it('should not encode @ in url params', function() {
    //encodeURIComponent is too agressive and doesn't follow http://www.ietf.org/rfc/rfc3986.txt

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -123,7 +123,20 @@ describe("resource", function() {
     R.get({a: 'foo#1'});
     R.get({a: 'doh!@foo', bar: 'baz#1'});
   });
+  
+  it('should not encode url params if url encoding is disabled', function() {
+    var R = $resource('/Path/:a', {}, {
+		  get : {method:'GET', params:{}, encoding:false}
+		});
 
+    $httpBackend.expect('GET', '/Path/foo#1').respond('{}');
+    $httpBackend.expect('GET', '/Path/doh!@foo?bar=baz#1').respond('{}');
+    $httpBackend.expect('GET', '/Path/http://localhost:8080').respond('{}');
+
+    R.get({a: 'foo#1'});
+    R.get({a: 'doh!@foo', bar: 'baz#1'});
+    R.get({a: 'http://localhost:8080'});
+  });
 
   it('should not encode @ in url params', function() {
    //encodeURIComponent is too agressive and doesn't follow http://www.ietf.org/rfc/rfc3986.txt


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): ngResource

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Disbale or Enable uri parts encoding.

Examples.
first scenario is the default one and behave like angularjs resource before pull request.

return $resource('/assets/empty:uriPart', {}, {
            post: {method: 'POST', encoding: true}
        });

second scenarion is the new supported one with this pull request and disable UriParts encondig.

return $resource('/assets/empty:uriPart', {}, {
            post: {method: 'POST', encoding: false}
        });

Found this old patch from me and want to share it with you.

**Other Comments:**
