### PR TITLE
refactor($scope): prevent multiple calls to listener on `$destroy`

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2011,6 +2011,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 boundTranscludeFn = linkQueue.shift(),
                 linkNode = $compileNode[0];
 
+            if (scope.$$destroyed) continue;
+
             if (beforeTemplateLinkNode !== beforeTemplateCompileNode) {
               var oldClasses = beforeTemplateLinkNode.className;
 
@@ -2037,6 +2039,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
       return function delayedNodeLinkFn(ignoreChildLinkFn, scope, node, rootElement, boundTranscludeFn) {
         var childBoundTranscludeFn = boundTranscludeFn;
+        if (scope.$$destroyed) return;
         if (linkQueue) {
           linkQueue.push(scope);
           linkQueue.push(node);

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -223,6 +223,10 @@ function $RootScopeProvider(){
           parent.$$childHead = parent.$$childTail = child;
         }
 
+        // When the new scope is not isolated or we inherit from `this`, and
+        // the parent scope is destroyed, the property `$$destroyed` is inherited
+        // prototypically. In all other cases, this property needs to be set
+        // when the parent scope is destroyed.
         // The listener needs to be added after the parent is set
         if (isolate || parent != this) child.$on('$destroy', destroyChild);
 

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -222,7 +222,15 @@ function $RootScopeProvider(){
         } else {
           parent.$$childHead = parent.$$childTail = child;
         }
+
+        // The listener needs to be added after the parent is set
+        if (isolate || parent != this) child.$on('$destroy', destroyChild);
+
         return child;
+
+        function destroyChild() {
+          child.$$destroyed = true;
+        }
       },
 
       /**

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4971,17 +4971,17 @@ describe('$compile', function() {
           return [$rootScope].concat(
             getChildScopes($rootScope)
           ).length;
+        }
 
-          function getChildScopes(scope) {
-            var children = [];
-            if (!scope.$$childHead) { return children; }
-            var childScope = scope.$$childHead;
-            do {
-              children.push(childScope);
-              children = children.concat(getChildScopes(childScope));
-            } while ((childScope = childScope.$$nextSibling));
-            return children;
-          }
+        function getChildScopes(scope) {
+          var children = [];
+          if (!scope.$$childHead) { return children; }
+          var childScope = scope.$$childHead;
+          do {
+            children.push(childScope);
+            children = children.concat(getChildScopes(childScope));
+          } while ((childScope = childScope.$$nextSibling));
+          return children;
         }
 
         beforeEach(module(function() {
@@ -5117,6 +5117,23 @@ describe('$compile', function() {
           expect(countScopes($rootScope)).toEqual(1);
         }));
 
+        it('should destroy mark as destroyed all sub scopes of the scope being destroyed',
+              inject(function($compile, $rootScope) {
+
+          element = $compile(
+            '<div toggle>' +
+              '<div ng:repeat="msg in [\'msg-1\']">{{ msg }}</div>' +
+            '</div>'
+          )($rootScope);
+
+          $rootScope.$apply('t = true');
+          var childScopes = getChildScopes($rootScope);
+
+          $rootScope.$apply('t = false');
+          for (var i = 0; i < childScopes.length; ++i) {
+            expect(childScopes[i].$$destroyed).toBe(true);
+          }
+        }));
       });
 
 

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1020,6 +1020,13 @@ describe('Scope', function() {
       expect(log).toBe('123');
     }));
 
+    it('should broadcast the $destroy only once', inject(function($rootScope, log) {
+      var isolateScope = first.$new(true);
+      isolateScope.$on('$destroy', log.fn('event'));
+      first.$destroy();
+      isolateScope.$destroy();
+      expect(log).toEqual('event');
+    }));
 
     it('should decrement ancestor $$listenerCount entries', inject(function($rootScope) {
       var EVENT = 'fooEvent',


### PR DESCRIPTION
Prevent isolated scopes from having listeners that get called multiple times when on `$destroy`
