### PR TITLE
perf(jQuery): only trigger $destroy if a handler exists

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1510,9 +1510,13 @@ function bindJQuery() {
     // the $destroy event on all removed nodes.
     originalCleanData = jQuery.cleanData;
     jQuery.cleanData = function(elems) {
+      var events;
       if (!skipDestroyOnNextJQueryCleanData) {
         for (var i = 0, elem; (elem = elems[i]) != null; i++) {
-          jQuery(elem).triggerHandler('$destroy');
+          events = jQuery._data(elem, "events");
+          if (events && events.$destroy) {
+            jQuery(elem).triggerHandler('$destroy');
+          }
         }
       } else {
         skipDestroyOnNextJQueryCleanData = false;


### PR DESCRIPTION
This is the exact same performance improvement that jQuery UI recently did: https://github.com/jquery/jquery-ui/commit/f7429edfe96d322cdec850f7207efba8125767a6
