### PR TITLE
refactor(Angular): add isPromise helper function

### DIFF
--- a/lib/promises-aplus/promises-aplus-test-adapter.js
+++ b/lib/promises-aplus/promises-aplus-test-adapter.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var isFunction = function isFunction(value){return typeof value == 'function';};
+var isPromiseLike = function isPromiseLike(obj) {return obj && isFunction(obj.then);};
 
 var $q = qFactory(process.nextTick, function noopExceptionHandler() {});
 

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -51,6 +51,7 @@
     "isFile": false,
     "isBlob": false,
     "isBoolean": false,
+    "isPromiseLike": false,
     "trim": false,
     "isElement": false,
     "makeMap": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -47,6 +47,7 @@
   isFile: true,
   isBlob: true,
   isBoolean: true,
+  isPromiseLike: true,
   trim: true,
   isElement: true,
   makeMap: true,
@@ -566,6 +567,11 @@ function isBlob(obj) {
 
 function isBoolean(value) {
   return typeof value === 'boolean';
+}
+
+
+function isPromiseLike(obj) {
+  return obj && isFunction(obj.then);
 }
 
 

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -895,7 +895,7 @@ function $HttpProvider() {
       if (cache) {
         cachedResp = cache.get(url);
         if (isDefined(cachedResp)) {
-          if (cachedResp.then) {
+          if (isPromiseLike(cachedResp)) {
             // cached request has already been sent, but there is no response yet
             cachedResp.then(removePendingReq, removePendingReq);
             return cachedResp;

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -132,7 +132,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
 
     if (timeout > 0) {
       var timeoutId = $browserDefer(timeoutRequest, timeout);
-    } else if (timeout && timeout.then) {
+    } else if (isPromiseLike(timeout)) {
       timeout.then(timeoutRequest);
     }
 

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -310,7 +310,7 @@ function qFactory(nextTick, exceptionHandler) {
             } catch(e) {
               return makePromise(e, false);
             }
-            if (callbackOutput && isFunction(callbackOutput.then)) {
+            if (isPromiseLike(callbackOutput)) {
               return callbackOutput.then(function() {
                 return makePromise(value, isResolved);
               }, function(error) {
@@ -335,7 +335,7 @@ function qFactory(nextTick, exceptionHandler) {
 
 
   var ref = function(value) {
-    if (value && isFunction(value.then)) return value;
+    if (isPromiseLike(value)) return value;
     return {
       then: function(callback) {
         var result = defer();


### PR DESCRIPTION
This can be used internally to remove the repeating pattern of `obj && obj.then`. For now, I don't see a good reason to expose this in angular's public interface.
