### PR TITLE
Added log enablers/disablers for all logger types on $logProvider

### DIFF
--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -45,6 +45,10 @@
  */
 function $LogProvider(){
   var debug = true,
+      error = true,
+      warn = true,
+      info = true,
+      log = true,
       self = this;
 
   /**
@@ -63,6 +67,69 @@ function $LogProvider(){
     }
   };
 
+  /**
+   * @ngdoc method
+   * @name $logProvider#errorEnabled
+   * @description
+   * @param {boolean=} flag enable or disable error level messages
+   * @returns {*} current value if used as getter or itself (chaining) if used as setter
+   */
+  this.errorEnabled = function(flag) {
+    if (isDefined(flag)){
+      error = flag;
+    return this;
+    } else {
+      return error;
+    }
+  };
+
+  /**
+   * @ngdoc method
+   * @name $logProvider#warnEnabled
+   * @description
+   * @param {boolean=} flag enable or disable warn level messages
+   * @returns {*} current value if used as getter or itself (chaining) if used as setter
+   */
+  this.warnEnabled = function(flag) {
+    if (isDefined(flag)){
+      warn = flag;
+    return this;
+    } else {
+      return warn;
+    }
+  };
+
+  /**
+   * @ngdoc method
+   * @name $logProvider#infoEnabled
+   * @description
+   * @param {boolean=} flag enable or disable info level messages
+   * @returns {*} current value if used as getter or itself (chaining) if used as setter
+   */
+  this.infoEnabled = function(flag) {
+    if (isDefined(flag)){
+      info = flag;
+    } else {
+      return info;
+    }
+  };
+
+  /**
+   * @ngdoc method
+   * @name $logProvider#logEnabled
+   * @description
+   * @param {boolean=} flag enable or disable log level messages
+   * @returns {*} current value if used as getter or itself (chaining) if used as setter
+   */
+  this.logEnabled = function(flag) {
+    if (isDefined(flag)){
+      log = flag;
+    return this;
+    } else {
+      return log;
+    }
+  };
+
   this.$get = ['$window', function($window){
     return {
       /**
@@ -72,8 +139,15 @@ function $LogProvider(){
        * @description
        * Write a log message
        */
-      log: consoleLog('log'),
+      log: (function () {
+        var fn = consoleLog('log');
 
+        return function() {
+          if (log) {
+            fn.apply(self, arguments);
+          }
+        };
+      }()),
       /**
        * @ngdoc method
        * @name $log#info
@@ -81,7 +155,15 @@ function $LogProvider(){
        * @description
        * Write an information message
        */
-      info: consoleLog('info'),
+      info: (function () {
+        var fn = consoleLog('info');
+
+        return function() {
+          if (info) {
+            fn.apply(self, arguments);
+          }
+        };
+      }()),
 
       /**
        * @ngdoc method
@@ -90,7 +172,15 @@ function $LogProvider(){
        * @description
        * Write a warning message
        */
-      warn: consoleLog('warn'),
+      warn: (function () {
+        var fn = consoleLog('warn');
+
+        return function() {
+          if (warn) {
+            fn.apply(self, arguments);
+          }
+        };
+      }()),
 
       /**
        * @ngdoc method
@@ -99,7 +189,15 @@ function $LogProvider(){
        * @description
        * Write an error message
        */
-      error: consoleLog('error'),
+      error: (function () {
+        var fn = consoleLog('error');
+
+        return function() {
+          if (error) {
+            fn.apply(self, arguments);
+          }
+        };
+      }()),
 
       /**
        * @ngdoc method

--- a/test/ng/logSpec.js
+++ b/test/ng/logSpec.js
@@ -1,11 +1,16 @@
 /* global $LogProvider: false */
 'use strict';
 
-function initService(debugEnabled) {
+function initService(enableDict) {
     return module(function($logProvider){
-      $logProvider.debugEnabled(debugEnabled);
+      $logProvider.logEnabled(enableDict.log);
+      $logProvider.infoEnabled(enableDict.info);
+      $logProvider.warnEnabled(enableDict.warn);
+      $logProvider.errorEnabled(enableDict.error);
+      $logProvider.debugEnabled(enableDict.debug);
     });
   }
+
 
 describe('$log', function() {
   var $window, logger, log, warn, info, error, debug;
@@ -119,7 +124,9 @@ describe('$log', function() {
 
   describe("$log.debug", function () {
 
-    beforeEach(initService(false));
+    beforeEach(initService({
+      debug: false
+    }));
 
     it("should skip debugging output if disabled", inject(
       function(){
@@ -156,6 +163,31 @@ describe('$log', function() {
       }}});
     });
 
+    it('should skip error output if disabled', function(){
+
+      initService({
+        error: false
+      });
+
+      inject(
+        function(){
+          $window.console = {log: log,
+                             warn: warn,
+                             info: info,
+                             error: error,
+                             debug: debug};
+        },
+        function($log){
+          $log.log();
+          $log.warn();
+          $log.info();
+          $log.error();
+          $log.debug();
+          expect(logger).toEqual('log;warn;info;debug;');
+        }
+      );
+    });
+
 
     it('should pass error if does not have trace', function() {
       $log.error('abc', e);
@@ -177,5 +209,80 @@ describe('$log', function() {
       $log.error('abc', e);
       expect(errorArgs).toEqual(['abc', 'message\nsourceURL:123']);
     });
+  });
+  describe("$log.warn", function () {
+
+    beforeEach(initService({
+      warn: false
+    }));
+
+    it("should skip debugging output if disabled", inject(
+      function(){
+        $window.console = {log: log,
+                           warn: warn,
+                           info: info,
+                           error: error,
+                           debug: debug};
+      },
+      function($log) {
+        $log.log();
+        $log.warn();
+        $log.info();
+        $log.error();
+        $log.debug();
+        expect(logger).toEqual('log;info;error;debug;');
+      }
+    ));
+
+  });
+  describe("$log.info", function () {
+
+    beforeEach(initService({
+      info: false
+    }));
+
+    it("should skip debugging output if disabled", inject(
+      function(){
+        $window.console = {log: log,
+                           warn: warn,
+                           info: info,
+                           error: error,
+                           debug: debug};
+      },
+      function($log) {
+        $log.log();
+        $log.warn();
+        $log.info();
+        $log.error();
+        $log.debug();
+        expect(logger).toEqual('log;warn;error;debug;');
+      }
+    ));
+
+  });
+  describe("$log.log", function () {
+
+    beforeEach(initService({
+      log: false
+    }));
+
+    it("should skip debugging output if disabled", inject(
+      function(){
+        $window.console = {log: log,
+                           warn: warn,
+                           info: info,
+                           error: error,
+                           debug: debug};
+      },
+      function($log) {
+        $log.log();
+        $log.warn();
+        $log.info();
+        $log.error();
+        $log.debug();
+        expect(logger).toEqual('warn;info;error;debug;');
+      }
+    ));
+
   });
 });


### PR DESCRIPTION
This is a pretty simple update.  It extends the log provider to allow toggling for each log output type, instead of just for `$log.debug`.
