### PR TITLE
docs(tutorial/step-7):Update tutorial/step-7 to fix grammar

### DIFF
--- a/docs/content/tutorial/step_07.ngdoc
+++ b/docs/content/tutorial/step_07.ngdoc
@@ -202,7 +202,7 @@ moved the controllers into their own module `phonecatControllers` (as shown belo
 
 We added `angular-route.js` to `index.html` and created a new `phonecatControllers` module in
 `controllers.js`. That's not all we need to do to be able to use their code, however. We also have
-to add the modules dependencies of our app. By listing these two modules as dependencies of
+to add the modules as dependencies of our app. By listing these two modules as dependencies of
 `phonecatApp`, we can use the directives and services they provide.
 
 


### PR DESCRIPTION
Request Type: docs

How to reproduce: 

Component(s): 

Impact: medium

Complexity: small

This issue is related to: 

**Detailed Description:**

docs(tutorial/step-7):

Fixes a missing 'as'.
_Previous:_
We also have to add the modules dependencies of our app. By listing these two modules as dependencies of `phonecatApp`, ...
_New:_
We also have to add the modules _as_ dependencies of our app. By listing ...

**Other Comments:**
