### PR TITLE
fix(ngSanitize): ensure &nbsp; is converted to non-breaking space in IE8

### DIFF
--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -379,7 +379,7 @@ function htmlParser( html, handler ) {
 }
 
 var hiddenPre=document.createElement("pre");
-var spaceRe = /^(\s*)([\s\S]*?)(\s*)$/;
+var spaceRe = /^([\s|\u00a0]*)([\s\S]*?)([\s|\u00a0]*)$/;
 /**
  * decodes all entities into regular string
  * @param value
@@ -387,12 +387,15 @@ var spaceRe = /^(\s*)([\s\S]*?)(\s*)$/;
  */
 function decodeEntities(value) {
   if (!value) { return ''; }
-
   // Note: IE8 does not preserve spaces at the start/end of innerHTML
   // so we must capture them and reattach them afterward
+  value = value.replace(/\&nbsp\;/g, '\u00a0');
+
   var parts = spaceRe.exec(value);
   var spaceBefore = parts[1];
   var spaceAfter = parts[3];
+  // IE8 does not encode &nbsp; as U+00A0 when setting it against innerHTML
+  // (see http://jsfiddle.net/caitp/w4r1dzwe/).
   var content = parts[2];
   if (content) {
     hiddenPre.innerHTML=content.replace(/</g,"&lt;");

--- a/test/ng/directive/ngBindSpec.js
+++ b/test/ng/directive/ngBindSpec.js
@@ -131,6 +131,20 @@ describe('ngBind*', function() {
           $rootScope.$digest();
           expect(angular.lowercase(element.html())).toEqual('<div>hello</div>');
         }));
+
+        it('should not collapse &nbsp; spaces', inject(function($rootScope, $compile) {
+          element = $compile('<div ng-bind-html="html"></div>')($rootScope);
+          $rootScope.html = '&nbsp;&nbsp;hi&nbsp;&nbsp;bye&nbsp;&nbsp;';
+          $rootScope.$digest();
+          expect(element.text().length).toBe(11);
+          if (msie < 9) {
+            // IE8 thinks it ought ot convert U+00A0 to U+0020. I don't know why IE8 does this,
+            // but there you go.
+            expect(element.text()).toBe('\u0020\u0020hi\u0020\u0020bye\u0020\u0020');
+          } else {
+            expect(element.text()).toBe('\u00a0\u00a0hi\u00a0\u00a0bye\u00a0\u00a0');
+          }
+        }));
       });
     });
 

--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -515,4 +515,19 @@ describe('decodeEntities', function() {
       expect(text).toEqual('');
     });
   });
+
+
+  it('should decode &nbsp; to U+00A0', function() {
+    /* global decodeEntities */
+    expect(decodeEntities('&nbsp;')).toBe('\u00A0');
+    htmlParser('&nbsp;&nbsp;hi&nbsp;&nbsp;bye&nbsp;&nbsp;', handler);
+    expect(text.length).toBe(11);
+    if (msie < 9) {
+      // IE8 thinks it ought ot convert U+00A0 to U+0020. I don't know why IE8 does this,
+      // but there you go.
+      expect(text).toBe('\u0020\u0020hi\u0020\u0020bye\u0020\u0020');
+    } else {
+      expect(text).toBe('\u00a0\u00a0hi\u00a0\u00a0bye\u00a0\u00a0');
+    }
+  });
 });


### PR DESCRIPTION
IE8 does not convert &nbsp; to a non-breaking space when set using innerHTML,
and instead converts it to a single U+0020 space character, which causes
whitespace to collapse in most HTML elements.

This CL explicitly converts &nbsp; with U+00A0 in order to prevent this.

Closes #8602
