### PR TITLE
docs: Fix broken link to to SCE

### DIFF
--- a/docs/content/error/$sce/unsafe.ngdoc
+++ b/docs/content/error/$sce/unsafe.ngdoc
@@ -10,7 +10,7 @@ Angular's {@link ng.$sce Strict Contextual Escaping (SCE)} mode
 contexts to result in a value that is trusted as safe for use in such a context.  (e.g. loading an
 Angular template from a URL requires that the URL is one considered safe for loading resources.)
 
-This helps prevent XSS and other security issues.  Read more at {@link
-api/ng.$sce Strict Contextual Escaping (SCE)}
+This helps prevent XSS and other security issues.  Read more at
+{@link ng.$sce Strict Contextual Escaping (SCE)}
 
 You may want to include the ngSanitize module to use the automatic sanitizing.


### PR DESCRIPTION
The second link to Strict Contextual Escaping (SCE) points to a 404.
