### PR TITLE
fix(ngEventDirs): check `scope.$$phase` only on `$rootScope`

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -958,7 +958,7 @@ function baseInputType(scope, element, attr, ctrl, $sniffer, $browser) {
     // a row.
     var revalidate = validity && ctrl.$$hasNativeValidators;
     if (ctrl.$viewValue !== value || (value === '' && revalidate)) {
-      if (scope.$$phase) {
+      if (scope.$root.$$phase) {
         ctrl.$setViewValue(value, event, revalidate);
       } else {
         scope.$apply(function() {

--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -51,7 +51,7 @@ forEach(
   'click dblclick mousedown mouseup mouseover mouseout mousemove mouseenter mouseleave keydown keyup keypress submit focus blur copy cut paste'.split(' '),
   function(name) {
     var directiveName = directiveNormalize('ng-' + name);
-    ngEventDirectives[directiveName] = ['$parse', function($parse) {
+    ngEventDirectives[directiveName] = ['$parse', '$rootScope', function($parse, $rootScope) {
       return {
         restrict: 'A',
         compile: function($element, attr) {
@@ -62,7 +62,7 @@ forEach(
               var callback = function() {
                 fn(scope, {$event:event});
               };
-              if (forceAsyncEvents[eventName] && scope.$$phase) {
+              if (forceAsyncEvents[eventName] && $rootScope.$$phase) {
                 scope.$evalAsync(callback);
               } else {
                 scope.$apply(callback);

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1157,6 +1157,7 @@ describe('input', function() {
           return eventName !== 'input';
         };
 
+        scope = scope.$new(true);
         compileInput('<input type="text" ng-model="name" name="alias" ng-change="change()" />');
 
         scope.field = 'fake field';

--- a/test/ng/directive/ngEventDirsSpec.js
+++ b/test/ng/directive/ngEventDirsSpec.js
@@ -44,15 +44,16 @@ describe('event directives', function() {
 
     it('should call the listener asynchronously during $apply',
         inject(function($rootScope, $compile) {
-      element = $compile('<input type="text" ng-focus="focus()">')($rootScope);
-      $rootScope.focus = jasmine.createSpy('focus');
+      var scope = $rootScope.$new(true);
+      element = $compile('<input type="text" ng-focus="focus()">')(scope);
+      scope.focus = jasmine.createSpy('focus');
 
-      $rootScope.$apply(function() {
+      scope.$apply(function() {
         element.triggerHandler('focus');
-        expect($rootScope.focus).not.toHaveBeenCalled();
+        expect(scope.focus).not.toHaveBeenCalled();
       });
 
-      expect($rootScope.focus).toHaveBeenCalledOnce();
+      expect(scope.focus).toHaveBeenCalledOnce();
     }));
 
     it('should call the listener synchronously inside of $apply if outside of $apply',
@@ -74,15 +75,16 @@ describe('event directives', function() {
 
     it('should call the listener asynchronously during $apply',
         inject(function($rootScope, $compile) {
-      element = $compile('<input type="text" ng-blur="blur()">')($rootScope);
-      $rootScope.blur = jasmine.createSpy('blur');
+      var scope = $rootScope.$new(true);
+      element = $compile('<input type="text" ng-blur="blur()">')(scope);
+      scope.blur = jasmine.createSpy('blur');
 
-      $rootScope.$apply(function() {
+      scope.$apply(function() {
         element.triggerHandler('blur');
-        expect($rootScope.blur).not.toHaveBeenCalled();
+        expect(scope.blur).not.toHaveBeenCalled();
       });
 
-      expect($rootScope.blur).toHaveBeenCalledOnce();
+      expect(scope.blur).toHaveBeenCalledOnce();
     }));
 
     it('should call the listener synchronously inside of $apply if outside of $apply',


### PR DESCRIPTION
Checking `scope.$$phase` is dangerous since it does not work on isolated scopes. It exists only on `$rootScope`, and isolated scopes do not inherit it.
