### PR TITLE
WIP - only watch the inputs of parsed expressions

### DIFF
--- a/benchmarks/parsed-expressions-bp/main.html
+++ b/benchmarks/parsed-expressions-bp/main.html
@@ -32,6 +32,11 @@
         </li>
 
         <li>
+          <input type="radio" ng-model="expressionType" value="shortCircuitingOperators" id="shortCircuitingOperators">
+          <label for="shortCircuitingOperators">AND/OR short-circuiting operators</label>
+        </li>
+
+        <li>
           <input type="radio" ng-model="expressionType" value="filters" id="filters">
           <label for="filters">Filters</label>
         </li>
@@ -132,6 +137,17 @@
           <span bm-pe-watch="rowIdx % 2 === 0"></span>
           <span bm-pe-watch="rowIdx / 1"></span>
           <span bm-pe-watch="-rowIdx * 2 * rowIdx + rowIdx / rowIdx + 1"></span>
+        </li>
+
+        <li ng-switch-when="shortCircuitingOperators" ng-repeat="(rowIdx, row) in ::data">
+          <span bm-pe-watch="rowIdx && row.odd"></span>
+          <span bm-pe-watch="row.odd && row.even"></span>
+          <span bm-pe-watch="row.odd && !row.even"></span>
+          <span bm-pe-watch="row.odd || row.even"></span>
+          <span bm-pe-watch="row.odd || row.even || row.index"></span>
+          <span bm-pe-watch="row.index === 1 || row.index === 2"></span>
+          <span bm-pe-watch="row.num0 < row.num1 && row.num1 < row.num2"></span>
+          <span bm-pe-watch="row.num0 < row.num1 || row.num1 < row.num2"></span>
         </li>
 
         <li ng-switch-when="filters" ng-repeat="(rowIdx, row) in ::data">

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1699,7 +1699,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                       attrs[attrName], newIsolateScopeDirective.name);
                 };
                 lastValue = isolateBindingContext[scopeName] = parentGet(scope);
-                var unwatch = scope.$watch($parse(attrs[attrName], function parentValueWatch(parentValue) {
+                var parentValueWatch = function parentValueWatch(parentValue) {
                   if (!compare(parentValue, isolateBindingContext[scopeName])) {
                     // we are out of sync and need to copy
                     if (!compare(parentValue, lastValue)) {
@@ -1711,7 +1711,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                     }
                   }
                   return lastValue = parentValue;
-                }), null, parentGet.literal);
+                };
+                parentValueWatch.externalInput = true;
+                var unwatch = scope.$watch($parse(attrs[attrName], parentValueWatch), null, parentGet.literal);
                 isolateScope.$on('$destroy', unwatch);
                 break;
 

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -377,6 +377,10 @@ Lexer.prototype = {
 };
 
 
+function isConstant(exp) {
+  return exp.constant;
+}
+
 /**
  * @constructor
  */
@@ -494,7 +498,8 @@ Parser.prototype = {
     return extend(function(self, locals) {
       return fn(self, locals, right);
     }, {
-      constant:right.constant
+      constant:right.constant,
+      inputs: [right]
     });
   },
 
@@ -502,15 +507,16 @@ Parser.prototype = {
     return extend(function(self, locals){
       return left(self, locals) ? middle(self, locals) : right(self, locals);
     }, {
-      constant: left.constant && middle.constant && right.constant
+      constant:left.constant && middle.constant && right.constant
     });
   },
 
-  binaryFn: function(left, fn, right) {
+  binaryFn: function(left, fn, right, isBranching) {
     return extend(function(self, locals) {
       return fn(self, locals, left, right);
     }, {
-      constant:left.constant && right.constant
+      constant: left.constant && right.constant,
+      inputs: !isBranching && [left, right]
     });
   },
 
@@ -558,7 +564,9 @@ Parser.prototype = {
       }
     }
 
-    return function $parseFilter(self, locals) {
+    var inputs = [inputFn].concat(argsFn || []);
+
+    return extend(function $parseFilter(self, locals) {
       var input = inputFn(self, locals);
       if (args) {
         args[0] = input;
@@ -572,7 +580,10 @@ Parser.prototype = {
       }
 
       return fn(input);
-    };
+    }, {
+      constant: !fn.externalInput && inputs.every(isConstant),
+      inputs: !fn.externalInput && inputs
+    });
   },
 
   expression: function() {
@@ -589,9 +600,11 @@ Parser.prototype = {
             this.text.substring(0, token.index) + '] can not be assigned to', token);
       }
       right = this.ternary();
-      return function $parseAssignment(scope, locals) {
+      return extend(function $parseAssignment(scope, locals) {
         return left.assign(scope, right(scope, locals), locals);
-      };
+      }, {
+        inputs: [left, right]
+      });
     }
     return left;
   },
