### PR TITLE
Preserve all $$ properties when call shallowClearAndCopy

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -28,10 +28,11 @@ function lookupDottedPath(obj, path) {
  * Create a shallow copy of an object and clear other fields from the destination
  */
 function shallowClearAndCopy(src, dst) {
+  var reg = /^\${2}/;
   dst = dst || {};
 
   angular.forEach(dst, function(value, key){
-    delete dst[key];
+    reg.test(key) || delete dst[key];
   });
 
   for (var key in src) {


### PR DESCRIPTION
ngRepeat directive need this property to keep DOM element.
Otherwise when resource updates, the associated element will be removed and a new same element will be created. 
