### PR TITLE
perf($compile): only use document fragments and copy data when necessary (replaceWith)

### DIFF
--- a/benchmarks/compile-bp/app.js
+++ b/benchmarks/compile-bp/app.js
@@ -1,0 +1,147 @@
+var app = angular.module('compileBenchmark', []);
+
+var registerDirective;
+app.config(function($compileProvider) {
+  if ($compileProvider.debugInfoEnabled) {
+    $compileProvider.debugInfoEnabled(false);
+  }
+
+  registerDirective = function(name, config) {
+    $compileProvider.directive(name, function() { return config; });
+  };
+});
+
+app.controller('DataController', function($element, $compile, $scope, $templateCache) {
+  //The set of directives which have been created
+  var directivesCreated = {};
+
+  //The current template being tested
+  var template;
+
+  $scope.oJSON = JSON.stringify($scope.o = {});
+
+  $scope.$watch("oJSON", function(oJSON) {
+    angular.copy(JSON.parse(oJSON), $scope.o);
+  });
+
+  $scope.$watchCollection("o", function(options) {
+    var json = $scope.oJSON = JSON.stringify(options);
+    var directiveName = "test" + json.toLowerCase().replace(/[^a-z0-9]+/g, '');
+
+    if (!directivesCreated[directiveName]) {
+      var directiveDef = {};
+
+      //Simple options
+      directiveDef.replace = options.replace || false;
+      directiveDef.transclude = options.transclude || false;
+      directiveDef.multiElement = options.multiElement || false;
+      directiveDef.controller = options.controller ? function testController(){} : undefined;
+
+      //Template
+      if (options.templateType) {
+        if (options.templateType === 'template') {
+          directiveDef.template = '<div></div>';
+        } else if (options.templateType === 'templateUrl') {
+          $templateCache.put(directiveDef.templateUrl = directiveName + 'tmpl', '<div></div>');
+        }
+      }
+
+      //Link method(s)
+      var link;
+      if (options.preLink) {
+        link = {pre: function testPreLink(){}, post: options.postLink && function testPostLink(){}};
+      } else if (options.postLink) {
+        link = function testLink(){};
+      }
+
+      //Compile/link declaration
+      if (options.compile) {
+        directiveDef.compile = function testCompile() { return link; };
+      } else if (link) {
+        directiveDef.link = link;
+      }
+
+      registerDirective(directiveName, directivesCreated[directiveName] = directiveDef);
+    }
+
+    //Single vs multiElement spanning
+    var eCount = options.elementCount || 1;
+    if (eCount <= 1) {
+      template = angular.element(document.createElement(directiveName));
+    } else {
+      template = angular.element();
+      template[template.length++] = angular.element('<div>').attr(directiveName+'-start', '')[0];
+      for (var i = 1; i < eCount - 1; i++) {
+        template[template.length++] = document.createElement('span');
+      }
+      template[template.length++] = angular.element('<div>').attr(directiveName+'-end', '')[0];
+    }
+
+    //Transcluded elements have children
+    if (options.transclude) {
+      template.append(document.createElement('div'));
+    }
+
+    //Root element vs has-parent
+    if (options.wrap) {
+      template = angular.element(document.createElement('div')).append(template);
+    }
+  });
+
+
+
+  // TEST STEPS / STATE
+
+  var RUN_COUNT = 5000;
+
+  var linkFns = [];
+  var elements = [];
+  function pushElements(elms) {
+    elements.push(elms);
+    return elms;
+  }
+
+  benchmarkSteps.push({
+    name: 'compile',
+    fn: function compile() {
+      for (var i=0; i<RUN_COUNT; i++) {
+        linkFns[i] = $compile( pushElements(template.clone()) );
+      }
+    }
+  });
+
+  benchmarkSteps.push({
+    name: 'link-clone',
+    fn: function linkClone() {
+      for (var i=0; i<RUN_COUNT; i++) {
+        linkFns[i]($scope, pushElements);
+      }
+    }
+  });
+
+  benchmarkSteps.push({
+    name: 'link',
+    fn: function link() {
+      for (var i=0; i<RUN_COUNT; i++) {
+        linkFns[i]($scope);
+      }
+    }
+  });
+
+  benchmarkSteps.push({
+    name: 'apply',
+    fn: function linkApply() {
+      $scope.$apply();
+    }
+  });
+
+  benchmarkSteps.push({
+    name: 'destroy',
+    fn: function destory() {
+      while (elements.length) {
+        elements.pop().remove();
+      }
+      linkFns = [];
+    }
+  });
+});

