### PR TITLE
fix(copy): clear array destinations correctly for non-array sources

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -803,6 +803,7 @@ function copy(source, destination, stackSource, stackDest) {
       forEach(destination, function(value, key) {
         delete destination[key];
       });
+      if (isArray(destination)) destination.length = 0;
       for ( var key in source) {
         if(source.hasOwnProperty(key)) {
           result = copy(source[key], null, stackSource, stackDest);

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -184,6 +184,12 @@ describe('angular', function() {
       expect(aCopy).toBe(aCopy.self);
       expect(aCopy.selfs[2]).not.toBe(a.selfs[2]);
     });
+
+    it('should clear destination arrays correctly when source is non-array', function() {
+      expect(copy(null, [1,2,3])).toEqual([]);
+      expect(copy(undefined, [1,2,3])).toEqual([]);
+      expect(copy({0: 1, 1: 2}, [1,2,3])).toEqual([1,2]);
+    });
   });
 
   describe("extend", function() {


### PR DESCRIPTION
Previously, we failed to modify the `length` property of an array destination when
dealing with non-array sources. This CL ensures that the length is correctly reset
to 0 before copying properties from the source object.

While it's not a super-important feature, it's literally a single line of code and
not very difficult to understand

Closes #8610
