### PR TITLE
Update ngInclude.js

### DIFF
--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -164,8 +164,7 @@
 
 /**
  * @ngdoc event
- * @name ng.directive:ngInclude#$includeContentError
- * @eventOf ng.directive:ngInclude
+ * @name ngInclude#$includeContentError
  * @eventType emit on the scope ngInclude was declared in
  * @description
  * Emitted when a template HTTP request yields an erronous response (status < 200 || status > 299)


### PR DESCRIPTION
The @eventOf tag was causing a warning on build. I removed the tag and changed the @name to match the previous comment blocks.
