### PR TITLE
test($parse): ensure CSP code paths are used when testing

### DIFF
--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -206,17 +206,13 @@ describe('parser', function() {
 
       describe('csp: ' + cspEnabled + ", unwrapPromises: " + unwrapPromisesEnabled, function() {
 
-        var originalSecurityPolicy;
+        beforeEach(module(function($provide) {
+          $provide.decorator('$sniffer', function($delegate) {
+            $delegate.csp = cspEnabled;
+            return $delegate;
+          });
+        }, provideLog));
 
-
-        beforeEach(function() {
-          originalSecurityPolicy = window.document.securityPolicy;
-          window.document.securityPolicy = {isActive : cspEnabled};
-        });
-
-        afterEach(function() {
-          window.document.securityPolicy = originalSecurityPolicy;
-        });
 
         beforeEach(module(function ($parseProvider, $provide) {
           $parseProvider.unwrapPromises(unwrapPromisesEnabled);


### PR DESCRIPTION
(Port from commit 1 in #9048)

Previously, the test suite was not actually taking CSP-mode paths when we were
expecting it to.
