### PR TITLE
chore(watchr-docs): remove watchr-docs.rb

### DIFF
--- a/watchr-docs.rb
+++ b/watchr-docs.rb
@@ -1,7 +1,0 @@
-# config file for watchr http://github.com/mynyml/watchr
-# install: gem install watchr
-# run: watch watchr-docs.rb
-
-watch( '^src/|^docs/' )  do
-   system 'echo "\n\ndoc run started @ `date`"; node docs/src/gen-docs.js'
-end


### PR DESCRIPTION
This file hasn't changed in forever, and doesn't seem to be in use any longer.

This is primarily to test the new Travis-CI queue, but are we actually using this file anywhere?
It doesn't look like it should work for the new docs anymore at all.
