### PR TITLE
Fixes bug when $location.search() is not returning actual search part of current url.

### DIFF
--- a/docs/content/guide/accessibility.ngdoc
+++ b/docs/content/guide/accessibility.ngdoc
@@ -6,8 +6,26 @@
 
 # Accessibility with ngAria
 
-You can use the `ngAria` module to have certain ARIA attributes automatically applied when you
-use certain directives.
+You can use the `ngAria` module to have common ARIA attributes automatically applied when you
+use certain directives. To enable `ngAria`, just require the module into your application and 
+the code will hook into your ng-show/ng-hide, input, textarea, button, select and 
+ng-required directives and add the appropriate ARIA states and properties.
+
+Currently, the following attributes are implemented:
+ * aria-hidden
+ * aria-checked
+ * aria-disabled
+ * aria-required
+ * aria-invalid
+ * aria-multiline
+ * aria-valuenow
+ * aria-valuemin
+ * aria-valuemax
+ * tabindex
+
+You can disable individual attributes by using the `{@link ngAria.$ariaProvider#config config}` method.
+
+###Example
 
 ```js
 angular.module('myApp', ['ngAria'])...
@@ -39,3 +57,4 @@ Accessibility best practices that apply to web apps in general also apply to Ang
 
 * [WebAim](http://webaim.org/)
 * [Using WAI-ARIA in HTML](http://www.w3.org/TR/2014/WD-aria-in-html-20140626/)
+* [Apps For All: Coding Accessible Web Applications](https://shop.smashingmagazine.com/apps-for-all-coding-accessible-web-applications.html)

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -11,6 +11,7 @@
     "jqLite": false,
     "jQuery": false,
     "slice": false,
+    "splice": false,
     "push": false,
     "toString": false,
     "ngMinErr": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -6,6 +6,7 @@
   jqLite: true,
   jQuery: true,
   slice: true,
+  splice: true,
   push: true,
   toString: true,
   ngMinErr: true,
@@ -161,6 +162,7 @@ var /** holds major version number for IE or NaN for real browsers */
     jqLite,           // delay binding since jQuery could be loaded after us.
     jQuery,           // delay binding
     slice             = [].slice,
+    splice            = [].splice,
     push              = [].push,
     toString          = Object.prototype.toString,
     ngMinErr          = minErr('ng'),

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -44,7 +44,7 @@
  * - [`children()`](http://api.jquery.com/children/) - Does not support selectors
  * - [`clone()`](http://api.jquery.com/clone/)
  * - [`contents()`](http://api.jquery.com/contents/)
- * - [`css()`](http://api.jquery.com/css/)
+ * - [`css()`](http://api.jquery.com/css/) - Only retrieves inline-styles, does not call `getComputedStyles()`
  * - [`data()`](http://api.jquery.com/data/)
  * - [`detach()`](http://api.jquery.com/detach/)
  * - [`empty()`](http://api.jquery.com/empty/)

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -182,6 +182,10 @@ function Browser(window, document, $log, $sniffer) {
 
   function fireUrlChange() {
     newLocation = null;
+    checkUrlChange();
+  }
+
+  function checkUrlChange() {
     if (lastBrowserUrl == self.url()) return;
 
     lastBrowserUrl = self.url();
@@ -237,7 +241,7 @@ function Browser(window, document, $log, $sniffer) {
    * Needs to be exported to be able to check for changes that have been done in sync,
    * as hashchange/popstate events fire in async.
    */
-  self.$$checkUrlChange = fireUrlChange;
+  self.$$checkUrlChange = checkUrlChange;
 
   //////////////////////////////////////////////////////////////
   // Misc API

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -1,4 +1,5 @@
 'use strict';
+/* global stripHash: true */
 
 /**
  * ! This is a private undocumented service !

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -153,8 +153,13 @@ function Browser(window, document, $log, $sniffer) {
     // setter
     if (url) {
       if (lastBrowserUrl == url) return;
+      var sameBase = lastBrowserUrl && stripHash(lastBrowserUrl) === stripHash(url);
       lastBrowserUrl = url;
-      if ($sniffer.history) {
+      // Don't use history API if only the hash changed
+      // due to a bug in IE10/IE11 which leads
+      // to not firing a `hashchange` nor `popstate` event
+      // in some cases (see #9143).
+      if (!sameBase && $sniffer.history) {
         if (replace) history.replaceState(null, '', url);
         else {
           history.pushState(null, '', url);

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1623,7 +1623,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             if (jqLiteIsTextNode(directiveValue)) {
               $template = [];
             } else {
-              $template = jqLite(wrapTemplate(directive.templateNamespace, trim(directiveValue)));
+              $template = removeComments(wrapTemplate(directive.templateNamespace, trim(directiveValue)));
             }
             compileNode = $template[0];
 
@@ -2105,7 +2105,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             if (jqLiteIsTextNode(content)) {
               $template = [];
             } else {
-              $template = jqLite(wrapTemplate(templateNamespace, trim(content)));
+              $template = removeComments(wrapTemplate(templateNamespace, trim(content)));
             }
             compileNode = $template[0];
 
@@ -2518,4 +2518,21 @@ function tokenDifference(str1, str2) {
     values += (values.length > 0 ? ' ' : '') + token;
   }
   return values;
+}
+
+function removeComments(jqNodes) {
+  jqNodes = jqLite(jqNodes);
+  var i = jqNodes.length;
+
+  if (i <= 1) {
+    return jqNodes;
+  }
+
+  while (i--) {
+    var node = jqNodes[i];
+    if (node.nodeType === 8) {
+      splice.call(jqNodes, i, 1);
+    }
+  }
+  return jqNodes;
 }

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -436,16 +436,16 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
         function getSelectedSet() {
           var selectedSet = false;
           if (multiple) {
-            var modelValue = ctrl.$modelValue;
-            if (trackFn && isArray(modelValue)) {
+            var viewValue = ctrl.$viewValue;
+            if (trackFn && isArray(viewValue)) {
               selectedSet = new HashMap([]);
               var locals = {};
-              for (var trackIndex = 0; trackIndex < modelValue.length; trackIndex++) {
-                locals[valueName] = modelValue[trackIndex];
-                selectedSet.put(trackFn(scope, locals), modelValue[trackIndex]);
+              for (var trackIndex = 0; trackIndex < viewValue.length; trackIndex++) {
+                locals[valueName] = viewValue[trackIndex];
+                selectedSet.put(trackFn(scope, locals), viewValue[trackIndex]);
               }
             } else {
-              selectedSet = new HashMap(modelValue);
+              selectedSet = new HashMap(viewValue);
             }
           }
           return selectedSet;
@@ -470,7 +470,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
               optionGroup,
               option,
               existingParent, existingOptions, existingOption,
-              modelValue = ctrl.$modelValue,
+              viewValue = ctrl.$viewValue,
               values = valuesFn(scope) || [],
               keys = keyName ? sortedKeys(values) : values,
               key,
@@ -508,10 +508,10 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
             } else {
               if (trackFn) {
                 var modelCast = {};
-                modelCast[valueName] = modelValue;
+                modelCast[valueName] = viewValue;
                 selected = trackFn(scope, modelCast) === trackFn(scope, locals);
               } else {
-                selected = modelValue === valueFn(scope, locals);
+                selected = viewValue === valueFn(scope, locals);
               }
               selectedSet = selectedSet || selected; // see if at least one item is selected
             }
@@ -527,7 +527,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
             });
           }
           if (!multiple) {
-            if (nullOption || modelValue === null) {
+            if (nullOption || viewValue === null) {
               // insert null option if we have a placeholder, or the model is null
               optionGroups[''].unshift({id:'', label:'', selected:!selectedSet});
             } else if (!selectedSet) {

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -89,7 +89,8 @@ function $HttpProvider() {
   var JSON_START = /^\s*(\[|\{[^\{])/,
       JSON_END = /[\}\]]\s*$/,
       PROTECTION_PREFIX = /^\)\]\}',?\n/,
-      CONTENT_TYPE_APPLICATION_JSON = {'Content-Type': 'application/json;charset=utf-8'};
+      APPLICATION_JSON = 'application/json',
+      CONTENT_TYPE_APPLICATION_JSON = {'Content-Type': APPLICATION_JSON + ';charset=utf-8'};
 
   /**
    * @ngdoc property
@@ -114,12 +115,15 @@ function $HttpProvider() {
    **/
   var defaults = this.defaults = {
     // transform incoming response data
-    transformResponse: [function(data) {
+    transformResponse: [function defaultHttpResponseTransform(data, headers) {
       if (isString(data)) {
         // strip json vulnerability protection prefix
         data = data.replace(PROTECTION_PREFIX, '');
-        if (JSON_START.test(data) && JSON_END.test(data))
+        var contentType = headers('Content-Type');
+        if ((contentType && contentType.indexOf(APPLICATION_JSON) === 0) ||
+            (JSON_START.test(data) && JSON_END.test(data))) {
           data = fromJson(data);
+        }
       }
       return data;
     }],

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -720,6 +720,9 @@ function $LocationProvider(){
 
       if (absHref && !elm.attr('target') && !event.isDefaultPrevented()) {
         if ($location.$$parseLinkUrl(absHref, relHref)) {
+          // We do a preventDefault for all urls that are part of the angular application,
+          // in html5mode and also without, so that we are able to abort navigation without
+          // getting double entries in the location history.
           event.preventDefault();
           // update location manually
           if ($location.absUrl() != $browser.url()) {

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -480,7 +480,7 @@ LocationHashbangInHtml5Url.prototype =
             if (value == null) delete search[key];
           });
 
-          this.$$search = search;
+          this.$$search = extend({}, search);
         } else {
           throw $locationMinErr('isrcharg',
               'The first argument of the `$location#search()` call must be a string or an object.');

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -475,12 +475,13 @@ LocationHashbangInHtml5Url.prototype =
           search = search.toString();
           this.$$search = parseKeyValue(search);
         } else if (isObject(search)) {
+          search = copy(search, {});
           // remove object undefined or null properties
           forEach(search, function(value, key) {
             if (value == null) delete search[key];
           });
 
-          this.$$search = extend({}, search);
+          this.$$search = search;
         } else {
           throw $locationMinErr('isrcharg',
               'The first argument of the `$location#search()` call must be a string or an object.');

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -481,7 +481,7 @@ LocationHashbangInHtml5Url.prototype =
             if (value == null) delete search[key];
           });
 
