### PR TITLE
fix(formController): do not let removed control effect form

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -71,10 +71,18 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
   form.$invalid = false;
   form.$submitted = false;
 
-  parentForm.$addControl(form);
-
   // Setup initial state of the control
   element.addClass(PRISTINE_CLASS);
+
+  this.$$setParentForm = function(form) {
+    parentForm = form;
+  };
+
+  this.$$getParentForm = function(form) {
+    return parentForm;
+  };
+
+  parentForm.$addControl(form);
 
   /**
    * @ngdoc method
@@ -128,6 +136,7 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
     if (control.$name) {
       form[control.$name] = control;
     }
+    control.$$setParentForm(form);
   };
 
   // Private API: rename a form control
@@ -162,6 +171,7 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
     });
 
     arrayRemove(controls, control);
+    control.$$setParentForm(nullFormCtrl);
   };
 
 

--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -7,11 +7,8 @@ var nullFormCtrl = {
   $$renameControl: nullFormRenameControl,
   $removeControl: noop,
   $setValidity: noop,
-  $$setPending: noop,
   $setDirty: noop,
-  $setPristine: noop,
-  $setSubmitted: noop,
-  $$clearControlValidity: noop
+  $setSubmitted: noop
 },
 SUBMITTED_CLASS = 'ng-submitted';
 

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1710,6 +1710,14 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
     }
   };
 
+  this.$$setParentForm = function(form) {
+    parentForm = form;
+  };
+
+  this.$$getParentForm = function(form) {
+    return parentForm;
+  };
+
   /**
    * @ngdoc method
    * @name ngModel.NgModelController#$render
@@ -1789,7 +1797,6 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
     unset: function(object, property) {
       delete object[property];
     },
-    parentForm: parentForm,
     $animate: $animate
   });
 
@@ -2392,12 +2399,12 @@ var ngModelDirective = function() {
 
         attr.$observe('name', function(newValue) {
           if (modelCtrl.$name !== newValue) {
-            formCtrl.$$renameControl(modelCtrl, newValue);
+            modelCtrl.$$getParentForm().$$renameControl(modelCtrl, newValue);
           }
         });
 
         scope.$on('$destroy', function() {
-          formCtrl.$removeControl(modelCtrl);
+          modelCtrl.$$getParentForm().$removeControl(modelCtrl);
         });
       },
       post: function(scope, element, attr, ctrls) {
@@ -2967,7 +2974,6 @@ function addSetValidityMethod(context) {
       classCache = {},
       set = context.set,
       unset = context.unset,
-      parentForm = context.parentForm,
       $animate = context.$animate;
 
   ctrl.$setValidity = setValidity;
@@ -3017,7 +3023,7 @@ function addSetValidityMethod(context) {
       combinedState = null;
     }
     toggleValidationCss(validationErrorKey, combinedState);
-    parentForm.$setValidity(validationErrorKey, combinedState, ctrl);
+    ctrl.$$getParentForm().$setValidity(validationErrorKey, combinedState, ctrl);
   }
 
   function createAndSet(name, value, options) {

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -22,6 +22,12 @@ var DEFAULT_REGEXP = /(\s+|^)default(\s+|$)/;
 
 var $ngModelMinErr = new minErr('ngModel');
 
+var validityStateMap = {
+  $pending: undefined,
+  $error: false,
+  $$success: true
+};
+
 var inputType = {
 
   /**
@@ -1712,6 +1718,9 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
 
   this.$$setParentForm = function(form) {
     parentForm = form;
+    if (parentForm !== nullFormCtrl) {
+      ctrl.$$reportValidity(parentForm);
+    }
   };
 
   this.$$getParentForm = function(form) {
@@ -3025,6 +3034,14 @@ function addSetValidityMethod(context) {
     toggleValidationCss(validationErrorKey, combinedState);
     ctrl.$$getParentForm().$setValidity(validationErrorKey, combinedState, ctrl);
   }
+
+  ctrl.$$reportValidity = function reportValidity(parentForm) {
+    forEach(validityStateMap, function(combinedState, key) {
+      forEach(ctrl[key], function(value, validationErrorKey) {
+        parentForm.$setValidity(validationErrorKey, combinedState, ctrl);
+      });
+    });
+  };
 
   function createAndSet(name, value, options) {
     if (!ctrl[name]) {

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -100,6 +100,20 @@ describe('form', function() {
     expect(form.$error.required).toEqual([control]);
   });
 
+  it('should be affected by invalid input controls that were re-added to the form', function() {
+    doc = $compile(
+      '<form name="myForm">' +
+        '<input name="alias" ng-model="value" store-model-ctrl/>' +
+      '</form>')(scope);
+
+    var form = scope.myForm;
+    form.$removeControl(control);
+    control.$setValidity('required', false);
+
+    form.$addControl(control);
+    expect(form.$error.required).toEqual([control]);
+  });
+
   it('should use ngForm value as form name', function() {
     doc = $compile(
       '<div ng-form="myForm">' +

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -58,6 +58,47 @@ describe('form', function() {
     expect(form.alias).toBeUndefined();
   });
 
+  it('should not be affected by input controls that were removed from the form', function() {
+    doc = $compile(
+      '<form name="myForm">' +
+        '<input name="alias" ng-model="value" store-model-ctrl/>' +
+      '</form>')(scope);
+
+    var form = scope.myForm;
+    form.$removeControl(control);
+
+    control.$setValidity('required', false);
+    expect(form.$error.required).toBeFalsy();
+  });
+
+  it('should not be affected by form controls that were removed from the form', function() {
+    doc = $compile(
+      '<form name="myForm">' +
+        '<div ng-form="nestedForm">' +
+          '<input type="text" name="alias" ng-model="value" store-model-ctrl/>' +
+        '</div>' +
+      '</form>')(scope);
+
+    var form = scope.myForm;
+    form.$removeControl(form.nestedForm);
+
+    control.$setValidity('required', false);
+    expect(form.$error.required).toBeFalsy();
+  });
+
+  it('should be affected by input controls that were re-added to the form', function() {
+    doc = $compile(
+      '<form name="myForm">' +
+        '<input name="alias" ng-model="value" store-model-ctrl/>' +
+      '</form>')(scope);
+
+    var form = scope.myForm;
+    form.$removeControl(control);
+    form.$addControl(control);
+
+    control.$setValidity('required', false);
+    expect(form.$error.required).toEqual([control]);
+  });
 
   it('should use ngForm value as form name', function() {
     doc = $compile(


### PR DESCRIPTION
This PR fixes some issues with manually removing and adding controls from forms:
1) Validity changes in removed control do not effect form validity
2) Validity of existing control is taken into account when adding control to form

Closes #9035 
