### PR TITLE
fix XSS vulnerability in ng-srcset

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -844,7 +844,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
         nodeName = nodeName_(this.$$element);
 
-				if ((nodeName === 'a' && key === 'href') ||
+        if ((nodeName === 'a' && key === 'href') ||
 						(nodeName === 'img' && key === 'src')) {
   	      // sanitize a[href] and img[src] values
 				  this[key] = value = $$sanitizeUri(value, key === 'src');

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -844,10 +844,42 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
         nodeName = nodeName_(this.$$element);
 
-        // sanitize a[href] and img[src] values
-        var isImage = nodeName === 'img' && (key === 'src' || key === 'srcset');
-        if ((nodeName === 'a' && key === 'href') || isImage) {
-          this[key] = value = $$sanitizeUri(value, isImage);
+				if ((nodeName === 'a' && key === 'href') ||
+						(nodeName === 'img' && key === 'src')) {
+  	      // sanitize a[href] and img[src] values
+				  this[key] = value = $$sanitizeUri(value, key === 'src');
+        } else if (nodeName === 'img' && key === 'srcset') {
+        	// sanitize img[srcset] values
+					var result = "";
+
+					// first check if there are spaces because it's not the same pattern
+					var trimedSrcset = trim(value);
+					var pattern = /\s/.test( trimedSrcset) ? /(\d+x\s*,|\d+w\s*,|\s+,|,\s+)/ : /(,)/;
+
+					// split srcset into tupple of uri and descriptor except for the last item
+					var rawUris = trimedSrcset.split(pattern);
+
+					// for each tupples
+					var nbrUrisWith2parts = Math.floor(rawUris.length / 2);
+					for (var i=0; i<nbrUrisWith2parts; i++) {
+						var innerIdx = i*2;
+						// sanitize the uri
+						result += $$sanitizeUri(trim( rawUris[innerIdx]), true);
+						// add the descriptor
+						result += ( " " + trim(rawUris[innerIdx+1]));
+					}
+
+					// split the last item into uri and descriptor
+					var lastTupple = trim(rawUris[i*2]).split(/\s/);
+
+					// sanitize the last uri
+					result += $$sanitizeUri(trim(lastTupple[0]), true);
+
+					// and add the last descriptor if any
+					if( lastTupple.length === 2) {
+						result += (" " + trim(lastTupple[1]));
+					}
+					this[key] = value = result;
         }
 
         if (writeAttr !== false) {

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -845,9 +845,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         nodeName = nodeName_(this.$$element);
 
         // sanitize a[href] and img[src] values
-        if ((nodeName === 'a' && key === 'href') ||
-            (nodeName === 'img' && key === 'src')) {
-          this[key] = value = $$sanitizeUri(value, key === 'src');
+        var isImage = nodeName === 'img' && (key === 'src' || key === 'srcset');
+        if ((nodeName === 'a' && key === 'href') || isImage) {
+          this[key] = value = $$sanitizeUri(value, isImage);
         }
 
         if (writeAttr !== false) {

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -845,41 +845,41 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         nodeName = nodeName_(this.$$element);
 
         if ((nodeName === 'a' && key === 'href') ||
-						(nodeName === 'img' && key === 'src')) {
-  	      // sanitize a[href] and img[src] values
-				  this[key] = value = $$sanitizeUri(value, key === 'src');
+            (nodeName === 'img' && key === 'src')) {
+          // sanitize a[href] and img[src] values
+          this[key] = value = $$sanitizeUri(value, key === 'src');
         } else if (nodeName === 'img' && key === 'srcset') {
-        	// sanitize img[srcset] values
-					var result = "";
+          // sanitize img[srcset] values
+          var result = "";
 
-					// first check if there are spaces because it's not the same pattern
-					var trimedSrcset = trim(value);
-					var pattern = /\s/.test( trimedSrcset) ? /(\d+x\s*,|\d+w\s*,|\s+,|,\s+)/ : /(,)/;
+          // first check if there are spaces because it's not the same pattern
+          var trimedSrcset = trim(value);
+          var pattern = /\s/.test( trimedSrcset) ? /(\d+x\s*,|\d+w\s*,|\s+,|,\s+)/ : /(,)/;
 
-					// split srcset into tupple of uri and descriptor except for the last item
-					var rawUris = trimedSrcset.split(pattern);
+          // split srcset into tupple of uri and descriptor except for the last item
+          var rawUris = trimedSrcset.split(pattern);
 
-					// for each tupples
-					var nbrUrisWith2parts = Math.floor(rawUris.length / 2);
-					for (var i=0; i<nbrUrisWith2parts; i++) {
-						var innerIdx = i*2;
-						// sanitize the uri
-						result += $$sanitizeUri(trim( rawUris[innerIdx]), true);
-						// add the descriptor
-						result += ( " " + trim(rawUris[innerIdx+1]));
-					}
+          // for each tupples
+          var nbrUrisWith2parts = Math.floor(rawUris.length / 2);
+          for (var i=0; i<nbrUrisWith2parts; i++) {
+            var innerIdx = i*2;
+            // sanitize the uri
+            result += $$sanitizeUri(trim( rawUris[innerIdx]), true);
+            // add the descriptor
+            result += ( " " + trim(rawUris[innerIdx+1]));
+          }
 
-					// split the last item into uri and descriptor
-					var lastTupple = trim(rawUris[i*2]).split(/\s/);
+          // split the last item into uri and descriptor
+          var lastTupple = trim(rawUris[i*2]).split(/\s/);
 
-					// sanitize the last uri
-					result += $$sanitizeUri(trim(lastTupple[0]), true);
+          // sanitize the last uri
+          result += $$sanitizeUri(trim(lastTupple[0]), true);
 
-					// and add the last descriptor if any
-					if( lastTupple.length === 2) {
-						result += (" " + trim(lastTupple[1]));
-					}
-					this[key] = value = result;
+          // and add the last descriptor if any
+          if( lastTupple.length === 2) {
+            result += (" " + trim(lastTupple[1]));
+          }
+          this[key] = value = result;
         }
 
         if (writeAttr !== false) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -5603,6 +5603,70 @@ describe('$compile', function() {
     });
   });
 
+  describe('img[srcset] sanitization', function() {
+
+    it('should NOT require trusted values for img srcset', inject(function($rootScope, $compile, $sce) {
+      element = $compile('<img srcset="{{testUrl}}"></img>')($rootScope);
+      $rootScope.testUrl = 'http://example.com/image.png';
+      $rootScope.$digest();
+      expect(element.attr('srcset')).toEqual('http://example.com/image.png');
+      // But it should accept trusted values anyway.
+      $rootScope.testUrl = $sce.trustAsUrl('http://example.com/image2.png');
+      $rootScope.$digest();
+      expect(element.attr('srcset')).toEqual('http://example.com/image2.png');
+    }));
+
+    it('should use $$sanitizeUri', function() {
+      var $$sanitizeUri = jasmine.createSpy('$$sanitizeUri');
+      module(function($provide) {
+        $provide.value('$$sanitizeUri', $$sanitizeUri);
+      });
+      inject(function($compile, $rootScope) {
+        element = $compile('<img srcset="{{testUrl}}"></img>')($rootScope);
+        $rootScope.testUrl = "someUrl";
+
+        $$sanitizeUri.andReturn('someSanitizedUrl');
+        $rootScope.$apply();
+        expect(element.attr('srcset')).toBe('someSanitizedUrl');
+        expect($$sanitizeUri).toHaveBeenCalledWith($rootScope.testUrl, true);
+      });
+    });
+
+    it('should sanitize all uris in srcset', inject(function($rootScope, $compile) {
+      /*jshint scripturl:true*/
+      element = $compile('<img srcset="{{testUrl}}"></img>')($rootScope);
+      var testSet = {
+        'http://example.com/image.png':'http://example.com/image.png',
+        ' http://example.com/image.png':'http://example.com/image.png',
+        'http://example.com/image.png ':'http://example.com/image.png',
+        'http://example.com/image.png 128w':'http://example.com/image.png 128w',
+        'http://example.com/image.png 2x':'http://example.com/image.png 2x',
+        'http://example.com/image.png 1.5x':'http://example.com/image.png 1.5x',
+        'http://example.com/image1.png 1x,http://example.com/image2.png 2x':'http://example.com/image1.png 1x,http://example.com/image2.png 2x',
+        'http://example.com/image1.png 1x ,http://example.com/image2.png 2x':'http://example.com/image1.png 1x ,http://example.com/image2.png 2x',
+        'http://example.com/image1.png 1x, http://example.com/image2.png 2x':'http://example.com/image1.png 1x,http://example.com/image2.png 2x',
+        'http://example.com/image1.png 1x , http://example.com/image2.png 2x':'http://example.com/image1.png 1x ,http://example.com/image2.png 2x',
+        'http://example.com/image1.png 48w,http://example.com/image2.png 64w':'http://example.com/image1.png 48w,http://example.com/image2.png 64w',
+        'http://example.com/image1.png 1x,http://example.com/image2.png 64w':'http://example.com/image1.png 1x,http://example.com/image2.png 64w',
+        'http://example.com/image1.png,http://example.com/image2.png':'http://example.com/image1.png ,http://example.com/image2.png',
+        'http://example.com/image1.png ,http://example.com/image2.png':'http://example.com/image1.png ,http://example.com/image2.png',
+        'http://example.com/image1.png, http://example.com/image2.png':'http://example.com/image1.png ,http://example.com/image2.png',
+        'http://example.com/image1.png , http://example.com/image2.png':'http://example.com/image1.png ,http://example.com/image2.png',
+        'http://example.com/image1.png 1x, http://example.com/image2.png 2x, http://example.com/image3.png 3x':
+          'http://example.com/image1.png 1x,http://example.com/image2.png 2x,http://example.com/image3.png 3x',
+        'javascript:doEvilStuff() 2x': 'unsafe:javascript:doEvilStuff() 2x',
+        'http://example.com/image1.png 1x,javascript:doEvilStuff() 2x':'http://example.com/image1.png 1x,unsafe:javascript:doEvilStuff() 2x',
+        'http://example.com/image1.jpg?x=a,b 1x,http://example.com/ima,ge2.jpg 2x':'http://example.com/image1.jpg?x=a,b 1x,http://example.com/ima,ge2.jpg 2x'
+      };
+      
+      forEach( testSet, function( ref, url) {
+        $rootScope.testUrl = url;
+        $rootScope.$digest();
+        expect(element.attr('srcset')).toEqual(ref);
+      });
+
+    }));
+  });
 
   describe('a[href] sanitization', function() {
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -5658,7 +5658,7 @@ describe('$compile', function() {
         'http://example.com/image1.png 1x,javascript:doEvilStuff() 2x':'http://example.com/image1.png 1x,unsafe:javascript:doEvilStuff() 2x',
         'http://example.com/image1.jpg?x=a,b 1x,http://example.com/ima,ge2.jpg 2x':'http://example.com/image1.jpg?x=a,b 1x,http://example.com/ima,ge2.jpg 2x'
       };
-      
+
       forEach( testSet, function( ref, url) {
         $rootScope.testUrl = url;
         $rootScope.$digest();

--- a/test/ng/directive/ngSrcSpec.js
+++ b/test/ng/directive/ngSrcSpec.js
@@ -8,13 +8,22 @@ describe('ngSrc', function() {
     dealoc(element);
   });
 
-  it('should not result empty string in img src', inject(function($rootScope, $compile) {
-    $rootScope.image = {};
-    element = $compile('<img ng-src="{{image.url}}">')($rootScope);
-    $rootScope.$digest();
-    expect(element.attr('src')).not.toBe('');
-    expect(element.attr('src')).toBe(undefined);
-  }));
+  describe('img[ng-src]', function() {
+    it('should not result empty string in img src', inject(function($rootScope, $compile) {
+      $rootScope.image = {};
+      element = $compile('<img ng-src="{{image.url}}">')($rootScope);
+      $rootScope.$digest();
+      expect(element.attr('src')).not.toBe('');
+      expect(element.attr('src')).toBe(undefined);
+    }));
+
+    it('should sanitize url', inject(function($rootScope, $compile) {
+      $rootScope.imageUrl = 'javascript:alert(1);';
+      element = $compile('<img ng-src="{{imageUrl}}">')($rootScope);
+      $rootScope.$digest();
+      expect(element.attr('src')).toBe('unsafe:javascript:alert(1);');
+    }));
+  });
 
   describe('iframe[ng-src]', function() {
     it('should pass through src attributes for the same domain', inject(function($compile, $rootScope) {

--- a/test/ng/directive/ngSrcsetSpec.js
+++ b/test/ng/directive/ngSrcsetSpec.js
@@ -20,7 +20,7 @@ describe('ngSrcset', function() {
     element = $compile('<img ng-srcset="{{imageUrl}}">')($rootScope);
     $rootScope.$digest();
     expect(element.attr('srcset')).toBe('http://example.com/image1.png 1x,http://example.com/image2.png 2x');
-  }));  
+  }));
 
   it('should sanitize evil url', inject(function($rootScope, $compile) {
     $rootScope.imageUrl = 'http://example.com/image1.png 1x, javascript:doEvilStuff() 2x';

--- a/test/ng/directive/ngSrcsetSpec.js
+++ b/test/ng/directive/ngSrcsetSpec.js
@@ -29,3 +29,4 @@ describe('ngSrcset', function() {
     expect(element.attr('srcset')).toBe('http://example.com/image1.png 1x,unsafe:javascript:doEvilStuff() 2x');
   }));
 });
+

--- a/test/ng/directive/ngSrcsetSpec.js
+++ b/test/ng/directive/ngSrcsetSpec.js
@@ -1,3 +1,4 @@
+/*jshint scripturl:true*/
 'use strict';
 
 describe('ngSrcset', function() {

--- a/test/ng/directive/ngSrcsetSpec.js
+++ b/test/ng/directive/ngSrcsetSpec.js
@@ -13,4 +13,11 @@ describe('ngSrcset', function() {
     $rootScope.$digest();
     expect(element.attr('srcset')).toBeUndefined();
   }));
+
+  it('should sanitize url', inject(function($rootScope, $compile) {
+    $rootScope.imageUrl = 'javascript:alert(1);';
+    element = $compile('<img ng-srcset="{{imageUrl}}">')($rootScope);
+    $rootScope.$digest();
+    expect(element.attr('srcset')).toBe('unsafe:javascript:alert(1);');
+  }));
 });

--- a/test/ng/directive/ngSrcsetSpec.js
+++ b/test/ng/directive/ngSrcsetSpec.js
@@ -15,10 +15,17 @@ describe('ngSrcset', function() {
     expect(element.attr('srcset')).toBeUndefined();
   }));
 
-  it('should sanitize url', inject(function($rootScope, $compile) {
-    $rootScope.imageUrl = 'javascript:alert(1);';
+  it('should sanitize good urls', inject(function($rootScope, $compile) {
+    $rootScope.imageUrl = 'http://example.com/image1.png 1x, http://example.com/image2.png 2x';
     element = $compile('<img ng-srcset="{{imageUrl}}">')($rootScope);
     $rootScope.$digest();
-    expect(element.attr('srcset')).toBe('unsafe:javascript:alert(1);');
+    expect(element.attr('srcset')).toBe('http://example.com/image1.png 1x,http://example.com/image2.png 2x');
+  }));  
+
+  it('should sanitize evil url', inject(function($rootScope, $compile) {
+    $rootScope.imageUrl = 'http://example.com/image1.png 1x, javascript:doEvilStuff() 2x';
+    element = $compile('<img ng-srcset="{{imageUrl}}">')($rootScope);
+    $rootScope.$digest();
+    expect(element.attr('srcset')).toBe('http://example.com/image1.png 1x,unsafe:javascript:doEvilStuff() 2x');
   }));
 });

--- a/test/ng/directive/ngSrcsetSpec.js
+++ b/test/ng/directive/ngSrcsetSpec.js
@@ -28,5 +28,4 @@ describe('ngSrcset', function() {
     $rootScope.$digest();
     expect(element.attr('srcset')).toBe('http://example.com/image1.png 1x,unsafe:javascript:doEvilStuff() 2x');
   }));
-  
 });

--- a/test/ng/directive/ngSrcsetSpec.js
+++ b/test/ng/directive/ngSrcsetSpec.js
@@ -28,4 +28,5 @@ describe('ngSrcset', function() {
     $rootScope.$digest();
     expect(element.attr('srcset')).toBe('http://example.com/image1.png 1x,unsafe:javascript:doEvilStuff() 2x');
   }));
+  
 });


### PR DESCRIPTION
There is a security issue with `ng-srcset`.

**URIs aren't sanitized**.

The behiavor is correct for `ng-src` but not for `ng-srcset`.

The probleme is with `src/ng/compile.js` that ignore `srcset`.

Here is the fix.

Laurent Trillaud
