### PR TITLE
'unshift' argument for provider's loader

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -146,7 +146,7 @@ function setupModuleLoader(window) {
            * @description
            * See {@link auto.$provide#provider $provide.provider()}.
            */
-          provider: invokeLater('$provide', 'provider'),
+          provider: invokeLater('$provide', 'provider', 'unshift'),
 
           /**
            * @ngdoc method


### PR DESCRIPTION
Providers are used in config blocks, but in case when config block invokes before provider, there is no-provider error. This situation may appear when module and config block declared in one file, and provider - in another. Eg.

_module.js_

```
angular.module("App", [])

.config(["fooProvider", function (fooProvider) {
}]);
```

_foo-provider.js_

```
function fooProvider () {
}

angular.module("App")
.provider("foo", fooProvider);
```

Code from _module.js_ always runs first and causes an error.
What do you think?
