### PR TITLE
test($http): ignore date-toJSON test if running in IE8

### DIFF
--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -463,6 +463,7 @@ describe('$http', function() {
       });
 
       it('should not double quote dates', function() {
+        if (msie < 9) return;
         $httpBackend.expect('GET', '/url?date=2014-07-15T17:30:00.000Z').respond('');
         $http({url: '/url', params: {date:new Date('2014-07-15T17:30:00.000Z')}, method: 'GET'});
       });


### PR DESCRIPTION
IE8 does not implement Date.prototype.toISOString(), which is necessary for
this feature. The feature still works if this method is polyfilled, but these
tests are not run with polyfills.

/CC @IgorMinar (Please review, shouldn't take long!)
