### PR TITLE
test(injector): allow service names with a single underscore

### DIFF
--- a/docs/content/guide/unit-testing.ngdoc
+++ b/docs/content/guide/unit-testing.ngdoc
@@ -338,6 +338,16 @@ We inject the $compile service and $rootScope before each jasmine test. The $com
 to render the aGreatEye directive. After rendering the directive we ensure that the directive has
 replaced the content and "lidless, wreathed in flame, 2 times" is present.
 
+<div class="alert alert-info">
+**Underscore notation**:
+
+The use of the underscore notation (e.g.: _$rootScope_) is a convention wide spread in AngularJS 
+community to keep the variable names clean in your tests. That's why the 
+{@link api/auto/service/$injector $injector} strips out the leading and the trailing underscores when 
+matching the parameters. The underscore rule applies ***only*** if the name starts and ends with exactly 
+one underscore, otherwise no replacing happens.
+</div>
+
 ### Testing Transclusion Directives
 
 Directives that use transclusion are treated specially by the compiler.  Before their compile

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -182,6 +182,10 @@ describe('injector', function() {
       expect(annotate(beforeEachFn)).toEqual(['foo']);
     });
 
+    it('should not strip service names with a single underscore', function() {
+      function beforeEachFn(_) { /* _ = _ */ }
+      expect(annotate(beforeEachFn)).toEqual(['_']);
+    });
 
     it('should handle no arg functions', function() {
       function $f_n0() {}


### PR DESCRIPTION
Just to prove that #9015 is ok.
