### PR TITLE
fix(ngEventDirs): execute `blur` and `focus` expression using `scope.$ev...

### DIFF
--- a/test/ng/directive/ngEventDirsSpec.js
+++ b/test/ng/directive/ngEventDirsSpec.js
@@ -39,4 +39,64 @@ describe('event directives', function() {
       expect($rootScope.formSubmitted).toEqual('foo');
     }));
   });
+
+  describe('focus', function() {
+
+    it('should call the listener asynchronously during $apply',
+        inject(function($rootScope, $compile) {
+      element = $compile('<input type="text" ng-focus="focus()">')($rootScope);
+      $rootScope.focus = jasmine.createSpy('focus');
+
+      $rootScope.$apply(function() {
+        element.triggerHandler('focus');
+        expect($rootScope.focus).not.toHaveBeenCalled();
+      });
+
+      expect($rootScope.focus).toHaveBeenCalledOnce();
+    }));
+
+    it('should call the listener synchronously inside of $apply if outside of $apply',
+        inject(function($rootScope, $compile) {
+      element = $compile('<input type="text" ng-focus="focus()" ng-model="value">')($rootScope);
+      $rootScope.focus = jasmine.createSpy('focus').andCallFake(function() {
+        $rootScope.value = 'newValue';
+      });
+
+      element.triggerHandler('focus');
+
+      expect($rootScope.focus).toHaveBeenCalledOnce();
+      expect(element.val()).toBe('newValue');
+    }));
+
+  });
+
+  describe('blur', function() {
+
+    it('should call the listener asynchronously during $apply',
+        inject(function($rootScope, $compile) {
+      element = $compile('<input type="text" ng-blur="blur()">')($rootScope);
+      $rootScope.blur = jasmine.createSpy('blur');
+
+      $rootScope.$apply(function() {
+        element.triggerHandler('blur');
+        expect($rootScope.blur).not.toHaveBeenCalled();
+      });
+
+      expect($rootScope.blur).toHaveBeenCalledOnce();
+    }));
+
+    it('should call the listener synchronously inside of $apply if outside of $apply',
+        inject(function($rootScope, $compile) {
+      element = $compile('<input type="text" ng-blur="blur()" ng-model="value">')($rootScope);
+      $rootScope.blur = jasmine.createSpy('blur').andCallFake(function() {
+        $rootScope.value = 'newValue';
+      });
+
+      element.triggerHandler('blur');
+
+      expect($rootScope.blur).toHaveBeenCalledOnce();
+      expect(element.val()).toBe('newValue');
+    }));
+
+  });
 });

--- a/test/ng/directive/ngKeySpec.js
+++ b/test/ng/directive/ngKeySpec.js
@@ -34,23 +34,5 @@ describe('ngKeyup and ngKeydown directives', function() {
     expect($rootScope.touched).toEqual(true);
   }));
 
-  it('should get called on focus', inject(function($rootScope, $compile) {
-    element = $compile('<input ng-focus="touched = true">')($rootScope);
-    $rootScope.$digest();
-    expect($rootScope.touched).toBeFalsy();
-
-    browserTrigger(element, 'focus');
-    expect($rootScope.touched).toEqual(true);
-  }));
-
-  it('should get called on blur', inject(function($rootScope, $compile) {
-    element = $compile('<input ng-blur="touched = true">')($rootScope);
-    $rootScope.$digest();
-    expect($rootScope.touched).toBeFalsy();
-
-    browserTrigger(element, 'blur');
-    expect($rootScope.touched).toEqual(true);
-  }));
-
 });
 


### PR DESCRIPTION
...alAsync`

BREAKING CHANGE:
The `blur` and `focus` event fire synchronously, also during DOM operations
that add/remove elements. This lead to errors as the Angular model was not
in a consistent state.

This change executes the expression of those events now asynchronously.

Related to #5945
Fixes #4979
