### PR TITLE
feat($http): adds xhrFields to $http config object

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -485,6 +485,10 @@ function $HttpProvider() {
      *      for more information.
      *    - **responseType** - `{string}` - see
      *      [requestType](https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest#responseType).
+     *    - **xhrFields** - `{object}` - Object that will be passed directly to
+     *      [XMLHttpRequest()](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#XMLHttpRequest%28%29),
+     *      that can be used to set [non-standard properties](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#Non-standard_properties).
+     *      This object can also be set on the `$http.defaults` object to apply it globally.
      *
      * @returns {HttpPromise} Returns a {@link ng.$q promise} object with the
      *   standard `then` method and two http specific methods: `success` and `error`. The `then`
@@ -594,7 +598,8 @@ function $HttpProvider() {
       var config = {
         method: 'get',
         transformRequest: defaults.transformRequest,
-        transformResponse: defaults.transformResponse
+        transformResponse: defaults.transformResponse,
+        xhrFields: defaults.xhrFields
       };
       var headers = mergeHeaders(requestConfig);
 
@@ -889,7 +894,7 @@ function $HttpProvider() {
         }
 
         $httpBackend(config.method, url, reqData, done, reqHeaders, config.timeout,
-            config.withCredentials, config.responseType);
+            config.withCredentials, config.responseType, config.xhrFields);
       }
 
       return promise;

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function createXhr(method) {
+function createXhr(method, xhrFields) {
     //if IE and the method is not RFC2616 compliant, or if XMLHttpRequest
     //is not available, try getting an ActiveXObject. Otherwise, use XMLHttpRequest
     //if it is available
@@ -8,7 +8,11 @@ function createXhr(method) {
       !window.XMLHttpRequest)) {
       return new window.ActiveXObject("Microsoft.XMLHTTP");
     } else if (window.XMLHttpRequest) {
-      return new window.XMLHttpRequest();
+      if(isObject(xhrFields)){
+        return new window.XMLHttpRequest(xhrFields);
+      } else {
+        return new window.XMLHttpRequest();
+      }
     }
 
     throw minErr('$httpBackend')('noxhr', "This browser does not support XMLHttpRequest.");
@@ -40,7 +44,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
   var ABORTED = -1;
 
   // TODO(vojta): fix the signature
-  return function(method, url, post, callback, headers, timeout, withCredentials, responseType) {
+  return function(method, url, post, callback, headers, timeout, withCredentials, responseType, xhrFields) {
     var status;
     $browser.$$incOutstandingRequestCount();
     url = url || $browser.url();
@@ -59,7 +63,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
       });
     } else {
 
-      var xhr = createXhr(method);
+      var xhr = createXhr(method, xhrFields);
 
       xhr.open(method, url, true);
       forEach(headers, function(value, key) {

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -1,4 +1,4 @@
-/* global createHttpBackend: false, createMockXhr: false, MockXhr: false */
+/* global createHttpBackend: false, createMockXhr: false, MockXhr: false, createXhr: false */
 'use strict';
 
 describe('$httpBackend', function() {
@@ -293,6 +293,30 @@ describe('$httpBackend', function() {
     expect(MockXhr.$$lastInstance.withCredentials).toBe(true);
   });
 
+  it('should pass xhrFields to createXhr', function() {
+    var createXhr = jasmine.createSpy('createXhr').andCallFake(createMockXhr);
+    $backend = createHttpBackend($browser, createXhr);
+    var xhrFields = {someField: 1};
+    $backend('GET', '/some.url', null, callback, {}, null, false, null, xhrFields);
+    expect(createXhr).toHaveBeenCalledWith('GET', xhrFields);
+  });
+
+  it('should pass xhrFields to XMLHttpRequest contructor', function(){
+    if (window.XMLHttpRequest) {
+      var xhrFields = {someField: 1};
+      var XMLHttpRequest = spyOn(window, 'XMLHttpRequest');
+      createXhr('GET', xhrFields);
+      expect(XMLHttpRequest).toHaveBeenCalledWith(xhrFields);
+    }
+  });
+
+  it('should not pass xhrFields to XMLHttpRequest contructor if undefined', function(){
+    if (window.XMLHttpRequest) {
+      var XMLHttpRequest = spyOn(window, 'XMLHttpRequest');
+      createXhr('GET', undefined);
+      expect(XMLHttpRequest).toHaveBeenCalledWith();
+    }
+  });
 
   describe('responseType', function() {
 
@@ -521,5 +545,5 @@ describe('$httpBackend', function() {
       expect(callback.mostRecentCall.args[0]).toBe(503);
     });
   });
-});
 
+});

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1470,4 +1470,52 @@ describe('$http', function() {
 
     $httpBackend.verifyNoOutstandingExpectation = noop;
   });
+
+  it('shoud pass xhrFields params', function(){
+    var $httpBackend = jasmine.createSpy('$httpBackend');
+
+    $httpBackend.andCallFake(function(m, u, d, c, h, t, w, r, xhrFields) {
+      expect(xhrFields.someField).toBe(1);
+    });
+
+    module(function($provide) {
+      $provide.value('$httpBackend', $httpBackend);
+    });
+
+    inject(function($http, $rootScope) {
+      $http({
+        method: 'GET',
+        url: 'some.html',
+        xhrFields : { someField: 1 }
+      });
+      $rootScope.$digest();
+      expect($httpBackend).toHaveBeenCalledOnce();
+    });
+
+    $httpBackend.verifyNoOutstandingExpectation = noop;
+  });
+
+  it('should use xhrFields from default', function() {
+    var $httpBackend = jasmine.createSpy('$httpBackend');
+
+    $httpBackend.andCallFake(function(m, u, d, c, h, t, w, r, xhrFields) {
+      expect(xhrFields.someField).toBe(1);
+    });
+
+    module(function($provide) {
+      $provide.value('$httpBackend', $httpBackend);
+    });
+
+    inject(function($http, $rootScope) {
+      $http.defaults.xhrFields = {someField: 1};
+      $http({
+        method: 'GET',
+        url: 'some.html'
+      });
+      $rootScope.$digest();
+      expect($httpBackend).toHaveBeenCalledOnce();
+    });
+
+    $httpBackend.verifyNoOutstandingExpectation = noop;
+  });
 });


### PR DESCRIPTION
The `xhrFields` object is passed to the XMLHttpRequest constructor making it possible to set non-standard properties on the XMLHttpRequest object. It is also possible to set the object on `$http.defaults` to use it globally. With this functionality it is possible to set the `mozSystem` and `mozAnon` properties, which is required to use angular in a packaged Firefox OS app. See https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest#XMLHttpRequest()

Closes #2318
