### PR TITLE
chore(jqLite): remove special characters from the expando property

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -99,7 +99,7 @@
  */
 
 var jqCache = JQLite.cache = {},
-    jqName = JQLite.expando = 'ng-' + new Date().getTime(),
+    jqName = JQLite.expando = 'ng' + new Date().getTime(),
     jqId = 1,
     addEventListenerFn = (window.document.addEventListener
       ? function(element, type, fn) {element.addEventListener(type, fn, false);}


### PR DESCRIPTION
Having special characters in the expando property created a memory bloat.
See https://code.google.com/p/chromium/issues/detail?id=378607#c6 to reproduce
