### PR TITLE
fix($location) solve when url is "javascript:" or "mailto:"

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -650,6 +650,9 @@ function $LocationProvider(){
       }
 
       var absHref = elm.prop('href');
+      
+      // Ignore when url is started with javascript: or mailto:
+	  if (absHref.toString().indexOf('javascript:') === 0 || absHref.toString().indexOf('mailto:') === 0) return;
 
       if (isObject(absHref) && absHref.toString() === '[object SVGAnimatedString]') {
         // SVGAnimatedString.animVal should be identical to SVGAnimatedString.baseVal, unless during


### PR DESCRIPTION
When url is started with "javascript:" or "mailto:"
It still do the redirect.
