### PR TITLE
feat(jqLite): support isDefaultPrevented for triggerHandler dummies

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -953,7 +953,12 @@ forEach({
     eventData = eventData || [];
 
     var event = [{
-      preventDefault: noop,
+      preventDefault: function() {
+        this.defaultPrevented = true;
+      },
+      isDefaultPrevented: function() {
+        return this.defaultPrevented === true;
+      },
       stopPropagation: noop
     }];
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1690,6 +1690,20 @@ describe('jqLite', function() {
       data = pokeSpy.mostRecentCall.args[1];
       expect(data.hello).toBe("world");
     });
+
+    it('should mark event as prevented if preventDefault is called', function() {
+      var element = jqLite('<a>poke</a>'),
+          pokeSpy = jasmine.createSpy('poke'),
+          event;
+
+      element.on('click', pokeSpy);
+      element.triggerHandler('click');
+      event = pokeSpy.mostRecentCall.args[0];
+
+      expect(event.isDefaultPrevented()).toBe(false);
+      event.preventDefault();
+      expect(event.isDefaultPrevented()).toBe(true);
+    });
   });
 
 


### PR DESCRIPTION
triggerHandler sends dummy events to an element, but although the event includes the preventDefault method, there is no way to see if it was called for the event. This is sometimes important when testing directives that use preventDefault
