### PR TITLE
docs(ngValue) Replace input[select] with option for clarity

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2445,9 +2445,9 @@ var CONSTANT_VALUE_REGEXP = /^(true|false|\d+)$/;
  * @name ngValue
  *
  * @description
- * Binds the given expression to the value of `input[select]` or `input[radio]`, so
- * that when the element is selected, the `ngModel` of that element is set to the
- * bound value.
+ * Binds the given expression to the value of `option` or `input[radio]`, so
+ * that when the element is selected, the `ngModel` of that element is set to
+ * the bound value.
  *
  * `ngValue` is useful when dynamically generating lists of radio buttons using `ng-repeat`, as
  * shown below.


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): forms

Impact: 

Complexity: small

This issue is related to: 

**Detailed Description:**

It is impossible to create an `input[select]`, so it appears the intention
here was actually `option`.

While `ngOptions` would probably be easier to use in most cases, someone may have a use case for using `ngValue` with `option` which is why I decided to change it in lieu of deleting it, as had been mentioned in the issue.

**Other Comments:**
