### PR TITLE
docs(guide/services): Replaced broken link

### DIFF
--- a/docs/content/guide/services.ngdoc
+++ b/docs/content/guide/services.ngdoc
@@ -299,5 +299,5 @@ it('should clear messages after alert', function() {
 
 ## Related API
 
-* {@link ./ng Angular Service API}
+* {@link angular.Module Module API}
 * {@link angular.injector Injector API}


### PR DESCRIPTION
Replaced broken link with link to more relevant API
