### PR TITLE
fix($parse): ternary should give assignment precedence in middle and right expressions

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -589,9 +589,9 @@ Parser.prototype = {
     var middle;
     var token;
     if ((token = this.expect('?'))) {
-      middle = this.ternary();
+      middle = this.assignment();
       if ((token = this.expect(':'))) {
-        return this.ternaryFn(left, middle, this.ternary());
+        return this.ternaryFn(left, middle, this.assignment());
       } else {
         this.throwError('expected :', token);
       }

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -321,6 +321,10 @@ describe('parser', function() {
         expect(scope.$eval('returnFalse() ? returnString() : returnInt()')).toEqual(returnFalse() ? returnString() : returnInt());
         expect(scope.$eval('returnTrue() ? returnString() : returnInt()')).toEqual(returnTrue() ? returnString() : returnInt());
         expect(scope.$eval('identity(returnFalse() ? returnString() : returnInt())')).toEqual(identity(returnFalse() ? returnString() : returnInt()));
+
+        // Assignment
+        expect(scope.$eval('false ? x=1 : x=2')).toEqual(2);
+        expect(scope.x).toEqual(2);
       });
 
       it('should parse string', function() {


### PR DESCRIPTION
Closes #8484
