### PR TITLE
fix(ngInclude): correctly add non-html namespaced template content

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -125,6 +125,7 @@
     "jqLiteController": false,
     "jqLiteInheritedData": false,
     "jqLiteBuildFragment": false,
+    "jqLiteParseHTML": false,
     "getBooleanAttrName": false,
     "getAliasedAttrName": false,
     "createEventHandler": false,

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -124,6 +124,7 @@
     "jqLiteAddNodes": false,
     "jqLiteController": false,
     "jqLiteInheritedData": false,
+    "jqLiteBuildFragment": false,
     "getBooleanAttrName": false,
     "getAliasedAttrName": false,
     "createEventHandler": false,

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -979,15 +979,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       var lastCompileNode;
       return function publicLinkFn(scope, cloneConnectFn, transcludeControllers, parentBoundTranscludeFn, futureParentElement){
         assertArg(scope, 'scope');
-        var shouldReplace = false;
         if (!namespace) {
-          // If there's no namespace, and no futureParentElement, then we're probably compiling
-          // nodes in-place, so we should use the $compileNode's parent element in order to figure
-          // out the namespace.
-          if (!futureParentElement && !cloneConnectFn) {
-            if ((futureParentElement = $compileNodes.parent())[0])
-              shouldReplace = true;
-          }
           namespace = detectNamespaceForChildElements(futureParentElement);
         }
         if (namespace !== 'html' && $compileNodes[0] !== lastCompileNode) {
@@ -1016,11 +1008,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         }
 
         compile.$$addScopeInfo($linkNode, scope);
-        // If we need to replace $compileNodes due to in-place compilation which resulted in
-        // namespace adaptation, then append them to the parent node. (For whatever reason, the
-        // $compileNodes are no longer children of the parent, so replacing is not possible)
-        if (shouldReplace && namespace !== 'html')
-          futureParentElement.append($linkNode);
+
         if (cloneConnectFn) cloneConnectFn($linkNode, scope);
         if (compositeLinkFn) compositeLinkFn(scope, $linkNode, $linkNode, parentBoundTranscludeFn);
         return $linkNode;

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -267,10 +267,11 @@ var ngIncludeFillContentDirective = ['$compile',
       priority: -400,
       require: 'ngInclude',
       link: function(scope, $element, $attr, ctrl) {
-        if (/SVG/.test($element[0].toString()) && nodeName_($element[0]) !== 'foreignobject') {
+        if (/SVG/.test($element[0].toString())) {
           // WebKit: https://bugs.webkit.org/show_bug.cgi?id=135698 --- SVG elements do not
           // support innerHTML, so detect this here and try to generate the contents
           // specially.
+          $element.empty();
           $compile(jqLiteBuildFragment(ctrl.template, document).childNodes)(scope,
               function namespaceAdaptedClone(clone) {
             $element.append(clone);

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -267,8 +267,10 @@ var ngIncludeFillContentDirective = ['$compile',
       priority: -400,
       require: 'ngInclude',
       link: function(scope, $element, $attr, ctrl) {
-        $element.html(ctrl.template);
-        $compile($element.contents())(scope);
+        $element.empty();
+        $compile(ctrl.template)(scope, function namespaceAdaptedClone(clone) {
+          $element.append(clone);
+        }, undefined, undefined, $element);
       }
     };
   }];

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -267,10 +267,8 @@ var ngIncludeFillContentDirective = ['$compile',
       priority: -400,
       require: 'ngInclude',
       link: function(scope, $element, $attr, ctrl) {
-        $element.empty();
-        $compile(ctrl.template)(scope, function namespaceAdaptedClone(clone) {
-          $element.append(clone);
-        }, undefined, undefined, $element);
+        $element.html(ctrl.template);
+        $compile($element.contents())(scope);
       }
     };
   }];

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -267,9 +267,21 @@ var ngIncludeFillContentDirective = ['$compile',
       priority: -400,
       require: 'ngInclude',
       link: function(scope, $element, $attr, ctrl) {
-        $element.empty();
-        $element.append(jqLite(jqLiteBuildFragment(ctrl.template, document).childNodes));
-        $compile($element.contents())(scope, undefined, null, null, $element);
+        var isSVGElement = /SVG/.test($element[0].toString());
+
+        if (isSVGElement) {
+          // WebKit: https://bugs.webkit.org/show_bug.cgi?id=135698 --- SVG elements do not
+          // support innerHTML, so detect this here and try to generate the contents
+          // specially.
+          $element.empty();
+          $element.append(jqLiteBuildFragment(ctrl.template, document).childNodes);
+          $compile($element.contents())(scope, function namespaceAdaptedClone(clone) {
+            $element.append(clone);
+          }, undefined, undefined, $element);
+          return;
+        }
+        $element.html(ctrl.template);
+        $compile($element.contents())(scope);
       }
     };
   }];

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -267,17 +267,8 @@ var ngIncludeFillContentDirective = ['$compile',
       priority: -400,
       require: 'ngInclude',
       link: function(scope, $element, $attr, ctrl) {
-        $element.html(ctrl.template);
-        if (!$element.contents().length && ctrl.template.length) {
-          // WebKit: https://bugs.webkit.org/show_bug.cgi?id=135698 --- SVG elements do not
-          // support innerHTML, so detect this here and try to generate the contents
-          // specially.
-          $element.append(jqLite(jqLiteBuildFragment(ctrl.template, document).childNodes));
-          $compile($element.contents())(scope, function namespaceAdaptedClone(clone) {
-            $element.append(clone);
-          }, undefined, undefined, $element);
-          return;
-        }
+        $element.empty();
+        $element.append(jqLite(jqLiteBuildFragment(ctrl.template, document).childNodes));
         $compile($element.contents())(scope, undefined, null, null, $element);
       }
     };

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -267,19 +267,17 @@ var ngIncludeFillContentDirective = ['$compile',
       priority: -400,
       require: 'ngInclude',
       link: function(scope, $element, $attr, ctrl) {
-        var isSVGElement = /SVG/.test($element[0].toString());
-
-        if (isSVGElement) {
+        if (/SVG/.test($element[0].toString()) && nodeName_($element[0]) !== 'foreignobject') {
           // WebKit: https://bugs.webkit.org/show_bug.cgi?id=135698 --- SVG elements do not
           // support innerHTML, so detect this here and try to generate the contents
           // specially.
-          $element.empty();
-          $element.append(jqLiteBuildFragment(ctrl.template, document).childNodes);
-          $compile($element.contents())(scope, function namespaceAdaptedClone(clone) {
+          $compile(jqLiteBuildFragment(ctrl.template, document).childNodes)(scope,
+              function namespaceAdaptedClone(clone) {
             $element.append(clone);
           }, undefined, undefined, $element);
           return;
         }
+
         $element.html(ctrl.template);
         $compile($element.contents())(scope);
       }

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -267,10 +267,18 @@ var ngIncludeFillContentDirective = ['$compile',
       priority: -400,
       require: 'ngInclude',
       link: function(scope, $element, $attr, ctrl) {
-        $element.empty();
-        $compile(ctrl.template)(scope, function namespaceAdaptedClone(clone) {
-          $element.append(clone);
-        }, undefined, undefined, $element);
+        $element.html(ctrl.template);
+        if (!$element.contents().length && ctrl.template.length) {
+          // WebKit: https://bugs.webkit.org/show_bug.cgi?id=135698 --- SVG elements do not
+          // support innerHTML, so detect this here and try to generate the contents
+          // specially.
+          $element.append(jqLite(jqLiteBuildFragment(ctrl.template, document).childNodes));
+          $compile($element.contents())(scope, function namespaceAdaptedClone(clone) {
+            $element.append(clone);
+          }, undefined, undefined, $element);
+          return;
+        }
+        $compile($element.contents())(scope, undefined, null, null, $element);
       }
     };
   }];

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -490,7 +490,7 @@ describe('ngInclude', function() {
   });
 });
 
-describe('ngInclude and transcludes', function() {
+ddescribe('ngInclude and transcludes', function() {
   var element, directive;
 
   beforeEach(module(function($compileProvider) {
@@ -588,6 +588,27 @@ describe('ngInclude and transcludes', function() {
       $rootScope.$apply();
       $httpBackend.flush();
       expect(root[0]).toBe(element[0]);
+    });
+  });
+
+
+  it('should correctly work with SVG content', function() {
+    if (!window.SVGRectElement) return;
+    module(function() {
+      directive('test', valueFn({
+        templateNamespace: 'svg',
+        templateUrl: 'my-rect.html',
+        replace: true
+      }));
+    });
+    inject(function($compile, $rootScope, $httpBackend) {
+      $httpBackend.expectGET('my-rect.html').respond('<g ng-include="\'include.svg\'"></g>');
+      $httpBackend.expectGET('include.svg').respond('<rect></rect>');
+      element = $compile('<svg><test></test></svg>')($rootScope);
+      $httpBackend.flush();
+      var child = element.find('rect');
+      expect(child.length).toBe(1);
+      expect(child[0] instanceof SVGRectElement).toBe(true);
     });
   });
 });

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -603,11 +603,11 @@ describe('ngInclude and transcludes', function() {
     });
     inject(function($compile, $rootScope, $httpBackend) {
       $httpBackend.expectGET('my-rect.html').respond('<g ng-include="\'include.svg\'"></g>');
-      $httpBackend.expectGET('include.svg').respond('<rect></rect>');
+      $httpBackend.expectGET('include.svg').respond('<rect></rect><rect></rect>');
       element = $compile('<svg><test></test></svg>')($rootScope);
       $httpBackend.flush();
       var child = element.find('rect');
-      expect(child.length).toBe(1);
+      expect(child.length).toBe(2);
       expect(child[0] instanceof SVGRectElement).toBe(true);
     });
   });

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -490,7 +490,7 @@ describe('ngInclude', function() {
   });
 });
 
