### PR TITLE
fix($location): don't rewrite hash-fragment links in same document

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -641,6 +641,13 @@ function $LocationProvider(){
         if (elm[0] === $rootElement[0] || !(elm = elm.parent())[0]) return;
       }
 
+      var href = elm.attr('href') || elm.attr('xlink:href');
+
+      if (href && href.indexOf('#' + hashPrefix + '/') !== 0 && href[0] === '#') {
+        // Don't rewrite hash-fragment links in the same document.
+        return;
+      }
+
       var absHref = elm.prop('href');
 
       if (isObject(absHref) && absHref.toString() === '[object SVGAnimatedString]') {

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -663,34 +663,33 @@ function $LocationProvider(){
       if (IGNORE_URI_REGEXP.test(absHref)) return;
 
       // Make relative links work in HTML5 mode for legacy browsers (or at least IE8 & 9)
-      // The href should be a regular url e.g. /link/somewhere or link/somewhere or ../somewhere or
-      // somewhere#anchor or http://example.com/somewhere
+      // The href should be a regular url e.g. /link/somewhere or link/somewhere or ../somewhere or somewhere#anchor or http://example.com/somewhere
       if (LocationMode === LocationHashbangInHtml5Url) {
-        // get the actual href attribute - see
-        // http://msdn.microsoft.com/en-us/library/ie/dd347148(v=vs.85).aspx
-        var href = elm.attr('href') || elm.attr('xlink:href');
+        // get the actual href attribute - see http://msdn.microsoft.com/en-us/library/ie/dd347148(v=vs.85).aspx
+        // TODO check browser is in standards mode
+        var href = elm[0].getAttribute('href');
 
-        if (href.indexOf('://') < 0) {         // Ignore absolute URLs
-          var prefix = '#' + hashPrefix;
+        if (href.indexOf('://' == -1)) {         // Ignore absolute URLs
           if (href[0] == '/') {
             // absolute path - replace old path
-            absHref = appBase + prefix + href;
+            absHref = serverBase(absHref) + href;
           } else if (href[0] == '#') {
             // local anchor
-            absHref = appBase + prefix + ($location.path() || '/') + href;
+            absHref = serverBase(absHref) + $location.path() + href;
           } else {
             // relative path - join with current path
             var stack = $location.path().split("/"),
               parts = href.split("/");
+            stack.pop(); // remove top file
             for (var i=0; i<parts.length; i++) {
               if (parts[i] == ".")
                 continue;
               else if (parts[i] == "..")
                 stack.pop();
-              else if (parts[i].length)
+              else
                 stack.push(parts[i]);
             }
-            absHref = appBase + prefix + stack.join('/');
+            absHref = serverBase(absHref) + stack.join("/");
           }
         }
       }

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -265,16 +265,6 @@ function LocationHashbangInHtml5Url(appBase, hashPrefix) {
       return appBaseNoFile;
     }
   };
-
-  this.$$compose = function() {
-    var search = toKeyValue(this.$$search),
-        hash = this.$$hash ? '#' + encodeUriSegment(this.$$hash) : '';
-
-    this.$$url = encodePath(this.$$path) + (search ? '?' + search : '') + hash;
-    // include hashPrefix in $$absUrl when $$url is empty so IE8 & 9 do not reload page because of removal of '#'
-    this.$$absUrl = appBase + hashPrefix + this.$$url;
-  };
-
 }
 
 
@@ -661,38 +651,6 @@ function $LocationProvider(){
 
       // Ignore when url is started with javascript: or mailto:
       if (IGNORE_URI_REGEXP.test(absHref)) return;
-
-      // Make relative links work in HTML5 mode for legacy browsers (or at least IE8 & 9)
-      // The href should be a regular url e.g. /link/somewhere or link/somewhere or ../somewhere or somewhere#anchor or http://example.com/somewhere
-      if (LocationMode === LocationHashbangInHtml5Url) {
-        // get the actual href attribute - see http://msdn.microsoft.com/en-us/library/ie/dd347148(v=vs.85).aspx
-        // TODO check browser is in standards mode
-        var href = elm[0].getAttribute('href');
-
-        if (href.indexOf('://' == -1)) {         // Ignore absolute URLs
-          if (href[0] == '/') {
-            // absolute path - replace old path
-            absHref = serverBase(absHref) + href;
-          } else if (href[0] == '#') {
-            // local anchor
-            absHref = serverBase(absHref) + $location.path() + href;
-          } else {
-            // relative path - join with current path
-            var stack = $location.path().split("/"),
-              parts = href.split("/");
-            stack.pop(); // remove top file
-            for (var i=0; i<parts.length; i++) {
-              if (parts[i] == ".")
-                continue;
-              else if (parts[i] == "..")
-                stack.pop();
-              else
-                stack.push(parts[i]);
-            }
-            absHref = serverBase(absHref) + stack.join("/");
-          }
-        }
-      }
 
       var rewrittenUrl = $location.$$rewrite(absHref);
 

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1164,6 +1164,32 @@ describe('$location', function() {
     });
 
 
+    it('should not rewrite when clicking on relative hash fragments', function() {
+      configureService('#foo', true, true, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser) {
+          browserTrigger(link, 'click');
+          expectNoRewrite($browser);
+        }
+      );
+    });
+
+
+    it('should not rewrite when clicking on relative hash fragments in old browser', function() {
+      configureService('#foo', true, false, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser) {
+          browserTrigger(link, 'click');
+          expectNoRewrite($browser);
+        }
+      );
+    });
+
+
     // don't run next tests on IE<9, as browserTrigger does not simulate pressed keys
     if (!msie || msie >= 9) {
 

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1164,51 +1164,6 @@ describe('$location', function() {
     });
 
 
-    it('should rewrite relative links relative to current path when history disabled', function() {
-      configureService('link', true, false, true);
-      inject(
-        initBrowser(),
-        initLocation(),
-        function($browser, $location) {
-          $location.path('/some');
-          browserTrigger(link, 'click');
-          expectRewriteTo($browser, 'http://host.com/base/index.html#!/some/link');
-        }
-      );
-    });
-
-
-    it('should replace current path when link begins with "/" and history disabled', function() {
-      configureService('/link', true, false, true);
-      inject(
-        initBrowser(),
-        initLocation(),
-        function($browser, $location) {
-          $location.path('/some');
-          browserTrigger(link, 'click');
-          expectRewriteTo($browser, 'http://host.com/base/index.html#!/link');
-        }
-      );
-    });
-
-
-    it('should replace current hash fragment when link begins with "#" history disabled', function() {
-      configureService('#link', true, false, true);
-      inject(
-        initBrowser(),
-        initLocation(),
-        function($browser, $location) {
-          // Initialize browser URL
-          $location.path('/some');
-          $location.hash('foo');
-          browserTrigger(link, 'click');
-          expect($location.hash()).toBe('link');
-          expectRewriteTo($browser, 'http://host.com/base/index.html#!/some#link');
-        }
-      );
-    });
-
-
     // don't run next tests on IE<9, as browserTrigger does not simulate pressed keys
     if (!msie || msie >= 9) {
 


### PR DESCRIPTION
$location will no longer rewrite hash fragment links in the same document
(specified via href="#hash...").

Closes #8478
