### PR TITLE
fix($location): path to work with full url

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -415,10 +415,19 @@ LocationHashbangInHtml5Url.prototype =
    * @param {(string|number)=} path New path
    * @return {string} path
    */
-  path: locationGetterSetter('$$path', function(path) {
-    path = path ? path.toString() : '';
-    return path.charAt(0) == '/' ? path : '/' + path;
-  }),
+  path: function(newPath) {
+    if (isUndefined(newPath))
+      return this['$$path'];
+	var index = newPath.indexOf(this.appBase);
+	if ( index >= 0 ) {
+		this.$$parse(newPath);
+		return this;
+	}
+	newPath = newPath ? newPath.toString() : '';
+    this['$$path'] =  newPath.charAt(0) == '/' ? newPath : '/' + newPath;
+    this.$$compose();
+    return this;
+  },
 
   /**
    * @ngdoc method

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -652,6 +652,16 @@ describe('$location', function() {
       expect($browser.url()).toBe('http://new.com/a/b#!/new/path');
     }));
 
+    it('should update browser when $location path is set using full url', inject(function($rootScope, $browser, $location) {
+      var $browserUrl = spyOnlyCallsWithArgs($browser, 'url').andCallThrough();
+      $location.path('http://new.com/a/b#!/new/path');
+      expect($browserUrl).not.toHaveBeenCalled();
+      $rootScope.$apply();
+
+      expect($browserUrl).toHaveBeenCalledOnce();
+      expect($browser.url()).toBe('http://new.com/a/b#!/new/path');
+      expect($location.path()).toBe('/new/path');
+    }));
 
     it('should update browser only once per $apply cycle', inject(function($rootScope, $browser, $location) {
       var $browserUrl = spyOnlyCallsWithArgs($browser, 'url').andCallThrough();


### PR DESCRIPTION
Changed the way $location.path is handled. Now path function will check if the path contain the base url (protocol://host) is this is there in the path. Mostly user has passed the full url instead of path.
We process it differently, by calling the parse method of the respective location object. Since parse method takes care if the url is HTML5 mode , HTML5 hashbang mode or non HTML5 urls and parses them respectively.

Currently i have made directly used the parse function which updates the whole location object. We can also ass a parsePath method to each of  LocationHashbangInHtml5Url,LocationHashbangUrl,  LocationHtml5Url classes which will copy implementation from parse method and get the path out of newUrl but won't update the location object. If this implementation have some issue i can work on making this change.

Closes #8617
