### PR TITLE
fix(ngAnimate): support removing classes from SVG elements when using jQuery

### DIFF
--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -140,7 +140,8 @@ function publishExternalAPI(angular){
     'getTestability': getTestability,
     '$$minErr': minErr,
     '$$csp': csp,
-    'reloadWithDebugInfo': reloadWithDebugInfo
+    'reloadWithDebugInfo': reloadWithDebugInfo,
+    '$$hasClass': jqLiteHasClass
   });
 
   angularModule = setupModuleLoader(window);

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -494,7 +494,7 @@ angular.module('ngAnimate', ['ng'])
 
         var toAdd = [], toRemove = [];
         forEach(map, function(status, className) {
-          var hasClass = element.hasClass(className);
+          var hasClass = angular.$$hasClass(element[0], className);
           var matchingAnimation = lookup[className] || {};
 
           // When addClass and removeClass is called then $animate will check to

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -4641,6 +4641,18 @@ describe("ngAnimate", function() {
         expect(child.hasClass('ng-enter')).toBe(false);
         expect(child.hasClass('ng-enter-active')).toBe(false);
       }));
+
+
+      it('should properly remove classes from SVG elements', inject(function($animate, $rootScope) {
+        var element = jqLite('<svg width="500" height="500"><rect class="class-of-doom"></rect></svg>');
+        var child = element.find('rect');
+        $animate.removeClass(child, 'class-of-doom');
+
+        $rootScope.$digest();
+        expect(child.attr('class')).toBe('');
+
+        dealoc(element);
+      }));
     });
   });
 });


### PR DESCRIPTION
Without this CL, ngShowHide will not work without the use of monkeypatched
fixes for jQuery such as https://github.com/kbwood/svg 's jquery-svgdom.js
script.

/CC @matsko / @IgorMinar --- as noted above, people can make this work by including third party
scripts, but I thought since this is technically a regression I would write a patch anyways and
see what people think.

So, the main thing is that this is not reusing the existing jqLiteHasClass method, because jqLite
is not exported unless jQuery is not found. We could fix this to support code reuse, if we want
to fix this at all.

There is one other use of `.hasClass()` in ngAnimate that I can see, so it's likely that another
SVG scenario is broken in jQuery by default, but I haven't investigated to see what that other
scenario is.

Balls in your court, do you think we should fix it or just defer the work to third party code
like jquery-svgdom

Closes #8872
