### PR TITLE
WIP: detect accidental interpolation

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1514,6 +1514,23 @@ function assertNotHasOwnProperty(name, context) {
   }
 }
 
+
+/**
+ * Throw an error when an interpolation is detected in an attribute value that should be an
+ * expression.
+ *
+ * @param attrs $attrs object
+ * @param attrName attribute name
+ */
+function assertNoInterpolation(attrs, attrName) {
+  if (/\{\{/.test(attrs[attrName])) {
+    throw new Error('Unexpected interpolation found in attribute ' + attrName +
+        ' of element ' + startingTag(attrs.$$element));
+  }
+};
+
+
+
 /**
  * Return the value accessible from the object by path. Any undefined traversals are ignored
  * @param {Object} obj starting object

--- a/src/ng/directive/ngBind.js
+++ b/src/ng/directive/ngBind.js
@@ -179,6 +179,7 @@ var ngBindTemplateDirective = ['$interpolate', function($interpolate) {
 var ngBindHtmlDirective = ['$sce', '$parse', function($sce, $parse) {
   return {
     compile: function (tElement, tAttrs) {
+      assertNoInterpolation(tAttrs, 'ngBindHtml');
       tElement.addClass('ng-binding');
 
       return function (scope, element, attr) {

--- a/test/ng/directive/ngBindSpec.js
+++ b/test/ng/directive/ngBindSpec.js
@@ -129,6 +129,13 @@ describe('ngBind*', function() {
     }));
 
 
+    it('should complain about accidental use of interpolation', inject(function($compile) {
+      expect(function() {
+        $compile('<div ng-bind-html="{{myHtml}}"></div>');
+      }).toThrow('Unexpected interpolation found in attribute ngBindHtml of element <div ng-bind-html="{{myHtml}}">');
+    }));
+
+
     describe('SCE disabled', function() {
       beforeEach(function() {
         module(function($sceProvider) { $sceProvider.enabled(false); });


### PR DESCRIPTION
throw an error when developer accidentaly uses interpolation instead of an expression

TODO:
- try to apply this to other directives
- try to apply this genericaly for directives with isolate scope definition
- add an error page
