### PR TITLE
feat(select): add $optionChangeListeners to selectDirective controller

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -260,6 +260,15 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
       ////////////////////////////
 
 
+      function notifyListeners(values) {
+        var index, length;
+
+        if (!(length = selectCtrl.$optionChangeListeners.length)) return;
+
+        for(index = 0; index < length; index++) {
+          selectCtrl.$optionChangeListeners[index](values || []);
+        }
+      }
 
       function setupAsSingle(scope, selectElement, ngModelCtrl, selectCtrl) {
         ngModelCtrl.$render = function() {
@@ -282,6 +291,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
           scope.$apply(function() {
             if (unknownOption.parent()) unknownOption.remove();
             ngModelCtrl.$setViewValue(selectElement.val());
+            notifyListeners();
           });
         });
       }
@@ -313,6 +323,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
               }
             });
             ctrl.$setViewValue(array);
+            notifyListeners();
           });
         });
       }
@@ -460,16 +471,6 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
           if (!renderScheduled) {
             scope.$$postDigest(render);
             renderScheduled = true;
-          }
-        }
-
-        function notifyListeners(values) {
-          var index, length;
-
-          if (!(length = selectCtrl.$optionChangeListeners.length)) return;
-
-          for(index = 0; index < length; index++) {
-            selectCtrl.$optionChangeListeners[index](values);
           }
         }
 

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -208,9 +208,13 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
         return optionsMap.hasOwnProperty(value);
       };
 
+      self.$optionChangeListeners = [];
+
       $scope.$on('$destroy', function() {
         // disable unknown option so that we don't do work when the whole select is being destroyed
         self.renderUnknownOption = noop;
+        // clear the listeners array for the same reason
+        self.$optionChangeListeners.length = 0;
       });
     }],
 
@@ -459,6 +463,15 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
           }
         }
 
+        function notifyListeners(values) {
+          var index, length;
+
+          if (!(length = selectCtrl.$optionChangeListeners.length)) return;
+
+          for(index = 0; index < length; index++) {
+            selectCtrl.$optionChangeListeners[index](values);
+          }
+        }
 
         function render() {
           renderScheduled = false;
@@ -482,7 +495,6 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
               lastElement,
               element,
               label;
-
 
           // We now build up the list of options we need (we merge later)
           for (index = 0; length = keys.length, index < length; index++) {
@@ -629,6 +641,9 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
           while(optionGroupsCache.length > groupIndex) {
             optionGroupsCache.pop()[0].element.remove();
           }
+
+          // Rendering of options are done, call the listeners if any
+          notifyListeners(values);
         }
       }
     }

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -851,6 +851,19 @@ describe('select', function() {
         expect(spy).not.toHaveBeenCalled();
       });
 
