### PR TITLE
Add version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "angularjs",
+  "version": "1.2.24",
   "branchVersion": "1.2.*",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Npm install fails because the 1.2.x branch does not have a version field in the package.json anymore.
