### PR TITLE
fix($browser): colon in url causes infinite digest in FF

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -122,7 +122,7 @@ function Browser(window, document, $log, $sniffer) {
   // URL API
   //////////////////////////////////////////////////////////////
 
-  var lastBrowserUrl = location.href,
+  var lastBrowserUrl = location.href.replace(/%3A/g, ":"),
       baseElement = document.find('base'),
       newLocation = null;
 
@@ -175,7 +175,7 @@ function Browser(window, document, $log, $sniffer) {
       // - newLocation is a workaround for an IE7-9 issue with location.replace and location.href
       //   methods not updating location.href synchronously.
       // - the replacement is a workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=407172
-      return newLocation || location.href.replace(/%27/g,"'");
+      return newLocation || location.href.replace(/%27/g,"'").replace(/%3A/g, ":");
     }
   };
 

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -466,6 +466,11 @@ describe('browser', function() {
       expect(browser.url()).toBe("http://ff-bug/?single'quote");
     });
 
+    it('should decode colons to work around FF bug', function() {
+      fakeWindow.location.href = "http://ff-bug/?https%3Awww.google.com";
+      expect(browser.url()).toBe("http://ff-bug/?https:www.google.com");
+    });
+
     it('should not set URL when the URL is already set', function() {
       var current = fakeWindow.location.href;
       sniffer.history = false;


### PR DESCRIPTION
Bug found when an angular app is running in an iframe + has a colon in the query string in Firefox. This stops angular from working until the page is refreshed, errors are: 

```
Error: [$rootScope:infdig] 10 $digest() iterations reached. Aborting!
Watchers fired in the last 5 iterations: [["fn: $locationWatch; newVal: 7; oldVal: 6"],["fn: $locationWatch; newVal: 8; oldVal: 7"],["fn: $locationWatch; newVal: 9; oldVal: 8"],["fn: $locationWatch; newVal: 10; oldVal: 9"],["fn: $locationWatch; newVal: 11; oldVal: 10"]]
```

(fixed with the addition to line 178)
and 

```
Exception { message: "", result: 2147500037, name: "NS_ERROR_FAILURE"}
```

(fixed with the addition to line 125).

What is happening is that Firefox's location.href encodes colons (after string position seven) to %3A. This doesn't match with other encoding and the app gets stuck. For example, we were passing in an absolute url through the query and getting issues; it also happened with the port on localhost. Very similar to: [#920](https://github.com/angular/angular.js/issues/920). 
To reproduce, just run a small app locally in Firefox (I was able to recreate with angular phonecat) in an iframe.  

```
<html>    
    <body>
        <iframe src="http://localhost:8000/app/index.html#/?url=https:www.google.com>
    </body>
</html>
```
