### PR TITLE
chore(travis): move docse2e tests into the unit tests vm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - JOB=unit
     - JOB=e2e TEST_TARGET=jqlite
     - JOB=e2e TEST_TARGET=jquery
-    - JOB=e2e TEST_TARGET=doce2e
   global:
     - SAUCE_USERNAME=angular-ci
     - SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -9,12 +9,11 @@ if [ $JOB = "unit" ]; then
   grunt test:promises-aplus
   grunt test:unit --browsers SL_Chrome,SL_Safari,SL_Firefox,SL_IE_9,SL_IE_10,SL_IE_11 --reporters dots
   grunt tests:docs --browsers SL_Chrome,SL_Safari,SL_Firefox,SL_IE_9,SL_IE_10,SL_IE_11 --reporters dots
+  grunt test:travis-protractor --specs "docs/app/e2e/docsAppE2E.js"
 elif [ $JOB = "e2e" ]; then
   export TARGET_SPECS="build/docs/ptore2e/**/*jqlite_test.js"
   if [ $TEST_TARGET = "jquery" ]; then
     TARGET_SPECS="build/docs/ptore2e/**/*jquery_test.js"
-  elif [ $TEST_TARGET = "doce2e" ]; then
-    TARGET_SPECS="docs/app/e2e/docsAppE2E.js"
   fi
   grunt test:travis-protractor --specs "$TARGET_SPECS"
 else


### PR DESCRIPTION
we spend more time making getting the build ready than running the docs e2e tests.

by piggy-backing on unit tests we'll finish the build faster
