### PR TITLE
add failing tests

### DIFF
--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -91,6 +91,37 @@ describe("resource", function() {
   });
 
 
+  it('should send the PUT  verb on instance with parameter alias', function() {
+    $httpBackend.expect('PUT', '/resource/123')
+      .respond({success: 'ok'});
+
+    var Resource = $resource('/resource/:id', {id:'@id'}, {
+      put: { method: 'PUT' }
+    });
+    var resource = new Resource({id: 123});
+    resource.$put().then(callback);
+  });
+
+  it('should send a verb on instance without parameter alias', function() {
+    $httpBackend.expect('PUT', '/resource/123')
+      .respond({success: 'ok'});
+
+    var Resource = $resource('/resource/:id', {}, {
+      put: { method: 'PUT' }
+    });
+    var resource = new Resource({id: 123});
+    resource.$put().then(callback);
+  });
+
+  it('should send the DELETE verb on instance', function() {
+    $httpBackend.expect('DELETE', '/resource/123', {id:'@id'})
+      .respond({success: 'ok'});
+
+    var Resource = $resource('/resource/:id');
+    var resource = new Resource({id: 123});
+    resource.$delete().then(callback);
+  });
+
   it("should build resource", function() {
     expect(typeof CreditCard).toBe('function');
     expect(typeof CreditCard.get).toBe('function');


### PR DESCRIPTION
Request Type: test

How to reproduce: 

Component(s): ngResource

Impact: medium

Complexity: medium

This issue is related to: 

**Detailed Description:**

Hello, this is not a pull request for merging, but just in order to show a supposed bug with some test cases. Maybe i am just doing something wrong and this is not a bug.

Here i add three tests, two of them fail, the following ones:

```
should send a verb on instance without parameter alias
should send the DELETE verb on instance
```

In these cases the request is sent to the whole `/resource/` instead that to `/resource/123` as desired.

The most annoying is the one about the delete action. The `DELETE` request is sent to the whole resource endpoint. With some server side APIs, for example python Eve, this will empty the whole collection. I wasn't able to get clues from the source code about the reason of the problem. I think that i don't have to sign the agreement since this is not meant to be merged, right?

Cheers

**Other Comments:**

The two tests fail also on the `v1.2.16` branch
