### PR TITLE
Backport $compiler fixes from 1.3 to v1.2.x

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -947,7 +947,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             //  or
             //  - there is no parentBoundTranscludeFn already and a transcludeFn was passed in
             if ( nodeLinkFn.transcludeOnThisElement || (!parentBoundTranscludeFn && transcludeFn) ) {
-              childBoundTranscludeFn = createBoundTranscludeFn(scope, nodeLinkFn.transclude || transcludeFn);
+              childBoundTranscludeFn = createBoundTranscludeFn(scope, nodeLinkFn.transclude || transcludeFn, parentBoundTranscludeFn);
             } else {
               childBoundTranscludeFn = parentBoundTranscludeFn;
             }
@@ -961,8 +961,13 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       }
     }
 
-    function createBoundTranscludeFn(scope, transcludeFn) {
-      return function boundTranscludeFn(transcludedScope, cloneFn, controllers) {
+    function createBoundTranscludeFn(scope, transcludeFn, previousBoundTranscludeFn) {
+
+      // If there is a previous boundTransclude function and it has a transclusionScope then
+      // use this instead of the current scope
+      scope = previousBoundTranscludeFn && previousBoundTranscludeFn.transclusionScope || scope;
+
+      var boundTranscludeFn = function(transcludedScope, cloneFn, controllers) {
         var scopeCreated = false;
 
         if (!transcludedScope) {
@@ -977,6 +982,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         }
         return clone;
       };
+
+      // Store the transclusionScope for nested transclusions
+      boundTranscludeFn.transclusionScope = scope;
+
+      return boundTranscludeFn;
     }
 
     /**
@@ -1749,7 +1759,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               safeAddClass(jqLite(linkNode), oldClasses);
             }
             if (afterTemplateNodeLinkFn.transclude) {
-              childBoundTranscludeFn = createBoundTranscludeFn(scope, afterTemplateNodeLinkFn.transclude);
+              childBoundTranscludeFn = createBoundTranscludeFn(scope, afterTemplateNodeLinkFn.transclude, boundTranscludeFn);
             } else {
               childBoundTranscludeFn = boundTranscludeFn;
             }

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1738,7 +1738,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           });
           afterTemplateChildLinkFn = compileNodes($compileNode[0].childNodes, childTranscludeFn);
 
-
           while(linkQueue.length) {
             var scope = linkQueue.shift(),
                 beforeTemplateLinkNode = linkQueue.shift(),
@@ -1775,13 +1774,17 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         });
 
       return function delayedNodeLinkFn(ignoreChildLinkFn, scope, node, rootElement, boundTranscludeFn) {
+        var childBoundTranscludeFn = boundTranscludeFn;
         if (linkQueue) {
           linkQueue.push(scope);
           linkQueue.push(node);
           linkQueue.push(rootElement);
-          linkQueue.push(boundTranscludeFn);
+          linkQueue.push(childBoundTranscludeFn);
         } else {
-          afterTemplateNodeLinkFn(afterTemplateChildLinkFn, scope, node, rootElement, boundTranscludeFn);
+          if (afterTemplateNodeLinkFn.transcludeOnThisElement) {
+            childBoundTranscludeFn = createBoundTranscludeFn(scope, afterTemplateNodeLinkFn.transclude, boundTranscludeFn);
+          }
+          afterTemplateNodeLinkFn(afterTemplateChildLinkFn, scope, node, rootElement, childBoundTranscludeFn);
         }
       };
     }

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -919,7 +919,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       return linkFnFound ? compositeLinkFn : null;
 
       function compositeLinkFn(scope, nodeList, $rootElement, boundTranscludeFn) {
-        var nodeLinkFn, childLinkFn, node, $node, childScope, childTranscludeFn, i, ii, n;
+        var nodeLinkFn, childLinkFn, node, $node, childScope, i, ii, n, childBoundTranscludeFn;
 
         // copy nodeList so that linking doesn't break due to live list updates.
         var nodeListLength = nodeList.length,
@@ -941,14 +941,19 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             } else {
               childScope = scope;
             }
-            childTranscludeFn = nodeLinkFn.transclude;
-            if (childTranscludeFn || (!boundTranscludeFn && transcludeFn)) {
-              nodeLinkFn(childLinkFn, childScope, node, $rootElement,
-                createBoundTranscludeFn(scope, childTranscludeFn || transcludeFn)
-              );
+
+            // We need to create a new boundTranscludeFn if
+            //  - a directive on this element wants to transclude
+            //  or
+            //  - there is no boundTranscludeFn already and a transcludeFn was passed in
+            if ( nodeLinkFn.transcludeOnThisElement || (!boundTranscludeFn && transcludeFn) ) {
+              childBoundTranscludeFn = createBoundTranscludeFn(scope, nodeLinkFn.transclude || transcludeFn);
             } else {
-              nodeLinkFn(childLinkFn, childScope, node, $rootElement, boundTranscludeFn);
+              childBoundTranscludeFn = boundTranscludeFn;
             }
+
+            nodeLinkFn(childLinkFn, childScope, node, $rootElement, childBoundTranscludeFn);
+
           } else if (childLinkFn) {
             childLinkFn(scope, node.childNodes, undefined, boundTranscludeFn);
           }
@@ -1324,7 +1329,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       }
 
       nodeLinkFn.scope = newScopeDirective && newScopeDirective.scope === true;
-      nodeLinkFn.transclude = hasTranscludeDirective && childTranscludeFn;
+      nodeLinkFn.transcludeOnThisElement = hasTranscludeDirective;
+      nodeLinkFn.transclude = childTranscludeFn;
+
       previousCompileContext.hasElementTranscludeDirective = hasElementTranscludeDirective;
 
       // might be normal or delayed nodeLinkFn depending on if templateUrl is present

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -978,7 +978,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
         var clone = transcludeFn(transcludedScope, cloneFn, controllers);
         if (scopeCreated) {
-          clone.on('$destroy', bind(transcludedScope, transcludedScope.$destroy));
+          clone.on('$destroy', function() { transcludedScope.$destroy(); });
         }
         return clone;
       };

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1319,7 +1319,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           }
 
           nodeLinkFn = compileTemplateUrl(directives.splice(i, directives.length - i), $compileNode,
-              templateAttrs, jqCollection, childTranscludeFn, preLinkFns, postLinkFns, {
+              templateAttrs, jqCollection, hasTranscludeDirective && childTranscludeFn, preLinkFns, postLinkFns, {
                 controllerDirectives: controllerDirectives,
                 newIsolateScopeDirective: newIsolateScopeDirective,
                 templateDirective: templateDirective,

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -918,7 +918,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       // return a linking function if we have found anything, null otherwise
       return linkFnFound ? compositeLinkFn : null;
 
-      function compositeLinkFn(scope, nodeList, $rootElement, boundTranscludeFn) {
+      function compositeLinkFn(scope, nodeList, $rootElement, parentBoundTranscludeFn) {
         var nodeLinkFn, childLinkFn, node, $node, childScope, i, ii, n, childBoundTranscludeFn;
 
         // copy nodeList so that linking doesn't break due to live list updates.
@@ -945,17 +945,17 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             // We need to create a new boundTranscludeFn if
             //  - a directive on this element wants to transclude
             //  or
-            //  - there is no boundTranscludeFn already and a transcludeFn was passed in
-            if ( nodeLinkFn.transcludeOnThisElement || (!boundTranscludeFn && transcludeFn) ) {
+            //  - there is no parentBoundTranscludeFn already and a transcludeFn was passed in
+            if ( nodeLinkFn.transcludeOnThisElement || (!parentBoundTranscludeFn && transcludeFn) ) {
               childBoundTranscludeFn = createBoundTranscludeFn(scope, nodeLinkFn.transclude || transcludeFn);
             } else {
-              childBoundTranscludeFn = boundTranscludeFn;
+              childBoundTranscludeFn = parentBoundTranscludeFn;
             }
 
             nodeLinkFn(childLinkFn, childScope, node, $rootElement, childBoundTranscludeFn);
 
           } else if (childLinkFn) {
-            childLinkFn(scope, node.childNodes, undefined, boundTranscludeFn);
+            childLinkFn(scope, node.childNodes, undefined, parentBoundTranscludeFn);
           }
         }
       }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3797,6 +3797,42 @@ describe('$compile', function() {
       });
 
 
+      it('should not pass transclusion into a templateUrl directive', function() {
+
+        module(function($compileProvider) {
+
+          $compileProvider.directive('transFoo', valueFn({
+            template: '<div>' +
+              '<div no-trans-bar></div>' +
+              '<div ng-transclude>this one should get replaced with content</div>' +
+              '<div class="foo" ng-transclude></div>' +
+            '</div>',
+            transclude: true
+
+          }));
+
+          $compileProvider.directive('noTransBar', valueFn({
+            templateUrl: 'noTransBar.html',
+            transclude: false
+
+          }));
+        });
+
+        inject(function($compile, $rootScope, $templateCache) {
+          $templateCache.put('noTransBar.html',
+            '<div>' +
+              // This ng-transclude is invalid. It should throw an error.
+              '<div class="bar" ng-transclude></div>' +
+            '</div>');
+
+          expect(function() {
+            element = $compile('<div trans-foo>content</div>')($rootScope);
+            $rootScope.$apply();
+          }).toThrowMinErr('ngTransclude', 'orphan',
+              'Illegal use of ngTransclude directive in the template! No parent directive that requires a transclusion found. Element: <div class="bar" ng-transclude="">');
+        });
+      });
+
       it('should make the result of a transclusion available to the parent directive in post-linking phase' +
           '(template)', function() {
         module(function() {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4055,6 +4055,73 @@ describe('$compile', function() {
       });
 
 
+      describe('nested isolated scope transcludes', function() {
+        beforeEach(module(function($compileProvider) {
+
+          $compileProvider.directive('trans', valueFn({
+            restrict: 'E',
+            template: '<div ng-transclude></div>',
+            transclude: true
+          }));
+
+          $compileProvider.directive('transAsync', valueFn({
+            restrict: 'E',
+            templateUrl: 'transAsync',
+            transclude: true
+          }));
+
+          $compileProvider.directive('iso', valueFn({
+            restrict: 'E',
+            transclude: true,
+            template: '<trans><span ng-transclude></span></trans>',
+            scope: {}
+          }));
+          $compileProvider.directive('isoAsync1', valueFn({
+            restrict: 'E',
+            transclude: true,
+            template: '<trans-async><span ng-transclude></span></trans-async>',
+            scope: {}
+          }));
+          $compileProvider.directive('isoAsync2', valueFn({
+            restrict: 'E',
+            transclude: true,
+            templateUrl: 'isoAsync',
+            scope: {}
+          }));
+        }));
+
+        beforeEach(inject(function($templateCache) {
+          $templateCache.put('transAsync', '<div ng-transclude></div>');
+          $templateCache.put('isoAsync', '<trans-async><span ng-transclude></span></trans-async>');
+        }));
+
+
+        it('should pass the outer scope to the transclude on the isolated template sync-sync', inject(function($compile, $rootScope) {
+
+          $rootScope.val = 'transcluded content';
+          element = $compile('<iso><span ng-bind="val"></span></iso>')($rootScope);
+          $rootScope.$digest();
+          expect(element.text()).toEqual('transcluded content');
+        }));
+
+        it('should pass the outer scope to the transclude on the isolated template async-sync', inject(function($compile, $rootScope) {
+
+          $rootScope.val = 'transcluded content';
+          element = $compile('<iso-async1><span ng-bind="val"></span></iso-async1>')($rootScope);
+          $rootScope.$digest();
+          expect(element.text()).toEqual('transcluded content');
+        }));
+
+        it('should pass the outer scope to the transclude on the isolated template async-async', inject(function($compile, $rootScope) {
+
+          $rootScope.val = 'transcluded content';
+          element = $compile('<iso-async2><span ng-bind="val"></span></iso-async2>')($rootScope);
+          $rootScope.$digest();
+          expect(element.text()).toEqual('transcluded content');
+        }));
+
+      });
+
       describe('multiple siblings receiving transclusion', function() {
 
         it("should only receive transclude from parent", function() {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3764,6 +3764,39 @@ describe('$compile', function() {
       });
 
 
+      it('should not pass transclusion into a template directive when the directive didn\'t request transclusion', function() {
+
+        module(function($compileProvider) {
+
+          $compileProvider.directive('transFoo', valueFn({
+            template: '<div>' +
+              '<div no-trans-bar></div>' +
+              '<div ng-transclude>this one should get replaced with content</div>' +
+              '<div class="foo" ng-transclude></div>' +
+            '</div>',
+            transclude: true
+
+          }));
+
+          $compileProvider.directive('noTransBar', valueFn({
+            template: '<div>' +
+              // This ng-transclude is invalid. It should throw an error.
+              '<div class="bar" ng-transclude></div>' +
+            '</div>',
+            transclude: false
+
+          }));
+        });
+
+        inject(function($compile, $rootScope) {
+          expect(function() {
+            $compile('<div trans-foo>content</div>')($rootScope);
+          }).toThrowMinErr('ngTransclude', 'orphan',
+              'Illegal use of ngTransclude directive in the template! No parent directive that requires a transclusion found. Element: <div class="bar" ng-transclude="">');
+        });
+      });
+
+
       it('should make the result of a transclusion available to the parent directive in post-linking phase' +
           '(template)', function() {
         module(function() {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3789,10 +3789,18 @@ describe('$compile', function() {
         });
 
         inject(function($compile, $rootScope) {
+          var message = 'Illegal use of ngTransclude directive in the template! No parent ' +
+                        'directive that requires a transclusion found. Element: <div class="bar" ' +
+                        'ng-transclude="">';
+          if (msie <= 8) {
+            // MSIE ヽ(｀Д´)ﾉ
+            message = 'Illegal use of ngTransclude directive in the template! No parent ' +
+                      'directive that requires a transclusion found. Element: <div class=bar ' +
+                      'ng-transclude>';
+          }
           expect(function() {
             $compile('<div trans-foo>content</div>')($rootScope);
-          }).toThrowMinErr('ngTransclude', 'orphan',
-              'Illegal use of ngTransclude directive in the template! No parent directive that requires a transclusion found. Element: <div class="bar" ng-transclude="">');
+          }).toThrowMinErr('ngTransclude', 'orphan', message);
         });
       });
 
@@ -3824,12 +3832,17 @@ describe('$compile', function() {
               // This ng-transclude is invalid. It should throw an error.
               '<div class="bar" ng-transclude></div>' +
             '</div>');
-
+          var message = 'Illegal use of ngTransclude directive in the template! No parent directive that '
+                      + 'requires a transclusion found. Element: <div class="bar" ng-transclude="">';
+          if (msie <= 8) {
+            // MSIE ヽ(｀Д´)ﾉ
+            message = 'Illegal use of ngTransclude directive in the template! No parent directive that '
+                    + 'requires a transclusion found. Element: <div class=bar ng-transclude>';
+          }
           expect(function() {
             element = $compile('<div trans-foo>content</div>')($rootScope);
             $rootScope.$apply();
-          }).toThrowMinErr('ngTransclude', 'orphan',
-              'Illegal use of ngTransclude directive in the template! No parent directive that requires a transclusion found. Element: <div class="bar" ng-transclude="">');
+          }).toThrowMinErr('ngTransclude', 'orphan', message);
         });
       });
 
@@ -4134,25 +4147,25 @@ describe('$compile', function() {
           }));
 
           $compileProvider.directive('transAsync', valueFn({
-            restrict: 'E',
+            restrict: 'A',
             templateUrl: 'transAsync',
             transclude: true
           }));
 
           $compileProvider.directive('iso', valueFn({
-            restrict: 'E',
+            restrict: 'A',
             transclude: true,
-            template: '<trans><span ng-transclude></span></trans>',
+            template: '<div trans><span ng-transclude></span></div>',
             scope: {}
           }));
           $compileProvider.directive('isoAsync1', valueFn({
-            restrict: 'E',
+            restrict: 'A',
             transclude: true,
-            template: '<trans-async><span ng-transclude></span></trans-async>',
+            template: '<div trans-async><span ng-transclude></span></div>',
             scope: {}
           }));
           $compileProvider.directive('isoAsync2', valueFn({
-            restrict: 'E',
+            restrict: 'A',
             transclude: true,
             templateUrl: 'isoAsync',
             scope: {}
@@ -4161,14 +4174,14 @@ describe('$compile', function() {
 
         beforeEach(inject(function($templateCache) {
           $templateCache.put('transAsync', '<div ng-transclude></div>');
-          $templateCache.put('isoAsync', '<trans-async><span ng-transclude></span></trans-async>');
+          $templateCache.put('isoAsync', '<div trans-async><span ng-transclude></span></div>');
         }));
 
 
         it('should pass the outer scope to the transclude on the isolated template sync-sync', inject(function($compile, $rootScope) {
 
           $rootScope.val = 'transcluded content';
-          element = $compile('<iso><span ng-bind="val"></span></iso>')($rootScope);
+          element = $compile('<div iso><span ng-bind="val"></span></div>')($rootScope);
           $rootScope.$digest();
           expect(element.text()).toEqual('transcluded content');
         }));
@@ -4176,7 +4189,7 @@ describe('$compile', function() {
         it('should pass the outer scope to the transclude on the isolated template async-sync', inject(function($compile, $rootScope) {
 
           $rootScope.val = 'transcluded content';
-          element = $compile('<iso-async1><span ng-bind="val"></span></iso-async1>')($rootScope);
+          element = $compile('<div iso-async1><span ng-bind="val"></span></div>')($rootScope);
           $rootScope.$digest();
           expect(element.text()).toEqual('transcluded content');
         }));
@@ -4184,7 +4197,7 @@ describe('$compile', function() {
         it('should pass the outer scope to the transclude on the isolated template async-async', inject(function($compile, $rootScope) {
 
           $rootScope.val = 'transcluded content';
-          element = $compile('<iso-async2><span ng-bind="val"></span></iso-async2>')($rootScope);
+          element = $compile('<div iso-async2><span ng-bind="val"></span></div>')($rootScope);
           $rootScope.$digest();
           expect(element.text()).toEqual('transcluded content');
         }));

--- a/test/ng/directive/ngIfSpec.js
+++ b/test/ng/directive/ngIfSpec.js
@@ -199,6 +199,28 @@ describe('ngIf and transcludes', function() {
       dealoc(element);
     });
   });
+
+
+  it('should use the correct transcluded scope', function() {
+    module(function($compileProvider) {
+      $compileProvider.directive('iso', valueFn({
+        link: function(scope) {
+          scope.val = 'value in iso scope';
+        },
+        restrict: 'E',
+        transclude: true,
+        template: '<div ng-if="true">val={{val}}-<div ng-transclude></div></div>',
+        scope: {}
+      }));
+    });
+    inject(function($compile, $rootScope) {
+      $rootScope.val = 'transcluded content';
+      var element = $compile('<iso><span ng-bind="val"></span></iso>')($rootScope);
+      $rootScope.$digest();
+      expect(trim(element.text())).toEqual('val=value in iso scope-transcluded content');
+      dealoc(element);
+    });
+  });
 });
 
 describe('ngIf animations', function () {

--- a/test/ng/directive/ngIfSpec.js
+++ b/test/ng/directive/ngIfSpec.js
@@ -207,7 +207,7 @@ describe('ngIf and transcludes', function() {
         link: function(scope) {
           scope.val = 'value in iso scope';
         },
-        restrict: 'E',
+        restrict: 'A',
         transclude: true,
         template: '<div ng-if="true">val={{val}}-<div ng-transclude></div></div>',
         scope: {}
@@ -215,7 +215,7 @@ describe('ngIf and transcludes', function() {
     });
     inject(function($compile, $rootScope) {
       $rootScope.val = 'transcluded content';
-      var element = $compile('<iso><span ng-bind="val"></span></iso>')($rootScope);
+      var element = $compile('<div iso><span ng-bind="val"></span></div>')($rootScope);
       $rootScope.$digest();
       expect(trim(element.text())).toEqual('val=value in iso scope-transcluded content');
       dealoc(element);


### PR DESCRIPTION
This doesn't include 2cde927e58c8d1588569d94a797e43cdfbcedaf9 which contained breaking changes,
but includes all of the transclusion fixes.
