### PR TITLE
Fixes bug when $location.search() is not returning search part of current url. Inluding tests.

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -475,6 +475,7 @@ LocationHashbangInHtml5Url.prototype =
           search = search.toString();
           this.$$search = parseKeyValue(search);
         } else if (isObject(search)) {
+          search = copy(search, {});
           // remove object undefined or null properties
           forEach(search, function(value, key) {
             if (value == null) delete search[key];

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -169,6 +169,16 @@ describe('$location', function() {
     });
 
 
+    it('search() should not use given object directly', function() {
+      var obj = {one: 1, two: true, three: null};
+      url.search(obj);
+      expect(obj).toEqual({one: 1, two: true, three: null});
+      obj.one = 'changed';
+      expect(url.search()).toEqual({one: 1, two: true});
+      expect(url.absUrl()).toBe('http://www.domain.com:9877/path/b?one=1&two#hash');
+    });
+
+
     it('search() should change single parameter', function() {
       url.search({id: 'old', preserved: true});
       url.search('id', 'new');


### PR DESCRIPTION
The issue appears when we set $location.search() with some object and after that change this object's properties, like that:

``` javascript
var obj = {foo: 'bar'};
$location.search(obj); // now url is set to '#?foo=bar'
obj.foo = 'boo';
var currentUrlObj = $location.search();
// current location is still '#?foo=bar' 
// while currentUrlObj is telling that current url object is {foo: 'boo'}
// which isn't correct
```

There's a little demo onJSBin:
http://jsbin.com/rekana/5/edit?js,output
And another JSBin with behaviour fixed on consumer's side:
http://jsbin.com/rekana/1/edit?js,output
I'm sure it's a bad idea to make someone think of that on the consumer's side.
