### PR TITLE
perf(select): Execute render after $digest cycle

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -224,6 +224,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
           optionsExp = attr.ngOptions,
           nullOption = false, // if false, user will not be able to select it (used by ngOptions)
           emptyOption,
+          renderScheduled = false,
           // we can't just jqLite('<option>') since jqLite is not smart enough
           // to create it in <select> and IE barfs otherwise.
           optionTemplate = jqLite(document.createElement('option')),
@@ -414,14 +415,16 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
         ctrl.$render = render;
 
         scope.$watchCollection(valuesFn, function () {
-          if (scope.$$postDigestQueue.indexOf(render) === -1) {
+          if (!renderScheduled) {
             scope.$$postDigest(render);
+            renderScheduled = true;
           }
         });
         if ( multiple ) {
           scope.$watchCollection(function() { return ctrl.$modelValue; }, function () {
-            if (scope.$$postDigestQueue.indexOf(render) === -1) {
+            if (!renderScheduled) {
               scope.$$postDigest(render);
+              renderScheduled = true;
             }
           });
         }
@@ -612,6 +615,8 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
           while(optionGroupsCache.length > groupIndex) {
             optionGroupsCache.pop()[0].element.remove();
           }
+
+          renderScheduled = false;
         }
       }
     }

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -413,9 +413,17 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
 
         ctrl.$render = render;
 
-        scope.$watchCollection(valuesFn, render);
+        scope.$watchCollection(valuesFn, function () {
+          if (scope.$$postDigestQueue.indexOf(render) === -1) {
+            scope.$$postDigest(render);
+          }
+        });
         if ( multiple ) {
-          scope.$watchCollection(function() { return ctrl.$modelValue; }, render);
+          scope.$watchCollection(function() { return ctrl.$modelValue; }, function () {
+            if (scope.$$postDigestQueue.indexOf(render) === -1) {
+              scope.$$postDigest(render);
+            }
+          });
         }
 
         function getSelectedSet() {


### PR DESCRIPTION
This is an optimization to defer execution of the render function in the
select directive after the $digest cycle completes inside the
$watchCollection expressions.  This does a check to see if the render
function is already registered in the $$postDigestQueue before it passes
it into $$postDigest, guaranteeing that the DOM manipulation happens
only in one execution after the model settles.
