### PR TITLE
Fixed documentation for controller `^` search

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -198,9 +198,9 @@
  *
  * * (no prefix) - Locate the required controller on the current element. Throw an error if not found.
  * * `?` - Attempt to locate the required controller or pass `null` to the `link` fn if not found.
- * * `^` - Locate the required controller by searching the element's parents. Throw an error if not found.
- * * `?^` - Attempt to locate the required controller by searching the element's parents or pass `null` to the
- *   `link` fn if not found.
+ * * `^` - Locate the required controller by searching the element and its parents. Throw an error if not found.
+ * * `?^` - Attempt to locate the required controller by searching the element and its parents parents or pass
+ *   `null` to the `link` fn if not found.
  *
  *
  * #### `controllerAs`


### PR DESCRIPTION
Added 'current element' to 'its parents'.
