### PR TITLE
clarify terminal parameter

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -129,7 +129,8 @@
  * #### `terminal`
  * If set to true then the current `priority` will be the last set of directives
  * which will execute (any directives at the current priority will still execute
- * as the order of execution on same `priority` is undefined).
+ * as the order of execution on same `priority` is undefined). Note that expressions 
+ * and other directives used in the directive's template will also be excluded from execution.
  *
  * #### `scope`
  * **If set to `true`,** then a new scope will be created for this directive. If multiple directives on the


### PR DESCRIPTION
Clarifies that the terminal parameter will also exclude execution of any directives and expressions in the directive's own template.
