### PR TITLE
feat(filterFilter): introduce new ":expression" syntax in pattern object

### DIFF
--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -173,4 +173,28 @@ describe('Filter: filter', function() {
 
   });
 
+  it('should parse as angular expression when used with ":expression" syntax', function() {
+    var items = [
+        {
+          foo: function() {
+            return {key: 1};
+          }
+        },
+        {
+          foo: function() {
+            return {key: 2};
+          }
+        },
+        {
+          foo: function() {
+            return 'foo';
+          }
+        }
+      ];
+
+    expect(filter(items, {':foo().key': 1})).toEqual([items[0]]);
+    expect(filter(items, {':foo().key': 2})).toEqual([items[1]]);
+    expect(filter(items, {':foo()': 'foo'})).toEqual([items[2]]);
+  });
+
 });


### PR DESCRIPTION
It is sometimes convenient to use an angular expression as a property key to be matched against the comparator value. This adds new syntax which can be used like this:

``` javascript
{":getData().name": "M"}
```

``` javascript
{":foo()": true}
```

``` javascript
{":progress.current+progress.total": 100}
```

  The parsed expression function persists within the iterator closure so that performance should be fine.
