### PR TITLE
feat(jqLite): cross-browser support for float style property

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -157,6 +157,12 @@ wrapMap.optgroup = wrapMap.option;
 wrapMap.tbody = wrapMap.tfoot = wrapMap.colgroup = wrapMap.caption = wrapMap.thead;
 wrapMap.th = wrapMap.td;
 
+// Firefox only supports cssFloat
+// https://developer.mozilla.org/en-US/docs/Web/CSS/float
+var cssMapping = {
+  'float': msie <= 8 ? 'styleFloat' : 'cssFloat'
+};
+
 function jqLiteIsTextNode(html) {
   return !HTML_REGEXP.test(html);
 }
@@ -540,6 +546,7 @@ forEach({
 
   css: function(element, name, value) {
     name = camelCase(name);
+    name = cssMapping[name] || name;
 
     if (isDefined(value)) {
       element.style[name] = value;

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -843,6 +843,18 @@ describe('jqLite', function() {
     });
 
 
+    it('should set and read float property', function() {
+      var selector = jqLite(a);
+
+      expect(selector.css('float', 'right')).toEqual(selector);
+      if(a.style.getPropertyValue) {
+        expect(a.style.getPropertyValue('float')).toEqual('right');
+      } else {
+        expect(a.style.getAttribute('float')).toEqual('right');
+      }
+    });
+
+
     it('should set a bunch of css properties specified via an object', function() {
       if (msie <= 8) {
         expect(jqLite(a).css('margin')).toBe('auto');


### PR DESCRIPTION
Change css() function to support `css('float', 'value')` in all major
browsers, since Firefox only accepts `cssFloat` property and Chrome
supports both.
