### PR TITLE
fix(NgModel): use string representation of the value in the ngMinlength and ngMaxlength

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2189,7 +2189,7 @@ var maxlengthDirective = function() {
         ctrl.$validate();
       });
       ctrl.$validators.maxlength = function(value) {
-        return ctrl.$isEmpty(value) || value.length <= maxlength;
+        return ctrl.$isEmpty(value) || value.toString().length <= maxlength;
       };
     }
   };
@@ -2207,7 +2207,7 @@ var minlengthDirective = function() {
         ctrl.$validate();
       });
       ctrl.$validators.minlength = function(value) {
-        return ctrl.$isEmpty(value) || value.length >= minlength;
+        return ctrl.$isEmpty(value) || value.toString().length >= minlength;
       };
     }
   };

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1400,6 +1400,11 @@ describe('input', function() {
 
       changeInputValueTo('aaa');
       expect(inputElm).toBeValid();
+
+      scope.$apply(function() {
+        scope.value = 1234;
+      });
+      expect(inputElm).toBeValid();
     });
 
     it('should listen on ng-minlength when minlength is observed', function() {
@@ -1445,6 +1450,11 @@ describe('input', function() {
       expect(inputElm).toBeInvalid();
 
       changeInputValueTo('aaa');
+      expect(inputElm).toBeValid();
+
+      scope.$apply(function() {
+        scope.value = 42;
+      });
       expect(inputElm).toBeValid();
     });
 


### PR DESCRIPTION
There is an issue - if ng-model value set to a nonstring (via js), the ngMinlength and ngMaxlength don't work properly.
Issue example http://plnkr.co/edit/y65LU7xJFSi4L9Ui4WqZ?p=preview

Fixes #7848
