### PR TITLE
feat(dateFilter): Add option to display date as am/pm

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -267,8 +267,11 @@ function weekGetter(size) {
    };
 }
 
-function ampmGetter(date, formats) {
-  return date.getHours() < 12 ? formats.AMPMS[0] : formats.AMPMS[1];
+function ampmGetter(capitalLetters) {
+  var ampms = (capitalLetters) ? 'AMPMS' : 'ampms';
+  return function(date, formats) {
+    return date.getHours() < 12 ? formats[ampms][0] : formats[ampms][1];
+  };
 }
 
 var DATE_FORMATS = {
@@ -294,13 +297,14 @@ var DATE_FORMATS = {
    sss: dateGetter('Milliseconds', 3),
   EEEE: dateStrGetter('Day'),
    EEE: dateStrGetter('Day', true),
-     a: ampmGetter,
+     a: ampmGetter(false),
+     A: ampmGetter(true),
      Z: timeZoneGetter,
     ww: weekGetter(2),
      w: weekGetter(1)
 };
 
-var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZEw']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|Z|w+))(.*)/,
+var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaAZEw']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|A|Z|w+))(.*)/,
     NUMBER_STRING = /^\-?\d+$/;
 
 /**
@@ -333,7 +337,8 @@ var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZEw']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d
  *   * `'ss'`: Second in minute, padded (00-59)
  *   * `'s'`: Second in minute (0-59)
  *   * `'.sss' or ',sss'`: Millisecond in second, padded (000-999)
- *   * `'a'`: am/pm marker
+ *   * `'a'`: am/pm marker, lowercase (am/pm)
+ *   * `'A'`: am/pm marker, uppercase (AM/PM)
  *   * `'Z'`: 4 digit (+sign) representation of the timezone offset (-1200-+1200)
  *   * `'ww'`: ISO-8601 week of year (00-53)
  *   * `'w'`: ISO-8601 week of year (0-53)
@@ -341,16 +346,16 @@ var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZEw']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d
  *   `format` string can also be one of the following predefined
  *   {@link guide/i18n localizable formats}:
  *
- *   * `'medium'`: equivalent to `'MMM d, y h:mm:ss a'` for en_US locale
+ *   * `'medium'`: equivalent to `'MMM d, y h:mm:ss A'` for en_US locale
  *     (e.g. Sep 3, 2010 12:05:08 pm)
- *   * `'short'`: equivalent to `'M/d/yy h:mm a'` for en_US  locale (e.g. 9/3/10 12:05 pm)
+ *   * `'short'`: equivalent to `'M/d/yy h:mm A'` for en_US  locale (e.g. 9/3/10 12:05 pm)
  *   * `'fullDate'`: equivalent to `'EEEE, MMMM d, y'` for en_US  locale
  *     (e.g. Friday, September 3, 2010)
  *   * `'longDate'`: equivalent to `'MMMM d, y'` for en_US  locale (e.g. September 3, 2010)
  *   * `'mediumDate'`: equivalent to `'MMM d, y'` for en_US  locale (e.g. Sep 3, 2010)
  *   * `'shortDate'`: equivalent to `'M/d/yy'` for en_US locale (e.g. 9/3/10)
- *   * `'mediumTime'`: equivalent to `'h:mm:ss a'` for en_US locale (e.g. 12:05:08 pm)
- *   * `'shortTime'`: equivalent to `'h:mm a'` for en_US locale (e.g. 12:05 pm)
+ *   * `'mediumTime'`: equivalent to `'h:mm:ss A'` for en_US locale (e.g. 12:05:08 pm)
+ *   * `'shortTime'`: equivalent to `'h:mm A'` for en_US locale (e.g. 12:05 pm)
  *
  *   `format` string can contain literal values. These need to be escaped by surrounding with single quotes (e.g.
  *   `"h 'in the morning'"`). In order to output a single quote, escape it - i.e., two single quotes in a sequence

--- a/src/ng/locale.js
+++ b/src/ng/locale.js
@@ -52,14 +52,15 @@ function $LocaleProvider(){
         DAY: 'Sunday,Monday,Tuesday,Wednesday,Thursday,Friday,Saturday'.split(','),
         SHORTDAY: 'Sun,Mon,Tue,Wed,Thu,Fri,Sat'.split(','),
         AMPMS: ['AM','PM'],
-        medium: 'MMM d, y h:mm:ss a',
-        short: 'M/d/yy h:mm a',
+        ampms: ['am', 'pm'],
+        medium: 'MMM d, y h:mm:ss A',
+        short: 'M/d/yy h:mm A',
         fullDate: 'EEEE, MMMM d, y',
         longDate: 'MMMM d, y',
         mediumDate: 'MMM d, y',
         shortDate: 'M/d/yy',
-        mediumTime: 'h:mm:ss a',
-        shortTime: 'h:mm a'
+        mediumTime: 'h:mm:ss A',
+        shortTime: 'h:mm A'
       },
 
       pluralCat: function(num) {

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -244,18 +244,24 @@ describe('filters', function() {
                       toEqual('10-09-03 07:05:08.001');
 
       expect(date(midnight, "yyyy-M-d h=H:m:saZ")).
-                      toEqual('2010-9-3 12=0:5:8AM-0500');
+                      toEqual('2010-9-3 12=0:5:8am-0500');
 
       expect(date(midnight, "yyyy-MM-dd hh=HH:mm:ssaZ")).
-                      toEqual('2010-09-03 12=00:05:08AM-0500');
+                      toEqual('2010-09-03 12=00:05:08am-0500');
 
       expect(date(midnight, "yyyy-MM-dd hh=HH:mm:ss.sssaZ")).
+                      toEqual('2010-09-03 12=00:05:08.123am-0500');
+
+      expect(date(midnight, "yyyy-MM-dd hh=HH:mm:ss.sssAZ")).
                       toEqual('2010-09-03 12=00:05:08.123AM-0500');
 
       expect(date(noon, "yyyy-MM-dd hh=HH:mm:ssaZ")).
-                      toEqual('2010-09-03 12=12:05:08PM-0500');
+                      toEqual('2010-09-03 12=12:05:08pm-0500');
 
       expect(date(noon, "yyyy-MM-dd hh=HH:mm:ss.sssaZ")).
+                      toEqual('2010-09-03 12=12:05:08.012pm-0500');
+
+      expect(date(noon, "yyyy-MM-dd hh=HH:mm:ss.sssAZ")).
                       toEqual('2010-09-03 12=12:05:08.012PM-0500');
 
       expect(date(noon, "EEE, MMM d, yyyy")).
@@ -301,12 +307,12 @@ describe('filters', function() {
 
     it('should treat single quoted strings as string literals', function() {
       expect(date(midnight, "yyyy'de' 'a'x'dd' 'adZ' h=H:m:saZ")).
-                      toEqual('2010de axdd adZ 12=0:5:8AM-0500');
+                      toEqual('2010de axdd adZ 12=0:5:8am-0500');
     });
 
     it('should treat a sequence of two single quotes as a literal single quote', function() {
       expect(date(midnight, "yyyy'de' 'a''dd' 'adZ' h=H:m:saZ")).
-                      toEqual("2010de a'dd adZ 12=0:5:8AM-0500");
+                      toEqual("2010de a'dd adZ 12=0:5:8am-0500");
     });
 
     it('should accept default formats', function() {


### PR DESCRIPTION
This adds a new option in order to choose whether to display a date as
AM/PM or am/pm.

Note: This contains a breaking change.  `a` now will display am/pm,
whereas the old behavior is specified by `A` for AM/PM.

This is in support of #8763 .
