### PR TITLE
refactor(ngView): remove previousElement bookkeeping

### DIFF
--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -188,7 +188,6 @@ function ngViewFactory(   $route,   $anchorScroll,   $animate) {
     link: function(scope, $element, attr, ctrl, $transclude) {
         var currentScope,
             currentElement,
-            previousElement,
             autoScrollExp = attr.autoscroll,
             onloadExp = attr.onload || '';
 
@@ -196,19 +195,12 @@ function ngViewFactory(   $route,   $anchorScroll,   $animate) {
         update();
 
         function cleanupLastView() {
-          if(previousElement) {
-            previousElement.remove();
-            previousElement = null;
-          }
           if(currentScope) {
             currentScope.$destroy();
             currentScope = null;
           }
           if(currentElement) {
-            $animate.leave(currentElement).then(function() {
-              previousElement = null;
-            });
-            previousElement = currentElement;
+            $animate.leave(currentElement);
             currentElement = null;
           }
         }

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -844,48 +844,6 @@ describe('ngView animations', function() {
         }
       });
     });
-
-    it('should destroy the previous leave animation if a new one takes place', function() {
-      module(function($provide) {
-        $provide.decorator('$animate', function($delegate, $$q) {
-          var emptyPromise = $$q.defer().promise;
-          $delegate.leave = function() {
-            return emptyPromise;
-          };
-          return $delegate;
-        });
-      });
-      inject(function ($compile, $rootScope, $animate, $location) {
-        var item;
-        var $scope = $rootScope.$new();
-        element = $compile(html(
-          '<div>' +
-            '<div ng-view></div>' +
-          '</div>'
-        ))($scope);
-
-        $scope.$apply('value = true');
-
-        $location.path('/bar');
-        $rootScope.$digest();
-
-        var destroyed, inner = element.children(0);
-        inner.on('$destroy', function() {
-          destroyed = true;
-        });
-
-        $location.path('/foo');
-        $rootScope.$digest();
-
-        $location.path('/bar');
-        $rootScope.$digest();
-
-        $location.path('/bar');
-        $rootScope.$digest();
-
-        expect(destroyed).toBe(true);
-      });
-    });
   });
 
 


### PR DESCRIPTION
it's unnecessary and inconsistent (because finishing animations reset  we see situations
where not previousElement is not always removed and more than one leave animation is going on at the same time).

Closes #7606
