### PR TITLE
refactor(ngRepeat): specify explicit `false` for cloneNode deepClone parameter

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -417,7 +417,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
               $transclude(function ngRepeatTransclude(clone, scope) {
                 block.scope = scope;
                 // http://jsperf.com/clone-vs-createcomment
-                var endNode = ngRepeatEndComment.cloneNode();
+                var endNode = ngRepeatEndComment.cloneNode(false);
                 clone[clone.length++] = endNode;
                 $animate.enter(clone, null, jqLite(previousNode));
                 previousNode = endNode;


### PR DESCRIPTION
This should provide a slight compat improvement for old versions of Opera, which did not treat the `false` as the default value.

There is no test for this fix as Opera 11 is not a browser which runs on the CI servers.

Closes #8883
