### PR TITLE
fix(input): $evalAsync than $apply on input blur

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2182,7 +2182,7 @@ var ngModelDirective = function() {
         }
 
         element.on('blur', function(ev) {
-          scope.$apply(function() {
+          scope.$evalAsync(function() {
             modelCtrl.$setTouched();
           });
         });


### PR DESCRIPTION
without $evalAsync I would have to wrap a few directives in a setTimeout to prevent digest loop conflicts

``` javascript
angular.module('directives', [])
.directive('focusOn', function($parse) {
  return function(scope, element, attrs) {

    // avoid $digest in progress
    setTimeout(function() {
      var getter = $parse(attrs.focusOn);
      if (getter(scope)) {
        element[0].focus();
      }
    }, 0);

  };

})
```
