### PR TITLE
refactor($http): move checking of the xsrf tokens to after cache check in $http

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -602,14 +602,6 @@ function $HttpProvider() {
       config.headers = headers;
       config.method = uppercase(config.method);
 
-      var xsrfValue = urlIsSameOrigin(config.url)
-          ? $browser.cookies()[config.xsrfCookieName || defaults.xsrfCookieName]
-          : undefined;
-      if (xsrfValue) {
-        headers[(config.xsrfHeaderName || defaults.xsrfHeaderName)] = xsrfValue;
-      }
-
-
       var serverRequest = function(config) {
         headers = config.headers;
         var reqData = transformData(config.data, headersGetter(headers), config.transformRequest);
@@ -883,6 +875,13 @@ function $HttpProvider() {
           // put the promise for the non-transformed response into cache as a placeholder
           cache.put(url, promise);
         }
+      }
+
+      var xsrfValue = urlIsSameOrigin(config.url)
+          ? $browser.cookies()[config.xsrfCookieName || defaults.xsrfCookieName]
+          : undefined;
+      if (xsrfValue) {
+        reqHeaders[(config.xsrfHeaderName || defaults.xsrfHeaderName)] = xsrfValue;
       }
 
       // if we won't have the response in cache, send the request to the backend

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -878,7 +878,7 @@ function $HttpProvider() {
       }
 
 
-      // if we won't have the response in cache, set the xsrf headers and 
+      // if we won't have the response in cache, set the xsrf headers and
       // send the request to the backend
       if (isUndefined(cachedResp)) {
         var xsrfValue = urlIsSameOrigin(config.url)

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -877,15 +877,17 @@ function $HttpProvider() {
         }
       }
 
-      var xsrfValue = urlIsSameOrigin(config.url)
-          ? $browser.cookies()[config.xsrfCookieName || defaults.xsrfCookieName]
-          : undefined;
-      if (xsrfValue) {
-        reqHeaders[(config.xsrfHeaderName || defaults.xsrfHeaderName)] = xsrfValue;
-      }
 
-      // if we won't have the response in cache, send the request to the backend
+      // if we won't have the response in cache, set the xsrf headers and 
+      // send the request to the backend
       if (isUndefined(cachedResp)) {
+        var xsrfValue = urlIsSameOrigin(config.url)
+            ? $browser.cookies()[config.xsrfCookieName || defaults.xsrfCookieName]
+            : undefined;
+        if (xsrfValue) {
+          reqHeaders[(config.xsrfHeaderName || defaults.xsrfHeaderName)] = xsrfValue;
+        }
+
         $httpBackend(config.method, url, reqData, done, reqHeaders, config.timeout,
             config.withCredentials, config.responseType);
       }

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -747,27 +747,27 @@ describe('$http', function() {
 
       it('should check the cache before setting the XSRF cookie', inject(function() {
         var testCache = $cacheFactory('testCache'),
-            self = {executionOrder: []};
+            execData = {executionOrder: []};
 
-        $browser.cookies = (function (cookiesFn, self) {
+        $browser.cookies = (function (cookiesFn, execData) {
           return function () {
-            self.executionOrder.push('cookies');
+            execData.executionOrder.push('cookies');
             return cookiesFn.apply(this, arguments);
           };
-        })($browser.cookies, self);
+        })($browser.cookies, execData);
 
-        testCache.get = (function (cacheGet, self) {
+        testCache.get = (function (cacheGet, execData) {
           return function () {
-            self.executionOrder.push('cache');
+            execData.executionOrder.push('cache');
             return cacheGet.apply(this, arguments);
           };
-        })(testCache.get, self);
+        })(testCache.get, execData);
 
         $httpBackend.expect('GET', '/url', undefined).respond('');
         $http({url: '/url', method: 'GET', cache: testCache});
         $httpBackend.flush();
 
-        expect(self.executionOrder).toEqual(['cache', 'cookies']);
+        expect(execData.executionOrder).toEqual(['cache', 'cookies']);
 
       }));
     });

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -280,7 +280,7 @@ describe('$http', function() {
       spyOn($rootScope, '$apply').andCallThrough();
     }]));
 
-    beforeEach(inject(['$httpBackend', '$http', '$cacheFactory', '$browser', 
+    beforeEach(inject(['$httpBackend', '$http', '$cacheFactory', '$browser',
           function($hb, $h, $cf, $br) {
       $httpBackend = $hb;
       $http = $h;
@@ -756,7 +756,7 @@ describe('$http', function() {
           };
         })($browser.cookies, self);
 
-        testCache.get = (function (cacheGet, self) { 
+        testCache.get = (function (cacheGet, self) {
           return function () {
             self.executionOrder.push('cache');
             return cacheGet.apply(this, arguments);

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -763,7 +763,6 @@ describe('$http', function() {
           };
         })(testCache.get, self);
 
-        
         $httpBackend.expect('GET', '/url', undefined).respond('');
         $http({url: '/url', method: 'GET', cache: testCache});
         $httpBackend.flush();


### PR DESCRIPTION
The pull request moves a place in the code where xsrf tokens are set to after the cache is checked, this way hopefully improving performance.

This is referenced in issue #7717.
