### PR TITLE
docs: ngSanitize is out ng core at AngularJS 1.2.21

### DIFF
--- a/docs/content/guide/migration.ngdoc
+++ b/docs/content/guide/migration.ngdoc
@@ -756,14 +756,16 @@ See [80739409](https://github.com/angular/angular.js/commit/807394095b991357225a
 
 ## ngBindHtmlUnsafe has been removed and replaced by ngBindHtml
 
-`ngBindHtml` which has been moved from `ngSanitize` module to the core `ng` module.
-
 `ngBindHtml` provides `ngBindHtmlUnsafe` like
 behavior (evaluate an expression and innerHTML the result into the DOM) when bound to the result
 of `$sce.trustAsHtml(string)`. When bound to a plain string, the string is sanitized via
 `$sanitize` before being innerHTML'd. If the `$sanitize` service isn't available (`ngSanitize`
 module is not loaded) and the bound expression evaluates to a value that is not trusted an
 exception is thrown.
+
+When using this directive you can either include `ngSanitize` in your module's dependencis (See the
+example at the {@link ngBindHtml} reference) or use the {@link $sce} service to set the value as
+trusted.
 
 See [dae69473](https://github.com/angular/angular.js/commit/dae694739b9581bea5dbc53522ec00d87b26ae55).
 


### PR DESCRIPTION
When using ngBindHTML directive, ngSanitize module must be added as a dependency.

Not doing so results in the following error:

```
Error: [$sce:unsafe] http://errors.angularjs.org/1.2.21/$sce/unsafe
    at Error (native)
    at http://somesite/js/angular.min.js?n9wkqz:6:450
    at e (http://somesite/js/angular.min.js?n9wkqz:117:34)
    at getTrusted (http://somesite/js/angular.min.js?n9wkqz:118:327)
    at Object.e.(anonymous function) [as getTrustedHtml] (http://somesite/js/angular.min.js?n9wkqz:120:71)
    at Object.fn (http://somesite/js/angular.min.js?n9wkqz:192:234)
    at k.$digest (http://somesite/js/angular.min.js?n9wkqz:109:213)
    at k.$apply (http://somesite/js/angular.min.js?n9wkqz:112:173)
    at h (http://somesite/js/angular.min.js?n9wkqz:72:300)
    at w (http://somesite/js/angular.min.js?n9wkqz:77:288) 
```

You can see that the API reference for ngBindHTML includes the module below:

![selection_004](https://cloud.githubusercontent.com/assets/108130/3837185/9cdf6e08-1de6-11e4-93fa-a4a99b919e8c.png)
