### PR TITLE
Add hint about bower installation failure

### DIFF
--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -128,6 +128,8 @@ Once you have Node.js installed on your machine you can download the tool depend
 npm install
 ```
 
+Sometimes this fails because bower (see below) asks about creating user statistics. <a href="http://stackoverflow.com/questions/22387857/stop-bower-from-asking-for-statistics-when-installing">Tell it to work non-interactively in your ~/.bowerrc file.</a>
+
 This command will download the following tools, into the `node_modules` directory:
 
 - [Bower][bower] - client-side code package manager


### PR DESCRIPTION
When running npm install, this failed for me due to the reasons mentioned in the StackOverflow article cited. Creating the config file worked for me, did not know where to apply the better ranked config option. Feel free to add that if you know better.
