### PR TITLE
fix(input): trigger modelValue update on viewValue property changes

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1794,10 +1794,10 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
     var viewValue = ctrl.$viewValue;
 
     $timeout.cancel(pendingDebounce);
-    if (!revalidate && ctrl.$$lastCommittedViewValue === viewValue) {
+    if (!revalidate && equals(ctrl.$$lastCommittedViewValue, viewValue)) {
       return;
     }
-    ctrl.$$lastCommittedViewValue = viewValue;
+    ctrl.$$lastCommittedViewValue = copy(viewValue);
 
     // change to dirty
     if (ctrl.$pristine) {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -184,6 +184,29 @@ describe('NgModelController', function() {
     });
 
 
+    it('should trigger an update to the model if the $viewValue is an object whose properties change', function() {
+      var log = [];
+
+      ctrl.$parsers.push(function(value) {
+        log.push(value && value.getFullYear());
+        return value;
+      });
+
+      // assign a date object to the $viewValue
+      var date = new Date(2000, 1, 1);
+      ctrl.$setViewValue(date);
+      expect(ctrl.$modelValue).toEqual(date);
+      expect(log).toEqual([2000]);
+
+      // update the date value (not changing the object identity)
+      log = [];
+      date.setFullYear(2001);
+      ctrl.$setViewValue(date);
+      expect(ctrl.$modelValue).toEqual(date);
+      expect(log).toEqual([2001]);
+    });
+
+
     it('should fire viewChangeListeners when the value changes in the view (even if invalid)',
         function() {
       var spy = jasmine.createSpy('viewChangeListener');


### PR DESCRIPTION
If the $viewValue is an object then we should trigger a model update
if properties on that object change.

Previously, we were only checking for change of object identity.

Closes #7965
