### PR TITLE
adds xhrFields to $http config object

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -512,6 +512,9 @@ function $HttpProvider() {
      *      for more information.
      *    - **responseType** - `{string}` - see
      *      [requestType](https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest#responseType).
+     *    - **xhrFields** - `{object}` - Map of strings representing properties to be set on the XHR object.
+     *      Can be used to set [non-standard properties](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#Non-standard_properties).
+     *      This object can also be set on the `$http.defaults` object to apply it globally.
      *
      * @returns {HttpPromise} Returns a {@link ng.$q promise} object with the
      *   standard `then` method and two http specific methods: `success` and `error`. The `then`
@@ -623,7 +626,8 @@ function $HttpProvider() {
       var config = {
         method: 'get',
         transformRequest: defaults.transformRequest,
-        transformResponse: defaults.transformResponse
+        transformResponse: defaults.transformResponse,
+        xhrFields: defaults.xhrFields
       };
       var headers = mergeHeaders(requestConfig);
 
@@ -930,7 +934,7 @@ function $HttpProvider() {
         }
 
         $httpBackend(config.method, url, reqData, done, reqHeaders, config.timeout,
-            config.withCredentials, config.responseType);
+            config.withCredentials, config.responseType, config.xhrFields);
       }
 
       return promise;

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -40,7 +40,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
   var ABORTED = -1;
 
   // TODO(vojta): fix the signature
-  return function(method, url, post, callback, headers, timeout, withCredentials, responseType) {
+  return function(method, url, post, callback, headers, timeout, withCredentials, responseType, xhrFields) {
     var status;
     $browser.$$incOutstandingRequestCount();
     url = url || $browser.url();
@@ -60,6 +60,12 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
     } else {
 
       var xhr = createXhr(method);
+
+      if(xhrFields) {
+        forEach(xhrFields, function(value, key){
+          xhr[key] = value;
+        });
+      }
 
       xhr.open(method, url, true);
       forEach(headers, function(value, key) {

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -312,6 +312,15 @@ describe('$httpBackend', function() {
     expect(MockXhr.$$lastInstance.withCredentials).toBe(true);
   });
 
+  it('should set xhrFields on xhr object', function(){
+    var xhrFields = {
+      field1: 'test',
+      field2: 'test2'
+    };
+    $backend('GET', '/some.url', null, callback, {}, null, false, null, xhrFields);
+    expect(MockXhr.$$lastInstance.field1).toBe(xhrFields.field1);
+    expect(MockXhr.$$lastInstance.field2).toBe(xhrFields.field2);
+  });
 
   describe('responseType', function() {
 
@@ -540,5 +549,5 @@ describe('$httpBackend', function() {
       expect(callback.mostRecentCall.args[0]).toBe(503);
     });
   });
-});
 
+});

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1507,4 +1507,52 @@ describe('$http', function() {
 
     $httpBackend.verifyNoOutstandingExpectation = noop;
   });
+
+  it('shoud pass xhrFields param to $httpBackend', function(){
+    var $httpBackend = jasmine.createSpy('$httpBackend');
+
+    $httpBackend.andCallFake(function(m, u, d, c, h, t, w, r, xhrFields) {
+      expect(xhrFields.someField).toBe(1);
+    });
+
+    module(function($provide) {
+      $provide.value('$httpBackend', $httpBackend);
+    });
+
+    inject(function($http, $rootScope) {
+      $http({
+        method: 'GET',
+        url: 'some.html',
+        xhrFields : { someField: 1 }
+      });
+      $rootScope.$digest();
+      expect($httpBackend).toHaveBeenCalledOnce();
+    });
+
+    $httpBackend.verifyNoOutstandingExpectation = noop;
+  });
+
+  it('should use xhrFields from default', function() {
+    var $httpBackend = jasmine.createSpy('$httpBackend');
+
+    $httpBackend.andCallFake(function(m, u, d, c, h, t, w, r, xhrFields) {
+      expect(xhrFields.someField).toBe(1);
+    });
+
+    module(function($provide) {
+      $provide.value('$httpBackend', $httpBackend);
+    });
+
+    inject(function($http, $rootScope) {
+      $http.defaults.xhrFields = {someField: 1};
+      $http({
+        method: 'GET',
+        url: 'some.html'
+      });
+      $rootScope.$digest();
+      expect($httpBackend).toHaveBeenCalledOnce();
+    });
+
+    $httpBackend.verifyNoOutstandingExpectation = noop;
+  });
 });


### PR DESCRIPTION
The properties of the `xhrFields` object is set on the XHR object making it possible to set non-standard properties. It is also possible to set the object on `$http.defaults` to use it globally. Please note that this will not work for certain non-standard read-only properties specified by Mozilla, such as `mosSystem` and `mozAnon` as they must be passed throught the constructor.
