### PR TITLE
feat(limitTo): Add support for numbers in limitTo

### DIFF
--- a/src/ng/filter/limitTo.js
+++ b/src/ng/filter/limitTo.js
@@ -7,10 +7,11 @@
  *
  * @description
  * Creates a new array or string containing only a specified number of elements. The elements
- * are taken from either the beginning or the end of the source array or string, as specified by
- * the value and sign (positive or negative) of `limit`.
+ * are taken from either the beginning or the end of the source array, string or number, as specified by
+ * the value and sign (positive or negative) of `limit`. If a number is used as input, it is
+ * converted to a string.
  *
- * @param {Array|string} input Source array or string to be limited.
+ * @param {Array|string|number} input Source array, string or number to be limited.
  * @param {string|number} limit The length of the returned array or string. If the `limit` number
  *     is positive, `limit` number of items from the beginning of the source array/string are copied.
  *     If the number is negative, `limit` number  of items from the end of the source array/string
@@ -26,8 +27,10 @@
            .controller('ExampleController', ['$scope', function($scope) {
              $scope.numbers = [1,2,3,4,5,6,7,8,9];
              $scope.letters = "abcdefghi";
+             $scope.longNumber = 2345432342;
              $scope.numLimit = 3;
              $scope.letterLimit = 3;
+             $scope.longNumberLimit = 3;
            }]);
        </script>
        <div ng-controller="ExampleController">
@@ -35,19 +38,25 @@
          <p>Output numbers: {{ numbers | limitTo:numLimit }}</p>
          Limit {{letters}} to: <input type="integer" ng-model="letterLimit">
          <p>Output letters: {{ letters | limitTo:letterLimit }}</p>
+         Limit {{longNumber}} to: <input type="integer" ng-model="longNumberLimit">
+         <p>Output long number: {{ longNumber | limitTo:longNumberLimit }}</p>
        </div>
      </file>
      <file name="protractor.js" type="protractor">
        var numLimitInput = element(by.model('numLimit'));
        var letterLimitInput = element(by.model('letterLimit'));
+       var longNumberLimitInput = element(by.model('longNumberLimit'));
        var limitedNumbers = element(by.binding('numbers | limitTo:numLimit'));
        var limitedLetters = element(by.binding('letters | limitTo:letterLimit'));
+       var limitedLongNumber = element(by.binding('longNumber | limitTo:longNumberLimit'));
 
        it('should limit the number array to first three items', function() {
          expect(numLimitInput.getAttribute('value')).toBe('3');
          expect(letterLimitInput.getAttribute('value')).toBe('3');
+         expect(longNumberLimitInput.getAttribute('value')).toBe('3');
          expect(limitedNumbers.getText()).toEqual('Output numbers: [1,2,3]');
          expect(limitedLetters.getText()).toEqual('Output letters: abc');
+         expect(limitedLongNumber.getText()).toEqual('Output long number: 234');
        });
 
        it('should update the output when -3 is entered', function() {
@@ -55,8 +64,11 @@
          numLimitInput.sendKeys('-3');
          letterLimitInput.clear();
          letterLimitInput.sendKeys('-3');
+         longNumberLimitInput.clear();
+         longNumberLimitInput.sendKeys('-3');
          expect(limitedNumbers.getText()).toEqual('Output numbers: [7,8,9]');
          expect(limitedLetters.getText()).toEqual('Output letters: ghi');
+         expect(limitedLongNumber.getText()).toEqual('Output long number: 342');
        });
 
        it('should not exceed the maximum size of input array', function() {
@@ -64,14 +76,18 @@
          numLimitInput.sendKeys('100');
          letterLimitInput.clear();
          letterLimitInput.sendKeys('100');
+         longNumberLimitInput.clear();
+         longNumberLimitInput.sendKeys('100');
          expect(limitedNumbers.getText()).toEqual('Output numbers: [1,2,3,4,5,6,7,8,9]');
          expect(limitedLetters.getText()).toEqual('Output letters: abcdefghi');
+         expect(limitedLongNumber.getText()).toEqual('Output long number: 2345432342');
        });
      </file>
    </example>
  */
 function limitToFilter(){
   return function(input, limit) {
+    if (isNumber(input)) input = input.toString();
     if (!isArray(input) && !isString(input)) return input;
 
     if (Math.abs(Number(limit)) === Infinity) {

--- a/test/ng/filter/limitToSpec.js
+++ b/test/ng/filter/limitToSpec.js
@@ -3,11 +3,13 @@
 describe('Filter: limitTo', function() {
   var items;
   var str;
+  var number;
   var limitTo;
 
   beforeEach(inject(function($filter) {
     items = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
     str = "tuvwxyz";
+    number = 100.045;
     limitTo = $filter('limitTo');
   }));
 
@@ -17,6 +19,8 @@ describe('Filter: limitTo', function() {
     expect(limitTo(items, '3')).toEqual(['a', 'b', 'c']);
     expect(limitTo(str, 3)).toEqual("tuv");
     expect(limitTo(str, '3')).toEqual("tuv");
+    expect(limitTo(number, 3)).toEqual("100");
+    expect(limitTo(number, '3')).toEqual("100");
   });
 
 
@@ -25,6 +29,8 @@ describe('Filter: limitTo', function() {
     expect(limitTo(items, '-3')).toEqual(['f', 'g', 'h']);
     expect(limitTo(str, -3)).toEqual("xyz");
     expect(limitTo(str, '-3')).toEqual("xyz");
+    expect(limitTo(number, -3)).toEqual("045");
+    expect(limitTo(number, '-3')).toEqual("045");
   });
 
 
@@ -45,8 +51,7 @@ describe('Filter: limitTo', function() {
   });
 
 
-  it('should return input if not String or Array', function() {
-    expect(limitTo(1,1)).toEqual(1);
+  it('should return input if not String or Array or Number', function() {
     expect(limitTo(null, 1)).toEqual(null);
     expect(limitTo(undefined, 1)).toEqual(undefined);
     expect(limitTo({}, 1)).toEqual({});
@@ -67,6 +72,8 @@ describe('Filter: limitTo', function() {
     expect(limitTo(str, '9')).toEqual(str);
     expect(limitTo(str, -9)).toEqual(str);
     expect(limitTo(str, '-9')).toEqual(str);
+    expect(limitTo(number, 9)).toEqual(number.toString());
+    expect(limitTo(number, '-9')).toEqual(number.toString());
   });
 
   it('should return entire input array when limited by Infinity', function() {


### PR DESCRIPTION
It would be nice if limitTo supports numbers. The expected behavior would change input to string and just run limitTo on that value. This becomes useful often when you have long decimal numbers, etc...
