### PR TITLE
feat(ngRoute): alias string as redirectTo property in .otherwise()

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -158,7 +158,6 @@ function $RouteProvider(){
         pathRegExp(redirectPath, route)
       );
     }
-
     return this;
   };
 
@@ -211,10 +210,14 @@ function $RouteProvider(){
    * Sets route definition that will be used on route change when no other route definition
    * is matched.
    *
-   * @param {Object} params Mapping information to be assigned to `$route.current`.
+   * @param {Object} params Mapping information to be assigned to `$route.current`. If of type
+   * string, the value is assumed to map to `redirectTo`.
    * @returns {Object} self
    */
   this.otherwise = function(params) {
+    if(typeof params === 'string') {
+      params = {redirectTo: params};
+    }
     this.when(null, params);
     return this;
   };

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -460,6 +460,23 @@ describe('$route', function() {
         expect(onChangeSpy).toHaveBeenCalled();
       });
     });
+
+
+    it('should interpret a string as a redirect route', function() {
+      module(function($routeProvider) {
+        $routeProvider.when('/foo', {templateUrl: 'foo.html'});
+        $routeProvider.when('/baz', {templateUrl: 'baz.html'});
+        $routeProvider.otherwise('/foo');
+      });
+
+      inject(function($route, $location, $rootScope) {
+          $location.path('/unknownRoute');
+          $rootScope.$digest();
+
+          expect($location.path()).toBe('/foo');
+          expect($route.current.templateUrl).toBe('foo.html');
+        });
+    });
   });
 
 


### PR DESCRIPTION
Allow .otherwise() to interpret a string parameter
as the redirectTo property to handle the common misinterpretation
that .otherwise() takes as a parameter the string to be matched
in the otherwise case.

Closes #7794
