### PR TITLE
test(attrs): remove invalid test from e2e suite

### DIFF
--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -69,12 +69,6 @@
           }, 5000, 'page should navigate to /123');
         });
 
-        xit('should execute ng-click but not reload when href empty string and name specified', function() {
-          element(by.id('link-4')).click();
-          expect(element(by.model('value')).getAttribute('value')).toEqual('4');
-          expect(element(by.id('link-4')).getAttribute('href')).toBe('');
-        });
-
         it('should execute ng-click but not reload when no href but name specified', function() {
           element(by.id('link-5')).click();
           expect(element(by.model('value')).getAttribute('value')).toEqual('5');


### PR DESCRIPTION
This test is incorrectly acting as documentation that the anchor tag directive
will preventDefault on clicks on elements with a name. This has not been the
case ever since f3de5b6eac90baf649506072162f36dbc6d2f028

Closes #6554
