### PR TITLE
fix($http): don't remove content-type header if data is set by request transf...

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -607,7 +607,7 @@ function $HttpProvider() {
         var reqData = transformData(config.data, headersGetter(headers), config.transformRequest);
 
         // strip content-type if data is undefined
-        if (isUndefined(config.data)) {
+        if (isUndefined(reqData)) {
           forEach(headers, function(value, header) {
             if (lowercase(header) === 'content-type') {
                 delete headers[header];

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -693,6 +693,22 @@ describe('$http', function() {
         $httpBackend.flush();
       });
 
+      it('should NOT delete Content-Type header if request data/body is set by request transform', function() {
+        $httpBackend.expect('POST', '/url', {'one' : 'two'}, function(headers) {
+          return headers['Content-Type'] == 'application/json;charset=utf-8';
+        }).respond('');
+
+        $http({
+          url: '/url',
+          method: 'POST',
+          transformRequest : function(data) {
+            data = {'one' : 'two'};
+            return data;
+          }
+        });
+
+        $httpBackend.flush();
+      });
 
       it('should set the XSRF cookie into a XSRF header', inject(function($browser) {
         function checkXSRF(secret, header) {


### PR DESCRIPTION
...orm

The test could arguably also go into the transform section, not sure about that.

Fixes #7910
