### PR TITLE
feat($compile): allow any attribute to use allOrNothing interpolation

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1074,7 +1074,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                     attrs[nName] = true; // presence means true
                   }
               }
-              addAttrInterpolateDirective(node, directives, value, nName);
+              addAttrInterpolateDirective(node, directives, value, nName, isNgAttr);
               addDirective(directives, nName, 'A', maxPriority, ignoreDirective, attrStartName,
                             attrEndName);
             }
@@ -1929,7 +1929,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     }
 
 
-    function addAttrInterpolateDirective(node, directives, value, name) {
+    function addAttrInterpolateDirective(node, directives, value, name, allOrNothing) {
       var interpolateFn = $interpolate(value, true);
 
       // no interpolation found -> ignore
@@ -1958,7 +1958,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 // we need to interpolate again, in case the attribute value has been updated
                 // (e.g. by another directive's compile function)
                 interpolateFn = $interpolate(attr[name], true, getTrustedContext(node, name),
-                    ALL_OR_NOTHING_ATTRS[name]);
+                    ALL_OR_NOTHING_ATTRS[name] || allOrNothing);
 
                 // if attribute was updated so that there is no interpolation going on we don't want to
                 // register any observers

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -5423,6 +5423,17 @@ describe('$compile', function() {
       expect(element.attr('test')).toBe('Misko');
     }));
 
+    it('should remove attribute if any bindings are undefined', inject(function($compile, $rootScope) {
+      element = $compile('<span ng-attr-test="{{name}}{{emphasis}}"></span>')($rootScope);
+      $rootScope.$digest();
+      expect(element.attr('test')).toBeUndefined();
+      $rootScope.name = 'caitp';
+      $rootScope.$digest();
+      expect(element.attr('test')).toBeUndefined();
+      $rootScope.emphasis = '!!!';
+      $rootScope.$digest();
+      expect(element.attr('test')).toBe('caitp!!!');
+    }));
 
     describe('in directive', function() {
       beforeEach(module(function() {


### PR DESCRIPTION
Previously, only a limited set of attributes would use allOrNothing
interpolation. It is now possible to request allOrNothing interpolation by
appending a '!' to the attribute name. This should result in attributes being
removed / not added to the node if their values are undefined, which can
prevent some kinds of errors in SVG elements.

Example:

```
<circle ng-attr-r!="{{dimensions.radius}}" x!="{{position.left}}">
```

Closes #8376
