### PR TITLE
Corrected controller name in html binding

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -72,7 +72,7 @@
  * @example
   <example module="orderByExample">
     <file name="index.html">
-      <div ng-controller="Ctrl">
+      <div ng-controller="ExampleController">
         <table class="friend">
           <tr>
             <th><a href="" ng-click="reverse=false;order('name', false)">Name</a>


### PR DESCRIPTION
Request Type: bug

How to reproduce: Go to https://docs.angularjs.org/api/ng/filter/orderBy and check the example in the bottom

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

This is a very tiny problem with one of the demos on the orderBy doc page.

**Other Comments:**

Controller was set to Ctrl and controller was named ExampleController in js. Changed the html binding to ExampleController to fix the demo.
