### PR TITLE
$parse performance/style

### DIFF
--- a/benchmarks/parsed-expressions-bp/app.js
+++ b/benchmarks/parsed-expressions-bp/app.js
@@ -1,0 +1,81 @@
+var app = angular.module('parsedExpressionBenchmark', []);
+
+app.config(function($compileProvider) {
+  if ($compileProvider.debugInfoEnabled) {
+    $compileProvider.debugInfoEnabled(false);
+  }
+});
+
+app.filter('noop', function() {
+  return function(input) {
+    return input;
+  };
+});
+
+//Executes the specified expression as a watcher
+app.directive('bmPeWatch', function() {
+  return {
+    restrict: 'A',
+    compile: function($element, $attrs) {
+      $element.text( $attrs.bmPeWatch );
+      return function($scope, $element, $attrs) {
+        $scope.$watch($attrs.bmPeWatch);
+      };
+    }
+  };
+});
+
+//Executes the specified expression as a watcher
+//Adds a simple wrapper method to allow use of $watch instead of $watchCollection
+app.directive('bmPeWatchLiteral', function($parse) {
+  function retZero() {
+    return 0;
+  }
+
+  return {
+    restrict: 'A',
+    compile: function($element, $attrs) {
+      $element.text( $attrs.bmPeWatchLiteral );
+      return function($scope, $element, $attrs) {
+        $scope.$watch( $parse($attrs.bmPeWatchLiteral, retZero) );
+      };
+    }
+  };
+});
+
+app.controller('DataController', function($scope, $rootScope) {
+  var totalRows = 2000;
+
+  var data = $scope.data = [];
+
+  $scope.func = function() {};
+
+  for (var i=0; i<totalRows; i++) {
+    data.push({
+      index: i,
+      odd:   i%2 === 0,
+      even:  i%2 === 1,
+      str0: "foo-" + Math.random()*Date.now(),
+      str1: "bar-" + Math.random()*Date.now(),
+      str2: "baz-" + Math.random()*Date.now(),
+      num0:  Math.random()*Date.now(),
+      num1:  Math.random()*Date.now(),
+      num2:  Math.random()*Date.now(),
+      date0: new Date(Math.random()*Date.now()),
+      date1: new Date(Math.random()*Date.now()),
+      date2: new Date(Math.random()*Date.now()),
+      func: function(){},
+      obj: data[i-1],
+      keys: data[i-1] && (data[i-1].keys || Object.keys(data[i-1]))
+    });
+  }
+
+  benchmarkSteps.push({
+    name: '$apply',
+    fn: function() {
+      for (var i=0; i<50; i++) {
+        $rootScope.$digest();
+      }
+    }
+  });
+});

--- a/benchmarks/parsed-expressions-bp/bp.conf.js
+++ b/benchmarks/parsed-expressions-bp/bp.conf.js
@@ -1,0 +1,11 @@
+module.exports = function(config) {
+  config.set({
+    scripts: [    {
+      id: 'angular',
+      src: '/build/angular.js'
+    },
+    {
+      src: 'app.js',
+    }]
+  });
+};

