### PR TITLE
docs($compile): fix documentation for ?^ controller search

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -199,7 +199,7 @@
  * * (no prefix) - Locate the required controller on the current element. Throw an error if not found.
  * * `?` - Attempt to locate the required controller or pass `null` to the `link` fn if not found.
  * * `^` - Locate the required controller by searching the element and its parents. Throw an error if not found.
- * * `?^` - Attempt to locate the required controller by searching the element and its parents parents or pass
+ * * `?^` - Attempt to locate the required controller by searching the element and its parents or pass
  *   `null` to the `link` fn if not found.
  *
  *


### PR DESCRIPTION
docs($compile): fix documentation for ?^ controller search

Fixed typo: 'parents parents' to 'parents'
