### PR TITLE
docs(guide/HTML Compiler): Change draggable example from span to div

### DIFF
--- a/docs/content/guide/compiler.ngdoc
+++ b/docs/content/guide/compiler.ngdoc
@@ -73,7 +73,7 @@ ng.$compileProvider#directive directive API} for in-depth documentation on how
 to write directives.
 
 Here is a directive which makes any element draggable. Notice the `draggable` attribute on the
-`<span>` element.
+`<div>` element.
 
 <example module="drag">
   <file name="script.js">
@@ -85,7 +85,8 @@ Here is a directive which makes any element draggable. Notice the `draggable` at
            position: 'relative',
            border: '1px solid red',
            backgroundColor: 'lightgrey',
-           cursor: 'pointer'
+           cursor: 'pointer',
+           width: '100px
           });
           element.on('mousedown', function(event) {
             // Prevent default dragging of selected content
@@ -113,7 +114,7 @@ Here is a directive which makes any element draggable. Notice the `draggable` at
       });
   </file>
   <file name="index.html">
-    <span draggable>Drag ME</span>
+    <div draggable>Drag ME</div>
   </file>
 </example>
 


### PR DESCRIPTION
The draggable example does not work as expected in Chrome (37.0.2062.124 m).  The span disappears when dragged beyond what appears to be a small area.  Changing the span to a div (with a width of 100px) resolves this issue.
