### PR TITLE
fix(ngResource): don't convert literal values into Resource objects when isArray is true

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -580,7 +580,14 @@ angular.module('ngResource', ['ng']).
                 if (action.isArray) {
                   value.length = 0;
                   forEach(data, function (item) {
-                    value.push(new Resource(item));
+                    if (typeof item === "object") {
+                      value.push(new Resource(item));
+                    } else {
+                      // Valid JSON values may be string literals, and these should not be converted
+                      // into objects. These items will not have access to the Resource prototype
+                      // methods, but unfortunately there
+                      value.push(item);
+                    }
                   });
                 } else {
                   shallowClearAndCopy(data, value);

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1113,6 +1113,27 @@ describe("resource", function() {
         $httpBackend.flush();
         expect(user).toEqualData([ {id: 1, name: 'user1'} ]);
       });
+
+      it('should not convert string literals in array into Resource objects', function() {
+        $httpBackend.expect('GET', '/names.json').respond(["mary", "jane"]);
+        var strings = $resource('/names.json').query();
+        $httpBackend.flush();
+        expect(strings).toEqualData(["mary", "jane"]);
+      });
+
+      it('should not convert number literals in array into Resource objects', function() {
+        $httpBackend.expect('GET', '/names.json').respond([213, 456]);
+        var numbers = $resource('/names.json').query();
+        $httpBackend.flush();
+        expect(numbers).toEqualData([213, 456]);
+      });
+
+      it('should not convert boolean literals in array into Resource objects', function() {
+        $httpBackend.expect('GET', '/names.json').respond([true, false]);
+        var bools = $resource('/names.json').query();
+        $httpBackend.flush();
+        expect(bools).toEqualData([true, false]);
+      });
     });
 
     describe('get', function(){


### PR DESCRIPTION
Previously non-object literals would be thrown out of Resource responses with isArray===true, or otherwise converted into Objects (in the case of string literals). The reason for this is because shallowClearAndCopy iterates over keys, and copies keys into the destination. Iterating over String keys results in integer keys, with a single-character value.

Not converting non-objects to Resources means that you lose the ability to perform Resource operations on them. However, they become usable as strings, numbers, or booleans, which is important.

In the future, it would be useful to make these useful as Resources while still retaining their primitive value usefulness. (@rodyhaddad can you think of a way to do this? You're the master of ES5 valueOf, as far as I know :P)

Closes #6314
