### PR TITLE
fix(ngRoute): change interpolation to support globbed routes

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -611,7 +611,7 @@ function $RouteProvider(){
         if (i === 0) {
           result.push(segment);
         } else {
-          var segmentMatch = segment.match(/(\w+)(.*)/);
+          var segmentMatch = segment.match(/(\w+)\*?(.*)/);
           var key = segmentMatch[1];
           result.push(params[key]);
           result.push(segmentMatch[2] || '');

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -1175,6 +1175,33 @@ describe('$route', function() {
     });
 
 
+    it('should support globbed route updating',  function() {
+      module(function($routeProvider) {
+        $routeProvider.when('/bar/:foo*', {});
+        $routeProvider.when('/baz/:foo*/edit', {});
+      });
+
+      inject(function($rootScope, $route, $location, $routeParams) {
+        $location.path('/bar/multi/segment/path');
+        $rootScope.$digest();
+        expect($routeParams).toEqual({foo: 'multi/segment/path'});
+        $route.updateParams({foo: 'new'});
+        $rootScope.$digest();
+        expect($routeParams).toEqual({foo: 'new'});
+        $location.path('/baz/multi/segment/path/edit');
+
+        $rootScope.$digest();
+        expect($routeParams).toEqual({foo: 'multi/segment/path'});
+        $route.updateParams({foo: 'new'});
+        $rootScope.$digest();
+        expect($routeParams).toEqual({foo: 'new'});
+        $route.updateParams({foo: 'new/multi'});
+        $rootScope.$digest();
+        expect($routeParams).toEqual({foo: 'new/multi'});
+      });
+    });
+
+
     it('should complain if called without an existing route', inject(function($route) {
       expect($route.updateParams).toThrowMinErr('ngRoute', 'norout');
     }));


### PR DESCRIPTION
Update regex so interpolation of an eager path segment does not
leave behind a *.

Includes new test cases that fail with previous regex.
