### PR TITLE
docs(guide/HTML Compiler): change draggable span to block

### DIFF
--- a/docs/content/guide/compiler.ngdoc
+++ b/docs/content/guide/compiler.ngdoc
@@ -85,7 +85,9 @@ Here is a directive which makes any element draggable. Notice the `draggable` at
            position: 'relative',
            border: '1px solid red',
            backgroundColor: 'lightgrey',
-           cursor: 'pointer'
+           cursor: 'pointer',
+           display: 'block',
+           width: '65px'
           });
           element.on('mousedown', function(event) {
             // Prevent default dragging of selected content


### PR DESCRIPTION
The draggable example does not work as expected in Chrome (37.0.2062.124 m). The span disappears when dragged beyond what appears to be a small area. Changing the span to a block element (with a width of 65px) resolves this issue.
An alternative solution would be to change the span to a div.
