### PR TITLE
feat(controller): allow named function syntax when registering controllers

### DIFF
--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -16,7 +16,7 @@ function $ControllerProvider() {
       CNTRL_REG = /^(\S+)(\s+as\s+(\w+))?$/;
 
   function fnName(fn) {
-    var nameMatch = fn.toString().match(/function ([^\(]+)/);
+    var nameMatch = fn.toString().match(/^function ([^\(]+)/);
     return nameMatch && nameMatch[1] || '';
   }
 

--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -15,6 +15,11 @@ function $ControllerProvider() {
       globals = false,
       CNTRL_REG = /^(\S+)(\s+as\s+(\w+))?$/;
 
+  function fnName(fn) {
+    var nameMatch = fn.toString().match(/function ([^\(]+)/);
+    return nameMatch && nameMatch[1] || '';
+  }
+
 
   /**
    * @ngdoc method
@@ -26,7 +31,12 @@ function $ControllerProvider() {
    */
   this.register = function(name, constructor) {
     assertNotHasOwnProperty(name, 'controller');
-    if (isObject(name)) {
+    if (isArray(name)) {
+      var fn = name[name.length - 1];
+      controllers[fn.name || fnName(fn)] = name;
+    } else if (isFunction(name)) {
+      controllers[name.name || fnName(name)] = name;
+    } else if (isObject(name)) {
       extend(controllers, name);
     } else {
       controllers[name] = constructor;

--- a/test/ng/controllerSpec.js
+++ b/test/ng/controllerSpec.js
@@ -59,6 +59,32 @@ describe('$controller', function() {
     });
 
 
+    it('should allow registration of controllers using named functions', function() {
+      var FooCtrl = function FooCtrl($scope) { $scope.foo = 'bar'; },
+          scope = {},
+          ctrl;
+
+      $controllerProvider.register(FooCtrl);
+      ctrl = $controller('FooCtrl', {$scope: scope});
+
+      expect(scope.foo).toBe('bar');
+      expect(ctrl instanceof FooCtrl).toBe(true);
+    });
+
+
+    it('should allow registration of controllers using named functions in array annotations', function() {
+      var FooCtrl = function FooCtrl($scope) { $scope.foo = 'bar'; },
+          scope = {},
+          ctrl;
+
+      $controllerProvider.register(['$scope', FooCtrl]);
+      ctrl = $controller('FooCtrl', {$scope: scope});
+
+      expect(scope.foo).toBe('bar');
+      expect(ctrl instanceof FooCtrl).toBe(true);
+    });
+
+
     it('should throw an exception if a controller is called "hasOwnProperty"', function () {
       expect(function() {
         $controllerProvider.register('hasOwnProperty', function($scope) {});


### PR DESCRIPTION
This pull-request means to introduce two new syntax for registering controllers:

``` js
$controllerProvider.register(function FooCtrl($scope) {
  // ...
});

$controllerProvider.register(['$sope', function FooCtrl($scope) {
  // ...
}]);
```

As it is shown above, using a named function we can remove the need for the first argument on the controller declaration, which was the controller's name.

This feature relies first on [Function.name](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name), which is currently implemented in most major browsers, with the exception of Internet Explorer. Because of that, I have also added a fallback method to get a function's name, which was mostly based on @dfkaye's [Gist](https://gist.github.com/dfkaye/6384439), although I've pretty much skiped the validation part which I think is unecessary for this case.

_P.s.: I've made tests for both use-cases and all test (including e2e) seem to be working just fine._
