### PR TITLE
fix($compile): make '='-bindings NaN-aware

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1507,7 +1507,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 if (parentGet.literal) {
                   compare = equals;
                 } else {
-                  compare = function(a,b) { return a === b; };
+                  compare = function(a,b) { return a === b || (a !== a && b !== b); };
                 }
                 parentSet = parentGet.assign || function() {
                   // reset the change, or we will throw this exception on every $digest

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2869,6 +2869,28 @@ describe('$compile', function() {
     });
 
 
+    it('should update parent scope when "="-bound NaN changes', inject(function($compile, $rootScope) {
+      $rootScope.num = NaN;
+      compile('<div my-component reference="num"></div>');
+      var isolateScope = element.isolateScope();
+      expect(isolateScope.reference).toBeNaN();
+
+      isolateScope.$apply(function(scope) { scope.reference = 64; });
+      expect($rootScope.num).toBe(64);
+    }));
+
+
+    it('should update isolate scope when "="-bound NaN changes', inject(function($compile, $rootScope) {
+      $rootScope.num = NaN;
+      compile('<div my-component reference="num"></div>');
+      var isolateScope = element.isolateScope();
+      expect(isolateScope.reference).toBeNaN();
+
+      $rootScope.$apply(function(scope) { scope.num = 64; });
+      expect(isolateScope.reference).toBe(64);
+    }));
+
+
     describe('bind-once', function () {
 
       function countWatches(scope) {


### PR DESCRIPTION
Update parent and child scopes correctly when a '='-binding changes from a NaN
value.

Closes #8553
