### PR TITLE
fix($location): links should respect absolute paths and base href when in html5mode

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -682,13 +682,18 @@ function $LocationProvider(){
             var hrefNoBase = baseHrefNoFile ? href.substr(baseHrefNoFile.length - 1) : href;
             absHref = appBase + prefix + hrefNoBase;
           } else if (href[0] != '/') { // Ignore absolute path outside of base
+            var beginsWithPrefix = beginsWith(prefix, href);
             if (beginsWith(prefix + '/', href)) {
               // local anchor with absolute path
               absHref = appBase + href;
-            } else if (href[0] == '#') {
+            } else if (!beginsWithPrefix && href[0] == '#') {
               // local anchor
               absHref = appBase + prefix + ($location.path() || '/') + href;
+            } else if (!beginsWithPrefix && baseHref) {
+              // local anchor and base[href] exists
+              absHref = appBase + prefix + '/' + href;
             } else {
+              href = beginsWithPrefix ? href.substr(prefix.length) : href;
               // relative path - join with current path
               var stack = $location.path().split("/"),
                 parts = href.split("/");

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -879,14 +879,10 @@ describe('$location', function() {
       return function($browser){
         if (atRoot) {
           $browser.url('http://host.com/');
-          if (!noBase) {
-            $browser.$$baseHref = '/index.html';
-          }
+          $browser.$$baseHref = noBase ? '' : '/index.html';
         } else {
           $browser.url('http://host.com/base');
-          if (!noBase) {
-            $browser.$$baseHref = '/base/index.html';
-          }
+          $browser.$$baseHref = noBase ? '' : '/base/index.html';
         }
       };
     }
@@ -1201,7 +1197,22 @@ describe('$location', function() {
     });
 
 
-    it('should rewrite relative links relative to current path when history disabled', function() {
+    it('should rewrite relative links relative to current path when no base and history enabled on old browser', function() {
+      configureService('link', true, false, true);
+      inject(
+        initBrowser(false, true),
+        initLocation(),
+        function($browser, $location) {
+          $location.path('/some');
+          expect($browser.url(), 'http://host.com/#!/some');
+          browserTrigger(link, 'click');
+          expectRewriteTo($browser, 'http://host.com/#!/some/link');
+        }
+      );
+    });
+
+
+    it('should rewrite relative links relative to base href when history enabled on old browser', function() {
       configureService('link', true, false, true);
       inject(
         initBrowser(),
@@ -1209,7 +1220,7 @@ describe('$location', function() {
         function($browser, $location) {
           $location.path('/some');
           browserTrigger(link, 'click');
-          expectRewriteTo($browser, 'http://host.com/base/index.html#!/some/link');
+          expectRewriteTo($browser, 'http://host.com/base/index.html#!/link');
         }
       );
     });
@@ -1238,6 +1249,20 @@ describe('$location', function() {
           $location.path('/some');
           browserTrigger(link, 'click');
           expectRewriteTo($browser, 'http://host.com/base/index.html#!/link');
+        }
+      );
+    });
+
+
+    it('should rewrite relative hashbang links when history enabled on old browser', function() {
+      configureService('#!link', true, false, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser, $location) {
+          $location.path('/some');
+          browserTrigger(link, 'click');
+          expectRewriteTo($browser, 'http://host.com/base/index.html#!/some/link');
         }
       );
     });

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1203,10 +1203,15 @@ describe('$location', function() {
         initBrowser(false, true),
         initLocation(),
         function($browser, $location) {
+          $location.path('/some/');
+          expect($browser.url(), 'http://host.com/#!/some/');
+          browserTrigger(link, 'click');
+          expectRewriteTo($browser, 'http://host.com/#!/some/link');
+
           $location.path('/some');
           expect($browser.url(), 'http://host.com/#!/some');
           browserTrigger(link, 'click');
-          expectRewriteTo($browser, 'http://host.com/#!/some/link');
+          expectRewriteTo($browser, 'http://host.com/#!/link');
         }
       );
     });
@@ -1254,15 +1259,42 @@ describe('$location', function() {
     });
 
 
-    it('should rewrite relative hashbang links when history enabled on old browser', function() {
-      configureService('#!link', true, false, true);
+    it('should replace current path when relative link leads to base and history enabled on old browser', function() {
+      configureService('../base/link', true, false, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser, $location) {
+          browserTrigger(link, 'click');
+          expectRewriteTo($browser, 'http://host.com/base/index.html#!/link');
+        }
+      );
+    });
+
+
+    it('should replace current path when relative link begins with "/base/" and history enabled on old browser', function() {
+      configureService('/base/#!/link', true, false, true);
       inject(
         initBrowser(),
         initLocation(),
         function($browser, $location) {
           $location.path('/some');
           browserTrigger(link, 'click');
-          expectRewriteTo($browser, 'http://host.com/base/index.html#!/some/link');
+          expectRewriteTo($browser, 'http://host.com/base/index.html#!/link');
+        }
+      );
+    });
+
+
+    it('should rewrite relative hashbang links with respect to base when history enabled on old browser', function() {
+      configureService('#!link', true, false, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser, $location) {
+          $location.path('/some/');
+          browserTrigger(link, 'click');
+          expectRewriteTo($browser, 'http://host.com/base/index.html#!/link');
         }
       );
     });

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -875,10 +875,19 @@ describe('$location', function() {
       });
     }
 
-    function initBrowser() {
+    function initBrowser(atRoot, noBase) {
       return function($browser){
-        $browser.url('http://host.com/base');
-        $browser.$$baseHref = '/base/index.html';
+        if (atRoot) {
+          $browser.url('http://host.com/');
+          if (!noBase) {
+            $browser.$$baseHref = '/index.html';
+          }
+        } else {
+          $browser.url('http://host.com/base');
+          if (!noBase) {
+            $browser.$$baseHref = '/base/index.html';
+          }
+        }
       };
     }
 
@@ -1206,8 +1215,22 @@ describe('$location', function() {
     });
 
 
-    it('should replace current path when link begins with "/" and history disabled', function() {
+    it('should replace current path when link begins with "/" and app is on root and history enabled on old browser', function() {
       configureService('/link', true, false, true);
+      inject(
+        initBrowser(true),
+        initLocation(),
+        function($browser, $location) {
+          $location.path('/some');
+          browserTrigger(link, 'click');
+          expectRewriteTo($browser, 'http://host.com/index.html#!/link');
+        }
+      );
+    });
+
+
+    it('should replace current path when relative link begins with "/base/" and history enabled on old browser', function() {
+      configureService('/base/link', true, false, true);
       inject(
         initBrowser(),
         initLocation(),
@@ -1215,6 +1238,47 @@ describe('$location', function() {
           $location.path('/some');
           browserTrigger(link, 'click');
           expectRewriteTo($browser, 'http://host.com/base/index.html#!/link');
+        }
+      );
+    });
+
+
+    it('should replace current path when link begins with "#!/" and history enabled on old browser', function() {
+      configureService('#!/link', true, false, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser, $location) {
+          $location.path('/some');
+          browserTrigger(link, 'click');
+          expectRewriteTo($browser, 'http://host.com/base/index.html#!/link');
+        }
+      );
+    });
+
+
+    it('should rewrite when relative link begins with "/" and app is on the root and there is no base tag and history enabled on old browser', function() {
+      configureService('/link', true, false, true);
+      inject(
+        initBrowser(true, true),
+        initLocation(),
+        function($browser, $location) {
+          browserTrigger(link, 'click');
+          expectRewriteTo($browser, 'http://host.com/#!/link');
+        }
+      );
+    });
+
+
+    it('should not rewrite when relative link begins with "/" and history enabled on old browser', function() {
+      configureService('/other_base/link', true, false, true);
+      inject(
+        initBrowser(),
+        initLocation(),
+        function($browser, $location) {
+          $location.path('/some');
+          browserTrigger(link, 'click');
+          expectNoRewrite($browser);
         }
       );
     });

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1309,7 +1309,7 @@ describe('$location', function() {
     });
 
 
-    it('should replace current hash fragment when link begins with "#" history disabled', function() {
+    it('should replace current hash fragment when link begins with "#" and history enabled on old browser', function() {
       configureService('#link', true, false, true);
       inject(
         initBrowser(),


### PR DESCRIPTION
Fixes absolute links on legacy browsers when html5Mode is enabled.

Clicking on a link out of the base's href shouldn't trigger rewriting the URL. This behavior was changed since https://github.com/angular/angular.js/commit/24f7999bc16e347208aa18c418da85489286674b .

This resolves the issue I found on https://github.com/angular/angular.js/commit/24f7999bc16e347208aa18c418da85489286674b#commitcomment-7815179 which has created different behavior when it comes to absolute links on legacy browsers.

Most of this is whitespace changes.
I've added these cases to consider:
1. Properly rewrite links starting with `/base/` when the base tag is present with a value of `/base/`.
2. Don't rewrite links that have a href beginning with `/` not in within the base (i.e. `/outer_base/link`)
3. Don't rewrite links at all if no base tag is present and href begins with `/`
4. Rewrite absolute links with hashbang followed by `/` properly (.i.e. `#!/base/thing`).

This change is meant to resolve those cases that were not tested since 1.2.17 and have mismatching test cases. It's not to add any new features.
