### PR TITLE
docs(ngResource): detail way to skip default json serialization/deserialization

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -136,10 +136,16 @@ function shallowClearAndCopy(src, dst) {
  *     `{function(data, headersGetter)|Array.<function(data, headersGetter)>}` –
  *     transform function or an array of such functions. The transform function takes the http
  *     request body and headers and returns its transformed (typically serialized) version.
+ *     By default, transformResponse will contain one function that checks if the request data is
+ *     an object and serializes to using angular.toJson. To prevent this behavior, set
+ *     `transformRequest = []`
  *   - **`transformResponse`** –
  *     `{function(data, headersGetter)|Array.<function(data, headersGetter)>}` –
  *     transform function or an array of such functions. The transform function takes the http
  *     response body and headers and returns its transformed (typically deserialized) version.
+ *     By default, transformResponse will contain one function that checks if the response looks like
+ *     a JSON string and deserializes it using angular.fromJson. To prevent this behavior, set
+ *     `transformResponse = []`
  *   - **`cache`** – `{boolean|Cache}` – If true, a default $http cache will be used to cache the
  *     GET request, otherwise if a cache instance built with
  *     {@link ng.$cacheFactory $cacheFactory}, this cache will be used for


### PR DESCRIPTION
docs(ngResource): detail way to skip default json serialization/deserialization

in reference to this pull request, an update in the documentation is the best way to go about it: https://github.com/angular/angular.js/pull/8632
