### PR TITLE
feat($http): add notify callback for loading requests

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -991,7 +991,7 @@ function $HttpProvider() {
         }
 
         $httpBackend(config.method, url, reqData, done, reqHeaders, config.timeout,
-            config.withCredentials, config.responseType);
+            config.withCredentials, config.responseType, notify);
       }
 
       return promise;
@@ -1023,6 +1023,14 @@ function $HttpProvider() {
           resolveHttpPromise();
           if (!$rootScope.$$phase) $rootScope.$apply();
         }
+      }
+
+
+      /**
+       * Notify callback registered to $httpBackend()
+       */
+      function notify(xhr) {
+        deferred.notify(xhr);
       }
 
 

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -40,7 +40,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
   var ABORTED = -1;
 
   // TODO(vojta): fix the signature
-  return function(method, url, post, callback, headers, timeout, withCredentials, responseType) {
+  return function(method, url, post, callback, headers, timeout, withCredentials, responseType, notify) {
     var status;
     $browser.$$incOutstandingRequestCount();
     url = url || $browser.url();
@@ -103,6 +103,8 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
               response,
               responseHeaders,
               statusText);
+        } else if (xhr && xhr.readyState == 3 && notify) {
+          notify(xhr);
         }
       };
 


### PR DESCRIPTION
Allows progress notifications for $http requests.

This makes use of the readyState 3 of XMLHttpRequest and uses the promises' notifications API which contains partial data except for IE 9 and below.

It's intentional that this _doesn't_ call $apply since this may occur many times in a short span of time.
I'll add tests if this proves to be useful to add.
