### PR TITLE
fix($compile): update '@'-bindings in controller when bindToController is true

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1697,7 +1697,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
               case '@':
                 attrs.$observe(attrName, function(value) {
-                  isolateScope[scopeName] = value;
+                  isolateBindingContext[scopeName] = value;
                 });
                 attrs.$$observers[attrName].$$scope = scope;
                 if( attrs[attrName] ) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3567,6 +3567,32 @@ describe('$compile', function() {
     });
 
 
+    it('should update @-bindings on controller when bindToController and attribute change observed', function(){
+      module(function($compileProvider) {
+        $compileProvider.directive('atBinding', valueFn({
+          template: '<p>{{At.text}}</p>',
+          scope: {
+            text: '@atBinding'
+          },
+          controller: function($scope) {},
+          bindToController: true,
+          controllerAs: 'At'
+        }));
+      });
+
+      inject(function($compile, $rootScope) {
+        element = $compile('<div at-binding="Test: {{text}}"></div>')($rootScope);
+        var p = element.find('p');
+        $rootScope.$digest();
+        expect(p.text()).toBe('Test: ');
+
+        $rootScope.text = 'Kittens';
+        $rootScope.$digest();
+        expect(p.text()).toBe('Test: Kittens');
+      });
+    });
+
+
     it('should expose isolate scope variables on controller with controllerAs when bindToController is true', function() {
       var controllerCalled = false;
       module(function($compileProvider) {


### PR DESCRIPTION
'@'-bindings were previously updating the scope when they ought to have been 
updating the controller (requested via `bindToController: true` +
controllerAs).

It's a one-line fix + test case.

Closes #9052
