### PR TITLE
Mentioned what a blur event is in docs for ngBlur

### DIFF
--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -403,6 +403,9 @@ forEach(
  * @description
  * Specify custom behavior on blur event.
  *
+ * The blur event fires when an element has lost focus. For more information see
+ * {@link https://developer.mozilla.org/en-US/docs/Web/Events/blur}
+ * 
  * Note: As the `blur` event is executed synchronously also during DOM manipulations
  * (e.g. removing a focussed input),
  * AngularJS executes the expression using `scope.$evalAsync` if the event is fired


### PR DESCRIPTION
I know this is obvious to anyone who has done much work with the DOM and javascript, but thought it was funny that no mention was made as to what a 'blur' is. The meaning wouldn't be obvious to a newbie.
