### PR TITLE
fix($compile): Handle the removal of an interpolated attribute

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2136,6 +2136,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                           "ng- versions (such as ng-click instead of onclick) instead.");
                 }
 
+                // If the attribute was removed, then we are done
+                if (!attr[name]) {
+                  return;
+                }
+
                 // we need to interpolate again, in case the attribute value has been updated
                 // (e.g. by another directive's compile function)
                 interpolateFn = $interpolate(attr[name], true, getTrustedContext(node, name),

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2512,6 +2512,24 @@ describe('$compile', function() {
       });
     });
 
+    it('should allow the attribute to be removed before the attribute interpolation', function () {
+       module(function() {
+         directive('removeAttr', function () {
+           return {
+             restrict:'A',
+             compile: function (tElement, tAttr) {
+               tAttr.$set('removeAttr', null);
+             }
+           };
+         });
+       });
+       inject(function ($rootScope, $compile) {
+         expect(function () {
+           element = $compile('<div remove-attr="{{ toBeRemoved }}"></div>')($rootScope);
+         }).not.toThrow();
+         expect(element.attr('remove-attr')).toBeUndefined();
+       });
+     });
 
     describe('SCE values', function() {
       it('should resolve compile and link both attribute and text bindings', inject(


### PR DESCRIPTION
Handle the removal of an interpolated attribute before the attribute interpolating directive is linked

Closes #9236
