### PR TITLE
WIP: Filter cache

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -575,7 +575,7 @@ function isPromiseLike(obj) {
 
 function isPrimitive(value) {
   var valueType;
-  return (value == null || (valueType = typeof value) === 'number' ||  valueType === 'string');
+  return (value == null || (valueType = typeof value) === 'string' ||  valueType === 'number');
 }
 
 

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -573,6 +573,12 @@ function isPromiseLike(obj) {
 }
 
 
+function isPrimitive(value) {
+  var valueType;
+  return (value == null || (valueType = typeof value) === 'number' ||  valueType === 'string');
+}
+
+
 var trim = function(value) {
   return isString(value) ? value.trim() : value;
 };

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -136,6 +136,7 @@ function $RootScopeProvider(){
       this.$$listenerCount = {};
       this.$$isolateBindings = {};
       this.$$applyAsyncQueue = [];
+      this.$$filterCache = createMap();
     }
 
     /**
@@ -207,6 +208,7 @@ function $RootScopeProvider(){
               this.$$listenerCount = {};
               this.$id = nextUid();
               this.$$ChildScope = null;
+              this.$$filterCache = createMap();
             };
             this.$$ChildScope.prototype = this;
           }

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -334,20 +334,6 @@ describe('parser', function() {
         expect(scope.$eval("'a' + 'b c'")).toEqual("ab c");
       });
 
-      it('should parse filters', function() {
-        $filterProvider.register('substring', valueFn(function(input, start, end) {
-          return input.substring(start, end);
-        }));
-
-        expect(function() {
-          scope.$eval("1|nonexistent");
-        }).toThrowMinErr('$injector', 'unpr', 'Unknown provider: nonexistentFilterProvider <- nonexistentFilter');
-
-        scope.offset =  3;
-        expect(scope.$eval("'abcd'|substring:1:offset")).toEqual("bc");
-        expect(scope.$eval("'abcd'|substring:1:3|uppercase")).toEqual("BC");
-      });
-
       it('should access scope', function() {
         scope.a =  123;
         scope.b = {c: 456};
@@ -590,12 +576,6 @@ describe('parser', function() {
     //    expect(scope.$eval('books[1]')).toEqual("moby");
       });
 
-      it('should evaluate grouped filters', function() {
-        scope.name = 'MISKO';
-        expect(scope.$eval('n = (name|lowercase)')).toEqual('misko');
-        expect(scope.$eval('n')).toEqual('misko');
-      });
-
       it('should evaluate remainder', function() {
         expect(scope.$eval('1%2')).toEqual(1);
       });
@@ -676,6 +656,32 @@ describe('parser', function() {
         scope.b = {c: "bc"};
         expect(scope.$eval('a + \n b.c + \r "\td" + \t \r\n\r "\r\n\n"')).toEqual("abc\td\r\n\n");
       });
+
+
+      describe('filters', function() {
+
+        it('should parse filters', function() {
+          $filterProvider.register('substring', valueFn(function(input, start, end) {
+            return input.substring(start, end);
+          }));
+
+          expect(function() {
+            scope.$eval("1|nonexistent");
+          }).toThrowMinErr('$injector', 'unpr', 'Unknown provider: nonexistentFilterProvider <- nonexistentFilter');
+
+          scope.offset =  3;
+          expect(scope.$eval("'abcd'|substring:1:offset")).toEqual("bc");
+          expect(scope.$eval("'abcd'|substring:1:3|uppercase")).toEqual("BC");
+        });
+
+
+        it('should evaluate grouped filters', function() {
+          scope.name = 'MISKO';
+          expect(scope.$eval('n = (name|lowercase)')).toEqual('misko');
+          expect(scope.$eval('n')).toEqual('misko');
+        });
+      });
+
 
       describe('sandboxing', function() {
         describe('Function constructor', function() {

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -571,9 +571,8 @@ describe('parser', function() {
 
         expect(scope.$eval('items[1] = "abc"')).toEqual("abc");
         expect(scope.$eval('items[1]')).toEqual("abc");
-    //    Dont know how to make this work....
-    //    expect(scope.$eval('books[1] = "moby"')).toEqual("moby");
-    //    expect(scope.$eval('books[1]')).toEqual("moby");
+        expect(scope.$eval('books[1] = "moby"')).toEqual("moby");
+        expect(scope.$eval('books[1]')).toEqual("moby");
       });
 
       it('should evaluate remainder', function() {


### PR DESCRIPTION
use a cache to avoid recomputing filters during dirty-checking.

in the modified large-table benchmark delivers 3x speed improvement for number filter (apply duration), but makes the uppercase filter 20% slower

TODO:
- more benchmarking
- special case dates since they are not primitives but can be cheaply compared via `getTime()`
- decide on whether to make the cache an opt-in or an opt-out
