### PR TITLE
Added ngBindOnce benchmarks on the largetable-bp

### DIFF
--- a/benchmarks/largetable-bp/main.html
+++ b/benchmarks/largetable-bp/main.html
@@ -8,15 +8,16 @@
       Large table rendered with AngularJS
       </p>
 
-      <div>none: <input type=radio ng-model="benchmarkType" value="none"></div>
-      <div>baseline binding: <input type=radio ng-model="benchmarkType" value="baselineBinding"></div>
-      <div>baseline interpolation: <input type=radio ng-model="benchmarkType" value="baselineInterpolation"></div>
-      <div>ngBind: <input type=radio ng-model="benchmarkType" value="ngBind"></div>
-      <div>interpolation: <input type=radio ng-model="benchmarkType" value="interpolation"></div>
-      <div>ngBind + fnInvocation: <input type=radio ng-model="benchmarkType" value="ngBindFn"></div>
-      <div>interpolation + fnInvocation: <input type=radio ng-model="benchmarkType" value="interpolationFn"></div>
-      <div>ngBind + filter: <input type=radio ng-model="benchmarkType" value="ngBindFilter"></div>
-      <div>ngBind + filter: <input type=radio ng-model="benchmarkType" value="interpolationFilter"></div>
+      <div>none: <input type="radio" ng-model="benchmarkType" value="none"></div>
+      <div>baseline binding: <input type="radio" ng-model="benchmarkType" value="baselineBinding"></div>
+      <div>baseline interpolation: <input type="radio" ng-model="benchmarkType" value="baselineInterpolation"></div>
+      <div>ngBind: <input type="radio" ng-model="benchmarkType" value="ngBind"></div>
+      <div>ngBindOnce: <input type="radio" ng-model="benchmarkType" value="ngBindOnce"></div>
+      <div>interpolation: <input type="radio" ng-model="benchmarkType" value="interpolation"></div>
+      <div>ngBind + fnInvocation: <input type="radio" ng-model="benchmarkType" value="ngBindFn"></div>
+      <div>interpolation + fnInvocation: <input type="radio" ng-model="benchmarkType" value="interpolationFn"></div>
+      <div>ngBind + filter: <input type="radio" ng-model="benchmarkType" value="ngBindFilter"></div>
+      <div>ngBind + filter: <input type="radio" ng-model="benchmarkType" value="interpolationFilter"></div>
 
       <ng-switch on="benchmarkType">
         <baseline-binding-table ng-switch-when="baselineBinding">
@@ -26,7 +27,17 @@
         <div ng-switch-when="ngBind">
           <h2>baseline binding</h2>
           <div ng-repeat="row in data">
-            <span ng-repeat="column in row"><span ng-bind="column.i"></span>:<span ng-bind="column.j"></span>|</span>
+            <span ng-repeat="column in row">
+              <span ng-bind="column.i"></span>:<span ng-bind="column.j"></span>|
+            </span>
+          </div>
+        </div>
+        <div ng-switch-when="ngBindOnce">
+          <h2>baseline binding once</h2>
+          <div ng-repeat="row in data">
+            <span ng-repeat="column in row">
+              <span ng-bind="::column.i"></span>:<span ng-bind="column.j"></span>|
+            </span>
           </div>
         </div>
         <div ng-switch-when="interpolation">

--- a/benchmarks/largetable-bp/main.html
+++ b/benchmarks/largetable-bp/main.html
@@ -35,8 +35,8 @@
         <div ng-switch-when="ngBindOnce">
           <h2>baseline binding once</h2>
           <div ng-repeat="row in data">
-            <span ng-repeat="column in row">
-              <span ng-bind="::column.i"></span>:<span ng-bind="column.j"></span>|
+            <span ng-repeat="column in ::row">
+              <span ng-bind="::column.i"></span>:<span ng-bind="::column.j"></span>|
             </span>
           </div>
         </div>


### PR DESCRIPTION
Hi @IgorMinar and @jeffbcross 
I wrote a basic benchmark to check the difference speed between the classic ngBind with the new ngBindOnce.

on my Google Chrome (Version 37.0.2062.120) I got this result after 10 loops:
1) ngBind

``` shell
destroy : mean: 319.08ms ± 4%       (stddev 12.44)      (min 301.03 / max 336.42)
create :  mean: 2362.93ms ± 14%     (stddev 336.86)     (min 2029.95 / max 3132.09)
$apply :  mean: 55.68ms ± 19%       (stddev 10.57)      (min 42.35 / max 68.67)
```

1) ngBindOnce

``` shell
destroy : mean: 312.34ms ± 3%       (stddev 10.58)        (min 299.78 / max 331.11)
create :  mean: 2441.22ms ± 24%     (stddev 583.30)       (min 2127.00 / max 4044.66)
$apply :  mean: 66.66ms ± 73%       (stddev 48.45)        (min 39.48 / max 200.60)
```

I stat writing this benchmark because after a first refactoring on [#ngtasty](https://github.com/Zizzamia/ng-tasty) I notice by using [Batarang](https://chrome.google.com/webstore/detail/angularjs-batarang/ighdmehidhipcmcojjgiloacoafjmpfk?hl=en) that the same binding with the new `bindOnce` was slightly slower during the first time binding.

In the end on Batarang and [Benchpress](https://github.com/angular/benchpress) looks that ngBindOnce is aroung 3% slower than the classic ngBind.

I hope my code can be useful.
Thank you :)
