### PR TITLE
fix(apis.js): Make $$hashKey property non-enumerable if possible.

### DIFF
--- a/src/apis.js
+++ b/src/apis.js
@@ -22,7 +22,18 @@ function hashKey(obj) {
       // must invoke on object to keep the right this
       key = obj.$$hashKey();
     } else if (key === undefined) {
-      key = obj.$$hashKey = nextUid();
+      key = nextUid();
+      // create a non-enumerable $$hashKey property if possible.
+      if (typeof Object.defineProperty == 'function') {
+        Object.defineProperty(obj, '$$hashKey', {
+          value: key,
+          enumerable: false,
+          configurable: true,
+          writable: true
+        });
+      } else {
+        obj.$$hashKey = key;
+      }
     }
   } else {
     key = obj;


### PR DESCRIPTION
Makes the annoying $$hashKey property non-enumerable for browsers which support Object.defineProperty.

The defined property is configurable (may be deleted) and writable (can be assigned to) for backward compatibility.
