### PR TITLE
Update ngSwitch.js

### DIFF
--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -142,11 +142,9 @@ var ngSwitchDirective = ['$animate', function($animate) {
           selectedElements = [],
           previousElements = [],
           selectedScopes = [];
-          
       if(!!attr.on && attr.ngSwitch === 'ng-switch'){
-        watchExpr = attr.on;
+          watchExpr = attr.on;
       }
-
       scope.$watch(watchExpr, function ngSwitchWatchAction(value) {
         var i, ii;
         for (i = 0, ii = previousElements.length; i < ii; ++i) {

--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -142,6 +142,10 @@ var ngSwitchDirective = ['$animate', function($animate) {
           selectedElements = [],
           previousElements = [],
           selectedScopes = [];
+          
+      if(!!attr.on && attr.ngSwitch === 'ng-switch'){
+        watchExpr = attr.on;
+      }
 
       scope.$watch(watchExpr, function ngSwitchWatchAction(value) {
         var i, ii;


### PR DESCRIPTION
As per example here https://docs.angularjs.org/api/ng/directive/ngSwitch
It is mentioned to use attr.on, when using the jade templating engine ngSwitch would always be set to ng-switch
Here is a simple fix to that problem.
