### PR TITLE
Typo in $http config documentation

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -480,7 +480,7 @@ function $HttpProvider() {
      *      caching.
      *    - **timeout** – `{number|Promise}` – timeout in milliseconds, or {@link ng.$q promise}
      *      that should abort the request when resolved.
-     *    - **withCredentials** - `{boolean}` - whether to to set the `withCredentials` flag on the
+     *    - **withCredentials** - `{boolean}` - whether to set the `withCredentials` flag on the
      *      XHR object. See [requests with credentials]https://developer.mozilla.org/en/http_access_control#section_5
      *      for more information.
      *    - **responseType** - `{string}` - see


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): $http

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Typo in the doc (double "to")

**Other Comments:**
