### PR TITLE
fix($animate): wait two until two digests are over until enabling animations

### DIFF
--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -434,7 +434,10 @@ describe('ngClass animations', function() {
     });
     inject(function($compile, $rootScope, $browser, $rootElement, $animate, $timeout, $document) {
 
-      // Animations are enabled right away since there are no remote HTTP template requests
+      // Animations need to digest twice in order to be enabled regardless if there are no template HTTP requests.
+      $rootScope.$digest();
+      digestQueue.shift()();
+
       $rootScope.$digest();
       digestQueue.shift()();
 


### PR DESCRIPTION
Even when no remote templates are to be downloaded, wait two digests until
enabling animations since all structural digests perform a post digest before
running animations.

Closes #8844

Broken Example (no remote templates -> `snapshot`):
http://plnkr.co/edit/LREaTTieMJj4lOPJTjI0?p=preview

Working example (no remote templates -> `this fix`):
http://plnkr.co/edit/CuigpbMIB4ZkdmhWJ1bO?p=preview

Working example (remote templates -> `snapshot`)
http://plnkr.co/edit/QLD5TVtWnHGvCLnFcCYw?p=preview

Working example (remote templates -> `this fix`)
http://plnkr.co/edit/YtjFzsb7bR2AwfXD9lF2?p=preview
