### PR TITLE
Improved check if the getter/setter method was called as a getter or setter.

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2362,7 +2362,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
            var _name = 'Brian';
            $scope.user = {
              name: function (newName) {
-               if (angular.isDefined(newName)) {
+               if (arguments > 0) {
                  _name = newName;
                }
                return _name;


### PR DESCRIPTION
If I have understood the example correct the angular.isDefined(newName) is used to determine if the method was called as a getter or setter. However sometimes the the argument might be called with undefined (for example when the user empties an input field with type date). Maybe an improvement would be to check this with arguments > 0 so that the example can be modified and used in all situations? http://stackoverflow.com/questions/25775852/angular-getter-setter-with-an-argument-that-can-be-undefined
