### PR TITLE
Update index.ngdoc

### DIFF
--- a/docs/content/api/index.ngdoc
+++ b/docs/content/api/index.ngdoc
@@ -6,7 +6,7 @@
 Welcome to the AngularJS API docs page. These pages contain the AngularJS reference materials for version <strong ng-bind="version"></strong>.
 
 The documentation is organized into **{@link guide/module modules}** which contain various components of an AngularJS application.
-These components are {@link guide/directive directives}, {@link guide/services services}, {@link guide/filter filters}, {@link guide/providers providers}, {@link guide/templates types}, global APIs and testing mocks.
+These components are {@link guide/directive directives}, {@link guide/services services}, {@link guide/filter filters}, {@link guide/providers providers}, {@link guide/templates templates}, global APIs and testing mocks.
 
 <div class="alert alert-info">
 **Angular Namespaces `$` and `$$`**


### PR DESCRIPTION
Link points to templates.  Modified the link label templates instead of types.
