### PR TITLE
docs($location): add note about breaking anchor links

### DIFF
--- a/docs/content/guide/$location.ngdoc
+++ b/docs/content/guide/$location.ngdoc
@@ -703,6 +703,12 @@ can recognize the crawler and serve a HTML snapshots. For more information about
 see [Making AJAX Applications
 Crawlable](http://code.google.com/web/ajaxcrawling/docs/specification.html).
 
+## Injecting $location and anchor links
+
+Injecting `$location` anywhere in the app, if html5mode is not enabled, may lead
+to the Angular breaking anchor links. Specifically, Angular will rewrite the 
+url by adding a `/` after the hash, which breaks anchor scrolling and may cause
+functionality issues on applications where `$location` does not control routing.
 
 # Testing with the $location service
 


### PR DESCRIPTION
As explained in #4608, $location injection can cause issues by inserting a / after a hash in the url, if html5mode is not enabled. Possible fix is in #8508.
