### PR TITLE
fix($location) don't rewrite location when clicking on "javascript:" or "mailto:" link

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -635,6 +635,8 @@ function $LocationProvider(){
     $location = new LocationMode(appBase, '#' + hashPrefix);
     $location.$$parse($location.$$rewrite(initialUrl));
 
+    var IGNORE_URI_REGEXP = /^\s*(javascript|mailto):/i;
+
     $rootElement.on('click', function(event) {
       // TODO(vojta): rewrite link when opening in new tab/window (in legacy browser)
       // currently we open nice url link and redirect then
@@ -656,6 +658,9 @@ function $LocationProvider(){
         // an animation.
         absHref = urlResolve(absHref.animVal).href;
       }
+
+      // Ignore when url is started with javascript: or mailto:
+      if (IGNORE_URI_REGEXP.test(absHref)) return;
 
       // Make relative links work in HTML5 mode for legacy browsers (or at least IE8 & 9)
       // The href should be a regular url e.g. /link/somewhere or link/somewhere or ../somewhere or

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1028,6 +1028,32 @@ describe('$location', function() {
     });
 
 
+    it('should not rewrite links with `javascript:` URI', function() {
+      configureService(' jAvAsCrIpT:throw new Error("Boom!")', true, true, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser) {
+          browserTrigger(link, 'click');
+          expectNoRewrite($browser);
+        }
+      );
+    });
+
+
+    it('should not rewrite links with `mailto:` URI', function() {
+      configureService(' mAiLtO:foo@bar.com', true, true, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser) {
+          browserTrigger(link, 'click');
+          expectNoRewrite($browser);
+        }
+      );
+    });
+
+
     it('should rewrite full url links to same domain and base path', function() {
       configureService('http://host.com/base/new', true);
       inject(


### PR DESCRIPTION
Previously, absent a specified target attribute, when clicking on an anchor tag with an href beginning with either "javascript:" or "mailto:", the framework would rewrite the URL, when it ought not to.

With this change, the browser is prevented from rewriting if the URL begins with a case-insensitive match for "javascript:" or "mailto:", optionally preceeded by whitespace.

Closes #8407
Closes #8425
