### PR TITLE
docs(navigation): side navigation footer overlap problem fix

### DIFF
--- a/docs/app/assets/css/docs.css
+++ b/docs/app/assets/css/docs.css
@@ -391,7 +391,6 @@ iframe.example {
   position:fixed;
   top:120px;
   bottom:0;
-  padding-bottom:120px;
   overflow:auto;
 }
 
@@ -412,6 +411,7 @@ iframe.example {
 
 .main-body-grid .side-navigation {
   position:relative;
+  padding-bottom:120px;
 }
 
 .main-body-grid .side-navigation.ng-hide {


### PR DESCRIPTION
Browser : Firefox 32 (MacOS)
URL: https://docs.angularjs.org/api/
Problem Root: Firefox not applying padding-bottom rule if position rules used.
Screenshot: 
![screen shot 2014-09-04 at 11 02 26](https://cloud.githubusercontent.com/assets/330566/4146339/e3dca238-3409-11e4-87c5-ccbdba4ec24e.png)
