### PR TITLE
fix: text that looks like an html tag but is not causes [$sanitize:badparse] error

### DIFF
--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -276,6 +276,10 @@ function htmlParser( html, handler ) {
           html = html.substring( match[0].length );
           match[0].replace( START_TAG_REGEXP, parseStartTag );
           chars = false;
+        } else {
+          // no ending tag found
+          if (handler.chars) handler.chars( '<' );
+          html = html.substring(1);
         }
       }
 

--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -20,6 +20,7 @@ describe('HTML', function() {
 
     var handler, start, text, comment;
     beforeEach(function() {
+      text = "";
       handler = {
           start: function(tag, attrs, unary){
             start = {
@@ -34,7 +35,7 @@ describe('HTML', function() {
             });
           },
           chars: function(text_){
-            text = text_;
+            text += text_;
           },
           end:function(tag) {
             expect(tag).toEqual(start.tag);
@@ -78,6 +79,11 @@ describe('HTML', function() {
       htmlParser('<tag attr="value">text</tag>', handler);
       expect(start).toEqual({tag:'tag', attrs:{attr:'value'}, unary:false});
       expect(text).toEqual('text');
+    });
+
+    it('should parse non ending tags', function() {
+      htmlParser('<nonEndingTag href <nonEndingTag href', handler);
+      expect(text).toEqual('<nonEndingTag href <nonEndingTag href');
     });
 
     it('should parse newlines in tags', function() {


### PR DESCRIPTION
The provided unit test fails with this error.

```
Error: [$sanitize:badparse] The sanitizer was unable to parse the following block of html: <
nonEndingTag href <nonEndingTag href
```

The provided change fixes it.
