### PR TITLE
Change JSDoc from DOMElement to HTMLElement

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -93,7 +93,7 @@
  * - `inheritedData()` - same as `data()`, but walks up the DOM until a value is found or the top
  *   parent element is reached.
  *
- * @param {string|DOMElement} element HTML string or DOMElement to be wrapped into jQuery.
+ * @param {string|HTMLElement} element HTML string or HTMLElement to be wrapped into jQuery.
  * @returns {Object} jQuery object.
  */
 


### PR DESCRIPTION
Wrong class type used for parameter argument on `angular.element()`. Should be `string` and `HTMLElement`.

https://developer.mozilla.org/en/docs/Web/API/HTMLElement
