### PR TITLE
Extend copies own enumerable properties only

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -327,7 +327,7 @@ function setHashKey(obj, h) {
  * @kind function
  *
  * @description
- * Extends the destination object `dst` by copying all of the properties from the `src` object(s)
+ * Extends the destination object `dst` by copying own enumerable properties from the `src` object(s)
  * to `dst`. You can specify multiple `src` objects.
  *
  * @param {Object} dst Destination object.


### PR DESCRIPTION
Extend makes a shallow copy.
