### PR TITLE
fix the protractor example(by.select to by.model).

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -123,7 +123,7 @@ var ngOptionsMinErr = minErr('ngOptions');
       <file name="protractor.js" type="protractor">
          it('should check ng-options', function() {
            expect(element(by.binding('{selected_color:myColor}')).getText()).toMatch('red');
-           element.all(by.select('myColor')).first().click();
+           element.all(by.model('myColor')).first().click();
            element.all(by.css('select[ng-model="myColor"] option')).first().click();
            expect(element(by.binding('{selected_color:myColor}')).getText()).toMatch('black');
            element(by.css('.nullable select[ng-model="myColor"]')).click();


### PR DESCRIPTION
I changed to `by.model` because `by.select` is deprecated.
