### PR TITLE
feat($location): add ability to opt-out of <base/> tag in html5Mode

### DIFF
--- a/docs/content/error/$location/nobase.ngdoc
+++ b/docs/content/error/$location/nobase.ngdoc
@@ -4,7 +4,19 @@
 @description
 
 If you configure {@link ng.$location `$location`} to use
-{@link api/ng.provider.$locationProvider `html5Mode`} (`history.pushState`), you need to specify the base URL for the application with a [`<base href="">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) tag.
+{@link api/ng.provider.$locationProvider `html5Mode`} (`history.pushState`), you need to specify the base URL for the application with a [`<base href="">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) tag or configure
+`$locationProvider` to not require a base tag by passing a definition object with
+`requireBase:false` to `$locationProvider.html5Mode()`:
+
+```javascript
+$locationProvider.html5Mode({
+  enabled: true,
+  requireBase: false
+});
+```
+
+Note that removing the requirement for a <base> tag will have adverse side effects when resolving
+relative paths with `$location` in IE9.
 
 The base URL is then used to resolve all relative URLs throughout the application regardless of the
 entry point into the app.

--- a/docs/content/guide/$location.ngdoc
+++ b/docs/content/guide/$location.ngdoc
@@ -91,10 +91,11 @@ To configure the `$location` service, retrieve the
 {@link ng.$locationProvider $locationProvider} and set the parameters as follows:
 
 
-- **html5Mode(mode)**: {boolean}<br />
-  `true` - see HTML5 mode<br />
-  `false` - see Hashbang mode<br />
-  default: `false`
+- **html5Mode(mode)**: {boolean|Object}<br />
+  `true` or `enabled:true` - see HTML5 mode<br />
+  `false` or `enabled:false` - see Hashbang mode<br />
+  `requireBase:true` - see Relative links<br />
+  default: `enabled:false`
 
 - **hashPrefix(prefix)**: {string}<br />
   prefix used for Hashbang URLs (used in Hashbang mode or in legacy browser in Html5 mode)<br />
@@ -328,9 +329,11 @@ reload to the original link.
 
 ### Relative links
 
-Be sure to check all relative links, images, scripts etc. Angular requires you to specify the url base in
-the head of your main html file (`<base href="/my-base">`). With that, relative urls will
-always be resolved to this base url, event if the initial url of the document was different.
+Be sure to check all relative links, images, scripts etc. Angular requires you to specify the url
+base in the head of your main html file (`<base href="/my-base">`) unless `html5Mode.requireBase` is
+set to `false` in the html5Mode definition object passed to `$locationProvider.html5Mode()`. With
+that, relative urls will always be resolved to this base url, event if the initial url of the
+document was different.
 
 There is one exception: Links that only contain a hash fragment (e.g. `<a href="#target">`)
 will only change `$location.hash()` and not modify the url otherwise. This is useful for scrolling

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1639,6 +1639,77 @@ describe('$location', function() {
     return undefined;
   }
 
+
+  describe('html5Mode', function() {
+    it('should set enabled and requireBase when called with object', function() {
+      module(function($locationProvider) {
+        expect($locationProvider.html5Mode()).toEqual({
+          enabled: false,
+          requireBase: true
+        });
+      });
+
+      inject(function(){});
+    });
+
+
+    it('should only overwrite existing properties if values are boolean', function() {
+      module(function($locationProvider) {
+        $locationProvider.html5Mode({
+          enabled: 'duh',
+          requireBase: 'probably'
+        });
+
+        expect($locationProvider.html5Mode()).toEqual({
+          enabled: false,
+          requireBase: true
+        });
+      });
+
+      inject(function(){});
+    });
+
+
+    it('should not set unknown input properties to html5Mode object', function() {
+      module(function($locationProvider) {
+        $locationProvider.html5Mode({
+          someProp: 'foo'
+        });
+
+        expect($locationProvider.html5Mode()).toEqual({
+          enabled: false,
+          requireBase: true
+        });
+      });
+
+      inject(function(){});
+    });
+
+
+    it('should default to enabled:false and requireBase:true', function() {
+      module(function($locationProvider) {
+        expect($locationProvider.html5Mode()).toEqual({
+          enabled: false,
+          requireBase: true
+        });
+      });
+
+      inject(function(){});
+    });
+
+
+    it('should return html5Mode object when called without value', function() {
+      module(function($locationProvider) {
+        expect($locationProvider.html5Mode()).toEqual({
+          enabled: false,
+          requireBase: true
+        });
+      });
+
+      inject(function(){});
+    });
+  });
+
   describe('LocationHtml5Url', function() {
     var location, locationIndex;
 
@@ -1660,6 +1731,39 @@ describe('$location', function() {
       expect(parseLinkAndReturn(locationIndex, 'http://server/pre/otherPath')).toEqual('http://server/pre/otherPath');
       // Note: relies on the previous state!
       expect(parseLinkAndReturn(location, 'someIgnoredAbsoluteHref', '#test')).toEqual('http://server/pre/otherPath#test');
+    });
+
+
+    it('should complain if no base tag present', function() {
+      module(function($locationProvider) {
+        $locationProvider.html5Mode(true);
+      });
+
+      inject(function($browser, $injector) {
+        $browser.$$baseHref = undefined;
+        expect(function() {
+          $injector.get('$location');
+        }).toThrowMinErr('$location', 'nobase',
+          "$location in HTML5 mode requires a <base> tag to be present!");
+      });
+    });
+
+
+    it('should not complain if baseOptOut set to true in html5Mode', function() {
+      module(function($locationProvider) {
+        $locationProvider.html5Mode({
+          enabled: true,
+          requireBase: false
+        });
+      });
+
+      inject(function($browser, $injector) {
+        $browser.$$baseHref = undefined;
+        expect(function() {
+          $injector.get('$location');
+        }).not.toThrowMinErr('$location', 'nobase',
+          "$location in HTML5 mode requires a <base> tag to be present!");
+      });
     });
   });
 


### PR DESCRIPTION
This feature allows disabling Angular's requirement of using a <base/> tag
when using location in html5Mode, for applications that do not require
using $location in html5Mode in IE9. To accomplish this, a getter/setter method 
was added to $locationProvider called baseOptOut, which accepts a single boolean 
parameter. The method is semantically similar to html5Mode() (returns this if
called with bool param, otherwise returns current value).
