### PR TITLE
style(ngLocale): change es-us lcoale currency format

### DIFF
--- a/src/ngLocale/angular-locale_es-us.js
+++ b/src/ngLocale/angular-locale_es-us.js
@@ -64,8 +64,8 @@ $provide.value("$locale", {
   },
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "\u20ac",
-    "DECIMAL_SEP": ",",
-    "GROUP_SEP": ".",
+    "DECIMAL_SEP": ".",
+    "GROUP_SEP": ",",
     "PATTERNS": [
       {
         "gSize": 3,


### PR DESCRIPTION
Fixed the angular-locale_es-us currency. Before `$1.234,56` After `$1,234.56`
http://publib.boulder.ibm.com/infocenter/forms/v3r5m0/index.jsp?topic=/com.ibm.form.designer.locales.doc/i_xfdl_r_formats_es_US.html

closes #8931
