### PR TITLE
fixes #8333

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -50,10 +50,9 @@
  */
 currencyFilter.$inject = ['$locale'];
 function currencyFilter($locale) {
-  var formats = $locale.NUMBER_FORMATS;
   return function(amount, currencySymbol){
-    if (isUndefined(currencySymbol)) currencySymbol = formats.CURRENCY_SYM;
-    return formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP, 2).
+    if (isUndefined(currencySymbol)) currencySymbol = $locale.NUMBER_FORMATS.CURRENCY_SYM;
+    return formatNumber(amount, $locale.NUMBER_FORMATS.PATTERNS[1], $locale.NUMBER_FORMATS.GROUP_SEP, $locale.NUMBER_FORMATS.DECIMAL_SEP, 2).
                 replace(/\u00A4/g, currencySymbol);
   };
 }
@@ -111,9 +110,8 @@ function currencyFilter($locale) {
 
 numberFilter.$inject = ['$locale'];
 function numberFilter($locale) {
-  var formats = $locale.NUMBER_FORMATS;
   return function(number, fractionSize) {
-    return formatNumber(number, formats.PATTERNS[0], formats.GROUP_SEP, formats.DECIMAL_SEP,
+    return formatNumber(number, $locale.NUMBER_FORMATS.PATTERNS[0], $locale.NUMBER_FORMATS.GROUP_SEP, $locale.NUMBER_FORMATS.DECIMAL_SEP,
       fractionSize);
   };
 }


### PR DESCRIPTION
Request Type: bug

How to reproduce: In a controller change the change the $locale.DATETIME_FORMATS and $locale.NUMBER_FORMATS and observer how dates change their format, but numbers and currency does not.

Component(s): misc core

Impact: small

Complexity: small

This issue is related to: 

**Detailed Description:**

The i18n locales provided with angular only allow you to use one locale, not multiple. To get around that you can use the date time and number formats in the i18n files and change them during runtime as follows:

```
angular.module('yourApp').service('servicename', function ($locale) {
    var locales = {
        'en': {
            "DATETIME_FORMATS": { ... },
            "NUMBER_FORMATS": { ... },
        },
        'da': { ... }
    }

    return {
        setLanguage: function (locale) {
            $locale.DATETIME_FORMATS = locales[locale].DATETIME_FORMATS;
            $locale.NUMBER_FORMATS = locales[locale].NUMBER_FORMATS;
        },
    }
});
```

This works for dates - however it does not work for the currency and number filters because the $locale provider is injected into a local variable and can thus not be changed post initialization.

Here is the code for the date filer:

```
dateFilter.$inject = ['$locale'];
function dateFilter($locale) {
....
  return function(date, format) {
...
    format = format || 'mediumDate';
    format = $locale.DATETIME_FORMATS[format] || format;
```

However here is the code for the number filter

```
numberFilter.$inject = ['$locale'];
function numberFilter($locale) {
  var formats = $locale.NUMBER_FORMATS;
  return function(number, fractionSize) {
    return formatNumber(number, formats.PATTERNS[0], formats.GROUP_SEP, formats.DECIMAL_SEP,
```

The fix is simple, change the number and currency filter to use the $locale when formatting is requested instead of during initialization.

**Other Comments:**
