### PR TITLE
Update index.ngdoc

### DIFF
--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -125,6 +125,11 @@ Once you have Node.js installed on your machine you can download the tool depend
 npm install
 ```
 
+<div class="alert alert-info">In Debian based distributions, before run this command, is needed 
+install the package nodejs-legacy `apt-get install nodejs-legacy`
+</div>
+
+
 This command will download the following tools, into the `node_modules` directory:
 
 - [Bower][bower] - client-side code package manager


### PR DESCRIPTION
nodejs-legacy extra package is needed in Debian, for compatibility.

In http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=614907#108 you will find this comments:
1. The nodejs package shall be changed to provide /usr/bin/nodejs, not /usr/bin/node. The package should declare a Breaks: relationship with any packages in Debian that reference /usr/bin/node.
2. The nodejs source package shall also provide a nodejs-legacy binary package at Priority: extra that contains /usr/bin/node as a symlink to /usr/bin/nodejs. No package in the archive may depend on or recommend the nodejs-legacy package, which is provided solely for upstream
   compatibility. This package declares shall also declare a Conflicts: relationship with the node package.
