### PR TITLE
fix(Angular): Infinite $digest Loop occur when using deep $watch on an o...

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -895,7 +895,8 @@ function equals(o1, o2) {
           return true;
         }
       } else if (isDate(o1)) {
-        return isDate(o2) && o1.getTime() == o2.getTime();
+        if (!isDate(o2)) return false;
+        return (isNaN(o1.getTime()) && isNaN(o2.getTime())) || (o1.getTime() === o2.getTime());
       } else if (isRegExp(o1) && isRegExp(o2)) {
         return o1.toString() == o2.toString();
       } else {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -362,6 +362,11 @@ describe('angular', function() {
       expect(equals(new Date(0), new Date(1))).toBe(false);
       expect(equals(new Date(0), 0)).toBe(false);
       expect(equals(0, new Date(0))).toBe(false);
+
+      expect(equals(new Date(undefined), new Date(undefined))).toBe(true);
+      expect(equals(new Date(undefined), new Date(0))).toBe(false);
+      expect(equals(new Date(undefined), new Date(null))).toBe(false);
+      expect(equals(new Date(undefined), new Date('wrong'))).toBe(true);
     });
 
     it('should correctly test for keys that are present on Object.prototype', function() {


### PR DESCRIPTION
...bject that contains an "Invalid Date"

Add better check for invalid dates in method equals.

fixes #8650