@@ -616,7 +629,7 @@ Parser.prototype = {
     var left = this.logicalAND();
     var token;
     while ((token = this.expect('||'))) {
-      left = this.binaryFn(left, token.fn, this.logicalAND());
+      left = this.binaryFn(left, token.fn, this.logicalAND(), true);
     }
     return left;
   },
@@ -625,7 +638,7 @@ Parser.prototype = {
     var left = this.equality();
     var token;
     if ((token = this.expect('&&'))) {
-      left = this.binaryFn(left, token.fn, this.logicalAND());
+      left = this.binaryFn(left, token.fn, this.logicalAND(), true);
     }
     return left;
   },
@@ -760,7 +773,6 @@ Parser.prototype = {
   // This is used with json array declaration
   arrayDeclaration: function () {
     var elementFns = [];
-    var allConstant = true;
     if (this.peekToken().text !== ']') {
       do {
         if (this.peek(']')) {
@@ -769,9 +781,6 @@ Parser.prototype = {
         }
         var elementFn = this.expression();
         elementFns.push(elementFn);
-        if (!elementFn.constant) {
-          allConstant = false;
-        }
       } while (this.expect(','));
     }
     this.consume(']');
@@ -784,13 +793,13 @@ Parser.prototype = {
       return array;
     }, {
       literal: true,
-      constant: allConstant
+      constant: elementFns.every(isConstant),
+      inputs: elementFns
     });
   },
 
   object: function () {
     var keys = [], values = [];
-    var allConstant = true;
     if (this.peekToken().text !== '}') {
       do {
         if (this.peek('}')) {
@@ -802,9 +811,6 @@ Parser.prototype = {
         this.consume(':');
         var value = this.expression();
         values.push(value);
-        if (!value.constant) {
-          allConstant = false;
-        }
       } while (this.expect(','));
     }
     this.consume('}');
@@ -817,7 +823,8 @@ Parser.prototype = {
       return object;
     }, {
       literal: true,
-      constant: allConstant
+      constant: values.every(isConstant),
+      inputs: values
     });
   }
 };
@@ -1045,6 +1052,9 @@ function $ParseProvider() {
               parsedExpression.$$watchDelegate = parsedExpression.literal ?
                 oneTimeLiteralWatchDelegate : oneTimeWatchDelegate;
             }
+            else if (parsedExpression.inputs) {
+              parsedExpression.$$watchDelegate = inputsWatchDelegate;
+            }
 
             cache[cacheKey] = parsedExpression;
           }
@@ -1057,6 +1067,81 @@ function $ParseProvider() {
           return addInterceptor(noop, interceptorFn);
       }
     };
