### PR TITLE
Update angular-locale_es-gt.js

### DIFF
--- a/src/ngLocale/angular-locale_es-gt.js
+++ b/src/ngLocale/angular-locale_es-gt.js
@@ -63,9 +63,9 @@ $provide.value("$locale", {
     "shortTime": "H:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
-    "DECIMAL_SEP": ",",
-    "GROUP_SEP": ".",
+    "CURRENCY_SYM": "Q",
+    "DECIMAL_SEP": ".",
+    "GROUP_SEP": ",",
     "PATTERNS": [
       {
         "gSize": 3,


### PR DESCRIPTION
Modificaciones necesarias para manejo de Quetzales (Moneda Guatemalteca) 

Q1,234.56

Changes needed to show Guatemalan currency correctly, above is an example of the correct format. 
