### PR TITLE
Added "local" to SanitizationWhitelis for BlackBerry 10 apps

### DIFF
--- a/src/ng/sanitizeUri.js
+++ b/src/ng/sanitizeUri.js
@@ -5,8 +5,8 @@
  * Private service to sanitize uris for links and images. Used by $compile and $sanitize.
  */
 function $$SanitizeUriProvider() {
-  var aHrefSanitizationWhitelist = /^\s*(https?|ftp|mailto|tel|file):/,
-    imgSrcSanitizationWhitelist = /^\s*((https?|ftp|file|blob):|data:image\/)/;
+  var aHrefSanitizationWhitelist = /^\s*(https?|ftp|mailto|tel|file|local):/,
+    imgSrcSanitizationWhitelist = /^\s*((https?|ftp|file|blob|local):|data:image\/)/;
 
   /**
    * @description

--- a/test/ng/sanitizeUriSpec.js
+++ b/test/ng/sanitizeUriSpec.js
@@ -110,6 +110,9 @@ describe('sanitizeUri', function() {
 
       testUrl = "file:///foo/bar.html";
       expect(sanitizeImg(testUrl)).toBe('file:///foo/bar.html');
+
+      testUrl = "local:///foo/bar.html";
+      expect(sanitizeImg(testUrl)).toBe('local:///foo/bar.html');
     });
 
     it('should not sanitize blob urls', function() {
@@ -220,6 +223,9 @@ describe('sanitizeUri', function() {
 
       testUrl = "file:///foo/bar.html";
       expect(sanitizeHref(testUrl)).toBe('file:///foo/bar.html');
+
+      testUrl = "local:///foo/bar.html";
+      expect(sanitizeHref(testUrl)).toBe('local:///foo/bar.html');
     }));
 
     it('should allow reconfiguration of the href whitelist', function() {


### PR DESCRIPTION
# Description

BlackBerry 10 browser use `local` as shortcut to application resources.
# Steps to reproduce

Packed a HTML5 app with Cordova for BlackBerry 10. And you will see that all application resources use `local:///``
. 
## Apache Cordova resolved the issue

[[BlackBerry10] resolveLocalFileURI should work with local:/// paths](https://issues.apache.org/jira/browse/CB-5810) on January 2014.
On the BB10 platform, local:/// is a shortcut to application resources
The file plugin should respect these URIs
# Related issues

["local" protocol should be included in imgSrcSanitizationWhitelist](https://github.com/driftyco/ionic/issues/1066) on [IonicFramework](http://ionicframework.com)
