### PR TITLE
fix(ngSwitch): use the correct transclusion scope

### DIFF
--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -166,9 +166,8 @@ var ngSwitchDirective = ['$animate', function($animate) {
         if ((selectedTranscludes = ngSwitchController.cases['!' + value] || ngSwitchController.cases['?'])) {
           scope.$eval(attr.change);
           forEach(selectedTranscludes, function(selectedTransclude) {
-            var selectedScope = scope.$new();
-            selectedScopes.push(selectedScope);
-            selectedTransclude.transclude(selectedScope, function(caseElement) {
+            selectedTransclude.transclude(function(caseElement, selectedScope) {
+              selectedScopes.push(selectedScope);
               var anchor = selectedTransclude.element;
 
               selectedElements.push(caseElement);
@@ -183,7 +182,7 @@ var ngSwitchDirective = ['$animate', function($animate) {
 
 var ngSwitchWhenDirective = ngDirective({
   transclude: 'element',
-  priority: 800,
+  priority: 1200,
   require: '^ngSwitch',
   multiElement: true,
   link: function(scope, element, attrs, ctrl, $transclude) {
@@ -194,7 +193,7 @@ var ngSwitchWhenDirective = ngDirective({
 
 var ngSwitchDefaultDirective = ngDirective({
   transclude: 'element',
-  priority: 800,
+  priority: 1200,
   require: '^ngSwitch',
   multiElement: true,
   link: function(scope, element, attr, ctrl, $transclude) {

--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -152,7 +152,7 @@ var ngSwitchDirective = ['$animate', function($animate) {
         previousElements.length = 0;
 
         for (i = 0, ii = selectedScopes.length; i < ii; ++i) {
-          var selected = selectedElements[i];
+          var selected = getBlockElements(selectedElements[i].clone);
           selectedScopes[i].$destroy();
           previousElements[i] = selected;
           $animate.leave(selected, function() {
@@ -169,8 +169,10 @@ var ngSwitchDirective = ['$animate', function($animate) {
             selectedTransclude.transclude(function(caseElement, selectedScope) {
               selectedScopes.push(selectedScope);
               var anchor = selectedTransclude.element;
+              caseElement[caseElement.length++] = document.createComment(' end ngSwitchWhen: ');
+              var block = { clone: caseElement };
 
-              selectedElements.push(caseElement);
+              selectedElements.push(block);
               $animate.enter(caseElement, anchor.parent(), anchor);
             });
           });

--- a/test/ng/directive/ngSwitchSpec.js
+++ b/test/ng/directive/ngSwitchSpec.js
@@ -251,25 +251,28 @@ describe('ngSwitch', function() {
   }));
 
 
-  it("should use the correct transclusion scope if there is a transclude directive on the ng-swith-when/ng-switch-default element", inject(function($rootScope, $compile) {
+  it("should interoperate with other transclusion directives like ngRepeat", inject(function($rootScope, $compile) {
     element = $compile(
-      '<div ng-switch="foo">' +
-          '<pre ng-switch-when="item1" ng-repeat="bar in bars">' +
-              'foo = {{foo}}' +
-              'bar = {{bar}}' +
-              '$index = {{$index}}' +
-          '</pre>' +
+      '<div ng-switch="value">' +
+          '<div ng-switch-when="foo" ng-repeat="foo in foos">{{value}}:{{foo}}|</div>' +
+          '<div ng-switch-default ng-repeat="bar in bars">{{value}}:{{bar}}|</div>' +
       '</div>'
     )($rootScope);
-    $rootScope.$apply('foo="item1";bars=["one", "two"]');
-    expect(element.text()).toEqual(
-      'foo = item1' +
-      'bar = one' +
-      '$index = 0' +
-      'foo = item1' +
-      'bar = two' +
-      '$index = 1'
-    );
+    $rootScope.$apply('value="foo";foos=["one", "two"]');
+    expect(element.text()).toEqual('foo:one|foo:two|');
+
+    $rootScope.$apply('value="foo";foos=["one"]');
+    expect(element.text()).toEqual('foo:one|');
+
+    $rootScope.$apply('value="foo";foos=["one","two","three"]');
+    expect(element.text()).toEqual('foo:one|foo:two|foo:three|');
+
+    $rootScope.$apply('value="bar";bars=["up", "down"]');
+    expect(element.text()).toEqual('bar:up|bar:down|');
+
+    $rootScope.$apply('value="bar";bars=["up", "down", "forwards", "backwards"]');
+    expect(element.text()).toEqual('bar:up|bar:down|bar:forwards|bar:backwards|');
+
   }));
 
 

--- a/test/ng/directive/ngSwitchSpec.js
+++ b/test/ng/directive/ngSwitchSpec.js
@@ -241,13 +241,35 @@ describe('ngSwitch', function() {
     $rootScope.url = 'x';
     $rootScope.$apply();
     expect(getChildScope()).toBeUndefined();
-    expect(child1.$destroy).toHaveBeenCalledOnce();
+    expect(child1.$destroy).toHaveBeenCalled();
 
     $rootScope.url = 'a';
     $rootScope.$apply();
     var child2 = getChildScope();
     expect(child2).toBeDefined();
     expect(child2).not.toBe(child1);
+  }));
+
+
+  it("should use the correct transclusion scope if there is a transclude directive on the ng-swith-when/ng-switch-default element", inject(function($rootScope, $compile) {
+    element = $compile(
+      '<div ng-switch="foo">' +
+          '<pre ng-switch-when="item1" ng-repeat="bar in bars">' +
+              'foo = {{foo}}' +
+              'bar = {{bar}}' +
+              '$index = {{$index}}' +
+          '</pre>' +
+      '</div>'
+    )($rootScope);
+    $rootScope.$apply('foo="item1";bars=["one", "two"]');
+    expect(element.text()).toEqual(
+      'foo = item1' +
+      'bar = one' +
+      '$index = 0' +
+      'foo = item1' +
+      'bar = two' +
+      '$index = 1'
+    );
   }));
 
 


### PR DESCRIPTION
If an ngSwitchWhen or ngSwitchDefault directive is on an element that also
contains a transclusion directive (such as ngRepeat) the new scope should
be the one provided by the bound transclusion function.

Previously we were incorrectly creating a simple child of the main ngSwitch
scope.

Closes #8235
