### PR TITLE
docs(error/$compile): add note that html comments can cause Invalid Template Root error

### DIFF
--- a/docs/content/error/$compile/tplrt.ngdoc
+++ b/docs/content/error/$compile/tplrt.ngdoc
@@ -37,3 +37,17 @@ elements. For example:
 ```
 <b>Hello</b> World!
 ```
+
+Watch out for html comments at the beginning or end of templates, as these can cause this error as
+well.  Consider the following template:
+
+```
+<div class='container'>
+  <div class='wrapper>
+     ...
+  </div> <!-- wrapper -->
+</div> <!-- container -->
+```
+
+The `<!-- container -->` comment is interpreted as a second root element and causes the template to
+be invalid.


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): $compile

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Users with comments in their templates can overlook the fact that these may be the cause of an Invalid Template Root error.  This note helps them identify when html comments are the cause of this error.

**Other Comments:**
