### PR TITLE
fix($compile): get $$observe listeners array as own property

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -929,7 +929,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
        */
       $observe: function(key, fn) {
         var attrs = this,
-            $$observers = (attrs.$$observers || (attrs.$$observers = {})),
+            $$observers = (attrs.$$observers || (attrs.$$observers = Object.create(null))),
             listeners = ($$observers[key] || ($$observers[key] = []));
 
         listeners.push(fn);

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3124,6 +3124,34 @@ describe('$compile', function() {
     }));
 
 
+    it('should be able to bind attribute names which are present in Object.prototype', function() {
+      module(function() {
+        directive('inProtoAttr', valueFn({
+          scope: {
+            'constructor': '@',
+            // Spidermonkey extension, may be obsolete in the future
+            'watch': '=',
+            'unwatch': '&'
+          }
+        }));
+      });
+      inject(function($rootScope) {
+        expect(function() {
+          compile('<div in-proto-attr constructor="hello, world" watch="[]" ' +
+                     'unwatch="value = !value"></div>');
+        }).not.toThrow();
+        var isolateScope = element.isolateScope();
+
+        expect(typeof isolateScope.constructor).toBe('string');
+        expect(isArray(isolateScope.watch)).toBe(true);
+        expect(typeof isolateScope.unwatch).toBe('function');
+        expect($rootScope.value).toBeUndefined();
+        isolateScope.unwatch();
+        expect($rootScope.value).toBe(true);
+      });
+    });
+
+
     describe('bind-once', function () {
 
       function countWatches(scope) {


### PR DESCRIPTION
Prevent accidentally treating a builtin function from Object.prototype as the
binding object, and thus preventing the compiler from throwing when using
attribute binding names which match a property of the Object prototype.

Closes #9343
