### PR TITLE
chore(doc-gen): move e2e tests into docs folder

### DIFF
--- a/docs/app/e2e/docsAppE2E.js
+++ b/docs/app/e2e/docsAppE2E.js
@@ -75,4 +75,14 @@ describe('docs.angularjs.org', function () {
       expect(element.all(by.css('.input-arguments p em')).first().getText()).toContain('(default: 0)');
     });
   });
+
+  describe("API pages", function() {
+    it("should display links to code on GitHub", function() {
+      browser.get('index-debug.html#!/api/ng/service/$http');
+      expect(element(by.css('.improve-docs')).getAttribute('href')).toMatch(/https?:\/\/github\.com\/angular\/angular\.js\/edit\/.+\/src\/ng\/http\.js/);
+
+      browser.get('index-debug.html#!/api/ng/service/$http');
+      expect(element(by.css('.view-source')).getAttribute('href')).toMatch(/https?:\/\/github\.com\/angular\/angular\.js\/tree\/.+\/src\/ng\/http\.js#L\d+/);
+    });
+  });
 });

--- a/protractor-conf.js
+++ b/protractor-conf.js
@@ -4,7 +4,7 @@ var config = require('./protractor-shared-conf').config;
 
 config.specs = [
   'build/docs/ptore2e/**/*.js',
-  'test/e2e/docsAppE2E.js'
+  'docs/app/e2e/docsAppE2E.js'
 ];
 
 config.capabilities = {

--- a/protractor-jenkins-conf.js
+++ b/protractor-jenkins-conf.js
@@ -5,7 +5,7 @@ exports.config = {
 
   specs: [
     'build/docs/ptore2e/**/*.js',
-    'test/e2e/docsAppE2E.js'
+    'docs/app/e2e/docsAppE2E.js'
   ],
 
   capabilities: {

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -14,7 +14,7 @@ elif [ $JOB = "e2e" ]; then
   if [ $TEST_TARGET = "jquery" ]; then
     TARGET_SPECS="build/docs/ptore2e/**/*jquery_test.js"
   elif [ $TEST_TARGET = "doce2e" ]; then
-    TARGET_SPECS="test/e2e/docsAppE2E.js"
+    TARGET_SPECS="docs/app/e2e/docsAppE2E.js"
   fi
   grunt test:travis-protractor --specs "$TARGET_SPECS"
 else


### PR DESCRIPTION
These tests didn't really fit in the test folder as the docs app is mostly
a separate entity from the AngularJS codebase.
