### PR TITLE
fix($parse): Handle one-time to `null`

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1055,7 +1055,8 @@ function $ParseProvider() {
             if (oneTimeParseFn.$$unwatch && self && self.$$postDigestQueue) {
               self.$$postDigestQueue.push(function () {
                 // create a copy if the value is defined and it is not a $sce value
-                if ((stable = isDefined(lastValue)) && !lastValue.$$unwrapTrustedValue) {
+                if ((stable = isDefined(lastValue)) &&
+                    (lastValue === null || !lastValue.$$unwrapTrustedValue)) {
                   lastValue = copy(lastValue, null);
                 }
               });

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1012,8 +1012,18 @@ describe('parser', function() {
 
           value.baz = 'baz';
           expect(fn()).toEqual({bar: 'bar'});
-
         }));
+
+        it('should not throw if the stable value is `null`', inject(function($parse, $rootScope) {
+          var fn = $parse('::foo');
+          $rootScope.$watch(fn);
+          $rootScope.foo = null;
+          $rootScope.$digest();
+          $rootScope.foo = 'foo';
+          $rootScope.$digest();
+          expect(fn()).toEqual(null);
+        }));
+
       });
 
 


### PR DESCRIPTION
Handles when a one-time binding stabilizes to `null`

Closes #7743
