### PR TITLE
fix($interpolate): use the first end symbol that forms a valid expression

### DIFF
--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -105,7 +105,7 @@ describe('$interpolate', function() {
       expect(function() {
         $interpolate('{{\\{\\{foo\\}\\}}}')(obj);
       }).toThrowMinErr('$parse', 'lexerr',
-        'Lexer Error: Unexpected next character  at columns 0-0 [\\] in expression [\\{\\{foo\\}\\]');
+        'Lexer Error: Unexpected next character  at columns 0-0 [\\] in expression [\\{\\{foo\\}\\}]');
     }));
 
 
@@ -115,6 +115,14 @@ describe('$interpolate', function() {
     // and maintenance burden of context-sensitive escaping)
     it('should evaluate expressions between escaped start/end symbols', inject(function($interpolate) {
       expect($interpolate('\\{\\{Hello, {{bar}}!\\}\\}')(obj)).toBe('{{Hello, World!}}');
+    }));
+
+    it('should pick the first end symbol location that forms a valid expression', inject(function($interpolate) {
+      expect($interpolate('{{{}}}')(obj)).toBe('{}');
+      expect($interpolate('{{"{{ }}"}}')(obj)).toBe('{{ }}');
+      expect($interpolate('{{{foo: "bar"}}}')(obj)).toBe('{"foo":"bar"}');
+      expect($interpolate('{{{foo: {"bar": "baz"}}}}')(obj)).toBe('{"foo":{"bar":"baz"}}');
+      expect($interpolate('{{[{foo: {"bar": "baz"}}]}}')(obj)).toBe('[{"foo":{"bar":"baz"}}]');
     }));
   });
 


### PR DESCRIPTION
When an interpolation string has multiple end symbol choices, pick the
occurrence that forms a valid expression

Closes #8642
