### PR TITLE
fix(parseKeyValue): ignore properties in prototype chain.

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1105,7 +1105,7 @@ function parseKeyValue(/**string*/keyValue) {
       key = tryDecodeURIComponent(key_value[0]);
       if ( isDefined(key) ) {
         var val = isDefined(key_value[1]) ? tryDecodeURIComponent(key_value[1]) : true;
-        if (!obj[key]) {
+        if (!hasOwnProperty.call(obj, key)) {
           obj[key] = val;
         } else if(isArray(obj[key])) {
           obj[key].push(val);

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -470,6 +470,13 @@ describe('angular', function() {
       expect(parseKeyValue('flag1&flag1=value&flag1=value2&flag1')).
       toEqual({flag1: [true,'value','value2',true]});
     });
+
+
+    it('should ignore properties higher in the prototype chain', function() {
+      expect(parseKeyValue('toString=123')).toEqual({
+        'toString': '123'
+      });
+    });
   });
 
   describe('toKeyValue', function() {


### PR DESCRIPTION
Previously, properties (typically functions) in the prototype chain
(Object.prototype) would shadow query parameters, and cause them to be
serialized incorrectly.

This CL guards against this by using hasOwnProperty() to ensure that only own
properties are a concern.

(CI testing for IE8)
