### PR TITLE
fix($parse): treat empty expressions as constant

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -381,6 +381,7 @@ Parser.prototype = {
     this.text = text;
     this.tokens = this.lexer.lex(text);
 
+    var origTokenLength = this.tokens.length;
     var value = this.statements();
 
     if (this.tokens.length !== 0) {
@@ -388,7 +389,7 @@ Parser.prototype = {
     }
 
     value.literal = !!value.literal;
-    value.constant = !!value.constant;
+    value.constant = origTokenLength === 0 || !!value.constant;
 
     return value;
   },

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1105,6 +1105,13 @@ describe('parser', function() {
           expect($parse('foo(1, 2, 3)').constant).toBe(false);
           expect($parse('"name" + id').constant).toBe(false);
         }));
+
+        it('should treat non-expressions as constant', inject(function($parse) {
+          expect($parse('').constant).toBe(true);
+          expect($parse('   ').constant).toBe(true);
+          expect($parse('::').constant).toBe(true);
+          expect($parse('::    ').constant).toBe(true);
+        }));
       });
 
       describe('null/undefined in expressions', function() {


### PR DESCRIPTION
Previously, empty expressions would not be treated as constant, and if they
were watched, $scope would not unwatch them automatically after their initial
work. This change ensures that empty expressions are properly treated as
constant.
