### PR TITLE
Add images attribute

### DIFF
--- a/docs/content/tutorial/step_08.ngdoc
+++ b/docs/content/tutorial/step_08.ngdoc
@@ -134,7 +134,10 @@ __`test/unit/controllersSpec.js`:__
 
     beforeEach(inject(function(_$httpBackend_, $rootScope, $routeParams, $controller) {
       $httpBackend = _$httpBackend_;
-      $httpBackend.expectGET('phones/xyz.json').respond({name:'phone xyz'});
+      $httpBackend.expectGET('phones/xyz.json').respond({
+        name:'phone xyz',
+        images: ["img/phones/xyz.jpg"]
+      });
 
       $routeParams.phoneId = 'xyz';
       scope = $rootScope.$new();
@@ -146,7 +149,10 @@ __`test/unit/controllersSpec.js`:__
       expect(scope.phone).toBeUndefined();
       $httpBackend.flush();
 
-      expect(scope.phone).toEqual({name:'phone xyz'});
+      expect(scope.phone).toEqual({
+        name:'phone xyz',
+        images: ["img/phones/xyz.jpg"]
+      });
     });
   });
 ...

--- a/docs/content/tutorial/step_08.ngdoc
+++ b/docs/content/tutorial/step_08.ngdoc
@@ -136,7 +136,7 @@ __`test/unit/controllersSpec.js`:__
       $httpBackend = _$httpBackend_;
       $httpBackend.expectGET('phones/xyz.json').respond({
         name:'phone xyz',
-        images: ["img/phones/xyz.jpg"]
+        images: ['image/url1.png', 'image/url2.png']
       });
 
       $routeParams.phoneId = 'xyz';
@@ -151,7 +151,7 @@ __`test/unit/controllersSpec.js`:__
 
       expect(scope.phone).toEqual({
         name:'phone xyz',
-        images: ["img/phones/xyz.jpg"]
+        images: ['image/url1.png', 'image/url2.png']
       });
     });
   });


### PR DESCRIPTION
The purpose of adding the image attribute is so that one of the tests in controllerSpecs.js does not fail in step_10.ngdoc when we add `$scope.mainImageUrl = data.images[0];` to PhoneDetailCtrl.
