### PR TITLE
Added comma to increase readability

### DIFF
--- a/README.closure.md
+++ b/README.closure.md
@@ -6,7 +6,7 @@ JavaScript in its `contrib/externs` directory.
 
 The definitions contain externs for use with the Closure compiler (aka
 JSCompiler). Passing these files to the --externs parameter of a compiler
-pass allows using type annotations for AngularJS objects. For example,
+pass, allows using type annotations for AngularJS objects. For example,
 Angular's $scope objects can be annotated as:
 ```js
 /** @type {angular.Scope} */


### PR DESCRIPTION
I added a comma to the sentence: "Passing these files to the --externs parameter of a compiler pass, allows using type annotations for AngularJS objects." This increases readability and corrects a slight grammatical error in the sentence. None of the source code was altered.
