### PR TITLE
fix(ngSanitize): ensure `html` is a string in htmlParser()

### DIFF
--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -232,6 +232,13 @@ function makeMap(str) {
  * @param {object} handler
  */
 function htmlParser( html, handler ) {
+  if (typeof html !== 'string') {
+    if (html === null || typeof html === 'undefined') {
+      html = '';
+    } else {
+      html = '' + html;
+    }
+  }
   var index, chars, match, stack = [], last = html, text;
   stack.last = function() { return stack[ stack.length - 1 ]; };
 

--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -228,6 +228,16 @@ describe('HTML', function() {
     .toEqual('<p> 10 &lt; <span>100</span> </p>');
   });
 
+  it('should accept non-string arguments', function() {
+    expectHTML(null).toBe('');
+    expectHTML(undefined).toBe('');
+    expectHTML(42).toBe('42');
+    expectHTML({}).toBe('[object Object]');
+    expectHTML([1, 2, 3]).toBe('1,2,3');
+    expectHTML(true).toBe('true');
+    expectHTML(false).toBe('false');
+  });
+
   describe('htmlSanitizerWriter', function() {
     /* global htmlSanitizeWriter: false */
     if (angular.isUndefined(window.htmlSanitizeWriter)) return;


### PR DESCRIPTION
Previously, $sanitize(nonString) would throw. Now, the type is converted to a
string before any work is done.

Closes #8416
