### PR TITLE
revert: fix($browser): don’t use history api when only the hash changes

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -1,5 +1,4 @@
 'use strict';
-/* global stripHash: true */
 
 /**
  * ! This is a private undocumented service !

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -153,13 +153,8 @@ function Browser(window, document, $log, $sniffer) {
     // setter
     if (url) {
       if (lastBrowserUrl == url) return;
-      var sameBase = lastBrowserUrl && stripHash(lastBrowserUrl) === stripHash(url);
       lastBrowserUrl = url;
-      // Don't use history API if only the hash changed
-      // due to a bug in IE10/IE11 which leads
-      // to not firing a `hashchange` nor `popstate` event
-      // in some cases (see #9143).
-      if (!sameBase && $sniffer.history) {
+      if ($sniffer.history) {
         if (replace) history.replaceState(null, '', url);
         else {
           history.pushState(null, '', url);

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -720,9 +720,6 @@ function $LocationProvider(){
 
       if (absHref && !elm.attr('target') && !event.isDefaultPrevented()) {
         if ($location.$$parseLinkUrl(absHref, relHref)) {
-          // We do a preventDefault for all urls that are part of the angular application,
-          // in html5mode and also without, so that we are able to abort navigation without
-          // getting double entries in the location history.
           event.preventDefault();
           // update location manually
           if ($location.absUrl() != $browser.url()) {

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -445,33 +445,11 @@ describe('browser', function() {
       expect(locationReplace).not.toHaveBeenCalled();
     });
 
-    it('should set location.href and not use pushState when the url only changed in the hash fragment to please IE10/11', function() {
-      sniffer.history = true;
-      browser.url('http://server/#123');
-
-      expect(fakeWindow.location.href).toEqual('http://server/#123');
-
-      expect(pushState).not.toHaveBeenCalled();
-      expect(replaceState).not.toHaveBeenCalled();
-      expect(locationReplace).not.toHaveBeenCalled();
-    });
-
     it('should use location.replace when history.replaceState not available', function() {
       sniffer.history = false;
       browser.url('http://new.org', true);
 
       expect(locationReplace).toHaveBeenCalledWith('http://new.org');
-
-      expect(pushState).not.toHaveBeenCalled();
-      expect(replaceState).not.toHaveBeenCalled();
-      expect(fakeWindow.location.href).toEqual('http://server/');
-    });
-
-    it('should use location.replace and not use replaceState when the url only changed in the hash fragment to please IE10/11', function() {
-      sniffer.history = true;
-      browser.url('http://server/#123', true);
-
-      expect(locationReplace).toHaveBeenCalledWith('http://server/#123');
 
       expect(pushState).not.toHaveBeenCalled();
       expect(replaceState).not.toHaveBeenCalled();


### PR DESCRIPTION
This reverts commit 0656484d3e709c5162570b0dd6473b0b6140e5b2 due to a
failing test in IE9.
