### PR TITLE
Update step_03.ngdoc

### DIFF
--- a/docs/content/tutorial/step_03.ngdoc
+++ b/docs/content/tutorial/step_03.ngdoc
@@ -143,16 +143,39 @@ Display the current value of the `query` model by adding a `{{query}}` binding i
 ### Display Query in Title
 Let's see how we can get the current value of the `query` model to appear in the HTML page title.
 
-* Add the following end-to-end test into the `describe` block within `test/e2e/scenarios.js`:
+* Add an end-to-end test into the `describe` block, `test/e2e/scenarios.js` should look like this:
 
   ```js
-    it('should display the current filter value in the title bar', function() {
+    describe('PhoneCat App', function() {
 
-      expect(browser.getTitle()).toMatch(/Google Phone Gallery:\s*$/);
-
-      element(by.model('query')).sendKeys('nexus');
-
-      expect(browser.getTitle()).toMatch(/Google Phone Gallery: nexus$/);
+      describe('Phone list view', function() {
+    
+        beforeEach(function() {
+          browser.get('app/index.html');
+        });
+    
+        var phoneList = element.all(by.repeater('phone in phones'));
+        var query = element(by.model('query'));
+    
+        it('should filter the phone list as user types into the search box', function() {
+          expect(phoneList.count()).toBe(3);
+    
+          query.sendKeys('nexus');
+          expect(phoneList.count()).toBe(1);
+    
+          query.clear();
+          query.sendKeys('motorola');
+          expect(phoneList.count()).toBe(2);
+        });
+    
+        it('should display the current filter value in the title bar', function() {
+          query.clear();
+          expect(browser.getTitle()).toMatch(/Google Phone Gallery:\s*$/);
+    
+          query.sendKeys('nexus');
+          expect(browser.getTitle()).toMatch(/Google Phone Gallery: nexus$/);
+        });
+      });
     });
   ```
 


### PR DESCRIPTION
1) The original document is not clear to a new developer in where to place the code.
2) The query.clear() statement to clear the query before the second test is missing in the original document. 
3) Refactored to use the query and phoneList variables in both tests, so its easier to read and understand.
