### PR TITLE
docs(tutorial): fix broken link

### DIFF
--- a/docs/content/tutorial/step_09.ngdoc
+++ b/docs/content/tutorial/step_09.ngdoc
@@ -110,7 +110,7 @@ Note that we call the helper function, `inject(function(checkmarkFilter) { ... }
 access to the filter that we want to test.  See {@link angular.mock.inject angular.mock.inject()}.
 
 Notice that the suffix 'Filter' is appended to your filter name when injected.
-See the {@link Filters Filter Guide} - 'Using filters in controllers and services' section where this is outlined.
+See the {@link guide/filters Filter Guide} - 'Using filters in controllers and services' section where this is outlined.
 
 You should now see the following output in the Karma tab:
 


### PR DESCRIPTION
Fixes a broken link that is preventing the docs task to run
