### PR TITLE
fix(select): make ngOptions support selectAs and trackBy together

### DIFF
--- a/docs/content/error/ngOptions/trkslct.ngdoc
+++ b/docs/content/error/ngOptions/trkslct.ngdoc
@@ -1,0 +1,28 @@
+@ngdoc error
+@name ngOptions:trkslct
+@fullName Comprehension expression cannot contain both selectAs and trackBy expressions.
+@description
+This error occurs when 'ngOptions' is passed a comprehension expression that contains both a
+`select as` expression and a `track by` expression. These two expressions are fundamentally
+incompatible.
+
+ * Example of bad expression: `<select ng-options="item.subItem as item.label for item in values track by item.id" ng-model="selected">`
+   `values: [{id: 1, label: 'aLabel', subItem: {name: 'aSubItem'}}, {id: 2, label: 'bLabel', subItem: {name: 'bSubItem'}}]`,
+   `$scope.selected = {name: 'aSubItem'};`
+ * trackBy is always applied to `value`, with purpose to preserve the selection,
+   (to `item` in this case)
+ * To calculate whether an item is selected, `ngOptions` does the following:
+   1. apply `trackBy` to the values in the array, e.g.
+      In the example: [1,2]
+   2. apply `trackBy` to the already selected value in `ngModel`:
+      In the example: this is not possible, as `trackBy` refers to `item.id`, but the selected
+      value from `ngModel` is `{name: aSubItem}`.
+
+Here's an example of correct syntax:
+
+```
+//track by with array
+<select ng-model="selected" ng-options="item.label for item in values track by item.id">
+```
+
+For more information on valid expression syntax, see 'ngOptions' in {@link ng.directive:select select} directive docs.

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -80,8 +80,7 @@ var ngOptionsMinErr = minErr('ngOptions');
 
  * <div class="alert alert-info">
  * **Note:** Using `selectAs` together with `trackexpr` is not possible (and will throw).
- * TODO: Add some nice reasoning here, add a minErr and a nice error page.
- * reasoning:
+ * Reasoning:
  * - Example: <select ng-options="item.subItem as item.label for item in values track by item.id" ng-model="selected">
  *   values: [{id: 1, label: 'aLabel', subItem: {name: 'aSubItem'}}, {id: 2, label: 'bLabel', subItem: {name: 'bSubItemß'}}],
  *   $scope.selected = {name: 'aSubItem'};
@@ -366,6 +365,13 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
             optionGroupsCache = [[{element: selectElement, label:''}]],
             //re-usable object to represent option's locals
             locals = {};
