### PR TITLE
fix(ngShow): Make ng-show consistent with ng-if

### DIFF
--- a/src/ng/directive/ngShowHide.js
+++ b/src/ng/directive/ngShowHide.js
@@ -159,10 +159,12 @@ var ngShowDirective = ['$animate', function($animate) {
   return {
     restrict: 'A',
     multiElement: true,
-    link: function(scope, element, attr) {
-      scope.$watch(attr.ngShow, function ngShowWatchAction(value){
-        $animate[value ? 'removeClass' : 'addClass'](element, 'ng-hide');
-      });
+    link: {
+      pre: function(scope, element, attr) {
+        scope.$watch(attr.ngShow, function ngShowWatchAction(value){
+          $animate[value ? 'removeClass' : 'addClass'](element, 'ng-hide');
+        });
+      }
     }
   };
 }];


### PR DESCRIPTION
Consistent in terms of propagation. The expected behavior is that both
are evaluated from the outside in.

Background: http://stackoverflow.com/questions/25159464/how-to-make-angular-directives-evaluate-from-outside-in

All tests are passing.

I think this is pretty self-contained, but if you want me to, I can also expand on the concrete scenario where this unexpected behavior caused a bug in our application.
