### PR TITLE
nested transclusion memory leak

### DIFF
--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3927,6 +3927,33 @@ describe('$compile', function() {
         });
       });
 
+      it('should not leak memory with nested transclusion', function() {
+        var calcCacheSize = function() {
+          var size = 0;
+          forEach(jqLite.cache, function(item, key) { size++; });
+          return size;
+        };
+
+        inject(function($compile, $rootScope) {
+          var size;
+
+          expect(calcCacheSize()).toEqual(0);
+
+          element = jqLite('<div><ul><li ng-repeat="n in nums">{{n}} => <i ng-if="0 === n%2">Even</i><i ng-if="1 === n%2">Odd</i></li></ul></div>');
+          $compile(element)($rootScope.$new());
+
+          $rootScope.nums = [0,1,2];
+          $rootScope.$apply();
+          size = calcCacheSize();
+
+          $rootScope.nums = [3,4,5];
+          $rootScope.$apply();
+          expect(calcCacheSize()).toEqual(size);
+
+          element.remove();
+          expect(calcCacheSize()).toEqual(0);
+        });
+      });
 
       it('should remove transclusion scope, when the DOM is destroyed', function() {
         module(function() {
@@ -3950,7 +3977,7 @@ describe('$compile', function() {
           $rootScope.username = 'Misko';
           $rootScope.select = true;
           element = $compile(
-              '<div><div box name="username" show="select">user: {{username}}</div></div>')
+              '<div ng-if="1<2"><div box name="username" show="select">user: {{username}}</div></div>')
               ($rootScope);
           $rootScope.$apply();
           expect(element.text()).toEqual('Hello: Misko!user: Misko');


### PR DESCRIPTION
When the transclude function creates the scope it destroys that scope on the '$destroy' jQuery event. If that element is a comment (because it was also transcluded, for example) then:
- jqLite adds and leaks data on the comment node, but $destroy seems to get called (the added test shows this)
- jQuery does not add/leak data on the comment node, so $destroy does not get called (the modified test shows this)

Here's another example: http://plnkr.co/edit/89BK3LXL6USYoATQhg2c?p=preview
