### PR TITLE
fix($animate): remove ng-animate class after canceling animation

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -923,8 +923,6 @@ angular.module('ngAnimate', ['ng'])
                 animationsToCancel.push(runningAnimations[klass]);
                 cleanup(element, klass);
               }
-              runningAnimations = {};
-              totalActiveAnimations = 0;
             }
           } else if(lastAnimation.event == 'setClass') {
             animationsToCancel.push(lastAnimation);
@@ -946,6 +944,8 @@ angular.module('ngAnimate', ['ng'])
             });
           }
         }
+        runningAnimations     = ngAnimateState.active || {};
+        totalActiveAnimations = ngAnimateState.totalActive || 0;
 
         if(runner.isClassBased && !runner.isSetClassOperation && !skipAnimation) {
           skipAnimation = (animationEvent == 'addClass') == element.hasClass(className); //opposite of XOR


### PR DESCRIPTION
`ng-animate` class gets stuck on element after canceling animation.
Bug example, double click button to catch it
http://plnkr.co/edit/vDQU8sJOKdoluHWdLJvJ?p=preview

Fixes #7766