+
+    function collectExpressionInputs(inputs, list) {
+      for (var i = 0, ii = inputs.length; i < ii; i++) {
+        var input = inputs[i];
+        if (!input.constant) {
+          if (input.inputs) {
+            collectExpressionInputs(input.inputs, list);
+          }
+          else if (-1 === list.indexOf(input)) {
+            list.push(input);
+          }
+        }
+      }
+
+      return list;
+    }
+
+    function simpleEquals(o1, o2) {
+      if (o1 == null || o2 == null) return o1 === o2; // null/undefined
+
+      if (typeof o1 === "object") {
+        //The same object is not supported because it may have been mutated
+        if (o1 === o2) return false;
+
+        if (typeof o2 !== "object") return false;
+
+        //Convert to primitive if possible
+        o1 = o1.valueOf();
+        o2 = o2.valueOf();
+
+        //If the type became a non-object then we can use the primitive check below
+        if (typeof o1 === "object") return false;
+      }
+
+      //Primitive or NaN
+      return o1 === o2 || (o1 !== o1 && o2 !== o2);
+    }
+
+    function inputsWatchDelegate(scope, listener, objectEquality, parsedExpression) {
+      var inputExpressions = parsedExpression.$$inputs ||
+                    (parsedExpression.$$inputs = collectExpressionInputs(parsedExpression.inputs, []));
+
+      var inputs = [simpleEquals/*=something that will never equal an evaluated input*/];
+      var lastResult;
+
+      if (1 === inputExpressions.length) {
+        inputs = inputs[0];
+        inputExpressions = inputExpressions[0];
+        return scope.$watch(function expressionInputWatch(scope) {
+          var newVal = inputExpressions(scope);
+          if (!simpleEquals(newVal, inputs)) {
+            lastResult = parsedExpression(scope);
+            inputs = newVal;
+          }
+          return lastResult;
+        }, listener, objectEquality);
+      }
+
+      return scope.$watch(function expressionInputsWatch(scope) {
+        var changed = false;
+
+        for (var i=0, ii=inputExpressions.length; i<ii; i++) {
+          var valI = inputExpressions[i](scope);
+          if (changed || (changed = !simpleEquals(valI, inputs[i]))) {
+            inputs[i] = valI;
+          }
+        }
+
+        if (changed) {
+          lastResult = parsedExpression(scope);
+        }
+
+        return lastResult;
+      }, listener, objectEquality);
+    }
 
     function oneTimeWatchDelegate(scope, listener, objectEquality, parsedExpression) {
       var unwatch, lastValue;
@@ -1123,7 +1208,17 @@ function $ParseProvider() {
         // initial value is defined (for bind-once)
         return isDefined(value) ? result : value;
       };
-      fn.$$watchDelegate = parsedExpression.$$watchDelegate;
+
+      //Propogate $$watchDelegates other then inputsWatchDelegate
+      if (parsedExpression.$$watchDelegate && parsedExpression.$$watchDelegate !== inputsWatchDelegate) {
+        fn.$$watchDelegate = parsedExpression.$$watchDelegate;
+      }
+      //Treat the interceptorFn similar to filters - it is assumed to be a pure function unless flagged
+      else if (!interceptorFn.externalInput) {
+        fn.$$watchDelegate = inputsWatchDelegate;
+        fn.inputs = [parsedExpression];
+      }
+
       return fn;
     }
   }];

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -515,6 +515,8 @@ function $RootScopeProvider(){
        *    de-registration function is executed, the internal watch operation is terminated.
        */
       $watchCollection: function(obj, listener) {
+        $watchCollectionInterceptor.externalInput = true;
+
         var self = this;
         // the current value, updated on each dirty-check run
         var newValue;

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -867,12 +867,15 @@ describe('ngRepeat', function() {
       // This creates one item, but it has no parent so we can't get to it
       $rootScope.items = [1, 2];
       $rootScope.$apply();
+      expect(logs).toContain(1);
+      expect(logs).toContain(2);
+      logs.length = 0;
 
       // This cleans up to prevent memory leak
       $rootScope.items = [];
       $rootScope.$apply();
       expect(angular.mock.dump(element)).toBe('<!-- ngRepeat: i in items -->');
-      expect(logs).toEqual([1, 2, 1, 2]);
+      expect(logs.length).toBe(0);
     }));
 
 
@@ -894,12 +897,15 @@ describe('ngRepeat', function() {
       // This creates one item, but it has no parent so we can't get to it
       $rootScope.items = [1, 2];
       $rootScope.$apply();
+      expect(logs).toContain(1);
+      expect(logs).toContain(2);
+      logs.length = 0;
 
       // This cleans up to prevent memory leak
       $rootScope.items = [];
       $rootScope.$apply();
       expect(sortedHtml(element)).toBe('<span>-</span><!-- ngRepeat: i in items --><span>-</span>');
-      expect(logs).toEqual([1, 2, 1, 2]);
+      expect(logs.length).toBe(0);
     }));
 
 

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1311,6 +1311,153 @@ describe('parser', function() {
         });
       });
 
