### PR TITLE
enabled multiple routes for one controller

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -40,6 +40,7 @@ function $RouteProvider(){
   }
 
   var routes = {};
+  var self = this;
 
   /**
    * @ngdoc method
@@ -141,6 +142,12 @@ function $RouteProvider(){
    * Adds a new route definition to the `$route` service.
    */
   this.when = function(path, route) {
+    if (path instanceof Array) {
+      for(var i = 0; i < path.length; i++) {
+        self.when(path[i], route);
+      }
+      return this;
+    }
     routes[path] = angular.extend(
       {reloadOnSearch: true},
       route,

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -40,7 +40,6 @@ function $RouteProvider(){
   }
 
   var routes = {};
-  var self = this;
 
   /**
    * @ngdoc method
@@ -65,6 +64,11 @@ function $RouteProvider(){
    *    * `color: brown`
    *    * `largecode: code/with/slashes`.
    *
+   *    * `path` can also be an array of paths, when you need to:
+   *        1. merge paths to one controller: e.g.`['/home', '/']`
+   *        2. merge alias urls into one controller: e.g.`['/user/search, '/user/find', '/user/query']`
+   *        3. merge url and its abbreviation into one controller: e.g.`['/user/login, '/login'']
+   *        4. map one deprecated url to another into one controller: e.g. `['/old/url, '/new/url']
    *
    * @param {Object} route Mapping information to be assigned to `$route.current` on route
    *    match.
@@ -142,9 +146,9 @@ function $RouteProvider(){
    * Adds a new route definition to the `$route` service.
    */
   this.when = function(path, route) {
-    if (path instanceof Array) {
+    if (angular.isArray(path)) {
       for(var i = 0; i < path.length; i++) {
-        self.when(path[i], route);
+        this.when(path[i], route);
       }
       return this;
     }

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -375,6 +375,25 @@ describe('$route', function() {
   });
 
 
+  it('should accept an array as a path', function() {
+    module(function($routeProvider) {
+      $routeProvider.when(['/foo', '/foo1', '/foo2'], {templateUrl: 'foo.html'});
+    });
+
+    inject(function($route, $location, $rootScope) {
+      $location.url('/foo');
+      $rootScope.$digest();
+      expect($route.current.templateUrl).toBe('foo.html');
+      $location.url('/foo1');
+      $rootScope.$digest();
+      expect($route.current.templateUrl).toBe('foo.html');
+      $location.url('/foo2');
+      $rootScope.$digest();
+      expect($route.current.templateUrl).toBe('foo.html');
+    });
+  });
+
+
   describe('otherwise', function() {
 
     it('should handle unknown routes with "otherwise" route definition', function() {


### PR DESCRIPTION
enabled multiple routes for one controller.

solve my own issue :
https://github.com/angular/angular.js/issues/9041

Multiple routes can be used:

for abbreviation.

> .when(['/user/login, '/login''],

for same meaning.

> .when(['/user/search, '/user/find', '/user/query'],

for redirection

> .when(['/user/search, '/user/find', '/user/query'],
