### PR TITLE
WIP STAGING for #8300 [[no-merge]]

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -216,7 +216,11 @@ module.exports = function(grunt) {
       },
       "promises-aplus-adapter": {
         dest:'tmp/promises-aplus-adapter++.js',
-        src:['src/ng/q.js','lib/promises-aplus/promises-aplus-test-adapter.js']
+        src: [
+          'lib/promises-aplus/promises-aplus-test-adapter-prefix.js',
+          'src/ng/q.js',
+          'lib/promises-aplus/promises-aplus-test-adapter.js'
+        ]
       }
     },
 

--- a/lib/promises-aplus/promises-aplus-test-adapter-prefix.js
+++ b/lib/promises-aplus/promises-aplus-test-adapter-prefix.js
@@ -1,0 +1,29 @@
+"use strict";
+var INVISIBLE = 1;
+var CONFIGURABLE = 2;
+var WRITABLE = 4;
+
+var defineProperty = function(target, propertyName, flags, value) {
+  if (typeof target === 'object' || typeof target === 'function') {
+    var desc = {
+      /*jshint bitwise: false */
+      enumerable: !(flags & INVISIBLE),
+      configurable: !!(flags & CONFIGURABLE),
+      writable: !!(flags & WRITABLE)
+    };
+    if (arguments.length > 3) {
+      desc.value = value;
+    }
+    Object.defineProperty(target, propertyName, desc);
+  }
+};
+
+var defineProperties = function(target, flags, properties) {
+  for (var key in properties) {
+    if (properties.hasOwnProperty(key)) {
+      defineProperty(target, key, flags, properties[key]);
+    }
+  }
+};
+
+var createObject = Object.create;

--- a/lib/promises-aplus/promises-aplus-test-adapter-prefix.js
+++ b/lib/promises-aplus/promises-aplus-test-adapter-prefix.js
@@ -27,3 +27,9 @@ var defineProperties = function(target, flags, properties) {
 };
 
 var createObject = Object.create;
+
+function bind1(self, fn) {
+  return function(value) {
+    return fn.call(self, value);
+  };
+}

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -87,6 +87,12 @@
     "getter": false,
     "getBlockElements": false,
     "VALIDITY_STATE_PROPERTY": false,
+    "INVISIBLE": true,
+    "CONFIGURABLE": true,
+    "WRITABLE": true,
+    "defineProperty": false,
+    "defineProperties": false,
+    "createObject": false,
 
     /* filters.js */
     "getFirstThursdayOfYear": false,

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -68,6 +68,7 @@
     "concat": false,
     "sliceArgs": false,
     "bind": false,
+    "bind1": false,
     "toJsonReplacer": false,
     "toJson": false,
     "fromJson": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -64,6 +64,7 @@
   concat: true,
   sliceArgs: true,
   bind: true,
+  bind1: true,
   toJsonReplacer: true,
   toJson: true,
   fromJson: true,
@@ -995,6 +996,18 @@ function bind(self, fn) {
     // in IE, native methods are not functions so they cannot be bound (note: they don't need to be)
     return fn;
   }
