### PR TITLE
refactor(map) Use Array.prototype.map instead of our own function

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -55,7 +55,6 @@
     "trim": false,
     "isElement": false,
     "makeMap": false,
-    "map": false,
     "size": false,
     "includes": false,
     "arrayRemove": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -50,7 +50,6 @@
   trim: true,
   isElement: true,
   makeMap: true,
-  map: true,
   size: true,
   includes: true,
   arrayRemove: true,
@@ -614,15 +613,6 @@ function makeMap(str) {
 
 function nodeName_(element) {
   return lowercase(element.nodeName || element[0].nodeName);
-}
-
-
-function map(obj, iterator, context) {
-  var results = [];
-  forEach(obj, function(value, index, list) {
-    results.push(iterator.call(context, value, index, list));
-  });
-  return results;
 }
 
 

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -118,7 +118,7 @@ function orderByFilter($parse){
     if (!(isArrayLike(array))) return array;
     if (!sortPredicate) return array;
     sortPredicate = isArray(sortPredicate) ? sortPredicate: [sortPredicate];
-    sortPredicate = map(sortPredicate, function(predicate){
+    sortPredicate = sortPredicate.map(function(predicate){
       var descending = false, get = predicate || identity;
       if (isString(predicate)) {
         if ((predicate.charAt(0) == '+' || predicate.charAt(0) == '-')) {

--- a/test/helpers/testabilityPatch.js
+++ b/test/helpers/testabilityPatch.js
@@ -335,7 +335,7 @@ var karmaDump = window.dump || function() {
 };
 
 window.dump = function () {
-  karmaDump.apply(undefined, map(arguments, function(arg) {
+  karmaDump.apply(undefined, Array.prototype.map.call(arguments, function(arg) {
     return angular.mock.dump(arg);
   }));
 };

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -147,12 +147,12 @@ describe('parser', function() {
 
     it('should tokenize function invocation', function() {
       var tokens = lex("a()");
-      expect(map(tokens, function(t) { return t.text;})).toEqual(['a', '(', ')']);
+      expect(tokens.map(function(t) { return t.text;})).toEqual(['a', '(', ')']);
     });
 
     it('should tokenize method invocation', function() {
       var tokens = lex("a.b.c (d) - e.f()");
-      expect(map(tokens, function(t) { return t.text;})).
+      expect(tokens.map(function(t) { return t.text;})).
           toEqual(['a.b', '.', 'c',  '(', 'd', ')', '-', 'e', '.', 'f', '(', ')']);
     });
 

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -41,7 +41,7 @@ describe('q', function() {
   }
 
   function _argumentsToString(args) {
-    return map(sliceArgs(args), _argToString).join(',');
+    return sliceArgs(args).map(_argToString).join(',');
   }
 
   // Help log invocation of success(), finally(), progress() and error()


### PR DESCRIPTION
On most browsers this comes with a nice performance improvement http://jsperf.com/angular-map-vs-native/4 The biggest being IE 11 where it is 8x faster. In Chrome 37 there's a small regression. Firefox 31 shows a bigger regression, however these results couldn't be repeated with Firefox 32.
