### PR TITLE
Pushed for CI: perf(ngBind): set textContent rather than using element.text()

### DIFF
--- a/src/ng/directive/ngBind.js
+++ b/src/ng/directive/ngBind.js
@@ -58,11 +58,9 @@ var ngBindDirective = ['$compile', function($compile) {
       $compile.$$addBindingClass(templateElement);
       return function ngBindLink(scope, element, attr) {
         $compile.$$addBindingInfo(element, attr.ngBind);
+        element = element[0];
         scope.$watch(attr.ngBind, function ngBindWatchAction(value) {
-          // We are purposefully using == here rather than === because we want to
-          // catch when value is "null or undefined"
-          // jshint -W041
-          element.text(value == undefined ? '' : value);
+          element.textContent = value === undefined ? '' : value;
         });
       };
     }
@@ -128,8 +126,9 @@ var ngBindTemplateDirective = ['$interpolate', '$compile', function($interpolate
       return function ngBindTemplateLink(scope, element, attr) {
         var interpolateFn = $interpolate(element.attr(attr.$attr.ngBindTemplate));
         $compile.$$addBindingInfo(element, interpolateFn.expressions);
+        element = element[0];
         attr.$observe('ngBindTemplate', function(value) {
-          element.text(value);
+          element.textContent = value === undefined ? '' : value;
         });
       };
     }


### PR DESCRIPTION
"Speeds up chrome with ~10% firefox by ~5%"

We don't really see this result in benchmarks
(https://www.dropbox.com/s/76wxqbvduade52s/big_table_benchmark_b1ee5396_vs_d580a954.zip?dl=0) 
However, it's basically harmless.

Side effects:

Use strict equality check for `undefined` to replace with empty string. Most
target browsers will output `undefined` rather than the empty string if we
don't do this. Previously, ngBindTemplate did not perform this check. However
the change has been made to make behaviour consistent across all target
browsers (chrome does output the empty string).

Closes #9369
