### PR TITLE
docs(guide): switch from ngmin to ng-annotate

### DIFF
--- a/docs/content/guide/index.ngdoc
+++ b/docs/content/guide/index.ngdoc
@@ -81,7 +81,7 @@ This is a short list of libraries with specific support and documentation for wo
 
 ### General
 
-* **Javascript minification: **[Background](http://thegreenpizza.github.io/2013/05/25/building-minification-safe-angular.js-applications/), [ngmin automation tool](http://www.thinkster.io/pick/XlWneEZCqY/angularjs-ngmin)
+* **Javascript minification: **[Background](http://thegreenpizza.github.io/2013/05/25/building-minification-safe-angular.js-applications/), [ng-annotate automation tool](https://github.com/olov/ng-annotate)
 * **Analytics and Logging:** [Angularyitcs (Google Analytics)](http://ngmodules.org/modules/angularytics), [Angulartics (Analytics)](https://github.com/luisfarzati/angulartics), [Logging Client-Side Errors](http://www.bennadel.com/blog/2542-Logging-Client-Side-Errors-With-AngularJS-And-Stacktrace-js.htm)
 * **SEO:** [By hand](http://www.yearofmoo.com/2012/11/angularjs-and-seo.html), [prerender.io](http://prerender.io/), [Brombone](http://www.brombone.com/), [SEO.js](http://getseojs.com/), [SEO4Ajax](http://www.seo4ajax.com/)
 

--- a/docs/content/guide/services.ngdoc
+++ b/docs/content/guide/services.ngdoc
@@ -135,8 +135,8 @@ code, your variable names will get renamed unless you use one of the annotation 
 </div>
 
 <div class="alert alert-info">
-  If you use a tool like [ngmin](https://github.com/btford/ngmin#ngmin) in your workflow you can
-  use implicit dependency notation within your codebase and let **ngmin** automatically convert such
+  If you use a tool like [ng-annotate](https://github.com/olov/ng-annotate) in your workflow you can
+  use implicit dependency notation within your codebase and let **ng-annotate** automatically convert such
   injectable functions to the array notation prior to minifying.
 </div>
 


### PR DESCRIPTION
Per last AWG meeting.

ng-annotate is an independent alternative to ngmin that is non-invasive
and more performant. For the background around the switch, see the discussion
at:
https://github.com/btford/ngmin/issues/93

cc @IgorMinar @olov
