### PR TITLE
Allowing angular-touch to work with jQuery.

### DIFF
--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -117,6 +117,8 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
       return; // Too old.
     }
 
+    // Use JQuery originalEvent
+    event = event.originalEvent || event;
     var touches = event.touches && event.touches.length ? event.touches : [event];
     var x = touches[0].clientX;
     var y = touches[0].clientY;
@@ -146,6 +148,8 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
   // Global touchstart handler that creates an allowable region for a click event.
   // This allowable region can be removed by preventGhostClick if we want to bust it.
   function onTouchStart(event) {
+    // Use JQuery originalEvent
+    event = event.originalEvent || event;
     var touches = event.touches && event.touches.length ? event.touches : [event];
     var x = touches[0].clientX;
     var y = touches[0].clientY;
@@ -191,6 +195,8 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     }
 
     element.on('touchstart', function(event) {
+      // Use JQuery originalEvent
+      event = event.originalEvent || event;
       tapping = true;
       tapElement = event.target ? event.target : event.srcElement; // IE uses srcElement.
       // Hack for Safari, which can target text nodes instead of containers.
@@ -218,7 +224,9 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
 
     element.on('touchend', function(event) {
       var diff = Date.now() - startTime;
-
+      
+      // Use JQuery originalEvent
+      event = event.originalEvent || event;
       var touches = (event.changedTouches && event.changedTouches.length) ? event.changedTouches :
           ((event.touches && event.touches.length) ? event.touches : [event]);
       var e = touches[0].originalEvent || touches[0];

--- a/src/ngTouch/swipe.js
+++ b/src/ngTouch/swipe.js
@@ -24,11 +24,10 @@ ngTouch.factory('$swipe', [function() {
   var MOVE_BUFFER_RADIUS = 10;
 
   function getCoordinates(event) {
+    // Use JQuery originalEvent
+    event = event.originalEvent || event;
     var touches = event.touches && event.touches.length ? event.touches : [event];
-    var e = (event.changedTouches && event.changedTouches[0]) ||
-        (event.originalEvent && event.originalEvent.changedTouches &&
-            event.originalEvent.changedTouches[0]) ||
-        touches[0].originalEvent || touches[0];
+    var e = (event.changedTouches && event.changedTouches[0]) || touches[0];
 
     return {
       x: e.clientX,


### PR DESCRIPTION
Angular includes a small subset of jQuery out of the box called jqLite. Normally, angular wraps all the elements it passes to its directives in jqLite. When jQuery is loaded ahead of angular, angular instead wraps its elements in the full implementation of jQuery. Additionally, angular wraps its events in jQuery. These jQuery events work throughout most of angular. Angular-touch currently was not working with those jQuery-wrapped events. Touches were registering inconsistently and rarely when using the ngClick directive. This commit should fix that. I took it from another person I found on github. I'm not sure why his changes were never merged into the main angular.js repo, but I've verified that it works and I decided to submit a pull request for it. There is a bug/issue thread I found relating to this. It is linked below.
https://github.com/angular/angular.js/issues/4001
