### PR TITLE
Use source object prototype in object copy

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -766,7 +766,7 @@ function copy(source, destination, stackSource, stackDest) {
       } else if (isRegExp(source)) {
         destination = new RegExp(source.source);
       } else if (isObject(source)) {
-        destination = copy(source, {}, stackSource, stackDest);
+        destination = copy(source, Object.create(Object.getPrototypeOf(source)), stackSource, stackDest);
       }
     }
   } else {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -162,7 +162,7 @@ describe('angular', function() {
     });
 
     it('should retain the source prototype on the destination', function () {
-      function A() {};
+      function A() {}
       var a = new A();
       var a_copy = copy(a);
 

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -160,6 +160,15 @@ describe('angular', function() {
       expect(aCopy).toBe(aCopy.self);
       expect(aCopy.selfs[2]).not.toBe(a.selfs[2]);
     });
+
+    it('should retain the source prototype on the destination', function () {
+      function A() {};
+      var a = new A();
+      var a_copy = copy(a);
+
+      expect(a instanceof A).toBe(true);
+      expect(a_copy instanceof A).toBe(true);
+    });
   });
 
   describe("extend", function() {


### PR DESCRIPTION
Whilst not strictly necessary for the likes of `$watch` to behave as expected, given that `angular.copy` is exposed it should honour the prototype of the source object such that, as the test ensures:

``` javascript
function A() {}
var a = new A();
var a_copy = angular.copy(a);
expect(a_copy instanceof A).toBe(true);
```

Otherwise users of `angular.copy` (read: at least me) end up having to create their own version of `angular.copy` to make this one change.
