### PR TITLE
removed invalid jsdoc tag

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -820,8 +820,7 @@ function $HttpProvider() {
 
      /**
       * @ngdoc method
-      * @name ng.$http#patch
-      * @methodOf ng.$http
+      * @name $http#patch
       *
       * @description
       * Shortcut method to perform `PATCH` request.


### PR DESCRIPTION
The @methodOf tag was causing a warning on build. I removed the tag and changed the @name to match the previous comment blocks.
