### PR TITLE
feat($parse): add support for '\b' and '\xXX'

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -120,7 +120,7 @@ var OPERATORS = extend(createMap(), {
     '!':function(self, locals, a){return !a(self, locals);}
 });
 /* jshint bitwise: true */
-var ESCAPE = {"n":"\n", "f":"\f", "r":"\r", "t":"\t", "v":"\v", "'":"'", '"':'"'};
+var ESCAPE = {"n":"\n", "f":"\f", "r":"\r", "t":"\t", "v":"\v", "b": "\b", "'":"'", '"':'"'};
 
 
 /////////////////////////////////////////
@@ -338,16 +338,25 @@ Lexer.prototype = {
     var string = '';
     var rawString = quote;
     var escape = false;
+    var hex;
     while (this.index < this.text.length) {
       var ch = this.text.charAt(this.index);
       rawString += ch;
       if (escape) {
         if (ch === 'u') {
-          var hex = this.text.substring(this.index + 1, this.index + 5);
+          hex = this.text.substring(this.index + 1, this.index + 5);
           if (!hex.match(/[\da-f]{4}/i))
             this.throwError('Invalid unicode escape [\\u' + hex + ']');
           this.index += 4;
           string += String.fromCharCode(parseInt(hex, 16));
+        } else if (ch === 'x') {
+          hex = this.text.substring(this.index + 1, this.index + 3);
+          if (!hex.match(/[\da-f]{2}/i))
+            this.throwError('Invalid hex escape [\\x' + hex + ']');
+          this.index += 2;
+          string += String.fromCharCode(parseInt(hex, 16));
+        } else if (ch >= '0' && ch <= '7') {
+          this.throwError('Octal literals are not allowed');
         } else {
           var rep = ESCAPE[ch];
           string = string + (rep || ch);

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -91,10 +91,10 @@ describe('parser', function() {
     });
 
     it('should tokenize escaped quoted string', function() {
-      var str = '"\\"\\n\\f\\r\\t\\v\\u00A0"';
+      var str = '"\\b\\t\\n\\v\\f\\r\\"\\\'\'\\\\\\u00A0\\x40"';
       var tokens = lex(str);
 
-      expect(tokens[0].string).toEqual('"\n\f\r\t\v\u00A0');
+      expect(tokens[0].string).toEqual('\b\t\n\v\f\r\"\'\'\\\u00A0\x40');
     });
 
     it('should tokenize unicode', function() {
@@ -190,6 +190,18 @@ describe('parser', function() {
       expect(function() {
         lex("'\\u1''bla'");
       }).toThrowMinErr("$parse", "lexerr", "Lexer Error: Invalid unicode escape [\\u1''b] at column 2 in expression ['\\u1''bla'].");
+    });
+
+    it('should throw error on invalid hex', function() {
+      expect(function() {
+        lex("'\\x1''bla'");
+      }).toThrowMinErr("$parse", "lexerr", "Lexer Error: Invalid hex escape [\\x1'] at column 2 in expression ['\\x1''bla'].");
+    });
+
+    it('should throw error on octal literals', function() {
+      expect(function() {
+        lex("'\\11''bla'");
+      }).toThrowMinErr("$parse", "lexerr", "Lexer Error: Octal literals are not allowed at column 2 in expression ['\\11''bla'].");
     });
   });
 


### PR DESCRIPTION
- Add suport for `'\b'` and `'\xXX'`
- Throw when octal literals are found
