### PR TITLE
docs(guide/controller): fix duplicate -Controller suffix

### DIFF
--- a/docs/content/guide/controller.ngdoc
+++ b/docs/content/guide/controller.ngdoc
@@ -158,7 +158,7 @@ Things to notice in the example above:
 - The `ng-controller` directive is used to (implicitly) create a scope for our template, and the
 scope is augmented (managed) by the `SpicyController` Controller.
 - `SpicyController` is just a plain JavaScript function. As an (optional) naming convention the name
-starts with capital letter and ends with "Controller" or "Controller".
+starts with capital letter and ends with "Controller".
 - Assigning a property to `$scope` creates or updates the model.
 - Controller methods can be created through direct assignment to scope (see the `chiliSpicy` method)
 - The Controller methods and properties are available in the template (for the `<div>` element and


### PR DESCRIPTION
Duplicate suffix in the docs introduced by #https://github.com/angular/angular.js/commit/f6877ed2d9d1bb8bc3ace0aa136890b411e78344

@btford may I ask why the convention is switching from the vastly used and shorter 'Ctrl' to 'Controller' ?
