### PR TITLE
docs($http): fix broken markdown link in withCredentials description

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -481,7 +481,7 @@ function $HttpProvider() {
      *    - **timeout** – `{number|Promise}` – timeout in milliseconds, or {@link ng.$q promise}
      *      that should abort the request when resolved.
      *    - **withCredentials** - `{boolean}` - whether to set the `withCredentials` flag on the
-     *      XHR object. See [requests with credentials]https://developer.mozilla.org/en/http_access_control#section_5
+     *      XHR object. See [requests with credentials](https://developer.mozilla.org/en/http_access_control#section_5)
      *      for more information.
      *    - **responseType** - `{string}` - see
      *      [requestType](https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest#responseType).


### PR DESCRIPTION
Markdown typo in $http config documentation
