### PR TITLE
fix($sce): fix adjustMatcher to replace multiple '*' and '**'

### DIFF
--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -36,8 +36,8 @@ function adjustMatcher(matcher) {
           'Illegal sequence *** in string matcher.  String: {0}', matcher);
     }
     matcher = escapeForRegexp(matcher).
-                  replace('\\*\\*', '.*').
-                  replace('\\*', '[^:/.?&;]*');
+                  replace(/\\\*\\\*/g, '.*').
+                  replace(/\\\*/g, '[^:/.?&;]*');
     return new RegExp('^' + matcher + '$');
   } else if (isRegExp(matcher)) {
     // The only other type of matcher allowed is a Regexp.

--- a/test/ng/sceSpecs.js
+++ b/test/ng/sceSpecs.js
@@ -316,6 +316,10 @@ describe('SCE', function() {
         expect(adjustMatcher(/^a.*b$/).exec('a.b')).not.toBeNull();
         expect(adjustMatcher(/^a.*b$/).exec('-a.b-')).toBeNull();
       });
+
+      it('should should match * and **', function() {
+        expect(adjustMatcher('*://*.example.com/**').exec('http://www.example.com/path')).not.toBeNull();
+      });
     });
 
     describe('regex matcher', function() {


### PR DESCRIPTION
On `$sceDelegateProvide` the `adjustMatcher` function was only replacing the first `*` and `**` found on the whitelisted and blacklisted urls. This caused $sceDelegate policy problems for example when trying to match `*://*.example.com/**` against `https://www.example.com/path`.
