### PR TITLE
docs($compile): fix typo 'default' spelling

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -234,7 +234,7 @@
  *
  * #### `template`
  * HTML markup that may:
- * * Replace the contents of the directive's element (defualt).
+ * * Replace the contents of the directive's element (default).
  * * Replace the directive's element itself (if `replace` is true - DEPRECATED).
  * * Wrap the contents of the directive's element (if `transclude` is true).
  *


### PR DESCRIPTION
Change spelling of 'defualt' to 'default'
