### PR TITLE
feat(ngLog): provides support to debug the application in chosen level

### DIFF
--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -45,7 +45,7 @@
  */
 function $LogProvider(){
   var debug = true,
-      level = 'debug',
+      level = 'log',
       self = this;
 
   /**
@@ -86,7 +86,7 @@ function $LogProvider(){
         var fn = consoleLog('log');
 
         return function() {
-          if (level == 'debug' || level == 'error' || level == 'warn' || level == 'info' || level == 'log') {
+          if (level == 'log') {
             fn.apply(self, arguments);
           }
         };
@@ -103,7 +103,7 @@ function $LogProvider(){
         var fn = consoleLog('info');
 
         return function() {
-          if (level == 'debug' || level == 'error' || level == 'warn' || level == 'info') {
+          if (level == 'log' || level == 'info') {
             fn.apply(self, arguments);
           }
         };
@@ -120,7 +120,7 @@ function $LogProvider(){
         var fn = consoleLog('warn');
 
         return function() {
-          if (level == 'debug' || level == 'error' || level == 'warn') {
+          if (level == 'log' || level == 'info' || level == 'warn') {
             fn.apply(self, arguments);
           }
         };
@@ -137,7 +137,7 @@ function $LogProvider(){
         var fn = consoleLog('error');
 
         return function() {
-          if (level == 'debug' || level == 'error') {
+          if (level == 'log' || level == 'info' || level == 'warn' || level == 'error') {
             fn.apply(self, arguments);
           }
         };
@@ -154,9 +154,7 @@ function $LogProvider(){
         var fn = consoleLog('debug');
 
         return function() {
-          if (
-            // debug ||
-            level == 'debug') {
+          if (debug) {
             fn.apply(self, arguments);
           }
         };

--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -73,15 +73,6 @@ function $LogProvider(){
     }
   };
 
-  this.debugLevel = function(flag) {
-    if (flag) {
-      level = flag;
-    return this;
-    } else {
-      return level;
-    }
-  };
-
   this.$get = ['$window', function($window){
     return {
       /**

--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -45,6 +45,7 @@
  */
 function $LogProvider(){
   var debug = true,
+      level = 'debug',
       self = this;
 
   /**
@@ -63,6 +64,24 @@ function $LogProvider(){
     }
   };
 
+  this.debugLevel = function(flag) {
+    if (isDefined(flag)) {
+      level = flag;
+    return this;
+    } else {
+      return level;
+    }
+  };
+
+  this.debugLevel = function(flag) {
+    if (flag) {
+      level = flag;
+    return this;
+    } else {
+      return level;
+    }
+  };
+
   this.$get = ['$window', function($window){
     return {
       /**
@@ -72,7 +91,15 @@ function $LogProvider(){
        * @description
        * Write a log message
        */
-      log: consoleLog('log'),
+      log: (function () {
+        var fn = consoleLog('log');
+
+        return function() {
+          if (level == 'debug' || level == 'error' || level == 'warn' || level == 'info' || level == 'log') {
+            fn.apply(self, arguments);
+          }
+        };
+      }()),
 
       /**
        * @ngdoc method
@@ -81,7 +108,15 @@ function $LogProvider(){
        * @description
        * Write an information message
        */
-      info: consoleLog('info'),
+      info: (function () {
+        var fn = consoleLog('info');
+
+        return function() {
+          if (level == 'debug' || level == 'error' || level == 'warn' || level == 'info') {
+            fn.apply(self, arguments);
+          }
+        };
+      }()),
 
       /**
        * @ngdoc method
@@ -90,7 +125,15 @@ function $LogProvider(){
        * @description
        * Write a warning message
        */
-      warn: consoleLog('warn'),
+      warn: (function () {
+        var fn = consoleLog('warn');
+
+        return function() {
+          if (level == 'debug' || level == 'error' || level == 'warn') {
+            fn.apply(self, arguments);
+          }
+        };
+      }()),
 
       /**
        * @ngdoc method
@@ -99,7 +142,15 @@ function $LogProvider(){
        * @description
        * Write an error message
        */
-      error: consoleLog('error'),
+      error: (function () {
+        var fn = consoleLog('error');
+
+        return function() {
+          if (level == 'debug' || level == 'error') {
+            fn.apply(self, arguments);
+          }
+        };
+      }()),
 
       /**
        * @ngdoc method
@@ -112,7 +163,9 @@ function $LogProvider(){
         var fn = consoleLog('debug');
 
         return function() {
-          if (debug) {
+          if (
+            // debug ||
+            level == 'debug') {
             fn.apply(self, arguments);
           }
         };
@@ -133,6 +186,7 @@ function $LogProvider(){
     }
 
     function consoleLog(type) {
+
       var console = $window.console || {},
           logFn = console[type] || console.log || noop,
           hasApply = false;

--- a/test/ng/logSpec.js
+++ b/test/ng/logSpec.js
@@ -1,9 +1,10 @@
 /* global $LogProvider: false */
 'use strict';
 
-function initService(debugEnabled) {
+function initService(debugEnabled, debugLevel) {
     return module(function($logProvider){
       $logProvider.debugEnabled(debugEnabled);
+      $logProvider.debugLevel(debugLevel);
     });
   }
 
@@ -119,7 +120,7 @@ describe('$log', function() {
 
   describe("$log.debug", function () {
 
-    beforeEach(initService(false));
+    beforeEach(initService(false, 'error'));
 
     it("should skip debugging output if disabled", inject(
       function(){

--- a/test/ng/logSpec.js
+++ b/test/ng/logSpec.js
@@ -120,7 +120,7 @@ describe('$log', function() {
 
   describe("$log.debug", function () {
 
-    beforeEach(initService(false, 'error'));
+    beforeEach(initService(false));
 
     it("should skip debugging output if disabled", inject(
       function(){
@@ -179,4 +179,47 @@ describe('$log', function() {
       expect(errorArgs).toEqual(['abc', 'message\nsourceURL:123']);
     });
   });
+
+  describe('$logLevel', function() {
+
+    it('should log all levels if not defined', function(){
+        $window.console = {log: log,
+                           warn: warn,
+                           info: info,
+                           error: error,
+                           debug: debug};
+      },
+
+      function($log) {
+        $log.log();
+        $log.info();
+        $log.warn();
+        $log.error();
+        $log.debug();
+        expect(logger).toEqual('log;info;warn;error;debug;');
+
+    });
+
+    it('should log only errors and warns if warn level is defined', function(){
+        $window.console = {log: log,
+                           warn: warn,
+                           info: info,
+                           error: error,
+                           debug: debug};
+        initService(true, 'warn');
+      },
+
+      function($log) {
+        $log.log();
+        $log.info();
+        $log.warn();
+        $log.error();
+        $log.debug();
+        expect(logger).toEqual('warn;error;debug;');
+
+    });
+
+  });
+
+
 });


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): jqLite

Impact: large

Complexity: small

This issue is related to: 

**Detailed Description:**

I think we need to set a level to debug the application. So, I've developed a feature that add an extra behaviour to $log. In the $logProvider, I created a method called debugLevel that receives a string as parameter and, based on that parameter, the application change its debug level.

With this feature, setting debugLevel to 'error' will log only error messages, while setting 'log' will debug the application in a "trace like" mode.
- error:   log only error messages;
- warn:   log warn and error messages;
- info:     log info, warn and error messages;
- log:      log log and all other messages (trace like).

~~I'm not able to write tests for this feature and I think the code can be cleaner, but it helped me a lot.~~ In the two last commits I've added two tests to this feature: one to ensure that if debugLevel is not defined, the application will log as default and one setting the level to 'warn'.

**Other Comments:**

ngLog can now log in window console based on a debug level, that can be redefined in LogProvider. Defaults to 'log'.
