### PR TITLE
docs(ngRepeat): update step_02.ngdoc with challenge 

### DIFF
--- a/docs/content/tutorial/step_02.ngdoc
+++ b/docs/content/tutorial/step_02.ngdoc
@@ -250,6 +250,8 @@ browser is limited, which results in your karma tests running extremely slow.
             <tr><th>row number</th></tr>
             <tr ng-repeat="i in [0, 1, 2, 3, 4, 5, 6, 7]"><td>{{i+1}}</td></tr>
           </table>
+  
+  Extra points: try and make an 8x8 table using an additional ng-repeat.
 
 * Make the unit test fail by changing `expect(scope.phones.length).toBe(3)` to instead use `toBe(4)`.
 


### PR DESCRIPTION
I tried making a 5x5 table using two ng-repeaters. This showed me that it is the element with the ng-repeat attribute on it that gets repeated, and not only the contents of it. Next time I won't be adding the repeater to the table tag :)
Anyway, this is why I propose to add a little challenge to the readers regarding ng-repeat.
