### PR TITLE
fix(): allow spaces around dots for identifiers

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -263,15 +263,15 @@ Lexer.prototype = {
     var ident = '';
     var start = this.index;
 
-    var lastDot, peekIndex, methodName, ch;
+    var lastDot, expectIdent, peekIndex, methodName, ch;
 
     while (this.index < this.text.length) {
       ch = this.text.charAt(this.index);
       if (ch === '.' || this.isIdent(ch) || this.isNumber(ch)) {
-        if (ch === '.') lastDot = this.index;
+        if (expectIdent = ch === '.') lastDot = this.index;
         ident += ch;
-      } else {
-        break;
+      } else if (!(this.isWhitespace(ch) && expectIdent)) {
+          break;
       }
       this.index++;
     }

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -71,6 +71,10 @@ describe('parser', function() {
       expect(tokens[i].string).toEqual('d"e');
     });
 
+    it('should tokenize identifiers with spaces after dots', function () {
+      expect(lex('foo. bar')[0].text).toEqual('foo.bar');
+    });
+
     it('should tokenize undefined', function() {
       var tokens = lex("undefined");
       var i = 0;
@@ -347,6 +351,14 @@ describe('parser', function() {
         expect(scope.$eval("a", scope)).toEqual(123);
         expect(scope.$eval("b.c", scope)).toEqual(456);
         expect(scope.$eval("x.y.z", scope)).not.toBeDefined();
+      });
+
+      it('should handle white-spaces around dots in paths', function () {
+        scope.a = {b: 4};
+        expect(scope.$eval("a . b", scope)).toEqual(4);
+        expect(scope.$eval("a. b", scope)).toEqual(4);
+        expect(scope.$eval("a .b", scope)).toEqual(4);
+        expect(scope.$eval("a    . \nb", scope)).toEqual(4);
       });
 
       it('should resolve deeply nested paths (important for CSP mode)', function() {


### PR DESCRIPTION
Fixes #4613
