### PR TITLE
fix(ngModel): minimize jank when toggling CSS classes during validation

### DIFF
--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -892,6 +892,51 @@ describe('NgModelController', function() {
       dealoc(element);
     }));
 
+
+    it('should minimize janky setting of classes during $validate() and ngModelWatch', inject(function($animate, $compile, $rootScope) {
+      var addClass = $animate.addClass;
+      var removeClass = $animate.removeClass;
+      var addClassCallCount = 0;
+      var removeClassCallCount = 0;
+      var input;
+      $animate.addClass = function(element, className) {
+        // Don't worry about classes that the input already has.
+        if (input && element[0] === input[0] && (' ' + element.attr('class') + ' ').indexOf(' ' + className + ' ') < 0) {
+          ++addClassCallCount;
+        }
+        return addClass.call($animate, element, className);
+      };
+
+      $animate.removeClass = function(element, className) {
+        // Don't worry about classes that the input doesn't have.
+        if (input && element[0] === input[0] && (' ' + element.attr('class') + ' ').indexOf(' ' + className + ' ') !== -1) {
+          ++removeClassCallCount;
+        }
+        return removeClass.call($animate, element, className);
+      };
+
+      dealoc(element);
+
+      $rootScope.value = "123456789";
+      element = $compile(
+        '<form name="form">' +
+            '<input type="text" ng-model="value" name="alias" ng-maxlength="10">' +
+        '</form>'
+      )($rootScope);
+
+      var form = $rootScope.form;
+      input = element.children().eq(0);
+
+      $rootScope.$digest();
+
+      expect(input).toBeValid();
+      expect(input).not.toHaveClass('ng-invalid-maxlength');
+      expect(input).toHaveClass('ng-valid-maxlength');
+      expect(addClassCallCount).toBe(2);
+      expect(removeClassCallCount).toBe(0);
+
+      dealoc(element);
+    }));
   });
 });
 


### PR DESCRIPTION
Previously, class toggling would always occur immediately. This causes
problems in cases where class changes happen super frequently, and can result
in flickering in some browsers which do not handle this jank well.

/cc @matsko please help review this! It is very much your area of expertise!

Closes #8234
