### PR TITLE
Fix ngRepeat to allow keys starting with $

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -338,7 +338,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
             // if object, extract keys, sort them and use to determine order of iteration over obj props
             collectionKeys = [];
             for (var itemKey in collection) {
-              if (collection.hasOwnProperty(itemKey) && itemKey.charAt(0) != '$') {
+              if (collection.hasOwnProperty(itemKey) && !(itemKey.charAt(0) === '$' && itemKey.charAt(1) === '$')) {
                 collectionKeys.push(itemKey);
               }
             }

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -146,6 +146,16 @@ describe('ngRepeat', function() {
     expect(element.text()).toEqual('misko:swe|shyam:set|');
   });
 
+  it('should iterate over an object/map and not strip keys that begin with $', function() {
+    element = $compile(
+      '<ul>' +
+        '<li ng-repeat="(key, value) in items">{{key}}:{{value}}|</li>' +
+      '</ul>')(scope);
+    scope.items = {'$1 - $10':'low price', '$11 - $20':'high price'};
+    scope.$digest();
+    expect(element.text()).toEqual('$1 - $10:low price|$11 - $20:high price|');
+  });
+
   it('should iterate over an object/map with identical values', function() {
     element = $compile(
       '<ul>' +
@@ -688,7 +698,7 @@ describe('ngRepeat', function() {
         '<ul>' +
             '<li ng-repeat="(key, val) in items">{{key}}:{{val}}:{{$first}}-{{$middle}}-{{$last}}|</li>' +
             '</ul>')(scope);
-    scope.items = {'misko':'m', 'shyam':'s', 'doug':'d', 'frodo':'f', '$toBeFilteredOut': 'xxxx'};
+    scope.items = {'misko':'m', 'shyam':'s', 'doug':'d', 'frodo':'f', '$$toBeFilteredOut': 'xxxx'};
     scope.$digest();
     expect(element.text()).
         toEqual('doug:d:true-false-false|' +
@@ -703,7 +713,7 @@ describe('ngRepeat', function() {
         '<ul>' +
             '<li ng-repeat="(key, val) in items">{{key}}:{{val}}:{{$even}}-{{$odd}}|</li>' +
             '</ul>')(scope);
-    scope.items = {'misko':'m', 'shyam':'s', 'doug':'d', 'frodo':'f', '$toBeFilteredOut': 'xxxx'};
+    scope.items = {'misko':'m', 'shyam':'s', 'doug':'d', 'frodo':'f', '$$toBeFilteredOut': 'xxxx'};
     scope.$digest();
     expect(element.text()).
         toEqual('doug:d:true-false|' +


### PR DESCRIPTION
Dear angular team,

The issue that this PR is addressing is very similar to https://github.com/angular/angular.js/issues/1463. ngRepeat Directive does not show object/map keys that begin with $. Plunker link http://plnkr.co/edit/0bzuZbzrVX9xLP7e6oHL?p=preview.

I have followed the same idea that was used in PR https://github.com/angular/angular.js/pull/6253.

Thanks for all the great work.
