### PR TITLE
test(select): relax test for IE8 bug

### DIFF
--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1006,34 +1006,34 @@ describe('select', function() {
           scope.values = [{id: 10, name: 'A'}, {id: 20, name: 'B'}];
         });
         expect(element.val()).toEqual('?');
-        expect(element.find('option').eq(0).attr('selected')).toEqual('selected');
+        expect(element.find('option').attr('selected')).toEqual('selected');
 
         scope.$apply(function() {
           scope.selected = 10;
         });
         // Here the ? option should disappear and the first real option should have selected attribute
         expect(element.val()).toEqual('0');
-        expect(element.find('option').eq(0).attr('selected')).toEqual('selected');
+        expect(element.find('option').attr('selected')).toEqual('selected');
 
         // Here the selected value is changed but we don't change the selected attribute
         scope.$apply(function() {
           scope.selected = 20;
         });
         expect(element.val()).toEqual('1');
-        expect(element.find('option').eq(0).attr('selected')).toEqual('selected');
+        expect(element.find('option').attr('selected')).toEqual('selected');
 
         scope.$apply(function() {
           scope.values.push({id: 30, name: 'C'});
         });
         expect(element.val()).toEqual('1');
-        expect(element.find('option').eq(0).attr('selected')).toEqual('selected');
+        expect(element.find('option').attr('selected')).toEqual('selected');
 
         // Here the ? option should reappear and have selected attribute
         scope.$apply(function() {
           scope.selected = undefined;
         });
         expect(element.val()).toEqual('?');
-        expect(element.find('option').eq(0).attr('selected')).toEqual('selected');
+        expect(element.find('option').attr('selected')).toEqual('selected');
       });
     });
 


### PR DESCRIPTION
There is a bug in IE8 (http://support.microsoft.com/kb/829907 and
http://yuilibrary.com/forum-archive/forum/viewtopic.php@p=14826.html):
when you clone an `<option>` element the selected attribute on the options
can become invalid.

This is not relevant to the proper behaviour of the `select` directive
since it uses `prop` not `attr` to store the selected status of each
option.

This test is only interested in there being at least on option with
the `selected` attribute, for conformance to accessibility guidelines.
So we can safely relax the test to check this rather than concerning
ourselves with which option actually has this attribute.
