### PR TITLE
docs(ngBind): irrelevant text removed from ngBindHtml’s example

### DIFF
--- a/src/ng/directive/ngBind.js
+++ b/src/ng/directive/ngBind.js
@@ -153,7 +153,6 @@ var ngBindTemplateDirective = ['$interpolate', function($interpolate) {
  * @param {expression} ngBindHtml {@link guide/expression Expression} to evaluate.
  *
  * @example
-   Try it here: enter text in text box and watch the greeting change.
 
    <example module="bindHtmlExample" deps="angular-sanitize.js">
      <file name="index.html">


### PR DESCRIPTION
The ngBindHtml’s example had a copied line from ngBindTemplate’s that’s irrelevant here.
