### PR TITLE
feat($resource): Allow functions in action timeout

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -595,8 +595,10 @@ function $HttpProvider() {
      *      GET request, otherwise if a cache instance built with
      *      {@link ng.$cacheFactory $cacheFactory}, this cache will be used for
      *      caching.
-     *    - **timeout** – `{number|Promise}` – timeout in milliseconds, or {@link ng.$q promise}
-     *      that should abort the request when resolved.
+     *   - **`timeout`** – `{number|Promise|Function}` – timeout in milliseconds, or
+     *      {@link ng.$q promise} that should abort the request when resolved or a function that returns
+     *      either a number or a promise. The function allows for the timeout to change with time and
+     *      provides a way to cancel an action multiple times (by providing a new promise each time).
      *    - **withCredentials** - `{boolean}` - whether to set the `withCredentials` flag on the
      *      XHR object. See [requests with credentials](https://developer.mozilla.org/docs/Web/HTTP/Access_control_CORS#Requests_with_credentials)
      *      for more information.

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -29,6 +29,7 @@ function $HttpBackendProvider() {
 function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDocument) {
   // TODO(vojta): fix the signature
   return function(method, url, post, callback, headers, timeout, withCredentials, responseType) {
+    var status, internalTimeout;
     $browser.$$incOutstandingRequestCount();
     url = url || $browser.url();
 
@@ -112,10 +113,12 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
       xhr.send(post || null);
     }
 
-    if (timeout > 0) {
-      var timeoutId = $browserDefer(timeoutRequest, timeout);
-    } else if (isPromiseLike(timeout)) {
-      timeout.then(timeoutRequest);
+    internalTimeout = angular.isFunction(timeout) ? timeout() : timeout;
+
+    if (internalTimeout > 0) {
+      var timeoutId = $browserDefer(timeoutRequest, internalTimeout);
+    } else if (internalTimeout && internalTimeout.then) {
+      internalTimeout.then(timeoutRequest);
     }
 
 

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -150,8 +150,10 @@ function shallowClearAndCopy(src, dst) {
  *     GET request, otherwise if a cache instance built with
  *     {@link ng.$cacheFactory $cacheFactory}, this cache will be used for
  *     caching.
- *   - **`timeout`** – `{number|Promise}` – timeout in milliseconds, or {@link ng.$q promise} that
- *     should abort the request when resolved.
+ *   - **`timeout`** – `{number|Promise|Function}` – timeout in milliseconds, or
+ *     {@link ng.$q promise} that should abort the request when resolved or a function that returns
+ *     either a number or a promise. The function allows for the timeout to change with time and
+ *     provides a way to cancel an action multiple times (by providing a new promise each time).
  *   - **`withCredentials`** - `{boolean}` - whether to set the `withCredentials` flag on the
  *     XHR object. See
  *     [requests with credentials](https://developer.mozilla.org/en/http_access_control#section_5)

--- a/test/helpers/matchers.js
+++ b/test/helpers/matchers.js
@@ -120,6 +120,28 @@ beforeEach(function() {
       return this.actual.callCount == 1;
     },
 
+    toHaveBeenCalledTwice: function() {
+      if (arguments.length > 0) {
+        throw new Error('toHaveBeenCalledTwice does not take arguments, use toHaveBeenCalledWith');
+      }
+
+      if (!jasmine.isSpy(this.actual)) {
+        throw new Error('Expected a spy, but got ' + jasmine.pp(this.actual) + '.');
+      }
+
+      this.message = function() {
+        var msg = 'Expected spy ' + this.actual.identity + ' to have been called twice, but was ',
+            count = this.actual.callCount;
+        return [
+          count === 0 ? msg + 'never called.' :
+                        msg + 'called ' + count + ' times.',
+          msg.replace('to have', 'not to have') + 'called once.'
+        ];
+      };
+
+      return this.actual.callCount == 2;
+    },
+
 
     toHaveBeenCalledOnceWith: function() {
       var expectedArgs = jasmine.util.argsToArray(arguments);

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -423,6 +423,61 @@ describe("resource", function() {
   });
 
 
+  it("should not perform action due to timeout", inject(function($q) {
+    $httpBackend.when('GET').respond({value: 123});
+    var deferred = $q.defer();
+    var R = $resource('/Path', {param: null}, {get: {method: 'GET', timeout: deferred.promise}});
+    R.get({}, callback);
+    deferred.resolve();
+    expect(callback).not.toHaveBeenCalled();
+  }));
+
+
+  it("should not perform action due to timeout provided by function", inject(function($q) {
+    $httpBackend.when('GET').respond({value: 123});
+    var deferred = $q.defer();
+    var R = $resource('/Path', {param: null}, {get: {method: 'GET',
+        timeout: function() { return deferred.promise; }}});
+    R.get({}, callback);
+    deferred.resolve();
+    expect(callback).not.toHaveBeenCalled();
+  }));
+
+
+  it("should not perform first action due to timeout", inject(function($q) {
+    $httpBackend.when('GET').respond({value: 123});
+    var deferred = $q.defer();
+
+    var R = $resource('/Path', {param: null}, {get: {method: 'GET',
+        timeout: function() { return deferred.promise; }}});
+    R.get({}, callback);
+    deferred.resolve();
+    expect(callback).not.toHaveBeenCalled();
+
+    deferred = $q.defer();
+    R.get({}, callback);
+    $httpBackend.flush();
+    expect(callback).toHaveBeenCalled();
+  }));
+
+
+  it("should not perform both actions due to timeout", inject(function($q) {
+    $httpBackend.when('GET').respond({value: 123});
+    var deferred = $q.defer();
+
+    var R = $resource('/Path', {param: null}, {get: {method: 'GET',
+        timeout: function() { return deferred.promise; }}});
+    R.get({}, callback);
+    deferred.resolve();
+    expect(callback).not.toHaveBeenCalled();
+
+    deferred = $q.defer();
+    deferred.resolve();
+    R.get({}, callback);
+    expect(callback).not.toHaveBeenCalled();
+  }));
+
+
   it("should read resource", function() {
     $httpBackend.expect('GET', '/CreditCard/123').respond({id: 123, number: '9876'});
     var cc = CreditCard.get({id: 123}, callback);


### PR DESCRIPTION
Support functions when configuring actions. This allows the timeout to change with time, when the function returns a number, and allows an action to be cancelled multiple times, when the function returns a new promise.

Closes #7974
