### PR TITLE
Fixed broken angular.copy example

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -735,7 +735,7 @@ function isLeafNode (node) {
  </div>
 
  <script>
-  angular.module('copyExample')
+  angular.module('copyExample', [])
     .controller('ExampleController', ['$scope', function($scope) {
       $scope.master= {};
 


### PR DESCRIPTION
Request Type: docs

How to reproduce: Go to angular.copy documentation (https://docs.angularjs.org/api/ng/function/angular.copy) and try example; it does not work.

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**
