### PR TITLE
docs(angular-mocks.js): fix missing brackets typo

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1472,7 +1472,7 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
    * "afterEach" clause.
    *
    * ```js
-   *   afterEach($httpBackend.verifyNoOutstandingExpectation);
+   *   afterEach($httpBackend.verifyNoOutstandingExpectation());
    * ```
    */
   $httpBackend.verifyNoOutstandingExpectation = function() {
@@ -1493,7 +1493,7 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
    * "afterEach" clause.
    *
    * ```js
-   *   afterEach($httpBackend.verifyNoOutstandingRequest);
+   *   afterEach($httpBackend.verifyNoOutstandingRequest());
    * ```
    */
   $httpBackend.verifyNoOutstandingRequest = function() {


### PR DESCRIPTION
The code snippet does not work without brackets (it is a code without effect). 
The function call is necessary in order to evaluate whether or not an exception should be thrown.
