### PR TITLE
Update step_05.ngdoc with JSONLint validation hint

### DIFF
--- a/docs/content/tutorial/step_05.ngdoc
+++ b/docs/content/tutorial/step_05.ngdoc
@@ -35,7 +35,9 @@ Following is a sample of the file:
 ]
 ```
 
-Note: We suggest that you copy and paste the contents of the JSON file that you prepare into [JSONLint](http://jsonlint.com/) (or similar equivalent). JSONLint will validate its contents and report parse errors.
+<div class="alert alert-info">
+  **Note:** Validating your JSON data with a JSON validator will ensure that it can be parsed correctly.
+</div>
 
 ## Controller
 

--- a/docs/content/tutorial/step_05.ngdoc
+++ b/docs/content/tutorial/step_05.ngdoc
@@ -35,6 +35,7 @@ Following is a sample of the file:
 ]
 ```
 
+Note: We suggest that you copy and paste the contents of the JSON file that you prepare into [JSONLint](http://jsonlint.com/) (or similar equivalent). JSONLint will validate its contents and report parse errors.
 
 ## Controller
 


### PR DESCRIPTION
Added suggestion to use JSONLint to validate the JSON file and identify errors. It is simpler to address JSON errors independently of other errors at compile-time.

Motivation was based on personal experience following an applied version of Step 5 of the AngularJS Tutorial using Ionic and incorrectly placing a semi-colon at the end of the JSON file, such that both of the following approaches resulted in errors and data was not displayed in the browser: 

```
$scope.sentences = data; 
```

```
$scope.sentences = angular.fromJson(data); 
```

Solution to the problem (i.e. using JSONLint that identified the incorrectly used semi-colon in the JSON file) was found thanks to a response to my StackOverflow post [Here](http://stackoverflow.com/questions/25829315/deserialise-json-string-to-object-with-angularjs-using-generate-ionic)
