### PR TITLE
fix($location): always resolve relative links in html5mode to `<base>` url

### DIFF
--- a/docs/content/error/$location/nobase.ngdoc
+++ b/docs/content/error/$location/nobase.ngdoc
@@ -1,0 +1,51 @@
+@ngdoc error
+@name $location:nobase
+@fullName $location in HTML5 mode requires a <base> tag to be present!
+@description
+
+If you configure {@link ng.$location `$location`} to use
+{@ng.provider.$locationProvider `html5Mode`} (`history.pushState`), you need to specify the base URL for the application with a [`<base href="">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) tag.
+
+The base URL is then used to resolve all relative URLs throughout the application regardless of the
+entry point into the app.
+
+If you are deploying your app into the root context (e.g. `https://myapp.com/`), set the base URL to `/`:
+
+```html
+<head>
+  <base href="/">
+  ...
+</head>
+```
+
+If you are deploying your app into a sub-context (e.g. `https://myapp.com/subapp/`), set the base URL to the
+URL of the subcontext:
+
+```html
+<head>
+  <base href="/myapp">
+  ...
+</head>
+```
+
+Before Angular 1.3 we didn't have this hard requirement and it was easy to write apps that worked
+when deployed in the root context but were broken when moved to a sub-context because in the
+sub-context all absolute urls would resolve to the root context of the app. To prevent this,
+use relative URLs throughout your app:
+
+```html
+<!-- wrong: -->
+<a href="/userProfile">User Profile</a>
+
+
+<!-- correct: -->
+<a href="userProfile">User Profile</a>
+
+```
+
+Additionally, if you want to support [browsers that don't have the `history.pushState`
+API](http://caniuse.com/#feat=history), the fallback mechanism provided by `$location`
+won't work well without specifying the base url of the application.
+
+In order to make it easier to migrate from hashbang mode to html5 mode, we require that the base
+URL is always specified when `$location`'s `html5mode` is enabled.

--- a/docs/content/guide/$location.ngdoc
+++ b/docs/content/guide/$location.ngdoc
@@ -325,20 +325,22 @@ to URLs that should be handled with `.`. Now, links to locations, which are not 
 are not prefixed with `.` and will not be intercepted by the `otherwise` rule in your `$routeProvider`.
 
 
+### Relative links
+
+Be sure to check all relative links, images, scripts etc. Angular requires you to specify the url base in
+the head of your main html file (`<base href="/my-base">`). With that, relative urls will
+always be resolved to this base url, event if the initial url of the document was different.
+
+There is one exception: Links that only contain a hash fragment (e.g. `<a href="#target">`)
+will only change `$location.hash()` and not modify the url otherwise. This is useful for scrolling
+to anchors on the same page without needing to know on which page the user currently is.
+
 ### Server side
 
 Using this mode requires URL rewriting on server side, basically you have to rewrite all your links
-to entry point of your application (e.g. index.html)
-
-### Relative links
-
-Be sure to check all relative links, images, scripts etc. You must either specify the url base in
-the head of your main html file (`<base href="/my-base">`) or you must use absolute urls
-(starting with `/`) everywhere because relative urls will be resolved to absolute urls using the
-initial absolute url of the document, which is often different from the root of the application.
-
-Running Angular apps with the History API enabled from document root is strongly encouraged as it
-takes care of all relative link issues.
+to entry point of your application (e.g. index.html). Requiring a `<base>` tag is also important for
+this case, as it allows Angular to differentiate between the part of the url that is the application
+base and the path that should be handeled by the application.
 
 ### Sending links among different browsers
 

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -127,21 +127,32 @@ function LocationHtml5Url(appBase, basePrefix) {
     this.$$absUrl = appBaseNoFile + this.$$url.substr(1); // first char is always '/'
   };
 
-  this.$$rewrite = function(url) {
+  this.$$parseLinkUrl = function(url, relHref) {
+    if (relHref && relHref[0] === '#') {
+      // special case for links to hash fragments:
+      // keep the old url and only replace the hash fragment
+      this.hash(relHref.slice(1));
+      return true;
+    }
     var appUrl, prevAppUrl;
+    var rewrittenUrl;
 
     if ( (appUrl = beginsWith(appBase, url)) !== undefined ) {
       prevAppUrl = appUrl;
       if ( (appUrl = beginsWith(basePrefix, appUrl)) !== undefined ) {
-        return appBaseNoFile + (beginsWith('/', appUrl) || appUrl);
+        rewrittenUrl = appBaseNoFile + (beginsWith('/', appUrl) || appUrl);
       } else {
-        return appBase + prevAppUrl;
+        rewrittenUrl = appBase + prevAppUrl;
       }
     } else if ( (appUrl = beginsWith(appBaseNoFile, url)) !== undefined ) {
-      return appBaseNoFile + appUrl;
+      rewrittenUrl = appBaseNoFile + appUrl;
     } else if (appBaseNoFile == url + '/') {
-      return appBaseNoFile;
+      rewrittenUrl = appBaseNoFile;
     }
+    if (rewrittenUrl) {
+      this.$$parse(rewrittenUrl);
+    }
+    return !!rewrittenUrl;
   };
 }
 
@@ -231,10 +242,12 @@ function LocationHashbangUrl(appBase, hashPrefix) {
     this.$$absUrl = appBase + (this.$$url ? hashPrefix + this.$$url : '');
   };
 
-  this.$$rewrite = function(url) {
+  this.$$parseLinkUrl = function(url, relHref) {
     if(stripHash(appBase) == stripHash(url)) {
-      return url;
+      this.$$parse(url);
+      return true;
     }
+    return false;
   };
 }
 
@@ -254,16 +267,28 @@ function LocationHashbangInHtml5Url(appBase, hashPrefix) {
 
   var appBaseNoFile = stripFile(appBase);
 
-  this.$$rewrite = function(url) {
+  this.$$parseLinkUrl = function(url, relHref) {
+    if (relHref && relHref[0] === '#') {
+      // special case for links to hash fragments:
+      // keep the old url and only replace the hash fragment
+      this.hash(relHref.slice(1));
+      return true;
+    }
+
+    var rewrittenUrl;
     var appUrl;
 
     if ( appBase == stripHash(url) ) {
-      return url;
+      rewrittenUrl = url;
     } else if ( (appUrl = beginsWith(appBaseNoFile, url)) ) {
-      return appBase + hashPrefix + appUrl;
+      rewrittenUrl = appBase + hashPrefix + appUrl;
     } else if ( appBaseNoFile === url + '/') {
-      return appBaseNoFile;
+      rewrittenUrl = appBaseNoFile;
     }
+    if (rewrittenUrl) {
+      this.$$parse(rewrittenUrl);
+    }
+    return !!rewrittenUrl;
   };
 
   this.$$compose = function() {
@@ -626,6 +651,10 @@ function $LocationProvider(){
         appBase;
 
     if (html5Mode) {
+      if (!baseHref) {
+        throw $locationMinErr('nobase',
+          "$location in HTML5 mode requires a <base> tag to be present!");
+      }
       appBase = serverBase(initialUrl) + (baseHref || '/');
       LocationMode = $sniffer.history ? LocationHtml5Url : LocationHashbangInHtml5Url;
     } else {
@@ -633,7 +662,7 @@ function $LocationProvider(){
       LocationMode = LocationHashbangUrl;
     }
     $location = new LocationMode(appBase, '#' + hashPrefix);
-    $location.$$parse($location.$$rewrite(initialUrl));
+    $location.$$parseLinkUrl(initialUrl, initialUrl);
 
     var IGNORE_URI_REGEXP = /^\s*(javascript|mailto):/i;
 
@@ -652,6 +681,9 @@ function $LocationProvider(){
       }
 
       var absHref = elm.prop('href');
+      // get the actual href attribute - see
+      // http://msdn.microsoft.com/en-us/library/ie/dd347148(v=vs.85).aspx
+      var relHref = elm.attr('href') || elm.attr('xlink:href');
 
       if (isObject(absHref) && absHref.toString() === '[object SVGAnimatedString]') {
         // SVGAnimatedString.animVal should be identical to SVGAnimatedString.baseVal, unless during
@@ -662,50 +694,15 @@ function $LocationProvider(){
       // Ignore when url is started with javascript: or mailto:
       if (IGNORE_URI_REGEXP.test(absHref)) return;
 
-      // Make relative links work in HTML5 mode for legacy browsers (or at least IE8 & 9)
-      // The href should be a regular url e.g. /link/somewhere or link/somewhere or ../somewhere or
-      // somewhere#anchor or http://example.com/somewhere
-      if (LocationMode === LocationHashbangInHtml5Url) {
-        // get the actual href attribute - see
-        // http://msdn.microsoft.com/en-us/library/ie/dd347148(v=vs.85).aspx
-        var href = elm.attr('href') || elm.attr('xlink:href');
-
-        if (href && href.indexOf('://') < 0) {         // Ignore absolute URLs
-          var prefix = '#' + hashPrefix;
-          if (href[0] == '/') {
-            // absolute path - replace old path
-            absHref = appBase + prefix + href;
-          } else if (href[0] == '#') {
-            // local anchor
-            absHref = appBase + prefix + ($location.path() || '/') + href;
-          } else {
-            // relative path - join with current path
-            var stack = $location.path().split("/"),
-              parts = href.split("/");
-            if (stack.length === 2 && !stack[1]) stack.length = 1;
-            for (var i=0; i<parts.length; i++) {
-              if (parts[i] == ".")
-                continue;
-              else if (parts[i] == "..")
-                stack.pop();
-              else if (parts[i].length)
-                stack.push(parts[i]);
-            }
-            absHref = appBase + prefix + stack.join('/');
-          }
-        }
-      }
-
-      var rewrittenUrl = $location.$$rewrite(absHref);
-
-      if (absHref && !elm.attr('target') && rewrittenUrl && !event.isDefaultPrevented()) {
-        event.preventDefault();
-        if (rewrittenUrl != $browser.url()) {
+      if (absHref && !elm.attr('target') && !event.isDefaultPrevented()) {
+        if ($location.$$parseLinkUrl(absHref, relHref)) {
+          event.preventDefault();
           // update location manually
-          $location.$$parse(rewrittenUrl);
-          $rootScope.$apply();
-          // hack to work around FF6 bug 684208 when scenario runner clicks on links
-          window.angular['ff-684208-preventDefault'] = true;
+          if ($location.absUrl() != $browser.url()) {
+            $rootScope.$apply();
+            // hack to work around FF6 bug 684208 when scenario runner clicks on links
+            window.angular['ff-684208-preventDefault'] = true;
+          }
         }
       }
     });

--- a/test/ng/anchorScrollSpec.js
+++ b/test/ng/anchorScrollSpec.js
@@ -110,6 +110,10 @@ describe('$anchorScroll', function() {
       return function($provide, $locationProvider) {
         $provide.value('$sniffer', {history: config.historyApi});
         $locationProvider.html5Mode(config.html5Mode);
+        $provide.decorator('$browser', function($delegate) {
+          $delegate.$$baseHref = '/';
+          return $delegate;
+        });
       };
     }
 

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -63,7 +63,7 @@ describe('$location', function() {
 
 
   it('should not infinitely digest when using a semicolon in initial path', function() {
-    module(function($windowProvider, $locationProvider, $browserProvider) {
+    module(function($windowProvider, $locationProvider, $browserProvider, $documentProvider) {
       $locationProvider.html5Mode(true);
       $windowProvider.$get = function() {
         var win = {};
@@ -82,6 +82,13 @@ describe('$location', function() {
         };
         return win;
       };
+      var baseElement = jqLite('<base href="/">');
+      $documentProvider.$get = function() {
+        return {
+          0: window.document,
+          find: jasmine.createSpy('find').andReturn(baseElement)
+        };
+      };
       $browserProvider.$get = function($document, $window) {
         var sniffer = {history: true, hashchange: false};
         var logs = {log:[], warn:[], info:[], error:[]};
@@ -93,6 +100,7 @@ describe('$location', function() {
         /* global Browser: false */
         var b = new Browser($window, $document, fakeLog, sniffer);
         b.pollFns = [];
+        b.$$baseHref = '/';
         return b;
       };
     });
@@ -796,18 +804,6 @@ describe('$location', function() {
       );
     });
 
-
-    it('should set appBase to serverBase if base[href] is missing', function() {
-      initService({html5Mode:true,hashPrefix: '!',supportHistory: true});
-      inject(
-          initBrowser({url:'http://domain.com/my/view1#anchor1',basePath: ''}),
-          function($rootScope, $location, $browser) {
-            expect($browser.url()).toBe('http://domain.com/my/view1#anchor1');
-            expect($location.path()).toBe('/my/view1');
-            expect($location.hash()).toBe('anchor1');
-          }
-      );
-    });
   });
 
   describe('PATH_MATCH', function() {
@@ -854,12 +850,12 @@ describe('$location', function() {
       module(function($provide, $locationProvider) {
         attrs = attrs ? ' ' + attrs + ' ' : '';
 
-        // fake the base behavior
         if (typeof linkHref === 'string') {
           if (!relLink) {
             if (linkHref[0] == '/') {
               linkHref = 'http://host.com' + linkHref;
             } else if(!linkHref.match(/:\/\//)) {
+              // fake the behavior of <base> tag
               linkHref = 'http://host.com/base/' + linkHref;
             }
           }
@@ -884,8 +880,8 @@ describe('$location', function() {
     }
 
     function initBrowser() {
-      return function($browser){
-        $browser.url('http://host.com/base');
+      return function($browser, $document){
+        $browser.url('http://host.com/base/index.html');
         $browser.$$baseHref = '/base/index.html';
       };
     }
@@ -999,12 +995,14 @@ describe('$location', function() {
 
 
     it('should produce relative paths correctly when $location.path() is "/" when history enabled on old browser', function() {
-      configureService({linkHref: 'partial1', html5Mode: true, supportHist: false, relLink: true});
+      configureService({linkHref: 'partial1', html5Mode: true, supportHist: false});
       inject(
         initBrowser(),
         initLocation(),
-        function($browser, $location) {
-          $location.path('/');
+        function($browser, $location, $rootScope) {
+          $rootScope.$apply(function() {
+            $location.path('/');
+          });
           browserTrigger(link, 'click');
           expectRewriteTo($browser, 'http://host.com/base/index.html#!/partial1');
         }
@@ -1199,44 +1197,16 @@ describe('$location', function() {
       );
     });
 
-
-    it('should rewrite relative links relative to current path when history disabled', function() {
-      configureService({linkHref: 'link', html5Mode: true, supportHist: false, relLink: true});
-      inject(
-        initBrowser(),
-        initLocation(),
-        function($browser, $location) {
-          $location.path('/some');
-          browserTrigger(link, 'click');
-          expectRewriteTo($browser, 'http://host.com/base/index.html#!/some/link');
-        }
-      );
-    });
-
-
-    it('should replace current path when link begins with "/" and history disabled', function() {
-      configureService({linkHref: '/link', html5Mode: true, supportHist: false, relLink: true});
-      inject(
-        initBrowser(),
-        initLocation(),
-        function($browser, $location) {
-          $location.path('/some');
-          browserTrigger(link, 'click');
-          expectRewriteTo($browser, 'http://host.com/base/index.html#!/link');
-        }
-      );
-    });
-
-
     it('should replace current hash fragment when link begins with "#" history disabled', function() {
       configureService({linkHref: '#link', html5Mode: true, supportHist: false, relLink: true});
       inject(
         initBrowser(),
         initLocation(),
-        function($browser, $location) {
-          // Initialize browser URL
-          $location.path('/some');
-          $location.hash('foo');
+        function($browser, $location, $rootScope) {
+          $rootScope.$apply(function() {
+            $location.path('/some');
+            $location.hash('foo');
+          });
           browserTrigger(link, 'click');
           expect($location.hash()).toBe('link');
           expectRewriteTo($browser, 'http://host.com/base/index.html#!/some#link');
@@ -1244,6 +1214,22 @@ describe('$location', function() {
       );
     });
 
+    it('should replace current hash fragment when link begins with "#" history enabled', function() {
+      configureService({linkHref: '#link', html5Mode: true, supportHist: true, relLink: true});
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser, $location, $rootScope) {
+          $rootScope.$apply(function() {
+            $location.path('/some');
+            $location.hash('foo');
+          });
+          browserTrigger(link, 'click');
+          expect($location.hash()).toBe('link');
+          expectRewriteTo($browser, 'http://host.com/base/some#link');
+        }
+      );
+    });
 
     // don't run next tests on IE<9, as browserTrigger does not simulate pressed keys
     if (!msie || msie >= 9) {
@@ -1356,7 +1342,8 @@ describe('$location', function() {
 
         var event = {
           target: jqLite(window.document.body).find('a')[0],
-          preventDefault: jasmine.createSpy('preventDefault')
+          preventDefault: jasmine.createSpy('preventDefault'),
+          isDefaultPrevented: jasmine.createSpy().andReturn(false)
         };
 
 
@@ -1386,7 +1373,8 @@ describe('$location', function() {
 
         var event = {
           target: jqLite(window.document.body).find('a')[0],
-          preventDefault: jasmine.createSpy('preventDefault')
+          preventDefault: jasmine.createSpy('preventDefault'),
+          isDefaultPrevented: jasmine.createSpy().andReturn(false)
         };
 
 
@@ -1551,8 +1539,12 @@ describe('$location', function() {
 
 
     it('should listen on click events on href and prevent browser default in html5 mode', function() {
-      module(function($locationProvider) {
+      module(function($locationProvider, $provide) {
         $locationProvider.html5Mode(true);
+        $provide.decorator('$browser', function($delegate) {
+          $delegate.$$baseHref = '/';
+          return $delegate;
+        });
         return function($rootElement, $compile, $rootScope) {
           $rootElement.html('<a href="http://server/somePath">link</a>');
           $compile($rootElement)($rootScope);
@@ -1609,6 +1601,13 @@ describe('$location', function() {
     );
   });
 
+  function parseLinkAndReturn(location, url, relHref) {
+    if (location.$$parseLinkUrl(url, relHref)) {
+      return location.absUrl();
+    }
+    return undefined;
+  }
+
   describe('LocationHtml5Url', function() {
     var location, locationIndex;
 
@@ -1618,13 +1617,18 @@ describe('$location', function() {
     });
 
     it('should rewrite URL', function() {
-      expect(location.$$rewrite('http://other')).toEqual(undefined);
-      expect(location.$$rewrite('http://server/pre')).toEqual('http://server/pre/');
-      expect(location.$$rewrite('http://server/pre/')).toEqual('http://server/pre/');
-      expect(location.$$rewrite('http://server/pre/otherPath')).toEqual('http://server/pre/otherPath');
-      expect(locationIndex.$$rewrite('http://server/pre')).toEqual('http://server/pre/');
-      expect(locationIndex.$$rewrite('http://server/pre/')).toEqual('http://server/pre/');
-      expect(locationIndex.$$rewrite('http://server/pre/otherPath')).toEqual('http://server/pre/otherPath');
+      expect(parseLinkAndReturn(location, 'http://other')).toEqual(undefined);
+      expect(parseLinkAndReturn(location, 'http://server/pre')).toEqual('http://server/pre/');
+      expect(parseLinkAndReturn(location, 'http://server/pre/')).toEqual('http://server/pre/');
+      expect(parseLinkAndReturn(location, 'http://server/pre/otherPath')).toEqual('http://server/pre/otherPath');
+      // Note: relies on the previous state!
+      expect(parseLinkAndReturn(location, 'someIgnoredAbsoluteHref', '#test')).toEqual('http://server/pre/otherPath#test');
+
+      expect(parseLinkAndReturn(locationIndex, 'http://server/pre')).toEqual('http://server/pre/');
+      expect(parseLinkAndReturn(locationIndex, 'http://server/pre/')).toEqual('http://server/pre/');
+      expect(parseLinkAndReturn(locationIndex, 'http://server/pre/otherPath')).toEqual('http://server/pre/otherPath');
+      // Note: relies on the previous state!
+      expect(parseLinkAndReturn(location, 'someIgnoredAbsoluteHref', '#test')).toEqual('http://server/pre/otherPath#test');
     });
   });
 
@@ -1632,14 +1636,21 @@ describe('$location', function() {
   describe('LocationHashbangUrl', function() {
     var location;
 
+    function parseLinkAndReturn(location, url, relHref) {
+      if (location.$$parseLinkUrl(url, relHref)) {
+        return location.absUrl();
+      }
+      return undefined;
+    }
+
     it('should rewrite URL', function() {
       /* jshint scripturl: true */
       location = new LocationHashbangUrl('http://server/pre/', '#');
 
-      expect(location.$$rewrite('http://other')).toEqual(undefined);
-      expect(location.$$rewrite('http://server/pre/')).toEqual('http://server/pre/');
-      expect(location.$$rewrite('http://server/pre/#otherPath')).toEqual('http://server/pre/#otherPath');
-      expect(location.$$rewrite('javascript:void(0)')).toEqual(undefined);
+      expect(parseLinkAndReturn(location, 'http://other')).toEqual(undefined);
+      expect(parseLinkAndReturn(location, 'http://server/pre/')).toEqual('http://server/pre/');
+      expect(parseLinkAndReturn(location, 'http://server/pre/#otherPath')).toEqual('http://server/pre/#/otherPath');
+      expect(parseLinkAndReturn(location, 'javascript:void(0)')).toEqual(undefined);
     });
 
     it("should not set hash if one was not originally specified", function() {
@@ -1689,13 +1700,18 @@ describe('$location', function() {
     });
 
     it('should rewrite URL', function() {
-      expect(location.$$rewrite('http://other')).toEqual(undefined);
-      expect(location.$$rewrite('http://server/pre')).toEqual('http://server/pre/');
-      expect(location.$$rewrite('http://server/pre/')).toEqual('http://server/pre/');
-      expect(location.$$rewrite('http://server/pre/otherPath')).toEqual('http://server/pre/#!otherPath');
-      expect(locationIndex.$$rewrite('http://server/pre')).toEqual('http://server/pre/');
-      expect(locationIndex.$$rewrite('http://server/pre/')).toEqual(undefined);
-      expect(locationIndex.$$rewrite('http://server/pre/otherPath')).toEqual('http://server/pre/index.html#!otherPath');
+      expect(parseLinkAndReturn(location, 'http://other')).toEqual(undefined);
+      expect(parseLinkAndReturn(location, 'http://server/pre')).toEqual('http://server/pre/#!');
+      expect(parseLinkAndReturn(location, 'http://server/pre/')).toEqual('http://server/pre/#!');
+      expect(parseLinkAndReturn(location, 'http://server/pre/otherPath')).toEqual('http://server/pre/#!/otherPath');
+      // Note: relies on the previous state!
+      expect(parseLinkAndReturn(location, 'someIgnoredAbsoluteHref', '#test')).toEqual('http://server/pre/#!/otherPath#test');
+
+      expect(parseLinkAndReturn(locationIndex, 'http://server/pre')).toEqual('http://server/pre/index.html#!');
+      expect(parseLinkAndReturn(locationIndex, 'http://server/pre/')).toEqual(undefined);
+      expect(parseLinkAndReturn(locationIndex, 'http://server/pre/otherPath')).toEqual('http://server/pre/index.html#!/otherPath');
+      // Note: relies on the previous state!
+      expect(parseLinkAndReturn(locationIndex, 'someIgnoredAbsoluteHref', '#test')).toEqual('http://server/pre/index.html#!/otherPath#test');
     });
   });
 });

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -297,9 +297,9 @@ describe('$location', function() {
     });
 
     it('should not rewrite when hashbang url is not given', function() {
-      initService(true, '!', true);
+      initService({html5Mode:true,hashPrefix: '!',supportHistory: true});
       inject(
-        initBrowser('http://domain.com/base/a/b', '/base'),
+        initBrowser({url:'http://domain.com/base/a/b',basePath: '/base'}),
         function($rootScope, $location, $browser) {
           expect($browser.url()).toBe('http://domain.com/base/a/b');
         }
@@ -532,24 +532,24 @@ describe('$location', function() {
   });
 
 
-  function initService(html5Mode, hashPrefix, supportHistory) {
+  function initService(options) {
     return module(function($provide, $locationProvider){
-      $locationProvider.html5Mode(html5Mode);
-      $locationProvider.hashPrefix(hashPrefix);
-      $provide.value('$sniffer', {history: supportHistory});
+      $locationProvider.html5Mode(options.html5Mode);
+      $locationProvider.hashPrefix(options.hashPrefix);
+      $provide.value('$sniffer', {history: options.supportHistory});
     });
   }
-  function initBrowser(url, basePath) {
+  function initBrowser(options) {
     return function($browser){
-      $browser.url(url);
-      $browser.$$baseHref = basePath;
+      $browser.url(options.url);
+      $browser.$$baseHref = options.basePath;
     };
   }
 
   describe('wiring', function() {
 
-    beforeEach(initService(false, '!', true));
-    beforeEach(inject(initBrowser('http://new.com/a/b#!', 'http://new.com/a/b')));
+    beforeEach(initService({html5Mode:false,hashPrefix: '!',supportHistory: true}));
+    beforeEach(inject(initBrowser({url:'http://new.com/a/b#!',basePath: 'http://new.com/a/b'})));
 
 
     it('should update $location when browser url changes', inject(function($browser, $location) {
@@ -673,9 +673,9 @@ describe('$location', function() {
   describe('disabled history', function() {
 
     it('should use hashbang url with hash prefix', function() {
-      initService(false, '!');
+      initService({html5Mode:false,hashPrefix: '!'});
       inject(
-        initBrowser('http://domain.com/base/index.html#!/a/b', '/base/index.html'),
+        initBrowser({url:'http://domain.com/base/index.html#!/a/b',basePath: '/base/index.html'}),
         function($rootScope, $location, $browser) {
           expect($browser.url()).toBe('http://domain.com/base/index.html#!/a/b');
           $location.path('/new');
@@ -688,9 +688,9 @@ describe('$location', function() {
 
 
     it('should use hashbang url without hash prefix', function() {
-      initService(false, '');
+      initService({html5Mode:false,hashPrefix: ''});
       inject(
-        initBrowser('http://domain.com/base/index.html#/a/b', '/base/index.html'),
+        initBrowser({url:'http://domain.com/base/index.html#/a/b',basePath: '/base/index.html'}),
         function($rootScope, $location, $browser) {
           expect($browser.url()).toBe('http://domain.com/base/index.html#/a/b');
           $location.path('/new');
@@ -711,9 +711,9 @@ describe('$location', function() {
     }));
 
     it('should use hashbang url with hash prefix', function() {
-      initService(true, '!!', false);
+      initService({html5Mode:true,hashPrefix: '!!',supportHistory: false});
       inject(
-        initBrowser('http://domain.com/base/index.html#!!/a/b', '/base/index.html'),
+        initBrowser({url:'http://domain.com/base/index.html#!!/a/b',basePath: '/base/index.html'}),
         function($rootScope, $location,  $browser) {
           expect($browser.url()).toBe('http://domain.com/base/index.html#!!/a/b');
           $location.path('/new');
@@ -726,9 +726,9 @@ describe('$location', function() {
 
 
     it('should redirect to hashbang url when new url given', function() {
-      initService(true, '!');
+      initService({html5Mode:true,hashPrefix: '!'});
       inject(
-        initBrowser('http://domain.com/base/new-path/index.html', '/base/index.html'),
+        initBrowser({url:'http://domain.com/base/new-path/index.html',basePath: '/base/index.html'}),
         function($browser, $location) {
           expect($browser.url()).toBe('http://domain.com/base/index.html#!/new-path/index.html');
         }
@@ -736,9 +736,9 @@ describe('$location', function() {
     });
 
     it('should correctly convert html5 url with path matching basepath to hashbang url', function () {
-      initService(true, '!', false);
+      initService({html5Mode:true,hashPrefix: '!',supportHistory: false});
       inject(
-        initBrowser('http://domain.com/base/index.html', '/base/index.html'),
+        initBrowser({url:'http://domain.com/base/index.html',basePath: '/base/index.html'}),
         function($browser, $location) {
           expect($browser.url()).toBe('http://domain.com/base/index.html#!/index.html');
         }
@@ -755,9 +755,9 @@ describe('$location', function() {
     }));
 
     it('should use new url', function() {
-      initService(true, '', true);
+      initService({html5Mode:true,hashPrefix: '',supportHistory: true});
       inject(
-        initBrowser('http://domain.com/base/old/index.html#a', '/base/index.html'),
+        initBrowser({url:'http://domain.com/base/old/index.html#a',basePath: '/base/index.html'}),
         function($rootScope, $location, $browser) {
           expect($browser.url()).toBe('http://domain.com/base/old/index.html#a');
           $location.path('/new');
@@ -770,9 +770,9 @@ describe('$location', function() {
 
 
     it('should rewrite when hashbang url given', function() {
-      initService(true, '!', true);
+      initService({html5Mode:true,hashPrefix: '!',supportHistory: true});
       inject(
-        initBrowser('http://domain.com/base/index.html#!/a/b', '/base/index.html'),
+        initBrowser({url:'http://domain.com/base/index.html#!/a/b',basePath: '/base/index.html'}),
         function($rootScope, $location, $browser) {
           expect($browser.url()).toBe('http://domain.com/base/a/b');
           $location.path('/new');
@@ -786,9 +786,9 @@ describe('$location', function() {
 
 
     it('should rewrite when hashbang url given (without hash prefix)', function() {
-      initService(true, '', true);
+      initService({html5Mode:true,hashPrefix: '',supportHistory: true});
       inject(
-        initBrowser('http://domain.com/base/index.html#/a/b', '/base/index.html'),
+        initBrowser({url:'http://domain.com/base/index.html#/a/b',basePath: '/base/index.html'}),
         function($rootScope, $location, $browser) {
           expect($browser.url()).toBe('http://domain.com/base/a/b');
           expect($location.path()).toBe('/a/b');
@@ -798,9 +798,9 @@ describe('$location', function() {
 
 
     it('should set appBase to serverBase if base[href] is missing', function() {
-      initService(true, '!', true);
+      initService({html5Mode:true,hashPrefix: '!',supportHistory: true});
       inject(
-          initBrowser('http://domain.com/my/view1#anchor1', ''),
+          initBrowser({url:'http://domain.com/my/view1#anchor1',basePath: ''}),
           function($rootScope, $location, $browser) {
             expect($browser.url()).toBe('http://domain.com/my/view1#anchor1');
             expect($location.path()).toBe('/my/view1');
@@ -843,12 +843,14 @@ describe('$location', function() {
 
     var root, link, originalBrowser, lastEventPreventDefault;
 
-    function configureService(linkHref, html5Mode, supportHist, relLink, attrs, content) {
-      if (typeof relLink !== "boolean") {
-        content = attrs;
-        attrs = relLink;
-        relLink = false;
-      }
+    function configureService(options) {
+      var linkHref = options.linkHref,
+          html5Mode = options.html5Mode,
+          supportHist = options.supportHist,
+          relLink = options.relLink,
+          attrs = options.attrs,
+          content = options.content;
+
       module(function($provide, $locationProvider) {
         attrs = attrs ? ' ' + attrs + ' ' : '';
 
@@ -917,7 +919,7 @@ describe('$location', function() {
 
 
     it('should rewrite rel link to new url when history enabled on new browser', function() {
-      configureService('link?a#b', true, true);
+      configureService({linkHref: 'link?a#b', html5Mode: true, supportHist: true});
       inject(
         initBrowser(),
         initLocation(),
@@ -930,7 +932,7 @@ describe('$location', function() {
 
 
     it('should do nothing if already on the same URL', function() {
-      configureService('/base/', true, true);
+      configureService({linkHref: '/base/', html5Mode: true, supportHist: true});
       inject(
         initBrowser(),
         initLocation(),
@@ -957,7 +959,7 @@ describe('$location', function() {
 
 
     it('should rewrite abs link to new url when history enabled on new browser', function() {
-      configureService('/base/link?a#b', true, true);
+      configureService({linkHref: '/base/link?a#b', html5Mode: true, supportHist: true});
       inject(
         initBrowser(),
         initLocation(),
@@ -970,7 +972,7 @@ describe('$location', function() {
 
 
     it('should rewrite rel link to hashbang url when history enabled on old browser', function() {
-      configureService('link?a#b', true, false);
+      configureService({linkHref: 'link?a#b', html5Mode: true, supportHist: false});
       inject(
         initBrowser(),
         initLocation(),
@@ -984,7 +986,7 @@ describe('$location', function() {
 
     // Regression (gh-7721)
     it('should not throw when clicking anchor with no href attribute when history enabled on old browser', function() {
-      configureService(null, true, false);
+      configureService({linkHref: null, html5Mode: true, supportHist: false});
       inject(
         initBrowser(),
         initLocation(),
@@ -997,7 +999,7 @@ describe('$location', function() {
 
 
     it('should produce relative paths correctly when $location.path() is "/" when history enabled on old browser', function() {
-      configureService('partial1', true, false, true);
+      configureService({linkHref: 'partial1', html5Mode: true, supportHist: false, relLink: true});
       inject(
         initBrowser(),
         initLocation(),
@@ -1011,7 +1013,7 @@ describe('$location', function() {
 
 
     it('should rewrite abs link to hashbang url when history enabled on old browser', function() {
-      configureService('/base/link?a#b', true, false);
+      configureService({linkHref: '/base/link?a#b', html5Mode: true, supportHist: false});
       inject(
         initBrowser(),
         initLocation(),
@@ -1024,7 +1026,7 @@ describe('$location', function() {
 
 
     it('should not rewrite full url links do different domain', function() {
-      configureService('http://www.dot.abc/a?b=c', true);
+      configureService({linkHref: 'http://www.dot.abc/a?b=c', html5Mode: true});
       inject(
         initBrowser(),
         initLocation(),
@@ -1037,7 +1039,7 @@ describe('$location', function() {
 
 
     it('should not rewrite links with target="_blank"', function() {
-      configureService('/a?b=c', true, true, 'target="_blank"');
+      configureService({linkHref: '/a?b=c', html5Mode: true, supportHist: true, attrs: 'target="_blank"'});
       inject(
         initBrowser(),
         initLocation(),
@@ -1050,7 +1052,7 @@ describe('$location', function() {
 
 
     it('should not rewrite links with target specified', function() {
-      configureService('/a?b=c', true, true, 'target="some-frame"');
+      configureService({linkHref: '/a?b=c', html5Mode: true, supportHist: true, attrs: 'target="some-frame"'});
       inject(
         initBrowser(),
         initLocation(),
@@ -1063,7 +1065,7 @@ describe('$location', function() {
 
 
     it('should not rewrite links with `javascript:` URI', function() {
-      configureService(' jAvAsCrIpT:throw new Error("Boom!")', true, true, true);
+      configureService({linkHref: ' jAvAsCrIpT:throw new Error("Boom!")', html5Mode: true, supportHist: true, relLink: true});
       inject(
         initBrowser(),
         initLocation(),
@@ -1076,7 +1078,7 @@ describe('$location', function() {
 
 
     it('should not rewrite links with `mailto:` URI', function() {
-      configureService(' mAiLtO:foo@bar.com', true, true, true);
+      configureService({linkHref: ' mAiLtO:foo@bar.com', html5Mode: true, supportHist: true, relLink: true});
       inject(
         initBrowser(),
         initLocation(),
@@ -1089,7 +1091,7 @@ describe('$location', function() {
 
 
     it('should rewrite full url links to same domain and base path', function() {
-      configureService('http://host.com/base/new', true);
+      configureService({linkHref: 'http://host.com/base/new', html5Mode: true});
       inject(
         initBrowser(),
         initLocation(),
@@ -1102,7 +1104,7 @@ describe('$location', function() {
 
 
     it('should rewrite when clicked span inside link', function() {
-      configureService('some/link', true, true, '', '<span>link</span>');
+      configureService({linkHref: 'some/link', html5Mode: true, supportHist: true, attrs: '', content: '<span>link</span>'});
       inject(
         initBrowser(),
         initLocation(),
@@ -1118,7 +1120,7 @@ describe('$location', function() {
 
     it('should not rewrite when link to different base path when history enabled on new browser',
         function() {
-      configureService('/other_base/link', true, true);
+      configureService({linkHref: '/other_base/link', html5Mode: true, supportHist: true});
       inject(
         initBrowser(),
         initLocation(),
@@ -1132,7 +1134,7 @@ describe('$location', function() {
 
     it('should not rewrite when link to different base path when history enabled on old browser',
         function() {
-      configureService('/other_base/link', true, false);
+      configureService({linkHref: '/other_base/link', html5Mode: true, supportHist: false});
       inject(
         initBrowser(),
         initLocation(),
@@ -1145,7 +1147,7 @@ describe('$location', function() {
 
 
     it('should not rewrite when link to different base path when history disabled', function() {
-      configureService('/other_base/link', false);
+      configureService({linkHref: '/other_base/link', html5Mode: false});
       inject(
         initBrowser(),
         initLocation(),
@@ -1159,7 +1161,7 @@ describe('$location', function() {
 
     it('should not rewrite when full link to different base path when history enabled on new browser',
         function() {
-      configureService('http://host.com/other_base/link', true, true);
+      configureService({linkHref: 'http://host.com/other_base/link', html5Mode: true, supportHist: true});
       inject(
         initBrowser(),
         initLocation(),
@@ -1173,7 +1175,7 @@ describe('$location', function() {
 
     it('should not rewrite when full link to different base path when history enabled on old browser',
         function() {
-      configureService('http://host.com/other_base/link', true, false);
+      configureService({linkHref: 'http://host.com/other_base/link', html5Mode: true, supportHist: false});
       inject(
         initBrowser(),
         initLocation(),
@@ -1186,7 +1188,7 @@ describe('$location', function() {
 
 
     it('should not rewrite when full link to different base path when history disabled', function() {
-      configureService('http://host.com/other_base/link', false);
+      configureService({linkHref: 'http://host.com/other_base/link', html5Mode: false});
       inject(
         initBrowser(),
         initLocation(),
@@ -1199,7 +1201,7 @@ describe('$location', function() {
 
 
     it('should rewrite relative links relative to current path when history disabled', function() {
-      configureService('link', true, false, true);
+      configureService({linkHref: 'link', html5Mode: true, supportHist: false, relLink: true});
       inject(
         initBrowser(),
         initLocation(),
@@ -1213,7 +1215,7 @@ describe('$location', function() {
 
 
     it('should replace current path when link begins with "/" and history disabled', function() {
-      configureService('/link', true, false, true);
+      configureService({linkHref: '/link', html5Mode: true, supportHist: false, relLink: true});
       inject(
         initBrowser(),
         initLocation(),
@@ -1227,7 +1229,7 @@ describe('$location', function() {
 
 
     it('should replace current hash fragment when link begins with "#" history disabled', function() {
-      configureService('#link', true, false, true);
+      configureService({linkHref: '#link', html5Mode: true, supportHist: false, relLink: true});
       inject(
         initBrowser(),
         initLocation(),
@@ -1247,7 +1249,7 @@ describe('$location', function() {
     if (!msie || msie >= 9) {
 
       it('should not rewrite when clicked with ctrl pressed', function() {
-        configureService('/a?b=c', true, true);
+        configureService({linkHref: '/a?b=c', html5Mode: true, supportHist: true});
         inject(
           initBrowser(),
           initLocation(),
@@ -1260,7 +1262,7 @@ describe('$location', function() {
 
 
       it('should not rewrite when clicked with meta pressed', function() {
-        configureService('/a?b=c', true, true);
+        configureService({linkHref: '/a?b=c', html5Mode: true, supportHist: true});
         inject(
           initBrowser(),
           initLocation(),


### PR DESCRIPTION
BREAKING CHANGE (since 1.2.0 and 1.3.0-beta.1):

Angular now requires a `<base>` tag when html5 mode of `$location` is enabled. Reasoning:
Using html5 mode without a `<base href="...">` tag makes relative links for images, links, ...
relative to the current url if the browser supports
the history API. However, if the browser does not support the history API Angular falls back to using the `#`,
and then all links would be broken.

BREAKING CHANGE (since 1.2.17 and 1.3.0-beta.10):

In html5 mode without a `<base>` tag on older browser that don't support the history API
relative paths were adding up. E.g. clicking on `<a href="page1">` and then on `<a href="page2">`
would produce `$location.path()==='/page1/page2'. The code that introduced this behavior was removed
and Angular now also requires a`<base>` tag to be present when using html5 mode.

Closes #8172
