### PR TITLE
fix(httpBackend): should not read statusText when request is aborted

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -81,7 +81,8 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
         // Safari respectively.
         if (xhr && xhr.readyState == 4) {
           var responseHeaders = null,
-              response = null;
+              response = null,
+              statusText = '';
 
           if(status !== ABORTED) {
             responseHeaders = xhr.getAllResponseHeaders();
@@ -91,11 +92,17 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
             response = ('response' in xhr) ? xhr.response : xhr.responseText;
           }
 
+          // Accessing statusText on an aborted xhr object will
+          // throw an 'c00c023f error' in IE9 and lower, don't touch it.
+          if (status !== ABORTED || (!msie || msie >= 10)) {
+            statusText = xhr.statusText;
+          }
+
           completeRequest(callback,
               status || xhr.status,
               response,
               responseHeaders,
-              xhr.statusText || '');
+              statusText);
         }
       };
 

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -92,6 +92,25 @@ describe('$httpBackend', function() {
     expect(callback).toHaveBeenCalledOnce();
   });
 
+  it('should not touch xhr.statusText when request is aborted on IE9 or lower', function() {
+    callback.andCallFake(function(status, response, headers, statusText) {
+      expect(statusText).toBe((!msie || msie >= 10) ? 'OK' : '');
+    });
+
+    $backend('GET', '/url', null, callback, {}, 2000);
+    xhr = MockXhr.$$lastInstance;
+    spyOn(xhr, 'abort');
+
+    fakeTimeout.flush();
+    expect(xhr.abort).toHaveBeenCalledOnce();
+
+    xhr.status = 0;
+    xhr.readyState = 4;
+    xhr.statusText = 'OK';
+    xhr.onreadystatechange();
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
   it('should call completion function with empty string if not present', function() {
     callback.andCallFake(function(status, response, headers, statusText) {
       expect(statusText).toBe('');


### PR DESCRIPTION
Request Type: bug

How to reproduce: Abort an XHR request in IE9. Observe "Error c00c023f" in the console.

Component(s): $http

Impact: medium

Complexity: small

**Detailed Description:**

Commit 1d2414ca93a0340840ea1e80c48edb51ec55cd48 introduced a regression which breaks IE9 by accessing the `statusText` property of an aborted xhr request. 
There's been a similar problem earlier which was fixed with commit 6f1050df4fa885bd59ce85adbef7350ea93911a3.

This PR changes the behavior to only access the `statusText` property if the request wasn't aborted.
