### PR TITLE
update angular.extend() documentation

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -328,7 +328,8 @@ function setHashKey(obj, h) {
  *
  * @description
  * Extends the destination object `dst` by copying all of the properties from the `src` object(s)
- * to `dst`. You can specify multiple `src` objects.
+ * to `dst`. You can specify multiple `src` objects. If you want to preserve original objects,
+ * you can do so by passing an empty object as the target: `var object = angular.extend({}, object1, object2)`.
  *
  * @param {Object} dst Destination object.
  * @param {...Object} src Source object(s).


### PR DESCRIPTION
How to preserve original objects similar to jQuery.extend().