-          this.$$search = extend({}, search);
+          this.$$search = search;
         } else {
           throw $locationMinErr('isrcharg',
               'The first argument of the `$location#search()` call must be a string or an object.');

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -646,6 +646,29 @@ describe('browser', function() {
         expect($location.path()).toBe('/someTestHash');
       });
     });
+
+  });
+
+  describe('integration test with $rootScope', function() {
+
+    beforeEach(module(function($provide, $locationProvider) {
+      $provide.value('$browser', browser);
+      browser.pollFns = [];
+    }));
+
+    it('should not interfere with legacy browser url replace behavior', function() {
+      inject(function($rootScope) {
+        var current = fakeWindow.location.href;
+        var newUrl = 'notyet';
+        sniffer.history = false;
+        browser.url(newUrl, true);
+        expect(browser.url()).toBe(newUrl);
+        $rootScope.$digest();
+        expect(browser.url()).toBe(newUrl);
+        expect(fakeWindow.location.href).toBe(current);
+      });
+    });
+
   });
 
 });

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -445,11 +445,33 @@ describe('browser', function() {
       expect(locationReplace).not.toHaveBeenCalled();
     });
 
+    it('should set location.href and not use pushState when the url only changed in the hash fragment to please IE10/11', function() {
+      sniffer.history = true;
+      browser.url('http://server/#123');
+
+      expect(fakeWindow.location.href).toEqual('http://server/#123');
+
+      expect(pushState).not.toHaveBeenCalled();
+      expect(replaceState).not.toHaveBeenCalled();
+      expect(locationReplace).not.toHaveBeenCalled();
+    });
+
     it('should use location.replace when history.replaceState not available', function() {
       sniffer.history = false;
       browser.url('http://new.org', true);
 
       expect(locationReplace).toHaveBeenCalledWith('http://new.org');
+
+      expect(pushState).not.toHaveBeenCalled();
+      expect(replaceState).not.toHaveBeenCalled();
+      expect(fakeWindow.location.href).toEqual('http://server/');
+    });
+
+    it('should use location.replace and not use replaceState when the url only changed in the hash fragment to please IE10/11', function() {
+      sniffer.history = true;
+      browser.url('http://server/#123', true);
+
+      expect(locationReplace).toHaveBeenCalledWith('http://server/#123');
 
       expect(pushState).not.toHaveBeenCalled();
       expect(replaceState).not.toHaveBeenCalled();

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -652,6 +652,9 @@ describe('browser', function() {
       $provide.value('$browser', browser);
       browser.pollFns = [];
 
+      sniffer.history = true;
+      $provide.value('$sniffer', sniffer);
+
       $locationProvider.html5Mode(true);
     }));
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -300,7 +300,7 @@ describe('$compile', function() {
       });
       inject(function($compile, $rootScope, $httpBackend) {
         $httpBackend.expect('GET', 'template.html').respond('<circle></circle>');
-        element = $compile('<svg><svg-circle-url ng-repeat="l in list"/></svg>')($rootScope);
+        element = $compile('<svg><g ng-repeat="l in list"><svg-circle-url></svg-circle-url></g></svg>')($rootScope);
 
         // initially the template is not yet loaded
         $rootScope.$apply(function() {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1078,6 +1078,22 @@ describe('$compile', function() {
             });
           });
         }
+
+        it('should ignore comment nodes when replacing with a template', function() {
+          module(function() {
+            directive('replaceWithComments', valueFn({
+              replace: true,
+              template: '<!-- ignored comment --><p>Hello, world!</p><!-- ignored comment-->'
+            }));
+          });
+          inject(function($compile, $rootScope) {
+            expect(function() {
+              element = $compile('<div><div replace-with-comments></div></div>')($rootScope);
+            }).not.toThrow();
+            expect(element.find('p').length).toBe(1);
+            expect(element.find('p').text()).toBe('Hello, world!');
+          });
+        });
       });
 
 
