### PR TITLE
fix($location): rewrite relative paths correctly path==='/' in legacy html5Mode

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -682,6 +682,7 @@ function $LocationProvider(){
             // relative path - join with current path
             var stack = $location.path().split("/"),
               parts = href.split("/");
+            if (stack.length === 2 && !stack[1]) stack.length = 1;
             for (var i=0; i<parts.length; i++) {
               if (parts[i] == ".")
                 continue;

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -996,6 +996,20 @@ describe('$location', function() {
     });
 
 
+    it('should produce relative paths correctly when $location.path() is "/" when history enabled on old browser', function() {
+      configureService('partial1', true, false, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser, $location) {
+          $location.path('/');
+          browserTrigger(link, 'click');
+          expectRewriteTo($browser, 'http://host.com/base/index.html#!/partial1');
+        }
+      );
+    });
+
+
     it('should rewrite abs link to hashbang url when history enabled on old browser', function() {
       configureService('/base/link?a#b', true, false);
       inject(


### PR DESCRIPTION
Currently, legacy browsers get to use a clever scheme for resolving relative
URIs in html5Mode, and resolve the URI relative to $location.path().

Currently, $location.path() can be '/' under certain circumstances, which
means that when we split $location.path() on '/' and later join by '/' after
adding another path component, we end up with '//pathComponent'. $$rewrite
fails to deal with this correctly, and effectively the $location is never
changed from the root path.

This CL corrects this by ensuring that the duplicate '/' situation does not
occur when resolving relative URIs.
