### PR TITLE
fix($parse): add `.assign()` function to settable expressions in CSP mode

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -897,7 +897,7 @@ function getterFn(path, options, fullExp) {
     if (pathKeysLength < 6) {
       fn = cspSafeGetterFn(pathKeys[0], pathKeys[1], pathKeys[2], pathKeys[3], pathKeys[4], fullExp);
     } else {
-      fn = function(scope, locals) {
+      fn = function cspSafeGetter(scope, locals) {
         var i = 0, val;
         do {
           val = cspSafeGetterFn(pathKeys[i++], pathKeys[i++], pathKeys[i++], pathKeys[i++],
@@ -926,14 +926,14 @@ function getterFn(path, options, fullExp) {
     var evaledFnGetter = new Function('s', 'l', code); // s=scope, l=locals
     /* jshint +W054 */
     evaledFnGetter.toString = valueFn(code);
-    evaledFnGetter.assign = function(self, value) {
-      return setter(self, path, value, path);
-    };
 
     fn = evaledFnGetter;
   }
 
   fn.sharedGetter = true;
+  fn.assign = function(self, value) {
+    return setter(self, path, value, path);
+  };
   getterFnCache[path] = fn;
   return fn;
 }

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -210,19 +210,12 @@ describe('parser', function() {
   forEach([true, false], function(cspEnabled) {
     describe('csp: ' + cspEnabled, function() {
 
-      var originalSecurityPolicy;
-
-
-      beforeEach(function() {
-        originalSecurityPolicy = window.document.securityPolicy;
-        window.document.securityPolicy = {isActive : cspEnabled};
-      });
-
-      afterEach(function() {
-        window.document.securityPolicy = originalSecurityPolicy;
-      });
-
-      beforeEach(module(provideLog));
+      beforeEach(module(function($provide) {
+        $provide.decorator('$sniffer', function($delegate) {
+          $delegate.csp = cspEnabled;
+          return $delegate;
+        });
+      }, provideLog));
 
       beforeEach(inject(function ($rootScope) {
         scope = $rootScope;


### PR DESCRIPTION
Due to changes to CSP-mode detection and the CSP api in general, the test suite was not able to
report regressions related to CSP.

This CL corrects the regression introduced where assignable expressions would not have an `assign` member function in CSP mode.

Closes #9048
