### PR TITLE
fix(select): Add exception for unsupported ngOptions use case

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -338,6 +338,12 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
             // - optionGroupsCache[?][0] is the parent: either the SELECT or OPTGROUP element
             optionGroupsCache = [[{element: selectElement, label:''}]];
 
+        if (track && match[2] && valueName !== match[1]) {
+          throw ngOptionsMinErr('trackSelect',
+            "Do not use 'track by' when your select ('{0}') is different from your value ('{1}')",
+            match[1], valueName);
+        }
+
         if (nullOption) {
           // compile the element since there might be bindings in it
           $compile(nullOption)(scope);

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -877,6 +877,15 @@ describe('select', function() {
         expect(element.val()).toEqual('4');
       });
 
+      it('should throw an error when trying to combine track by with a complex select expression', function() {
+        expect(function() {
+          createSelect({
+            'ng-model': 'selected',
+            'ng-options': 'item.id as item.name for item in values track by item.id'
+          });
+        }).toThrowMinErr('ngOptions','trackSelect', "Do not use 'track by' when your select ('item.id') is different from your value ('item')");
+      });
+
 
       it('should bind to scope value through experession', function() {
         createSelect({


### PR DESCRIPTION
ngOptions introduced `track by` in c32a859bdb93699cc080f9affed4bcff63005a64.
Using `track by` puts constraints on the value you can use in the interpolation
expression in ngOptions. This patch adds an exception
if you use ngOptions in an unsupported way.

Part 2 of the split of angular/angular.js#8544 as requested by @btford 
