### PR TITLE
Update filters.js documentation

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -26,12 +26,16 @@
          <input type="number" ng-model="amount"> <br>
          default currency symbol ($): <span id="currency-default">{{amount | currency}}</span><br>
          custom currency identifier (USD$): <span>{{amount | currency:"USD$"}}</span>
+         custom currency identifier (Euro): <span>{{amount | currency:"&euro;"}}</span>
+         custom currency identifier (Rupee): <span>{{amount | currency:"&#8377;"}}</span>
        </div>
      </file>
      <file name="protractor.js" type="protractor">
        it('should init with 1234.56', function() {
          expect(element(by.id('currency-default')).getText()).toBe('$1,234.56');
          expect(element(by.binding('amount | currency:"USD$"')).getText()).toBe('USD$1,234.56');
+         expect(element(by.binding('amount | currency:"&euro;")).getText()).toBe('€1,234.56');
+         expect(element(by.binding('amount | currency:"&#8377;")).getText()).toBe('₹1,234.56');)
        });
        it('should update', function() {
          if (browser.params.browser == 'safari') {
@@ -43,6 +47,8 @@
          element(by.model('amount')).sendKeys('-1234');
          expect(element(by.id('currency-default')).getText()).toBe('($1,234.00)');
          expect(element(by.binding('amount | currency:"USD$"')).getText()).toBe('(USD$1,234.00)');
+         expect(element(by.binding('amount | currency:"&euro;")).getText()).toBe('€1,234.56');
+         expect(element(by.binding('amount | currency:"&#8377;")).getText()).toBe('₹1,234.56');)
        });
      </file>
    </example>


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

Added documentation for the use of the 'currency' filter (added examples and tests for Euro and Rupee). Tests have not been tested.

**Other Comments:**

Added examples for currency (Euro and Rupee). Please confirm that the Rupee and the Euro sign in the tests will work as expected.
