### PR TITLE
fixed controller name in markup

### DIFF
--- a/docs/content/guide/forms.ngdoc
+++ b/docs/content/guide/forms.ngdoc
@@ -136,7 +136,7 @@ This allows us to extend the above example with these features:
 
 <example module="formExample">
   <file name="index.html">
-    <div ng-controller="Controller">
+    <div ng-controller="ExampleController">
       <form name="form" class="css-form" novalidate>
         Name:
           <input type="text" ng-model="user.name" name="uName" required /><br />


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): forms

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The "Binding to form and control state" sample had a wrong controller name which prevents the sample from running

**Other Comments:**
