### PR TITLE
$timeout no longer causes a digest

### DIFF
--- a/docs/content/error/$rootScope/inprog.ngdoc
+++ b/docs/content/error/$rootScope/inprog.ngdoc
@@ -102,7 +102,7 @@ your callback handler to always run asynchronously by using the `$timeout` servi
 ```
 function MyController($scope, thirdPartyComponent) {
   thirdPartyComponent.getData(function(someData) {
-    $timeout(function() {
+    $timeout(function() {}).then(function(){
       $scope.someData = someData;
     }, 0);
   });
@@ -170,7 +170,7 @@ myApp.directive('setFocusIf', function($timeout) {
     link: function($scope, $element, $attr) {
       $scope.$watch($attr.setFocusIf, function(value) {
         if ( value ) {
-          $timeout(function() {
+          $timeout(function() {}).then(function(){
             // We must reevaluate the value in case it was changed by a subsequent
             // watch handler in the digest.
             if ( $scope.$eval($attr.setFocusIf) ) {


### PR DESCRIPTION
Since https://github.com/angular/angular.js/commit/19b6b3433ae9f8523cbc72ae97dbcf0c06960148 $timeout no longer causes a digest - because of this the examples in this page no longer work. I've updated them using the suggested workaround.
