### PR TITLE
feat(shutdown): Add the ability for an app to shutdown

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -86,6 +86,7 @@
     "angularInit": false,
     "bootstrap": false,
     "getTestability": false,
+    "shutdown": false,
     "snake_case": false,
     "bindJQuery": false,
     "assertArg": false,

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -86,6 +86,7 @@
   $$SanitizeUriProvider,
   $SceProvider,
   $SceDelegateProvider,
+  $ShutdownProvider,
   $SnifferProvider,
   $TemplateCacheProvider,
   $TemplateRequestProvider,
@@ -125,6 +126,7 @@ var version = {
 function publishExternalAPI(angular) {
   extend(angular, {
     'bootstrap': bootstrap,
+    'shutdown': shutdown,
     'copy': copy,
     'extend': extend,
     'merge': merge,
@@ -160,6 +162,8 @@ function publishExternalAPI(angular) {
 
   angularModule('ng', ['ngLocale'], ['$provide',
     function ngModule($provide) {
+      // $shutdown provider needs to be first as other providers might use it.
+      $provide.provider('$shutdown', $ShutdownProvider);
       // $$sanitizeUriProvider needs to be before $compileProvider as it is used by it.
       $provide.provider({
         $$sanitizeUri: $$SanitizeUriProvider

--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -135,8 +135,6 @@ function $IntervalProvider() {
     function interval(fn, delay, count, invokeApply) {
       var hasParams = arguments.length > 4,
           args = hasParams ? sliceArgs(arguments, 4) : [],
-          setInterval = $window.setInterval,
-          clearInterval = $window.clearInterval,
           iteration = 0,
           skipApply = (isDefined(invokeApply) && !invokeApply),
           deferred = (skipApply ? $$q : $q).defer(),
@@ -144,7 +142,7 @@ function $IntervalProvider() {
 
       count = isDefined(count) ? count : 0;
 
-      promise.$$intervalId = setInterval(function tick() {
+      promise.$$intervalId = $browser.interval(function tick() {
         if (skipApply) {
           $browser.defer(callback);
         } else {
@@ -154,7 +152,7 @@ function $IntervalProvider() {
 
         if (count > 0 && iteration >= count) {
           deferred.resolve(iteration);
-          clearInterval(promise.$$intervalId);
+          $browser.interval.cancel(promise.$$intervalId);
           delete intervals[promise.$$intervalId];
         }
 
@@ -191,7 +189,7 @@ function $IntervalProvider() {
         // Interval cancels should not report as unhandled promise.
         intervals[promise.$$intervalId].promise.catch(noop);
         intervals[promise.$$intervalId].reject('canceled');
-        $window.clearInterval(promise.$$intervalId);
+        $browser.interval.cancel(promise.$$intervalId);
         delete intervals[promise.$$intervalId];
         return true;
       }

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1671,6 +1671,110 @@ describe('angular', function() {
     });
   });
 
+  describe('shutdown', function() {
+    it('should be able to shutdown an angular app', function() {
+      var element = jqLite('<div>bootstrap me!</div>');
+      angular.bootstrap(element);
+
+      angular.shutdown(element);
+      expect(element.data('$injector')).toBeUndefined();
+      expect(element.text()).toBe('bootstrap me!');
+    });
+
+    it('should be able to shutdown on any element that is part of the app', function() {
+      var element = jqLite('<div><span>Bootstrap me!</span></div>');
+
+      angular.bootstrap(element);
+      angular.shutdown(element.find('span'));
+      expect(element.data('$injector')).toBeUndefined();
+      expect(element.text()).toBe('Bootstrap me!');
+    });
+
+    it('should throw if trying to shutdown an element that is not part of an app', function() {
+      var element = jqLite('<div>Not an app</div>');
+
+      expect(function() {
+        angular.shutdown(element);
+        }).toThrowMinErr('ng', 'shtdwn', 'Element not part of an app');
+    });
+
+    it('should preserve the html as it is', function() {
+      var element = jqLite('<div>Hello World<span ng-if="false">Do not see me</span></div>');
+
+      angular.bootstrap(element);
+      angular.shutdown(element);
+      expect(element.text()).toBe('Hello World');
+    });
+
+    it('should remove all the data from all the elements', function() {
+      var element = jqLite('<div><span>Bootstrap me!</span></div>');
+
+      angular.bootstrap(element);
+      element.find('span').data('foo', 'bar');
+      angular.shutdown(element);
+      expect(element.find('span').data('foo')).toBeUndefined();
+    });
+
+    describe('setTimeout and setInterval shutdown', function() {
+      var setTimeoutSpy, setInternalSpy;
+      beforeEach(inject(function($window) {
+        spyOn($window, 'setInterval').and.returnValue(42);
+        spyOn($window, 'clearInterval');
+        spyOn($window, 'setTimeout');
+      }));
+
+      it('should stop calling the window setTimeout', inject(function($window) {
+        var element = jqLite('<div><span>Bootstrap me!</span></div>'),
+          injector = angular.bootstrap(element),
+          $timeout = injector.get('$timeout');
+
+        $timeout(function() {});
+        expect($window.setTimeout).toHaveBeenCalledOnce();
+        angular.shutdown(element);
+        $timeout(function() {});
+        expect($window.setTimeout).toHaveBeenCalledOnce();
+      }));
+
+      it('should cancel all active interval calls', inject(function($window) {
+        var element = jqLite('<div><span>Bootstrap me!</span></div>'),
+          injector = angular.bootstrap(element),
+          $interval = injector.get('$interval');
+
+        $interval(function() {}, 100);
+        expect($window.setInterval).toHaveBeenCalledOnce();
+        expect($window.clearInterval).not.toHaveBeenCalled();
+        angular.shutdown(element);
+        expect($window.clearInterval).toHaveBeenCalledOnce();
+        expect($window.clearInterval.calls.mostRecent().args[0]).toBe(42);
+      }));
+
+      it('should not cancel intervals that were already canceled', inject(function($window) {
+        var element = jqLite('<div><span>Bootstrap me!</span></div>'),
+          injector = angular.bootstrap(element),
+          $interval = injector.get('$interval'),
+          intervalPromise = $interval(function() {}, 100);
+
+        $interval.cancel(intervalPromise);
+        expect($window.setInterval).toHaveBeenCalledOnce();
+        expect($window.clearInterval).toHaveBeenCalledOnce();
+        angular.shutdown(element);
+        expect($window.setInterval).toHaveBeenCalledOnce();
+        expect($window.clearInterval).toHaveBeenCalledOnce();
+      }));
+    });
+
+    it('should destroy the root scope', function() {
+      var element = jqLite('<div><span>Bootstrap me!</span></div>'),
+        injector = angular.bootstrap(element),
+        rootScope = injector.get('$rootScope'),
+        listener = jasmine.createSpy('listener');
+
+      rootScope.$on('$destroy', listener);
+      angular.shutdown(element);
+      expect(listener).toHaveBeenCalled();
+    });
+  });
+
 
   describe('angular service', function() {
     it('should override services', function() {

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -738,7 +738,7 @@ describe('browser', function() {
       browser.onUrlChange(callback);
       fakeWindow.location.href = 'http://server/new';
 
-      browser.$$applicationDestroyed();
+      browser.shutdown();
 
       fakeWindow.fire('popstate');
       expect(callback).not.toHaveBeenCalled();

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1075,10 +1075,10 @@ describe('Scope', function() {
     }));
 
 
-    it('should call $browser.$$applicationDestroyed when destroying rootScope', inject(function($rootScope, $browser) {
-      spyOn($browser, '$$applicationDestroyed');
+    it('should call shutdown when destroying rootScope', inject(function($rootScope, $browser) {
+      spyOn($browser, 'shutdown');
       $rootScope.$destroy();
-      expect($browser.$$applicationDestroyed).toHaveBeenCalledOnce();
+      expect($browser.shutdown).toHaveBeenCalledOnce();
     }));
 
 


### PR DESCRIPTION
Adds a new `$shutdown` service that can be used to shutdown an app and the `$shutdownProvider` that can be used to register tasks that need to be executed when shutting down an app.

Added tasks for `$rootElement`, `$rootScope` and `$browser` to be able to shutdown an app

Refactor `$interval` so it delegates to `$browser` just like `$timeout` does
