### PR TITLE
fix(input): improve html5 validation support (v1.2.x)

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -100,6 +100,7 @@
     "assertNotHasOwnProperty": false,
     "getter": false,
     "getBlockElements": false,
+    "VALIDITY_STATE_PROPERTY": false,
 
     /* AngularPublic.js */
     "version": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -13,6 +13,7 @@
     -angularModule,
     -nodeName_,
     -uid,
+    -VALIDITY_STATE_PROPERTY,
 
     -lowercase,
     -uppercase,
@@ -101,6 +102,10 @@
  *
  * <div doc-module-components="ng"></div>
  */
+
+// The name of a form control's ValidityState property.
+// This is used so that it's possible for internal tests to create mock ValidityStates.
+var VALIDITY_STATE_PROPERTY = 'validity';
 
 /**
  * @ngdoc function

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -101,6 +101,7 @@
     "assertNotHasOwnProperty": false,
     "getter": false,
     "getBlockElements": false,
+    "VALIDITY_STATE_PROPERTY": true,
 
     /* filters.js */
     "getFirstThursdayOfYear": false,


### PR DESCRIPTION
This CL improves mocking support for HTML5 validation, and ensures that it
works correctly along with debounced commission of view values.
