### PR TITLE
docs(versions): remove gruntUtils import from docs config

### DIFF
--- a/docs/config/services/gitData.js
+++ b/docs/config/services/gitData.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var gruntUtils = require('../../../lib/grunt/utils');
 var versionInfo = require('../../../lib/versions/version-info');
 
 /**


### PR DESCRIPTION
The dgeni config dependency on `gruntUtils` was removed in [this commit](https://github.com/angular/angular.js/commit/11c5bb7f3de13722a84c5503129097393056061e#diff-8ed4eab9f198d24f876871aa2ce43b5aL9).
