### PR TITLE
ngSwitch attemps to remove DOM elements twice due to async iteration

### DIFF
--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -154,7 +154,7 @@ var ngSwitchDirective = ['$animate', function($animate) {
             return function(){
               previousElements.splice(i, 1).remove();
             };
-          }(i));
+          }(i)));
         }
 
         selectedElements.length = 0;

--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -146,18 +146,15 @@ var ngSwitchDirective = ['$animate', function($animate) {
 
       scope.$watch(watchExpr, function ngSwitchWatchAction(value) {
         var i, ii;
-        for (i = 0, ii = previousElements.length; i < ii; ++i) {
-          previousElements[i].remove();
-        }
-        previousElements.length = 0;
-
         for (i = 0, ii = selectedScopes.length; i < ii; ++i) {
           var selected = getBlockNodes(selectedElements[i].clone);
           selectedScopes[i].$destroy();
           previousElements[i] = selected;
-          $animate.leave(selected).then(function() {
-            previousElements[i] ? previousElements.splice(i, 1) : angular.noop();
-          });
+          $animate.leave(selected).then((function(i) {
+            return function(){
+              previousElements.splice(i, 1).remove();
+            };
+          }(i));
         }
 
         selectedElements.length = 0;

--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -156,7 +156,7 @@ var ngSwitchDirective = ['$animate', function($animate) {
           selectedScopes[i].$destroy();
           previousElements[i] = selected;
           $animate.leave(selected).then(function() {
-            previousElements.splice(i, 1);
+            previousElements[i] ? previousElements.splice(i, 1) : angular.noop();
           });
         }
 

--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -146,6 +146,11 @@ var ngSwitchDirective = ['$animate', function($animate) {
 
       scope.$watch(watchExpr, function ngSwitchWatchAction(value) {
         var i, ii;
+        for (i = 0, ii = previousElements.length; i < ii; ++i) {
+          previousElements[i].remove();
+        }
+        previousElements.length = 0;
+
         for (i = 0, ii = selectedScopes.length; i < ii; ++i) {
           var selected = getBlockNodes(selectedElements[i].clone);
           selectedScopes[i].$destroy();


### PR DESCRIPTION
Basically, I just added a check so that there isn't an attempted splice of the previousElement if it has already been removed by an earlier watch iteration between the time that the callback was defined and actually executed
