### PR TITLE
docs: Update noscp.ngdoc to use properly formatted json

### DIFF
--- a/docs/content/error/$controller/noscp.ngdoc
+++ b/docs/content/error/$controller/noscp.ngdoc
@@ -12,10 +12,10 @@ $controller(MyController);
 $controller(MyController, {scope: newScope});
 ```
 
-To fix the example above please provide a scope to the $controller call:
+To fix the example above please provide a scope (using the `$scope` property in the locals object) to the $controller call:
 
 ```
-$controller(MyController, {$scope, newScope});
+$controller(MyController, {$scope: newScope});
 ```
 
 Please consult the {@link ng.$controller $controller} service api docs to learn more.


### PR DESCRIPTION
Fix the "correct" example to have the proper syntax for creating the locals object and provide a more explicit explanation as to how the scope object should be provided.
