### PR TITLE
docs(Custom directives to access DOM): improve readability

### DIFF
--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -67,8 +67,8 @@ element that adds extra behavior to the element. The {@link ng.directive:ngModel
 stores/updates the value of the input field into/from a variable.
 
 <div class="alert alert-info">
-**Custom directives to access the DOM**: In Angular, the only place where an application touches the DOM is
- within directives. This is good as artifacts that access the DOM are hard to test.
+**Custom directives to access the DOM**: In Angular, the only place where an application should access the DOM is
+ within directives. This is important because artifacts that access the DOM are hard to test.
  If you need to access the DOM directly you should write a custom directive for this. The
  {@link directive directives guide} explains how to do this.
 </div>


### PR DESCRIPTION
When I first read the "Custom directives to access DOM"  I thought the wording was a little confusing.

I still dislike the wording "artifacts that access the DOM are hard to test" because tools like Protractor makes it pretty easy. Perhaps a better explanation would somehow explain that DOM manipulation outside of directives creates tight coupling that decreases testability, which is obviously undesirable.  Is it worth trying to include a sentence like this, or is the current definition sufficient?
