### PR TITLE
fix(i18n): fix typo at i18n generation code

### DIFF
--- a/i18n/src/parser.js
+++ b/i18n/src/parser.js
@@ -18,7 +18,7 @@ function parsePattern(pattern) {
   var p = {
             minInt: 1,
             minFrac: 0,
-            macFrac: 0,
+            maxFrac: 0,
             posPre: '',
             posSuf: '',
             negPre: '',


### PR DESCRIPTION
Fix typo at i18n generation code. This would remove the property `macFrac` that has no meaning from all the generated locales

To complete the patch, there is a need to generate the i18n locales once again, but adding this to this PR would make it really hard to spot the single change
