### PR TITLE
Updating the provider documentation

### DIFF
--- a/docs/content/guide/providers.ngdoc
+++ b/docs/content/guide/providers.ngdoc
@@ -132,9 +132,11 @@ In the code above, we see how the `apiToken` service is defined via the Factory 
 on the `clientId` service. The factory service then uses NSA-proof encryption to produce an authentication
 token.
 
-Note: It is best practice to name the factory functions as `<serviceId>Factory`
+<div class="alert alert-success">
+**Best Practice:** name the factory functions as `<serviceId>Factory`
 (e.g. apiTokenFactory). While this naming convention is not required, it helps when navigating the code base
 or looking at stack traces in the debugger.
+</div>
 
 Just like with Value recipe, Factory recipe can create a service of any type, whether it be a
 primitive, object literal, function, or even an instance of a custom type.
@@ -193,8 +195,7 @@ that would mess with the teachers.
 
 ## Provider Recipe
 
-There are two more recipe types left to cover. They are both fairly specialized and are used
-infrequently. As already mentioned in the intro, the Provider recipe is the core recipe type and
+As already mentioned in the intro, the Provider recipe is the core recipe type and
 all the other recipe types are just syntactic sugar on top of it. It is the most verbose recipe
 with the most abilities, but for most services it's overkill.
 


### PR DESCRIPTION
Highlighted the Best Practices section, and took the styling from the Services doc. I also removed some superfluous wording that was in the "Provider Recipe"
