### PR TITLE
Fixes Argentina's currency.

### DIFF
--- a/src/ngLocale/angular-locale_es-ar.js
+++ b/src/ngLocale/angular-locale_es-ar.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "H:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [
@@ -86,10 +86,10 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "-",
-        "negSuf": "\u00a0\u00a4",
-        "posPre": "",
-        "posSuf": "\u00a0\u00a4"
+        "negPre": "\u00a4-",
+        "negSuf": "",
+        "posPre": "\u00a4",
+        "posSuf": ""
       }
     ]
   },


### PR DESCRIPTION
Currency symbol is '$'. The symbol is placed before the number.

Closes #8583
