### PR TITLE
Update $location.ngdoc

### DIFF
--- a/docs/content/guide/$location.ngdoc
+++ b/docs/content/guide/$location.ngdoc
@@ -60,7 +60,7 @@ changes to $location are reflected into the browser address bar.
 
   <tr>
     <td class="head">aware of docroot/context from which the application is loaded</td>
-    <td>no - window.location.path returns "/docroot/actual/path"</td>
+    <td>no - window.location.pathname returns "/docroot/actual/path"</td>
     <td>yes - $location.path() returns "/actual/path"</td>
   </tr>
 


### PR DESCRIPTION
Minor documentation fix.
"window.location.path" did not work in Chrome, and googling does not reveal any references to it for any browser.  It seems it is supposed to be "window.location.pathname".

Thanks!
