### PR TITLE
chore(compare-master-to-stable): make checks for bugfixes better

### DIFF
--- a/compare-master-to-stable.js
+++ b/compare-master-to-stable.js
@@ -145,7 +145,7 @@ then(allInSeries(function (branch) {
         line = line.split(' ');
         var sha = line.shift();
         var msg = line.join(' ');
-        return sha + (msg.toLowerCase().indexOf('fix') === -1 ? '   ' : ' * ') + msg;
+        return sha + ((/fix\([^\)]+\):/i.test(msg))  ? ' * ' : '   ') + msg;
       });
       branch.log = log.map(function (line) {
         return line.substr(41);


### PR DESCRIPTION
The current version alerts you if a docs fix has something like "Fixes typo in
foo", which is not how bugfixes are worded, which makes it harder to find real fixes.
