### PR TITLE
fix(linky): handle the double quote character in email addresses

### DIFF
--- a/src/ngSanitize/filter/linky.js
+++ b/src/ngSanitize/filter/linky.js
@@ -142,7 +142,7 @@ angular.module('ngSanitize').filter('linky', ['$sanitize', function($sanitize) {
         html.push('" ');
       }
       html.push('href="');
-      html.push(url);
+      html.push(url.replace('"', '&quot;'));
       html.push('">');
       addText(text);
       html.push('</a>');

--- a/test/ngSanitize/filter/linkySpec.js
+++ b/test/ngSanitize/filter/linkySpec.js
@@ -29,6 +29,10 @@ describe('linky', function() {
       toEqual('my email is &#34;<a href="mailto:me@example.com">me@example.com</a>&#34;');
   });
 
+  it('should handle quotes in the email', function() {
+    expect(linky('foo@"bar.com')).toEqual('<a href="mailto:foo@&#34;bar.com">foo@&#34;bar.com</a>');
+  });
+
   it('should handle target:', function() {
     expect(linky("http://example.com", "_blank")).
       toEqual('<a target="_blank" href="http://example.com">http://example.com</a>');


### PR DESCRIPTION
Handle the double quote character as part of the domain in email addresses

Closes #8945
