### PR TITLE
docs($compile): add missing header

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -452,7 +452,7 @@
  * }
  * ```
  *
- * Below is an example using `$compileProvider`.
+ * ## Example
  *
  * <div class="alert alert-warning">
  * **Note**: Typically directives are registered with `module.directive`. The example below is


### PR DESCRIPTION
Without this header, it looked like this example is part of the section about the attributes object.
