### PR TITLE
fix($location): set `baseHref` in mock browser to `/`

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -120,7 +120,7 @@ angular.mock.$Browser = function() {
     }
   };
 
-  self.$$baseHref = '';
+  self.$$baseHref = '/';
   self.baseHref = function() {
     return this.$$baseHref;
   };

--- a/test/ng/anchorScrollSpec.js
+++ b/test/ng/anchorScrollSpec.js
@@ -110,10 +110,6 @@ describe('$anchorScroll', function() {
       return function($provide, $locationProvider) {
         $provide.value('$sniffer', {history: config.historyApi});
         $locationProvider.html5Mode(config.html5Mode);
-        $provide.decorator('$browser', function($delegate) {
-          $delegate.$$baseHref = '/';
-          return $delegate;
-        });
       };
     }
 

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -100,7 +100,6 @@ describe('$location', function() {
         /* global Browser: false */
         var b = new Browser($window, $document, fakeLog, sniffer);
         b.pollFns = [];
-        b.$$baseHref = '/';
         return b;
       };
     });
@@ -1541,10 +1540,6 @@ describe('$location', function() {
     it('should listen on click events on href and prevent browser default in html5 mode', function() {
       module(function($locationProvider, $provide) {
         $locationProvider.html5Mode(true);
-        $provide.decorator('$browser', function($delegate) {
-          $delegate.$$baseHref = '/';
-          return $delegate;
-        });
         return function($rootElement, $compile, $rootScope) {
           $rootElement.html('<a href="http://server/somePath">link</a>');
           $compile($rootElement)($rootScope);


### PR DESCRIPTION
Set the default value for the base tag in the mock browser to `/`,
as we now always require a base tag to be present for html5 mode.

Fixes #8866.