@@ -1977,6 +1993,26 @@ describe('$compile', function() {
             });
           });
         }
+
+        it('should ignore comment nodes when replacing with a templateUrl', function() {
+          module(function() {
+            directive('replaceWithComments', valueFn({
+              replace: true,
+              templateUrl: 'templateWithComments.html'
+            }));
+          });
+          inject(function($compile, $rootScope, $httpBackend) {
+            $httpBackend.whenGET('templateWithComments.html').
+              respond('<!-- ignored comment --><p>Hello, world!</p><!-- ignored comment-->');
+            expect(function() {
+              element = $compile('<div><div replace-with-comments></div></div>')($rootScope);
+            }).not.toThrow();
+            $httpBackend.flush();
+            expect(element.find('p').length).toBe(1);
+            expect(element.find('p').text()).toBe('Hello, world!');
+          });
+        });
+
       });
 
 

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1550,6 +1550,130 @@ describe('select', function() {
         expect(scope.value).toBe(false);
       });
     });
+
+    describe('ngModelCtrl', function() {
+      it('should prefix the model value with the word "the" using $parsers', function() {
+        createSelect({
+          'name': 'select',
+          'ng-model': 'value',
+          'ng-options': 'item for item in [\'first\', \'second\', \'third\', \'fourth\']',
+        });
+
+        scope.form.select.$parsers.push(function(value) {
+          return 'the ' + value;
+        });
+
+        element.val('2');
+        browserTrigger(element, 'change');
+        expect(scope.value).toBe('the third');
+        expect(element.val()).toBe('2');
+      });
+
+      it('should prefix the view value with the word "the" using $formatters', function() {
+        createSelect({
+          'name': 'select',
+          'ng-model': 'value',
+          'ng-options': 'item for item in [\'the first\', \'the second\', \'the third\', \'the fourth\']',
+        });
+
+        scope.form.select.$formatters.push(function(value) {
+          return 'the ' + value;
+        });
+
+        scope.$apply(function() {
+          scope.value = 'third';
+        });
+        expect(element.val()).toBe('2');
+      });
+
+      it('should fail validation when $validators fail', function() {
+        createSelect({
+          'name': 'select',
+          'ng-model': 'value',
+          'ng-options': 'item for item in [\'first\', \'second\', \'third\', \'fourth\']',
+        });
+
+        scope.form.select.$validators.fail = function() {
+          return false;
+        };
+
+        element.val('2');
+        browserTrigger(element, 'change');
+        expect(element).toBeInvalid();
+        expect(scope.value).toBeUndefined();
+        expect(element.val()).toBe('2');
+      });
+
+      it('should pass validation when $validators pass', function() {
+        createSelect({
+          'name': 'select',
+          'ng-model': 'value',
+          'ng-options': 'item for item in [\'first\', \'second\', \'third\', \'fourth\']',
+        });
+
+        scope.form.select.$validators.pass = function() {
+          return true;
+        };
+
+        element.val('2');
+        browserTrigger(element, 'change');
+        expect(element).toBeValid();
+        expect(scope.value).toBe('third');
+        expect(element.val()).toBe('2');
+      });
+
+      it('should fail validation when $asyncValidators fail', inject(function($q, $rootScope) {
+        var defer;
+        createSelect({
+          'name': 'select',
+          'ng-model': 'value',
+          'ng-options': 'item for item in [\'first\', \'second\', \'third\', \'fourth\']',
+        });
+
+        scope.form.select.$asyncValidators.async = function() {
+          defer = $q.defer();
+          return defer.promise;
+        };
+
+        element.val('2');
+        browserTrigger(element, 'change');
+        expect(scope.form.select.$pending).toBeDefined();
+        expect(scope.value).toBeUndefined();
+        expect(element.val()).toBe('2');
+
+        defer.reject();
+        $rootScope.$digest();
+        expect(scope.form.select.$pending).toBeUndefined();
+        expect(scope.value).toBeUndefined();
+        expect(element.val()).toBe('2');
+      }));
+
+      it('should pass validation when $asyncValidators pass', inject(function($q, $rootScope) {
+        var defer;
+        createSelect({
+          'name': 'select',
+          'ng-model': 'value',
+          'ng-options': 'item for item in [\'first\', \'second\', \'third\', \'fourth\']',
+        });
+
+        scope.form.select.$asyncValidators.async = function() {
+          defer = $q.defer();
+          return defer.promise;
+        };
+
+        element.val('2');
+        browserTrigger(element, 'change');
+        expect(scope.form.select.$pending).toBeDefined();
+        expect(scope.value).toBeUndefined();
+        expect(element.val()).toBe('2');
+
+        defer.resolve();
+        $rootScope.$digest();
+        expect(scope.form.select.$pending).toBeUndefined();
+        expect(scope.value).toBe('third');
+        expect(element.val()).toBe('2');
+      }));
+    });
   });
 
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1020,6 +1020,61 @@ describe('$http', function() {
           });
 
 
