### PR TITLE
perf($compile): move $$isolateBinding creation to directive factory instead of on each link

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -545,6 +545,31 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
   // 'on' and be composed of only English letters.
   var EVENT_HANDLER_ATTR_REGEXP = /^(on[a-z]+|formaction)$/;
 
+  function parseIsolateBindings(scope, directiveName) {
+    var LOCAL_REGEXP = /^\s*([@=&])(\??)\s*(\w*)\s*$/;
+
+    var bindings = {};
+
+    forEach(scope, function(definition, scopeName) {
+      var match = definition.match(LOCAL_REGEXP);
+
+      if (!match) {
+        throw $compileMinErr('iscp',
+            "Invalid isolate scope definition for directive '{0}'." +
+            " Definition: {... {1}: '{2}' ...}",
+            directiveName, scopeName, definition);
+      }
+
+      bindings[scopeName] = {
+        attrName: match[3] || scopeName,
+        mode: match[1],
+        optional: match[2] === '?'
+      };
+    });
+
+    return bindings;
+  }
+
   /**
    * @ngdoc method
    * @name $compileProvider#directive
@@ -582,6 +607,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 directive.name = directive.name || name;
                 directive.require = directive.require || (directive.controller && directive.name);
                 directive.restrict = directive.restrict || 'EA';
+                if (isObject(directive.scope)) {
+                  directive.$$isolateBindings = parseIsolateBindings(directive.scope, directive.name);
+                }
                 directives.push(directive);
               } catch (e) {
                 $exceptionHandler(e);
@@ -1460,8 +1488,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         $element = attrs.$$element;
 
         if (newIsolateScopeDirective) {
-          var LOCAL_REGEXP = /^\s*([@=&])(\??)\s*(\w*)\s*$/;
-
           isolateScope = scope.$new(true);
 
           if (templateDirective && (templateDirective === newIsolateScopeDirective ||
@@ -1475,15 +1501,12 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
           safeAddClass($element, 'ng-isolate-scope');
 
-          forEach(newIsolateScopeDirective.scope, function(definition, scopeName) {
-            var match = definition.match(LOCAL_REGEXP) || [],
-                attrName = match[3] || scopeName,
-                optional = (match[2] == '?'),
-                mode = match[1], // @, =, or &
+          forEach(isolateScope.$$isolateBindings = newIsolateScopeDirective.$$isolateBindings, function(definition, scopeName) {
+            var attrName = definition.attrName,
+                optional = definition.optional,
+                mode = definition.mode, // @, =, or &
                 lastValue,
                 parentGet, parentSet, compare;
-
-            isolateScope.$$isolateBindings[scopeName] = mode + attrName;
 
             switch (mode) {
 
@@ -1539,12 +1562,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                   return parentGet(scope, locals);
                 };
                 break;
-
-              default:
-                throw $compileMinErr('iscp',
-                    "Invalid isolate scope definition for directive '{0}'." +
-                    " Definition: {... {1}: '{2}' ...}",
-                    newIsolateScopeDirective.name, scopeName, definition);
             }
           });
         }

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -133,7 +133,6 @@ function $RootScopeProvider(){
       this.$$postDigestQueue = [];
       this.$$listeners = {};
       this.$$listenerCount = {};
-      this.$$isolateBindings = {};
     }
 
     /**

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3274,14 +3274,25 @@ describe('$compile', function() {
 
       expect(typeof componentScope.$$isolateBindings).toBe('object');
 
-      expect(componentScope.$$isolateBindings.attr).toBe('@attr');
-      expect(componentScope.$$isolateBindings.attrAlias).toBe('@attr');
-      expect(componentScope.$$isolateBindings.ref).toBe('=ref');
-      expect(componentScope.$$isolateBindings.refAlias).toBe('=ref');
-      expect(componentScope.$$isolateBindings.reference).toBe('=reference');
-      expect(componentScope.$$isolateBindings.expr).toBe('&expr');
-      expect(componentScope.$$isolateBindings.exprAlias).toBe('&expr');
+      expect(componentScope.$$isolateBindings.attr.mode).toBe('@');
+      expect(componentScope.$$isolateBindings.attr.attrName).toBe('attr');
+      expect(componentScope.$$isolateBindings.attrAlias.attrName).toBe('attr');
+      expect(componentScope.$$isolateBindings.ref.mode).toBe('=');
+      expect(componentScope.$$isolateBindings.ref.attrName).toBe('ref');
+      expect(componentScope.$$isolateBindings.refAlias.attrName).toBe('ref');
+      expect(componentScope.$$isolateBindings.reference.mode).toBe('=');
+      expect(componentScope.$$isolateBindings.reference.attrName).toBe('reference');
+      expect(componentScope.$$isolateBindings.expr.mode).toBe('&');
+      expect(componentScope.$$isolateBindings.expr.attrName).toBe('expr');
+      expect(componentScope.$$isolateBindings.exprAlias.attrName).toBe('expr');
 
+      var firstComponentScope = componentScope,
+          first$$isolateBindings = componentScope.$$isolateBindings;
+
+      dealoc(element);
+      compile('<div><span my-component>');
+      expect(componentScope).not.toBe(firstComponentScope);
+      expect(componentScope.$$isolateBindings).toBe(first$$isolateBindings);
     }));
   });
 


### PR DESCRIPTION
Currently isolated scope info is parsed during the directive linking and a new $$isolateBindings is generated for every link. If the parsing fails an iscp error is thrown on every link of the directive.

This moves the parsing into the directive factory, creates a single shared $$isolateBindings, and will only throw the iscp error once if the parsing fails instead of once per link.

I'm not sure if batarang still uses $$isolateBindings (I can't find any reference to it)? Or if batarang depends on the $$isolateBindings format? Currently this PR changes the $$isolateBindings format, and also only puts $$isolateBindings on isolated scopes instead of every Scope instance.
