### PR TITLE
srcset used instead of src for img attribute

### DIFF
--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -140,7 +140,7 @@
  *
  * The buggy way to write it:
  * ```html
- * <img srcset="http://www.gravatar.com/avatar/{{hash}} 2x"/>
+ * <img src="http://www.gravatar.com/avatar/{{hash}} 2x"/>
  * ```
  *
  * The correct way to write it:


### PR DESCRIPTION
In `ngSrc` documentation `srcset` is used instead of `src` as `img` element attribute in the example.
