### PR TITLE
Implement a first approach of orderBy filter benchmarks by using benchpress

### DIFF
--- a/benchmarks/filters/app.js
+++ b/benchmarks/filters/app.js
@@ -1,0 +1,41 @@
+var app = angular.module('filtersBenchmark', []);
+
+app.controller('DataController', function($rootScope, $scope) {
+  this.ngRepeatCount = 1000;
+  this.rows = [];
+  var self = this;
+
+  $scope.benchmarkType = 'basic';
+
+  $scope.rawProperty = function(key) {
+    return function(item) {
+      return item[key];
+    };
+  };
+
+  // Returns a random integer between min (included) and max (excluded)
+  function getRandomInt(min, max) {
+    return Math.floor(Math.random() * (max - min)) + min;
+  }
+
+  benchmarkSteps.push({
+    name: '$apply',
+    fn: function() {
+      var oldRows = self.rows;
+      $rootScope.$apply(function() {
+        self.rows = [];
+      });
+      self.rows = oldRows;
+      if (self.rows.length !== self.ngRepeatCount) {
+        self.rows = [];
+        for (var i = 0; i < self.ngRepeatCount; i++) {
+          self.rows.push({
+            'name': getRandomInt(i, (i + 40)),
+            'index': i
+          });
+        }
+      }
+      $rootScope.$apply();
+    }
+  });
+});

--- a/benchmarks/filters/bp.conf.js
+++ b/benchmarks/filters/bp.conf.js
@@ -1,0 +1,10 @@
+module.exports = function(config) {
+  config.set({
+    scripts: [{
+      id: 'angular',
+      src: '/build/angular.js'
+    },{
+      src: 'app.js',
+    }]
+  });
+};

--- a/benchmarks/filters/main.html
+++ b/benchmarks/filters/main.html
@@ -1,0 +1,82 @@
+<div class="container-fluid" ng-app="filtersBenchmark">
+  <div class="row" ng-controller="DataController as ctrl">
+    <div class="col-lg-8">
+      <p>Filters</p>
+
+      <p>
+        <label>Number of ngRepeats:</label>
+        <input type="number" ng-model="ctrl.ngRepeatCount">
+      </p>
+
+      <p>
+        <div class="radio">
+          <label>
+            <input type="radio" ng-model="benchmarkType" value="basic">basic
+          </label>
+        </div>
+        <pre><code>ng-repeat="row in ctrl.rows"</code></pre>
+        <br />
+        <div class="radio">
+          <label>
+            <input type="radio" ng-model="benchmarkType" value="orderBy">orderBy
+          </label>
+        </div>
+        <pre><code>ng-repeat="row in ctrl.rows | orderBy:'name'"</code></pre>
+        <br />
+        <div class="radio">
+          <label>
+            <input type="radio" ng-model="benchmarkType" value="orderByArray">orderBy array expression
+          </label>
+        </div>
+        <pre><code>ng-repeat="row in ctrl.rows | orderBy:['name', 'index']"</code></pre>
+        <br />
+        <div class="radio">
+          <label>
+            <input type="radio" ng-model="benchmarkType" 
+            value="orderByFunction">orderBy function expression
+          </label>
+        </div>
+        <pre><code>ng-repeat="row in ctrl.rows | orderBy:rawProperty('name')"</code></pre>
+        <br />
+        <div class="radio">
+          <label>
+            <input type="radio" ng-model="benchmarkType" 
+            value="orderByArrayFunction">orderBy array function expression
+          </label>
+        </div>
+        <pre><code>ng-repeat="row in ctrl.rows | orderBy:[rawProperty('name'), rawProperty('index')]"</code></pre>
+      </p>
+
+
+      Debug output:
+      <ng-switch on="benchmarkType">
+        <div ng-switch-when="basic">
+          <span ng-repeat="row in ctrl.rows">
+            <span ng-bind="row.name"></span>,
+          </span> 
+        </div>
+        <div ng-switch-when="orderBy">
+          <span ng-repeat="row in ctrl.rows | orderBy:'name'">
+            <span ng-bind="row.name"></span>,
+          </span> 
+        </div>
+        <div ng-switch-when="orderByArray">
+          <span ng-repeat="row in ctrl.rows | orderBy:['name', 'index']">
+            <span ng-bind="row.name"></span>,
+          </span> 
+        </div>
+        <div ng-switch-when="orderByFunction">
+          <span ng-repeat="row in ctrl.rows | orderBy:rawProperty('name')">
+            <span ng-bind="row.name"></span>,
+          </span> 
+        </div>
+        <div ng-switch-when="orderByArrayFunction">
+          <span ng-repeat="row in ctrl.rows | orderBy:[rawProperty('name'), rawProperty('index')]">
+            <span ng-bind="row.name"></span>,
+          </span> 
+        </div>
+      </ng-switch>
+
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Hi @jeffbcross , please take a look this pull request and I'm curious to understand if the way I implementing 
the benchmarks for `orderBy` is correct.

In this commit I try to see the different benchmark between different expression param.
https://docs.angularjs.org/api/ng/filter/orderBy 

About the tool [benchpress](https://github.com/angular/benchpress), I don't really understand the part
`Select number of samples to collect and average:` what really does, because if I change the number does not
looks something happen.

The tool is not hard to set, and for my personal experience the hardest part was figure out what is the best way to test my directive and capture the best realistic benchmark.

In the end I really like that this tool could be an official way cross of all AngularJS directives/filters to test the performance release by release.
