### PR TITLE
fix($browser): don’t use history api when only the hash changes

### DIFF
--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -652,6 +652,9 @@ describe('browser', function() {
       $provide.value('$browser', browser);
       browser.pollFns = [];
 
+      sniffer.history = true;
+      $provide.value('$sniffer', sniffer);
+
       $locationProvider.html5Mode(true);
     }));
 


### PR DESCRIPTION
Prevent side effects in IE9