+          it('should deserialize json numbers when response header contains application/json',
+              function() {
+            $httpBackend.expect('GET', '/url').respond('123', {'Content-Type': 'application/json'});
+            $http({method: 'GET', url: '/url'}).success(callback);
+            $httpBackend.flush();
+
+            expect(callback).toHaveBeenCalledOnce();
+            expect(callback.mostRecentCall.args[0]).toEqual(123);
+          });
+
+
+          it('should deserialize json strings when response header contains application/json',
+              function() {
+            $httpBackend.expect('GET', '/url').respond('"asdf"', {'Content-Type': 'application/json'});
+            $http({method: 'GET', url: '/url'}).success(callback);
+            $httpBackend.flush();
+
+            expect(callback).toHaveBeenCalledOnce();
+            expect(callback.mostRecentCall.args[0]).toEqual('asdf');
+          });
+
+
+          it('should deserialize json nulls when response header contains application/json',
+              function() {
+            $httpBackend.expect('GET', '/url').respond('null', {'Content-Type': 'application/json'});
+            $http({method: 'GET', url: '/url'}).success(callback);
+            $httpBackend.flush();
+
+            expect(callback).toHaveBeenCalledOnce();
+            expect(callback.mostRecentCall.args[0]).toEqual(null);
+          });
+
+
+          it('should deserialize json true when response header contains application/json',
+              function() {
+            $httpBackend.expect('GET', '/url').respond('true', {'Content-Type': 'application/json'});
+            $http({method: 'GET', url: '/url'}).success(callback);
+            $httpBackend.flush();
+
+            expect(callback).toHaveBeenCalledOnce();
+            expect(callback.mostRecentCall.args[0]).toEqual(true);
+          });
+
+
+          it('should deserialize json false when response header contains application/json',
+              function() {
+            $httpBackend.expect('GET', '/url').respond('false', {'Content-Type': 'application/json'});
+            $http({method: 'GET', url: '/url'}).success(callback);
+            $httpBackend.flush();
+
+            expect(callback).toHaveBeenCalledOnce();
+            expect(callback.mostRecentCall.args[0]).toEqual(false);
+          });
+
+
           it('should deserialize json with security prefix', function() {
             $httpBackend.expect('GET', '/url').respond(')]}\',\n[1, "abc", {"foo":"bar"}]');
             $http({method: 'GET', url: '/url'}).success(callback);

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -169,6 +169,16 @@ describe('$location', function() {
     });
 
 
+    it('search() should not use given object directly', function() {
+      var obj = {one: 1, two: true, three: null};
+      url.search(obj);
+      expect(obj).toEqual({one: 1, two: true, three: null});
+      obj.one = 'changed';
+      expect(url.search()).toEqual({one: 1, two: true});
+      expect(url.absUrl()).toBe('http://www.domain.com:9877/path/b?one=1&two#hash');
+    });
+
+
     it('search() should change single parameter', function() {
       url.search({id: 'old', preserved: true});
       url.search('id', 'new');


### PR DESCRIPTION
The issue appears when we set $location.search() with some object and after that change this object's properties, like that:

``` javascript
var obj = {foo: 'bar'};
$location.search(obj); // now url is set to '#?foo=bar'
obj.foo = 'boo';
var currentUrlObj = $location.search();
// current location is still '#?foo=bar' 
// while currentUrlObj is telling that current url object is {foo: 'boo'}
// which isn't correct
```

There's a little demo onJSBin:
http://jsbin.com/rekana/5/edit?js,output
And another JSBin with behaviour fixed on consumer's side:
http://jsbin.com/rekana/1/edit?js,output
I'm sure it's a bad idea to make someone think of that on the consumer's side.
