### PR TITLE
perf($compile): remove no longer need nodeType filter when setting $scope data

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -865,14 +865,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           $linkNode.data('$' + name + 'Controller', instance);
         });
 
-        // Attach scope only to non-text nodes.
-        for(var i = 0, ii = $linkNode.length; i<ii; i++) {
-          var node = $linkNode[i],
-              nodeType = node.nodeType;
-          if (nodeType === 1 /* element */ || nodeType === 9 /* document */) {
-            $linkNode.eq(i).data('$scope', scope);
-          }
-        }
+        $linkNode.data('$scope', scope);
 
         if (cloneConnectFn) cloneConnectFn($linkNode, scope);
         if (compositeLinkFn) compositeLinkFn(scope, $linkNode, $linkNode, parentBoundTranscludeFn);


### PR DESCRIPTION
Now that a196c8bc added the nodeType check it doesn't have to be done by the link function.  This avoids the `.eq()` call which created a new jQuery/jqLite object for each element.
