### PR TITLE
Fix Money simbol for Argentina

### DIFF
--- a/src/ngLocale/angular-locale_es-ar.js
+++ b/src/ngLocale/angular-locale_es-ar.js
@@ -63,7 +63,7 @@ $provide.value("$locale", {
     "shortTime": "H:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u20ac",
+    "CURRENCY_SYM": "$",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [


### PR DESCRIPTION
es-ar is Argentina translation. Argentina has pesos with '$' currency symbol.
