### PR TITLE
docs($http) Clarify how to specify JSONP callback.

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -782,7 +782,7 @@ function $HttpProvider() {
      * Shortcut method to perform `JSONP` request.
      *
      * @param {string} url Relative or absolute URL specifying the destination of the request.
-     *                     Should contain `JSON_CALLBACK` string.
+     *                     The name of the callback should be the string `JSON_CALLBACK`.
      * @param {Object=} config Optional configuration object
      * @returns {HttpPromise} Future object
      */


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): $http

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

**Other Comments:**

Make clear that it is the name of the callback that should be `JSON_CALLBACK`, instead of the current vague description that implies the string can be located anywhere in the URL.
