### PR TITLE
Clarify that jQuery should be loaded first

### DIFF
--- a/docs/content/tutorial/step_12.ngdoc
+++ b/docs/content/tutorial/step_12.ngdoc
@@ -105,7 +105,7 @@ __`app/index.html`.__
 
 <div class="alert alert-error">
   **Important:** Be sure to use jQuery version `1.10.x`, as AngularJS does not yet support jQuery `2.x`. Also, be sure
-  to load jQuery before all AngularJS modules, as otherwise AngularJS wont detect the presence of jQuery and animations
+  to load jQuery before all AngularJS modules, because otherwise AngularJS wont detect the presence of jQuery and animations
   wont work as expected.
 </div>
 

--- a/docs/content/tutorial/step_12.ngdoc
+++ b/docs/content/tutorial/step_12.ngdoc
@@ -104,7 +104,9 @@ __`app/index.html`.__
 ```
 
 <div class="alert alert-error">
-  **Important:** Be sure to use jQuery version `1.10.x`. AngularJS does not yet support jQuery `2.x`.
+  **Important:** Be sure to use jQuery version `1.10.x`, as AngularJS does not yet support jQuery `2.x`. Also, be sure
+  to load jQuery before all AngularJS modules, as otherwise AngularJS wont detect the presence of jQuery and animations
+  wont work as expected.
 </div>
 
 Animations can now be created within the CSS code (`animations.css`) as well as the JavaScript code (`animations.js`).

--- a/docs/content/tutorial/step_12.ngdoc
+++ b/docs/content/tutorial/step_12.ngdoc
@@ -105,8 +105,8 @@ __`app/index.html`.__
 
 <div class="alert alert-error">
   **Important:** Be sure to use jQuery version `1.10.x`, as AngularJS does not yet support jQuery `2.x`. Also, be sure
-  to load jQuery before all AngularJS modules, because otherwise AngularJS wont detect the presence of jQuery and animations
-  wont work as expected.
+  to load jQuery before all AngularJS modules, because otherwise AngularJS won't detect the presence of jQuery and animations
+  will not work as expected.
 </div>
 
 Animations can now be created within the CSS code (`animations.css`) as well as the JavaScript code (`animations.js`).


### PR DESCRIPTION
jQuery needs to be loaded before _all_ AngularJS modules in the app, 'cause otherwise AngularJS will not detect the presence of jQuery and animations (and I'm sure also other things) will not work as expected.

This requirement is implied in the tutorial, but not made absolutely clear to those who, like me, like to write their own code as the walk through the tutorial, and therefore might make the mistake of loading jQuery after Angular.
