### PR TITLE
fix(ngTouch): leaving an element must end swiping

### DIFF
--- a/src/ngTouch/swipe.js
+++ b/src/ngTouch/swipe.js
@@ -29,7 +29,8 @@ ngTouch.factory('$swipe', [function() {
     'mouse': {
       start: 'mousedown',
       move: 'mousemove',
-      end: 'mouseup'
+      end: 'mouseup',
+      cancel: 'mouseleave'
     },
     'touch': {
       start: 'touchstart',
@@ -118,8 +119,10 @@ ngTouch.factory('$swipe', [function() {
       var events = getEvents(pointerTypes, 'cancel');
       if (events) {
         element.on(events, function(event) {
-          active = false;
-          eventHandlers['cancel'] && eventHandlers['cancel'](event);
+          if (active === true) {
+            active = false;
+            eventHandlers['cancel'] && eventHandlers['cancel'](event);
+          }
         });
       }
 

--- a/test/ngTouch/swipeSpec.js
+++ b/test/ngTouch/swipeSpec.js
@@ -31,7 +31,7 @@ describe('$swipe', function() {
 
   describe('pointerTypes', function() {
     var usedEvents;
-    var MOUSE_EVENTS = ['mousedown','mousemove','mouseup'].sort();
+    var MOUSE_EVENTS = ['mousedown','mousemove','mouseup','mouseleave'].sort();
     var TOUCH_EVENTS = ['touchcancel','touchend','touchmove','touchstart'].sort();
     var ALL_EVENTS = MOUSE_EVENTS.concat(TOUCH_EVENTS).sort();
 


### PR DESCRIPTION
when user leaves a swiping area, it keeps on swiping. with this fix leaving area acts as a swipe cancel.

closes: #4810
