### PR TITLE
feat($compile): inject directive name to directive controller

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -189,6 +189,7 @@
  * * `$scope` - Current scope associated with the element
  * * `$element` - Current element
  * * `$attrs` - Current attributes object for the element
+ * * `$name` - Name of the directive
  * * `$transclude` - A transclude linking function pre-bound to the correct transclusion scope:
  *   `function([scope], cloneLinkingFn, futureParentElement)`.
  *    * `scope`: optional argument to override the scope.
@@ -1606,6 +1607,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               $scope: directive === newIsolateScopeDirective || directive.$$isolateScope ? isolateScope : scope,
               $element: $element,
               $attrs: attrs,
+              $name: directive.name,
               $transclude: transcludeFn
             }, controllerInstance;
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3689,6 +3689,25 @@ describe('$compile', function() {
     });
 
 
+    it('should get the directive\'s name injected as $name', function() {
+      module(function() {
+        directive('dirA', function(log) {
+          return {
+            controller: function($name, $attrs) {
+              log($name);
+              log($attrs[$name]);
+            }
+          };
+        });
+      });
+      inject(function(log, $compile, $rootScope) {
+        element = $compile('<div dir-a="foo"></div>')($rootScope);
+        $rootScope.$digest();
+        expect(log).toEqual('dirA; foo');
+      });
+    });
+
+
     it('should require controller of an isolate directive from a non-isolate directive on the ' +
         'same element', function() {
       var IsolateController = function() {};


### PR DESCRIPTION
Most often this might be useful for sharing controller code between directives, in particular for accessing the value of the directive's 'main' attribute: `$attrs[$name]`

For example, see [this SO question](http://stackoverflow.com/q/19230264/76173). 
