### PR TITLE
Add a warning about the usage of ng-src

### DIFF
--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -122,6 +122,11 @@
  * <img ng-src="http://www.gravatar.com/avatar/{{hash}}"/>
  * ```
  *
+ * <div class="alert alert-warning">Using `ngSrc` with a value that is not undefined will trigger a network call.
+ * In the example above, if `hash` is undefined, a call would be made to *http://www.gravatar.com/avatar/*.
+ * <br />Instead, if you use the following `<img ng-src="{{fullUrl}}"/>`, no network call would be triggered
+ * if the `fullUrl` is undefined.</div>
+ * 
  * @element IMG
  * @param {template} ngSrc any string which can contain `{{}}` markup.
  */


### PR DESCRIPTION
The example is confusing and lead to incorrect usage of ng-src. In development, you may get a DirectoryListing when fetching a resource without the `hash`, but in production if DirectoryListing is disabled, you get a 404.
By adding the warning, the user will be aware of the implication of ng-src.
