### PR TITLE
chore(css) separate selectors and declarations by new lines

### DIFF
--- a/css/angular-scenario.css
+++ b/css/angular-scenario.css
@@ -13,7 +13,8 @@ body {
   text-align: center;
 }
 
-#json, #xml {
+#json,
+#xml {
   display: none;
 }
 

--- a/css/angular.css
+++ b/css/angular.css
@@ -1,7 +1,11 @@
 @charset "UTF-8";
 
-[ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak],
-.ng-cloak, .x-ng-cloak,
+[ng\:cloak],
+[ng-cloak],
+[data-ng-cloak],
+[x-ng-cloak],
+.ng-cloak,
+.x-ng-cloak,
 .ng-hide:not(.ng-animate) {
   display: none !important;
 }


### PR DESCRIPTION
This PR follows the Google [CSS guidelines](https://google-styleguide.googlecode.com/svn/trunk/htmlcssguide.xml) rule to start a [new line for each selector and declaration](https://google-styleguide.googlecode.com/svn/trunk/htmlcssguide.xml?showone=Selector_and_Declaration_Separation#Selector_and_Declaration_Separation). Separated selectors and declarations by new lines for readability and consistency in the two CSS files. 
