### PR TITLE
length validator fix for input[tel] et al.

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -603,7 +603,7 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   if (attr.ngMinlength) {
     var minlength = int(attr.ngMinlength);
     var minLengthValidator = function(value) {
-      return validate(ctrl, 'minlength', ctrl.$isEmpty(value) || value.length >= minlength, value);
+      return validate(ctrl, 'minlength', ctrl.$isEmpty(value) || value.toString().length >= minlength, value);
     };
 
     ctrl.$parsers.push(minLengthValidator);
@@ -614,7 +614,7 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   if (attr.ngMaxlength) {
     var maxlength = int(attr.ngMaxlength);
     var maxLengthValidator = function(value) {
-      return validate(ctrl, 'maxlength', ctrl.$isEmpty(value) || value.length <= maxlength, value);
+      return validate(ctrl, 'maxlength', ctrl.$isEmpty(value) || value.toString().length <= maxlength, value);
     };
 
     ctrl.$parsers.push(maxLengthValidator);


### PR DESCRIPTION
Input values that contain all numbers (such as zip codes, phone numbers, etc) will always be invalid unless the value is converted to a string first. 

e.g. 1234.length is always undefined, and '1234'.length equals 4, which is what should be checked against minlength and maxlength.
