### PR TITLE
docs(CHANGELOG.md): fix work-around for removed, undocumented `change` a...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,10 +134,10 @@ Example:
 
 ```js
 angular.module("switchChangeWorkaround", []).
-  directive("onSwitchChanged", function() {
+  directive("onSwitchChanged", function () {
     return {
-      linke: function($scope, $attrs) {
-        $scope.$parent.$eval($attrs.change);
+      link: function (scope, elem, attrs) {
+        scope.$parent.$eval(attrs.onSwitchChanged);
       }
     };
   });


### PR DESCRIPTION
...ttribute of ngSwitch

Fix the JavaScript errors in the work-around proposed in 0f806d9 in order to emulate the behaviour
of the removed `change` attribute of ngSwitch.