+      describe('watched $parse expressions', function() {
+        it('should respect short-circuiting AND if it could have side effects', function() {
+          var bCalled = 0;
+          scope.b = function() { bCalled++; }
+
+          scope.$watch("a && b()");
+          scope.$digest();
+          scope.$digest();
+          expect(bCalled).toBe(0);
+
+          scope.a = true;
+          scope.$digest();
+          expect(bCalled).toBe(1);
+          scope.$digest();
+          expect(bCalled).toBe(2);
+        });
+        it('should respect short-circuiting OR if it could have side effects', function() {
+          var bCalled = false;
+          scope.b = function() { bCalled = true; }
+
+          scope.$watch("a || b()");
+          scope.$digest();
+          expect(bCalled).toBe(true);
+
+          bCalled = false;
+          scope.a = true;
+          scope.$digest();
+          expect(bCalled).toBe(false);
+        });
+        it('should respect the branching ternary operator if it could have side effects', function() {
+          var bCalled = false;
+          scope.b = function() { bCalled = true; }
+
+          scope.$watch("a ? b() : 1");
+          scope.$digest();
+          expect(bCalled).toBe(false);
+
+          scope.a = true;
+          scope.$digest();
+          expect(bCalled).toBe(true);
+        });
+        it('should not invoke filters unless the input/arguments change', function() {
+          var filterCalled = false;
+          $filterProvider.register('foo', valueFn(function(input) {
+            filterCalled = true;
+            return input;
+          }));
+
+          scope.$watch("a | foo:b:1");
+          scope.a = 0;
+          scope.$digest();
+          expect(filterCalled).toBe(true);
+
+          filterCalled = false;
+          scope.$digest();
+          expect(filterCalled).toBe(false);
+
+          scope.a++;
+          scope.$digest();
+          expect(filterCalled).toBe(true);
+        });
+        it('should invoke filters if they are marked as having externalInput', function() {
+          var filterCalled = false;
+          $filterProvider.register('foo', valueFn(extend(function(input) {
+            filterCalled = true;
+            return input;
+          }, {externalInput: true})));
+
+          scope.$watch("a | foo:b:1");
+          scope.a = 0;
+          scope.$digest();
+          expect(filterCalled).toBe(true);
+
+          filterCalled = false;
+          scope.$digest();
+          expect(filterCalled).toBe(true);
+        });
+        it('should not invoke interceptorFns unless the input changes', inject(function($parse) {
+          var called = false;
+          function interceptor(v) {
+            called = true;
+            return v;
+          }
+          scope.$watch($parse("a", interceptor));
+          scope.a = scope.b = 0;
+          scope.$digest();
+          expect(called).toBe(true);
+
+          called = false;
+          scope.$digest();
+          expect(called).toBe(false);
+
+          scope.a++;
+          scope.$digest();
+          expect(called).toBe(true);
+        }));
+        it('should invoke interceptorFns if the yare marked as having externalInput', inject(function($parse) {
+          var called = false;
+          function interceptor() {
+            called = true;
+          }
+          interceptor.externalInput = true;
+
+          scope.$watch($parse("a", interceptor));
+          scope.a = 0;
+          scope.$digest();
+          expect(called).toBe(true);
+
+          called = false;
+          scope.$digest();
+          expect(called).toBe(true);
+
+          scope.a++;
+          called = false;
+          scope.$digest();
+          expect(called).toBe(true);
+        }));
+        it('should treat constants inputted to filters as constants', inject(function($parse) {
+          var filterCalls = 0;
+          $filterProvider.register('foo', valueFn(function(input) {
+            filterCalls++;
+            return input;
+          }));
+
+          var parsed = $parse('{x: 1} | foo:1');
+
+          expect( parsed.constant ).toBe(true);
+
+          var watcherCalls = 0;
+          scope.$watch(parsed, function(input) {
+            expect(input).toEqual({x:1});
+            watcherCalls++;
+          });
+
+          scope.$digest();
+          expect(filterCalls).toBe(1);
+          expect(watcherCalls).toBe(1);
+
+          scope.$digest();
+          expect(filterCalls).toBe(1);
+          expect(watcherCalls).toBe(1);
+        }));
+        it('should not treat constants passed to filters with externalInput as constants', inject(function($parse) {
+
+        }));
+      });
+
       describe('locals', function() {
         it('should expose local variables', inject(function($parse) {
           expect($parse('a')({a: 0}, {a: 1})).toEqual(1);


### PR DESCRIPTION
This is a newer version of https://github.com/jbedard/angular.js/commit/844d04cb584b77f822b907549fedc5b52d527660 which was discussed as an alternative to https://github.com/angular/angular.js/pull/8942.

The first commit should be good either way and makes `a | noop` about 20% faster in the benchmakrs by avoiding 2 unnecessary wrapper functions (binaryFn and valueFn). I can put this in a separate PR if wanted, but the main change depends on it.

The main change:
- expression inputs are watched instead of the full expression - for example `a + -a * b -b + 5` will watch `a` and `b`
- when expression inputs change the full expression get evaluated, otherwise the previous result is assumed to still be valid
- inputs are currently: variables/properties, field access (`foo().field`), object index (`obj[sub-exp]`) and function calls (and ; separated statements, at least for now)
- this means all other expressions are not watched
- I added (and have not tested) a `externalInput` flag that filters can set if they have some external state, then those filters will be considered inputs

In the expression watching benchmarks (which do not have the issues listed below):
- operators are about 2x faster
- filters are about 3x faster
- object/array literals are about 5x faster
- directly watching input expressions should be unchanged

Issues:
- This only works for primitives today. If any inputs return a non-primitive it is assumed to have changed and executes the full statement. This will hurt performance for expressions with non-primitives inputs.
- All inputs get executed per digest, if any change and the full expression gets executed then those child input expressions will get re-executed. For basic property inputs I think this is fine (although could be an area of improvement) - but for anything with side effects this will be an issue. The issue is not so much the double-calling but the fact that branching expressions should not always call their child expressions. The best example I can think of would be something such as: `$rootScope.$watch('isLoggedIn || loggedOutAction()')`. In this case, with the current implementation, `isLoggedIn` and `loggedOutAction()` would be considered inputs and executed in the watcher.

I might try other solutions to fix the two issues - maybe something simpler that only supports filters/literals for now which will get the best performance gains with the easiest workaround for those 2 issues.
