### PR TITLE
Added "geo" to SanitizationWhitelist

### DIFF
--- a/src/ng/sanitizeUri.js
+++ b/src/ng/sanitizeUri.js
@@ -5,7 +5,7 @@
  * Private service to sanitize uris for links and images. Used by $compile and $sanitize.
  */
 function $$SanitizeUriProvider() {
-  var aHrefSanitizationWhitelist = /^\s*(https?|ftp|mailto|tel|file):/,
+  var aHrefSanitizationWhitelist = /^\s*(https?|ftp|mailto|tel|geo|file):/,
     imgSrcSanitizationWhitelist = /^\s*((https?|ftp|file|blob):|data:image\/)/;
 
   /**

--- a/test/ng/sanitizeUriSpec.js
+++ b/test/ng/sanitizeUriSpec.js
@@ -218,6 +218,12 @@ describe('sanitizeUri', function() {
       testUrl = "mailto:foo@bar.com";
       expect(sanitizeHref(testUrl)).toBe('mailto:foo@bar.com');
 
+      testUrl = "tel:123456789";
+      expect(sanitizeHref(testUrl)).toBe('tel:123456789');
+
+      testUrl = "geo:37.422,-122.084058";
+      expect(sanitizeHref(testUrl)).toBe('geo:37.422,-122.084058');
+
       testUrl = "file:///foo/bar.html";
       expect(sanitizeHref(testUrl)).toBe('file:///foo/bar.html');
     }));


### PR DESCRIPTION
# Description

An Uniform Resource Identifier (URI) for geographic locations using the 'geo' scheme name. A 'geo' URI identifies a physical location in a two- or three-dimensional coordinate reference system in a compact, simple, human-readable, and protocol-independent way.[1]

The `geo` URI, like its siblings `mailto`and `tel`, works opening the link in the correct application. In this case, Android ([Maps intents](http://developer.android.com/guide/components/intents-common.html#Maps) and BlackBerry 10 (tested on my device) devices support this feature and open the link in the native map app.
# Steps to reproduce

Create a link with a geo position like: `<a href="geo:37.422,-122.084058">Google offices</a>`.
# Extra information
- [geo URI on Wikipedia](https://en.wikipedia.org/wiki/Geo_URI)
- Included test for `geo` uri
- Extra ball: Included test for `tel` uri
