### PR TITLE
perf(input): prevent multiple $digest when input is blurred

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2182,6 +2182,8 @@ var ngModelDirective = function() {
         }
 
         element.on('blur', function(ev) {
+          if (modelCtrl.$touched) return;
+
           scope.$apply(function() {
             modelCtrl.$setTouched();
           });

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -472,6 +472,23 @@ describe('ngModel', function() {
     dealoc(element);
   }));
 
+  it('should not cause a digest on "blur" event if control is already touched',
+      inject(function($compile, $rootScope) {
+
+    var element = $compile('<form name="myForm">' +
+                             '<input name="myControl" ng-model="value" >' +
+                           '</form>')($rootScope);
+    var inputElm = element.find('input');
+    var control = $rootScope.myForm.myControl;
+
+    control.$setTouched();
+    spyOn($rootScope, '$apply');
+    browserTrigger(inputElm, 'blur');
+
+    expect($rootScope.$apply).not.toHaveBeenCalled();
+
+    dealoc(element);
+  }));
 
   it('should register/deregister a nested ngModel with parent form when entering or leaving DOM',
       inject(function($compile, $rootScope) {


### PR DESCRIPTION
@kevinjamesus86 noticed that the input control would trigger a $digest
cycle every time it was blurred, https://github.com/angular/angular.js/commit/adcc5a00bf582d2b291c18e99093bb0854f7217c#commitcomment-7129512.

After the control is in a $touched state, other $digest cycles are
unnecesary.

References #7673
