### PR TITLE
Fix #6128 and #8150

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -990,12 +990,12 @@ function $HttpProvider() {
 
             forEach(value, function(v) {
               if (isObject(v)) {
-                if (isDefined(v.toJSON)){
-                  v = v.toJSON();
-                }
-                else {
-                  v = toJson(v);
-                }
+                if (v instanceof Date){
+                  v = v.toISOString(); //toISOString() only supported in IE8 and above
+                  }
+                  else if (isObject(v)) {
+                    v = toJson(v);
+                  }
               }
               parts.push(encodeUriQuery(key) + '=' +
                          encodeUriQuery(v));

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 
 /**
  * Parse headers into key value object
@@ -990,7 +990,12 @@ function $HttpProvider() {
 
             forEach(value, function(v) {
               if (isObject(v)) {
-                v = toJson(v);
+                if (isDefined(v.toJSON)){
+                  v = v.toJSON();
+                }
+                else {
+                  v = toJson(v);
+                }
               }
               parts.push(encodeUriQuery(key) + '=' +
                          encodeUriQuery(v));

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -341,6 +341,11 @@ describe('$http', function() {
         $httpBackend.expect('GET', '/url').respond('');
         $http({url: '/url', params: {}, method: 'GET'});
       });
+
+      it('should not double quote dates', function() {
+        $httpBackend.expect('GET', '/url?date=2014-07-15T17:30:00.000Z').respond('');
+        $http({url: '/url', params: {date:new Date('2014-07-15T17:30:00.000Z')}, method: 'GET'});
+      });
     });
 
 


### PR DESCRIPTION
Request Type: bug

How to reproduce: it('should not double quote dates', function() {
        $httpBackend.expect('GET', '/url?date=2014-07-15T17:30:00.000Z').respond('');
        $http({url: '/url', params: {date:new Date('2014-07-15T17:30:00.000Z')}, method: 'GET'});
      })

Currently, datetimes passed into $http.get params are wrapped in double quotes and then escaped giving urls like this: /url?date=%222014-07-15T17:30:00.000Z%22

Component(s): $http

Impact: large

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

See comments on #6128, #8150
