### PR TITLE
docs(CONTRIBUTING.md): Revert "Added a not about type"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ For large fixes, please build and test the documentation before submitting the P
 accidentally introduced any layout or formatting issues. You should also make sure that your commit message
 is labeled "docs:" and follows the **Git Commit Guidelines** outlined below.
 
-If you're just making a small change, don't worry about filing an issue first. Use the friendly blue "Improve this doc" button at the top right of the doc page to fork the repository in-place and make a quick change on the fly. When naming the commit, it is advised to still label it according to the commit guidelines below, by starting the commit message with **docs** and referencing the filename. Since this is not obvious and some changes are made on the fly, this is not strictly necessary and we will understand if this isn't done the first few times. 
+If you're just making a small change, don't worry about filing an issue first. Use the friendly blue "Improve this doc" button at the top right of the doc page to fork the repository in-place and make a quick change on the fly.
 
 ## <a name="submit"></a> Submission Guidelines
 


### PR DESCRIPTION
This reverts commit 86d33c5f9d77f1e8a97b4c423e5497198fbc23cd by @RichardLitt

As the 'Improve this docs' button has been improved a bit itself.
See angular/dgeni-packages#75
