### PR TITLE
fix(NgModel): use string representation of the value in the ngMinlength and ngMaxlength v1.2.x

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -584,7 +584,7 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   if (attr.ngMinlength) {
     var minlength = int(attr.ngMinlength);
     var minLengthValidator = function(value) {
-      return validate(ctrl, 'minlength', ctrl.$isEmpty(value) || value.length >= minlength, value);
+      return validate(ctrl, 'minlength', ctrl.$isEmpty(value) || value.toString().length >= minlength, value);
     };
 
     ctrl.$parsers.push(minLengthValidator);
@@ -595,7 +595,7 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   if (attr.ngMaxlength) {
     var maxlength = int(attr.ngMaxlength);
     var maxLengthValidator = function(value) {
-      return validate(ctrl, 'maxlength', ctrl.$isEmpty(value) || value.length <= maxlength, value);
+      return validate(ctrl, 'maxlength', ctrl.$isEmpty(value) || value.toString().length <= maxlength, value);
     };
 
     ctrl.$parsers.push(maxLengthValidator);

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -761,6 +761,16 @@ describe('input', function() {
       changeInputValueTo('aaa');
       expect(scope.value).toBe('aaa');
     });
+
+    it('should use string representation of the value', function(){
+      compileInput('<input type="text" ng-model="value" ng-minlength="3" />');
+
+      scope.$apply(function() {
+        scope.value = 123;
+      });
+
+      expect(inputElm).toBeValid();
+    });
   });
 
 
@@ -774,6 +784,16 @@ describe('input', function() {
 
       changeInputValueTo('aaa');
       expect(scope.value).toBe('aaa');
+    });
+
+    it('should use string representation of the value', function(){
+      compileInput('<input type="text" ng-model="value" ng-maxlength="5" />');
+
+      scope.$apply(function() {
+        scope.value = 123;
+      });
+
+      expect(inputElm).toBeValid();
     });
   });
 


### PR DESCRIPTION
Issue with nonstrings, like in master branch, see https://github.com/angular/angular.js/pull/7856

Example for v1.2.18 http://plnkr.co/edit/K2PraexZazCgCJqzfwTI?p=preview
