### PR TITLE
Allow ordering for Array inheritors

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -115,7 +115,7 @@
 orderByFilter.$inject = ['$parse'];
 function orderByFilter($parse){
   return function(array, sortPredicate, reverseOrder) {
-    if (!isArray(array)) return array;
+    if (!(isArray(array) || array instanceof Array)) return array;
     if (!sortPredicate) return array;
     sortPredicate = isArray(sortPredicate) ? sortPredicate: [sortPredicate];
     sortPredicate = map(sortPredicate, function(predicate){

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -115,7 +115,7 @@
 orderByFilter.$inject = ['$parse'];
 function orderByFilter($parse){
   return function(array, sortPredicate, reverseOrder) {
-    if (!(isArray(array) || array instanceof Array)) return array;
+    if (!isArrayLike(array)) return array;
     if (!sortPredicate) return array;
     sortPredicate = isArray(sortPredicate) ? sortPredicate: [sortPredicate];
     sortPredicate = map(sortPredicate, function(predicate){

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -18,7 +18,7 @@ describe('Filter: orderBy', function() {
   });
 
   it('should sort inherited from array', function(){
-    function BaseCollection(){};
+    function BaseCollection(){}
     BaseCollection.prototype = Array.prototype;
     var child = new BaseCollection();
     child.push({a:2});

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -17,6 +17,19 @@ describe('Filter: orderBy', function() {
     expect(orderBy([{a:15}, {a:2}], 'a', "reverse")).toEqualData([{a:15}, {a:2}]);
   });
 
+  it('should sort inherited from array', function(){
+    function BaseCollection(){};
+    BaseCollection.prototype = Array.prototype;
+    var child = new BaseCollection();
+    child.push({a:2});
+    child.push({a:15});
+
+    expect(Array.isArray(child)).toBe(false);
+    expect(child instanceof Array).toBe(true);
+
+    expect(orderBy(child, 'a', true)).toEqualData([{a:15}, {a:2}]);
+  });
+
   it('should sort array by predicate', function() {
     expect(orderBy([{a:15, b:1}, {a:2, b:1}], ['a', 'b'])).toEqualData([{a:2, b:1}, {a:15, b:1}]);
     expect(orderBy([{a:15, b:1}, {a:2, b:1}], ['b', 'a'])).toEqualData([{a:2, b:1}, {a:15, b:1}]);


### PR DESCRIPTION
Hello,

yesterday I faced an issue with angular.
We use Coffeescript and its classes very widely in our rails project. We have a BaseCollection class, which was inherited from Array. It works cool, but there's one negative effect: I was unable to order this object with ng-repeat and orderBy.

I started digging and revealed, that angular rejects any objects, but Arrays itself. The problem was that Array.isArray does not define Array inheritors as arrays, while when I inherite from class I must follow the Liskov substitution principle and not to break Array functionality (and we do in our project).

Here's [a short demonstration](http://jsfiddle.net/2ja03bfn/7) of the issue. Issue can be reproduced in 1.2.x, but in 1.1.x everything works fine.

I suggest to allow array-like objects to be sorted. I've also added a test to cover this and checked the green-red-green process with `grunt test:jqlite`. Please take a look at my fix or fix that issue by yourself in more diligent way.
