### PR TITLE
feat(FormController): add $submitted $setSubmitted

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -6,8 +6,11 @@ var nullFormCtrl = {
   $removeControl: noop,
   $setValidity: noop,
   $setDirty: noop,
+  $setSubmitted: noop,
   $setPristine: noop
 };
+
+var SUBMITTED_CLASS = 'ng-submitted';
 
 /**
  * @ngdoc type
@@ -56,6 +59,7 @@ function FormController(element, attrs, $scope, $animate) {
 
   // init state
   form.$name = attrs.name || attrs.ngForm;
+  form.$submitted = false;
   form.$dirty = false;
   form.$pristine = true;
   form.$valid = true;
@@ -211,6 +215,20 @@ function FormController(element, attrs, $scope, $animate) {
     form.$dirty = true;
     form.$pristine = false;
     parentForm.$setDirty();
+  };
+
+
+  /**
+   * @ngdoc method
+   * @name form.FormController#$setSubmitted
+   *
+   * @description
+   * Sets the form to a submitted state.
+   *
+   */
+  form.$setSubmitted = function() {
+    $animate.addClass(element, SUBMITTED_CLASS);
+    form.$submitted = true;
   };
 
   /**
@@ -422,6 +440,7 @@ var formDirectiveFactory = function(isNgForm) {
               // on a button in the form. Looks like an IE9 specific bug.
               var handleFormSubmission = function(event) {
                 scope.$apply(function() {
+                  controller.$setSubmitted();
                   controller.$commitViewValue();
                 });
 


### PR DESCRIPTION
allowing <code>$submitted</code> on <code>FormController</code> allows the user more convenience when dealing with ngMessages for example
https://yearofmoo.github.io/ngMessages/

``` javascript
angular.module('yolo', ['ngMessages'])
.controller('exampleCtrl', function($scope) { 
    this.model = '';
    $scope.submitted = false;
    $scope.submit = function() {
      $scope.submitted = true;
    };
    $scope.interacted = function(field) {
      return $scope.submitted || field.$dirty;
    };
}
```

``` html
<form name="userForm">
  <input name="emailAddress" ng-model="ctrl.model">
  <div 
    ng-messages="userForm.emailAddress.$error" 
    ng-if="interacted(userForm.emailAddress)" 
    ng-messages-include="error-messages"
  ></div>
</form>
```

with <code>$submitted</code> would simply be

``` javascript
angular.module('yolo', ['ngMessages'])
.controller('exampleCtrl', function($scope) { 
    this.model = '';
}
```

``` html
<form name="userForm">
  <input name="emailAddress" ng-model="ctrl.model">
  <div 
    ng-messages="userForm.emailAddress.$error" 
    ng-if="userForm.$submitted || userForm.emailAddress.$dirty" 
    ng-messages-include="error-messages"
  ></div>
</form>
```

~~I can also add <code>.ng-submitted</code> class etc  that would help for styles~~
I also added <code>.ng-submitted</code> to the form for styling input errors when the form is submitted and still dirty
