### PR TITLE
fix(ngRepeat): allow aliasAs identifiers which contain but do not match reserved words

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -267,7 +267,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
       var keyIdentifier = match[2];
 
       if (aliasAs && (!/^[$a-zA-Z_][$a-zA-Z0-9_]*$/.test(aliasAs) ||
-          /^null|undefined|this|\$index|\$first|\$middle|\$last|\$even|\$odd|\$parent$/.test(aliasAs))) {
+          /^(null|undefined|this|\$index|\$first|\$middle|\$last|\$even|\$odd|\$parent)$/.test(aliasAs))) {
         throw ngRepeatMinErr('badident', "alias '{0}' is invalid --- must be a valid JS identifier which is not a reserved name.",
           aliasAs);
       }

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -418,6 +418,36 @@ describe('ngRepeat', function() {
     });
 
 
+    it('should support alias identifiers containing reserved words', inject(function($exceptionHandler) {
+      scope.x = 'bl';
+      scope.items = [
+        { name : 'red' },
+        { name : 'blue' },
+        { name : 'green' },
+        { name : 'black' },
+        { name : 'orange' },
+        { name : 'blonde' }
+      ];
+      forEach([
+        'null2',
+        'qthis',
+        'qthisq',
+        'fundefined',
+        '$$parent'
+      ], function(name) {
+        var expr = 'item in items | filter:x as ' + name + ' track by $index';
+        element = $compile('<div><div ng-repeat="' + expr + '"></div></div>')(scope);
+        scope.$digest();
+        expect(scope[name]).toEqual([
+          { name: 'blue' },
+          { name: 'black' },
+          { name: 'blonde' }
+        ]);
+        dealoc(element);
+      });
+    }));
+
+
     it('should throw if alias identifier is not a simple identifier', inject(function($exceptionHandler) {
       scope.x = 'bl';
       scope.items = [


### PR DESCRIPTION
Currently if a reserved word occurs anywhere within the aliasAs identifier, we
throw. This CL fixes this behaviour by allowing these identifiers, since they
are technically perfectly valid.
