### PR TITLE
'unshift' argument for provider's loader

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -142,7 +142,7 @@ function setupModuleLoader(window) {
            * @description
            * See {@link auto.$provide#provider $provide.provider()}.
            */
-          provider: invokeLater('$provide', 'provider'),
+          provider: invokeLater('$provide', 'provider', 'unshift'),
 
           /**
            * @ngdoc method

--- a/test/loaderSpec.js
+++ b/test/loaderSpec.js
@@ -46,8 +46,8 @@ describe('module loader', function() {
     expect(myModule.requires).toEqual(['other']);
     expect(myModule._invokeQueue).toEqual([
       ['$provide', 'constant', ['abc', 123] ],
-      ['$injector', 'invoke', ['config'] ],
       ['$provide', 'provider', ['sk', 'sv'] ],
+      ['$injector', 'invoke', ['config'] ],
       ['$provide', 'factory', ['fk', 'fv'] ],
       ['$provide', 'service', ['a', 'aa'] ],
       ['$provide', 'value', ['k', 'v'] ],


### PR DESCRIPTION
Providers are used in config blocks, but in case when config block invokes before provider, there is no-provider error. This situation may appear when module and config block declared in one file, and provider - in another. Eg.

_module.js_

```
angular.module("App", [])

.config(function (fooProvider) {});
```

_foo-provider.js_

```
function fooProvider () {
  return {
    $get: function () {}
  };
}

angular.module("App")
.provider("foo", fooProvider);
```

Code from _module.js_ always runs first and causes an error. There is [fiddle](http://jsfiddle.net/garmashnikolay/9p5cgde4/1/)
What do you think?
