### PR TITLE
chore(ci): remove repeated tests running from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - JOB=unit
     - JOB=e2e TEST_TARGET=jqlite
     - JOB=e2e TEST_TARGET=jquery
-    - JOB=e2e TEST_TARGET=doce2e
   global:
     - SAUCE_USERNAME=angular-ci
     - SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987


### PR DESCRIPTION
In b2902446eb41591f5d868846d3c5bad3a888bcba the doce2e tests were moved
into the 'unit' test job on Travis, but only half of this change ever made
it into v1.2.x. This change fixes up the other half, so that the doce2e
tests are run only once.
