### PR TITLE
fix(jqLite): fix regression where mutating the dom tree on a event breaks jqLite.remove

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -248,7 +248,7 @@ function jqLiteDealoc(element, onlyDescendants){
 
   if (element.childNodes && element.childNodes.length) {
     // we use querySelectorAll because documentFragments don't have getElementsByTagName
-    var descendants = element.getElementsByTagName ? element.getElementsByTagName('*') :
+    var descendants = element.getElementsByTagName ? sliceArgs(element.getElementsByTagName('*')) :
                     element.querySelectorAll ? element.querySelectorAll('*') : [];
     for (var i = 0, l = descendants.length; i < l; i++) {
       jqLiteRemoveData(descendants[i]);

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -535,6 +535,16 @@ describe('jqLite', function() {
         browserTrigger(span);
         expect(log).toEqual('click;');
       });
+
+      it('should work if the descendants of the element change while it\'s being removed', function() {
+        var div = jqLite('<div><p><span>text</span></p></div>');
+        div.find('p').on('$destroy', function() {
+          div.find('span').remove();
+        });
+        expect(function() {
+          div.remove();
+        }).not.toThrow();
+      });
     });
   });
 


### PR DESCRIPTION
012ab1f8745c8985d3f132c2dfa8fd84e7dc7041 introduced a regression where if a user's `$destroy` event modified the descendant DOM tree, `jqLite.remove` would break.
This is because it uses `getElementsByTagName` and caches the length of the returned live NodeList

cc @ggoodman
