### PR TITLE
fix(input): fix false initial 'number' validation error in input[number]...

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1161,15 +1161,15 @@ function badInputChecker(scope, element, attr, ctrl) {
 }
 
 function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
-  badInputChecker(scope, element, attr, ctrl);
-  baseInputType(scope, element, attr, ctrl, $sniffer, $browser);
-
   ctrl.$$parserName = 'number';
   ctrl.$parsers.push(function(value) {
     if (ctrl.$isEmpty(value))      return null;
     if (NUMBER_REGEXP.test(value)) return parseFloat(value);
     return undefined;
   });
+
+  badInputChecker(scope, element, attr, ctrl);
+  baseInputType(scope, element, attr, ctrl, $sniffer, $browser);
 
   ctrl.$formatters.push(function(value) {
     if (!ctrl.$isEmpty(value)) {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -3689,15 +3689,6 @@ describe('input', function() {
           expect(scope.form.alias.$error.required).toBeTruthy();
         });
 
-        it('should be invalid when the user enters an invalid value', function() {
-          compileInput('<input type="number" ng-model="value" name="alias" ng-required="true" />');
-
-          changeInputValueTo('Hello, world !');
-          expect(inputElm.val()).toBe('');
-          expect(inputElm).toBeInvalid();
-          expect(scope.form.alias.$error.required).toBeTruthy();
-        });
-
         it('should change from invalid to valid when the value is empty and the ngRequired expression changes to false', function() {
           compileInput('<input type="number" ng-model="value" name="alias" ng-required="ngRequiredExpr" />');
 
@@ -3732,15 +3723,6 @@ describe('input', function() {
           changeInputValueTo('42');
           expect(inputElm).toBeValid();
           expect(scope.value).toBe(42);
-          expect(scope.form.alias.$error.required).toBeFalsy();
-        });
-
-        it('should not have the "required" error flag set even if the value is not a number', function() {
-          compileInput('<input type="number" ng-model="value" name="alias" ng-required="false" />');
-
-          changeInputValueTo('Hello, world !');
-          expect(inputElm.val()).toBe('');
-          expect(inputElm).toBeValid();
           expect(scope.form.alias.$error.required).toBeFalsy();
         });
 


### PR DESCRIPTION
... with observed attributes

When no value has been set for an input[number] it's viewValue is undefined. This lead to false
parse validation errors, when `ctrl.$validate()` was fired before interacting with the element. A
typical situation of this happening is when other directives on the same element `$observe()`
attribute values. (Such directives are ngRequired, min, max etc.)
More specifically, the parser for native HTML5 validation returns undefined when the input is
invalid and returns the value unchanged when the input is valid. Thus, when the value itself is
undefined, the NgModelController is tricked into believing there is a native validation error.

Closes #9106
