### PR TITLE
chore(e2e): update protractor to 1.0.0-rc4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2738,7 +2738,7 @@
       }
     },
     "protractor": {
-      "version": "1.0.0-rc2",
+      "version": "1.0.0-rc4",
       "dependencies": {
         "request": {
           "version": "2.36.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "karma-sauce-launcher": "0.2.0",
     "karma-script-launcher": "0.1.0",
     "karma-browserstack-launcher": "0.0.7",
-    "protractor": "1.0.0-rc2",
+    "protractor": "1.0.0-rc4",
     "yaml-js": "~0.0.8",
     "rewire": "1.1.3",
     "promises-aplus-tests": "~1.3.2",


### PR DESCRIPTION
This change contains a stability improvement to use data URLs instead of
about:blank for resetting the URL.
