### PR TITLE
fix($AnchorScroll): Don't fire scroll event on initialization of autoScr...

### DIFF
--- a/src/ng/anchorScroll.js
+++ b/src/ng/anchorScroll.js
@@ -92,8 +92,11 @@ function $AnchorScrollProvider() {
     // (no url change, no $location.hash() change), browser native does scroll
     if (autoScrollingEnabled) {
       $rootScope.$watch(function autoScrollWatch() {return $location.hash();},
-        function autoScrollWatchAction() {
-          $rootScope.$evalAsync(scroll);
+        function autoScrollWatchAction(newValue, oldValue) {
+          // Prevent unnecessary scroll event from being fired on watch creation.
+          if(newValue !== oldValue) {
+            $rootScope.$evalAsync(scroll);
+          }
         });
     }
 


### PR DESCRIPTION
...ollWatch

Currently when your application is bootstrapped and you have used a directive that requires $anchorScroll (such as ngInclude), a scroll event will be $evalAsync'd that can cause the window to unnecessarily scroll to the top.
