### PR TITLE
fix(injector): allow multiple loading of function modules

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -591,7 +591,7 @@ function createInjector(modulesToLoad) {
   var INSTANTIATING = {},
       providerSuffix = 'Provider',
       path = [],
-      loadedModules = new HashMap(),
+      loadedModules = new HashMap([], true),
       providerCache = {
         $provide: {
             provider: supportObject(provider),

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1958,6 +1958,12 @@ if(window.jasmine || window.mocha) {
   (window.afterEach || window.teardown)(function() {
     var injector = currentSpec.$injector;
 
+    angular.forEach(currentSpec.$modules, function(module) {
+      if (module && module.$$hashKey) {
+        module.$$hashKey = undefined;
+      }
+    });
+
     currentSpec.$injector = null;
     currentSpec.$modules = null;
     currentSpec = null;

--- a/test/ApiSpecs.js
+++ b/test/ApiSpecs.js
@@ -22,6 +22,36 @@ describe('api', function() {
       expect(map.get('b')).toBe(1);
       expect(map.get('c')).toBe(undefined);
     });
+
+    it('should maintain hashKey for object keys', function() {
+      var map = new HashMap();
+      var key = {};
+      map.get(key);
+      expect(key.$$hashKey).toBeDefined();
+    });
+
+    it('should maintain hashKey for function keys', function() {
+      var map = new HashMap();
+      var key = function() {};
+      map.get(key);
+      expect(key.$$hashKey).toBeDefined();
+    });
+
+    it('should share hashKey between HashMap by default', function() {
+      var map1 = new HashMap(), map2 = new HashMap();
+      var key1 = {}, key2 = {};
+      map1.get(key1);
+      map2.get(key2);
+      expect(key1.$$hashKey).not.toEqual(key2.$$hashKey);
+    });
+
+    it('should maintain hashKey per HashMap if flag is passed', function() {
+      var map1 = new HashMap([], true), map2 = new HashMap([], true);
+      var key1 = {}, key2 = {};
+      map1.get(key1);
+      map2.get(key2);
+      expect(key1.$$hashKey).toEqual(key2.$$hashKey);
+    });
   });
 });
 

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -293,6 +293,29 @@ describe('injector', function() {
       expect(log).toEqual('abc');
     });
 
+    it('should load different instances of dependent functions', function() {
+      function  generateValueModule(name, value) {
+        return function ($provide) {
+          $provide.value(name, value);
+        };
+      }
+      var injector = createInjector([generateValueModule('name1', 'value1'),
+                                     generateValueModule('name2', 'value2')]);
+      expect(injector.get('name2')).toBe('value2');
+    });
+
+    it('should load same instance of dependent function only once', function() {
+      var count = 0;
+      function valueModule($provide) {
+        count++;
+        $provide.value('name', 'value');
+      }
+
+      var injector = createInjector([valueModule, valueModule]);
+      expect(injector.get('name')).toBe('value');
+      expect(count).toBe(1);
+    });
+
     it('should execute runBlocks after injector creation', function() {
       var log = '';
       angular.module('a', [], function(){ log += 'a'; }).run(function() { log += 'A'; });

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -805,6 +805,23 @@ describe('ngMock', function() {
             expect(example).toEqual('win');
           });
         });
+
+        describe('module cleanup', function() {
+          function testFn() {
+
+          }
+
+          it('should add hashKey to module function', function() {
+            module(testFn);
+            inject(function () {
+              expect(testFn.$$hashKey).toBeDefined();
+            });
+          });
+
+          it('should cleanup hashKey after previous test', function() {
+            expect(testFn.$$hashKey).toBeUndefined();
+          });
+        });
       });
 
       describe('in DSL', function() {


### PR DESCRIPTION
**TEST PR** Just verifying that this passes on IE8

Change HashMap to give $$hashKey also for functions so it will be possible to
load multiple module function instances. In order to prevent problem in
angular's test suite,  added an option to HashMap to maintain its own id
counter and added cleanup of $$hashKey from all module functions after each 
test.

Before this CL, functions were added to the HashMap via toString(), which
could potentially return the same value for different actual instances of a
function. This corrects this behaviour by ensuring that functions are mapped
with hashKeys, and ensuring that hashKeys are removed from functions and
objects at the end of tests.

In addition to these changes, the injector uses its own set of UIDs in order
to prevent confusingly breaking tests which expect scopes or ng-repeated items
to have specific hash keys.

Closes #7255
