### PR TITLE
docs($interval): fix missing square brackets in example

### DIFF
--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -83,7 +83,7 @@ function $IntervalProvider() {
       *           // Make sure that the interval nis destroyed too
       *           $scope.stopFight();
       *         });
-      *       })
+      *       }])
       *       // Register the 'myCurrentTime' directive factory method.
       *       // We inject $interval and dateFilter service since the factory method is DI.
       *       .directive('myCurrentTime', ['$interval', 'dateFilter',
@@ -112,7 +112,7 @@ function $IntervalProvider() {
       *               $interval.cancel(stopTime);
       *             });
       *           }
-      *         });
+      *         }]);
       *   </script>
       *
       *   <div>


### PR DESCRIPTION
Request Type: docs

How to reproduce: Go to https://docs.angularjs.org/api/ng/service/$interval

View example - bindings not complete and buttons do not work

Component(s): 

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The docs example was missing closing ] for dependency injections.

**Other Comments:**
