### PR TITLE
docs(versions): remove the trailing slash in URLs when switch versions

### DIFF
--- a/docs/app/src/versions.js
+++ b/docs/app/src/versions.js
@@ -5,10 +5,10 @@ angular.module('versions', [])
   $scope.docs_version  = NG_VERSIONS[0];
 
   $scope.jumpToDocsVersion = function(version) {
-    var currentPagePath = $location.path();
+    var currentPagePath = $location.path().replace(/\/$/, '');
 
     // TODO: We need to do some munging of the path for different versions of the API...
-    
+
 
     $window.location = version.docsUrl + currentPagePath;
   };


### PR DESCRIPTION
Because https://docs.angularjs.org/api/ can handler the trailing slash, but https://code.angularjs.org/1.2.24/docs/api/ can not.

Fix #9043
