### PR TITLE
feat(ngAria): add an ngAria module to make a11y easier

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -153,6 +153,9 @@ module.exports = function(grunt) {
       },
       ngTouch: {
         files: { src: 'src/ngTouch/**/*.js' },
+      },
+      ngAria: {
+        files: {src: 'src/ngAria/**/*.js'},
       }
     },
 
@@ -220,6 +223,10 @@ module.exports = function(grunt) {
         dest: 'build/angular-cookies.js',
         src: util.wrap(files['angularModules']['ngCookies'], 'module')
       },
+      aria: {
+        dest: 'build/angular-aria.js',
+        src: util.wrap(files['angularModules']['ngAria'], 'module')
+      },
       "promises-aplus-adapter": {
         dest:'tmp/promises-aplus-adapter++.js',
         src:['src/ng/q.js','lib/promises-aplus/promises-aplus-test-adapter.js']
@@ -236,7 +243,8 @@ module.exports = function(grunt) {
       touch: 'build/angular-touch.js',
       resource: 'build/angular-resource.js',
       route: 'build/angular-route.js',
-      sanitize: 'build/angular-sanitize.js'
+      sanitize: 'build/angular-sanitize.js',
+      aria: 'build/angular-aria.js'
     },
 
 

--- a/angularFiles.js
+++ b/angularFiles.js
@@ -108,6 +108,9 @@ var angularFiles = {
       'src/ngTouch/directive/ngClick.js',
       'src/ngTouch/directive/ngSwipe.js'
     ],
+    'ngAria': [
+      'src/ngAria/aria.js'
+    ]
   },
 
   'angularScenario': [
@@ -141,7 +144,8 @@ var angularFiles = {
     'test/ngRoute/**/*.js',
     'test/ngSanitize/**/*.js',
     'test/ngMock/*.js',
-    'test/ngTouch/**/*.js'
+    'test/ngTouch/**/*.js',
+    'test/ngAria/*.js'
   ],
 
   'karma': [
@@ -175,7 +179,8 @@ var angularFiles = {
     'test/ngRoute/**/*.js',
     'test/ngResource/*.js',
     'test/ngSanitize/**/*.js',
-    'test/ngTouch/**/*.js'
+    'test/ngTouch/**/*.js',
+    'test/ngAria/*.js'
   ],
 
   'karmaJquery': [
@@ -203,7 +208,8 @@ angularFiles['angularSrcModules'] = [].concat(
   angularFiles['angularModules']['ngRoute'],
   angularFiles['angularModules']['ngSanitize'],
   angularFiles['angularModules']['ngMock'],
-  angularFiles['angularModules']['ngTouch']
+  angularFiles['angularModules']['ngTouch'],
+  angularFiles['angularModules']['ngAria']
 );
 
 if (exports) {

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -1,0 +1,263 @@
+'use strict';
+
+/**
+ * @ngdoc module
+ * @name ngAria
+ * @description
+ *
+ * The `ngAria` module provides support for to embed aria tags that convey state or semantic information
+ * about the application in order to allow assistive technologies to convey appropriate information to
+ * persons with disabilities.
+ *
+ * <div doc-module-components="ngAria"></div>
+ *
+ * # Usage
+ * To enable the addition of the aria tags, just require the module into your application and the tags will
+ * hook into your ng-show/ng-hide, input, textarea, button, select and ng-required directives and adds the
+ * appropriate aria-tags.
+ *
+ * Currently, the following aria tags are implemented:
+ *
+ * + aria-hidden
+ * + aria-checked
+ * + aria-disabled
+ * + aria-required
+ * + aria-invalid
+ * + aria-multiline
+ * + aria-valuenow
+ * + aria-valuemin
+ * + aria-valuemax
+ * + tabindex
+ *
+ * You can disable individual aria tags by using the {@link ngAria.$ariaProvider#config config} method.
+ */
+
+ /* global -ngAriaModule */
+var ngAriaModule = angular.module('ngAria', ['ng']).
+                        provider('$aria', $AriaProvider);
+
+/**
+ * @ngdoc provider
+ * @name $ariaProvider
+ *
+ * @description
+ *
+ * Used for configuring aria attributes.
+ *
+ * ## Dependencies
+ * Requires the {@link ngAria `ngAria`} module to be installed.
+ */
+function $AriaProvider() {
+  var config = {
+    ariaHidden : true,
+    ariaChecked: true,
+    ariaDisabled: true,
+    ariaRequired: true,
+    ariaInvalid: true,
+    ariaMultiline: true,
+    ariaValue: true,
+    tabindex: true
+  };
+
+  /**
+   * @ngdoc method
+   * @name $ariaProvider#config
+   *
+   * @param {object} config object to enable/disable specific aria tags
+   *
+   *  - **ariaHidden** – `{boolean}` – Enables/disables aria-hidden tags
+   *  - **ariaChecked** – `{boolean}` – Enables/disables aria-checked tags
+   *  - **ariaDisabled** – `{boolean}` – Enables/disables aria-disabled tags
+   *  - **ariaRequired** – `{boolean}` – Enables/disables aria-required tags
+   *  - **ariaInvalid** – `{boolean}` – Enables/disables aria-invalid tags
+   *  - **ariaMultiline** – `{boolean}` – Enables/disables aria-multiline tags
+   *  - **ariaValue** – `{boolean}` – Enables/disables aria-valuemin, aria-valuemax and aria-valuenow tags
+   *  - **tabindex** – `{boolean}` – Enables/disables tabindex tags
+   *
+   * @description
+   * Enables/disables various aria tags
+   */
+  this.config = function(newConfig) {
+    config = angular.extend(config, newConfig);
+  };
+
+  function dashCase(input) {
+    return input.replace(/[A-Z]/g, function(letter, pos) {
+      return (pos ? '-' : '') + letter.toLowerCase();
+    });
+  }
+
+  function watchAttr(attrName, ariaName) {
+    var ariaDashName = dashCase(ariaName);
+    return function(scope, elem, attr) {
+      if (!config[ariaName] || elem.attr(ariaDashName)) {
+        return;
+      }
+      var destroyWatcher = attr.$observe(attrName, function(newVal) {
+        elem.attr(ariaDashName, !angular.isUndefined(newVal));
+      });
+      scope.$on('$destroy', destroyWatcher);
+    };
+  }
+
+  function watchExpr(attrName, ariaName, negate) {
+    var ariaDashName = dashCase(ariaName);
+    return function(scope, elem, attr) {
+      if (config[ariaName] && !attr[ariaName]) {
+        scope.$watch(attr[attrName], function(boolVal) {
+          if (negate) {
+            boolVal = !boolVal;
+          }
+          elem.attr(ariaDashName, boolVal);
+        });
+      }
+    };
+  }
+
+  function watchNgModelProperty (prop, watchFn) {
+    var ariaAttrName = 'aria-' + prop,
+        configName = 'aria' + prop[0].toUpperCase() + prop.substr(1);
+    return function watchNgModelPropertyLinkFn(scope, elem, attr, ngModel) {
+      if (!config[configName] || elem.attr(ariaAttrName) || !ngModel) {
+        return;
+      }
+      scope.$watch(watchFn(ngModel), function(newVal) {
+        elem.attr(ariaAttrName, !!newVal);
+      });
+    };
+  }
+
+  this.$get = function() {
+    return {
+      watchExpr: watchExpr,
+      ariaChecked: watchExpr('ngModel', 'ariaChecked'),
+      ariaDisabled: watchExpr('ngDisabled', 'ariaDisabled'),
+      ariaRequired: watchNgModelProperty('required', function(ngModel) {
+        return function ngAriaModelWatch() {
+          return ngModel.$error.required;
+        };
+      }),
+      ariaInvalid: watchNgModelProperty('invalid', function(ngModel) {
+        return function ngAriaModelWatch() {
+          return ngModel.$invalid;
+        };
+      }),
+      ariaValue: function(scope, elem, attr, ngModel) {
+        if (config.ariaValue) {
+          if (attr.min && !elem.attr('aria-valuemin')) {
+            elem.attr('aria-valuemin', attr.min);
+          }
+          if (attr.max && !elem.attr('aria-valuemax')) {
+            elem.attr('aria-valuemax', attr.max);
+          }
+          if (ngModel && !elem.attr('aria-valuenow')) {
+            scope.$watch(function ngAriaModelWatch() {
+              return ngModel.$modelValue;
+            }, function ngAriaValueNowReaction(newVal) {
+              elem.attr('aria-valuenow', newVal);
+            });
+          }
+        }
+      },
+      radio: function(scope, elem, attr, ngModel) {
+        if (config.ariaChecked && ngModel && !elem.attr('aria-checked')) {
+          var needsTabIndex = config.tabindex && !elem.attr('tabindex');
+          scope.$watch(function() {
+            return ngModel.$modelValue;
+          }, function(newVal) {
+            elem.attr('aria-checked', newVal === attr.value);
+            if (needsTabIndex) {
+              elem.attr('tabindex', 0 - (newVal !== attr.value));
+            }
+          });
+        }
+      },
+      multiline: function(scope, elem, attr) {
+        if (config.ariaMultiline && !elem.attr('aria-multiline')) {
+          elem.attr('aria-multiline', true);
+        }
+      },
+      roleChecked: function(scope, elem, attr) {
+        if (config.ariaChecked && attr.checked && !elem.attr('aria-checked')) {
+          elem.attr('aria-checked', true);
+        }
+      },
+      tabindex: function(scope, elem, attr) {
+        if (config.tabindex && !elem.attr('tabindex')) {
+          elem.attr('tabindex', 0);
+        }
+      }
+    };
+  };
+}
+
+var ngAriaRequired = ['$aria', function($aria) {
+  return {
+    require: '?ngModel',
+    link: $aria.ariaRequired
+  };
+}];
+
+var ngAriaTabindex = ['$aria', function($aria) {
+  return $aria.tabindex;
+}];
+
+ngAriaModule.directive('ngShow', ['$aria', function($aria) {
+  return $aria.watchExpr('ngShow', 'ariaHidden', true);
+}])
+.directive('ngHide', ['$aria', function($aria) {
+  return $aria.watchExpr('ngHide', 'ariaHidden', false);
+}])
+.directive('input', ['$aria', function($aria) {
+  return {
+    restrict: 'E',
+    require: '?ngModel',
+    link: function(scope, elem, attr, ngModel) {
+      if (attr.type === 'checkbox') {
+        $aria.ariaChecked(scope, elem, attr);
+      } else if (attr.type === 'radio') {
+        $aria.radio(scope, elem, attr, ngModel);
+      } else if (attr.type === 'range') {
+        $aria.ariaValue(scope, elem, attr, ngModel);
+      }
+      $aria.ariaInvalid(scope, elem, attr, ngModel);
+    }
+  };
+}])
+.directive('textarea', ['$aria', function($aria) {
+  return {
+    restrict: 'E',
+    require: '?ngModel',
+    link: function(scope, elem, attr, ngModel) {
+      $aria.ariaInvalid(scope, elem, attr, ngModel);
+      $aria.multiline(scope, elem, attr);
+    }
+  };
+}])
+.directive('ngRequired', ngAriaRequired)
+.directive('required', ngAriaRequired)
+.directive('ngDisabled', ['$aria', function($aria) {
+  return $aria.ariaDisabled;
+}])
+.directive('role', ['$aria', function($aria) {
+  return {
+    restrict: 'A',
+    require: '?ngModel',
+    link: function(scope, elem, attr, ngModel) {
+      if (attr.role === 'textbox') {
+        $aria.multiline(scope, elem, attr);
+      } else if (attr.role === 'progressbar' || attr.role === 'slider') {
+        $aria.ariaValue(scope, elem, attr, ngModel);
+      } else if (attr.role === 'checkbox' || attr.role === 'menuitemcheckbox') {
+        $aria.roleChecked(scope, elem, attr);
+        $aria.tabindex(scope, elem, attr);
+      } else if (attr.role === 'radio' || attr.role === 'menuitemradio') {
+        $aria.radio(scope, elem, attr, ngModel);
+      } else if (attr.role === 'button') {
+        $aria.tabindex(scope, elem, attr);
+      }
+    }
+  };
+}])
+.directive('ngClick', ngAriaTabindex)
+.directive('ngDblclick', ngAriaTabindex);

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -1,0 +1,510 @@
+'use strict';
+
+describe('$aria', function() {
+  var scope, $compile, element;
+
+  beforeEach(module('ngAria'));
+
+  function injectScopeAndCompiler() {
+    return inject(function(_$compile_, _$rootScope_) {
+      $compile = _$compile_;
+      scope = _$rootScope_;
+    });
+  }
+
+  function compileInput(inputHtml) {
+    element = $compile(inputHtml)(scope);
+    scope.$digest();
+  }
+
+  describe('aria-hidden', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach aria-hidden to ng-show', function() {
+      compileInput('<div ng-show="val"></div>');
+      scope.$apply('val = false');
+      expect(element.attr('aria-hidden')).toBe('true');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-hidden')).toBe('false');
+    });
+
+    it('should attach aria-hidden to ng-hide', function() {
+      compileInput('<div ng-hide="val"></div>');
+      scope.$apply('val = false');
+      expect(element.attr('aria-hidden')).toBe('false');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-hidden')).toBe('true');
+    });
+
+    it('should not change aria-hidden if it is already present on ng-show', function() {
+      compileInput('<div ng-show="val" aria-hidden="userSetValue"></div>');
+      expect(element.attr('aria-hidden')).toBe('userSetValue');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-hidden')).toBe('userSetValue');
+    });
+
+    it('should not change aria-hidden if it is already present on ng-hide', function() {
+      compileInput('<div ng-hide="val" aria-hidden="userSetValue"></div>');
+      expect(element.attr('aria-hidden')).toBe('userSetValue');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-hidden')).toBe('userSetValue');
+    });
+  });
+
+
+  describe('aria-hidden when disabled', function() {
+    beforeEach(configAriaProvider({
+      ariaHidden: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not attach aria-hidden', function() {
+      scope.$apply('val = false');
+      compileInput('<div ng-show="val"></div>');
+      expect(element.attr('aria-hidden')).toBeUndefined();
+
+      compileInput('<div ng-hide="val"></div>');
+      expect(element.attr('aria-hidden')).toBeUndefined();
+    });
+  });
+
+  describe('aria-checked', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach itself to input type="checkbox"', function() {
+      compileInput('<input type="checkbox" ng-model="val">');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-checked')).toBe('true');
+
+      scope.$apply('val = false');
+      expect(element.attr('aria-checked')).toBe('false');
+    });
+
+    it('should attach itself to input type="radio"', function() {
+      var element = $compile('<input type="radio" ng-model="val" value="one">' +
+          '<input type="radio" ng-model="val" value="two">')(scope);
+
+      scope.$apply("val='one'");
+      expect(element.eq(0).attr('aria-checked')).toBe('true');
+      expect(element.eq(1).attr('aria-checked')).toBe('false');
+
+      scope.$apply("val='two'");
+      expect(element.eq(0).attr('aria-checked')).toBe('false');
+      expect(element.eq(1).attr('aria-checked')).toBe('true');
+    });
+
+    it('should attach itself to role="radio"', function() {
+      scope.$apply("val = 'one'");
+      compileInput('<div role="radio" ng-model="val" value="{{val}}"></div>');
+      expect(element.attr('aria-checked')).toBe('true');
+    });
+
+    it('should attach itself to role="checkbox"', function() {
+      compileInput('<div role="checkbox" checked="checked"></div>');
+      expect(element.attr('aria-checked')).toBe('true');
+    });
+
+    it('should attach itself to role="menuitemradio"', function() {
+      scope.$apply("val = 'one'");
+      compileInput('<div role="menuitemradio" ng-model="val" value="{{val}}"></div>');
+      expect(element.attr('aria-checked')).toBe('true');
+    });
+
+    it('should attach itself to role="menuitemcheckbox"', function() {
+      compileInput('<div role="menuitemcheckbox" checked="checked"></div>');
+      expect(element.attr('aria-checked')).toBe('true');
+    });
+
+    it('should not attach itself if an aria-checked value is already present', function() {
+      var element = [
+        $compile("<input type='checkbox' ng-model='val1' aria-checked='userSetValue'>")(scope),
+        $compile("<input type='radio' ng-model='val2' value='one' aria-checked='userSetValue'><input type='radio' ng-model='val2' value='two'>")(scope),
+        $compile("<div role='radio' ng-model='val' value='{{val3}}' aria-checked='userSetValue'></div>")(scope),
+        $compile("<div role='menuitemradio' ng-model='val' value='{{val3}}' aria-checked='userSetValue'></div>")(scope),
+        $compile("<div role='checkbox' checked='checked' aria-checked='userSetValue'></div>")(scope),
+        $compile("<div role='menuitemcheckbox' checked='checked' aria-checked='userSetValue'></div>")(scope)
+      ];
+      scope.$apply("val1=true;val2='one';val3='1'");
+      expectAriaAttrOnEachElement(element, 'aria-checked', 'userSetValue');
+    });
+  });
+
+  describe('aria-checked when disabled', function() {
+    beforeEach(configAriaProvider({
+      ariaChecked: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not attach aria-checked', function() {
+      compileInput("<div role='radio' ng-model='val' value='{{val}}'></div>");
+      expect(element.attr('aria-checked')).toBeUndefined();
+
+      compileInput("<div role='menuitemradio' ng-model='val' value='{{val}}'></div>");
+      expect(element.attr('aria-checked')).toBeUndefined();
+
+      compileInput("<div role='checkbox' checked='checked'></div>");
+      expect(element.attr('aria-checked')).toBeUndefined();
+
+      compileInput("<div role='menuitemcheckbox' checked='checked'></div>");
+      expect(element.attr('aria-checked')).toBeUndefined();
+    });
+  });
+
+  describe('aria-disabled', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach itself to input elements', function() {
+      scope.$apply('val = false');
+      compileInput("<input ng-disabled='val'>");
+      expect(element.attr('aria-disabled')).toBe('false');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-disabled')).toBe('true');
+    });
+
+    it('should attach itself to textarea elements', function() {
+      scope.$apply('val = false');
+      compileInput('<textarea ng-disabled="val"></textarea>');
+      expect(element.attr('aria-disabled')).toBe('false');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-disabled')).toBe('true');
+    });
+
+    it('should attach itself to button elements', function() {
+      scope.$apply('val = false');
+      compileInput('<button ng-disabled="val"></button>');
+      expect(element.attr('aria-disabled')).toBe('false');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-disabled')).toBe('true');
+    });
+
+    it('should attach itself to select elements', function() {
+      scope.$apply('val = false');
+      compileInput('<select ng-disabled="val"></select>');
+      expect(element.attr('aria-disabled')).toBe('false');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-disabled')).toBe('true');
+    });
+
+    it('should not attach itself if an aria-disabled attribute is already present', function() {
+      var element = [
+        $compile("<input aria-disabled='userSetValue' ng-disabled='val'>")(scope),
+        $compile("<textarea aria-disabled='userSetValue' ng-disabled='val'></textarea>")(scope),
+        $compile("<button aria-disabled='userSetValue' ng-disabled='val'></button>")(scope),
+        $compile("<select aria-disabled='userSetValue' ng-disabled='val'></select>")(scope)
+      ];
+
+      scope.$apply('val = true');
+      expectAriaAttrOnEachElement(element, 'aria-disabled', 'userSetValue');
+    });
+  });
+
+  describe('aria-disabled when disabled', function() {
+    beforeEach(configAriaProvider({
+      ariaDisabled: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not attach aria-disabled', function() {
+      var element = [
+        $compile("<input ng-disabled='val'>")(scope),
+        $compile("<textarea ng-disabled='val'></textarea>")(scope),
+        $compile("<button ng-disabled='val'></button>")(scope),
+        $compile("<select ng-disabled='val'></select>")(scope)
+      ];
+
+      scope.$apply('val = false');
+      expectAriaAttrOnEachElement(element, 'aria-disabled', undefined);
+    });
+  });
+
+  describe('aria-invalid', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach aria-invalid to input', function() {
+      compileInput('<input ng-model="txtInput" ng-minlength="10">');
+      scope.$apply("txtInput='LTten'");
+      expect(element.attr('aria-invalid')).toBe('true');
+
+      scope.$apply("txtInput='morethantencharacters'");
+      expect(element.attr('aria-invalid')).toBe('false');
+    });
+
+    it('should not attach itself if aria-invalid is already present', function() {
+      compileInput('<input ng-model="txtInput" ng-minlength="10" aria-invalid="userSetValue">');
+      scope.$apply("txtInput='LTten'");
+      expect(element.attr('aria-invalid')).toBe('userSetValue');
+    });
+  });
+
+  describe('aria-invalid when disabled', function() {
+    beforeEach(configAriaProvider({
+      ariaInvalid: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not attach aria-invalid if the option is disabled', function() {
+      scope.$apply("txtInput='LTten'");
+      compileInput('<input ng-model="txtInput" ng-minlength="10">');
+      expect(element.attr('aria-invalid')).toBeUndefined();
+    });
+  });
+
+  describe('aria-required', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach aria-required to input', function() {
+      compileInput('<input ng-model="val" required>');
+      expect(element.attr('aria-required')).toBe('true');
+
+      scope.$apply("val='input is valid now'");
+      expect(element.attr('aria-required')).toBe('false');
+    });
+
+    it('should attach aria-required to textarea', function() {
+      compileInput('<textarea ng-model="val" required></textarea>');
+      expect(element.attr('aria-required')).toBe('true');
+
+      scope.$apply("val='input is valid now'");
+      expect(element.attr('aria-required')).toBe('false');
+    });
+
+    it('should attach aria-required to select', function() {
+      compileInput('<select ng-model="val" required></select>');
+      expect(element.attr('aria-required')).toBe('true');
+
+      scope.$apply("val='input is valid now'");
+      expect(element.attr('aria-required')).toBe('false');
+    });
+
+    it('should attach aria-required to ngRequired', function() {
+      compileInput('<input ng-model="val" ng-required="true">');
+      expect(element.attr('aria-required')).toBe('true');
+
+      scope.$apply("val='input is valid now'");
+      expect(element.attr('aria-required')).toBe('false');
+    });
+
+    it('should not attach itself if aria-required is already present', function() {
+      compileInput("<input ng-model='val' required aria-required='userSetValue'>");
+      expect(element.attr('aria-required')).toBe('userSetValue');
+
+      compileInput("<textarea ng-model='val' required aria-required='userSetValue'></textarea>");
+      expect(element.attr('aria-required')).toBe('userSetValue');
+
+      compileInput("<select ng-model='val' required aria-required='userSetValue'></select>");
+      expect(element.attr('aria-required')).toBe('userSetValue');
+
+      compileInput("<input ng-model='val' ng-required='true' aria-required='userSetValue'>");
+      expect(element.attr('aria-required')).toBe('userSetValue');
+    });
+  });
+
+  describe('aria-required when disabled', function() {
+    beforeEach(configAriaProvider({
+      ariaRequired: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not add the aria-required attribute', function() {
+      compileInput("<input ng-model='val' required>");
+      expect(element.attr('aria-required')).toBeUndefined();
+
+      compileInput("<textarea ng-model='val' required></textarea>");
+      expect(element.attr('aria-required')).toBeUndefined();
+
+      compileInput("<select ng-model='val' required></select>");
+      expect(element.attr('aria-required')).toBeUndefined();
+    });
+  });
+
+  describe('aria-multiline', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach itself to textarea', function() {
+      compileInput('<textarea></textarea>');
+      expect(element.attr('aria-multiline')).toBe('true');
+    });
+
+    it('should attach itself role="textbox"', function() {
+      compileInput('<div role="textbox"></div>');
+      expect(element.attr('aria-multiline')).toBe('true');
+    });
+
+    it('should not attach itself if aria-multiline is already present', function() {
+      compileInput('<textarea aria-multiline="userSetValue"></textarea>');
+      expect(element.attr('aria-multiline')).toBe('userSetValue');
+
+      compileInput('<div role="textbox" aria-multiline="userSetValue"></div>');
+      expect(element.attr('aria-multiline')).toBe('userSetValue');
+    });
+  });
+
+  describe('aria-multiline when disabled', function() {
+    beforeEach(configAriaProvider({
+      ariaMultiline: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not attach itself to textarea', function() {
+      compileInput('<textarea></textarea>');
+      expect(element.attr('aria-multiline')).toBeUndefined();
+    });
+
+    it('should not attach itself role="textbox"', function() {
+      compileInput('<div role="textbox"></div>');
+      expect(element.attr('aria-multiline')).toBeUndefined();
+    });
+  });
+
+  describe('aria-value', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach to input type="range"', function() {
+      var element = [
+        $compile('<input type="range" ng-model="val" min="0" max="100">')(scope),
+        $compile('<div role="progressbar" min="0" max="100" ng-model="val">')(scope),
+        $compile('<div role="slider" min="0" max="100" ng-model="val">')(scope)
+      ];
+
+      scope.$apply('val = 50');
+      expectAriaAttrOnEachElement(element, 'aria-valuenow', "50");
+      expectAriaAttrOnEachElement(element, 'aria-valuemin', "0");
+      expectAriaAttrOnEachElement(element, 'aria-valuemax', "100");
+
+      scope.$apply('val = 90');
+      expectAriaAttrOnEachElement(element, 'aria-valuenow', "90");
+    });
+
+    it('should not attach if aria-value* is already present', function() {
+      var element = [
+        $compile('<input type="range" ng-model="val" min="0" max="100" aria-valuenow="userSetValue1" aria-valuemin="userSetValue2" aria-valuemax="userSetValue3">')(scope),
+        $compile('<div role="progressbar" min="0" max="100" ng-model="val" aria-valuenow="userSetValue1" aria-valuemin="userSetValue2" aria-valuemax="userSetValue3">')(scope),
+        $compile('<div role="slider" min="0" max="100" ng-model="val" aria-valuenow="userSetValue1" aria-valuemin="userSetValue2" aria-valuemax="userSetValue3">')(scope)
+      ];
+
+      scope.$apply('val = 50');
+      expectAriaAttrOnEachElement(element, 'aria-valuenow', 'userSetValue1');
+      expectAriaAttrOnEachElement(element, 'aria-valuemin', 'userSetValue2');
+      expectAriaAttrOnEachElement(element, 'aria-valuemax', 'userSetValue3');
+    });
+  });
+
+
+  describe('aria-value when disabled', function() {
+    beforeEach(configAriaProvider({
+      ariaValue: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not attach itself', function() {
+      scope.$apply('val = 50');
+
+      compileInput('<input type="range" ng-model="val" min="0" max="100">');
+      expect(element.attr('aria-valuenow')).toBeUndefined();
+      expect(element.attr('aria-valuemin')).toBeUndefined();
+      expect(element.attr('aria-valuemax')).toBeUndefined();
+
+      compileInput('<div role="progressbar" min="0" max="100" ng-model="val">');
+      expect(element.attr('aria-valuenow')).toBeUndefined();
+      expect(element.attr('aria-valuemin')).toBeUndefined();
+      expect(element.attr('aria-valuemax')).toBeUndefined();
+    });
+  });
+
+  describe('tabindex', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach tabindex to role=button, role=checkbox, ng-click and ng-dblclick', function() {
+      compileInput('<div role="button"></div>');
+      expect(element.attr('tabindex')).toBe('0');
+
+      compileInput('<div role="checkbox"></div>');
+      expect(element.attr('tabindex')).toBe('0');
+
+      compileInput('<div ng-click="someAction()"></div>');
+      expect(element.attr('tabindex')).toBe('0');
+
+      compileInput('<div ng-dblclick="someAction()"></div>');
+      expect(element.attr('tabindex')).toBe('0');
+    });
+
+    it('should not attach tabindex if it is already on an element', function() {
+      compileInput('<div role="button" tabindex="userSetValue"></div>');
+      expect(element.attr('tabindex')).toBe('userSetValue');
+
+      compileInput('<div role="checkbox" tabindex="userSetValue"></div>');
+      expect(element.attr('tabindex')).toBe('userSetValue');
+
+      compileInput('<div ng-click="someAction()" tabindex="userSetValue"></div>');
+      expect(element.attr('tabindex')).toBe('userSetValue');
+
+      compileInput('<div ng-dblclick="someAction()" tabindex="userSetValue"></div>');
+      expect(element.attr('tabindex')).toBe('userSetValue');
+    });
+
+    it('should set proper tabindex values for radiogroup', function() {
+      compileInput('<div role="radiogroup">' +
+                     '<div role="radio" ng-model="val" value="one">1</div>' +
+                     '<div role="radio" ng-model="val" value="two">2</div>' +
+                   '</div>');
+
+      var one = element.contents().eq(0);
+      var two = element.contents().eq(1);
+
+      scope.$apply("val = 'one'");
+      expect(one.attr('tabindex')).toBe('0');
+      expect(two.attr('tabindex')).toBe('-1');
+
+      scope.$apply("val = 'two'");
+      expect(one.attr('tabindex')).toBe('-1');
+      expect(two.attr('tabindex')).toBe('0');
+
+      dealoc(element);
+    });
+  });
+
+  describe('tabindex when disabled', function() {
+    beforeEach(configAriaProvider({
+      tabindex: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not add a tabindex attribute', function() {
+      compileInput('<div role="button"></div>');
+      expect(element.attr('tabindex')).toBeUndefined();
+
+      compileInput('<div role="checkbox"></div>');
+      expect(element.attr('tabindex')).toBeUndefined();
+
+      compileInput('<div ng-click="someAction()"></div>');
+      expect(element.attr('tabindex')).toBeUndefined();
+
+      compileInput('<div ng-dblclick="someAction()"></div>');
+      expect(element.attr('tabindex')).toBeUndefined();
+    });
+  });
+});
+
+function expectAriaAttrOnEachElement(elem, ariaAttr, expected) {
+  angular.forEach(elem, function(val) {
+    expect(angular.element(val).attr(ariaAttr)).toBe(expected);
+  });
+}
+
+function configAriaProvider (config) {
+  return function() {
+    angular.module('ariaTest', ['ngAria']).config(function($ariaProvider) {
+      $ariaProvider.config(config);
+    });
+    module('ariaTest');
+  };
+}


### PR DESCRIPTION
I made some significant refactors to #8342, notably:
- DRYing up the implementation
- unDRYing up the specs so that the assertions/failures are more specific
- Naming watch functions to make debugging easier
