### PR TITLE
fix($rootScope): remove support for a watch listener to be a string

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -315,7 +315,7 @@ function $RootScopeProvider(){
        *
        *    - `string`: Evaluated as {@link guide/expression expression}
        *    - `function(scope)`: called with current `scope` as a parameter.
-       * @param {(function()|string)=} listener Callback called whenever the return value of
+       * @param {function()=} listener Callback called whenever the return value of
        *   the `watchExpression` changes.
        *
        *    - `string`: Evaluated as {@link guide/expression expression}
@@ -340,10 +340,8 @@ function $RootScopeProvider(){
 
         lastDirtyWatch = null;
 
-        // in the case user pass string, we need to compile it, do we really need this ?
         if (!isFunction(listener)) {
-          var listenFn = compileToFn(listener || noop, 'listener');
-          watcher.fn = function(newVal, oldVal, scope) {listenFn(scope);};
+          watcher.fn = noop;
         }
 
         if (!array) {

--- a/test/BinderSpec.js
+++ b/test/BinderSpec.js
@@ -442,7 +442,9 @@ describe('Binder', function() {
   it('ItShouldFireChangeListenersBeforeUpdate', inject(function($rootScope, $compile) {
     element = $compile('<div ng-bind="name"></div>')($rootScope);
     $rootScope.name = '';
-    $rootScope.$watch('watched', 'name=123');
+    $rootScope.$watch('watched', function () {
+      $rootScope.name = 123;
+    });
     $rootScope.watched = 'change';
     $rootScope.$apply();
     expect($rootScope.name).toBe(123);

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1143,7 +1143,9 @@ describe('Scope', function() {
     it('should cause a $digest rerun', inject(function($rootScope) {
       $rootScope.log = '';
       $rootScope.value = 0;
-      $rootScope.$watch('value', 'log = log + ".";');
+      $rootScope.$watch('value', function () {
+        $rootScope.log = $rootScope.log + ".";
+      });
       $rootScope.$watch('init', function() {
         $rootScope.$evalAsync('value = 123; log = log + "=" ');
         expect($rootScope.value).toEqual(0);


### PR DESCRIPTION
BREAKING CHANGE:

Previously, it was possible for a listener passed to $watch
to be a string, interpreted as an angular expresison. This is no longer supported.
The listener now has to be a function.
Passing a listener to $watch is still optional.
