### PR TITLE
fix(ngModel): don't parse before validating if viewValue is undefined

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2053,14 +2053,17 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
   };
 
   this.$$parseAndValidate = function() {
-    var parserValid = true,
-        viewValue = ctrl.$$lastCommittedViewValue,
-        modelValue = viewValue;
-    for(var i = 0; i < ctrl.$parsers.length; i++) {
-      modelValue = ctrl.$parsers[i](modelValue);
-      if (isUndefined(modelValue)) {
-        parserValid = false;
-        break;
+    var viewValue = ctrl.$$lastCommittedViewValue;
+    var modelValue = viewValue;
+    var parserValid = isUndefined(modelValue) ? undefined : true;
+
+    if (parserValid) {
+      for(var i = 0; i < ctrl.$parsers.length; i++) {
+        modelValue = ctrl.$parsers[i](modelValue);
+        if (isUndefined(modelValue)) {
+          parserValid = false;
+          break;
+        }
       }
     }
     if (isNumber(ctrl.$modelValue) && isNaN(ctrl.$modelValue)) {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -3717,6 +3717,18 @@ describe('input', function() {
         expect(inputElm).toBeInvalid();
         expect(scope.form.alias.$error.required).toBeTruthy();
       });
+
+      it('should not invalidate number if ng-required=false and model is undefined', function() {
+        compileInput('<input type="number" ng-model="value" name="alias" ng-required="required">');
+
+        scope.$apply("required = false");
+
+        expect(inputElm).toBeValid();
+
+        scope.$apply("required = true");
+
+        expect(inputElm).toBeInvalid();
+      });
     });
 
     describe('minlength', function() {


### PR DESCRIPTION
Prevents unintentionally reporting an undefined view value as a parse error...

Closes #9106