+}
+
+
+function bind1(self, fn) {
+  // For performance reasons, no sanity-checks are performed here. This method is not publicly
+  // exposed, and so failures here should cause test failures in core if issues are present.
+  //
+  // Due to not currying arguments, and not testing for error conditions, this should perform
+  // somewhat better than angular.bind() for the cases where it is needed.
+  return function(value) {
+    return fn.call(self, value);
+  };
 }
 
 

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1581,6 +1581,7 @@ function defineProperty(target, propertyName, flags, value) {
   if (isObject(target) || isFunction(target)) {
     if (Object.defineProperty) {
       var desc = {
+        /*jshint bitwise: false */
         enumerable: !(flags & INVISIBLE),
         configurable: !!(flags & CONFIGURABLE),
         writable: !!(flags & WRITABLE)
@@ -1599,4 +1600,11 @@ function defineProperties(target, flags, propertyNameAndValues) {
   forEach(propertyNameAndValues, function(value, propertyName) {
     defineProperty(target, propertyName, flags, value);
   });
+}
+
+function createObject(prototype) {
+  if (Object.create) return Object.create(prototype);
+  function C() {}
+  C.prototype = prototype;
+  return new C();
 }

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1572,3 +1572,31 @@ function getBlockElements(nodes) {
 
   return jqLite(elements);
 }
+
+var INVISIBLE = 1;
+var CONFIGURABLE = 2;
+var WRITABLE = 4;
+
+function defineProperty(target, propertyName, flags, value) {
+  if (isObject(target) || isFunction(target)) {
+    if (Object.defineProperty) {
+      var desc = {
+        enumerable: !(flags & INVISIBLE),
+        configurable: !!(flags & CONFIGURABLE),
+        writable: !!(flags & WRITABLE)
+      };
+      if (arguments.length > 3) {
+        desc.value = value;
+      }
+      Object.defineProperty(target, propertyName, desc);
+    }
+  } else {
+    target[propertyName] = value;
+  }
+}
+
+function defineProperties(target, flags, propertyNameAndValues) {
+  forEach(propertyNameAndValues, function(value, propertyName) {
+    defineProperty(target, propertyName, flags, value);
+  });
+}

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1590,9 +1590,9 @@ function defineProperty(target, propertyName, flags, value) {
         desc.value = value;
       }
       Object.defineProperty(target, propertyName, desc);
+    } else {
+      target[propertyName] = value;
     }
-  } else {
-    target[propertyName] = value;
   }
 }
 

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -960,7 +960,7 @@ function $HttpProvider() {
         // normalize internal statuses to 0
         status = Math.max(status, 0);
 
-        (isSuccess(status) ? deferred.resolve : deferred.reject)({
+        deferred[(isSuccess(status) ? 'resolve' : 'reject')]({
           data: response,
           status: status,
           headers: headersGetter(headers),

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -61,6 +61,11 @@ function isError(obj) {
 
 var $Deferred = function Deferred(Q) {
   this.promise = new Q(internalPromiseResolver);
+
+  // Hacks because $timeout depends on unbound execution of functions
+  this.resolve = bind1(this, this.resolve);
+  this.reject = bind1(this, this.reject);
+  this.notify = bind1(this, this.notify);
 };
 
 defineProperties($Deferred.prototype, WRITABLE, {

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -60,9 +60,7 @@ function isError(obj) {
 }
 
 var $Deferred = function Deferred(Q) {
-  defineProperties(this, INVISIBLE|WRITABLE, {
-    promise: new Q(internalPromiseResolver)
-  });
+  this.promise = new Q(internalPromiseResolver);
 };
 
 defineProperties($Deferred.prototype, WRITABLE, {
@@ -127,22 +125,20 @@ function $Q(resolver, nextTick) {
   }
 
   // Private properties
-  defineProperties(this, INVISIBLE|WRITABLE, {
-    $$bitField: NO_STATE,
+  this.$$bitField = NO_STATE;
 
-    // From Bluebird: Typical promise has exactly one parallel handler,
-    // store the first ones directly on the Promise.
-    $$fulfillmentHandler0: void 0,
-    $$rejectionHandler0: void 0,
+  // store nextTick in the prototype, so that types which use $rootScope.$evalAsync and types
+  // which use $browser.defer() are both instances of the same Promise type.
+  this.$$nextTick = nextTick;
 
-    // store nextTick in the prototype, so that types which use $rootScope.$evalAsync and types
-    // which use $browser.defer() are both instances of the same Promise type.
-    $$nextTick: nextTick,
+  // From Bluebird: Typical promise has exactly one parallel handler,
+  // store the first ones directly on the Promise.
+  this.$$fulfillmentHandler0 =
+  this.$$rejectionHandler0 =
 
-    $$promise0: void 0,
-    $$receiver0: void 0,
-    $$settledValue: void 0
-  });
+  this.$$promise0 =
+  this.$$receiver0 =
+  this.$$settledValue = void 0;
 
   if (resolver !== internalPromiseResolver) this.$$resolveFromResolver(resolver);
 }

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -523,9 +523,7 @@ defineProperties($Q.prototype, INVISIBLE|WRITABLE, {
           }
         } catch (e) {
           // TODO(@caitp): improve error logging
-          if (this.$$unhandledException) {
-            
-          }
+          this.$$exceptionHandler(e);
         }
       } else if (receiver instanceof $Q && receiver.$$isProxied()) {
         receiver.$$progressUnchecked(progressValue);

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -269,7 +269,8 @@ function Promise$handleFinalCallback(callback, value, isResolved, Q) {
 
 defineProperties($Q.prototype, INVISIBLE|WRITABLE, {
   then: function Promise$then(didFulfill, didReject, didProgress) {
-    var ret = new $Q(internalPromiseResolver, this.$$nextTick);
+    var Q = this.constructor;
+    var ret = new Q(internalPromiseResolver);
     var callbackIndex = this.$$addCallbacks(didFulfill, didReject, didProgress, ret, void 0);
     if (this.isResolved()) {
       this.$$invoke(this.$$queueSettleAt, this, callbackIndex);
@@ -280,7 +281,8 @@ defineProperties($Q.prototype, INVISIBLE|WRITABLE, {
 
 
   catch: function Promise$catch(handler) {
-    var ret = new $Q(internalPromiseResolver, this.$$nextTick);
+    var Q = this.constructor;
+    var ret = new Q(internalPromiseResolver);
     var callbackIndex = this.$$addCallbacks(null, handler, null, ret, void 0);
     if (this.isResolved()) {
       this.$$invoke(this.$$queueSettleAt, this, callbackIndex);
@@ -295,7 +297,7 @@ defineProperties($Q.prototype, INVISIBLE|WRITABLE, {
     return this.then(function(value) {
       return Promise$handleFinalCallback(handler, value, true, Q);
     }, function(error) {
-      return Promise$handleFinalCallback(handler, error, false, Q);      
+      return Promise$handleFinalCallback(handler, error, false, Q);
     });
   },
 
@@ -1357,7 +1359,7 @@ function qFactory(nextTick, exceptionHandler) {
       nextTick(function awaitValue() {
         Promise$$castToPromise(value, void 0, Q).then(function(value) {
           result.resolve(Promise$$castToPromise(value, result.promise, Q).
-            then(fulfillWhen, rejectWhen, progressWhen));        
+            then(fulfillWhen, rejectWhen, progressWhen));
         }, function(reason) {
           result.resolve(rejectWhen(reason));
         }, progressWhen);

--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -73,7 +73,7 @@ function $TimeoutProvider() {
       */
     timeout.cancel = function(promise) {
       if (promise && promise.$$timeoutId in deferreds) {
-        deferreds[promise.$$timeoutId].reject('canceled');
+        deferreds[promise.$$timeoutId].rejectGently('canceled');
         delete deferreds[promise.$$timeoutId];
         return $browser.defer.cancel(promise.$$timeoutId);
       }

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -31,7 +31,7 @@
   http://jsperf.com/throw-vs-return
 */
 
-describe('q', function() {
+ddescribe('q', function() {
   var q, defer, deferred, promise, log;
 
   // The following private functions are used to help with logging for testing invocation of the
@@ -298,7 +298,7 @@ describe('q', function() {
       });
 
 
-      it('should not break if a callbacks registers another callback', function() {
+      iit('should not break if a callbacks registers another callback', function() {
         var promise = createPromise();
         promise.then(function() {
           log.push('outer');

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -2100,22 +2100,21 @@ describe('q', function() {
     });
 
 
-    // TODO: fix these after improving error logging
-    // it('should still reject the promise, when exception is thrown in success handler, even if exceptionHandler rethrows', function() {
-    //   deferred.promise.then(function() { throw 'reject'; }).then(null, errorSpy);
-    //   deferred.resolve('resolve');
-    //   mockNextTick.flush();
-    //   expect(exceptionExceptionSpy).toHaveBeenCalled();
-    //   expect(errorSpy).toHaveBeenCalled();
-    // });
+    it('should still reject the promise, when exception is thrown in success handler, even if exceptionHandler rethrows', function() {
+      deferred.promise.then(function() { throw 'reject'; }).then(null, errorSpy);
+      deferred.resolve('resolve');
+      mockNextTick.flush();
+      expect(exceptionExceptionSpy).toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalled();
+    });
 
 
-    // it('should still reject the promise, when exception is thrown in error handler, even if exceptionHandler rethrows', function() {
-    //   deferred.promise.then(null, function() { throw 'reject again'; }).then(null, errorSpy);
-    //   deferred.reject('reject');
-    //   mockNextTick.flush();
-    //   expect(exceptionExceptionSpy).toHaveBeenCalled();
-    //   expect(errorSpy).toHaveBeenCalled();
-    // });
+    it('should still reject the promise, when exception is thrown in error handler, even if exceptionHandler rethrows', function() {
+     deferred.promise.then(null, function() { throw 'reject again'; }).then(null, errorSpy);
+     deferred.reject('reject');
+     mockNextTick.flush();
+     expect(exceptionExceptionSpy).toHaveBeenCalled();
+     expect(errorSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -875,14 +875,13 @@ describe('q', function() {
       });
 
 
-      // By putting work in the prototype chain of an object, we can't support unbound execution.
-      // it('should support non-bound execution', function() {
-      //   var resolver = deferred.resolve;
-      //   promise.then(success(), error());
-      //   resolver('detached');
-      //   mockNextTick.flush();
-      //   expect(logStr()).toBe('success(detached)->detached');
-      // });
+      it('should support non-bound execution', function() {
+        var resolver = deferred.resolve;
+        promise.then(success(), error());
+        resolver('detached');
+        mockNextTick.flush();
+        expect(logStr()).toBe('success(detached)->detached');
+      });
 
 
       it('should not break if a callbacks registers another callback', function() {
@@ -995,14 +994,13 @@ describe('q', function() {
       });
 
 
-      // By putting work in the prototype chain, we can't support unbound execution.
-      // it('should support non-bound execution', function() {
-      //   var rejector = deferred.reject;
-      //   promise.then(success(), error());
-      //   rejector('detached');
-      //   mockNextTick.flush();
-      //   expect(logStr()).toBe('error(detached)->reject(detached)');
-      // });
+      it('should support non-bound execution', function() {
+        var rejector = deferred.reject;
+        promise.then(success(), error());
+        rejector('detached');
+        mockNextTick.flush();
+        expect(logStr()).toBe('error(detached)->reject(detached)');
+      });
     });
 
 
@@ -1088,14 +1086,13 @@ describe('q', function() {
       });
 
 
-      // By putting work in the prototype chain of an object, we can't support unbound execution.
-      // it('should support non-bound execution', function() {
-      //   var notify = deferred.notify;
-      //   promise.then(success(), error(), progress());
-      //   notify('detached');
-      //   mockNextTick.flush();
-      //   expect(logStr()).toBe('progress(detached)->detached');
-      // });
+      it('should support non-bound execution', function() {
+        var notify = deferred.notify;
+        promise.then(success(), error(), progress());
+        notify('detached');
+        mockNextTick.flush();
+        expect(logStr()).toBe('progress(detached)->detached');
+      });
 
 
       it("should not save and re-emit progress notifications between ticks", function () {


### PR DESCRIPTION
Staging ground for $q improvements in #8300, this is a work in progress.

The work is in 3 stages, each building on the previous stage:
1. Add constructor for promises (ES6-style interface, landed in f3a763fd2edd8a37b80c79a5aaa1444460cd2df7)
2. Port subset of functionality from [Bluebird](github.com/petkaantonov/bluebird), we can now get a perf improvement by sticking methods used for each promise in the prototype chain and avoid creating garbage.
3. Modify the error logging behaviour to be similar to Bluebird, by only logging an error for unhandlde rejections.

This is somewhat challenging, as promises in $q currently behave somewhat inconsistently (sometimes rethrowing errors, sometimes not, etc), and it will take some time to finalize this. Hence, staging ground.
