### PR TITLE
feat(dateFilter): add `utc` argument to format in UTC.

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -241,21 +241,30 @@ function timeZoneGetter(date, utc) {
   return paddedZone;
 }
 
+function makeDate(year, month, day, utc) {
+  if (utc) {
+    return new Date(Date.UTC(year, month, day));
+  } else {
+    return new Date(year, month, day);
+  }
+}
+
 function getFirstThursdayOfYear(year, utc) {
     // 0 = index of January
-    var firstDay = new Date(year, 0, 1),
+    var firstDay = makeDate(year, 0, 1, utc),
       dayOfWeekOnFirst = utc ? firstDay.getUTCDay() : firstDay.getDay();
     // 4 = index of Thursday (+1 to account for 1st = 5)
     // 11 = index of *next* Thursday (+1 account for 1st = 12)
-    return new Date(year, 0, ((dayOfWeekOnFirst <= 4) ? 5 : 12) - dayOfWeekOnFirst);
+    return makeDate(year, 0, ((dayOfWeekOnFirst <= 4) ? 5 : 12) - dayOfWeekOnFirst, utc);
 }
 
 function getThursdayThisWeek(datetime, utc) {
-    return new Date(utc ? datetime.getUTCFullYear() : datetime.getFullYear(),
+    return makeDate(utc ? datetime.getUTCFullYear() : datetime.getFullYear(),
       utc ? datetime.getUTCMonth() : datetime.getMonth(),
       // 4 = index of Thursday
       (utc ? datetime.getUTCDate() : datetime.getDate()) +
-        (4 - (utc ? datetime.getUTCDay() : datetime.getDay())));
+        (4 - (utc ? datetime.getUTCDay() : datetime.getDay())),
+      utc);
 }
 
 function weekGetter(size, utc) {

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -213,8 +213,8 @@ function padNumber(num, digits, trim) {
 
 function dateGetter(name, size, offset, trim) {
   offset = offset || 0;
-  return function(date) {
-    var value = date['get' + name]();
+  return function(date, utc) {
+    var value = date['get' + (utc ? 'UTC' : '') + name]();
     if (offset > 0 || value > -offset)
       value += offset;
     if (value === 0 && offset == -12 ) value = 12;
@@ -223,16 +223,16 @@ function dateGetter(name, size, offset, trim) {
 }
 
 function dateStrGetter(name, shortForm) {
-  return function(date, formats) {
-    var value = date['get' + name]();
+  return function(date, utc, formats) {
+    var value = date['get' + (utc ? 'UTC' : '') + name]();
     var get = uppercase(shortForm ? ('SHORT' + name) : name);
 
     return formats[get][value];
   };
 }
 
-function timeZoneGetter(date) {
-  var zone = -1 * date.getTimezoneOffset();
+function timeZoneGetter(date, utc) {
+  var zone = utc ? 0 : -1 * date.getTimezoneOffset();
   var paddedZone = (zone >= 0) ? "+" : "";
 
   paddedZone += padNumber(Math[zone > 0 ? 'floor' : 'ceil'](zone / 60), 2) +
@@ -241,24 +241,27 @@ function timeZoneGetter(date) {
   return paddedZone;
 }
 
-function getFirstThursdayOfYear(year) {
+function getFirstThursdayOfYear(year, utc) {
     // 0 = index of January
-    var dayOfWeekOnFirst = (new Date(year, 0, 1)).getDay();
+    var firstDay = new Date(year, 0, 1),
+      dayOfWeekOnFirst = utc ? firstDay.getUTCDay() : firstDay.getDay();
     // 4 = index of Thursday (+1 to account for 1st = 5)
     // 11 = index of *next* Thursday (+1 account for 1st = 12)
     return new Date(year, 0, ((dayOfWeekOnFirst <= 4) ? 5 : 12) - dayOfWeekOnFirst);
 }
 
-function getThursdayThisWeek(datetime) {
-    return new Date(datetime.getFullYear(), datetime.getMonth(),
+function getThursdayThisWeek(datetime, utc) {
+    return new Date(utc ? datetime.getUTCFullYear() : datetime.getFullYear(),
+      utc ? datetime.getUTCMonth() : datetime.getMonth(),
       // 4 = index of Thursday
-      datetime.getDate() + (4 - datetime.getDay()));
+      (utc ? datetime.getUTCDate() : datetime.getDate()) +
+        (4 - (utc ? datetime.getUTCDay() : datetime.getDay())));
 }
 
-function weekGetter(size) {
+function weekGetter(size, utc) {
    return function(date) {
-      var firstThurs = getFirstThursdayOfYear(date.getFullYear()),
-         thisThurs = getThursdayThisWeek(date);
+      var firstThurs = getFirstThursdayOfYear(utc ? date.getUTCFullYear() : date.getFullYear(), utc),
+         thisThurs = getThursdayThisWeek(date, utc);
 
       var diff = +thisThurs - +firstThurs,
          result = 1 + Math.round(diff / 6.048e8); // 6.048e8 ms per week
@@ -267,8 +270,8 @@ function weekGetter(size) {
    };
 }
 
-function ampmGetter(date, formats) {
-  return date.getHours() < 12 ? formats.AMPMS[0] : formats.AMPMS[1];
+function ampmGetter(date, utc, formats) {
+  return (utc ? date.getUTCHours() : date.getHours()) < 12 ? formats.AMPMS[0] : formats.AMPMS[1];
 }
 
 var DATE_FORMATS = {
@@ -362,6 +365,7 @@ var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZEw']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d
  *    specified in the string input, the time is considered to be in the local timezone.
  * @param {string=} format Formatting rules (see Description). If not specified,
  *    `mediumDate` is used.
+ * @param {boolean} utc true if formatting in UTC rather than local.
  * @returns {string} Formatted string or the input if input is not recognized as date/millis.
  *
  * @example
@@ -369,8 +373,10 @@ var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZEw']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d
      <file name="index.html">
        <span ng-non-bindable>{{1288323623006 | date:'medium'}}</span>:
            <span>{{1288323623006 | date:'medium'}}</span><br>
-       <span ng-non-bindable>{{1288323623006 | date:'yyyy-MM-dd HH:mm:ss Z'}}</span>:
-          <span>{{1288323623006 | date:'yyyy-MM-dd HH:mm:ss Z'}}</span><br>
+       <span ng-non-bindable>{{1288323623006 | date:'yyyy-MM-dd HH:mm:ss Z':false}}</span>:
+          <span>{{1288323623006 | date:'yyyy-MM-dd HH:mm:ss Z':false}}</span><br>
+       <span ng-non-bindable>{{1288323623006 | date:'yyyy-MM-dd HH:mm:ss Z':true}}</span>:
+          <span>{{1288323623006 | date:'yyyy-MM-dd HH:mm:ss Z':true}}</span><br>
        <span ng-non-bindable>{{1288323623006 | date:'MM/dd/yyyy @ h:mma'}}</span>:
           <span>{{'1288323623006' | date:'MM/dd/yyyy @ h:mma'}}</span><br>
      </file>
@@ -378,8 +384,10 @@ var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZEw']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d
        it('should format date', function() {
          expect(element(by.binding("1288323623006 | date:'medium'")).getText()).
             toMatch(/Oct 2\d, 2010 \d{1,2}:\d{2}:\d{2} (AM|PM)/);
-         expect(element(by.binding("1288323623006 | date:'yyyy-MM-dd HH:mm:ss Z'")).getText()).
+         expect(element(by.binding("1288323623006 | date:'yyyy-MM-dd HH:mm:ss Z':false")).getText()).
             toMatch(/2010\-10\-2\d \d{2}:\d{2}:\d{2} (\-|\+)?\d{4}/);
+         expect(element(by.binding("1288323623006 | date:'yyyy-MM-dd HH:mm:ss Z':true")).getText()).
+            toMatch(/2010\-10\-2\d \d{2}:\d{2}:\d{2} \+0000/);
          expect(element(by.binding("'1288323623006' | date:'MM/dd/yyyy @ h:mma'")).getText()).
             toMatch(/10\/2\d\/2010 @ \d{1,2}:\d{2}(AM|PM)/);
        });
@@ -417,7 +425,7 @@ function dateFilter($locale) {
   }
 
 
-  return function(date, format) {
+  return function(date, format, utc) {
     var text = '',
         parts = [],
         fn, match;
@@ -449,7 +457,7 @@ function dateFilter($locale) {
 
     forEach(parts, function(value){
       fn = DATE_FORMATS[value];
-      text += fn ? fn(date, $locale.DATETIME_FORMATS)
+      text += fn ? fn(date, !!utc, $locale.DATETIME_FORMATS)
                  : value.replace(/(^'|'$)/g, '').replace(/''/g, "'");
     });
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -720,6 +720,10 @@ angular.mock.TzDate = function (offset, timestamp) {
     return self.date.getDay();
   };
 
+  self.getUTCDay = function() {
+    return self.origDate.getUTCDay();
+  };
+
   // provide this method only on browsers that already have it
   if (self.toISOString) {
     self.toISOString = function() {
@@ -734,7 +738,7 @@ angular.mock.TzDate = function (offset, timestamp) {
   }
 
   //hide all methods not implemented in this mock that the Date prototype exposes
-  var unimplementedMethods = ['getUTCDay',
+  var unimplementedMethods = [
       'getYear', 'setDate', 'setFullYear', 'setHours', 'setMilliseconds',
       'setMinutes', 'setMonth', 'setSeconds', 'setTime', 'setUTCDate', 'setUTCFullYear',
       'setUTCHours', 'setUTCMilliseconds', 'setUTCMinutes', 'setUTCMonth', 'setUTCSeconds',

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -223,11 +223,14 @@ describe('filters', function() {
     it('should do basic filter', function() {
       expect(date(noon)).toEqual(date(noon, 'mediumDate'));
       expect(date(noon, '')).toEqual(date(noon, 'mediumDate'));
+      expect(date(noon, '', true)).toEqual(date(noon, 'mediumDate', true));
     });
 
     it('should accept number or number string representing milliseconds as input', function() {
       expect(date(noon.getTime())).toEqual(date(noon.getTime(), 'mediumDate'));
       expect(date(noon.getTime() + "")).toEqual(date(noon.getTime() + "", 'mediumDate'));
+      expect(date(noon.getTime(), null, true)).toEqual(date(noon.getTime(), 'mediumDate', true));
+      expect(date(noon.getTime() + "", null, true)).toEqual(date(noon.getTime() + "", 'mediumDate', true));
     });
 
     it('should accept various format strings', function() {
@@ -268,11 +271,53 @@ describe('filters', function() {
                       toEqual('September 03, 1');
     });
 
+    it('should accept various format strings formatted as UTC', function() {
+      expect(date(secondWeek, 'yyyy-Ww', true)).
+                      toEqual('2013-W2');
+
+      expect(date(secondWeek, 'yyyy-Www', true)).
+                      toEqual('2013-W02');
+
+      expect(date(morning, "yy-MM-dd HH:mm:ss", true)).
+                      toEqual('10-09-03 12:05:08');
+
+      expect(date(morning, "yy-MM-dd HH:mm:ss.sss", true)).
+                      toEqual('10-09-03 12:05:08.001');
+
+      expect(date(midnight, "yyyy-M-d h=H:m:saZ", true)).
+                      toEqual('2010-9-3 5=5:5:8AM+0000');
+
+      expect(date(midnight, "yyyy-MM-dd hh=HH:mm:ssaZ", true)).
+                      toEqual('2010-09-03 05=05:05:08AM+0000');
+
+      expect(date(midnight, "yyyy-MM-dd hh=HH:mm:ss.sssaZ", true)).
+                      toEqual('2010-09-03 05=05:05:08.123AM+0000');
+
+      expect(date(noon, "yyyy-MM-dd hh=HH:mm:ssaZ", true)).
+                      toEqual('2010-09-03 05=17:05:08PM+0000');
+
+      expect(date(noon, "yyyy-MM-dd hh=HH:mm:ss.sssaZ", true)).
+                      toEqual('2010-09-03 05=17:05:08.012PM+0000');
+
+      expect(date(noon, "EEE, MMM d, yyyy", true)).
+                      toEqual('Fri, Sep 3, 2010');
+
+      expect(date(noon, "EEEE, MMMM dd, yyyy", true)).
+                      toEqual('Friday, September 03, 2010');
+
+      expect(date(earlyDate, "MMMM dd, y", true)).
+                      toEqual('September 03, 1');
+    });
+
     it('should accept negative numbers as strings', function() {
       //Note: this tests a timestamp set for 3 days before the unix epoch.
       //The behavior of `date` depends on your timezone, which is why we check just
       //the year and not the whole daye. See Issue #4218
       expect(date('-259200000').split(' ')[2]).toEqual('1969');
+    });
+
+    it('should accept negative numbers as strings formatted as UTC', function() {
+      expect(date('-259200000', null, true)).toEqual('Dec 29, 1969');
     });
 
     it('should format timezones correctly (as per ISO_8601)', function() {
@@ -299,14 +344,42 @@ describe('filters', function() {
                     toEqual('2010-09-03T06:35:08-0530');
     });
 
+    it('should format timezones as +0000 formatted as UTC', function() {
+      //Note: TzDate's first argument is offset, _not_ timezone.
+      var utc       = new angular.mock.TzDate( 0, '2010-09-03T12:05:08.000Z');
+      var eastOfUTC = new angular.mock.TzDate(-5, '2010-09-03T12:05:08.000Z');
+      var westOfUTC = new angular.mock.TzDate(+5, '2010-09-03T12:05:08.000Z');
+      var eastOfUTCPartial = new angular.mock.TzDate(-5.5, '2010-09-03T12:05:08.000Z');
+      var westOfUTCPartial = new angular.mock.TzDate(+5.5, '2010-09-03T12:05:08.000Z');
+
+      expect(date(utc, "yyyy-MM-ddTHH:mm:ssZ", true)).
+                    toEqual('2010-09-03T12:05:08+0000');
+
+      expect(date(eastOfUTC, "yyyy-MM-ddTHH:mm:ssZ", true)).
+                    toEqual('2010-09-03T12:05:08+0000');
+
+      expect(date(westOfUTC, "yyyy-MM-ddTHH:mm:ssZ", true)).
+                    toEqual('2010-09-03T12:05:08+0000');
+
+      expect(date(eastOfUTCPartial, "yyyy-MM-ddTHH:mm:ssZ", true)).
+                    toEqual('2010-09-03T12:05:08+0000');
+
+      expect(date(westOfUTCPartial, "yyyy-MM-ddTHH:mm:ssZ", true)).
+                    toEqual('2010-09-03T12:05:08+0000');
+    });
+
     it('should treat single quoted strings as string literals', function() {
       expect(date(midnight, "yyyy'de' 'a'x'dd' 'adZ' h=H:m:saZ")).
                       toEqual('2010de axdd adZ 12=0:5:8AM-0500');
+      expect(date(midnight, "yyyy'de' 'a'x'dd' 'adZ' h=H:m:saZ", true)).
+                      toEqual('2010de axdd adZ 5=5:5:8AM+0000');
     });
 
     it('should treat a sequence of two single quotes as a literal single quote', function() {
       expect(date(midnight, "yyyy'de' 'a''dd' 'adZ' h=H:m:saZ")).
                       toEqual("2010de a'dd adZ 12=0:5:8AM-0500");
+      expect(date(midnight, "yyyy'de' 'a''dd' 'adZ' h=H:m:saZ", true)).
+                      toEqual("2010de a'dd adZ 5=5:5:8AM+0000");
     });
 
     it('should accept default formats', function() {
@@ -336,6 +409,33 @@ describe('filters', function() {
                       toEqual('12:05 PM');
     });
 
+    it('should accept default formats formatted as UTC', function() {
+
+      expect(date(noon, "medium", true)).
+                      toEqual('Sep 3, 2010 5:05:08 PM');
+
+      expect(date(noon, "short", true)).
+                      toEqual('9/3/10 5:05 PM');
+
+      expect(date(noon, "fullDate", true)).
+                      toEqual('Friday, September 3, 2010');
+
+      expect(date(noon, "longDate", true)).
+                      toEqual('September 3, 2010');
+
+      expect(date(noon, "mediumDate", true)).
+                      toEqual('Sep 3, 2010');
+
+      expect(date(noon, "shortDate", true)).
+                      toEqual('9/3/10');
+
+      expect(date(noon, "mediumTime", true)).
+                      toEqual('5:05:08 PM');
+
+      expect(date(noon, "shortTime", true)).
+                      toEqual('5:05 PM');
+    });
+
     it('should parse format ending with non-replaced string', function() {
       expect(date(morning, 'yy/xxx')).toEqual('10/xxx');
     });
@@ -363,6 +463,28 @@ describe('filters', function() {
       expect(date('2003-09-10T13Z', format)).toEqual('2003-09-' + localDay + ' 00');
     });
 
+    it('should support various iso8061 date strings with timezone as input formatted as UTC', function() {
+      var format = 'yyyy-MM-dd ss';
+
+      var localDay = new Date(Date.UTC(2003, 9, 10, 13, 2, 3, 0)).getDate();
+
+      //full ISO8061
+      expect(date('2003-09-10T13:02:03.000Z', format, true)).toEqual('2003-09-' + localDay + ' 03');
+
+      expect(date('2003-09-10T13:02:03.000+00:00', format, true)).toEqual('2003-09-' + localDay + ' 03');
+
+      expect(date('20030910T033203-0930', format, true)).toEqual('2003-09-' + localDay + ' 03');
+
+      //no millis
+      expect(date('2003-09-10T13:02:03Z', format, true)).toEqual('2003-09-' + localDay + ' 03');
+
+      //no seconds
+      expect(date('2003-09-10T13:02Z', format, true)).toEqual('2003-09-' + localDay + ' 00');
+
+      //no minutes
+      expect(date('2003-09-10T13Z', format, true)).toEqual('2003-09-' + localDay + ' 00');
+    });
+
 
     it('should parse iso8061 date strings without timezone as local time', function() {
       var format = 'yyyy-MM-dd HH-mm-ss';
@@ -374,6 +496,18 @@ describe('filters', function() {
 
       //no time
       expect(date('2003-09-10', format)).toEqual('2003-09-10 00-00-00');
+    });
+
+    it('should parse iso8061 date strings without timezone as local time even if formatted as UTC', function() {
+      var format = 'yyyy-MM-dd HH-mm-ss';
+
+      //full ISO8061 without timezone
+      expect(date('2003-09-10T03:02:04.000', format, true)).toEqual('2003-09-10 10-02-04');
+
+      expect(date('20030910T030204', format, true)).toEqual('2003-09-10 10-02-04');
+
+      //no time
+      expect(date('2003-09-10', format, true)).toEqual('2003-09-10 07-00-00');
     });
 
     it('should support different degrees of subsecond precision', function () {
@@ -389,6 +523,21 @@ describe('filters', function() {
       expect(date('2003-09-10T13:02:03.123Z', format)).toEqual('2003-09-' + localDay + ' 03');
       expect(date('2003-09-10T13:02:03.12Z', format)).toEqual('2003-09-' + localDay + ' 03');
       expect(date('2003-09-10T13:02:03.1Z', format)).toEqual('2003-09-' + localDay + ' 03');
+    });
+
+    it('should support different degrees of subsecond precision formatted as UTC', function () {
+      var format = 'yyyy-MM-dd ss';
+
+      var localDay = new Date(Date.UTC(2003, 9-1, 10, 13, 2, 3, 123)).getDate();
+
+      expect(date('2003-09-10T13:02:03.12345678Z', format, true)).toEqual('2003-09-' + localDay + ' 03');
+      expect(date('2003-09-10T13:02:03.1234567Z', format, true)).toEqual('2003-09-' + localDay + ' 03');
+      expect(date('2003-09-10T13:02:03.123456Z', format, true)).toEqual('2003-09-' + localDay + ' 03');
+      expect(date('2003-09-10T13:02:03.12345Z', format, true)).toEqual('2003-09-' + localDay + ' 03');
+      expect(date('2003-09-10T13:02:03.1234Z', format, true)).toEqual('2003-09-' + localDay + ' 03');
+      expect(date('2003-09-10T13:02:03.123Z', format, true)).toEqual('2003-09-' + localDay + ' 03');
+      expect(date('2003-09-10T13:02:03.12Z', format, true)).toEqual('2003-09-' + localDay + ' 03');
+      expect(date('2003-09-10T13:02:03.1Z', format, true)).toEqual('2003-09-' + localDay + ' 03');
     });
   });
 });


### PR DESCRIPTION
If a truthy value is passed in as the third argument to dateFilter,
it will format in UTC rather than local time.

Closes #6546
