### PR TITLE
use ng-hide for showing the "no results found" text

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -142,7 +142,7 @@
           <li class="animate-repeat" ng-repeat="friend in friends | filter:q as results">
             [{{$index + 1}}] {{friend.name}} who is {{friend.age}} years old.
           </li>
-          <li class="animate-repeat" ng-if="results.length == 0">
+          <li class="animate-repeat" ng-hide="results.length">
             <strong>No results found...</strong>
           </li>
         </ul>


### PR DESCRIPTION
I think it's better to use ng-hide instead of ng-if to show the "no results found" text.

What do you think?
