### PR TITLE
fix($compile): fix ng-attr vs normal attribute ordering

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1027,7 +1027,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               directiveNormalize(nodeName_(node).toLowerCase()), 'E', maxPriority, ignoreDirective);
 
           // iterate over the attributes
-          for (var attr, name, nName, ngAttrName, value, nAttrs = node.attributes,
+          for (var attr, name, nName, ngAttrName, value, isNgAttr, nAttrs = node.attributes,
                    j = 0, jj = nAttrs && nAttrs.length; j < jj; j++) {
             var attrStartName = false;
             var attrEndName = false;
@@ -1035,9 +1035,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             attr = nAttrs[j];
             if (!msie || msie >= 8 || attr.specified) {
               name = attr.name;
+              value = trim(attr.value);
+
               // support ngAttr attribute binding
               ngAttrName = directiveNormalize(name);
-              if (NG_ATTR_BINDING.test(ngAttrName)) {
+              if (isNgAttr = NG_ATTR_BINDING.test(ngAttrName)) {
                 name = snake_case(ngAttrName.substr(6), '-');
               }
 
@@ -1050,9 +1052,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
               nName = directiveNormalize(name.toLowerCase());
               attrsMap[nName] = name;
-              attrs[nName] = value = trim(attr.value);
-              if (getBooleanAttrName(node, nName)) {
-                attrs[nName] = true; // presence means true
+              if (isNgAttr || !attrs.hasOwnProperty(nName)) {
+                  attrs[nName] = value;
+                  if (getBooleanAttrName(node, nName)) {
+                    attrs[nName] = true; // presence means true
+                  }
               }
               addAttrInterpolateDirective(node, directives, value, nName);
               addDirective(directives, nName, 'A', maxPriority, ignoreDirective, attrStartName,

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -5117,6 +5117,26 @@ describe('$compile', function() {
       expect(element.attr('test')).toBe('Misko');
     }));
 
+    it('should override the attr on digest', function() {
+      var attrOnLink = '';
+      module(function($compileProvider) {
+        $compileProvider.directive('test', valueFn({
+          restrict: 'E',
+          link: function(s, e, attrs) {
+            attrOnLink += attrs.foo;
+          }
+        }));
+      });
+
+      inject(function($compile, $rootScope) {
+        $rootScope.value = 42;
+        element = $compile('<test ng-attr-foo="{{value}}" foo="Answer?"></test>')($rootScope);
+        expect(element.attr('foo')).toBe('Answer?');
+        expect(attrOnLink).toBe('42');
+        $rootScope.$digest();
+        expect(element.attr('foo')).toBe('42');
+      });
+    });
 
     it('should work with different prefixes', inject(function($compile, $rootScope) {
       $rootScope.name = "Misko";


### PR DESCRIPTION
This ensures ng-attr always overrides normal attributes of the same name.

Fixes: #7051
