### PR TITLE
Update JSDoc for ngAnimate.enabled to show optional value

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -831,7 +831,7 @@ angular.module('ngAnimate', ['ng'])
          * @kind function
          *
          * @param {boolean=} value If provided then set the animation on or off.
-         * @param {DOMElement} element If provided then the element will be used to represent the enable/disable operation
+         * @param {DOMElement=} element If provided then the element will be used to represent the enable/disable operation
          * @return {boolean} Current animation state.
          *
          * @description


### PR DESCRIPTION
The docs show that param 'element' (of type DOMElement) is required when it is optional.
