### PR TITLE
chore(shallowCopy): ensure primitives return the src argument

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -825,7 +825,8 @@ function copy(source, destination, stackSource, stackDest) {
 }
 
 /**
- * Creates a shallow copy of an object, an array or a primitive.
+ * Creates a shallow copy of an object or an array, primitives
+ * will return src.  Do not use with primitive wrappers.
  *
  * Assumes that there no proto properties for objects
  */
@@ -844,6 +845,8 @@ function shallowCopy(src, dst) {
         dst[key] = src[key];
       }
     }
+  } else {
+    dst = src;
   }
 
   return dst || src;

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -264,6 +264,10 @@ describe('angular', function() {
     });
 
     it('should handle primitives', function() {
+      var src = 1,
+          dst = 2;
+
+      expect(shallowCopy(src, dst)).toBe(src);
       expect(shallowCopy('test')).toBe('test');
       expect(shallowCopy(3)).toBe(3);
       expect(shallowCopy(true)).toBe(true);


### PR DESCRIPTION
var x = 1,
    y = 2;

y = shallowCopy(x, y);
console.log(y);

Prior to this fix, y would return 2 rather than 1.
