### PR TITLE
docs($cacheFactory): prevent example breaking on key update

### DIFF
--- a/src/ng/cacheFactory.js
+++ b/src/ng/cacheFactory.js
@@ -68,7 +68,9 @@
            $scope.cache = $cacheFactory('cacheId');
            $scope.put = function(key, value) {
              $scope.cache.put(key, value);
-             $scope.keys.push(key);
+             if($scope.keys.indexOf(key) === -1) {
+               $scope.keys.push(key);
+             }
            };
          }]);
      </file>


### PR DESCRIPTION
The example for $cacheFactory breaks when a user tries to update a value for a key.
Setting a new value for an existing key results in duplicate key entries in the key array, thus breaking the ng-repeat directive.
With this fix the key is only added if it isn't contained in the array already.
