### PR TITLE
fix(input): make checkbox ngTrueValue work with required

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1253,9 +1253,9 @@ function checkboxInputType(scope, element, attr, ctrl, $sniffer, $browser, $filt
     element[0].checked = ctrl.$viewValue;
   };
 
-  // Override the standard `$isEmpty` because a value of `false` means empty in a checkbox.
+  // Override the standard `$isEmpty` because an empty checkbox is always set to `false`
   ctrl.$isEmpty = function(value) {
-    return value !== trueValue;
+    return value === false;
   };
 
   ctrl.$formatters.push(function(value) {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -3623,7 +3623,7 @@ describe('input', function() {
 
 
     it('should be required if false', function() {
-      compileInput('<input type="checkbox" ng:model="value" required />');
+      compileInput('<input type="checkbox" ng-model="value" required />');
 
       browserTrigger(inputElm, 'click');
       expect(inputElm[0].checked).toBe(true);
@@ -3632,6 +3632,16 @@ describe('input', function() {
       browserTrigger(inputElm, 'click');
       expect(inputElm[0].checked).toBe(false);
       expect(inputElm).toBeInvalid();
+    });
+
+    it('should set the ngTrueValue when required directive is present', function() {
+      compileInput('<input type="checkbox" ng-model="value" required ng-true-value="\'yes\'" />');
+
+      expect(inputElm).toBeInvalid();
+
+      browserTrigger(inputElm, 'click');
+      expect(inputElm[0].checked).toBe(true);
+      expect(inputElm).toBeValid();
     });
   });
 


### PR DESCRIPTION
Fixes #5164 

The viewValue in a checkbox is always set to false (by default). Comparing to the trueValue is therefore incorrect.
