### PR TITLE
test($compile): add test for optional `require` in directives with `^` operator

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1764,7 +1764,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 "Controller '{0}', required by directive '{1}', can't be found!",
                 require, directiveName);
           }
-          return value;
+          return value || null;
         } else if (isArray(require)) {
           value = [];
           forEach(require, function(require) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4095,38 +4095,38 @@ describe('$compile', function() {
     });
 
 
-    it("should not throw an error if required controller can't be found and is optional",function() {
+    it("should pass null if required controller can't be found and is optional",function() {
       module(function() {
         directive('dep', function(log) {
           return {
             require: '?^main',
             link: function(scope, element, attrs, controller) {
-              log('dep:' + !!controller);
+              log('dep:' + controller);
             }
           };
         });
       });
       inject(function(log, $compile, $rootScope) {
         $compile('<div main><div dep></div></div>')($rootScope);
-        expect(log).toEqual('dep:false');
+        expect(log).toEqual('dep:null');
       });
     });
 
 
-    it("should not throw an error if required controller can't be found and is optional with the question mark on the right",function() {
+    it("should pass null if required controller can't be found and is optional with the question mark on the right",function() {
       module(function() {
         directive('dep', function(log) {
           return {
             require: '^?main',
             link: function(scope, element, attrs, controller) {
-              log('dep:' + !!controller);
+              log('dep:' + controller);
             }
           };
         });
       });
       inject(function(log, $compile, $rootScope) {
         $compile('<div main><div dep></div></div>')($rootScope);
-        expect(log).toEqual('dep:false');
+        expect(log).toEqual('dep:null');
       });
     });
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4095,6 +4095,42 @@ describe('$compile', function() {
     });
 
 
+    it("should not throw an error if required controller can't be found and is optional",function() {
+      module(function() {
+        directive('dep', function(log) {
+          return {
+            require: '?^main',
+            link: function(scope, element, attrs, controller) {
+              log('dep:' + !!controller);
+            }
+          };
+        });
+      });
+      inject(function(log, $compile, $rootScope) {
+        $compile('<div main><div dep></div></div>')($rootScope);
+        expect(log).toEqual('dep:false');
+      });
+    });
+
+
+    it("should not throw an error if required controller can't be found and is optional with the question mark on the right",function() {
+      module(function() {
+        directive('dep', function(log) {
+          return {
+            require: '^?main',
+            link: function(scope, element, attrs, controller) {
+              log('dep:' + !!controller);
+            }
+          };
+        });
+      });
+      inject(function(log, $compile, $rootScope) {
+        $compile('<div main><div dep></div></div>')($rootScope);
+        expect(log).toEqual('dep:false');
+      });
+    });
+
+
     it('should have optional controller on current element', function() {
       module(function() {
         directive('dep', function(log) {


### PR DESCRIPTION
The directive property `require` allows optional requirement via
the `?` before or after the `^` operator. Add tests to ensure this
functionality is not lost inadvertently.

Closes #9391
