### PR TITLE
feat(ngTransclude): Add support for use current scope

### DIFF
--- a/src/ng/directive/ngTransclude.js
+++ b/src/ng/directive/ngTransclude.js
@@ -8,6 +8,8 @@
  * @description
  * Directive that marks the insertion point for the transcluded DOM of the nearest parent directive that uses transclusion.
  *
+ * @param {boolean=} ngTransclude If set to false Angular will use default scope.
+ *
  * Any existing content of the element that this directive is placed on will be removed before the transcluded content is inserted.
  *
  * @element ANY
@@ -65,9 +67,14 @@ var ngTranscludeDirective = ngDirective({
        startingTag($element));
     }
 
-    $transclude(function(clone) {
+    var transcludeArgs = [];
+    if (toBoolean($attrs['ngTransclude'] || 'true') == false) {
+      transcludeArgs.push($scope);
+    }
+    transcludeArgs.push(function(clone) {
       $element.empty();
       $element.append(clone);
     });
+    $transclude.apply(this, transcludeArgs);
   }
 });


### PR DESCRIPTION
Added support for use current scope.
If do not to want create new scope at ngTransclude directive, This code can use current scope in ngTransclude

```
<div ng-transclude="false"></div>
```
