### PR TITLE
feat($http): add overrideMimeType passthrough

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -484,7 +484,10 @@ function $HttpProvider() {
      *      XHR object. See [requests with credentials]https://developer.mozilla.org/en/http_access_control#section_5
      *      for more information.
      *    - **responseType** - `{string}` - see
-     *      [requestType](https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest#responseType).
+     *      [requestType](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#responseType).
+     *    - **overrideMimeType** - `{string}` - force the response to be treated as the given MIME
+     *      type by calling [overrideMimeType()](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#overrideMimeType%28%29)
+     *      on the XHR object.
      *
      * @returns {HttpPromise} Returns a {@link ng.$q promise} object with the
      *   standard `then` method and two http specific methods: `success` and `error`. The `then`
@@ -625,6 +628,10 @@ function $HttpProvider() {
 
         if (isUndefined(config.withCredentials) && !isUndefined(defaults.withCredentials)) {
           config.withCredentials = defaults.withCredentials;
+        }
+
+        if (isUndefined(config.overrideMimeType) && !isUndefined(defaults.overrideMimeType)) {
+          config.overrideMimeType = defaults.overrideMimeType;
         }
 
         // send request
@@ -888,7 +895,7 @@ function $HttpProvider() {
       // if we won't have the response in cache, send the request to the backend
       if (isUndefined(cachedResp)) {
         $httpBackend(config.method, url, reqData, done, reqHeaders, config.timeout,
-            config.withCredentials, config.responseType);
+            config.withCredentials, config.responseType, config.overrideMimeType);
       }
 
       return promise;

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -40,7 +40,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
   var ABORTED = -1;
 
   // TODO(vojta): fix the signature
-  return function(method, url, post, callback, headers, timeout, withCredentials, responseType) {
+  return function(method, url, post, callback, headers, timeout, withCredentials, responseType, overrideMimeType) {
     var status;
     $browser.$$incOutstandingRequestCount();
     url = url || $browser.url();
@@ -118,6 +118,10 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
             throw e;
           }
         }
+      }
+
+      if (overrideMimeType) {
+        xhr.overrideMimeType(overrideMimeType);
       }
 
       xhr.send(post || null);

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1625,6 +1625,10 @@ function MockXhr() {
   };
 
   this.abort = angular.noop;
+
+  this.overrideMimeType = function(type) {
+    this.$$overrideMimeType = type;
+  };
 }
 
 

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -294,6 +294,12 @@ describe('$httpBackend', function() {
   });
 
 
+  it('should call overrideMimeType', function() {
+    $backend('GET', '/some.url', null, callback, {}, null, null, null, 'text/plain;charset=x-user-defined');
+    expect(MockXhr.$$lastInstance.$$overrideMimeType).toBe('text/plain;charset=x-user-defined');
+  });
+
+
   describe('responseType', function() {
 
     it('should set responseType and return xhr.response', function() {

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1383,13 +1383,14 @@ describe('$http', function() {
   });
 
 
-  it('should pass timeout, withCredentials and responseType', function() {
+  it('should pass timeout, withCredentials, responseType, and overrideMimeType', function() {
     var $httpBackend = jasmine.createSpy('$httpBackend');
 
-    $httpBackend.andCallFake(function(m, u, d, c, h, timeout, withCredentials, responseType) {
+    $httpBackend.andCallFake(function(m, u, d, c, h, timeout, withCredentials, responseType, overrideMimeType) {
       expect(timeout).toBe(12345);
       expect(withCredentials).toBe(true);
       expect(responseType).toBe('json');
+      expect(overrideMimeType).toBe('text/plain;charset=x-user-defined');
     });
 
     module(function($provide) {
@@ -1402,7 +1403,8 @@ describe('$http', function() {
         url: 'some.html',
         timeout: 12345,
         withCredentials: true,
-        responseType: 'json'
+        responseType: 'json',
+        overrideMimeType: 'text/plain;charset=x-user-defined',
       });
       $rootScope.$digest();
       expect($httpBackend).toHaveBeenCalledOnce();
@@ -1412,11 +1414,12 @@ describe('$http', function() {
   });
 
 
-  it('should use withCredentials from default', function() {
+  it('should use withCredentials and overrideMimeType from default', function() {
     var $httpBackend = jasmine.createSpy('$httpBackend');
 
-    $httpBackend.andCallFake(function(m, u, d, c, h, timeout, withCredentials, responseType) {
+    $httpBackend.andCallFake(function(m, u, d, c, h, timeout, withCredentials, responseType, overrideMimeType) {
       expect(withCredentials).toBe(true);
+      expect(overrideMimeType).toBe('text/plain;charset=x-user-defined');
     });
 
     module(function($provide) {
@@ -1425,6 +1428,7 @@ describe('$http', function() {
 
     inject(function($http, $rootScope) {
       $http.defaults.withCredentials = true;
+      $http.defaults.overrideMimeType = 'text/plain;charset=x-user-defined';
       $http({
         method: 'GET',
         url: 'some.html',


### PR DESCRIPTION
Call xhr.overrideMimeType() by defining config.overrideMimeType or $http.defaults.overrideMimeType

Closes #7669
