### PR TITLE
fix($compile): remove comment nodes from templates before asserting single root node

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1481,7 +1481,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             if (jqLiteIsTextNode(directiveValue)) {
               $template = [];
             } else {
-              $template = jqLite(wrapTemplate(directive.templateNamespace, trim(directiveValue)));
+              $template = removeComments(jqLite(wrapTemplate(directive.templateNamespace, trim(directiveValue))));
             }
             compileNode = $template[0];
 
@@ -1951,7 +1951,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             if (jqLiteIsTextNode(content)) {
               $template = [];
             } else {
-              $template = jqLite(wrapTemplate(templateNamespace, trim(content)));
+              $template = removeComments(jqLite(wrapTemplate(templateNamespace, trim(content))));
             }
             compileNode = $template[0];
 
@@ -2361,4 +2361,17 @@ function tokenDifference(str1, str2) {
     values += (values.length > 0 ? ' ' : '') + token;
   }
   return values;
+}
+
+function removeComments(jqNodes) {
+  var i = jqNodes.length;
+  var splice = Array.prototype.splice;
+
+  if (i <= 1) return jqNodes;
+
+  while (i--) {
+    var node = jqNodes[i];
+    if (node.nodeType === 8) splice.call(jqNodes, i, 1);
+  }
+  return jqNodes;
 }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1078,6 +1078,22 @@ describe('$compile', function() {
             });
           });
         }
+
+        it('should ignore comment nodes when replacing with a template', function() {
+          module(function() {
+            directive('replaceWithComments', valueFn({
+              replace: true,
+              template: '<!-- ignored comment --><p>Hello, world!</p><!-- ignored comment-->'
+            }));
+          });
+          inject(function($compile, $rootScope) {
+            expect(function() {
+              element = $compile('<div><div replace-with-comments></div></div>')($rootScope);
+            }).not.toThrow();
+            expect(element.find('p').length).toBe(1);
+            expect(element.find('p').text()).toBe('Hello, world!');
+          });
+        });
       });
 
 
@@ -1977,6 +1993,26 @@ describe('$compile', function() {
             });
           });
         }
+
+        it('should ignore comment nodes when replacing with a templateUrl', function() {
+          module(function() {
+            directive('replaceWithComments', valueFn({
+              replace: true,
+              templateUrl: 'templateWithComments.html'
+            }));
+          });
+          inject(function($compile, $rootScope, $httpBackend) {
+            $httpBackend.whenGET('templateWithComments.html').
+              respond('<!-- ignored comment --><p>Hello, world!</p><!-- ignored comment-->');
+            expect(function() {
+              element = $compile('<div><div replace-with-comments></div></div>')($rootScope);
+            }).not.toThrow();
+            $httpBackend.flush();
+            expect(element.find('p').length).toBe(1);
+            expect(element.find('p').text()).toBe('Hello, world!');
+          });
+        });
+
       });
 
 


### PR DESCRIPTION
The compiler will no longer throw if a directive template contains comment
nodes in addition to a single root node.

The comment nodes will be removed before processing.

Closes #9212
