### PR TITLE
Update directive.ngdoc

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -636,8 +636,8 @@ To do this, we need to use the `transclude` option.
     </div>
   </file>
   <file name="my-dialog.html">
-    <div class="alert" ng-transclude>
-    </div>
+    <h1 class="alert" ng-transclude>
+    </h1>
   </file>
 </example>
 


### PR DESCRIPTION
Currently it's a bit unclear what's the role of ng-transclude in my-dialog.html. Having ng-transclude in h1 (instead of div) makes it easily noticeable that contents of my-dialog tag in index.html are getting WRAPPED by contents of ng-transclude tag in my-dialog.html.
