### PR TITLE
Clarify that `$event` is a jQuery Event Object

### DIFF
--- a/docs/content/guide/expression.ngdoc
+++ b/docs/content/guide/expression.ngdoc
@@ -167,7 +167,8 @@ expression, delegate to a JavaScript method instead.
 ## `$event`
 
 Directives like {@link ng.directive:ngClick `ngClick`} and {@link ng.directive:ngFocus `ngFocus`}
-expose a `$event` object within the scope of that expression.
+expose a `$event` object within the scope of that expression. The object is an instance of a [jQuery
+Event Object](http://api.jquery.com/category/events/event-object/).
 
 <example module="eventExampleApp">
   <file name="index.html">


### PR DESCRIPTION
I couldn't find documentation on this, but it looks like the `$event`, e.g., inside an ngClick directive, is an instance of a jQuery Event object. Is this correct? If so, then I think this is important information to share in the documentation. Otherwise people who are relatively new to this framework will have no idea how to use the objects that are passed around without finding crafty ways to run test code and inspect objects.