--- a/benchmarks/parsed-expressions-bp/main.html
+++ b/benchmarks/parsed-expressions-bp/main.html
@@ -1,0 +1,192 @@
+<div ng-app="parsedExpressionBenchmark" ng-cloak>
+  <div ng-controller="DataController">
+    <div class="container-fluid">
+      <p>
+        Tests the execution of $parse()ed expressions. Each test tries to isolate specific expression types. Expressions should (probably) not be constant so they get evaluated per digest.
+      </p>
+
+      <ul style="list-style:none">
+        <li>
+          <input type="radio" ng-model="expressionType" value="simpleProperty" id="simpleProperty">
+          <label for="simpleProperty">Simple Properties</label>
+        </li>
+
+        <li>
+          <input type="radio" ng-model="expressionType" value="fieldAccess" id="fieldAccess">
+          <label for="fieldAccess">Field Accessors</label>
+        </li>
+
+        <li>
+          <input type="radio" ng-model="expressionType" value="fieldIndex" id="fieldIndex">
+          <label for="fieldIndex">Field Indexors</label>
+        </li>
+
+        <li>
+          <input type="radio" ng-model="expressionType" value="operators" id="operators">
+          <label for="operators">Binary/Unary operators</label>
+        </li>
+
+        <li>
+          <input type="radio" ng-model="expressionType" value="filters" id="filters">
+          <label for="filters">Filters</label>
+        </li>
+
+        <li>
+          <input type="radio" ng-model="expressionType" value="functionCalls" id="functionCalls">
+          <label for="functionCalls">Function calls</label>
+        </li>
+
+        <li>
+          <input type="radio" ng-model="expressionType" value="objectLiterals" id="objectLiterals">
+          <label for="objectLiterals">Object Literals</label>
+        </li>
+
+        <li>
+          <input type="radio" ng-model="expressionType" value="arrayLiterals" id="arrayLiterals">
+          <label for="arrayLiterals">Array Literals</label>
+        </li>
+      </ul>
+
+      <!--
+        NOTES:
+          - ensure each tested expression has at least one variable in it to avoid constant expressions
+      -->
+
+      <ul ng-switch="expressionType">
+        <li ng-switch-when="simpleProperty" ng-repeat="(rowIdx, row) in data">
+          <span bm-pe-watch="rowIdx"></span>
+          <span bm-pe-watch="row.index"></span>
+          <span bm-pe-watch="row.num0"></span>
+          <span bm-pe-watch="row.num1"></span>
+          <span bm-pe-watch="row.str0"></span>
+          <span bm-pe-watch="row.str1"></span>
+          <span bm-pe-watch="row.obj"></span>
+          <span bm-pe-watch="row.obj.obj"></span>
+          <span bm-pe-watch="row.obj.obj.obj"></span>
+          <span bm-pe-watch="row.obj.obj.obj.obj"></span>
+          <span bm-pe-watch="row.obj.obj.obj.obj.obj"></span>
+          <span bm-pe-watch="row.obj.obj.obj.obj.obj.obj"></span>
+        </li>
+
+        <li ng-switch-when="fieldAccess" ng-repeat="(rowIdx, row) in data">
+          <span bm-pe-watch="row .index"></span>
+          <span bm-pe-watch="row .obj . index"></span>
+          <span bm-pe-watch="row.obj .index"></span>
+          <span bm-pe-watch="row .obj .index"></span>
+          <span bm-pe-watch="row .obj.obj .index"></span>
+          <span bm-pe-watch="row .obj.obj .obj .index"></span>
+          <span bm-pe-watch="row .obj .obj .index"></span>
+          <span bm-pe-watch="row .obj .obj.obj .index"></span>
+          <span bm-pe-watch="row .obj .obj .obj.index"></span>
+          <span bm-pe-watch="row .num1"></span>
+          <span bm-pe-watch="row. num1"></span>
+          <span bm-pe-watch="row . num1"></span>
+          <span bm-pe-watch="row . num2"></span>
+        </li>
+
+        <li ng-switch-when="fieldIndex" ng-repeat="(rowIdx, row) in data">
+          <span bm-pe-watch="data[rowIdx]"></span>
+          <span bm-pe-watch="data[row['index']]['index']"></span>
+          <span bm-pe-watch="data[rowIdx]['obj']"></span>
+          <span bm-pe-watch="data[rowIdx]['obj']['obj']"></span>
+          <span bm-pe-watch="row[row['keys'][0]]"></span>
+          <span bm-pe-watch="row[row['keys'][1]]"></span>
+          <span bm-pe-watch="row[row['keys'][2]]"></span>
+          <span bm-pe-watch="row[row['keys'][3]]"></span>
+          <span bm-pe-watch="row[row['keys'][4]]"></span>
+          <span bm-pe-watch="row[row['keys'][5]]"></span>
+          <span bm-pe-watch="row['str0']"></span>
+          <span bm-pe-watch="row['str1']"></span>
+        </li>
+
+        <li ng-switch-when="operators" ng-repeat="(rowIdx, row) in data">
+          <span bm-pe-watch="-rowIdx"></span>
+          <span bm-pe-watch="rowIdx + 1"></span>
+          <span bm-pe-watch="rowIdx - 1"></span>
+          <span bm-pe-watch="rowIdx * 2"></span>
+          <span bm-pe-watch="rowIdx + -1"></span>
+          <span bm-pe-watch="rowIdx - -1"></span>
+          <span bm-pe-watch="-rowIdx * 2 + 1"></span>
+          <span bm-pe-watch="rowIdx % 2"></span>
+          <span bm-pe-watch="rowIdx % 2 === 1"></span>
+          <span bm-pe-watch="rowIdx % 2 === 0"></span>
+          <span bm-pe-watch="rowIdx / 1"></span>
+          <span bm-pe-watch="-rowIdx * 2 * rowIdx + rowIdx / rowIdx + 1"></span>
+        </li>
+
+        <li ng-switch-when="filters" ng-repeat="(rowIdx, row) in data">
+          <span bm-pe-watch="rowIdx | noop"></span>
+          <span bm-pe-watch="rowIdx | noop | noop"></span>
+          <span bm-pe-watch="rowIdx | noop | noop | noop"></span>
+          <span bm-pe-watch="-rowIdx | noop"></span>
+          <span bm-pe-watch="rowIdx | noop:1"></span>
+          <span bm-pe-watch="rowIdx | noop:1 | noop"></span>
+          <span bm-pe-watch="rowIdx | noop:1 | noop:2 | noop:3"></span>
+          <span bm-pe-watch="rowIdx | noop:1:2:3:4:5"></span>
+          <span bm-pe-watch="rowIdx | noop:rowIdx"></span>
+          <span bm-pe-watch="rowIdx | noop:rowIdx:rowIdx:rowIdx"></span>
+          <span bm-pe-watch="rowIdx | noop | noop:1 | noop"></span>
+          <span bm-pe-watch="rowIdx | noop | noop:null:undefined:0"></span>
+        </li>
+
+        <li ng-switch-when="functionCalls" ng-repeat="(rowIdx, row) in data">
+          <span bm-pe-watch="func()"></span>
+          <span bm-pe-watch="func(1)"></span>
+          <span bm-pe-watch="func(1, 2)"></span>
+          <span bm-pe-watch="func(1, 2, 3)"></span>
+          <span bm-pe-watch="func(1, 2, 3, 4)"></span>
+          <span bm-pe-watch="row.func()"></span>
+          <span bm-pe-watch="row.func(1)"></span>
+          <span bm-pe-watch="row.func(1, 2)"></span>
+          <span bm-pe-watch="row.func(1, 2, 3)"></span>
+          <span bm-pe-watch="row.func(1, 2, 3, 4)"></span>
+          <span bm-pe-watch="func(func())"></span>
+          <span bm-pe-watch="func(func(), func())"></span>
+          <span bm-pe-watch="row.func(row.func())"></span>
+          <span bm-pe-watch="row.func(row.func(), row.func())"></span>
+        </li>
+
+        <li ng-switch-when="objectLiterals" ng-repeat="(rowIdx, row) in data">
+          <span bm-pe-watch-literal="{foo: rowIdx}"></span>
+          <span bm-pe-watch-literal="{foo: row, bar: rowIdx}"></span>
+          <span bm-pe-watch-literal="{0: row, 1: rowIdx, 2: 3}"></span>
+          <span bm-pe-watch-literal="{str: 'foo', num: rowIdx, b: true}"></span>
+          <span bm-pe-watch-literal="{a: {b: {c: {d: {e: {f: rowIdx}}}}}"></span>
+          <span bm-pe-watch-literal="{a: rowIdx, b: 1, c: 2, d: 3, e: 4, f: 5, g: rowIdx, h: 6, i: 7, j: 8, k: rowIdx}"></span>
+        </li>
+
+        <li ng-switch-when="arrayLiterals" ng-repeat="(rowIdx, row) in data">
+          <span bm-pe-watch-literal="[rowIdx]"></span>
+          <span bm-pe-watch-literal="[rowIdx, 0]"></span>
+          <span bm-pe-watch-literal="[rowIdx, 0, 1]"></span>
+          <span bm-pe-watch-literal="[rowIdx, 0, 1, 2]"></span>
+          <span bm-pe-watch-literal="[rowIdx, 0, 1, 2, 3]"></span>
+          <span bm-pe-watch-literal="[[], [rowIdx], [], [], [3], [[[]]]"></span>
+          <span bm-pe-watch-literal="[rowIdx, undefined, null, true, false]"></span>
+          <span bm-pe-watch-literal="[[][0], [0][0], [][rowIdx]]"></span>
+          <span bm-pe-watch-literal="[0, rowIdx]"></span>
+          <span bm-pe-watch-literal="[0, 1, rowIdx]"></span>
+          <span bm-pe-watch-literal="[0, 1, 2, rowIdx]"></span>
+          <span bm-pe-watch-literal="[0, 1, 2, 3, rowIdx]"></span>
+        </li>
+
+        <!--
+        <li ng-switch-when="" ng-repeat="(rowIdx, row) in data">
+          <span bm-pe-watch=""></span>
+          <span bm-pe-watch=""></span>
+          <span bm-pe-watch=""></span>
+          <span bm-pe-watch=""></span>
+          <span bm-pe-watch=""></span>
+          <span bm-pe-watch=""></span>
+          <span bm-pe-watch=""></span>
+          <span bm-pe-watch=""></span>
+          <span bm-pe-watch=""></span>
+          <span bm-pe-watch=""></span>
+          <span bm-pe-watch=""></span>
+          <span bm-pe-watch=""></span>
+        </li>
+        -->
+      </ul>
+    </div>
+  </div>
+</div>

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -531,7 +531,7 @@ Parser.prototype = {
         // TODO(size): maybe we should not support multiple statements?
         return (statements.length === 1)
             ? statements[0]
-            : function(self, locals) {
+            : function $parseStatements(self, locals) {
                 var value;
                 for (var i = 0, ii = statements.length; i < ii; i++) {
                   value = statements[i](self, locals);
@@ -598,7 +598,7 @@ Parser.prototype = {
             this.text.substring(0, token.index) + '] can not be assigned to', token);
       }
       right = this.ternary();
-      return function(scope, locals) {
+      return function $parseAssignment(scope, locals) {
         return left.assign(scope, right(scope, locals), locals);
       };
     }
@@ -788,7 +788,7 @@ Parser.prototype = {
     }
     this.consume(']');
 
-    return extend(function(self, locals) {
+    return extend(function $parseArrayLiteral(self, locals) {
       var array = [];
       for (var i = 0; i < elementFns.length; i++) {
         array.push(elementFns[i](self, locals));
@@ -821,7 +821,7 @@ Parser.prototype = {
     }
     this.consume('}');
 
-    return extend(function(self, locals) {
+    return extend(function $parseObjectLiteral(self, locals) {
       var object = {};
       for (var i = 0; i < keyValues.length; i++) {
         var keyValue = keyValues[i];

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -533,11 +533,8 @@ Parser.prototype = {
             ? statements[0]
             : function(self, locals) {
                 var value;
-                for (var i = 0; i < statements.length; i++) {
-                  var statement = statements[i];
-                  if (statement) {
-                    value = statement(self, locals);
-                  }
+                for (var i = 0, ii = statements.length; i < ii; i++) {
+                  value = statements[i](self, locals);
                 }
                 return value;
               };

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -790,7 +790,7 @@ Parser.prototype = {
 
     return extend(function $parseArrayLiteral(self, locals) {
       var array = [];
-      for (var i = 0; i < elementFns.length; i++) {
+      for (var i = 0, ii = elementFns.length; i < ii; i++) {
         array.push(elementFns[i](self, locals));
       }
       return array;
@@ -823,7 +823,7 @@ Parser.prototype = {
 
     return extend(function $parseObjectLiteral(self, locals) {
       var object = {};
-      for (var i = 0; i < keyValues.length; i++) {
+      for (var i = 0, ii = keyValues.length; i < ii; i++) {
         var keyValue = keyValues[i];
         object[keyValue.key] = keyValue.value(self, locals);
       }

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -545,13 +545,10 @@ Parser.prototype = {
   filterChain: function() {
     var left = this.expression();
     var token;
-    while (true) {
-      if ((token = this.expect('|'))) {
-        left = this.binaryFn(left, token.fn, this.filter());
-      } else {
-        return left;
-      }
+    while ((token = this.expect('|'))) {
+      left = this.binaryFn(left, token.fn, this.filter());
     }
+    return left;
   },
 
   filter: function() {
@@ -624,13 +621,10 @@ Parser.prototype = {
   logicalOR: function() {
     var left = this.logicalAND();
     var token;
-    while (true) {
-      if ((token = this.expect('||'))) {
-        left = this.binaryFn(left, token.fn, this.logicalAND());
-      } else {
-        return left;
-      }
+    while ((token = this.expect('||'))) {
+      left = this.binaryFn(left, token.fn, this.logicalAND());
     }
+    return left;
   },
 
   logicalAND: function() {

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -80,12 +80,21 @@ function ensureSafeFunction(obj, fullExpression) {
   }
 }
 
+//Keyword constants
+var CONSTANTS = createMap();
+forEach({
+  'null':function(){return null;},
+  'true':function(){return true;},
+  'false':function(){return false;},
+  'undefined':function(){}
+}, function(constFunc, name) {
+  constFunc.constant = constFunc.literal = constFunc.$$parseShared = true;
+  CONSTANTS[name] = constFunc;
+});
+
+//Operators - will be wrapped by binaryFn/unaryFn/assignment/filter
 var OPERATORS = extend(createMap(), {
     /* jshint bitwise : false */
-    'null':function(){return null;},
-    'true':function(){return true;},
-    'false':function(){return false;},
-    undefined:noop,
     '+':function(self, locals, a,b){
       a=a(self, locals); b=b(self, locals);
       if (isDefined(a)) {
@@ -305,30 +314,11 @@ Lexer.prototype = {
       }
     }
 
-
-    var token = {
+    this.tokens.push({
       index: start,
-      text: ident
-    };
-
-    var fn = OPERATORS[ident];
-
-    if (fn) {
-      token.fn = fn;
-      token.constant = true;
-    } else {
-      var getter = getterFn(ident, this.options, parserText);
-      // TODO(perf): consider exposing the getter reference
-      token.fn = extend(function $parsePathGetter(self, locals) {
-        return getter(self, locals);
-      }, {
-        assign: function(self, value) {
-          return setter(self, ident, value, parserText);
-        }
-      });
-    }
-
-    this.tokens.push(token);
+      text: ident,
+      fn: CONSTANTS[ident] || getterFn(ident, this.options, parserText)
+    });
 
     if (methodName) {
       this.tokens.push({
@@ -397,6 +387,7 @@ var Parser = function (lexer, $filter, options) {
 Parser.ZERO = extend(function () {
   return 0;
 }, {
+  $$parseShared: true,
   constant: true
 });
 
@@ -935,9 +926,14 @@ function getterFn(path, options, fullExp) {
     var evaledFnGetter = new Function('s', 'l', code); // s=scope, l=locals
     /* jshint +W054 */
     evaledFnGetter.toString = valueFn(code);
+    evaledFnGetter.assign = function(self, value) {
+      return setter(self, path, value, path);
+    };
+
     fn = evaledFnGetter;
   }
 
+  fn.$$parseShared = true;
   getterFnCache[path] = fn;
   return fn;
 }
@@ -1005,6 +1001,21 @@ function $ParseProvider() {
   this.$get = ['$filter', '$sniffer', function($filter, $sniffer) {
     $parseOptions.csp = $sniffer.csp;
 
+    function wrapSharedExpression(exp) {
+      var wrapped = exp;
+
+      if (exp.$$parseShared) {
+        wrapped = function $parseWrapper(self, locals) {
+          return exp(self, locals);
+        };
+        wrapped.literal = exp.literal;
+        wrapped.constant = exp.constant;
+        wrapped.assign = exp.assign;
+      }
+
+      return wrapped;
+    }
+
     return function $parse(exp, interceptorFn) {
       var parsedExpression, oneTime, cacheKey;
 
@@ -1027,6 +1038,9 @@ function $ParseProvider() {
             if (parsedExpression.constant) {
               parsedExpression.$$watchDelegate = constantWatchDelegate;
             } else if (oneTime) {
+              //oneTime is not part of the exp passed to the Parser so we may have to
+              //wrap the parsedExpression before adding a $$watchDelegate
+              parsedExpression = wrapSharedExpression(parsedExpression);
               parsedExpression.$$watchDelegate = parsedExpression.literal ?
                 oneTimeLiteralWatchDelegate : oneTimeWatchDelegate;
             }

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -258,7 +258,7 @@ Lexer.prototype = {
   },
 
   readIdent: function() {
-    var parser = this;
+    var parserText = this.text;
 
     var ident = '';
     var start = this.index;
@@ -317,13 +317,13 @@ Lexer.prototype = {
       token.fn = fn;
       token.constant = true;
     } else {
-      var getter = getterFn(ident, this.options, this.text);
+      var getter = getterFn(ident, this.options, parserText);
       // TODO(perf): consider exposing the getter reference
       token.fn = extend(function $parsePathGetter(self, locals) {
         return getter(self, locals);
       }, {
         assign: function(self, value) {
-          return setter(self, ident, value, parser.text);
+          return setter(self, ident, value, parserText);
         }
       });
     }
@@ -686,9 +686,9 @@ Parser.prototype = {
   },
 
   fieldAccess: function(object) {
-    var parser = this;
+    var parserText = this.text;
     var field = this.expect().text;
-    var getter = getterFn(field, this.options, this.text);
+    var getter = getterFn(field, this.options, parserText);
 
     return extend(function $parseFieldAccess(scope, locals, self) {
       return getter(self || object(scope, locals));
@@ -696,13 +696,13 @@ Parser.prototype = {
       assign: function(scope, value, locals) {
         var o = object(scope, locals);
         if (!o) object.assign(scope, o = {});
-        return setter(o, field, value, parser.text);
+        return setter(o, field, value, parserText);
       }
     });
   },
 
   objectIndex: function(obj) {
-    var parser = this;
+    var parserText = this.text;
 
     var indexFn = this.expression();
     this.consume(']');
@@ -712,15 +712,15 @@ Parser.prototype = {
           i = indexFn(self, locals),
           v;
 
-      ensureSafeMemberName(i, parser.text);
+      ensureSafeMemberName(i, parserText);
       if (!o) return undefined;
-      v = ensureSafeObject(o[i], parser.text);
+      v = ensureSafeObject(o[i], parserText);
       return v;
     }, {
       assign: function(self, value, locals) {
-        var key = ensureSafeMemberName(indexFn(self, locals), parser.text);
+        var key = ensureSafeMemberName(indexFn(self, locals), parserText);
         // prevent overwriting of Function.constructor which would break ensureSafeObject check
-        var o = ensureSafeObject(obj(self, locals), parser.text);
+        var o = ensureSafeObject(obj(self, locals), parserText);
         if (!o) obj.assign(self, o = {});
         return o[key] = value;
       }

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -722,7 +722,7 @@ describe('parser', function() {
               scope.$eval('a.toString.constructor = 1', scope);
             }).toThrowMinErr(
                     '$parse', 'isecfn', 'Referencing Function in Angular expressions is disallowed! ' +
-                    'Expression: a.toString.constructor = 1');
+                    'Expression: a.toString.constructor');
           });
 
 


### PR DESCRIPTION
c074181 might be the only one worth merging to allow the Parser/Lexer objects to be GCed.

f4ea3c9 addresses a TODO although I didn't notice any major improvements (even though the removed wrapper method is often ~10% when profiling...).  Unfortunately the wrapper method is still needed for the expressions returned from `$parse`, but use of `getterFn`s within other expressions don't have the wrapper. This also required a minor error message change.

f4ea3c9 could be expanded in other ways though. Maybe allowing `$parse`ed methods to return something such as a `$$watchFn` property that can be watched instead of the full expression being watched.  The simple case would be returning the raw `getterFn` instead of the wrapper for simple `foo.bar` expressions.  A more complicated case would be expressions such as `myVar % 2 === 0` returning only the `myVar` `getterFn` to be watched (and then a special watch delegate to see if the full expression actually changed, which makes it more complicated...). Or only watching the input+args to filters etc. Not sure how common or useful those would be though...

The rest are mostly style/simplifying but I thought I'd leave them in there.
