### PR TITLE
perf(extend): remove use of forEach to remove calls/closures/passing arguments

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -337,13 +337,16 @@ function setHashKey(obj, h) {
  */
 function extend(dst) {
   var h = dst.$$hashKey;
-  forEach(arguments, function(obj) {
-    if (obj !== dst) {
-      forEach(obj, function(value, key) {
-        dst[key] = value;
-      });
+  for (var i = 1, ii = arguments.length; i < ii; i++) {
+    var obj = arguments[i];
+    if (obj && obj !== dst) {
+      var keys = Object.keys(obj);
+      for (var j = 0, jj = keys.length; j < jj; j++) {
+        var key = keys[j];
+        dst[key] = obj[key];
+      }
     }
-  });
+  }
 
   setHashKey(dst,h);
   return dst;


### PR DESCRIPTION
I found this made `$parse` almost 50% faster when not cached, I assume other cases will also benefit. This also removes the "bad value context for arguments value" warning in the chrome profiler.
