### PR TITLE
fix($interval): do not invoke $apply when invokeApply is false

### DIFF
--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -138,6 +138,7 @@ function $IntervalProvider() {
           iteration = 0,
           skipApply = (isDefined(invokeApply) && !invokeApply);
 
+      deferred.$$skipApply = skipApply;
       count = isDefined(count) ? count : 0;
 
       promise.then(null, null, fn);

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -171,8 +171,8 @@
 function $QProvider() {
 
   this.$get = ['$rootScope', '$exceptionHandler', function($rootScope, $exceptionHandler) {
-    return qFactory(function(callback) {
-      $rootScope.$evalAsync(callback);
+    return qFactory(function(callback, skipApply) {
+      $rootScope.$evalAsync(callback, skipApply);
     }, $exceptionHandler);
   }];
 }
@@ -208,7 +208,7 @@ function qFactory(nextTick, exceptionHandler) {
         if (pending) {
           var callbacks = pending;
           pending = undefined;
-          value = ref(val);
+          value = ref(val, deferred.$$skipApply);
 
           if (callbacks.length) {
             nextTick(function() {
@@ -217,7 +217,7 @@ function qFactory(nextTick, exceptionHandler) {
                 callback = callbacks[i];
                 value.then(callback[0], callback[1], callback[2]);
               }
-            });
+            }, deferred.$$skipApply);
           }
         }
       },
@@ -239,7 +239,7 @@ function qFactory(nextTick, exceptionHandler) {
                 callback = callbacks[i];
                 callback[2](progress);
               }
-            });
+            }, deferred.$$skipApply);
           }
         }
       },
@@ -331,14 +331,14 @@ function qFactory(nextTick, exceptionHandler) {
   };
 
 
-  var ref = function(value) {
+  var ref = function(value, skipApply) {
     if (value && isFunction(value.then)) return value;
     return {
       then: function(callback) {
         var result = defer();
         nextTick(function() {
           result.resolve(callback(value));
-        });
+        }, skipApply);
         return result.promise;
       }
     };

--- a/test/ng/intervalSpec.js
+++ b/test/ng/intervalSpec.js
@@ -98,6 +98,21 @@ describe('$interval', function() {
   }));
 
 
+  it('should NOT call $rootScope.$digest if invokeApply is set to false',
+      inject(function($interval, $rootScope, $window, $browser) {
+    var digestSpy = spyOn($rootScope, '$digest').andCallThrough();
+    var resolveSpy = jasmine.createSpy('resolve');
+    var notifySpy = jasmine.createSpy('notify');
+    $interval(noop, 1000, 1, false).then(resolveSpy, null, notifySpy);
+
+    $window.flush(4000);
+    $browser.defer.flush();
+    expect(digestSpy).not.toHaveBeenCalled();
+    expect(resolveSpy).toHaveBeenCalledOnce();
+    expect(notifySpy).toHaveBeenCalledOnce();
+  }));
+
+
   it('should allow you to specify the delay time', inject(function($interval, $window) {
     var counter = 0;
     $interval(function() { counter++; }, 123);


### PR DESCRIPTION
This CL allows $q Deferred objects to avoid invoking $rootScope.$digest, by optionally adding asynchronously invoked functions to a different queue which is processed outside of $digest.

Needless to say, this is a hack, and it would be great if there was a better way to do this (such as not using Promises for $interval at all). However, I felt that changing the API to not use promises would have been a much bigger API change than this.

Serious review needed!

Closes #7103
