### PR TITLE
Introduce callback "after-animation" to ngInclude

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -502,7 +502,7 @@
       }
     },
     "dgeni-packages": {
-      "version": "0.9.6",
+      "version": "0.9.7",
       "dependencies": {
         "lodash": {
           "version": "2.4.1"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "canonical-path": "0.0.2",
     "winston": "~0.7.2",
     "dgeni": "^0.3.0",
-    "dgeni-packages": "^0.9.6",
+    "dgeni-packages": "^0.9.7",
     "gulp-jshint": "~1.4.2",
     "jshint-stylish": "~0.1.5",
     "node-html-encoder": "0.0.2",

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -180,6 +180,7 @@ var ngIncludeDirective = ['$http', '$templateCache', '$anchorScroll', '$animate'
     compile: function(element, attr) {
       var srcExp = attr.ngInclude || attr.src,
           onloadExp = attr.onload || '',
+          clientAfterAnimation = attr.afterAnimation,
           autoScrollExp = attr.autoscroll;
 
       return function(scope, $element, $attr, ctrl, $transclude) {
@@ -210,6 +211,9 @@ var ngIncludeDirective = ['$http', '$templateCache', '$anchorScroll', '$animate'
           var afterAnimation = function() {
             if (isDefined(autoScrollExp) && (!autoScrollExp || scope.$eval(autoScrollExp))) {
               $anchorScroll();
+            }
+            if(isDefined(clientAfterAnimation)){
+              scope.$eval(clientAfterAnimation);
             }
           };
           var thisChangeId = ++changeCounter;

--- a/test/e2e/docsAppE2E.js
+++ b/test/e2e/docsAppE2E.js
@@ -37,7 +37,7 @@ describe('docs.angularjs.org', function () {
       var nameInput = element(by.model('user.name'));
       nameInput.sendKeys('!!!');
 
-      var code = element(by.css('tt'));
+      var code = element.all(by.css('tt')).first();
       expect(code.getText()).toContain('guest!!!');
     });
 
@@ -66,6 +66,13 @@ describe('docs.angularjs.org', function () {
     it('should display formatted error messages on error doc pages', function() {
       browser.get('index-debug.html#!error/ng/areq?p0=Missing&p1=not%20a%20function,%20got%20undefined');
       expect(element(by.css('.minerr-errmsg')).getText()).toEqual("Argument 'Missing' is not a function, got undefined");
+    });
+  });
+
+  describe("templates", function() {
+    it("should show parameter defaults", function() {
+      browser.get('index-debug.html#!/api/ng/service/$timeout');
+      expect(element.all(by.css('.input-arguments p em')).first().getText()).toContain('(default: 0)');
     });
   });
 });

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -487,6 +487,42 @@ describe('ngInclude', function() {
         }
     ));
   });
+
+  describe('afterAnimation', function() {
+    function compileAndLink(tpl) {
+      return function($compile, $rootScope) {
+        element = $compile(tpl)($rootScope);
+      };
+    }
+
+    beforeEach(module(function(){}, 'ngAnimateMock'));
+
+    beforeEach(inject(
+        putIntoCache('template.html', 'CONTENT'),
+        putIntoCache('another.html', 'CONTENT')));
+
+    it('should call animationCallback after the "enter" animation completes', inject(
+        compileAndLink('<div><ng:include src="tpl" after-animation="animationCallback()"></ng:include></div>'),
+        function($rootScope, $animate, $timeout) {
+          var hasBeenCalled = false;
+
+          $rootScope.$apply("tpl = 'template.html'");
+
+          $rootScope.$apply(function () {
+            $rootScope.animationCallback = function(){
+              hasBeenCalled = true;
+            };
+          });
+
+          $animate.triggerCallbacks();
+
+          expect(hasBeenCalled).toBe(true);
+
+        }
+    ));
+  });
+
+
 });
 
 describe('ngInclude and transcludes', function() {


### PR DESCRIPTION
The after-animation-callback can be used to hook into the rendering of the ngInclude-directive. This is useful in case the client wants to restore a scrolling-position after the view has been rendered.

This can be used as a generalization of the anchorscroll, which can only scroll to a defined anchor in the document. 

The usecase which led to the development of this pull-request contained the need to scroll to a specific numer of pixels, which could only be realized by hooking into the after-animation event and exposing it to the client.
