### PR TITLE
Test showing that all tests still pass when the skipDestroyOnNextJQueryCleanData flag is removed completely (it used to fail then)

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -89,8 +89,6 @@
     "createMap": false,
     "VALIDITY_STATE_PROPERTY": false,
 
-    "skipDestroyOnNextJQueryCleanData": true,
-
     /* filters.js */
     "getFirstThursdayOfYear": false,
 

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1439,7 +1439,7 @@ function snake_case(name, separator) {
 }
 
 var bindJQueryFired = false;
-var skipDestroyOnNextJQueryCleanData;
+//var skipDestroyOnNextJQueryCleanData;
 function bindJQuery() {
   var originalCleanData;
 
@@ -1468,13 +1468,13 @@ function bindJQuery() {
     // the $destroy event on all removed nodes.
     originalCleanData = jQuery.cleanData;
     jQuery.cleanData = function(elems) {
-      if (!skipDestroyOnNextJQueryCleanData) {
+//      if (!skipDestroyOnNextJQueryCleanData) {
         for (var i = 0, elem; (elem = elems[i]) != null; i++) {
           jQuery(elem).triggerHandler('$destroy');
         }
-      } else {
-        skipDestroyOnNextJQueryCleanData = false;
-      }
+//      } else {
+//        skipDestroyOnNextJQueryCleanData = false;
+//      }
       originalCleanData(elems);
     };
   } else {

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2091,7 +2091,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         // that would break if another library patches the method after Angular does (one
         // example is jQuery UI). Instead, set a flag indicating scope destroying should be
         // skipped this one time.
-        skipDestroyOnNextJQueryCleanData = true;
+//        skipDestroyOnNextJQueryCleanData = true;
         jQuery.cleanData([firstElementToRemove]);
       }
 


### PR DESCRIPTION
cc @IgorMinar

This is not a real PR, it's just made to have the tests run to illustrate my point at https://github.com/angular/angular.js/pull/8695#issuecomment-52823441

Test showing that all tests still pass when the skipDestroyOnNextJQueryCleanData flag is removed completely (it used to fail then).
