### PR TITLE
chore(tests): use jquery again in e2e tests

### DIFF
--- a/docs/gulpfile.js
+++ b/docs/gulpfile.js
@@ -42,7 +42,7 @@ gulp.task('assets', ['bower'], function() {
     copyComponent('open-sans-fontface'),
     copyComponent('lunr.js','/*.js'),
     copyComponent('google-code-prettify'),
-    copyComponent('jquery', '/jquery.*'),
+    copyComponent('jquery', '/dist/*.js'),
     copyComponent('marked', '/**/*.js', '../node_modules', 'package.json')
   );
 });


### PR DESCRIPTION
jQuery was not included in e2e tests, but we did not notice it
as Angular fell back to jqlite…
