### PR TITLE
fix(ngForm): don't clear validity of whole form when removing control

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -160,8 +160,6 @@ function FormController(element, attrs, $scope, $animate) {
     function clear(queue, validationToken) {
       form.$setValidity(validationToken, true, control);
     }
-
-    parentForm.$$clearControlValidity(form);
   };
 
   form.$$setPending = function(validationToken, control) {

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -494,6 +494,35 @@ describe('form', function() {
       expect(doc.find('div').hasClass('ng-valid-required')).toBe(true);
     });
 
+  it('should leave the parent form invalid when deregister a removed input', function() {
+    doc = jqLite(
+      '<form name="parent">' +
+        '<div class="ng-form" name="child">' +
+          '<input ng-if="inputPresent" ng-model="modelA" name="inputA" required>' +
+          '<input ng-model="modelB" name="inputB" required>' +
+        '</div>' +
+      '</form>');
+    $compile(doc)(scope);
+    scope.inputPresent = true;
+    scope.$apply();
+
+    var parent = scope.parent,
+        child = scope.child,
+        inputA = child.inputA,
+        inputB = child.inputB;
+
+    expect(parent).toBeDefined();
+    expect(child).toBeDefined();
+    expect(parent.$error.required).toEqual([child]);
+    expect(child.$error.required).toEqual([inputB, inputA]);
+
+    //remove child input
+    scope.inputPresent = false;
+    scope.$apply();
+
+    expect(parent.$error.required).toEqual([child]);
+    expect(child.$error.required).toEqual([inputB]);
+  });
 
     it('should chain nested forms in repeater', function() {
       doc = jqLite(


### PR DESCRIPTION
calling `$$clearControlValidity` on the parent of a nested form caused the parent form to look like there are no more errors on the nested form even if it still had some inputs with errors. there is no need to call this method recursively since `$setValidity` will propagate the new validity state well enough.