+      it('should remove listeners on scope.$destroy', function(){
+        createSingleSelect();
+
+        var
+          ctrl = element.controller('select');
+
+        ctrl.$optionChangeListeners.push(function(){});
+
+        scope.$destroy();
+
+        expect(ctrl.$optionChangeListeners.length).toEqual(0);
+      });
+
     });
 
     describe('binding', function() {

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -832,7 +832,7 @@ describe('select', function() {
         expect(spy.mostRecentCall.args[0]).toEqual([values[2]]);
       });
 
-      it('should not trigger when there\'s no ng-options', function(){
+      it('should trigger when there\'s no ng-options with empty value list on single', function(){
         createSelect({
           'ng-model': 'selected'
         });
@@ -843,12 +843,24 @@ describe('select', function() {
 
         ctrl.$optionChangeListeners.push(spy);
 
-        scope.$apply(function(){
-          scope.values = [{name: 'A'}, {name: 'B'}, {name: 'C'}];
-          scope.selected = scope.values[0];
+        browserTrigger(element, 'change');
+        expect(spy.callCount).toEqual(1);
+      });
+
+      it('should trigger when there\'s no ng-options with empty value list on multiple', function(){
+        createSelect({
+          'ng-model': 'selected',
+          'multiple': true
         });
 
-        expect(spy).not.toHaveBeenCalled();
+        var
+          ctrl = element.controller('select'),
+          spy = jasmine.createSpy('optionChangeListener');
+
+        ctrl.$optionChangeListeners.push(spy);
+
+        browserTrigger(element, 'change');
+        expect(spy.callCount).toEqual(1);
       });
 
       it('should remove listeners on scope.$destroy', function(){

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -788,6 +788,71 @@ describe('select', function() {
       expect(scope.selected).toBe(scope.values[0]);
     });
 
+    describe('$optionChangeListeners', function(){
+
+      it('should pass the reference objects from ng-options item list', function(){
+        createSingleSelect();
+        var
+          options = [{name: 'A'}, {name: 'B'}, {name: 'C'}],
+          ctrl = element.controller('select'),
+          spy = jasmine.createSpy('optionChangeListener');
+
+        ctrl.$optionChangeListeners.push(spy);
+
+        scope.$apply(function(){
+          scope.values = options;
+          scope.selected = scope.values[0];
+        });
+
+        expect(spy).toHaveBeenCalledWith(options);
+      });
+
+      it('should pass the filtered items to the listeners', function(){
+        createSelect({
+          'ng-model': 'selected',
+          'ng-options': 'value.id as value.name for value in values | filter:{id:3}'
+        });
+
+        var
+          ctrl = element.controller('select'),
+          values = [{name: 'A', id: 1}, {name: 'B', id: 2}, {name: 'C', id: 3}],
+          spy = jasmine.createSpy('optionChangeListener');
+
+        ctrl.$optionChangeListeners.push(spy);
+
+        scope.$apply(function(){
+          scope.values = values;
+          scope.selected = scope.values[0];
+        });
+
+        // it's a subset of our values, but retaining references
+        // first call = when the element is compiled
+        // second call = when the options are filtered
+        expect(spy.callCount).toEqual(2);
+        expect(spy.mostRecentCall.args[0]).toEqual([values[2]]);
+      });
+
+      it('should not trigger when there\'s no ng-options', function(){
+        createSelect({
+          'ng-model': 'selected'
+        });
+
+        var
+          ctrl = element.controller('select'),
+          spy = jasmine.createSpy('optionChangeListener');
+
+        ctrl.$optionChangeListeners.push(spy);
+
+        scope.$apply(function(){
+          scope.values = [{name: 'A'}, {name: 'B'}, {name: 'C'}];
+          scope.selected = scope.values[0];
+        });
+
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+    });
+
     describe('binding', function() {
 
       it('should bind to scope value', function() {


### PR DESCRIPTION
Adds `$optionChangeListeners` to the selectDirective controller, this is fully backward compatible and has no impact on performance whatsoever if the dev decides not to use it, and has no impact on existing code.

The reasoning behind this feature is that `ng-options` expression is un$parseable from outside the `optionDirective`, and you can't have the current set resulting from the `ng-options` expressions without relying on a scope. This forces the dev to create a custom directive to watch for changes on a `filtered` variable from the underlaying scope (like `ng-options="item.text for item in (filtered = (items | filter:fn1 | filter:fn2))"` and it's not portable between directives, like `$viewChangeListeners` in `NgModelController`.
This makes isolated select controllers easier to accomplish and scope agnostic, aka web components style. 

This also encourages future proof directive code, since it won't depend on the DOM or manually crafted  enforced scopes, nor needs to watch over collections (that increases $digest overhead). 

Pseudo-code:

``` js
.directive('selectPlugin', function(){
  return {
     restrict: 'A',
     require: 'select',
     link: function(scope, el, attrs, select){
       select.$optionChangeListeners.push(function selectListener(items){
          if (el.selectPlugin.initialized) {
            el.selectPlugin.refresh();
          } else {
            el.selectPlugin.init();
          }
       });
     }
  };
});
```

``` html
<select select-plugin ng-options="item.id as item.name for item in items | filter:filterFn"></select>
```

Closes #9222
