### PR TITLE
feat(mocks): Injected function(s) now return value(s).

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2170,6 +2170,7 @@ if(window.jasmine || window.mocha) {
         injector = currentSpec.$injector = angular.injector(modules, strictDi);
         currentSpec.$injectorStrict = strictDi;
       }
+      var blockFnReturns = [];
       for(var i = 0, ii = blockFns.length; i < ii; i++) {
         if (currentSpec.$injectorStrict) {
           // If the injector is strict / strictDi, and the spec wants to inject using automatic
@@ -2178,7 +2179,7 @@ if(window.jasmine || window.mocha) {
         }
         try {
           /* jshint -W040 *//* Jasmine explicitly provides a `this` object when calling functions */
-          injector.invoke(blockFns[i] || angular.noop, this);
+          blockFnReturns.push(injector.invoke(blockFns[i] || angular.noop, this));
           /* jshint +W040 */
         } catch (e) {
           if (e.stack && errorForStack) {
@@ -2188,6 +2189,11 @@ if(window.jasmine || window.mocha) {
         } finally {
           errorForStack = null;
         }
+      }
+      if (blockFnReturns.length == 1) {
+        return blockFnReturns[0];
+      } else {
+        return blockFnReturns;
       }
     }
   };


### PR DESCRIPTION
I just ran into this problem:

``` javascript
describe('foo', function() {
  // Create a scope and setup the module...

  var createController = inject(function($controller) {
    return $controller('Foo', {scope: scope});
  });

  it('should create the controller', function() {
    var ctrl = createController();
    expect(ctrl).not.toBeUndefined(); // FAIL
  });
});
```

I was trying to do some setup on a fake injected service in my spec before creating the controller.

It turns out that while inject returns your function injected it does not respect your function's return value. So in my example, the return of the controller goes nowhere.

However, the `Injector.invoke` call _does_ return the value of the invoked function. In my commit, I simply pass it back from `inject`. If more than one function is used in `inject`, then an array of return values is passed back.

I'm not sure if there is something I'm missing, so I would love to hear what you think about this change. I think that it makes the `inject` function work as expected.
