### PR TITLE
docs(docs.css): better code for commas in TOC on mobile

### DIFF
--- a/docs/app/assets/css/docs.css
+++ b/docs/app/assets/css/docs.css
@@ -635,12 +635,14 @@ ul.events > li {
     display:inline-block;
     padding:3px 0;
   }
-  .nav-index-group .nav-index-listing:not(.nav-index-section) + .nav-index-listing:not(.nav-index-section):after {
-      padding-right:5px;
-      content:",  ";
+  .nav-index-group .nav-index-listing:not(.nav-index-section):after {
+    padding-right:5px;
+    margin-left:-3px;
+    content:",  ";
   }
-  .nav-index-group .nav-index-listing:last-child {
+  .nav-index-group .nav-index-listing:last-child:after {
     content:"";
+    display:inline-block;
   }
   .nav-index-group .nav-index-section {
     display:block;


### PR DESCRIPTION
It's still not perfect, but now it looks like this:
![image](https://cloud.githubusercontent.com/assets/94334/3873813/ff4686ae-2137-11e4-8766-db9317085fc3.png)
