### PR TITLE
chore(ci): update protractor to 1.0.0-rc5 and increase global timeout fo...

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2738,7 +2738,7 @@
       }
     },
     "protractor": {
-      "version": "1.0.0-rc4",
+      "version": "1.0.0-rc5",
       "dependencies": {
         "request": {
           "version": "2.36.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "karma-sauce-launcher": "0.2.0",
     "karma-script-launcher": "0.1.0",
     "karma-browserstack-launcher": "0.0.7",
-    "protractor": "1.0.0-rc4",
+    "protractor": "1.0.0-rc5",
     "yaml-js": "~0.0.8",
     "rewire": "1.1.3",
     "promises-aplus-tests": "~1.3.2",

--- a/protractor-travis-conf.js
+++ b/protractor-travis-conf.js
@@ -27,4 +27,7 @@ config.multiCapabilities = [{
   'build': process.env.TRAVIS_BUILD_NUMBER
 }];
 
+config.allScriptsTimeout = 30000;
+config.getPageTimeout = 30000;
+
 exports.config = config;


### PR DESCRIPTION
...r loading pages

This should help with occasional safari page load timeouts. In a test of
4500 page loads, the current 10 second limit caused 3 errors while a 30 second limit
caused none.
