### PR TITLE
feat(cookies): Expose setting of expiration for $cookies

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -22,7 +22,7 @@
  * @param {object} $log console.log or an object with the same interface.
  * @param {object} $sniffer $sniffer service
  */
-function Browser(window, document, $log, $sniffer) {
+function Browser(window, document, $log, $sniffer, expiry) {
   var self = this,
       rawDocument = document[0],
       location = window.location,
@@ -291,8 +291,11 @@ function Browser(window, document, $log, $sniffer) {
 
     if (name) {
       if (value === undefined) {
+        if (!expiry) {
+          expiry = 'Thu, 01 Jan 1970 00:00:00 GMT';
+        }
         rawDocument.cookie = encodeURIComponent(name) + "=;path=" + cookiePath +
-                                ";expires=Thu, 01 Jan 1970 00:00:00 GMT";
+                                ";expires=" + expiry;
       } else {
         if (isString(value)) {
           cookieLength = (rawDocument.cookie = encodeURIComponent(name) + '=' + encodeURIComponent(value) +
@@ -383,8 +386,11 @@ function Browser(window, document, $log, $sniffer) {
 }
 
 function $BrowserProvider(){
+  var self = this;
+  this.$$cookieExpiry = null;
+
   this.$get = ['$window', '$log', '$sniffer', '$document',
       function( $window,   $log,   $sniffer,   $document){
-        return new Browser($window, $document, $log, $sniffer);
+        return new Browser($window, $document, $log, $sniffer, self.$$cookieExpiry);
       }];
 }

--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -43,84 +43,102 @@ angular.module('ngCookies', ['ng']).
    *   }]);
    * ```
    */
-   factory('$cookies', ['$rootScope', '$browser', function ($rootScope, $browser) {
-      var cookies = {},
-          lastCookies = {},
-          lastBrowserCookies,
-          runEval = false,
-          copy = angular.copy,
-          isUndefined = angular.isUndefined;
-
-      //creates a poller fn that copies all cookies from the $browser to service & inits the service
-      $browser.addPollFn(function() {
-        var currentCookies = $browser.cookies();
-        if (lastBrowserCookies != currentCookies) { //relies on browser.cookies() impl
-          lastBrowserCookies = currentCookies;
-          copy(currentCookies, lastCookies);
-          copy(currentCookies, cookies);
-          if (runEval) $rootScope.$apply();
-        }
-      })();
-
-      runEval = true;
-
-      //at the end of each eval, push cookies
-      //TODO: this should happen before the "delayed" watches fire, because if some cookies are not
-      //      strings or browser refuses to store some cookies, we update the model in the push fn.
-      $rootScope.$watch(push);
-
-      return cookies;
 
 
-      /**
-       * Pushes all the cookies from the service to the browser and verifies if all cookies were
-       * stored.
-       */
-      function push() {
-        var name,
-            value,
-            browserCookies,
-            updated;
+  /**
+   * @ngdoc provider
+   * @name $cookiesProvider
+   * @description
+   * Use `$cookiesProvider` to change the default expiration of the cookie.
+   * */
+   provider('$cookies', ['$browserProvider', function($browserProvider) {
+    /**
+     * @ngdoc method
+     * @name $cookiesProvider#setExpiry
+     * @param {string} expiry Expiration date to be set on cookie.
+     **/
+      this.setExpiry = function (expiry) {
+        $browserProvider.$$cookieExpiry = expiry;
+      };
+      this.$get = ['$rootScope', '$browser', function ($rootScope, $browser) {
+        var cookies = {},
+            lastCookies = {},
+            lastBrowserCookies,
+            runEval = false,
+            copy = angular.copy,
+            isUndefined = angular.isUndefined;
 
-        //delete any cookies deleted in $cookies
-        for (name in lastCookies) {
-          if (isUndefined(cookies[name])) {
-            $browser.cookies(name, undefined);
+        //creates a poller fn that copies all cookies from the $browser to service & inits the service
+        $browser.addPollFn(function() {
+          var currentCookies = $browser.cookies();
+          if (lastBrowserCookies != currentCookies) { //relies on browser.cookies() impl
+            lastBrowserCookies = currentCookies;
+            copy(currentCookies, lastCookies);
+            copy(currentCookies, cookies);
+            if (runEval) $rootScope.$apply();
           }
-        }
+        })();
 
-        //update all cookies updated in $cookies
-        for(name in cookies) {
-          value = cookies[name];
-          if (!angular.isString(value)) {
-            value = '' + value;
-            cookies[name] = value;
+        runEval = true;
+
+        //at the end of each eval, push cookies
+        //TODO: this should happen before the "delayed" watches fire, because if some cookies are not
+        //      strings or browser refuses to store some cookies, we update the model in the push fn.
+        $rootScope.$watch(push);
+
+        return cookies;
+
+
+        /**
+         * Pushes all the cookies from the service to the browser and verifies if all cookies were
+         * stored.
+         */
+        function push() {
+          var name,
+              value,
+              browserCookies,
+              updated;
+
+          //delete any cookies deleted in $cookies
+          for (name in lastCookies) {
+            if (isUndefined(cookies[name])) {
+              $browser.cookies(name, undefined);
+            }
           }
-          if (value !== lastCookies[name]) {
-            $browser.cookies(name, value);
-            updated = true;
-          }
-        }
 
-        //verify what was actually stored
-        if (updated){
-          updated = false;
-          browserCookies = $browser.cookies();
-
-          for (name in cookies) {
-            if (cookies[name] !== browserCookies[name]) {
-              //delete or reset all cookies that the browser dropped from $cookies
-              if (isUndefined(browserCookies[name])) {
-                delete cookies[name];
-              } else {
-                cookies[name] = browserCookies[name];
-              }
+          //update all cookies updated in $cookies
+          for(name in cookies) {
+            value = cookies[name];
+            if (!angular.isString(value)) {
+              value = '' + value;
+              cookies[name] = value;
+            }
+            if (value !== lastCookies[name]) {
+              $browser.cookies(name, value);
               updated = true;
             }
           }
+
+          //verify what was actually stored
+          if (updated){
+            updated = false;
+            browserCookies = $browser.cookies();
+
+            for (name in cookies) {
+              if (cookies[name] !== browserCookies[name]) {
+                //delete or reset all cookies that the browser dropped from $cookies
+                if (isUndefined(browserCookies[name])) {
+                  delete cookies[name];
+                } else {
+                  cookies[name] = browserCookies[name];
+                }
+                updated = true;
+              }
+            }
+          }
         }
-      }
-    }]).
+      }];
+   }]).
 
 
   /**

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -23,6 +23,7 @@ angular.mock = {};
  * that there are several helper methods available which can be used in tests.
  */
 angular.mock.$BrowserProvider = function() {
+  this.$$cookieExpiry = null;
   this.$get = function() {
     return new angular.mock.$Browser();
   };
@@ -35,6 +36,8 @@ angular.mock.$Browser = function() {
   self.$$url = "http://server/";
   self.$$lastUrl = self.$$url; // used by url polling fn
   self.pollFns = [];
+  self.$$expiry = angular.mock.$BrowserProvider.$$cookieExpiry ||
+    'Thu, 01 Jan 1970 00:00:00 GMT';
 
   // TODO(vojta): remove this temporary api
   self.$$completeOutstandingRequest = angular.noop;


### PR DESCRIPTION
This makes a modification on $browser in order
to optionally expose setting the expiration date on a cookie, as well as
the necessary modification on $cookies in order to support a public
facing api.
