### PR TITLE
$location.search(search, [paramValue]) documentation now reflects that paramValue can be a Number

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -427,7 +427,7 @@ LocationHashbangInHtml5Url.prototype =
    * If the argument is a hash object containing an array of values, these values will be encoded
    * as duplicate search parameters in the url.
    *
-   * @param {(string|Array<string>|boolean)=} paramValue If `search` is a string, then `paramValue`
+   * @param {(string|Number|Array<string>|boolean)=} paramValue If `search` is a string or a Number, then `paramValue`
    * will override only a single search property.
    *
    * If `paramValue` is an array, it will override the property of the `search` component of


### PR DESCRIPTION
I've amended the documentation to reflect that paramValue can also accept a `Number` as the value to set in the same manner it currently accepts a `string`.  I'm aware of it being used like this at present (without issue that I'm aware of) and so this PR just makes it a recognised usage of the API.
