### PR TITLE
fix($location): right button click in firefox

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -837,7 +837,7 @@ function $LocationProvider() {
       // TODO(vojta): rewrite link when opening in new tab/window (in legacy browser)
       // currently we open nice url link and redirect then
 
-      if (!html5Mode.rewriteLinks || event.ctrlKey || event.metaKey || event.which == 2) return;
+      if (!html5Mode.rewriteLinks || event.ctrlKey || event.metaKey || event.which == 2 || event.button == 2) return;
 
       var elm = jqLite(event.target);
 

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1504,6 +1504,40 @@ describe('$location', function() {
       );
     });
 
+    it('should not rewrite when right click pressed', function() {
+      configureService({linkHref: '/a?b=c', html5Mode: true, supportHist: true});
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser) {
+          var rightClick;
+          if (document.createEvent) {
+            rightClick = document.createEvent('MouseEvents');
+            rightClick.initMouseEvent('click', true, true, window, 1, 10, 10, 10,  10, false,
+                                      false, false, false, 2, null);
+
+            link.dispatchEvent(rightClick);
+          } else if (document.createEventObject) { // for IE
+            rightClick = document.createEventObject();
+            rightClick.type = 'click';
+            rightClick.cancelBubble = true;
+            rightClick.detail = 1;
+            rightClick.screenX = 10;
+            rightClick.screenY = 10;
+            rightClick.clientX = 10;
+            rightClick.clientY = 10;
+            rightClick.ctrlKey = false;
+            rightClick.altKey = false;
+            rightClick.shiftKey = false;
+            rightClick.metaKey = false;
+            rightClick.button = 2;
+            link.fireEvent('onclick', rightClick);
+          }
+          expectNoRewrite($browser);
+        }
+      );
+    });
+
 
     it('should not mess up hash urls when clicking on links in hashbang mode', function() {
       var base;


### PR DESCRIPTION
When user click right mouse button on links in firefox, browser goes to
link. See http://jsfiddle.net/kromxr/76fKM/12/

Closes #7984
