### PR TITLE
feat(ngController): add optional locals attribute for injection locals

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1630,6 +1630,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             controller = directive.controller;
             if (controller == '@') {
               controller = attrs[directive.name];
+              if (attrs.locals) {
+                extend(locals, scope.$eval(attrs.locals));
+              }
             }
 
             controllerInstance = $controller(controller, locals, true, directive.controllerAs);

--- a/src/ng/directive/ngController.js
+++ b/src/ng/directive/ngController.js
@@ -30,6 +30,9 @@
  * The controller instance can be published into a scope property by specifying
  * `ng-controller="as propertyName"`.
  *
+ * You can also provide injection locals for the controller by specifying a `locals` attribute, e.g.
+ * `ng-controller="ChildController" locals="{settingsCtrl: settings}"`.
+ *
  * If the current `$controllerProvider` is configured to use globals (via
  * {@link ng.$controllerProvider#allowGlobals `$controllerProvider.allowGlobals()` }), this may
  * also be the name of a globally accessible constructor function (not recommended).

--- a/test/ng/directive/ngControllerSpec.js
+++ b/test/ng/directive/ngControllerSpec.js
@@ -37,6 +37,10 @@ describe('ngController', function() {
       this.mark = 'works';
     });
 
+    $controllerProvider.register('Locals', function($scope, mark) {
+      $scope.mark = mark;
+    });
+
   }));
 
   afterEach(function() {
@@ -60,6 +64,13 @@ describe('ngController', function() {
 
   it('should publish controller into scope from module', inject(function($compile, $rootScope) {
     element = $compile('<div ng-controller="PublicModule as p">{{p.mark}}</div>')($rootScope);
+    $rootScope.$digest();
+    expect(element.text()).toBe('works');
+  }));
+
+
+  it('should evaluate and inject controller with locals', inject(function($compile, $rootScope) {
+    element = $compile('<div ng-controller="Locals" locals="{mark: \'works\'}">{{mark}}</div>')($rootScope);
     $rootScope.$digest();
     expect(element.text()).toBe('works');
   }));


### PR DESCRIPTION
This enables templates to provide or override injected services when instantiating a controller,
similar to the $controller service.

It is also similar to the ngView route.resolve option and makes the reuse of view controllers in
templates more viable.
