### PR TITLE
fix(input): by default, do not trim input[type=password] values

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -908,6 +908,7 @@ function addNativeHtml5Validators(ctrl, validatorName, badFlags, ignoreFlags, va
 function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   var validity = element.prop(VALIDITY_STATE_PROPERTY);
   var placeholder = element[0].placeholder, noevent = {};
+  var type = element[0].type.toLowerCase();
   ctrl.$$validityState = validity;
 
   // In composition mode, users are still inputing intermediate text buffer,
@@ -942,8 +943,8 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 
     // By default we will trim the value
     // If the attribute ng-trim exists we will avoid trimming
-    // e.g. <input ng-model="foo" ng-trim="false">
-    if (!attr.ngTrim || attr.ngTrim !== 'false') {
+    // If input type is 'password', the value is never trimmed
+    if (type !== 'password' && (!attr.ngTrim || attr.ngTrim !== 'false')) {
       value = trim(value);
     }
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2967,6 +2967,30 @@ describe('input', function() {
       expect(scope.items[0].selected).toBe(false);
     });
   });
+
+
+  describe('password', function() {
+    // Under no circumstances should input[type=password] trim inputs
+    it('should not trim if ngTrim is unspecified', function() {
+      compileInput('<input type="password" ng-model="password">');
+      changeInputValueTo(' - - untrimmed - - ');
+      expect(scope.password.length).toBe(' - - untrimmed - - '.length);
+    });
+
+
+    it('should not trim if ngTrim !== false', function() {
+      compileInput('<input type="password" ng-model="password" ng-trim="true">');
+      changeInputValueTo(' - - untrimmed - - ');
+      expect(scope.password.length).toBe(' - - untrimmed - - '.length);
+    });
+
+
+    it('should not trim if ngTrim === false', function() {
+      compileInput('<input type="password" ng-model="password" ng-trim="false">');
+      changeInputValueTo(' - - untrimmed - - ');
+      expect(scope.password.length).toBe(' - - untrimmed - - '.length);
+    });
+  });
 });
 
 describe('NgModel animations', function() {


### PR DESCRIPTION
Previously, all input types using ngModel and textInputType() would trim values if the ng-trim attribute was unspecified. This is undesirable for passwords because a user's input should always be canonical in that case.

This CL changes this behaviour by only trimming by-default if the input type is not password. In the future, if other input types need to be checked, or if the input type needs to be checked at runtime, this may be refactored to support those cases.

BREAKING CHANGE:

Previously, input[type=password] would trim values by default. This is no longer the case, and requires an explicit `ng-trim="value other than 'false'"` to ensure that the value is trimmed in casees where this is actually desirable.

Example:

``` html
<!-- WILL NOT TRIM VALUE -->
<input type="password" ng-model="password">
<input type="password" ng-model="password" ng-trim="false">

<!-- WILL TRIM VALUE -->
<input type="password" ng-model="password" ng-trim="ANYTHING ELSE"> 
```

Closes #8230
