### PR TITLE
docs(ngSwitch): fix priority

### DIFF
--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -42,7 +42,7 @@
  *
  *
  * @scope
- * @priority 800
+ * @priority 1200
  * @param {*} ngSwitch|on expression to match against <tt>ng-switch-when</tt>.
  * On child elements add:
  *


### PR DESCRIPTION
Fixes priority of ngSwitch due to the change of #8244

Fixes #8244
