### PR TITLE
fix(jqLite): allow `triggerHandler()` to accept custom event

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -948,13 +948,8 @@ forEach({
   clone: jqLiteClone,
 
   triggerHandler: function(element, eventName, eventData) {
-    // Copy event handlers in case event handlers array is modified during execution.
-    var eventFns = (jqLiteExpandoStore(element, 'events') || {})[eventName],
-        eventFnsCopy = shallowCopy(eventFns || []);
 
-    eventData = eventData || [];
-
-    var event = [{
+    var event = {
       preventDefault: function() {
         this.defaultPrevented = true;
       },
@@ -962,10 +957,21 @@ forEach({
         return this.defaultPrevented === true;
       },
       stopPropagation: noop
-    }];
+    };
+
+    if ( eventName.type ) {
+      extend(event, eventName);
+      eventName = event.type;
+    }
+
+    var handlerArgs = [event].concat(eventData || []);
+
+    // Copy event handlers in case event handlers array is modified during execution.
+    var eventFns = (jqLiteExpandoStore(element, 'events') || {})[eventName],
+        eventFnsCopy = shallowCopy(eventFns || []);
 
     forEach(eventFnsCopy, function(fn) {
-      fn.apply(element, event.concat(eventData));
+      fn.apply(element, handlerArgs);
     });
   }
 }, function(fn, name){

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -947,7 +947,7 @@ forEach({
 
   clone: jqLiteClone,
 
-  triggerHandler: function(element, event, eventData) {
+  triggerHandler: function(element, event, extraParameters) {
 
     var dummyEvent, eventFnsCopy, handlerArgs;
     var eventName = event.type || event;
@@ -971,7 +971,7 @@ forEach({
 
       // Copy event handlers in case event handlers array is modified during execution.
       eventFnsCopy = shallowCopy(eventFns);
-      handlerArgs = eventData ? [dummyEvent].concat(eventData) : [dummyEvent];
+      handlerArgs = extraParameters ? [dummyEvent].concat(extraParameters) : [dummyEvent];
 
       forEach(eventFnsCopy, function(fn) {
         fn.apply(element, handlerArgs);

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1718,9 +1718,11 @@ describe('jqLite', function() {
       element.triggerHandler('click');
       event = pokeSpy.mostRecentCall.args[0];
       expect(event.preventDefault).toBeDefined();
+      expect(event.target).toEqual(element[0]);
+      expect(event.type).toEqual('click');
     });
 
-    it('should pass data as an additional argument', function() {
+    it('should pass extra parameters as an additional argument', function() {
       var element = jqLite('<a>poke</a>'),
           pokeSpy = jasmine.createSpy('poke'),
           data;
@@ -1780,6 +1782,8 @@ describe('jqLite', function() {
       actualEvent = pokeSpy.mostRecentCall.args[0];
       expect(actualEvent.preventDefault).toBeDefined();
       expect(actualEvent.someProp).toEqual('someValue');
+      expect(actualEvent.target).toEqual(element[0]);
+      expect(actualEvent.type).toEqual('click');
     });
   });
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1765,6 +1765,22 @@ describe('jqLite', function() {
       expect(clickOnceSpy).toHaveBeenCalledOnce();
       expect(clickSpy.callCount).toBe(2);
     });
+
+    it("should accept a custom event instead of eventName", function() {
+      var element = jqLite('<a>poke</a>'),
+          pokeSpy = jasmine.createSpy('poke'),
+          customEvent = {
+            type: 'click',
+            someProp: 'someValue'
+          },
+          actualEvent;
+
+      element.on('click', pokeSpy);
+      element.triggerHandler(customEvent);
+      actualEvent = pokeSpy.mostRecentCall.args[0];
+      expect(actualEvent.preventDefault).toBeDefined();
+      expect(actualEvent.someProp).toEqual('someValue');
+    });
   });
 
 


### PR DESCRIPTION
In some scenarios you want to be able to specify properties on the event
that is passed to the event handler. JQuery does this by overloading the
first parameter (`eventName`). If it is an object with a `type` property
then we assume that it must be a custom event.

In this case the custom event must provide the `type` property which is
the name of the event to be triggered.  `triggerHandler` will continue to
provide dummy default functions for `preventDefault()`, `isDefaultPrevented()`
and `stopPropagation()` but you may override these with your own versions
in your custom object if you wish.

Closes #8469
