### PR TITLE
refactor($http): simplify buildUrl function

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -1060,7 +1060,7 @@ function $HttpProvider() {
           if (isObject(v)) {
             if (isDate(v)){
               v = v.toISOString();
-            } else if (isObject(v)) {
+            } else {
               v = toJson(v);
             }
           }


### PR DESCRIPTION
Small refactor to the $http's `buildUrl` function:
- avoid double `isObject` check
- shaves off few bytes by replacing if statement with a ternary operator  
