### PR TITLE
docs($event): clarify $event is jQuery.Event

### DIFF
--- a/docs/content/guide/expression.ngdoc
+++ b/docs/content/guide/expression.ngdoc
@@ -167,7 +167,8 @@ expression, delegate to a JavaScript method instead.
 ## `$event`
 
 Directives like {@link ng.directive:ngClick `ngClick`} and {@link ng.directive:ngFocus `ngFocus`}
-expose a `$event` object within the scope of that expression.
+expose a `$event` object within the scope of that expression. The object is an instance of a [jQuery
+Event Object](http://api.jquery.com/category/events/event-object/).
 
 <example module="eventExampleApp">
   <file name="index.html">


### PR DESCRIPTION
The docs should state that an `$event` object is an instance of a jQuery.Event object. Whenever objects are passed around in a framework it's really helpful for the docs to state what’s inside the objects and how to expect them to be populated/work. I had to mess around in my console and with code to figure out what the `$event` object was.
