### PR TITLE
fix typo in descriptions and add test to match blank object attribute

### DIFF
--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -81,17 +81,6 @@ describe('Filter: filter', function() {
     ]);
   });
 
-  it('should be able to use exact match to match empty strings', function() {
-    var items = [{person: {name: 'John'}},
-                 {person: {name: 'Rita'}},
-                 {person: {name: 'Billy'}},
-                 {person: {name: ''}},
-                 {person: {name: 'Joan'}}];
-    expect(filter(items, {person: {name: ''}}).length).toBe(5);
-    expect(filter(items, {person: {name: ''}}, true).length).toBe(1);
-  });
-
-
   it('should match any properties for given "$" property', function() {
     var items = [{first: 'tom', last: 'hevery'},
                  {first: 'adam', last: 'hevery', alias: 'tom', done: false},
@@ -170,6 +159,15 @@ describe('Filter: filter', function() {
 
     });
 
+    it('should be able to use exact match to match empty strings', function() {
+      var items = [{person: {name: 'John'}},
+                   {person: {name: 'Rita'}},
+                   {person: {name: 'Billy'}},
+                   {person: {name: ''}},
+                   {person: {name: 'Joan'}}];
+      expect(filter(items, {person: {name: ''}}).length).toBe(5);
+      expect(filter(items, {person: {name: ''}}, true).length).toBe(1);
+    });
 
   });
 

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -49,7 +49,7 @@ describe('Filter: filter', function() {
     expect(filter(items, function(i) {return i.done;}).length).toBe(1);
   });
 
-  it('should take object as perdicate', function() {
+  it('should take object as predicate', function() {
     var items = [{first: 'misko', last: 'hevery'},
                  {first: 'adam', last: 'abrons'}];
 
@@ -61,7 +61,7 @@ describe('Filter: filter', function() {
   });
 
 
-  it('should support predicat object with dots in the name', function() {
+  it('should support predicate object with dots in the name', function() {
     var items = [{'first.name': 'misko', 'last.name': 'hevery'},
                  {'first.name': 'adam', 'last.name': 'abrons'}];
 
@@ -79,6 +79,16 @@ describe('Filter: filter', function() {
     expect(filter(items, {person: {name: 'Jo'}})).toEqual([
       {person: {name: 'John'}}, {person: {name: 'Joan'}}
     ]);
+  });
+
+  it('should be able to use exact match to match empty strings', function() {
+    var items = [{person: {name: 'John'}},
+                 {person: {name: 'Rita'}},
+                 {person: {name: 'Billy'}},
+                 {person: {name: ''}},
+                 {person: {name: 'Joan'}}];
+    expect(filter(items, {person: {name: ''}}).length).toBe(5);
+    expect(filter(items, {person: {name: ''}}, true).length).toBe(1);
   });
 
 


### PR DESCRIPTION
Request Type: test

How to reproduce: 

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

while investigating #7890 I found a couple of typos in the filter tests, and used the test suite to prove the problem was working as specified. There were no test cases specifically to show the behaviour that I could find, so committed it as an example of matching empty string through use of exact match.

**Other Comments:**

test(filter): fix typo in descriptions and add test to match blank object attribute

Two descriptions contain typo's to the word predicate.
Also, to prove behaviour in ticket 7890, create a new test to display filter

Closes #7891
