### PR TITLE
fix(orderBy): changes orderBy to use case sensitive comparison to break ...

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -154,8 +154,12 @@ function orderByFilter($parse){
       var t2 = typeof v2;
       if (t1 == t2) {
         if (t1 == "string") {
-           v1 = v1.toLowerCase();
-           v2 = v2.toLowerCase();
+           var v1Lower = v1.toLowerCase();
+           var v2Lower = v2.toLowerCase();
+           if (v1Lower !== v2Lower) {
+              v1 = v1Lower;
+              v2 = v2Lower;
+           }
         }
         if (v1 === v2) return 0;
         return v1 < v2 ? -1 : 1;

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -45,4 +45,10 @@ describe('Filter: orderBy', function() {
       return orderBy([{"Tip %": .15}, {"Tip %": .25}, {"Tip %": .40}], '"Tip %\'');
     }).toThrow();
   });
+
+  it('should sort strings in a case sensitive way', function() {
+    var array = [{name:"Bb"}, {name:"BB"}, {name:"bb"}, {name:'Aa'}, {name:'aa'}, {name:'AA'}];
+    expect(orderBy(array, 'name', true)).toEqualData([{name:"bb"}, {name:"Bb"}, {name:"BB"}, {name:'aa'}, {name:'Aa'}, {name:'AA'}]);
+    expect(orderBy(array, 'name', true)).toEqualData(orderBy(array, 'name', false).reverse());
+  });
 });


### PR DESCRIPTION
...ties on strings

Previously running orderBy on an array of strings such as ['A cow', 'a cow'] would
result in ['A cow', 'a cow'], regardless of the value of reverseOrder.  This is because orderBy cast
all strings to lowercase before comparing them.

This commit changes the behavior to result in ['a cow', 'A cow'] when reverseOrder is true,
and ['A cow', 'a cow'] when reverse order is false.
