### PR TITLE
docs($location): hashPrefix, html5Mode are methods

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -551,7 +551,7 @@ function $LocationProvider(){
       html5Mode = false;
 
   /**
-   * @ngdoc property
+   * @ngdoc method
    * @name $locationProvider#hashPrefix
    * @description
    * @param {string=} prefix Prefix for hash part (containing path and search)
@@ -567,7 +567,7 @@ function $LocationProvider(){
   };
 
   /**
-   * @ngdoc property
+   * @ngdoc method
    * @name $locationProvider#html5Mode
    * @description
    * @param {boolean=} mode Use HTML5 strategy if available.


### PR DESCRIPTION
Such getter-setter methods of $interpolateProvider are marked as methods, not properties.

Also, empty entries are generated for these members in the HTML output if they are marked as properties. See https://docs.angularjs.org/api/ng/provider/$locationProvider
![image](https://cloud.githubusercontent.com/assets/94334/3338436/d4112a20-f85b-11e3-982f-e0097fc53796.png)
