### PR TITLE
feat($http): add option for unsafe xhr requests in FirefoxOS

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -485,6 +485,8 @@ function $HttpProvider() {
      *      for more information.
      *    - **responseType** - `{string}` - see
      *      [requestType](https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest#responseType).
+     *    - **xhrConfig** - `{Object}` - config pass to XMLHttpRequest. See
+     *      [XMLHttpRequest()](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#XMLHttpRequest())
      *
      * @returns {HttpPromise} Returns a {@link ng.$q promise} object with the
      *   standard `then` method and two http specific methods: `success` and `error`. The `then`
@@ -889,7 +891,7 @@ function $HttpProvider() {
         }
 
         $httpBackend(config.method, url, reqData, done, reqHeaders, config.timeout,
-            config.withCredentials, config.responseType);
+            config.withCredentials, config.responseType, config.xhrConfig);
       }
 
       return promise;

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function createXhr(method) {
+function createXhr(method, config) {
     //if IE and the method is not RFC2616 compliant, or if XMLHttpRequest
     //is not available, try getting an ActiveXObject. Otherwise, use XMLHttpRequest
     //if it is available
@@ -8,6 +8,9 @@ function createXhr(method) {
       !window.XMLHttpRequest)) {
       return new window.ActiveXObject("Microsoft.XMLHTTP");
     } else if (window.XMLHttpRequest) {
+      if (isObject(config)) {
+        return new window.XMLHttpRequest(config);
+      }
       return new window.XMLHttpRequest();
     }
 
@@ -40,7 +43,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
   var ABORTED = -1;
 
   // TODO(vojta): fix the signature
-  return function(method, url, post, callback, headers, timeout, withCredentials, responseType) {
+  return function(method, url, post, callback, headers, timeout, withCredentials, responseType, xhrConfig) {
     var status;
     $browser.$$incOutstandingRequestCount();
     url = url || $browser.url();
@@ -59,7 +62,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
       });
     } else {
 
-      var xhr = createXhr(method);
+      var xhr = createXhr(method, xhrConfig);
 
       xhr.open(method, url, true);
       forEach(headers, function(value, key) {


### PR DESCRIPTION
Previously, it was not possible to pass settings to the constructor of the XMLHttpRequest.  This
adds an optional config property `xhrConfig` to the $http constructor, allowing us to do so.  This
is required for use of the mozAnon and mozSystem options for FirefoxOS.
See https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest#XMLHttpRequest() for details.

Closes #2318
