### PR TITLE
docs(content): update Angular 1.2 mentions to Angular 1.3

### DIFF
--- a/docs/content/error/$injector/modulerr.ngdoc
+++ b/docs/content/error/$injector/modulerr.ngdoc
@@ -7,5 +7,5 @@ This error occurs when a module fails to load due to some exception. The error
 message above should provide additional context.
 
 In AngularJS `1.2.0` and later, `ngRoute` has been moved to its own module.
-If you are getting this error after upgrading to `1.2.x`, be sure that you've
+If you are getting this error after upgrading to `1.2.x` or later, be sure that you've
 installed {@link ngRoute `ngRoute`}.

--- a/docs/content/guide/animations.ngdoc
+++ b/docs/content/guide/animations.ngdoc
@@ -6,7 +6,7 @@
 
 # Animations
 
-AngularJS 1.2 provides animation hooks for common directives such as `ngRepeat`, `ngSwitch`, and `ngView`, as well as custom directives
+AngularJS 1.3 provides animation hooks for common directives such as `ngRepeat`, `ngSwitch`, and `ngView`, as well as custom directives
 via the `$animate` service. These animation hooks are set in place to trigger animations during the life cycle of various directives and when
 triggered, will attempt to perform a CSS Transition, CSS Keyframe Animation or a JavaScript callback Animation (depending on if an animation is
 placed on the given directive). Animations can be placed using vanilla CSS by following the naming conventions set in place by AngularJS

--- a/docs/content/tutorial/step_07.ngdoc
+++ b/docs/content/tutorial/step_07.ngdoc
@@ -33,17 +33,17 @@ We are using [Bower][bower] to install client side dependencies.  This step upda
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "angular": "1.2.x",
-    "angular-mocks": "~1.2.x",
-    "jquery": "1.10.2",
+    "angular": "~1.3.0",
+    "angular-mocks": "~1.3.0",
+    "jquery": "2.1.1",
     "bootstrap": "~3.1.1",
-    "angular-route": "~1.2.x"
+    "angular-route": "~1.3.0"
   }
 }
 ```
 
-The new dependency `"angular-route": "~1.2.x"` tells bower to install a version of the
-angular-route component that is compatible with version 1.2.x.  We must tell bower to download
+The new dependency `"angular-route": "~1.3.0"` tells bower to install a version of the
+angular-route component that is compatible with version 1.3.x.  We must tell bower to download
 and install this dependency.
 
 If you have bower installed globally then you can run `bower install` but for this project we have

--- a/docs/content/tutorial/step_11.ngdoc
+++ b/docs/content/tutorial/step_11.ngdoc
@@ -32,17 +32,17 @@ We are using [Bower][bower] to install client side dependencies.  This step upda
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "angular": "1.2.x",
-    "angular-mocks": "~1.2.x",
+    "angular": "~1.3.0",
+    "angular-mocks": "~1.3.0",
     "bootstrap": "~3.1.1",
-    "angular-route": "~1.2.x",
-    "angular-resource": "~1.2.x"
+    "angular-route": "~1.3.0",
+    "angular-resource": "~1.3.0"
   }
 }
 ```
 
-The new dependency `"angular-resource": "~1.2.x"` tells bower to install a version of the
-angular-resource component that is compatible with version 1.2.x.  We must ask bower to download
+The new dependency `"angular-resource": "~1.3.0"` tells bower to install a version of the
+angular-resource component that is compatible with version 1.3.x.  We must ask bower to download
 and install this dependency. We can do this by running:
 
 ```

--- a/docs/content/tutorial/step_12.ngdoc
+++ b/docs/content/tutorial/step_12.ngdoc
@@ -36,20 +36,20 @@ We are using [Bower][bower] to install client side dependencies.  This step upda
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "angular": "1.2.x",
-    "angular-mocks": "~1.2.x",
+    "angular": "~1.3.0",
+    "angular-mocks": "~1.3.0",
     "bootstrap": "~3.1.1",
-    "angular-route": "~1.2.x",
-    "angular-resource": "~1.2.x",
-    "jquery": "1.10.2",
-    "angular-animate": "~1.2.x"
+    "angular-route": "~1.3.0",
+    "angular-resource": "~1.3.0",
+    "jquery": "~2.1.1",
+    "angular-animate": "~1.3.0"
   }
 }
 ```
 
-* `"angular-animate": "~1.2.x"` tells bower to install a version of the
-angular-animate component that is compatible with version 1.2.x.
-* `"jquery": "1.10.2"` tells bower to install the 1.10.2 version of jQuery.  Note that this is not an
+* `"angular-animate": "~1.3.0"` tells bower to install a version of the
+angular-animate component that is compatible with version 1.3.x.
+* `"jquery": "2.1.1"` tells bower to install the 2.1.1 version of jQuery.  Note that this is not an
 Angular library, it is the standard jQuery library.  We can use bower to install a wide range of 3rd
 party libraries.
 

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -221,7 +221,7 @@
  *
  * ### CSS Staggering Animations
  * A Staggering animation is a collection of animations that are issued with a slight delay in between each successive operation resulting in a
- * curtain-like effect. The ngAnimate module, as of 1.2.0, supports staggering animations and the stagger effect can be
+ * curtain-like effect. The ngAnimate module, as of 1.3.0, supports staggering animations and the stagger effect can be
  * performed by creating a **ng-EVENT-stagger** CSS class and attaching that class to the base CSS class used for
  * the animation. The style property expected within the stagger class can either be a **transition-delay** or an
  * **animation-delay** property (or both if your animation contains both transitions and keyframe animations).


### PR DESCRIPTION
Angular 1.3 docs now describe the process of using this version instead of
the older 1.2 that is the latest stable version.

Also, update jQuery 1.10.x mentions to 2.1.x.

@IgorMinar this is re our latest talk at the AWG meeting. This merge should probably wait until http://docs.angularjs.org is switched to point to the latest commit on the `1.2.x` branch by default instead of `master`.
