### PR TITLE
refactor(docs) use $window and add description for code directive

### DIFF
--- a/docs/app/src/directives.js
+++ b/docs/app/src/directives.js
@@ -15,8 +15,15 @@ angular.module('directives', [])
   };
 }])
 
-
-.directive('code', function() {
+/**
+ * code Directive
+ *
+ * @description The code blocks are prettified using google-code-pretify's prettyPrintOne.
+ * The prettyPrintOne function is invoked with `prettyPrintOne(html, lang, linenums)`, where `html` is
+ * the innerHTML of the element, `lang` allows language declaration by adding `class="lang-javascript"`
+ * and `linenums` is boolean which adds line numbers  by adding a class name `linenum`.
+ */
+.directive('code', ['$window', function($window) {
   return {
     restrict: 'E',
     terminal: true,
@@ -25,8 +32,8 @@ angular.module('directives', [])
       var match = /lang-(\S+)/.exec(element[0].className);
       var lang = match && match[1];
       var html = element.html();
-      element.html(window.prettyPrintOne(html, lang, linenums));
+      element.html($window.prettyPrintOne(html, lang, linenums));
     }
   };
-});
+}]);
 

--- a/docs/app/test/directivesSpec.js
+++ b/docs/app/test/directivesSpec.js
@@ -6,18 +6,18 @@ describe("code", function() {
 
   beforeEach(module('directives'));
 
-  beforeEach(inject(function($rootScope, $compile) {
+  beforeEach(inject(function($rootScope, $compile, $window) {
     // Provide stub for pretty print function
-    oldPP = window.prettyPrintOne;
-    prettyPrintOne = window.prettyPrintOne = jasmine.createSpy();
+    oldPP = $window.prettyPrintOne;
+    prettyPrintOne = $window.prettyPrintOne = jasmine.createSpy();
 
     scope = $rootScope.$new();
     compile = $compile;
   }));
 
-  afterEach(function() {
-    window.prettyPrintOne = oldPP;
-  });
+  afterEach(inject(function($window) {
+    $window.prettyPrintOne = oldPP;
+  }));
 
 
   it('should pretty print innerHTML', function() {


### PR DESCRIPTION
- This refactors to use <code>$window</code>, the Angular way instead  of using `window` Object. 
- Also adds documentation to the `code` directive. 

P.S. also signed Contributor License Agreement (CLA). 
