### PR TITLE
feat(ngRoute): add method for changing url params

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -449,7 +449,7 @@ function $RouteProvider(){
            * @param {Object} newParams mapping of URL parameter names to values
            */
           updateParams: function(newParams) {
-            newParams = defaults(newParams, this.current.params);
+            newParams = angular.extend({}, this.current.params, newParams);
             $location.path(interpolate(this.current.$$route.originalPath, newParams));
           }
         };
@@ -603,23 +603,6 @@ function $RouteProvider(){
         }
       });
       return result.join('');
-    }
-
-    /**
-     * @returns {Object} object composed of all keys in `object` and `defaults`,
-     *                   where keys missing in `object` have the value from the
-     *                   same key in `defaults`
-     */
-    function defaults(object, other) {
-      var o = angular.copy(object);
-
-      for (var key in other) {
-        if (other.hasOwnProperty(key)) {
-          o[key] = o[key] || other[key];
-        }
-      }
-
-      return o;
     }
   }];
 }

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -436,6 +436,21 @@ function $RouteProvider(){
           reload: function() {
             forceReload = true;
             $rootScope.$evalAsync(updateRoute);
+          },
+
+          /**
+           * @ngdoc method
+           * @name $route#update
+           *
+           * @description
+           * Causes `$route` service to update the current URL, replacing
+           * current route parameters with those specified in `newParams`.
+           *
+           * @param {Object} newParams mapping of URL parameter names to values
+           */
+          update: function(newParams) {
+            newParams = defaults(newParams, this.current.params);
+            $location.path(interpolate(this.current.$$route.originalPath, newParams));
           }
         };
 
@@ -588,6 +603,23 @@ function $RouteProvider(){
         }
       });
       return result.join('');
+    }
+
+    /**
+     * @returns {Object} object composed of all keys in `object` and `defaults`,
+     *                   where keys missing in `object` have the value from the
+     *                   same key in `defaults`
+     */
+    function defaults(object, other) {
+      var o = angular.copy(object);
+
+      for (var key in other) {
+        if (other.hasOwnProperty(key)) {
+          o[key] = o[key] || other[key];
+        }
+      }
+
+      return o;
     }
   }];
 }

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -440,7 +440,7 @@ function $RouteProvider(){
 
           /**
            * @ngdoc method
-           * @name $route#update
+           * @name $route#updateParams
            *
            * @description
            * Causes `$route` service to update the current URL, replacing
@@ -448,7 +448,7 @@ function $RouteProvider(){
            *
            * @param {Object} newParams mapping of URL parameter names to values
            */
-          update: function(newParams) {
+          updateParams: function(newParams) {
             newParams = defaults(newParams, this.current.params);
             $location.path(interpolate(this.current.$$route.originalPath, newParams));
           }

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -1046,77 +1046,6 @@ describe('$route', function() {
       });
     });
 
