### PR TITLE
fix($parse): mark empty expressions as constants and literals

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -989,7 +989,7 @@ function getterFn(path, options, fullExp) {
  *  service.
  */
 function $ParseProvider() {
-  var cache = {};
+  var cache = {'': extend(function () {}, {literal: true, constant: true})};
 
   var $parseOptions = {
     csp: false

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1039,6 +1039,13 @@ describe('parser', function() {
       });
 
       describe('literal', function() {
+        it('should mark an empty expressions as literal', inject(function($parse) {
+          expect($parse('').literal).toBe(true);
+          expect($parse('   ').literal).toBe(true);
+          expect($parse('::').literal).toBe(true);
+          expect($parse('::    ').literal).toBe(true);
+        }));
+
         it('should mark scalar value expressions as literal', inject(function($parse) {
           expect($parse('0').literal).toBe(true);
           expect($parse('"hello"').literal).toBe(true);
@@ -1068,6 +1075,13 @@ describe('parser', function() {
       });
 
       describe('constant', function() {
+        it('should mark an empty expressions as constant', inject(function($parse) {
+          expect($parse('').constant).toBe(true);
+          expect($parse('   ').constant).toBe(true);
+          expect($parse('::').constant).toBe(true);
+          expect($parse('::    ').constant).toBe(true);
+        }));
+
         it('should mark scalar value expressions as constant', inject(function($parse) {
           expect($parse('12.3').constant).toBe(true);
           expect($parse('"string"').constant).toBe(true);


### PR DESCRIPTION
In response of [#1405 (comment)](https://github.com/angular/angular.js/issues/1405#issuecomment-45525863)

I decided to mark it as a literal because `$parse('undefined')` is a literal.
