### PR TITLE
docs(guide/module) fixed disabled global cntl

### DIFF
--- a/docs/content/guide/module.ngdoc
+++ b/docs/content/guide/module.ngdoc
@@ -99,7 +99,7 @@ The above is a suggestion. Tailor it to your needs.
     angular.module('xmpl.directive', []);
 
     angular.module('xmpl.filter', []);
-
+    
     angular.module('xmpl', ['xmpl.service', 'xmpl.directive', 'xmpl.filter']).
       run(function(greeter, user) {
         // This is effectively part of the main method initialization code
@@ -107,13 +107,11 @@ The above is a suggestion. Tailor it to your needs.
           salutation: 'Bonjour'
         });
         user.load('World');
+      }).
+      controller('XmplController', function($scope, greeter, user){
+        $scope.greeting = greeter.greet(user.name);
       });
 
-
-    // A Controller for your app
-    var XmplController = function($scope, greeter, user) {
-      $scope.greeting = greeter.greet(user.name);
-    };
   </file>
 </example>
 


### PR DESCRIPTION
Example contained a global controller.

**How to reproduce:** https://docs.angularjs.org/guide/module

**Plunker with fix:** http://plnkr.co/jwu6ZBTNzOZjVqy1lLEo
