### PR TITLE
feat($parse): Adds range operators

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -150,6 +150,14 @@ Lexer.prototype = {
         this.readNumber();
       } else if (this.isIdent(this.ch)) {
         this.readIdent();
+      } else if (this.is('.') && this.peek() === '.') {
+        if (this.peek(2) === '.') {
+          this.tokens.push({index: this.index, text: '...'});
+          this.index += 3;
+        } else {
+          this.tokens.push({index: this.index, text: '..'});
+          this.index += 2;
+        }
       } else if (this.is('(){}[].,;:?')) {
         this.tokens.push({
           index: this.index,
@@ -228,7 +236,7 @@ Lexer.prototype = {
     var start = this.index;
     while (this.index < this.text.length) {
       var ch = lowercase(this.text.charAt(this.index));
-      if (ch == '.' || this.isNumber(ch)) {
+      if (ch == '.' && this.peek() !== '.' || this.isNumber(ch)) {
         number += ch;
       } else {
         var peekCh = this.peek();
@@ -267,7 +275,7 @@ Lexer.prototype = {
 
     while (this.index < this.text.length) {
       ch = this.text.charAt(this.index);
-      if (ch === '.' || this.isIdent(ch) || this.isNumber(ch)) {
+      if (ch === '.' && this.peek() !== '.' || this.isIdent(ch) || this.isNumber(ch)) {
         if (ch === '.') lastDot = this.index;
         ident += ch;
       } else {
@@ -744,7 +752,9 @@ Parser.prototype = {
   // This is used with json array declaration
   arrayDeclaration: function () {
     var elementFns = [];
+    var rangeOp;
     var allConstant = true;
+
     if (this.peekToken().text !== ']') {
       do {
         if (this.peek(']')) {
@@ -752,9 +762,17 @@ Parser.prototype = {
           break;
         }
         var elementFn = this.expression();
-        elementFns.push(elementFn);
         if (!elementFn.constant) {
           allConstant = false;
+        }
+        if ((rangeOp = this.expect('..', '...'))) {
+          var rangeEndFn = this.expression();
+          if (!rangeEndFn.constant) {
+            allConstant = false;
+          }
+          elementFns.push({left: elementFn, right: rangeEndFn, range: rangeOp.text});
+        } else {
+          elementFns.push(elementFn);
         }
       } while (this.expect(','));
     }
@@ -763,7 +781,12 @@ Parser.prototype = {
     return extend(function(self, locals) {
       var array = [];
       for (var i = 0; i < elementFns.length; i++) {
-        array.push(elementFns[i](self, locals));
+        if (elementFns[i].range) {
+          array.push.apply(array,
+              range(elementFns[i].left(self, locals), elementFns[i].right(self, locals), elementFns[i].range));
+        } else {
+          array.push(elementFns[i](self, locals));
+        }
       }
       return array;
     }, {
@@ -806,6 +829,26 @@ Parser.prototype = {
     });
   }
 };
+
+
+function range(left, right, op) {
+  var result = [];
+  var reverse = (left > right);
+  var cmp = (op === '..' ? function (lhs, rhs) { return lhs <= rhs; } : function (lhs, rhs) { return lhs < rhs; });
+  var comparator;
+  var i;
+
+  if (reverse) {
+    comparator = function(lhs, rhs) { return cmp(rhs, lhs); };
+  } else {
+    comparator = cmp;
+  }
+  if (isNumber(left) && isNumber(right)) {
+    var next = reverse ? function() { --i; } : function() { ++i; };
+    for (i = left; comparator(i, right); next()) result.push(i);
+  }
+  return result;
+}
 
 
 //////////////////////////////////////////////////

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -143,6 +143,12 @@ describe('parser', function() {
       expect(map(tokens, function(t) { return t.text;})).toEqual(['a', '(', ')']);
     });
 
+    it('should tokenize ranges', function() {
+      expect(map(lex('[1..10]'), function(t) { return t.text;})).toEqual(['[', 1, '..', 10, ']']);
+      expect(map(lex('[1...10]'), function(t) { return t.text;})).toEqual(['[', 1, '...', 10, ']']);
+      expect(map(lex('[-1, 1..10, 12]'), function(t) { return t.text;})).toEqual(['[', '-', 1, ',', 1, '..', 10, ',', 12, ']']);
+    });
+
     it('should tokenize method invocation', function() {
       var tokens = lex("a.b.c (d) - e.f()");
       expect(map(tokens, function(t) { return t.text;})).
@@ -459,6 +465,18 @@ describe('parser', function() {
         expect(scope.$eval("[1, 2]")[1]).toEqual(2);
         expect(scope.$eval("[1, 2,]")[1]).toEqual(2);
         expect(scope.$eval("[1, 2,]").length).toEqual(2);
+      });
+
+      it('should evaluate array ranges', function() {
+        expect(scope.$eval("[0..9]")).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        expect(scope.$eval("[0...9]")).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+        expect(scope.$eval("[9..0]")).toEqual([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
+        expect(scope.$eval("[9...0]")).toEqual([9, 8, 7, 6, 5, 4, 3, 2, 1]);
+        expect(scope.$eval("[20, 9...0, 10]")).toEqual([20, 9, 8, 7, 6, 5, 4, 3, 2, 1, 10]);
+        scope.start = 0;
+        scope.end = 10;
+        expect(scope.$eval("[start..end]")).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        expect(scope.$eval("[start...end]")).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
       });
 
       it('should evaluate array access', function() {


### PR DESCRIPTION
Adds the operators '..' and '...' that work as range operators. These new operators are only valid within an array declaration and allows the array to be declared as a range. E.g.

``` html
<div ng-repeat="index in [1...pages.length]">{{index}}</div>
```
