### PR TITLE
fix(loader): allow 'ng' module to be extended with filters/directives/etc

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -712,8 +712,10 @@ function createInjector(modulesToLoad, strictDi) {
         if (isString(module)) {
           moduleFn = angularModule(module);
           runBlocks = runBlocks.concat(loadModules(moduleFn.requires)).concat(moduleFn._runBlocks);
+          var isCore = module === 'ng';
+          if (isCore) runInvokeQueue(moduleFn._configBlocks);
           runInvokeQueue(moduleFn._invokeQueue);
-          runInvokeQueue(moduleFn._configBlocks);
+          if (!isCore) runInvokeQueue(moduleFn._configBlocks);
         } else if (isFunction(module)) {
             runBlocks.push(providerInjector.invoke(module));
         } else if (isArray(module)) {


### PR DESCRIPTION
Due to a regression in c0b4e2d, it is no longer possible to add new controllers, directives, filters, or animations to the `ng` module. This is becuase `config` blocks are always evaluated after regular invoke blocks, and the registration of these types depend on angular's config blocks to have been run.

This solution simply ensures that `ng`'s config blocks are run before its invoke blocks are run.

Closes #7709
