### PR TITLE
fix(numberFilter): format numbers that round to zero as nonnegative

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -153,6 +153,10 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
     number = +(Math.round(+(number.toString() + 'e' + fractionSize)).toString() + 'e' + -fractionSize);
 
+    if (number === 0) {
+      isNegative = false;
+    }
+
     var fraction = ('' + number).split(DECIMAL_SEP);
     var whole = fraction[0];
     fraction = fraction[1] || '';

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -83,6 +83,11 @@ describe('filters', function() {
       num = formatNumber(123.1, pattern, ',', '.', 3);
       expect(num).toBe('123.100');
     });
+
+    it('should format numbers that round to zero as nonnegative', function(){
+      var num = formatNumber(-0.01, pattern, ',', '.', 1);
+      expect(num).toBe('0.0');
+    });
   });
 
   describe('currency', function() {
@@ -176,7 +181,7 @@ describe('filters', function() {
       expect(number(1e-6, 6)).toEqual('0.000001');
       expect(number(1e-7, 6)).toEqual('0.000000');
 
-      expect(number(-1e-50, 0)).toEqual('-0');
+      expect(number(-1e-50, 0)).toEqual('0');
       expect(number(-1e-6, 6)).toEqual('-0.000001');
       expect(number(-1e-7, 6)).toEqual('-0.000000');
     });


### PR DESCRIPTION
Previously when a negative number was rounded to 0 by the number filter
it would be formatted as a negative number.  This means something like
`{{ -0.01 | number: 1 }}` would output `-0.0`.  Now it will output `0.0`
instead.

Closes #8489
