### PR TITLE
docs(guide/concepts.ngdoc) protocol relative URL

### DIFF
--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -323,7 +323,7 @@ The following example shows how this is done with Angular:
     angular.module('finance3', [])
       .factory('currencyConverter', ['$http', function($http) {
         var YAHOO_FINANCE_URL_PATTERN =
-              'http://query.yahooapis.com/v1/public/yql?q=select * from '+
+              '//query.yahooapis.com/v1/public/yql?q=select * from '+
               'yahoo.finance.xchange where pair in ("PAIRS")&format=json&'+
               'env=store://datatables.org/alltableswithkeys&callback=JSON_CALLBACK';
         var currencies = ['USD', 'EUR', 'CNY'];


### PR DESCRIPTION
Request Type: bug

How to reproduce: Open the angular docs from https: https://docs.angularjs.org/guide/concepts

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

When accessing the docs from https, the "Accessing the backend" example fails because it contains a hard coded protocol. By making the URL protocol relative, the example should work over http and https.
