### PR TITLE
feat ($http): Add custom createXhr factory to config object

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -743,6 +743,8 @@ function $HttpProvider() {
      *      for more information.
      *    - **responseType** - `{string}` - see
      *      [requestType](https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest#responseType).
+     *    - **createXhr** - `{function(method)}` - a function that constructs the XHR object. Use this
+     *      to create customized or non-standard XHR objects.
      *
      * @returns {HttpPromise} Returns a {@link ng.$q promise} object with the
      *   standard `then` method and two http specific methods: `success` and `error`. The `then`
@@ -861,7 +863,8 @@ function $HttpProvider() {
         method: 'get',
         transformRequest: defaults.transformRequest,
         transformResponse: defaults.transformResponse,
-        paramSerializer: defaults.paramSerializer
+        paramSerializer: defaults.paramSerializer,
+        createXhr: defaults.createXhr
       }, requestConfig);
 
       config.headers = mergeHeaders(requestConfig);
@@ -1176,7 +1179,7 @@ function $HttpProvider() {
         }
 
         $httpBackend(config.method, url, reqData, done, reqHeaders, config.timeout,
-            config.withCredentials, config.responseType);
+            config.withCredentials, config.responseType, config.createXhr);
       }
 
       return promise;

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -28,7 +28,7 @@ function $HttpBackendProvider() {
 
 function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDocument) {
   // TODO(vojta): fix the signature
-  return function(method, url, post, callback, headers, timeout, withCredentials, responseType) {
+  return function(method, url, post, callback, headers, timeout, withCredentials, responseType, customCreateXhr) {
     $browser.$$incOutstandingRequestCount();
     url = url || $browser.url();
 
@@ -46,7 +46,12 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
       });
     } else {
 
-      var xhr = createXhr();
+      var xhr;
+      if (customCreateXhr && typeof customCreateXhr === 'function') {
+        xhr = customCreateXhr(method);
+      } else {
+        xhr = createXhr();
+      }
 
       xhr.open(method, url, true);
       forEach(headers, function(value, key) {

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -231,6 +231,11 @@ describe('$httpBackend', function() {
     expect(MockXhr.$$lastInstance.withCredentials).toBe(true);
   });
 
+  it('should use custom createXhr', function() {
+    var createXhr = jasmine.createSpy('createXhr').andReturn(new MockXhr());
+    $backend('GET', '/whatever', null, callback, {}, null, null, null, createXhr);
+    expect(createXhr).toHaveBeenCalledOnceWith('GET');
+  });
 
   describe('responseType', function() {
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1896,6 +1896,57 @@ describe('$http', function() {
 
     $httpBackend.verifyNoOutstandingExpectation = noop;
   });
+
+  it('should pass createXhr', function() {
+    var $httpBackend = jasmine.createSpy('$httpBackend');
+    var dummyCreateXhr = function() {};
+
+    $httpBackend.andCallFake(function(m, u, d, c, h, t, wc, rt, createXhr) {
+      expect(createXhr).toBe(dummyCreateXhr);
+    });
+
+    module(function($provide) {
+      $provide.value('$httpBackend', $httpBackend);
+    });
+
+    inject(function($http, $rootScope) {
+      $http({
+        method: 'GET',
+        url: 'some.html',
+        createXhr: dummyCreateXhr
+      });
+      $rootScope.$digest();
+      expect($httpBackend).toHaveBeenCalledOnce();
+    });
+
+    $httpBackend.verifyNoOutstandingExpectation = noop;
+  });
+
+  it('should use createXhr from default', function() {
+    var $httpBackend = jasmine.createSpy('$httpBackend');
+    var dummyCreateXhr = function() {};
+
+    $httpBackend.andCallFake(function(m, u, d, c, h, t, wc, rt, createXhr) {
+      expect(createXhr).toBe(dummyCreateXhr);
+    });
+
+    module(function($provide) {
+      $provide.value('$httpBackend', $httpBackend);
+    });
+
+    inject(function($http, $rootScope) {
+      $http.defaults.createXhr = dummyCreateXhr;
+      $http({
+        method: 'GET',
+        url: 'some.html'
+      });
+      $rootScope.$digest();
+      expect($httpBackend).toHaveBeenCalledOnce();
+    });
+
+    $httpBackend.verifyNoOutstandingExpectation = noop;
+  });
+
 });
 
 


### PR DESCRIPTION
To be able to construct non-standard or customised XHR objects a factory an optional factory function can be added to the config object. This is required for use of the mozAnon and mozSystem options for FirefoxOS.
See https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest#XMLHttpRequest() for details.

This is an alternative solution to the one suggested in PR  #7903. Closes #2318