--- a/benchmarks/compile-bp/bp.conf.js
+++ b/benchmarks/compile-bp/bp.conf.js
@@ -1,0 +1,11 @@
+module.exports = function(config) {
+  config.set({
+    scripts: [{
+      id: 'angular',
+      src: '/build/angular.js'
+    },
+    {
+      src: 'app.js',
+    }]
+  });
+};

--- a/benchmarks/compile-bp/main.html
+++ b/benchmarks/compile-bp/main.html
@@ -1,0 +1,81 @@
+<style>
+[ng-cloak] { display: none; }
+</style>
+<div ng-app="compileBenchmark" ng-cloak>
+  <div ng-controller="DataController">
+    <div class="container-fluid">
+      <p>
+        Directive $compile/link performance.
+      </p>
+
+      <!-- A couple options aren't compatible or have requirements, just show a message -->
+      <ul style="color:red">
+        <li ng-if="o.multiElement && !o.wrap">Multi Element currently requires a parent node (Wrap)</li>
+        <li ng-if="o.replace && !o.templateType">Replace without a template?</li>
+      </ul>
+
+      <ul style="list-style:none">
+        <li>
+          <input type="text" ng-model="oJSON" width="250">
+        </li>
+
+        <li>
+          <label for="compile">Compile</label>
+          <input type="checkbox" ng-model="o.compile" id="compile">
+        </li>
+
+        <li>
+          Link:
+          <label for="preLink">PRE</label>
+          <input type="checkbox" ng-model="o.preLink" id="preLink">
+          <label for="postLink">POST</label>
+          <input type="checkbox" ng-model="o.postLink" id="postLink">
+        </li>
+
+        <li>
+          Template:
+          <label for="tt-none">None</label>
+          <input type="radio" name="templateType" ng-model="o.templateType" ng-value="false" selected id="tt-none">
+          <label for="tt-template">Yes</label>
+          <input type="radio" name="templateType" ng-model="o.templateType" value="template" id="tt-template">
+          <label for="tt-url">URL</label>
+          <input type="radio" name="templateType" ng-model="o.templateType" value="templateUrl" id="tt-url">
+        </li>
+
+        <li>
+          <label for="replace">Replace</label>
+          <input type="checkbox" ng-model="o.replace" id="replace">
+        </li>
+
+        <li>
+          Transclude:
+          <label for="t-none">None</label>
+          <input type="radio" ng-model="o.transclude" ng-value="false" id="t-none">
+          <label for="t-yes">Yes</label>
+          <input type="radio" ng-model="o.transclude" ng-value="true" id="t-yes">
+          <label for="t-element">Element</label>
+          <input type="radio" ng-model="o.transclude" value="element" id="t-element">
+        </li>
+
+        <li>
+          <label for="controller">Controller</label>
+          <input type="checkbox" ng-model="o.controller" id="controller">
+        </li>
+
+        <li>
+          <label for="wrap">Wrap</label>
+          <input type="checkbox" ng-model="o.wrap" id="wrap">
+        </li>
+
+        <li>
+          <label for="multiElement">Multi Element</label>
+          <input type="checkbox" ng-model="o.multiElement" id="multiElement">
+          <label for="elementCount" ng-show="o.multiElement">
+            Elements
+            <input type="number" ng-model="o.elementCount" id="elementCount" placeholder="1">
+          </label>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -59,6 +59,7 @@
     "isElement": false,
     "makeMap": false,
     "includes": false,
+    "indexOf": false,
     "arrayRemove": false,
     "copy": false,
     "shallowCopy": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -53,6 +53,7 @@
   isElement: true,
   makeMap: true,
   includes: true,
+  indexOf: true,
   arrayRemove: true,
   copy: true,
   shallowCopy: true,
@@ -631,8 +632,10 @@ function nodeName_(element) {
   return lowercase(element.nodeName || (element[0] && element[0].nodeName));
 }
 