-    describe('update', function() {
-      it('should support single-parameter route updating', function() {
-        var routeChangeSpy = jasmine.createSpy('route change');
-
-        module(function($routeProvider) {
-          $routeProvider.when('/bar/:barId', {controller: angular.noop});
-        });
-
-        inject(function($route, $routeParams, $location, $rootScope) {
-          $rootScope.$on('$routeChangeSuccess', routeChangeSpy);
-
-          $location.path('/bar/1');
-          $rootScope.$digest();
-          routeChangeSpy.reset();
-
-          $route.updateParams({barId: '2'});
-          $rootScope.$digest();
-
-          expect($routeParams).toEqual({barId: '2'});
-          expect(routeChangeSpy).toHaveBeenCalledOnce();
-          expect($location.path()).toEqual('/bar/2');
-        });
-      });
-
-      it('should support total multi-parameter route updating', function() {
-        var routeChangeSpy = jasmine.createSpy('route change');
-
-        module(function($routeProvider) {
-          $routeProvider.when('/bar/:barId/:fooId/:spamId/:eggId', {controller: angular.noop});
-        });
-
-        inject(function($route, $routeParams, $location, $rootScope) {
-          $rootScope.$on('$routeChangeSuccess', routeChangeSpy);
-
-          $location.path('/bar/1/2/3/4');
-          $rootScope.$digest();
-          routeChangeSpy.reset();
-
-          $route.updateParams({barId: '5', fooId: '6', spamId: '7', eggId: '8'});
-          $rootScope.$digest();
-
-          expect($routeParams).toEqual({barId: '5', fooId: '6', spamId: '7', eggId: '8'});
-          expect(routeChangeSpy).toHaveBeenCalledOnce();
-          expect($location.path()).toEqual('/bar/5/6/7/8');
-        });
-      });
-
-      it('should support partial multi-parameter route updating', function() {
-        var routeChangeSpy = jasmine.createSpy('route change');
-
-        module(function($routeProvider) {
-          $routeProvider.when('/bar/:barId/:fooId/:spamId/:eggId', {controller: angular.noop});
-        });
-
-        inject(function($route, $routeParams, $location, $rootScope) {
-          $rootScope.$on('$routeChangeSuccess', routeChangeSpy);
-
-          $location.path('/bar/1/2/3/4');
-          $rootScope.$digest();
-          routeChangeSpy.reset();
-
-          $route.updateParams({barId: '5', fooId: '6'});
-          $rootScope.$digest();
-
-          expect($routeParams).toEqual({barId: '5', fooId: '6', spamId: '3', eggId: '4'});
-          expect(routeChangeSpy).toHaveBeenCalledOnce();
-          expect($location.path()).toEqual('/bar/5/6/3/4');
-        });
-      });
-    });
-
     describe('reload', function() {
 
       it('should reload even if reloadOnSearch is false', function() {
@@ -1145,6 +1074,77 @@ describe('$route', function() {
           expect($routeParams).toEqual({barId:'123', a:'b'});
           expect(routeChangeSpy).toHaveBeenCalledOnce();
         });
+      });
+    });
+  });
+
+  describe('update', function() {
+    it('should support single-parameter route updating', function() {
+      var routeChangeSpy = jasmine.createSpy('route change');
+
+      module(function($routeProvider) {
+        $routeProvider.when('/bar/:barId', {controller: angular.noop});
+      });
+
+      inject(function($route, $routeParams, $location, $rootScope) {
+        $rootScope.$on('$routeChangeSuccess', routeChangeSpy);
+
+        $location.path('/bar/1');
+        $rootScope.$digest();
+        routeChangeSpy.reset();
+
+        $route.updateParams({barId: '2'});
+        $rootScope.$digest();
+
+        expect($routeParams).toEqual({barId: '2'});
+        expect(routeChangeSpy).toHaveBeenCalledOnce();
+        expect($location.path()).toEqual('/bar/2');
+      });
+    });
+
+    it('should support total multi-parameter route updating', function() {
+      var routeChangeSpy = jasmine.createSpy('route change');
+
+      module(function($routeProvider) {
+        $routeProvider.when('/bar/:barId/:fooId/:spamId/:eggId', {controller: angular.noop});
+      });
+
+      inject(function($route, $routeParams, $location, $rootScope) {
+        $rootScope.$on('$routeChangeSuccess', routeChangeSpy);
+
+        $location.path('/bar/1/2/3/4');
+        $rootScope.$digest();
+        routeChangeSpy.reset();
+
+        $route.updateParams({barId: '5', fooId: '6', spamId: '7', eggId: '8'});
+        $rootScope.$digest();
+
+        expect($routeParams).toEqual({barId: '5', fooId: '6', spamId: '7', eggId: '8'});
+        expect(routeChangeSpy).toHaveBeenCalledOnce();
+        expect($location.path()).toEqual('/bar/5/6/7/8');
+      });
+    });
+
+    it('should support partial multi-parameter route updating', function() {
+      var routeChangeSpy = jasmine.createSpy('route change');
+
+      module(function($routeProvider) {
+        $routeProvider.when('/bar/:barId/:fooId/:spamId/:eggId', {controller: angular.noop});
+      });
+
+      inject(function($route, $routeParams, $location, $rootScope) {
+        $rootScope.$on('$routeChangeSuccess', routeChangeSpy);
+
+        $location.path('/bar/1/2/3/4');
+        $rootScope.$digest();
+        routeChangeSpy.reset();
+
+        $route.updateParams({barId: '5', fooId: '6'});
+        $rootScope.$digest();
+
+        expect($routeParams).toEqual({barId: '5', fooId: '6', spamId: '3', eggId: '4'});
+        expect(routeChangeSpy).toHaveBeenCalledOnce();
+        expect($location.path()).toEqual('/bar/5/6/3/4');
       });
     });
   });

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -1061,7 +1061,7 @@ describe('$route', function() {
           $rootScope.$digest();
           routeChangeSpy.reset();
 
-          $route.update({barId: '2'});
+          $route.updateParams({barId: '2'});
           $rootScope.$digest();
 
           expect($routeParams).toEqual({barId: '2'});
@@ -1084,7 +1084,7 @@ describe('$route', function() {
           $rootScope.$digest();
           routeChangeSpy.reset();
 
-          $route.update({barId: '5', fooId: '6', spamId: '7', eggId: '8'});
+          $route.updateParams({barId: '5', fooId: '6', spamId: '7', eggId: '8'});
           $rootScope.$digest();
 
           expect($routeParams).toEqual({barId: '5', fooId: '6', spamId: '7', eggId: '8'});
@@ -1107,7 +1107,7 @@ describe('$route', function() {
           $rootScope.$digest();
           routeChangeSpy.reset();
 
-          $route.update({barId: '5', fooId: '6'});
+          $route.updateParams({barId: '5', fooId: '6'});
           $rootScope.$digest();
 
           expect($routeParams).toEqual({barId: '5', fooId: '6', spamId: '3', eggId: '4'});

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -1046,6 +1046,73 @@ describe('$route', function() {
       });
     });
 
+    describe('update', function() {
+      it('should support single-parameter route updating', function() {
+        var routeChangeSpy = jasmine.createSpy('route change');
+
+        module(function($routeProvider) {
+          $routeProvider.when('/bar/:barId', {controller: angular.noop});
+        });
+
+        inject(function($route, $routeParams, $location, $rootScope) {
+          $rootScope.$on('$routeChangeSuccess', routeChangeSpy);
+
+          $location.path('/bar/1');
+          $rootScope.$digest();
+          routeChangeSpy.reset();
+
+          $route.update({barId: '2'});
+          $rootScope.$digest();
+
+          expect($routeParams).toEqual({barId: '2'});
+          expect(routeChangeSpy).toHaveBeenCalledOnce();
+        });
+      });
+
+      it('should support total multi-parameter route updating', function() {
+        var routeChangeSpy = jasmine.createSpy('route change');
+
+        module(function($routeProvider) {
+          $routeProvider.when('/bar/:barId/:fooId/:spamId/:eggId', {controller: angular.noop});
+        });
+
+        inject(function($route, $routeParams, $location, $rootScope) {
+          $rootScope.$on('$routeChangeSuccess', routeChangeSpy);
+
+          $location.path('/bar/1/1/1/1');
+          $rootScope.$digest();
+          routeChangeSpy.reset();
+
+          $route.update({barId: '2', fooId: '2', spamId: '2', eggId: '2'});
+          $rootScope.$digest();
+
+          expect($routeParams).toEqual({barId: '2', fooId: '2', spamId: '2', eggId: '2'});
+          expect(routeChangeSpy).toHaveBeenCalledOnce();
+        });
+      });
+
+      it('should support partial multi-parameter route updating', function() {
+        var routeChangeSpy = jasmine.createSpy('route change');
+
+        module(function($routeProvider) {
+          $routeProvider.when('/bar/:barId/:fooId/:spamId/:eggId', {controller: angular.noop});
+        });
+
+        inject(function($route, $routeParams, $location, $rootScope) {
+          $rootScope.$on('$routeChangeSuccess', routeChangeSpy);
+
+          $location.path('/bar/1/1/1/1');
+          $rootScope.$digest();
+          routeChangeSpy.reset();
+
+          $route.update({barId: '2', fooId: '2'});
+          $rootScope.$digest();
+
+          expect($routeParams).toEqual({barId: '2', fooId: '2', spamId: '1', eggId: '1'});
+          expect(routeChangeSpy).toHaveBeenCalledOnce();
+        });
+      });
+    });
 
     describe('reload', function() {
 

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -1066,6 +1066,7 @@ describe('$route', function() {
 
           expect($routeParams).toEqual({barId: '2'});
           expect(routeChangeSpy).toHaveBeenCalledOnce();
+          expect($location.path()).toEqual('/bar/2');
         });
       });
 
@@ -1088,6 +1089,7 @@ describe('$route', function() {
 
           expect($routeParams).toEqual({barId: '5', fooId: '6', spamId: '7', eggId: '8'});
           expect(routeChangeSpy).toHaveBeenCalledOnce();
+          expect($location.path()).toEqual('/bar/5/6/7/8');
         });
       });
 
@@ -1110,6 +1112,7 @@ describe('$route', function() {
 
           expect($routeParams).toEqual({barId: '5', fooId: '6', spamId: '3', eggId: '4'});
           expect(routeChangeSpy).toHaveBeenCalledOnce();
+          expect($location.path()).toEqual('/bar/5/6/3/4');
         });
       });
     });

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -1079,14 +1079,14 @@ describe('$route', function() {
         inject(function($route, $routeParams, $location, $rootScope) {
           $rootScope.$on('$routeChangeSuccess', routeChangeSpy);
 
-          $location.path('/bar/1/1/1/1');
+          $location.path('/bar/1/2/3/4');
           $rootScope.$digest();
           routeChangeSpy.reset();
 
-          $route.update({barId: '2', fooId: '2', spamId: '2', eggId: '2'});
+          $route.update({barId: '5', fooId: '6', spamId: '7', eggId: '8'});
           $rootScope.$digest();
 
-          expect($routeParams).toEqual({barId: '2', fooId: '2', spamId: '2', eggId: '2'});
+          expect($routeParams).toEqual({barId: '5', fooId: '6', spamId: '7', eggId: '8'});
           expect(routeChangeSpy).toHaveBeenCalledOnce();
         });
       });
@@ -1101,14 +1101,14 @@ describe('$route', function() {
         inject(function($route, $routeParams, $location, $rootScope) {
           $rootScope.$on('$routeChangeSuccess', routeChangeSpy);
 
-          $location.path('/bar/1/1/1/1');
+          $location.path('/bar/1/2/3/4');
           $rootScope.$digest();
           routeChangeSpy.reset();
 
-          $route.update({barId: '2', fooId: '2'});
+          $route.update({barId: '5', fooId: '6'});
           $rootScope.$digest();
 
-          expect($routeParams).toEqual({barId: '2', fooId: '2', spamId: '1', eggId: '1'});
+          expect($routeParams).toEqual({barId: '5', fooId: '6', spamId: '3', eggId: '4'});
           expect(routeChangeSpy).toHaveBeenCalledOnce();
         });
       });


### PR DESCRIPTION
Request Type: feature

How to reproduce: 

Component(s): ngRoute

Impact: medium

Complexity: small

This issue is related to: 

**Detailed Description:**

Add a `$route#update` method for changing the current route
parameters without having to manually build a URL and call `$location#path`.
Useful for apps with a structure involving programmatically moving
between pages on the same route, but with different `:param`
values.

**Other Comments:**
