### PR TITLE
Updated e2e spec to remove warning

### DIFF
--- a/docs/content/tutorial/step_06.ngdoc
+++ b/docs/content/tutorial/step_06.ngdoc
@@ -73,7 +73,7 @@ __`test/e2e/scenarios.js`__:
     it('should render phone specific links', function() {
       var query = element(by.model('query'));
       query.sendKeys('nexus');
-      element(by.css('.phones li a')).click();
+      element.all(by.css('.phones li a')).first().click();
       browser.getLocationAbsUrl().then(function(url) {
         expect(url.split('#')[1]).toBe('/phones/nexus-s');
       });


### PR DESCRIPTION
Request Type: docs

How to reproduce: the bug is fixed already in the code, but the document was not updated

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

In step-6 of angular phonecat tutorial, the node snippet for protractor test is not up to date. The code was giving a warning message which has already been updated but in the step 6, it still shows the old code.

**Other Comments:**

lement(by.css(.phones li a)).click();

selenium will throw a warning message that more then one element found.

element.all(by.css('.phones li a')).first().click(); fixes the issue
