### PR TITLE
Remove invalid caveat description

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -282,9 +282,6 @@ using `templateUrl` instead:
   </file>
 </example>
 
-Great! But what if we wanted to have our directive match the tag name `<my-customer>` instead?
-If we simply put a `<my-customer>` element into the HTML, it doesn't work.
-
 <div class="alert alert-warning">
 **Note:** When you create a directive, it is restricted to attribute and elements only by default. In order to
 create directives that are triggered by class name, you need to use the `restrict` option.


### PR DESCRIPTION
The text said a directive wouldn't work out of the box as an element, but the note inmediatelly bellow says that by default the directives restrict to elements or attributes, which is the actual behavior.
