### PR TITLE
refactor(injector): remove unused code

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -191,7 +191,10 @@ function annotate(fn, strictDi, name) {
  *   {@link guide/di $inject Annotation} rules.
  * @param {Object=} self The `this` for the invoked method.
  * @param {Object=} locals Optional object. If preset then any argument names are read from this
- *                         object first, before the `$injector` is consulted.
+ *                         object first, before the `$injector` is consulted. If `locals` is
+ *                         a string, then it's treated as the service's name (might be useful
+ *                         for 3rd party libraries which use the smart-injector style for
+ *                         providing more debug information).
  * @returns {*} the value returned by the invoked `fn` function.
  */
 


### PR DESCRIPTION
The removed code isn't being used:
- there isn't a single place in the code where `invoke` would be
  called with a string argument in the third position.
- the fourth parameter is also not documented,
  so when called from outside of the framework's source,
  the third parameter is meant to be the locals object.
