### PR TITLE
feat($swipe) Add config param to allow choosing X/Y thresholds.

### DIFF
--- a/src/ngTouch/swipe.js
+++ b/src/ngTouch/swipe.js
@@ -121,8 +121,8 @@ ngTouch.factory('$swipe', [function() {
       var startCoords;
       // Last event's position.
       var lastPos;
-      // Whether an swipe is still being determined to be a scroll.
-      var active = false;
+      // Whether a swipe is still being determined to be a scroll.
+      var scrollActive = false;
       // Whether a swipe is active.
       var swipeActive = false;
 
@@ -143,7 +143,7 @@ ngTouch.factory('$swipe', [function() {
       pointerTypes = pointerTypes || config.pointerTypes;
       element.on(getEvents(pointerTypes, 'start'), function(event) {
         startCoords = getCoordinates(event);
-        active = true;
+        scrollActive = true;
         totalX = 0;
         totalY = 0;
         lastPos = startCoords;
@@ -152,13 +152,13 @@ ngTouch.factory('$swipe', [function() {
       var events = getEvents(pointerTypes, 'cancel');
       if (events) {
         element.on(events, function(event) {
-          active = false;
+          scrollActive = false;
           eventHandlers['cancel'] && eventHandlers['cancel'](event);
         });
       }
 
       element.on(getEvents(pointerTypes, 'move'), function(event) {
-        if (!active) return;
+        if (!scrollActive) return;
 
         // Android will send a touchcancel if it thinks we're starting to scroll.
         // So when the total distance (+ or - or both) exceeds 10px in either direction,
@@ -188,7 +188,7 @@ ngTouch.factory('$swipe', [function() {
         // One of absTotalX or absTotalY has exceeded the threshold, so decide on swipe vs. scroll.
         if (!swipeActive && absTotalY > absTotalX && absTotalY > config.scrollThreshold) {
           // Allow native scrolling to take over.
-          active = false;
+          scrollActive = false;
           swipeActive = false;
           eventHandlers['cancel'] && eventHandlers['cancel'](event);
           return;
@@ -201,8 +201,8 @@ ngTouch.factory('$swipe', [function() {
       });
 
       element.on(getEvents(pointerTypes, 'end'), function(event) {
-        if (!active) return;
-        active = false;
+        if (!scrollActive) return;
+        scrollActive = false;
         swipeActive = false;
         eventHandlers['end'] && eventHandlers['end'](getCoordinates(event), event);
       });

--- a/src/ngTouch/swipe.js
+++ b/src/ngTouch/swipe.js
@@ -23,7 +23,7 @@
 
 ngTouch.factory('$swipe', [function() {
   // The total distance in any direction before we make the call on swipe vs. scroll.
-  var MOVE_BUFFER_RADIUS = 10;
+  var DEFAULT_THRESHOLD = 10;
 
   var POINTER_EVENTS = {
     'mouse': {
@@ -68,6 +68,18 @@ ngTouch.factory('$swipe', [function() {
      * @ngdoc method
      * @name $swipe#bind
      *
+     * @param {DOMElement} element Element to listen for swipes on.
+     * @param {object} eventHandlers An object of handlers to handle each of the
+     *   `start`, `move`, `end`, and `cancel` events
+     * @param {object|Array} configOrPointerTypes Either an optional config object, or an array
+     *   containing the pointer arrays to use. The configuration object supports three properties:
+     *
+     *   - **swipeThreshold** - `{number}` - Number of pixels to wait before the event is
+     *     determined to be a swipe. Default is 10 (see function description above for more).
+     *   - **scrollThreshold** - `{number}` - Number of pixels to wait before the event is
+     *     determined to be a scroll. Default is 10 (see function description above for more).
+     *   - **pointerTypes** - `{Array}` - Array of pointer event names to handle.
+     *
      * @description
      * The main method of `$swipe`. It takes an element to be watched for swipe motions, and an
      * object containing event handlers.
@@ -82,10 +94,16 @@ ngTouch.factory('$swipe', [function() {
      * watching for `touchmove` or `mousemove` events. These events are ignored until the total
      * distance moved in either dimension exceeds a small threshold.
      *
+     * The threshold is `10` (pixels) by default, but is configurable by passing in a `config`
+     * object with properties for the `x` and `y` thresholds respectively `swipeThreshold` and
+     * `scrollThreshold`.
+     *
      * Once this threshold is exceeded, either the horizontal or vertical delta is greater.
-     * - If the horizontal distance is greater, this is a swipe and `move` and `end` events follow.
-     * - If the vertical distance is greater, this is a scroll, and we let the browser take over.
-     *   A `cancel` event is sent.
+     *
+     * - If the horizontal distance is greater and you haven't moved vertically the
+     *   `scrollThreshold`, this is a swipe and `move` and `end` events follow.
+     * - If the vertical distance is greater (or you've met the vertical `scrollThreshold`),
+     *   this is a scroll, and we let the browser take over. A `cancel` event is sent.
      *
      * `move` is called on `mousemove` and `touchmove` after the above logic has determined that
      * a swipe is in progress.
@@ -96,17 +114,33 @@ ngTouch.factory('$swipe', [function() {
      * as described above.
      *
      */
-    bind: function(element, eventHandlers, pointerTypes) {
+    bind: function(element, eventHandlers, config) {
       // Absolute total movement, used to control swipe vs. scroll.
       var totalX, totalY;
       // Coordinates of the start position.
       var startCoords;
       // Last event's position.
       var lastPos;
-      // Whether a swipe is active.
+      // Whether an swipe is still being determined to be a scroll.
       var active = false;
+      // Whether a swipe is active.
+      var swipeActive = false;
 
-      pointerTypes = pointerTypes || ['mouse', 'touch'];
+      var pointerTypes = null;
+
+      if (isArray(config)) {
+        pointerTypes = config;
+        config = {};
+      }
+
+      // Set up config for threshold radii with fallback.
+      config = angular.extend({
+        swipeThreshold: DEFAULT_THRESHOLD,
+        scrollThreshold: DEFAULT_THRESHOLD,
+        pointerTypes: ['mouse', 'touch']
+      }, config);
+
+      pointerTypes = pointerTypes || config.pointerTypes;
       element.on(getEvents(pointerTypes, 'start'), function(event) {
         startCoords = getCoordinates(event);
         active = true;
@@ -135,23 +169,32 @@ ngTouch.factory('$swipe', [function() {
         if (!startCoords) return;
         var coords = getCoordinates(event);
 
-        totalX += Math.abs(coords.x - lastPos.x);
-        totalY += Math.abs(coords.y - lastPos.y);
+        totalX += coords.x - lastPos.x;
+        totalY += coords.y - lastPos.y;
+
+        // we want totalX/Y to be the amount move +/- from the original spot,
+        // but we need to compare against their absolute values in the
+        // comparisons below
+        var absTotalX = Math.abs(totalX);
+        var absTotalY = Math.abs(totalY);
 
         lastPos = coords;
 
-        if (totalX < MOVE_BUFFER_RADIUS && totalY < MOVE_BUFFER_RADIUS) {
+        // don't do anything if neither threshold has been met
+        if (absTotalX < config.swipeThreshold && absTotalY < config.scrollThreshold) {
           return;
         }
 
-        // One of totalX or totalY has exceeded the buffer, so decide on swipe vs. scroll.
-        if (totalY > totalX) {
+        // One of absTotalX or absTotalY has exceeded the threshold, so decide on swipe vs. scroll.
+        if (!swipeActive && absTotalY > absTotalX && absTotalY > config.scrollThreshold) {
           // Allow native scrolling to take over.
           active = false;
+          swipeActive = false;
           eventHandlers['cancel'] && eventHandlers['cancel'](event);
           return;
         } else {
           // Prevent the browser from scrolling.
+          swipeActive = true;
           event.preventDefault();
           eventHandlers['move'] && eventHandlers['move'](coords, event);
         }
@@ -160,10 +203,13 @@ ngTouch.factory('$swipe', [function() {
       element.on(getEvents(pointerTypes, 'end'), function(event) {
         if (!active) return;
         active = false;
+        swipeActive = false;
         eventHandlers['end'] && eventHandlers['end'](getCoordinates(event), event);
       });
     }
   };
 }]);
 
-
+var isArray = Array.isArray || function isArrayPolyfill(obj) {
+  return Object.prototype.toString.call(obj) === '[object Array]';
+};

--- a/test/ngTouch/swipeSpec.js
+++ b/test/ngTouch/swipeSpec.js
@@ -379,6 +379,174 @@ describe('$swipe', function() {
         expect(events.move).not.toHaveBeenCalled();
         expect(events.end).not.toHaveBeenCalled();
       }));
+
+      it('should allow you to move back and forth within the threshold', inject(function($rootScope, $swipe, $compile) {
+        var events = {
+          start: jasmine.createSpy('startSpy'),
+          move: jasmine.createSpy('moveSpy'),
+          cancel: jasmine.createSpy('cancelSpy'),
+          end: jasmine.createSpy('endSpy')
+        };
+
+        // default threshold is 10, 10
+        $swipe.bind(element, events);
+
+        expect(events.start).not.toHaveBeenCalled();
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, startEvent,{
+          keys: [],
+          x: 100,
+          y: 40
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 100,
+          y: 45
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 100,
+          y: 35
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 100,
+          y: 45
+        });
+
+        expect(events.start).toHaveBeenCalled();
+        expect(events.move.calls.length).toBe(0);
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+      }));
+
+      it('should allow you to change the y threshold', inject(function($rootScope, $swipe, $compile) {
+        element = $compile('<div></div>')($rootScope);
+        var events = {
+          start: jasmine.createSpy('startSpy'),
+          move: jasmine.createSpy('moveSpy'),
+          cancel: jasmine.createSpy('cancelSpy'),
+          end: jasmine.createSpy('endSpy')
+        };
+
+        $swipe.bind(element, events, {
+          scrollThreshold: 30
+        });
+
+        expect(events.start).not.toHaveBeenCalled();
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, startEvent,{
+          keys: [],
+          x: 100,
+          y: 40
+        });
+
+        expect(events.start).toHaveBeenCalled();
+
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 100,
+          y: 69
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 100,
+          y: 11
+        });
+
+        expect(events.start).toHaveBeenCalled();
+
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.move.calls.length).toBe(0);
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 100,
+          y: 9
+        });
+
+        expect(events.cancel).toHaveBeenCalled();
+        expect(events.move.calls.length).toBe(0);
+        expect(events.end).not.toHaveBeenCalled();
+      }));
+
+      it('should allow you to change the x and y threshold', inject(function($rootScope, $swipe, $compile) {
+        element = $compile('<div></div>')($rootScope);
+        var events = {
+          start: jasmine.createSpy('startSpy'),
+          move: jasmine.createSpy('moveSpy'),
+          cancel: jasmine.createSpy('cancelSpy'),
+          end: jasmine.createSpy('endSpy')
+        };
+
+        $swipe.bind(element, events, {
+          swipeThreshold: 20,
+          scrollThreshold: 30
+        });
+
+        expect(events.start).not.toHaveBeenCalled();
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, startEvent,{
+          keys: [],
+          x: 100,
+          y: 40
+        });
+
+        expect(events.start).toHaveBeenCalled();
+
+        expect(events.move).not.toHaveBeenCalled();
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.end).not.toHaveBeenCalled();
+
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 119,
+          y: 69
+        });
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.move.calls.length).toBe(0);
+
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 121,
+          y: 69
+        });
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.move.calls.length).toBe(1);
+
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 131,
+          y: 69
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 131,
+          y: 150
+        });
+        browserTrigger(element, moveEvent,{
+          keys: [],
+          x: 200,
+          y: 200
+        });
+
+        expect(events.cancel).not.toHaveBeenCalled();
+        expect(events.move.calls.length).toBe(4);
+      }));
     });
   }
 


### PR DESCRIPTION
Closes #4550
Closes #5812
- Create config parameter to pass in swipe/scroll (X/Y) thresholds.
- Allow the new thresholds to be applied to how the function determines when
  to scroll and when to swipe.
- Fix bug where swiping back and forth within the thresholds would cause a bad
  cancel event.
- Fix bug where if you went back inside the thresholds, you could potentially
  cancel a swipe in progress.
- Add tests for all these changes.
- Clean up the docs and add definition for the parameters used in
  `$swipe.bind`.
