### PR TITLE
fix($http): fix response headers with an empty value

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -48,7 +48,8 @@ function headersGetter(headers) {
     if (!headersObj) headersObj =  parseHeaders(headers);
 
     if (name) {
-      return headersObj[lowercase(name)] || null;
+      name = lowercase(name);
+      return name in headersObj ? headersObj[name] : null;
     }
 
     return headersObj;

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -549,12 +549,6 @@ describe('$http', function() {
       });
 
 
-      it('getter function should allow headers without value', function() {
-        // I don't know how to fix: 'headersGetter' is not defined.
-        // expect(headersGetter('key:')('key')).toBe('');
-      });
-
-
       it('should merge headers with same key', function() {
         expect(parseHeaders('key: a\nkey:b\n').key).toBe('a, b');
       });
@@ -767,6 +761,16 @@ describe('$http', function() {
       it('get() should allow config param', function() {
         $httpBackend.expect('GET', '/url', undefined, checkHeader('Custom', 'Header')).respond('');
         $http.get('/url', {headers: {'Custom': 'Header'}});
+      });
+
+
+      it('should handle empty response header', function() {
+        $httpBackend.expect('GET', '/url', undefined)
+            .respond(200, '', { 'Custom-Empty-Response-Header': '' });
+        $http.get('/url').success(callback);
+        $httpBackend.flush();
+        expect(callback).toHaveBeenCalledOnce();
+        expect(callback.mostRecentCall.args[2]('custom-empty-response-Header')).toBe('');
       });
 
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -549,6 +549,12 @@ describe('$http', function() {
       });
 
 
+      it('getter function should allow headers without value', function() {
+        // I don't know how to fix: 'headersGetter' is not defined.
+        // expect(headersGetter('key:')('key')).toBe('');
+      });
+
+
       it('should merge headers with same key', function() {
         expect(parseHeaders('key: a\nkey:b\n').key).toBe('a, b');
       });


### PR DESCRIPTION
Empty response header values are legal (http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html). Return an empty string instead of null, which is returned when the header does not exist.

Closes #7779
