### PR TITLE
feat($interpolate): use custom toString member if present

### DIFF
--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -272,7 +272,11 @@ function $InterpolateProvider() {
               break;
             }
             default: {
-              value = toJson(value);
+              if(isFunction(value.toString) && value.toString !== Object.prototype.toString && !isArray(value)) {
+                value = value.toString();
+              } else {
+                value = toJson(value);
+              }
             }
           }
 

--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -36,6 +36,21 @@ describe('$interpolate', function() {
     expect($interpolate('{{ false }}')({})).toEqual('false');
   }));
 
+  it('should use custom toString when present', inject(function($interpolate, $rootScope) {
+    var scope = $rootScope.$new();
+    scope.a = {
+      toString: function() {
+        return 'foo';
+      }
+    };
+
+    expect($interpolate('{{ a }}')(scope)).toEqual('foo');
+  }));
+
+  it('should NOT use toString on array objects', inject(function($interpolate) {
+    expect($interpolate('{{a}}')({ a: [] })).toEqual('[]');
+  }));
+
 
   it('should return interpolation function', inject(function($interpolate, $rootScope) {
     var interpolateFn = $interpolate('Hello {{name}}!');


### PR DESCRIPTION
BREAKING CHANGE: use custom toString implementation when present on object value types.
Behavior is consistent with other implementations.

Closes #7317
