### PR TITLE
feat(rootScope): allow $apply expressions to prevent unnecessary digest

### DIFF
--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -60,8 +60,8 @@ forEach(
           var fn = $parse(attr[directiveName], /* interceptorFn */ null, /* expensiveChecks */ true);
           return function ngEventHandler(scope, element) {
             element.on(eventName, function(event) {
-              var callback = function() {
-                fn(scope, {$event:event});
+              var callback = function(scope, locals) {
+                fn(scope, {$event:event, $abortApply: locals && locals.$abortApply});
               };
               if (forceAsyncEvents[eventName] && $rootScope.$$phase) {
                 scope.$evalAsync(callback);

--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -61,7 +61,11 @@ forEach(
           return function ngEventHandler(scope, element) {
             element.on(eventName, function(event) {
               var callback = function(scope, locals) {
-                fn(scope, {$event:event, $abortApply: locals && locals.$abortApply});
+                fn(scope, {
+                  $event:event,
+                  $abortApply: locals && locals.$abortApply,
+                  $partialDigest: locals && locals.$partialDigest
+                });
               };
               if (forceAsyncEvents[eventName] && $rootScope.$$phase) {
                 scope.$evalAsync(callback);

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -1023,16 +1023,26 @@ function $RootScopeProvider() {
        */
       $apply: function(expr) {
         var abortApply = false;
+        var scopeForDigest = $rootScope;
+        var currentScope = this;
+
         try {
           beginPhase('$apply');
-          return this.$eval(expr, {$abortApply: function() {abortApply = true;}});
+          return this.$eval(expr, {
+            $abortApply: function() {
+              abortApply = true;
+            },
+            $partialDigest: function(scope) {
+              scopeForDigest = scope || currentScope;
+            }
+          });
         } catch (e) {
           $exceptionHandler(e);
         } finally {
           clearPhase();
           if (!abortApply) {
             try {
-              $rootScope.$digest();
+              scopeForDigest.$digest();
             } catch (e) {
               $exceptionHandler(e);
               throw e;

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -1022,18 +1022,21 @@ function $RootScopeProvider() {
        * @returns {*} The result of evaluating the expression.
        */
       $apply: function(expr) {
+        var abortApply = false;
         try {
           beginPhase('$apply');
-          return this.$eval(expr);
+          return this.$eval(expr, {$abortApply: function() {abortApply = true;}});
         } catch (e) {
           $exceptionHandler(e);
         } finally {
           clearPhase();
-          try {
-            $rootScope.$digest();
-          } catch (e) {
-            $exceptionHandler(e);
-            throw e;
+          if (!abortApply) {
+            try {
+              $rootScope.$digest();
+            } catch (e) {
+              $exceptionHandler(e);
+              throw e;
+            }
           }
         }
       },

--- a/test/ng/directive/ngClickSpec.js
+++ b/test/ng/directive/ngClickSpec.js
@@ -23,4 +23,12 @@ describe('ngClick', function() {
     browserTrigger(element, 'click');
     expect($rootScope.event).toBeDefined();
   }));
+
+  it('should abort apply if abort argument is invoked', inject(function($rootScope, $compile) {
+    element = $compile('<div ng-click="a = 1; $abortApply()">{{a}}</div>')($rootScope);
+    $rootScope.$digest();
+
+    browserTrigger(element, 'click');
+    expect(element.text()).toBe('');
+  }));
 });

--- a/test/ng/directive/ngClickSpec.js
+++ b/test/ng/directive/ngClickSpec.js
@@ -31,4 +31,16 @@ describe('ngClick', function() {
     browserTrigger(element, 'click');
     expect(element.text()).toBe('');
   }));
+
+  it('should digest locally if $partialDigest is invoked', inject(function($rootScope, $compile) {
+    var scope = $rootScope.$new();
+    element = $compile('<div ng-click="a = 1; $partialDigest()">{{a}}</div>')(scope);
+    $rootScope.$digest();
+
+    var watchSpy = jasmine.createSpy('watchSpy');
+    $rootScope.$watch(watchSpy);
+    browserTrigger(element, 'click');
+    expect(element.text()).toBe('1');
+    expect(watchSpy).not.toHaveBeenCalled();
+  }));
 });

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1333,6 +1333,12 @@ describe('Scope', function() {
       expect(log).toEqual('1');
     }));
 
+    it('should abort apply if abort argument is invoked', inject(function ($rootScope) {
+      var watchSpy = jasmine.createSpy('watchSpy');
+      $rootScope.$watch(watchSpy);
+      $rootScope.$apply('$abortApply()');
+      expect(watchSpy).not.toHaveBeenCalled();
+    }));
 
     it('should catch exceptions', function() {
       module(function($exceptionHandlerProvider) {

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1333,11 +1333,38 @@ describe('Scope', function() {
       expect(log).toEqual('1');
     }));
 
-    it('should abort apply if abort argument is invoked', inject(function ($rootScope) {
+    it('should abort apply if abort argument is invoked', inject(function($rootScope) {
       var watchSpy = jasmine.createSpy('watchSpy');
       $rootScope.$watch(watchSpy);
       $rootScope.$apply('$abortApply()');
       expect(watchSpy).not.toHaveBeenCalled();
+    }));
+
+    it('should perform digest locally if $partialDigest is invoked', inject(function($rootScope) {
+      var watchRootSpy = jasmine.createSpy('watchRootSpy');
+      var watchSpy = jasmine.createSpy('watchSpy');
+      var child = $rootScope.$new();
+
+      $rootScope.$watch(watchRootSpy);
+      child.$watch(watchSpy);
+      child.$apply('$partialDigest()');
+
+      expect(watchRootSpy).not.toHaveBeenCalled();
+      expect(watchSpy).toHaveBeenCalled();
+    }));
+
+    it('should perform digest on specific scope', inject(function($rootScope) {
+      var watchRootSpy = jasmine.createSpy('watchRootSpy');
+      var watchSpy = jasmine.createSpy('watchSpy');
+      var child = $rootScope.$new();
+      var grandChild = child.$new();
+
+      $rootScope.$watch(watchRootSpy);
+      child.$watch(watchSpy);
+      grandChild.$apply('$partialDigest($parent)');
+
+      expect(watchRootSpy).not.toHaveBeenCalled();
+      expect(watchSpy).toHaveBeenCalled();
     }));
 
     it('should catch exceptions', function() {


### PR DESCRIPTION
This allows, for example to prevent unnecessary digest in ngClick handler function in case the handler does not have any immediate side effects.

Closes #8286
