### PR TITLE
fix $browser: change to encodeURIComponent and decodeURIComponent for co...

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -280,16 +280,16 @@ function Browser(window, document, $log, $sniffer) {
    * @returns {Object} Hash of all cookies (if called without any parameter)
    */
   self.cookies = function(name, value) {
-    /* global escape: false, unescape: false */
+    /* global encodeURIComponent: false, decodeURIComponent: false */
     var cookieLength, cookieArray, cookie, i, index;
 
     if (name) {
       if (value === undefined) {
-        rawDocument.cookie = escape(name) + "=;path=" + cookiePath +
+        rawDocument.cookie = encodeURIComponent(name) + "=;path=" + cookiePath +
                                 ";expires=Thu, 01 Jan 1970 00:00:00 GMT";
       } else {
         if (isString(value)) {
-          cookieLength = (rawDocument.cookie = escape(name) + '=' + escape(value) +
+          cookieLength = (rawDocument.cookie = encodeURIComponent(name) + '=' + encodeURIComponent(value) +
                                 ';path=' + cookiePath).length + 1;
 
           // per http://www.ietf.org/rfc/rfc2109.txt browser must allow at minimum:
@@ -313,12 +313,12 @@ function Browser(window, document, $log, $sniffer) {
           cookie = cookieArray[i];
           index = cookie.indexOf('=');
           if (index > 0) { //ignore nameless cookies
-            name = unescape(cookie.substring(0, index));
+            name = decodeURIComponent(cookie.substring(0, index));
             // the first value that is seen for a cookie is the most
             // specific one.  values for the same cookie name that
             // follow are for less specific paths.
             if (lastCookies[name] === undefined) {
-              lastCookies[name] = unescape(cookie.substring(index + 1));
+              lastCookies[name] = decodeURIComponent(cookie.substring(index + 1));
             }
           }
         }

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -280,7 +280,6 @@ function Browser(window, document, $log, $sniffer) {
    * @returns {Object} Hash of all cookies (if called without any parameter)
    */
   self.cookies = function(name, value) {
-    /* global encodeURIComponent: false, decodeURIComponent: false */
     var cookieLength, cookieArray, cookie, i, index;
 
     if (name) {

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -250,7 +250,7 @@ describe('browser', function() {
         var i, longVal = '', cookieStr;
 
         for(i=0; i<4083; i++) {
-          longVal += '+';
+          longVal += 'x';
         }
 
         cookieStr = document.cookie;
@@ -322,6 +322,11 @@ describe('browser', function() {
         browser.cookies(' cookie name ', ' cookie value ');
         expect(browser.cookies()[' cookie name ']).toEqual(' cookie value ');
         expect(browser.cookies()['cookie name']).not.toBeDefined();
+      });
+
+      it('should unscape special characters in cookie values', function() {
+        document.cookie = 'cookie_name=cookie_value_%E2%82%AC';
+        expect(browser.cookies()['cookie_name']).toEqual('cookie_value_€');
       });
     });
 


### PR DESCRIPTION
Request Type: bug

How to reproduce: Include special characters (€) in a cookie and it will not decode correctly.

Component(s): ngCookies

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

the self.cookies method in $browser was using escape and unescape to handle the cookie name and value. These methods are deprecated and cause problems with some special characters (€). The method has been changed to use the replacement encodeURIComponent and decodeURIComponent.