+var indexOf = Array.prototype.indexOf;
+
 function includes(array, obj) {
-  return Array.prototype.indexOf.call(array, obj) != -1;
+  return indexOf.call(array, obj) != -1;
 }
 
 function arrayRemove(array, value) {

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -171,6 +171,13 @@ function jqLiteAcceptsData(node) {
   return nodeType === NODE_TYPE_ELEMENT || !nodeType || nodeType === NODE_TYPE_DOCUMENT;
 }
 
+function jqLiteHasData(node) {
+  for (var key in jqCache[node.ng339]) {
+    return true;
+  }
+  return false;
+}
+
 function jqLiteBuildFragment(html, context) {
   var tmp, tag, wrap,
       fragment = context.createDocumentFragment(),
@@ -545,7 +552,8 @@ function getAliasedAttrName(element, name) {
 
 forEach({
   data: jqLiteData,
-  removeData: jqLiteRemoveData
+  removeData: jqLiteRemoveData,
+  hasData: jqLiteHasData
 }, function(fn, name) {
   JQLite[name] = fn;
 });

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2229,7 +2229,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 // it was cloned therefore we have to clone as well.
                 linkNode = jqLiteClone(compileNode);
               }
-              replaceWith(linkRootElement, jqLite(beforeTemplateLinkNode), linkNode);
+              replaceWith(linkRootElement, [beforeTemplateLinkNode], linkNode);
 
               // Copy in CSS classes from original node
               safeAddClass(jqLite(linkNode), oldClasses);
@@ -2414,60 +2414,56 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
      *
      * @param {JqLite=} $rootElement The root of the compile tree. Used so that we can replace nodes
      *                               in the root of the tree.
-     * @param {JqLite} elementsToRemove The jqLite element which we are going to replace. We keep
-     *                                  the shell, but replace its DOM node reference.
+     * @param {JqLite|Array} elementsToRemove The elements which we are going to replace. We keep
+     *                                        the shell, but replace its DOM node reference.
      * @param {Node} newNode The new DOM node.
      */
     function replaceWith($rootElement, elementsToRemove, newNode) {
       var firstElementToRemove = elementsToRemove[0],
           removeCount = elementsToRemove.length,
           parent = firstElementToRemove.parentNode,
-          i, ii;
+          i;
 
-      if ($rootElement) {
-        for (i = 0, ii = $rootElement.length; i < ii; i++) {
-          if ($rootElement[i] == firstElementToRemove) {
-            $rootElement[i++] = newNode;
-            for (var j = i, j2 = j + removeCount - 1,
-                     jj = $rootElement.length;
-                 j < jj; j++, j2++) {
-              if (j2 < jj) {
-                $rootElement[j] = $rootElement[j2];
-              } else {
-                delete $rootElement[j];
-              }
-            }
-            $rootElement.length -= removeCount - 1;
+      if ($rootElement && (i = indexOf.call($rootElement, firstElementToRemove)) !== -1) {
+        $rootElement.splice(i, removeCount, newNode);
 
-            // If the replaced element is also the jQuery .context then replace it
-            // .context is a deprecated jQuery api, so we should set it only when jQuery set it
-            // http://api.jquery.com/context/
-            if ($rootElement.context === firstElementToRemove) {
-              $rootElement.context = newNode;
-            }
-            break;
-          }
+        // If the replaced element is also the jQuery .context then replace it
+        // .context is a deprecated jQuery api, so we should set it only when jQuery set it
+        // http://api.jquery.com/context/
+        if ($rootElement.context === firstElementToRemove) {
+          $rootElement.context = newNode;
         }
       }
 
+      // Add new node to the parent in place of the firstElementToRemove
       if (parent) {
         parent.replaceChild(newNode, firstElementToRemove);
       }
 
-      // TODO(perf): what's this document fragment for? is it needed? can we at least reuse it?
-      var fragment = document.createDocumentFragment();
-      fragment.appendChild(firstElementToRemove);
+      // If multiple elements are being replaced they will be placed into a temporary fragment
+      // so they can still be traversed via .nextSibling or .parent.children while detached.
+      // This also detaches the elementsToRemove if they have a parent.
+      if (removeCount > 1) {
+        var fragment = document.createDocumentFragment();
+        for (i = 0; i < removeCount; i++) {
+          fragment.appendChild(elementsToRemove[i]);
+        }
+      }
 
       // Copy over user data (that includes Angular's $scope etc.). Don't copy private
       // data here because there's no public interface in jQuery to do that and copying over
       // event listeners (which is the main use of private data) wouldn't work anyway.
-      jqLite(newNode).data(jqLite(firstElementToRemove).data());
+      if (jqLite.hasData(firstElementToRemove)) {
+        jqLite.data(newNode, jqLite.data(firstElementToRemove));
+      }
 
       // Remove data of the replaced element. We cannot just call .remove()
       // on the element it since that would deallocate scope that is needed
       // for the new node. Instead, remove the data "manually".
       if (!jQuery) {
-        delete jqLite.cache[firstElementToRemove[jqLite.expando]];
+        for (i = 0; i < removeCount; i++) {
+          delete jqLite.cache[elementsToRemove[i][jqLite.expando]];
+        }
       } else {
         // jQuery 2.x doesn't expose the data storage. Use jQuery.cleanData to clean up after
         // the replaced element. The cleanData version monkey-patched by Angular would cause
@@ -2477,18 +2473,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         // example is jQuery UI). Instead, set a flag indicating scope destroying should be
         // skipped this one time.
         skipDestroyOnNextJQueryCleanData = true;
-        jQuery.cleanData([firstElementToRemove]);
+        jQuery.cleanData(elementsToRemove);
       }
 
-      for (var k = 1, kk = elementsToRemove.length; k < kk; k++) {
-        var element = elementsToRemove[k];
-        jqLite(element).remove(); // must do this way to clean up expando
-        fragment.appendChild(element);
-        delete elementsToRemove[k];
-      }
-
-      elementsToRemove[0] = newNode;
-      elementsToRemove.length = 1;
+      //Modify elementsToRemove jqLite/Array replacing all content with the newnode
+      elementsToRemove.splice(0, removeCount, newNode);
     }
 
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2425,7 +2425,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           i;
 
       if ($rootElement && (i = indexOf.call($rootElement, firstElementToRemove)) !== -1) {
-        $rootElement.splice(i, removeCount, newNode);
+        if (removeCount === 1) {
+          $rootElement[i] = newNode;
+        } else {
+          $rootElement.splice(i, removeCount, newNode);
+        }
 
         // If the replaced element is also the jQuery .context then replace it
         // .context is a deprecated jQuery api, so we should set it only when jQuery set it
@@ -2477,7 +2481,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       }
 
       //Modify elementsToRemove jqLite/Array replacing all content with the newnode
-      elementsToRemove.splice(0, removeCount, newNode);
+      if (removeCount === 1) {
+        elementsToRemove[0] = newNode;
+      } else {
+        elementsToRemove.splice(0, removeCount, newNode);
+      }
     }
 
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -402,13 +402,16 @@ describe('jqLite', function() {
     });
 
 
-    it('should provide the non-wrapped data calls', function() {
+    it('should provide the non-wrapped get/remove/has data calls', function() {
       var node = document.createElement('div');
 
+      expect(jqLite.hasData(node)).toBe(false);
       expect(jqLite.data(node, "foo")).toBeUndefined();
+      expect(jqLite.hasData(node)).toBe(false);
 
       jqLite.data(node, "foo", "bar");
 
+      expect(jqLite.hasData(node)).toBe(true);
       expect(jqLite.data(node, "foo")).toBe("bar");
       expect(jqLite(node).data("foo")).toBe("bar");
 
@@ -421,6 +424,9 @@ describe('jqLite', function() {
       jqLite.removeData(node);
       jqLite.removeData(node);
       expect(jqLite.data(node, "bar")).toBeUndefined();
+
+      jqLite(node).remove();
+      expect(jqLite.hasData(node)).toBe(false);
     });
 
     it('should emit $destroy event if element removed via remove()', function() {


### PR DESCRIPTION
This does a few things, all within the internal `replaceWith`...
- only creates the document fragment if needed and clarifies why it's there
- only copies data if the node `hasData` to avoid creating empty data to copy (a jqLite version of `hasData` was added)
- uses the static data methods to avoid creating jqLite/jQuery objects
- cleans the data of all replaced elements the same way (this will no longer trigger $destroy on nodes 1+, like node 0, which seems correct to me)
- uses jqLite/jQuery/Array.splice to do the array modifications
