### PR TITLE
fix(ngMock): respond did not always take a statusText argument

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1097,7 +1097,7 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
     return function() {
       return angular.isNumber(status)
           ? [status, data, headers, statusText]
-          : [200, status, data];
+          : [200, status, data, headers];
     };
   }
 

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1110,6 +1110,14 @@ describe('ngMock', function() {
         expect(callback).toHaveBeenCalledOnceWith(200, 'first', 'header: val', 'OK');
       });
 
+      it('should default status code to 200', function() {
+        hb.expect('GET', '/url1').respond('first', {'header': 'val'}, 'OK');
+        hb('GET', '/url1', null, callback);
+        hb.flush();
+
+        expect(callback).toHaveBeenCalledOnceWith(200, 'first', 'header: val', 'OK');
+      });
+
       it('should take function', function() {
         hb.expect('GET', '/some').respond(function (m, u, d, h) {
           return [301, m + u + ';' + d + ';a=' + h.a, {'Connection': 'keep-alive'}, 'Moved Permanently'];
@@ -1120,22 +1128,6 @@ describe('ngMock', function() {
 
         expect(callback).toHaveBeenCalledOnceWith(301, 'GET/some;data;a=b', 'Connection: keep-alive', 'Moved Permanently');
       });
-
-      it('should default status code to 200', function() {
-        callback.andCallFake(function(status, response) {
-          expect(status).toBe(200);
-          expect(response).toBe('some-data');
-        });
-
-        hb.expect('GET', '/url1').respond('some-data');
-        hb.expect('GET', '/url2').respond('some-data', {'X-Header': 'true'});
-        hb('GET', '/url1', null, callback);
-        hb('GET', '/url2', null, callback);
-        hb.flush();
-        expect(callback).toHaveBeenCalled();
-        expect(callback.callCount).toBe(2);
-      });
-
 
       it('should default response headers to ""', function() {
         hb.expect('GET', '/url1').respond(200, 'first');


### PR DESCRIPTION
minor fix so that `respond` can take a `statusText` argument even when having status 200 by default
