### PR TITLE
improve interpolation of params in ngRoute

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -606,19 +606,20 @@ function $RouteProvider(){
      * @returns {string} interpolation of the redirect path with the parameters
      */
     function interpolate(string, params) {
-      var result = [];
-      angular.forEach((string||'').split(':'), function(segment, i) {
-        if (i === 0) {
-          result.push(segment);
+      return (string||'').replace(/(\/)?:(\w+)([?*])?/g, interpolateReplacer);
+
+      function interpolateReplacer(_, slash, key, option) {
+        var optional = option === '?';
+        var value = params[key];
+        delete params[key];
+
+        if (optional && value == null) {
+          return '';
         } else {
-          var segmentMatch = segment.match(/(\w+)(.*)/);
-          var key = segmentMatch[1];
-          result.push(params[key]);
-          result.push(segmentMatch[2] || '');
-          delete params[key];
+          slash = slash || '';
+          return slash + (value || '');
         }
-      });
-      return result.join('');
+      }
     }
   }];
 }

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -813,6 +813,47 @@ describe('$route', function() {
     });
 
 
+    it('should interpolate optional route vars in the redirected path from original path', function() {
+      module(function($routeProvider) {
+        $routeProvider.when('/foo/:id/foo/:subid?/:extraId', {redirectTo: '/bar/:id/:subid?/23'});
+        $routeProvider.when('/bar/:id/:subid?/:subsubid', {templateUrl: 'bar.html'});
+      });
+
+      inject(function($route, $location, $rootScope) {
+        $location.path('/foo/id1/foo/subid3/gah');
+        $rootScope.$digest();
+
+        expect($location.path()).toEqual('/bar/id1/subid3/23');
+        expect($location.search()).toEqual({extraId: 'gah'});
+        expect($route.current.params).toEqual({id:'id1', subid:'subid3', subsubid:'23', extraId:'gah'});
+        expect($route.current.templateUrl).toEqual('bar.html');
+
+        $location.path('/foo/id1/foo/gah');
+        $rootScope.$digest();
+
+        expect($location.path()).toEqual('/bar/id1/23');
+        expect($location.search()).toEqual({extraId: 'gah'});
+        expect($route.current.params).toEqual({id:'id1', subsubid:'23', extraId:'gah'});
+      });
+    });
+
+
+    it('should interpolate catch-all route vars in the redirected path from original path', function() {
+      module(function($routeProvider) {
+        $routeProvider.when('/baz/:id/:path*', {redirectTo: '/path/:path*/:id'});
+        $routeProvider.when('/path/:path*/:id', {templateUrl: 'foo.html'});
+      });
+
+      inject(function($route, $location, $rootScope) {
+        $location.path('/baz/1/foovalue/barvalue');
+        $rootScope.$digest();
+        expect($location.path()).toEqual('/path/foovalue/barvalue/1');
+        expect($route.current.params).toEqual({id:'1', path:'foovalue/barvalue'});
+        expect($route.current.templateUrl).toEqual('foo.html');
+      });
+    });
+
+
     it('should interpolate route vars in the redirected path from original search', function() {
       module(function($routeProvider) {
         $routeProvider.when('/bar/:id/:subid/:subsubid', {templateUrl: 'bar.html'});


### PR DESCRIPTION
Request Type: bug

How to reproduce: 6f776102b23f413f7f2443ef
1. create a route with optional parameters, eg. $routeProvider.when('/profile/:userId?', ...)
2. angular will add the automatic redirect with or without the trailing /, in this case '/profile/userId?/'
3. point your browser to the redirect http://localhost/#!/profile/0/, you'll see the encoded ? (%3F) at the end of the url: http://localhost/#!/profile/0%3F

Component(s): ngRoute

Impact: medium

Complexity: small

This issue is related to: 

**Detailed Description:**

In line with #5746, this changes how parameters are interpolated in redirectTo strings.

First, I added a test case (it's my first in Javascript ever, so bear with me) which exhibits the failure:

```
        Expected '/bar/id1/subid3?/23' to equal '/bar/id1/subid3/23'.
        Error: Expected '/bar/id1/subid3?/23' to equal '/bar/id1/subid3/23'.
            at null.<anonymous> (/home/vtc/src/angular.js/test/ngRoute/routeSpec.js:826:34)
            at Object.invoke (/home/vtc/src/angular.js/src/auto/injector.js:801:17)
            at workFn (/home/vtc/src/angular.js/src/ngMock/angular-mocks.js:2187:20)
            at window.inject.angular.mock.inject (/home/vtc/src/angular.js/src/ngMock/angular-mocks.js:2159:42)
            at null.<anonymous> (/home/vtc/src/angular.js/test/ngRoute/routeSpec.js:822:7)
        Expected '/bar/id1/?/23' to equal '/bar/id1/23'.
        Error: Expected '/bar/id1/?/23' to equal '/bar/id1/23'.
            at null.<anonymous> (/home/vtc/src/angular.js/test/ngRoute/routeSpec.js:832:34)
            at Object.invoke (/home/vtc/src/angular.js/src/auto/injector.js:801:17)
            at workFn (/home/vtc/src/angular.js/src/ngMock/angular-mocks.js:2187:20)
            at window.inject.angular.mock.inject (/home/vtc/src/angular.js/src/ngMock/angular-mocks.js:2159:42)
            at null.<anonymous> (/home/vtc/src/angular.js/test/ngRoute/routeSpec.js:822:7)
        Expected '/path/foovalue/barvalue*/1' to equal '/path/foovalue/barvalue/1'.
        Error: Expected '/path/foovalue/barvalue*/1' to equal '/path/foovalue/barvalue/1'.
            at null.<anonymous> (/home/vtc/src/angular.js/test/ngRoute/routeSpec.js:837:34)
            at Object.invoke (/home/vtc/src/angular.js/src/auto/injector.js:801:17)
            at workFn (/home/vtc/src/angular.js/src/ngMock/angular-mocks.js:2187:20)
            at window.inject.angular.mock.inject (/home/vtc/src/angular.js/src/ngMock/angular-mocks.js:2159:42)
            at null.<anonymous> (/home/vtc/src/angular.js/test/ngRoute/routeSpec.js:822:7)
```

Alas, the fix from Pasvaz in #5746 lead to an error too:

```
        Expected '/bar/id1//23' to equal '/bar/id1/23'.
        Error: Expected '/bar/id1//23' to equal '/bar/id1/23'.
            at null.<anonymous> (/home/vtc/src/angular.js/test/ngRoute/routeSpec.js:832:34)
            at Object.invoke (/home/vtc/src/angular.js/src/auto/injector.js:801:17)
            at workFn (/home/vtc/src/angular.js/src/ngMock/angular-mocks.js:2187:20)
            at window.inject.angular.mock.inject (/home/vtc/src/angular.js/src/ngMock/angular-mocks.js:2159:42)
            at null.<anonymous> (/home/vtc/src/angular.js/test/ngRoute/routeSpec.js:822:7)l
```

Note the doubled slash, which is kind of awkward. So, a slash should be removed when the optional parameter is missing.

Now string interpolation is done similar to the generation of the regexp in route, using a replace function.

All good, tests pass.

**Other Comments:**

I don't know what your preference is, should I reorder the commits in order to keep the tests passing for every single commit?
