### PR TITLE
refactor(angularInit): remove unnecessary forEach

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1307,15 +1307,6 @@ function angularInit(element, bootstrap) {
       module,
       config = {};
 
-  // The element `element` has priority over any other element
-  forEach(ngAttrPrefixes, function(prefix) {
-    var name = prefix + 'app';
-
-    if (!appElement && element.hasAttribute && element.hasAttribute(name)) {
-      appElement = element;
-      module = element.getAttribute(name);
-    }
-  });
   forEach(ngAttrPrefixes, function(prefix) {
     var name = prefix + 'app';
     var candidate;


### PR DESCRIPTION
It seems like we only ever call this with document, so this removed forEach will never do anything.
