### PR TITLE
fix($animate): clear the GCS cache even when no animation is detected

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -1419,6 +1419,16 @@ angular.module('ngAnimate', ['ng'])
       var parentCounter = 0;
       var animationReflowQueue = [];
       var cancelAnimationReflow;
+      function clearCacheAfterReflow() {
+        if (!cancelAnimationReflow) {
+          cancelAnimationReflow = $$animateReflow(function() {
+            animationReflowQueue = [];
+            cancelAnimationReflow = null;
+            lookupCache = {};
+          });
+        }
+      }
+
       function afterReflow(element, callback) {
         if (cancelAnimationReflow) {
           cancelAnimationReflow();
@@ -1764,6 +1774,7 @@ angular.module('ngAnimate', ['ng'])
         //to perform at all
         var preReflowCancellation = animateBefore(animationEvent, element, className);
         if (!preReflowCancellation) {
+          clearCacheAfterReflow();
           animationComplete();
           return;
         }
@@ -1820,6 +1831,7 @@ angular.module('ngAnimate', ['ng'])
             afterReflow(element, animationCompleted);
             return cancellationMethod;
           }
+          clearCacheAfterReflow();
           animationCompleted();
         },
 
@@ -1829,6 +1841,7 @@ angular.module('ngAnimate', ['ng'])
             afterReflow(element, animationCompleted);
             return cancellationMethod;
           }
+          clearCacheAfterReflow();
           animationCompleted();
         },
 
@@ -1838,6 +1851,7 @@ angular.module('ngAnimate', ['ng'])
             afterReflow(element, animationCompleted);
             return cancellationMethod;
           }
+          clearCacheAfterReflow();
           animationCompleted();
         },
 


### PR DESCRIPTION
$animate aims to speed up redundant calls to getComputedStyle to prevent
unessarry reflows in the event that similar elements are being animated
at the same time. A hidden bug was causing the GCS cache not to be reset
if an CSS-based animation was not found. This patch ensures that the
GCS lookup cache is always cleared after one animation reflow has
passed.

Closes #8813
