### PR TITLE
fix(input): make maxlength and minlength work with non-string values

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2319,7 +2319,7 @@ var maxlengthDirective = function() {
         ctrl.$validate();
       });
       ctrl.$validators.maxlength = function(value) {
-        return ctrl.$isEmpty(value) || value.length <= maxlength;
+        return ctrl.$isEmpty(value) || String(value).length <= maxlength;
       };
     }
   };
@@ -2337,7 +2337,7 @@ var minlengthDirective = function() {
         ctrl.$validate();
       });
       ctrl.$validators.minlength = function(value) {
-        return ctrl.$isEmpty(value) || value.length >= minlength;
+        return ctrl.$isEmpty(value) || String(value).length >= minlength;
       };
     }
   };

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2318,8 +2318,11 @@ var maxlengthDirective = function() {
         maxlength = int(value) || 0;
         ctrl.$validate();
       });
-      ctrl.$validators.maxlength = function(value) {
-        return ctrl.$isEmpty(value) || String(value).length <= maxlength;
+      ctrl.$validators.maxlength = function(value, viewValue) {
+        if (!isString(value)) {
+          value = viewValue;
+        }
+        return ctrl.$isEmpty(value) || value.length <= maxlength;
       };
     }
   };
@@ -2336,8 +2339,11 @@ var minlengthDirective = function() {
         minlength = int(value) || 0;
         ctrl.$validate();
       });
-      ctrl.$validators.minlength = function(value) {
-        return ctrl.$isEmpty(value) || String(value).length >= minlength;
+      ctrl.$validators.minlength = function(value, viewValue) {
+        if (!isString(value)) {
+          value = viewValue;
+        }
+        return ctrl.$isEmpty(value) || value.length >= minlength;
       };
     }
   };


### PR DESCRIPTION
Request Type: bug

How to reproduce: 

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

Validity for inputs with maxlength attribute and an underlying non-string model value is always false: e.g. the length property for a numeric data type returns undefined
