### PR TITLE
docs(jsdoc): remove `@kind function` for providers

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -539,7 +539,6 @@ var $compileMinErr = minErr('$compile');
 /**
  * @ngdoc provider
  * @name $compileProvider
- * @kind function
  *
  * @description
  */

--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -5,7 +5,6 @@ var $interpolateMinErr = minErr('$interpolate');
 /**
  * @ngdoc provider
  * @name $interpolateProvider
- * @kind function
  *
  * @description
  *

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -997,7 +997,6 @@ function getterFn(path, options, fullExp) {
 /**
  * @ngdoc provider
  * @name $parseProvider
- * @kind function
  *
  * @description
  * `$parseProvider` can be used for configuring the default behavior of the {@link ng.$parse $parse}

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -23,7 +23,6 @@ var ngRouteModule = angular.module('ngRoute', ['ng']).
 /**
  * @ngdoc provider
  * @name $routeProvider
- * @kind function
  *
  * @description
  *


### PR DESCRIPTION
As @petebacondarwin wrote in #7425, `@kind function` "is only relevant where we want to be able to tell the difference between a service that is an object and a service that is also callable". Also its presence leads to generation of strange 'Usage' sections in the docs for providers.

![image](https://cloud.githubusercontent.com/assets/94334/4076121/5272fd12-2eb7-11e4-897b-9b8f11adb738.png)
