### PR TITLE
fix($http): reject $http promise when timeout occurs

### DIFF
--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -164,7 +164,7 @@ describe('$httpBackend', function() {
 
   it('should not try to read response data when request is aborted', function() {
     callback.andCallFake(function(status, response, headers) {
-      expect(status).toBe(-1);
+      expect(status).toBe(-2);
       expect(response).toBe(null);
       expect(headers).toBe(null);
     });
@@ -183,7 +183,7 @@ describe('$httpBackend', function() {
 
   it('should abort request on timeout', function() {
     callback.andCallFake(function(status, response) {
-      expect(status).toBe(-1);
+      expect(status).toBe(-2);
     });
 
     $backend('GET', '/url', null, callback, {}, 2000);
@@ -204,7 +204,7 @@ describe('$httpBackend', function() {
 
   it('should abort request on timeout promise resolution', inject(function($timeout) {
     callback.andCallFake(function(status, response) {
-      expect(status).toBe(-1);
+      expect(status).toBe(-2);
     });
 
     $backend('GET', '/url', null, callback, {}, $timeout(noop, 2000));

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1308,6 +1308,20 @@ describe('$http', function() {
         $httpBackend.verifyNoOutstandingExpectation();
         $httpBackend.verifyNoOutstandingRequest();
       }));
+
+
+      it('should reject promise when timeout promise resolves', inject(function($timeout) {
+        var onFulfilled = jasmine.createSpy('onFulfilled');
+        var onRejected = jasmine.createSpy('onRejected');
+        $httpBackend.expect('GET', '/some').respond(200);
+
+        $http({method: 'GET', url: '/some', timeout: $timeout(noop, 10)}).then(onFulfilled, onRejected);
+
+        $timeout.flush(100);
+
+        expect(onFulfilled).not.toHaveBeenCalled();
+        expect(onRejected).toHaveBeenCalledOnce();
+      }));
     });
 
 


### PR DESCRIPTION
Previously, timed out $http requests would result in a fulfilled promise, rather than a rejection. This CL corrects this unexpected behaviour.

BREAKING CHANGE:

Currently, request timeout is treated as a successful request. This is unexpected, as a timeout is generally a failure, however it's possible some applications depend on this behaviour.

If your application depends on this, it's possible to migrate by simply moving the code which handles a timeout into a rejection/error handler, rather than a success handler.

Example:

``` js
$http.get('/some/slow/resource', {
  timeout: 1
}).
  error(function(res) {
    if (res.statusText === "Timedout") {
      console.log("request timed out!");
    }
  });
```

Fixes #7686
