### PR TITLE
Missing example in Forms guide

### DIFF
--- a/docs/content/guide/forms.ngdoc
+++ b/docs/content/guide/forms.ngdoc
@@ -209,6 +209,7 @@ only when the control loses focus (blur event).
         <input type="text" ng-model="user.data" /><br />
       </form>
       <pre>username = "{{user.name}}"</pre>
+      <pre>userdata = "{{user.data}}"</pre>
     </div>
   </file>
   <file name="script.js">


### PR DESCRIPTION
When explaining ng-model-options, there's no print of user.data to show the difference between the default behaviour and updateOn: 'blur'
