### PR TITLE
chore(npm-shrinkwrap): fix karma dependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3199,13 +3199,13 @@
       }
     },
     "karma": {
-      "version": "0.12.23",
+      "version": "0.12.13",
       "dependencies": {
         "di": {
           "version": "0.0.1"
         },
         "socket.io": {
-          "version": "0.9.17",
+          "version": "0.9.16",
           "dependencies": {
             "socket.io-client": {
               "version": "0.9.16",
@@ -3214,13 +3214,13 @@
                   "version": "1.2.5"
                 },
                 "ws": {
-                  "version": "0.4.32",
+                  "version": "0.4.31",
                   "dependencies": {
                     "commander": {
-                      "version": "2.1.0"
+                      "version": "0.6.1"
                     },
                     "nan": {
-                      "version": "1.0.0"
+                      "version": "0.3.2"
                     },
                     "tinycolor": {
                       "version": "0.0.1"
@@ -3255,12 +3255,10 @@
           }
         },
         "chokidar": {
-          "version": "0.8.4",
+          "version": "0.8.2",
           "dependencies": {
             "fsevents": {
-              "version": "0.2.1",
-              "from": "git://github.com/pipobscure/fsevents#7dcdf9fa3f8956610fd6f69f72c67bace2de7138",
-              "resolved": "git://github.com/pipobscure/fsevents#7dcdf9fa3f8956610fd6f69f72c67bace2de7138",
+              "version": "0.2.0",
               "dependencies": {
                 "nan": {
                   "version": "0.8.0"
@@ -3273,21 +3271,10 @@
           }
         },
         "glob": {
-          "version": "3.2.11",
+          "version": "3.2.9",
           "dependencies": {
             "inherits": {
               "version": "2.0.1"
-            },
-            "minimatch": {
-              "version": "0.3.0",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0"
-                },
-                "sigmund": {
-                  "version": "1.0.0"
-                }
-              }
             }
           }
         },
@@ -3321,12 +3308,7 @@
                   "version": "0.3.2"
                 },
                 "mkdirp": {
-                  "version": "0.5.0",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8"
-                    }
-                  }
+                  "version": "0.4.0"
                 },
                 "ncp": {
                   "version": "0.4.2"
@@ -3342,12 +3324,12 @@
               "version": "0.0.2"
             },
             "minimist": {
-              "version": "0.0.10"
+              "version": "0.0.8"
             }
           }
         },
         "rimraf": {
-          "version": "2.2.8"
+          "version": "2.2.6"
         },
         "q": {
           "version": "0.9.7"
@@ -3362,7 +3344,7 @@
           "version": "1.2.11"
         },
         "log4js": {
-          "version": "0.6.20",
+          "version": "0.6.14",
           "dependencies": {
             "async": {
               "version": "0.1.15"
@@ -3371,7 +3353,7 @@
               "version": "1.1.4"
             },
             "readable-stream": {
-              "version": "1.0.31",
+              "version": "1.0.27-1",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1"
@@ -3380,7 +3362,7 @@
                   "version": "0.0.1"
                 },
                 "string_decoder": {
-                  "version": "0.10.31"
+                  "version": "0.10.25-1"
                 },
                 "inherits": {
                   "version": "2.0.1"
@@ -3390,7 +3372,7 @@
           }
         },
         "useragent": {
-          "version": "2.0.9",
+          "version": "2.0.8",
           "dependencies": {
             "lru-cache": {
               "version": "2.2.4"
@@ -3439,7 +3421,7 @@
               "version": "0.0.3"
             },
             "debug": {
-              "version": "0.8.1"
+              "version": "0.8.0"
             },
             "methods": {
               "version": "0.1.0"
@@ -3454,7 +3436,7 @@
               "version": "2.2.0",
               "dependencies": {
                 "readable-stream": {
-                  "version": "1.1.13",
+                  "version": "1.1.13-1",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1"
@@ -3463,7 +3445,7 @@
                       "version": "0.0.1"
                     },
                     "string_decoder": {
-                      "version": "0.10.31"
+                      "version": "0.10.25-1"
                     },
                     "inherits": {
                       "version": "2.0.1"
@@ -3478,7 +3460,7 @@
           }
         },
         "source-map": {
-          "version": "0.1.38",
+          "version": "0.1.33",
           "dependencies": {
             "amdefine": {
               "version": "0.1.0"
@@ -3486,8 +3468,7 @@
           }
         }
       }
-    },
-    "karma-browserstack-launcher": {
+    },    "karma-browserstack-launcher": {
       "version": "0.0.7",
       "dependencies": {
         "browserstack": {


### PR DESCRIPTION
Updating to karma 0.12.13 (in commit 408508ad2972d7f5cf131be37c87d206cf10a5b7)
caused `iit` and `ddescribe` to crash and disconnect the browser stopping the
test run.

It appears that the problem is with one of the dependencies of karma rather
than karma itself. At least one of the karma dependencies updated in line
with karma's dependencies' semver specifications but subtly changed their
behaviour to break karma.  Possibly this is related to chokidar, glob,
minimatch or fsevents.
