### PR TITLE
Update step_05.ngdoc

### DIFF
--- a/docs/content/tutorial/step_05.ngdoc
+++ b/docs/content/tutorial/step_05.ngdoc
@@ -172,17 +172,14 @@ methods on a service called $httpBackend:
 describe('PhoneCat controllers', function() {
 
   describe('PhoneListCtrl', function(){
-    var scope, ctrl, $httpBackend;
+    var scope, ctrl, $http;
 
     // Load our app module definition before each test.
     beforeEach(module('phonecatApp'));
 
-    // The injector ignores leading and trailing underscores here (i.e. _$httpBackend_).
-    // This allows us to inject a service but then attach it to a variable
-    // with the same name as the service in order to avoid a name conflict.
-    beforeEach(inject(function(_$httpBackend_, $rootScope, $controller) {
-      $httpBackend = _$httpBackend_;
-      $httpBackend.expectGET('phones/phones.json').
+    beforeEach(inject(function($httpBackend, $rootScope, $controller) {
+      $http = $httpBackend;
+      $http.expectGET('phones/phones.json').
           respond([{name: 'Nexus S'}, {name: 'Motorola DROID'}]);
 
       scope = $rootScope.$new();


### PR DESCRIPTION
`_$httpBackend_` is a cryptic way to name variables. Because of this, even you had to write a comment about this why did you use it that way! This is crazy.

So, just making `_$httpBackend_` as `$httpBackend`, and the local var `$httpBackend` to `$http` we can easily smooth this complexity.

Elegancy is the key.
