### PR TITLE
ngDisabled doc: clarify "don't do this" example

### DIFF
--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -160,7 +160,7 @@
  *
  * @description
  *
- * The following markup will make the button enabled on Chrome/Firefox but not on IE8 and older IEs:
+ * We shouldn't do this, because it will make the button enabled on Chrome/Firefox but not on IE8 and older IEs:
  * ```html
  * <div ng-init="scope = { isDisabled: false }">
  *  <button disabled="{{scope.isDisabled}}">Disabled</button>


### PR DESCRIPTION
It's not clear until you read the whole thing that it's an explanation of what _not_ to do and why, so if you scan the page from the top, you may use this bad solution.
