### PR TITLE
fix($compile): updating the jQuery .context when it is replaced

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2021,6 +2021,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               }
             }
             $rootElement.length -= removeCount - 1;
+
+            //If the replaced element is also the jQuery .context then replace it
+            if ($rootElement.context === firstElementToRemove) {
+              $rootElement.context = newNode;
+            }
             break;
           }
         }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -696,6 +696,29 @@ describe('$compile', function() {
           expect(child).toHaveClass('log'); // merged from replace directive template
         }));
 
+        it('should update references to replaced jQuery context', function() {
+          module(function($compileProvider) {
+            $compileProvider.directive('foo', function() {
+              return {
+                replace: true,
+                template: '<div></div>'
+              };
+            });
+          });
+
+          inject(function($compile, $rootScope) {
+            element = jqLite(document.createElement('span')).attr('foo', '');
+            expect(nodeName_(element)).toBe('span');
+
+            var preCompiledNode = element[0];
+
+            var linked = $compile(element)($rootScope);
+            expect(linked).toBe(element);
+            expect(nodeName_(element)).toBe('div');
+            expect(element.context).not.toBe(preCompiledNode);
+          });
+        });
+
         it("should fail if replacing and template doesn't have a single root element", function() {
           module(function() {
             directive('noRootElem', function() {


### PR DESCRIPTION
This allows replaced DOM nodes to be GCed when using jQuery. The issue is pretty minor and the jQuery .context might be removed in the future (see https://api.jquery.com/context/), but the fix is pretty simple.

Fixes #7900
