### PR TITLE
fix(jqLite): use .children to fetch child elements but fallback to .childNodes for SVGs in IE

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -248,7 +248,7 @@ function jqLiteClone(element) {
 function jqLiteDealoc(element){
   jqLiteRemoveData(element);
   var childElement;
-  for ( var i = 0, children = element.children, l = (children && children.length) || 0; i < l; i++) {
+  for ( var i = 0, children = element.children || element.childNodes, ii = (children && children.length) || 0; i < ii; i++) {
     childElement = children[i];
     jqLiteDealoc(childElement);
   }
@@ -432,8 +432,8 @@ function jqLiteInheritedData(element, name, value) {
 }
 
 function jqLiteEmpty(element) {
-  for (var i = 0, childNodes = element.childNodes; i < childNodes.length; i++) {
-    jqLiteDealoc(childNodes[i]);
+  for (var i = 0, children = element.children || element.childNodes, ii = children.length; i < ii; i++) {
+    jqLiteDealoc(children[i]);
   }
   while (element.firstChild) {
     element.removeChild(element.firstChild);
@@ -632,8 +632,8 @@ forEach({
     if (isUndefined(value)) {
       return element.innerHTML;
     }
-    for (var i = 0, childNodes = element.childNodes; i < childNodes.length; i++) {
-      jqLiteDealoc(childNodes[i]);
+    for (var i = 0, children = element.children || element.childNodes, ii = children.length; i < ii; i++) {
+      jqLiteDealoc(children[i]);
     }
     element.innerHTML = value;
   },
@@ -853,7 +853,7 @@ forEach({
 
   children: function(element) {
     var children = [];
-    forEach(element.childNodes, function(element){
+    forEach(element.children || element.childNodes, function(element) {
       if (element.nodeType === 1)
         children.push(element);
     });

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -386,6 +386,25 @@ describe('jqLite', function() {
       selected.removeData('prop2');
     });
 
+    it('should add and remove data on SVGs', function() {
+      var calcCacheSize = function() {
+        var count = 0;
+        for (var k in jqLite.cache) { ++count; }
+        return count;
+      };
+
+      var svg = jqLite('<svg><rect></rect></svg>');
+
+      svg.data('svg-level', 1);
+      expect(svg.data('svg-level')).toBe(1);
+
+      svg.children().data('rect-level', 2);
+      expect(svg.children().data('rect-level')).toBe(2);
+
+      svg.remove();
+      expect(calcCacheSize()).toEqual(0);
+    });
+
 
     it('should not add to the cache if the node is a comment or text node', function() {
       var calcCacheSize = function() {


### PR DESCRIPTION
e35abc9d broke `jqLiteDealoc` on SVG elements in IE because `.children` is not supported on SVGs in IE (https://developer.mozilla.org/en-US/docs/Web/API/ParentNode.children#Browser_compatibility).

This change adds an SVG test and fixes it by doing `.children || .childNodes`. I also added `.children` in a few more places in addition to where e35abc9d originally did. Although if the `.childNodes` fallback is always required for IE, is it still worth using `.children`?
