### PR TITLE
test($compile): add test for alternative syntax to get controllers from ancestors

### DIFF
--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3720,6 +3720,25 @@ describe('$compile', function() {
     });
 
 
+    it('should get required parent controller when the question mark precedes the ^^', function() {
+      module(function() {
+        directive('nested', function(log) {
+          return {
+            require: '?^^nested',
+            controller: function($scope) {},
+            link: function(scope, element, attrs, controller) {
+              log(!!controller);
+            }
+          };
+        });
+      });
+      inject(function(log, $compile, $rootScope) {
+        element = $compile('<div nested><div nested></div></div>')($rootScope);
+        expect(log).toEqual('true; false');
+      });
+    });
+
+
     it('should throw if required parent is not found', function() {
       module(function() {
         directive('nested', function() {


### PR DESCRIPTION
Because the regex that tests the `require` value will match more than just `^^?`,
it is important to test other common ways to specify a controller requirement
to ensure that a breaking change isn't introduced inadvertently. This adds a test
for `?^^`.

Closes #9389
