### PR TITLE
Clarification of default transformations

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -261,7 +261,7 @@ function $HttpProvider() {
      * # Transforming Requests and Responses
      *
      * Both requests and responses can be transformed using transform functions. By default, Angular
-     * applies these transformations:
+     * applies the request and response transformations below:
      *
      * Request transformations:
      *


### PR DESCRIPTION
The trail of colons (a : followed by more :) leads to a subtle clarity error in the default transformations list. I hope that this small enhancement clears the confusion. Thanks.