+
+        if (trackFn && selectAsFn) {
+          throw ngOptionsMinErr('trkslct',
+            "Comprehension expression cannot contain both selectAs ('{0}') " +
+            "and trackBy ('{1}') expressions.",
+            selectAs, track);
+        }
 
         if (nullOption) {
           // compile the element since there might be bindings in it

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -665,7 +665,7 @@ describe('select', function() {
 
     describe('trackBy', function() {
       beforeEach(function() {
-        scope.arr = [{id: 10, label: 'ten'}, {id:'20', label: 'twenty'}];
+        scope.arr = [{id: 10, label: 'ten'}, {id:20, label: 'twenty'}];
         scope.obj = {'10': {score: 10, label: 'ten'}, '20': {score: 20, label: 'twenty'}};
       });
 
@@ -1330,6 +1330,27 @@ describe('select', function() {
         expect(options.length).toEqual(2);
         expect(sortedHtml(options[0])).toEqual('<option value="0">C</option>');
         expect(sortedHtml(options[1])).toEqual('<option value="1">B</option>');
+      });
+
+
+      it('should update options in the DOM from object source', function() {
+        compile(
+          '<select ng-model="selected" ng-options="val.id as val.name for (key, val) in values"></select>'
+        );
+
+        scope.$apply(function() {
+          scope.values = {a: {id: 10, name: 'A'}, b: {id: 20, name: 'B'}};
+          scope.selected = scope.values.a.id;
+        });
+
+        scope.$apply(function() {
+          scope.values.a.name = 'C';
+        });
+
+        var options = element.find('option');
+        expect(options.length).toEqual(2);
+        expect(sortedHtml(options[0])).toEqual('<option value="a">C</option>');
+        expect(sortedHtml(options[1])).toEqual('<option value="b">B</option>');
       });
 
 

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -583,6 +583,354 @@ describe('select', function() {
       }, blank, unknown);
     }
 
+    describe('selectAs expression', function() {
+      beforeEach(function() {
+        scope.arr = [{id: 10, label: 'ten'}, {id:20, label: 'twenty'}];
+        scope.obj = {'10': {score: 10, label: 'ten'}, '20': {score: 20, label: 'twenty'}};
+      });
+
+      it('should support single select with array source', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'ng-options': 'item.id as item.label for item in arr'
+        });
+
+        scope.$apply(function() {
+          scope.selected = 10;
+        });
+        expect(element.val()).toBe('0');
+
+        element.val('1');
+        browserTrigger(element, 'change');
+        expect(scope.selected).toBe(20);
+      });
+
+
+      it('should support multi select with array source', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'multiple': true,
+          'ng-options': 'item.id as item.label for item in arr'
+        });
+
+        scope.$apply(function() {
+          scope.selected = [10,20];
+        });
+        expect(element.val()).toEqual(['0','1']);
+        expect(scope.selected).toEqual([10,20]);
+
+        element.children()[0].selected = false;
+        browserTrigger(element, 'change');
+        expect(scope.selected).toEqual([20]);
+        expect(element.val()).toEqual(['1']);
+      });
+
+
+      it('should support single select with object source', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'ng-options': 'val.score as val.label for (key, val) in obj'
+        });
+
+        scope.$apply(function() {
+          scope.selected = 10;
+        });
+        expect(element.val()).toBe('10');
+
+        element.val('20');
+        browserTrigger(element, 'change');
+        expect(scope.selected).toBe(20);
+      });
+
+
+      it('should support multi select with object source', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'multiple': true,
+          'ng-options': 'val.score as val.label for (key, val) in obj'
+        });
+
+        scope.$apply(function() {
+          scope.selected = [10,20];
+        });
+        expect(element.val()).toEqual(['10','20']);
+
+        element.children()[0].selected = false;
+        browserTrigger(element, 'change');
+        expect(scope.selected).toEqual([20]);
+        expect(element.val()).toEqual(['20']);
+      });
+    });
+
+
+    describe('trackBy', function() {
+      beforeEach(function() {
+        scope.arr = [{id: 10, label: 'ten'}, {id:'20', label: 'twenty'}];
+        scope.obj = {'10': {score: 10, label: 'ten'}, '20': {score: 20, label: 'twenty'}};
+      });
+
+
+      it('should preserve value even when reference has changed (single&array)', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'ng-options': 'item.label for item in arr track by item.id'
+        });
+
+        scope.$apply(function() {
+          scope.selected = scope.arr[0];
+        });
+        expect(element.val()).toBe('0');
+
+        scope.$apply(function() {
+          scope.arr[0] = {id: 10, label: 'new ten'};
+        });
+        expect(element.val()).toBe('0');
+
+        element.children()[1].selected = 1;
+        browserTrigger(element, 'change');
+        expect(scope.selected).toEqual(scope.arr[1]);
+      });
+
+
+      it('should preserve value even when reference has changed (multi&array)', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'multiple': true,
+          'ng-options': 'item.label for item in arr track by item.id'
+        });
+
+        scope.$apply(function() {
+          scope.selected = scope.arr;
+        });
+        expect(element.val()).toEqual(['0','1']);
+
+        scope.$apply(function() {
+          scope.arr[0] = {id: 10, label: 'new ten'};
+        });
+        expect(element.val()).toEqual(['0','1']);
+
+        element.children()[0].selected = false;
+        browserTrigger(element, 'change');
+        expect(scope.selected).toEqual([scope.arr[1]]);
+      });
+
+
+      it('should preserve value even when reference has changed (single&object)', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'ng-options': 'val.label for (key, val) in obj track by val.score'
+        });
+
+        scope.$apply(function() {
+          scope.selected = scope.obj['10'];
+        });
+        expect(element.val()).toBe('10');
+
+        scope.$apply(function() {
+          scope.obj['10'] = {score: 10, label: 'ten'};
+        });
+        expect(element.val()).toBe('10');
+
+        element.val('20');
+        browserTrigger(element, 'change');
+        expect(scope.selected).toBe(scope.obj[20]);
+      });
+
+
+      it('should preserve value even when reference has changed (multi&object)', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'multiple': true,
+          'ng-options': 'val.label for (key, val) in obj track by val.score'
+        });
+
+        scope.$apply(function() {
+          scope.selected = [scope.obj['10']];
+        });
+        expect(element.val()).toEqual(['10']);
+
+        scope.$apply(function() {
+          scope.obj['10'] = {score: 10, label: 'ten'};
+        });
+        expect(element.val()).toEqual(['10']);
+
+        element.children()[1].selected = 'selected';
+        browserTrigger(element, 'change');
+        expect(scope.selected).toEqual([scope.obj[10], scope.obj[20]]);
+      });
+    });
+
+
+    describe('selectAs+trackBy', function() {
+      beforeEach(function() {
+        scope.arr = [{id: 10, label: 'ten'}, {id:'20', label: 'twenty'}];
+        scope.obj = {'10': {score: 10, label: 'ten'}, '20': {score: 20, label: 'twenty'}};
+      });
+
+
+      it('should bind selectAs expression result to scope (array&single)', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'ng-options': 'item.id as item.name for item in values track by item.id'
+        });
+
+        scope.$apply(function() {
+          scope.values = [{id: 10, name: 'A'}, {id: 20, name: 'B'}];
+          scope.selected = 10;
+        });
+        expect(element.val()).toEqual('0');
+
+        scope.$apply(function() {
+          scope.selected = 20;
+        });
+        expect(element.val()).toEqual('1');
+
+        element.val('0');
+        browserTrigger(element, 'change');
+        expect(scope.selected).toBe(10);
+      });
+
+
+      it('should bind selectAs expression result to scope (array&multiple)',function() {
+        createSelect({
+          'ng-model': 'selected',
+          'multiple': true,
+          'ng-options': 'item.id as item.name for item in values track by item.id'
+        });
+
+        scope.$apply(function() {
+          scope.values = [{id: 10, name: 'A'}, {id: 20, name: 'B'}];
+          scope.selected = [10];
+        });
+        expect(element.val()).toEqual(['0']);
+
+        scope.$apply(function() {
+          scope.selected = [20];
+        });
+        expect(element.val()).toEqual(['1']);
+
+        element.children(0).attr('selected', 'selected');
+        element.children(1).attr('selected', 'selected');
+        browserTrigger(element, 'change');
+        expect(scope.selected).toEqual([10, 20]);
+      });
+
+
+      it('should bind selectAs expression result to scope (object&single)', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'ng-options': 'value.score as value.label for (key, value) in obj track by value.score'
+        });
+
+        scope.$apply(function() {
+          scope.selected = 10;
+        });
+        expect(element.val()).toEqual('10');
+
+        scope.$apply(function() {
+          scope.selected = 20;
+        });
+        expect(element.val()).toEqual('20');
+
+        element.val('10');
+        browserTrigger(element, 'change');
+        expect(scope.selected).toBe(10);
+      });
+
+
+      it('should bind selectAs expression result to scope (object&multiple)', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'multiple': true,
+          'ng-options': 'value.score as value.label for (key, value) in obj track by value.score'
+        });
+
+        scope.$apply(function() {
+          scope.selected = [10];
+        });
+        expect(element.val()).toEqual(['10']);
+
+        scope.$apply(function() {
+          scope.selected = [20];
+        });
+        expect(element.val()).toEqual(['20']);
+
+        element.find('option')[0].selected = 'selected';
+        browserTrigger(element, 'change');
+        expect(scope.selected).toEqual([10, 20]);
+      });
+
+
+      it('should correctly assign model if track & select expressions differ (array&single)', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'ng-options': 'item.label as item.label for item in arr track by item.id'
+        });
+
+        scope.$apply(function() {
+          scope.selected = 'ten';
+        });
+        expect(element.val()).toBe('0');
+
+        element.val('1');
+        browserTrigger(element, 'change');
+        expect(scope.selected).toBe('twenty');
+      });
+
+
+      it('should correctly assign model if track & select expressions differ (array&multiple)', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'multiple': true,
+          'ng-options': 'item.label as item.label for item in arr track by item.id'
+        });
+
+        scope.$apply(function() {
+          scope.selected = ['ten'];
+        });
+        expect(element.val()).toEqual(['0']);
+
+        element.find('option')[1].selected = 'selected';
+        browserTrigger(element, 'change');
+        expect(scope.selected).toEqual(['ten', 'twenty']);
+      });
+
+
+      it('should correctly assign model if track & select expressions differ (object&single)', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'ng-options': 'val.label as val.label for (key, val) in obj track by val.score'
+        });
+
+        scope.$apply(function() {
+          scope.selected = 'ten';
+        });
+        expect(element.val()).toBe('10');
+
+        element.val('20');
+        browserTrigger(element, 'change');
+        expect(scope.selected).toBe('twenty');
+      });
+
+
+      it('should correctly assign model if track & select expressions differ (object&multiple)', function() {
+        createSelect({
+          'ng-model': 'selected',
+          'multiple': true,
+          'ng-options': 'val.label as val.label for (key, val) in obj track by val.score'
+        });
+
+        scope.$apply(function() {
+          scope.selected = ['ten'];
+        });
+        expect(element.val()).toEqual(['10']);
+
+        element.find('option')[1].selected = 'selected';
+        browserTrigger(element, 'change');
+        expect(scope.selected).toEqual(['ten', 'twenty']);
+      });
+    });
+
 
     it('should throw when not formated "? for ? in ?"', function() {
       expect(function() {
@@ -924,23 +1272,23 @@ describe('select', function() {
                           {id: 2, name: 'second'},
                           {id: 3, name: 'third'},
                           {id: 4, name: 'forth'}];
-          scope.selected = {id: 2};
+          scope.selected = scope.values[1];
         });
 
-        expect(element.val()).toEqual('2');
+        expect(element.val()).toEqual('1');
 
         var first = jqLite(element.find('option')[0]);
         expect(first.text()).toEqual('first');
-        expect(first.attr('value')).toEqual('1');
+        expect(first.attr('value')).toEqual('0');
         var forth = jqLite(element.find('option')[3]);
         expect(forth.text()).toEqual('forth');
-        expect(forth.attr('value')).toEqual('4');
+        expect(forth.attr('value')).toEqual('3');
 
         scope.$apply(function() {
           scope.selected = scope.values[3];
         });
 
-        expect(element.val()).toEqual('4');
+        expect(element.val()).toEqual('3');
       });
 
 

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -663,7 +663,7 @@ describe('select', function() {
     });
 
 
-    describe('trackBy', function() {
+    describe('trackBy expression', function() {
       beforeEach(function() {
         scope.arr = [{id: 10, label: 'ten'}, {id:20, label: 'twenty'}];
         scope.obj = {'10': {score: 10, label: 'ten'}, '20': {score: 20, label: 'twenty'}};
@@ -761,173 +761,22 @@ describe('select', function() {
     });
 
 
-    describe('selectAs+trackBy', function() {
+    describe('selectAs+trackBy expression', function() {
       beforeEach(function() {
         scope.arr = [{id: 10, label: 'ten'}, {id:'20', label: 'twenty'}];
         scope.obj = {'10': {score: 10, label: 'ten'}, '20': {score: 20, label: 'twenty'}};
       });
 
 
-      it('should bind selectAs expression result to scope (array&single)', function() {
-        createSelect({
-          'ng-model': 'selected',
-          'ng-options': 'item.id as item.name for item in values track by item.id'
-        });
+      it('should throw a helpful minerr', function() {
+        expect(function() {
 
-        scope.$apply(function() {
-          scope.values = [{id: 10, name: 'A'}, {id: 20, name: 'B'}];
-          scope.selected = 10;
-        });
-        expect(element.val()).toEqual('0');
+            createSelect({
+              'ng-model': 'selected',
+              'ng-options': 'item.id as item.name for item in values track by item.id'
+            });
 
-        scope.$apply(function() {
-          scope.selected = 20;
-        });
-        expect(element.val()).toEqual('1');
-
-        element.val('0');
-        browserTrigger(element, 'change');
-        expect(scope.selected).toBe(10);
-      });
-
-
-      it('should bind selectAs expression result to scope (array&multiple)',function() {
-        createSelect({
-          'ng-model': 'selected',
-          'multiple': true,
-          'ng-options': 'item.id as item.name for item in values track by item.id'
-        });
-
-        scope.$apply(function() {
-          scope.values = [{id: 10, name: 'A'}, {id: 20, name: 'B'}];
-          scope.selected = [10];
-        });
-        expect(element.val()).toEqual(['0']);
-
-        scope.$apply(function() {
-          scope.selected = [20];
-        });
-        expect(element.val()).toEqual(['1']);
-
-        element.children(0).attr('selected', 'selected');
-        element.children(1).attr('selected', 'selected');
-        browserTrigger(element, 'change');
-        expect(scope.selected).toEqual([10, 20]);
-      });
-
-
-      it('should bind selectAs expression result to scope (object&single)', function() {
-        createSelect({
-          'ng-model': 'selected',
-          'ng-options': 'value.score as value.label for (key, value) in obj track by value.score'
-        });
-
-        scope.$apply(function() {
-          scope.selected = 10;
-        });
-        expect(element.val()).toEqual('10');
-
-        scope.$apply(function() {
-          scope.selected = 20;
-        });
-        expect(element.val()).toEqual('20');
-
-        element.val('10');
-        browserTrigger(element, 'change');
-        expect(scope.selected).toBe(10);
-      });
-
-
-      it('should bind selectAs expression result to scope (object&multiple)', function() {
-        createSelect({
-          'ng-model': 'selected',
-          'multiple': true,
-          'ng-options': 'value.score as value.label for (key, value) in obj track by value.score'
-        });
-
-        scope.$apply(function() {
-          scope.selected = [10];
-        });
-        expect(element.val()).toEqual(['10']);
-
-        scope.$apply(function() {
-          scope.selected = [20];
-        });
-        expect(element.val()).toEqual(['20']);
-
-        element.find('option')[0].selected = 'selected';
-        browserTrigger(element, 'change');
-        expect(scope.selected).toEqual([10, 20]);
-      });
-
-
-      it('should correctly assign model if track & select expressions differ (array&single)', function() {
-        createSelect({
-          'ng-model': 'selected',
-          'ng-options': 'item.label as item.label for item in arr track by item.id'
-        });
-
-        scope.$apply(function() {
-          scope.selected = 'ten';
-        });
-        expect(element.val()).toBe('0');
-
-        element.val('1');
-        browserTrigger(element, 'change');
-        expect(scope.selected).toBe('twenty');
-      });
-
-
-      it('should correctly assign model if track & select expressions differ (array&multiple)', function() {
-        createSelect({
-          'ng-model': 'selected',
-          'multiple': true,
-          'ng-options': 'item.label as item.label for item in arr track by item.id'
-        });
-
-        scope.$apply(function() {
-          scope.selected = ['ten'];
-        });
-        expect(element.val()).toEqual(['0']);
-
-        element.find('option')[1].selected = 'selected';
-        browserTrigger(element, 'change');
-        expect(scope.selected).toEqual(['ten', 'twenty']);
-      });
-
-
-      it('should correctly assign model if track & select expressions differ (object&single)', function() {
-        createSelect({
-          'ng-model': 'selected',
-          'ng-options': 'val.label as val.label for (key, val) in obj track by val.score'
-        });
-
-        scope.$apply(function() {
-          scope.selected = 'ten';
-        });
-        expect(element.val()).toBe('10');
-
-        element.val('20');
-        browserTrigger(element, 'change');
-        expect(scope.selected).toBe('twenty');
-      });
-
-
-      it('should correctly assign model if track & select expressions differ (object&multiple)', function() {
-        createSelect({
-          'ng-model': 'selected',
-          'multiple': true,
-          'ng-options': 'val.label as val.label for (key, val) in obj track by val.score'
-        });
-
-        scope.$apply(function() {
-          scope.selected = ['ten'];
-        });
-        expect(element.val()).toEqual(['10']);
-
-        element.find('option')[1].selected = 'selected';
-        browserTrigger(element, 'change');
-        expect(scope.selected).toEqual(['ten', 'twenty']);
+        }).toThrowMinErr('ngOptions', 'trkslct', "Comprehension expression cannot contain both selectAs ('item.id') and trackBy ('item.id') expressions.")
       });
     });
 
@@ -1264,7 +1113,7 @@ describe('select', function() {
       it('should bind to scope value and track/identify objects', function() {
         createSelect({
           'ng-model': 'selected',
-          'ng-options': 'item as item.name for item in values track by item.id'
+          'ng-options': 'item.name for item in values track by item.id'
         });
 
         scope.$apply(function() {


### PR DESCRIPTION
This commit implements a function, "getSelected()", that takes the
selectAs expression into account when determining if a particular
option is selected or not. Previously, the selectAs part of the
ngOptions comprehension expression was being ignored.

Fixes #6564
