### PR TITLE
docs(tutorial/step_09): note about 'Filter' suffix

### DIFF
--- a/docs/content/tutorial/step_09.ngdoc
+++ b/docs/content/tutorial/step_09.ngdoc
@@ -109,6 +109,9 @@ for this test run.
 Note that we call the helper function, `inject(function(checkmarkFilter) { ... })`, to get
 access to the filter that we want to test.  See {@link angular.mock.inject angular.mock.inject()}.
 
+Notice that the suffix 'Filter' is appended to your filter name when injected.
+See the {@link Filters Filter Guide} - 'Using filters in controllers and services' section where this is outlined.
+
 You should now see the following output in the Karma tab:
 
 <pre>Chrome 22.0: Executed 4 of 4 SUCCESS (0.034 secs / 0.012 secs)</pre>


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The tutorial left out the fact that 'Filter' was appended to filter names when injected into unit tests. Will save some people time to remind them here in this step.

**Other Comments:**

Reminder that 'Filter' is appended to filter names when injected. Link to Filter guide where this is mentioned.
