### PR TITLE
docs($location): break up long sentence for readability

### DIFF
--- a/docs/content/guide/$location.ngdoc
+++ b/docs/content/guide/$location.ngdoc
@@ -245,7 +245,7 @@ it('should show example', inject(
 ## HTML5 mode
 
 In HTML5 mode, the `$location` service getters and setters interact with the browser URL address
-through the HTML5 history API, which allows for use of regular URL path and search segments,
+through the HTML5 history API. This allows for use of regular URL path and search segments,
 instead of their hashbang equivalents. If the HTML5 History API is not supported by a browser, the
 `$location` service will fall back to using the hashbang URLs automatically. This frees you from
 having to worry about whether the browser displaying your app supports the history API  or not; the


### PR DESCRIPTION
Old: 
![screen shot 2014-09-18 at 11 52 58 am](https://cloud.githubusercontent.com/assets/6385848/4325602/d93fd47c-3f66-11e4-970f-482305e2ba81.png)

New: 
![screen shot 2014-09-18 at 11 53 42 am](https://cloud.githubusercontent.com/assets/6385848/4325612/f13bb316-3f66-11e4-9f54-2d58f04ff230.png)
