### PR TITLE
pass the return value back to the caller

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2227,7 +2227,7 @@ if(window.jasmine || window.mocha) {
         }
         try {
           /* jshint -W040 *//* Jasmine explicitly provides a `this` object when calling functions */
-          injector.invoke(blockFns[i] || angular.noop, this);
+          return injector.invoke(blockFns[i] || angular.noop, this);
           /* jshint +W040 */
         } catch (e) {
           if (e.stack && errorForStack) {


### PR DESCRIPTION
This would allow injection in unit tests to be written like this:
var $q = inject(function($q){return arguments[0]})
instead of needing to write a closure over $q and aliasing $q to _$q_ in the inject() call
