### PR TITLE
feat(input): support constant expressions for ngTrueValue/ngFalseValue

### DIFF
--- a/docs/content/error/ngModel/constexpr.ngdoc
+++ b/docs/content/error/ngModel/constexpr.ngdoc
@@ -1,0 +1,21 @@
+@ngdoc error
+@name ngModel:constexpr
+@fullName Non-Constant Expression
+@description
+
+Some attributes used in conjunction with ngModel (such as ngTrueValue or ngFalseValue) will only
+accept constant expressions.
+
+Examples using constant expressions include:
+
+```
+<input type="checkbox" ng-model="..." ng-true-value="'truthyValue'">
+<input type="checkbox" ng-model="..." ng-false-value="0">
+```
+
+Examples of non-constant expressions include:
+
+```
+<input type="checkbox" ng-model="..." ng-true-value="someValue">
+<input type="checkbox" ng-model="..." ng-false-value="{foo: someScopeValue}">
+```

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2528,8 +2528,8 @@ describe('input', function() {
 
 
     it('should allow custom enumeration', function() {
-      compileInput('<input type="checkbox" ng-model="name" ng-true-value="y" ' +
-          'ng-false-value="n">');
+      compileInput('<input type="checkbox" ng-model="name" ng-true-value="\'y\'" ' +
+          'ng-false-value="\'n\'">');
 
       scope.$apply(function() {
         scope.name = 'y';
@@ -2551,6 +2551,27 @@ describe('input', function() {
 
       browserTrigger(inputElm, 'click');
       expect(scope.name).toEqual('n');
+    });
+
+
+    it('should throw if ngTrueValue is present and not a constant expression', function() {
+      expect(function() {
+        compileInput('<input type="checkbox" ng-model="value" ng-true-value="yes" />');
+      }).toThrowMinErr('ngModel', 'constexpr', "Expected constant expression for `ngTrueValue`, but saw `yes`.");
+    });
+
+
+    it('should throw if ngFalseValue is present and not a constant expression', function() {
+      expect(function() {
+        compileInput('<input type="checkbox" ng-model="value" ng-false-value="no" />');
+      }).toThrowMinErr('ngModel', 'constexpr', "Expected constant expression for `ngFalseValue`, but saw `no`.");
+    });
+
+
+    it('should not throw if ngTrueValue or ngFalseValue are not present', function() {
+      expect(function() {
+        compileInput('<input type="checkbox" ng-model="value" />');
+      }).not.toThrow();
     });
 
 


### PR DESCRIPTION
ngTrueValue and ngFalseValue now support parsed expressions which the parser
determines to be constant values.

BREAKING CHANGE:

Previously, these attributes would always be treated as strings. However, they
are now parsed as expressions, and will throw if an expression is
non-constant.

To convert non-constant strings into constant expressions, simply wrap them in
an extra pair of quotes, like so:

```
<input type="checkbox" ng-model="..." ng-true-value="'truthyValue'">
```

(This is an alternative solution to #5346, /CC @IgorMinar PTAL)
