### PR TITLE
refactor($q): remove redundant callbacks from when method

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -487,10 +487,10 @@ function qFactory(nextTick, exceptionHandler) {
    */
 
 
-  var when = function(value, callback, errback, progressBack) {
+  var when = function(value) {
     var result = new Deferred();
     result.resolve(value);
-    return result.promise.then(callback, errback, progressBack);
+    return result.promise;
   };
 
   /**


### PR DESCRIPTION
The `when` method had some extra callbacks parameters which are not documented and not used inside angular
