### PR TITLE
fix($parse): ternary and assignment operator precedence

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -589,9 +589,9 @@ Parser.prototype = {
     var middle;
     var token;
     if ((token = this.expect('?'))) {
-      middle = this.ternary();
+      middle = this.filterChain();
       if ((token = this.expect(':'))) {
-        return this.ternaryFn(left, middle, this.ternary());
+        return this.ternaryFn(left, middle, this.filterChain());
       } else {
         this.throwError('expected :', token);
       }

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -265,6 +265,7 @@ describe('parser', function() {
         var returnString = scope.returnString = function(){ return 'asd'; };
         var returnInt = scope.returnInt = function(){ return 123; };
         var identity = scope.identity = function(x){ return x; };
+        var foo;
 
         // Simple.
         expect(scope.$eval('0?0:2')).toEqual(0?0:2);
@@ -315,6 +316,9 @@ describe('parser', function() {
         expect(scope.$eval('1?2:1&&1')).toEqual(1?2:1&&1);
         expect(scope.$eval('1?1:0||0')).toEqual(1?1:0||0);
         expect(scope.$eval('1?2:0||1')).toEqual(1?2:0||1);
+
+        // Precedence with respect to assignmets
+        expect(scope.$eval('1?foo=true:foo=false')).toEqual(1?foo=true:foo=false);
 
         // Function calls.
         expect(scope.$eval('returnTrue() ? returnString() : returnInt()')).toEqual(returnTrue() ? returnString() : returnInt());


### PR DESCRIPTION
Properly handle assignemnts inside ternary operators

Closes #8484
