### PR TITLE
Update step_07.ngdoc

### DIFF
--- a/docs/content/tutorial/step_07.ngdoc
+++ b/docs/content/tutorial/step_07.ngdoc
@@ -26,15 +26,16 @@ We are using [Bower][bower] to install client side dependencies.  This step upda
 
 ```json
 {
-  "name": "angular-seed",
+  "name": "angular-phonecat",
   "description": "A starter project for AngularJS",
   "version": "0.0.0",
-  "homepage": "https://github.com/angular/angular-seed",
+  "homepage": "https://github.com/angular/angular-phonecat",
   "license": "MIT",
   "private": true,
   "dependencies": {
     "angular": "1.2.x",
     "angular-mocks": "~1.2.x",
+    "jquery": "1.10.2",
     "bootstrap": "~3.1.1",
     "angular-route": "~1.2.x"
   }


### PR DESCRIPTION
Going through the tutorial, I was a little confused when the bower.json example had the name set to angular-seed.  It appears that this is something that was corrected in the angular-phonecat project, but the tutorial documentation hasn't been updated to match.

Changed the example JSON to be the latest bower.json for angular-phonecat step-7.
