### PR TITLE
Update ngPluralize.js

### DIFF
--- a/src/ng/directive/ngPluralize.js
+++ b/src/ng/directive/ngPluralize.js
@@ -76,7 +76,7 @@
  * When one person, perhaps John, views the document, "John is viewing" will be shown.
  * When three people view the document, no explicit number rule is found, so
  * an offset of 2 is taken off 3, and Angular uses 1 to decide the plural category.
- * In this case, plural category 'one' is matched and "John, Marry and one other person are viewing"
+ * In this case, plural category 'one' is matched and "John, Mary and one other person are viewing"
  * is shown.
  *
  * Note that when you specify offsets, you must provide explicit number rules for


### PR DESCRIPTION
Just a silly change to the name of one of the examples that appears to be a typo. Changing Marry to Mary as the first would be a verb and the latter would be an extremely common name.
