### PR TITLE
Fixed 9091: ngRoute should load the template after resolve

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -536,15 +536,21 @@ function $RouteProvider(){
         $q.when(next).
           then(function() {
             if (next) {
-              var locals = angular.extend({}, next.resolve),
-                  template, templateUrl;
+              var locals = angular.extend({}, next.resolve);
 
               angular.forEach(locals, function(value, key) {
                 locals[key] = angular.isString(value) ?
                     $injector.get(value) : $injector.invoke(value, null, null, key);
               });
 
-              if (angular.isDefined(template = next.template)) {
+              return $q.all(locals);
+            }
+          }).
+          then(function(locals) {
+           if(next) {
+            var template, templateUrl;
+            
+            if (angular.isDefined(template = next.template)) {
                 if (angular.isFunction(template)) {
                   template = template(next.params);
                 }
@@ -561,8 +567,9 @@ function $RouteProvider(){
               if (angular.isDefined(template)) {
                 locals['$template'] = template;
               }
-              return $q.all(locals);
-            }
+
+             return $q.all(locals);
+           }
           }).
           // after route change
           then(function(locals) {

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -548,25 +548,25 @@ function $RouteProvider(){
           }).
           then(function(locals) {
            if(next) {
-            var template, templateUrl;
-            
-            if (angular.isDefined(template = next.template)) {
-                if (angular.isFunction(template)) {
-                  template = template(next.params);
-                }
-              } else if (angular.isDefined(templateUrl = next.templateUrl)) {
-                if (angular.isFunction(templateUrl)) {
-                  templateUrl = templateUrl(next.params);
-                }
-                templateUrl = $sce.getTrustedResourceUrl(templateUrl);
-                if (angular.isDefined(templateUrl)) {
-                  next.loadedTemplateUrl = templateUrl;
-                  template = $templateRequest(templateUrl);
-                }
-              }
-              if (angular.isDefined(template)) {
-                locals['$template'] = template;
-              }
+             var template, templateUrl;
+
+             if (angular.isDefined(template = next.template)) {
+               if (angular.isFunction(template)) {
+                 template = template(next.params);
+               }
+             } else if (angular.isDefined(templateUrl = next.templateUrl)) {
+               if (angular.isFunction(templateUrl)) {
+                 templateUrl = templateUrl(next.params);
+               }
+               templateUrl = $sce.getTrustedResourceUrl(templateUrl);
+               if (angular.isDefined(templateUrl)) {
+                 next.loadedTemplateUrl = templateUrl;
+                 template = $templateRequest(templateUrl);
+               }
+             }
+             if (angular.isDefined(template)) {
+               locals['$template'] = template;
+             }
 
              return $q.all(locals);
            }


### PR DESCRIPTION
Currently ngRoute will load the template while it is still resolving. https://github.com/angular/angular.js/issues/9091
This patch will stop that behavior and will resolve before the template gets loaded, so that people could change the template via:
 $route.current.template/$route.current.templateUrl, so you could build more powereful Applications with the default router. (loading a template based on the resolved resource)
