### PR TITLE
fix($location): allow 0 in path() and hash()

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -416,7 +416,7 @@ LocationHashbangInHtml5Url.prototype =
    * @return {string} path
    */
   path: locationGetterSetter('$$path', function(path) {
-    path = path ? path.toString() : '';
+    path = path !== null ? path.toString() : '';
     return path.charAt(0) == '/' ? path : '/' + path;
   }),
 
@@ -513,7 +513,7 @@ LocationHashbangInHtml5Url.prototype =
    * @return {string} hash
    */
   hash: locationGetterSetter('$$hash', function(hash) {
-    return hash ? hash.toString() : '';
+    return hash !== null ? hash.toString() : '';
   }),
 
   /**

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -142,6 +142,11 @@ describe('$location', function() {
       expect(url.absUrl()).toBe('http://www.domain.com:9877/1?search=a&b=c&d#hash');
     });
 
+    it('path() should allow using 0 as path', function() {
+      url.path(0);
+      expect(url.path()).toBe('/0');
+      expect(url.absUrl()).toBe('http://www.domain.com:9877/0?search=a&b=c&d#hash');
+    });
 
     it('path() should set to empty path on null value', function () {
       url.path('/foo');
@@ -240,6 +245,11 @@ describe('$location', function() {
       expect(url.absUrl()).toBe('http://www.domain.com:9877/path/b?search=a&b=c&d#5');
     });
 
+    it('hash() should allow using 0', function() {
+      url.hash(0);
+      expect(url.hash()).toBe('0');
+      expect(url.absUrl()).toBe('http://www.domain.com:9877/path/b?search=a&b=c&d#0');
+    });
 
     it('hash() should accept null parameter', function() {
       url.hash(null);


### PR DESCRIPTION
This handles a corner case with numeric 0 after adb5c6d6cc76b928436743707727ab0974d6810b was merged.
