### PR TITLE
chore(docs) use $document and consistent css property spacing

### DIFF
--- a/docs/app/assets/css/doc_widgets.css
+++ b/docs/app/assets/css/doc_widgets.css
@@ -22,7 +22,7 @@ ul.doc-example > li.doc-example-heading {
 span.nojsfiddle {
   float: right;
   font-size: 14px;
-  margin-right:10px;
+  margin-right: 10px;
   margin-top: 10px;
 }
 
@@ -42,7 +42,7 @@ form.jsfiddle button {
   color: #7989D6;
   border-color: #7989D6;
   -moz-border-radius: 8px;
-  -webkit-border-radius:8px;
+  -webkit-border-radius: 8px;
   border-radius: 8px;
 }
 

--- a/docs/app/assets/css/docs.css
+++ b/docs/app/assets/css/docs.css
@@ -1,21 +1,21 @@
 html, body {
-  position:relative;
-  height:100%;
+  position: relative;
+  height: 100%;
 }
 
 #wrapper {
-  min-height:100%;
-  position:relative;
-  padding-bottom:120px;
+  min-height: 100%;
+  position: relative;
+  padding-bottom: 120px;
 }
 
 .footer {
-  border-top:20px solid white;
-  position:absolute;
-  bottom:0;
-  left:0;
-  right:0;
-  z-index:100;
+  border-top: 20px solid white;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
   padding-top: 2em;
   background-color: #333;
   color: white;
@@ -23,20 +23,20 @@ html, body {
 }
 
 .header-fixed {
-  position:fixed;
-  z-index:1000;
-  top:0;
-  left:0;
-  right:0;
+  position: fixed;
+  z-index: 1000;
+  top: 0;
+  left: 0;
+  right: 0;
 }
 
 .header-branding {
-  min-height:41px!important;
+  min-height: 41px !important;
 }
 
 .docs-navbar-primary {
-  border-radius:0!important;
-  margin-bottom:0!important;
+  border-radius: 0 !important;
+  margin-bottom: 0 !important;
 }
 
 /* Logo */
@@ -49,7 +49,7 @@ h1,h2,h3,h4,h5,h6 {
 }
 
 .subnav-body {
-  margin:70px 0 20px;
+  margin: 70px 0 20px;
 }
 
 .header .brand {
@@ -58,32 +58,32 @@ h1,h2,h3,h4,h5,h6 {
 }
 
 .header .brand img {
-  margin-top:5px;
+  margin-top: 5px;
   height: 30px;
 }
 
 .docs-search {
-  margin:10px 0;
-  padding:4px 0 4px 20px;
-  background:white;
-  border-radius:20px;
-  vertical-align:middle;
+  margin: 10px 0;
+  padding: 4px 0 4px 20px;
+  background: white;
+  border-radius: 20px;
+  vertical-align: middle;
 }
 
 .docs-search > .search-query {
-  font-size:14px;
-  border:0;
-  width:80%;
-  color:#555;
+  font-size: 14px;
+  border: 0;
+  width: 80%;
+  color: #555;
 }
 
 .docs-search > .search-icon {
-  font-size:15px;
-  margin-right:10px;
+  font-size: 15px;
+  margin-right: 10px;
 }
 
 .docs-search > .search-query:focus {
-  outline:0;
+  outline: 0;
 }
 
 /* end: Logo */
@@ -101,86 +101,86 @@ h1,h2,h3,h4,h5,h6 {
 .naked-list,
 .naked-list ul,
 .naked-list li {
-  list-style:none;
-  margin:0;
-  padding:0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .nav-index-section a {
-  font-weight:bold;
+  font-weight: bold;
   font-family: "Open Sans";
-  color:black!important;
-  margin-top:10px;
-  display:block;
+  color: black !important;
+  margin-top: 10px;
+  display: block;
 }
 
 .nav-index-group {
-  margin-bottom:20px!important;
+  margin-bottom: 20px !important;
 }
 
 .nav-index-group-heading {
-  color:#6F0101;
-  font-weight:bold;
-  font-size:1.2em;
-  padding:0;
-  margin:0;
-  border-bottom:1px soild #aaa;
-  margin-bottom:5px;
+  color: #6F0101;
+  font-weight: bold;
+  font-size: 1.2em;
+  padding: 0;
+  margin: 0;
+  border-bottom: 1px soild #aaa;
+  margin-bottom: 5px;
 }
 
 .nav-breadcrumb {
-  margin:4px 0;
-  padding:0;
+  margin: 4px 0;
+  padding: 0;
 }
 
 .nav-breadcrumb-entry {
   font-family: "Open Sans";
-  padding:0;
-  margin:0;
-  font-size:18px;
-  display:inline-block;
-  vertical-align:middle;
+  padding: 0;
+  margin: 0;
+  font-size: 18px;
+  display: inline-block;
+  vertical-align: middle;
 }
 
 .nav-breadcrumb-entry > .divider {
-  color:#555;
-  display:inline-block;
-  padding-left:8px;
+  color: #555;
+  display: inline-block;
+  padding-left: 8px;
 }
 
 .nav-breadcrumb-entry > span,
 .nav-breadcrumb-entry > a {
-  color:#6F0101;
+  color: #6F0101;
 }
 
 .step-list > li:nth-child(1) {
-  padding-left:20px;
+  padding-left: 20px;
 }
 
 .step-list > li:nth-child(2) {
-  padding-left:40px;
+  padding-left: 40px;
 }
 
 .step-list > li:nth-child(3) {
-  padding-left:60px;
+  padding-left: 60px;
 }
 
 .api-profile-header-heading {
-  margin:0;
-  padding:0;
+  margin: 0;
+  padding: 0;
 }
 
 .api-profile-header-structure,
 .api-profile-header-structure a {
   font-family: "Open Sans";
-  font-weight:bold;
-  color:#999;
+  font-weight: bold;
+  color: #999;
 }
 
 .api-profile-section {
-  margin-top:30px;
-  padding-top:30px;
-  border-top:1px solid #aaa;
+  margin-top: 30px;
+  padding-top: 30px;
+  border-top: 1px solid #aaa;
 }
 
 pre {
@@ -192,23 +192,23 @@ pre {
 .aside-nav a:link,
 .aside-nav a:visited,
 .aside-nav a:active {
-  color:#999;
+  color: #999;
 }
 .aside-nav a:hover {
-  color:black;
+  color: black;
 }
 
 .api-profile-description > p:first-child {
-  margin:15px 0;
-  font-size:18px;
+  margin: 15px 0;
+  font-size: 18px;
 }
 
 p > code,
 code.highlighted {
-  background:#f4f4f4;
-  border-radius:5px;
-  padding:2px 5px;
-  color:maroon;
+  background: #f4f4f4;
+  border-radius: 5px;
+  padding: 2px 5px;
+  color: maroon;
 }
 
 ul + p {
@@ -216,8 +216,8 @@ ul + p {
 }
 
 .docs-version-jump {
-  min-width:100%;
-  max-width:100%;
+  min-width: 100%;
+  max-width: 100%;
 }
 
 .picker {
@@ -263,14 +263,14 @@ ul + p {
 }
 
 .picker:after {
-  content:"";
+  content: "";
   position: absolute;
   right: 8%;
   top: 50%;
   z-index: 0;
   color: #999;
   width: 0;
-  margin-top:-2px;
+  margin-top: -2px;
   height: 0;
   border-top: 6px solid;
   border-right: 6px solid transparent;
@@ -283,48 +283,48 @@ iframe.example {
 }
 
 .search-results-frame {
-  clear:both;
-  display:table;
-  width:100%;
+  clear: both;
+  display: table;
+  width: 100%;
 }
 
 .search-results.ng-hide {
-  display:none;
+  display: none;
 }
 
 .search-results-container {
-  padding-bottom:1em;
-  border-top:1px solid #111;
-  background:#181818;
-  box-shadow:inset 0 0 10px #111;
+  padding-bottom: 1em;
+  border-top: 1px solid #111;
+  background: #181818;
+  box-shadow: inset 0 0 10px #111;
 }
 
 .search-results-container .search-results-group {
-  vertical-align:top;
-  padding:10px 10px;
-  display:inline-block;
+  vertical-align: top;
+  padding: 10px 10px;
+  display: inline-block;
 }
 
 .search-results-group-heading {
   font-family: "Open Sans";
-  padding-left:10px;
-  color:white;
+  padding-left: 10px;
+  color: white;
 }
 
 .search-results-frame > .search-results-group:first-child > .search-results {
-  border-right:1px solid #050505;
+  border-right: 1px solid #050505;
 }
 
-.search-results-group.col-group-api { width:30%; }
-.search-results-group.col-group-guide { width:30%; }
-.search-results-group.col-group-tutorial { width:25%; }
+.search-results-group.col-group-api { width: 30%; }
+.search-results-group.col-group-guide { width: 30%; }
+.search-results-group.col-group-tutorial { width: 25%; }
 .search-results-group.col-group-misc,
-.search-results-group.col-group-error { float:right; clear:both; width:15% }
+.search-results-group.col-group-error { float: right; clear: both; width: 15% }
 
 
 .search-results-group.col-group-api .search-result {
-  width:48%;
-  display:inline-block;
+  width: 48%;
+  display: inline-block;
 }
 
 .search-close {
@@ -339,135 +339,135 @@ iframe.example {
   border-top-right-radius: 5px;
   border-top-left-radius: 5px;
   width: 200px;
-  box-shadow:0 0 10px #111;
+  box-shadow: 0 0 10px #111;
 }
 
 .variables-matrix {
-  border:1px solid #ddd;
-  width:100%;
-  margin:10px 0;
+  border: 1px solid #ddd;
+  width: 100%;
+  margin: 10px 0;
 }
 
 .variables-matrix td,
 .variables-matrix th {
-  padding:10px;
+  padding: 10px;
 }
 
 .variables-matrix td {
-  border-top:1px solid #eee;
+  border-top: 1px solid #eee;
 }
 
 .variables-matrix td + td,
 .variables-matrix th + th {
-  border-left:1px solid #eee;
+  border-left: 1px solid #eee;
 }
 
 .variables-matrix tr:nth-child(even) td {
-  background:#f5f5f5;
+  background: #f5f5f5;
 }
 
 .variables-matrix th {
-  background:#f1f1f1;
+  background: #f1f1f1;
 }
 
 .sup-header {
-  padding-top:10px;
-  padding-bottom:5px;
-  background:rgba(245,245,245,0.88);
-  box-shadow:0 0 2px #999;
+  padding-top: 10px;
+  padding-bottom: 5px;
+  background: rgba(245,245,245,0.88);
+  box-shadow: 0 0 2px #999;
 }
 
 .main-body-grid {
-  margin-top:120px;
-  position:relative;
+  margin-top: 120px;
+  position: relative;
 }
 
 .main-body-grid > .grid-left,
 .main-body-grid > .grid-right {
-  padding:20px 0;
+  padding: 20px 0;
 }
 
 .main-body-grid > .grid-left {
-  position:fixed;
-  top:120px;
-  bottom:0;
-  padding-bottom:120px;
-  overflow:auto;
+  position: fixed;
+  top: 120px;
+  bottom: 0;
+  padding-bottom: 120px;
+  overflow: auto;
 }
 
 .main-header-grid > .grid-left,
 .main-body-grid > .grid-left {
-  width:260px;
+  width: 260px;
 }
 
 .main-header-grid > .grid-right,
 .main-body-grid > .grid-right {
-  margin-left:270px;
-  position:relative;
+  margin-left: 270px;
+  position: relative;
 }
 
 .main-header-grid > .grid-left {
-  float:left;
+  float: left;
 }
 
 .main-body-grid .side-navigation {
-  position:relative;
+  position: relative;
 }
 
 .main-body-grid .side-navigation.ng-hide {
-  display:block!important;
+  display: block!important;
 }
 
 .variables-matrix td {
-  vertical-align:top;
-  padding:5px;
+  vertical-align: top;
+  padding: 5px;
 }
 
 .type-hint {
-  display:inline-block;
+  display: inline-block;
   background: gray;
 }
 
 .variables-matrix .type-hint {
-  text-align:center;
-  min-width:60px;
-  margin:1px 5px;
+  text-align: center;
+  min-width: 60px;
+  margin: 1px 5px;
 }
 
 .type-hint + .type-hint {
-  margin-top:5px;
+  margin-top: 5px;
 }
 
 .type-hint-expression {
-  background:purple;
+  background: purple;
 }
 
 .type-hint-date {
-  background:pink;
+  background: pink;
 }
 
 .type-hint-string {
-  background:#3a87ad;
+  background: #3a87ad;
 }
 
 .type-hint-function {
-  background:green;
+  background: green;
 }
 
 .type-hint-object {
-  background:#999;
+  background: #999;
 }
 
 .type-hint-array {
-  background:#F90;;
+  background: #F90;;
 }
 
 .type-hint-boolean {
-  background:rgb(18, 131, 39);
+  background: rgb(18, 131, 39);
 }
 
 .type-hint-number {
-  background:rgb(189, 63, 66);
+  background: rgb(189, 63, 66);
 }
 
 .type-hint-regexp {
@@ -479,19 +479,19 @@ iframe.example {
 }
 
 .runnable-example-frame {
-  width:100%;
-  height:300px;
+  width: 100%;
+  height: 300px;
   border: 1px solid #ddd;
-  border-radius:5px;
+  border-radius: 5px;
 }
 
 .runnable-example-tabs {
-  margin-top:10px;
-  margin-bottom:20px;
+  margin-top: 10px;
+  margin-bottom: 20px;
 }
 
 .tutorial-nav {
-  display:block;
+  display: block;
 }
 
 h1 + ul, h1 + ul > li,
@@ -500,23 +500,23 @@ ul.tutorial-nav, ul.tutorial-nav > li,
 .usage > ul, .usage > ul > li,
 ul.methods, ul.methods > li,
 ul.events, ul.events > li {
-  list-style:none;
-  padding:0;
+  list-style: none;
+  padding: 0;
 }
 
 h2 {
-  border-top:1px solid #eee;
-  margin-top:30px;
-  padding-top:30px;
+  border-top: 1px solid #eee;
+  margin-top: 30px;
+  padding-top: 30px;
 }
 
 h4 {
-  margin-top:20px;
-  padding-top:20px;
+  margin-top: 20px;
+  padding-top: 20px;
 }
 
 .btn {
-  color:#428bca;
+  color: #428bca;
   position: relative;
   width: auto;
   display: inline-block;
@@ -539,26 +539,26 @@ h4 {
 }
 
 .btn + .btn {
-  margin-left:10px;
+  margin-left: 10px;
 }
 
 .btn:hover {
-  color:black!important;
-  border: 1px solid #ddd!important;
-  background:white!important;
+  color: black !important;
+  border: 1px solid #ddd !important;
+  background: white !important;
 }
 
 .view-source, .improve-docs {
-  position:relative;
-  z-index:100;
+  position: relative;
+  z-index: 100;
 }
 
 .view-source {
-  margin-right:10px;
+  margin-right: 10px;
 }
 
 .improve-docs {
-  float:right;
+  float: right;
 }
 
 .return-arguments,
@@ -566,17 +566,17 @@ h4 {
 .return-arguments th + th,
 .return-arguments td,
 .return-arguments td + td {
-  border-radius:0;
-  border:0;
+  border-radius: 0;
+  border: 0;
 }
 
 .return-arguments td:first-child {
-  width:100px;
+  width: 100px;
 }
 
 ul.methods > li,
 ul.events > li {
-  margin-bottom:40px;
+  margin-bottom: 40px;
 }
 
 @media only screen and (min-width: 769px) and (max-width: 991px) {
@@ -590,63 +590,63 @@ ul.events > li {
 
 @media only screen and (max-width : 768px) {
   .picker, .picker select {
-    width:auto;
-    display:block;
-    margin-bottom:10px;
+    width: auto;
+    display: block;
+    margin-bottom: 10px;
   }
   .docs-navbar-primary {
-    text-align:center;
+    text-align: center;
   }
   .main-body-grid {
-    margin-top:0;
+    margin-top: 0;
   }
   .main-header-grid > .grid-left,
   .main-body-grid > .grid-left,
   .main-header-grid > .grid-right,
   .main-body-grid > .grid-right {
-    display:block;
-    float:none;
-    width:auto!important;
-    margin-left:0;
+    display: block;
+    float: none;
+    width: auto !important;
+    margin-left: 0;
   }
   .main-body-grid > .grid-left,
   .header-fixed, .footer {
-    position:static!important;
+    position: static !important;
   }
   .main-body-grid > .grid-left {
-    background:#efefef;
-    margin-left:-1em;
-    margin-right:-1em;
-    padding:1em;
-    width:auto!important;
-    overflow:visible;
+    background: #efefef;
+    margin-left: -1em;
+    margin-right: -1em;
+    padding: 1em;
+    width: auto !important;
+    overflow: visible;
   }
   .main-header-grid > .grid-right,
   .main-body-grid > .grid-right {
-    margin-left:0;
+    margin-left: 0;
   }
   .main-body-grid .side-navigation {
-    display:block!important;
+    display: block !important;
   }
   .main-body-grid .side-navigation.ng-hide {
-    display:none!important;
+    display: none !important;
   }
   .nav-index-group .nav-index-listing {
-    display:inline-block;
-    padding:3px 0;
+    display: inline-block;
+    padding: 3px 0;
   }
   .nav-index-group .nav-index-listing:not(.nav-index-section) + .nav-index-listing:not(.nav-index-section):after {
-      padding-right:5px;
-      content:",  ";
+      padding-right: 5px;
+      content: ",  ";
   }
   .nav-index-group .nav-index-listing:last-child {
-    content:"";
+    content: "";
   }
   .nav-index-group .nav-index-section {
-    display:block;
+    display: block;
   }
   .toc-toggle {
-    margin-bottom:20px;
+    margin-bottom: 20px;
   }
   .toc-close {
     position: absolute;
@@ -658,33 +658,33 @@ ul.events > li {
     background: #eee;
     border-radius: 5px;
     width: 90%;
-    border:1px solid #ddd;
-    box-shadow:0 0 10px #bbb;
+    border: 1px solid #ddd;
+    box-shadow: 0 0 10px #bbb;
   }
   .navbar-brand {
-    float:none;
-    text-align:center;
+    float: none;
+    text-align: center;
   }
   .search-results-container {
-    padding-bottom:60px;
-    text-align:left;
+    padding-bottom: 60px;
+    text-align: left;
   }
   .search-results-group {
-    float:none!important;
-    display:block!important;
-    width:auto!important;
-    border:0!important;
-    padding:0!important;
+    float: none !important;
+    display: block !important;
+    width: auto !important;
+    border: 0! important;
+    padding: 0! important;
   }
   .search-results-group .search-result {
-    display:inline-block!important;
-    padding:0 5px;
-    width:auto!important;
+    display: inline-block !important;
+    padding: 0 5px;
+    width: auto !important;
   }
   .search-results-group .search-result:after {
-    content:", ";
+    content: ", ";
   }
   #wrapper {
-    padding-bottom:0px;
+    padding-bottom: 0px;
   }
 }

--- a/docs/app/src/search.js
+++ b/docs/app/src/search.js
@@ -127,13 +127,13 @@ angular.module('search', [])
   };
 })
 
-.directive('docsSearchInput', ['$document',function($document) {
+.directive('docsSearchInput', ['$document', function($document) {
   return function(scope, element, attrs) {
     var ESCAPE_KEY_KEYCODE = 27,
         FORWARD_SLASH_KEYCODE = 191;
     angular.element($document[0].body).on('keydown', function(event) {
       var input = element[0];
-      if(event.keyCode == FORWARD_SLASH_KEYCODE && document.activeElement != input) {
+      if(event.keyCode == FORWARD_SLASH_KEYCODE && $document[0].activeElement != input) {
         event.stopPropagation();
         event.preventDefault();
         input.focus();


### PR DESCRIPTION
This PR addresses two things:
- Fixes a spacing issue in line [130](https://github.com/sathify/angular.js/blob/d603be48702e5c791ee68ae83cecdf5a7cadabc9/docs/app/src/search.js#L130) & uses `$document[0]`  in line [136](https://github.com/sathify/angular.js/blob/d603be48702e5c791ee68ae83cecdf5a7cadabc9/docs/app/src/search.js#L136) to be consistent with line [134](https://github.com/sathify/angular.js/blob/d603be48702e5c791ee68ae83cecdf5a7cadabc9/docs/app/src/search.js#L134). Both diff in [this file](https://github.com/sathify/angular.js/compare/angular:master...sathify:fix-styles-typo?expand=1#diff-7cf20216c891e60c1e004397cf1dafa4R129).
- Adds a space after ':' in CSS property declarations where they don't exist for consistency and readability.

Please note: none of the CSS property has been altered in the PR so it does not change any style or look of the docs site. Simply makes it a little more consistent in property declarations. The docs CSS however is messy and could use a larger refactor. I'm not sure about the priority and if there are any plans but I'm more than willing to help refactor/organize/rewrite it. 
