### PR TITLE
fix(select): Clarify documentation and add exception for ngOptions

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -70,6 +70,13 @@ var ngOptionsMinErr = minErr('ngOptions');
  *   * `trackexpr`: Used when working with an array of objects. The result of this expression will be
  *      used to identify the objects in the array. The `trackexpr` will most likely refer to the
  *     `value` variable (e.g. `value.propertyName`).
+ *   <div class="alert alert-warning>
+ *   Do not use `track by` when you have a complex `select` expression that is different from `value`.
+ *   Use `track by` if you want to assign complex objects to the model. Use a complex `select`
+ *   expression like `item.value as item.label for item in items` if your items are object but your
+ *   model values correspond to properties of these objects.
+ *   See an example [in this jsfiddle](http://jsfiddle.net/0vpsv1wa/1/).
+ *   </div>
  *
  * @example
     <example module="selectExample">
@@ -336,6 +343,12 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
             // - optionGroupsCache[0] is the options with no option group
             // - optionGroupsCache[?][0] is the parent: either the SELECT or OPTGROUP element
             optionGroupsCache = [[{element: selectElement, label:''}]];
+
+        if (track && match[2] && valueName !== match[1]) {
+          throw ngOptionsMinErr('trackSelect',
+            "Do not use 'track by' when your select ('{0}') is different from your value ('{1}')",
+            match[1], valueName);
+        }
 
         if (nullOption) {
           // compile the element since there might be bindings in it

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -850,6 +850,15 @@ describe('select', function() {
         expect(element.val()).toEqual('4');
       });
 
+      it('should throw an error when trying to combine track by with a complex select expression', function() {
+        expect(function() {
+          createSelect({
+            'ng-model': 'selected',
+            'ng-options': 'item.id as item.name for item in values track by item.id'
+          });
+        }).toThrowMinErr('ngOptions','trackSelect', "Do not use 'track by' when your select ('item.id') is different from your value ('item')");
+      });
+
 
       it('should bind to scope value through experession', function() {
         createSelect({


### PR DESCRIPTION
ngOptions introduced `track by` in c32a859bdb93699cc080f9affed4bcff63005a64.
Using `track by` puts constraints on the value you can use in the interpolation expression in ngOptions.
This patch both documents this and adds an exception if you use ngOptions in an unsupported way.

Closes angular/angular.js#6564