-ddescribe('ngInclude and transcludes', function() {
+describe('ngInclude and transcludes', function() {
   var element, directive;
 
   beforeEach(module(function($compileProvider) {
@@ -592,7 +592,7 @@ ddescribe('ngInclude and transcludes', function() {
   });
 
 
-  it('should correctly work with SVG content', function() {
+  it('should construct SVG template elements with correct namespace', function() {
     if (!window.SVGRectElement) return;
     module(function() {
       directive('test', valueFn({

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -490,7 +490,7 @@ describe('ngInclude', function() {
   });
 });
 
-describe('ngInclude and transcludes', function() {
+ddescribe('ngInclude and transcludes', function() {
   var element, directive;
 
   beforeEach(module(function($compileProvider) {
@@ -592,7 +592,7 @@ describe('ngInclude and transcludes', function() {
   });
 
 
-  it('should construct SVG template elements with correct namespace', function() {
+  it('should correctly work with SVG content', function() {
     if (!window.SVGRectElement) return;
     module(function() {
       directive('test', valueFn({

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -362,6 +362,46 @@ describe('ngInclude', function() {
   }));
 
 
+  it('should construct SVG template elements with correct namespace', function() {
+    if (!window.SVGRectElement) return;
+    module(function($compileProvider) {
+      $compileProvider.directive('test', valueFn({
+        templateNamespace: 'svg',
+        templateUrl: 'my-rect.html',
+        replace: true
+      }));
+    });
+    inject(function($compile, $rootScope, $httpBackend) {
+      $httpBackend.expectGET('my-rect.html').respond('<g ng-include="\'include.svg\'"></g>');
+      $httpBackend.expectGET('include.svg').respond('<rect></rect><rect></rect>');
+      element = $compile('<svg><test></test></svg>')($rootScope);
+      $httpBackend.flush();
+      var child = element.find('rect');
+      expect(child.length).toBe(2);
+      expect(child[0] instanceof SVGRectElement).toBe(true);
+    });
+  });
+
+
+  it('should compile only the template content of an SVG template', function() {
+    if (!window.SVGRectElement) return;
+    module(function($compileProvider) {
+      $compileProvider.directive('test', valueFn({
+        templateNamespace: 'svg',
+        templateUrl: 'my-rect.html',
+        replace: true
+      }));
+    });
+    inject(function($compile, $rootScope, $httpBackend) {
+      $httpBackend.expectGET('my-rect.html').respond('<g ng-include="\'include.svg\'"><a></a></g>');
+      $httpBackend.expectGET('include.svg').respond('<rect></rect><rect></rect>');
+      element = $compile('<svg><test></test></svg>')($rootScope);
+      $httpBackend.flush();
+      expect(element.find('a').length).toBe(0);
+    });
+  });
+
+
   describe('autoscroll', function() {
     var autoScrollSpy;
 
@@ -588,27 +628,6 @@ describe('ngInclude and transcludes', function() {
       $rootScope.$apply();
       $httpBackend.flush();
       expect(root[0]).toBe(element[0]);
-    });
-  });
-
-
-  it('should construct SVG template elements with correct namespace', function() {
-    if (!window.SVGRectElement) return;
-    module(function() {
-      directive('test', valueFn({
-        templateNamespace: 'svg',
-        templateUrl: 'my-rect.html',
-        replace: true
-      }));
-    });
-    inject(function($compile, $rootScope, $httpBackend) {
-      $httpBackend.expectGET('my-rect.html').respond('<g ng-include="\'include.svg\'"></g>');
-      $httpBackend.expectGET('include.svg').respond('<rect></rect><rect></rect>');
-      element = $compile('<svg><test></test></svg>')($rootScope);
-      $httpBackend.flush();
-      var child = element.find('rect');
-      expect(child.length).toBe(2);
-      expect(child[0] instanceof SVGRectElement).toBe(true);
     });
   });
 });


### PR DESCRIPTION
It is now possible for ngInclude to correctly load SVG content in non-blink
browsers, which do not sort out the namespace when parsing HTML.

/CC @tbosch / @IgorMinar

Closes #7538
