### PR TITLE
perf(jqLite): only take str.split() path when needed

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -728,7 +728,7 @@ forEach({
     }
 
     // http://jsperf.com/string-indexof-vs-split
-    var types = type.indexOf(' ') ? type.split(' ') : [type];
+    var types = type.indexOf(' ') >= 0 ? type.split(' ') : [type];
     var i = types.length;
 
     while (i--) {


### PR DESCRIPTION
bda673f8e785f299407c8c45887f37448a0f0192 changed code to only use
`str.split()` when necessary, but the result was that `str.split()` would
always be taken unless ' ' was the first character in the string, negating the
effectiveness of the perf fix.

/cc @IgorMinar --- re https://github.com/angular/angular.js/commit/bda673f8e785f299407c8c45887f37448a0f0192#commitcomment-7417474

Lets check this in fast, since it's such a tiny change
