### PR TITLE
Bootstrap example does not work without specifying ng-controller

### DIFF
--- a/docs/content/guide/bootstrap.ngdoc
+++ b/docs/content/guide/bootstrap.ngdoc
@@ -87,7 +87,9 @@ Here is an example of manually initializing Angular:
 <!doctype html>
 <html>
 <body>
-  Hello {{greetMe}}!
+  <div ng-controller="MyController">
+    Hello {{greetMe}}!
+  </div>
   <script src="http://code.angularjs.org/snapshot/angular.js"></script>
 
   <script>


### PR DESCRIPTION
I have modified the documentation to include a <div> with a ng-controller attribute. Found that the code from the documentation fails to work without a ng-controller.
