### PR TITLE
fix(directives): fix `this` keyword inside link functions

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1541,9 +1541,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           try {
             linkFn = directive.compile($compileNode, templateAttrs, childTranscludeFn);
             if (isFunction(linkFn)) {
-              addLinkFns(null, linkFn, attrStart, attrEnd);
+              addLinkFns(null, angular.bind(directive, linkFn), attrStart, attrEnd);
             } else if (linkFn) {
-              addLinkFns(linkFn.pre, linkFn.post, attrStart, attrEnd);
+              addLinkFns(angular.bind(directive, linkFn.pre), angular.bind(directive, linkFn.post), attrStart, attrEnd);
             }
           } catch (e) {
             $exceptionHandler(e, startingTag($compileNode));

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1541,9 +1541,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           try {
             linkFn = directive.compile($compileNode, templateAttrs, childTranscludeFn);
             if (isFunction(linkFn)) {
-              addLinkFns(null, angular.bind(directive, linkFn), attrStart, attrEnd);
+              addLinkFns(null, bind(directive, linkFn), attrStart, attrEnd);
             } else if (linkFn) {
-              addLinkFns(angular.bind(directive, linkFn.pre), angular.bind(directive, linkFn.post), attrStart, attrEnd);
+              addLinkFns(bind(directive, linkFn.pre), bind(directive, linkFn.post), attrStart, attrEnd);
             }
           } catch (e) {
             $exceptionHandler(e, startingTag($compileNode));

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -190,6 +190,96 @@ describe('$compile', function() {
       });
       inject(function($compile) {});
     });
+
+    it('should preserve context within declaration', function() {
+      module(function() {
+        directive('ff', function(log) {
+          var declaration = {
+            restrict: 'E',
+            template: function(){
+              log('ff template: ' + (this === declaration));
+            },
+            compile: function(){
+              log('ff compile: ' + (this === declaration));
+              return function(){
+                log('ff post: ' + (this === declaration));
+              };
+            }
+          };
+          return declaration;
+        });
+
+        directive('fff', function(log) {
+          var declaration = {
+            restrict: 'E',
+            link: {
+              pre: function(){
+                log('fff pre: ' + (this === declaration));
+              },
+              post: function(){
+                log('fff post: ' + (this === declaration));
+              }
+            }
+          };
+          return declaration;
+        });
+
+        directive('ffff', function(log) {
+          var declaration = {
+            restrict: 'E',
+            compile: function(){
+              return {
+                pre: function(){
+                  log('ffff pre: ' + (this === declaration));
+                },
+                post: function(){
+                  log('ffff post: ' + (this === declaration));
+                }
+              };
+            }
+          };
+          return declaration;
+        });
+
+        directive('fffff', function(log) {
+          var declaration = {
+            restrict: 'E',
+            templateUrl: function(){
+              log('fffff: ' + (this === declaration));
+            }
+          };
+          return declaration;
+        });
+
+        directive('ffffff', function(log) {
+          var declaration = {
+            restrict: 'E',
+            link: function(){
+              log('ffffff: ' + (this === declaration));
+            }
+          };
+          return declaration;
+        });
+      });
+      inject(function($compile, $rootScope, log) {
+        $compile('<ff></ff>')($rootScope);
+        $compile('<fff></fff>')($rootScope);
+        $compile('<ffff></ffff>')($rootScope);
+        $compile('<fffff></fffff>')($rootScope);
+        $compile('<ffffff></ffffff>')($rootScope);
+        expect(log).toEqual(
+          'ff template: true; '+
+          'ff compile: true; '+
+          'ff post: true; '+
+          'fff pre: true; '+
+          'fff post: true; '+
+          'ffff pre: true; '+
+          'ffff post: true; '+
+          'fffff: true; '+
+          'ffffff: true'
+        );
+      });
+    });
   });
 
 


### PR DESCRIPTION
Directive functions `template`, `templateUrl` and `compile` were properly bound to the definition object of the directive, but `link` was not. This made very hard for Coffeescript and Typescript users to have proper "classes" defined (using `class` keyword) because link would not retain the context of `this`. 

Closes #8549
