### PR TITLE
fix($browser): Cache `location.href` only during page reload phase

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -125,7 +125,7 @@ function Browser(window, document, $log, $sniffer) {
 
   var lastBrowserUrl = location.href,
       baseElement = document.find('base'),
-      newLocation = null;
+      reloadLocation = null;
 
   /**
    * @name $browser#url
@@ -166,7 +166,9 @@ function Browser(window, document, $log, $sniffer) {
           history.pushState(null, '', url);
         }
       } else {
-        newLocation = url;
+        if (!sameBase) {
+          reloadLocation = url;
+        }
         if (replace) {
           location.replace(url);
         } else {
@@ -176,10 +178,10 @@ function Browser(window, document, $log, $sniffer) {
       return self;
     // getter
     } else {
-      // - newLocation is a workaround for an IE7-9 issue with location.replace and location.href
-      //   methods not updating location.href synchronously.
+      // - reloadLocation is needed as browsers don't allow to read out
+      //   the new location.href if a reload happened.
       // - the replacement is a workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=407172
-      return newLocation || location.href.replace(/%27/g,"'");
+      return reloadLocation || location.href.replace(/%27/g,"'");
     }
   };
 
@@ -187,11 +189,6 @@ function Browser(window, document, $log, $sniffer) {
       urlChangeInit = false;
 
   function fireUrlChange() {
-    newLocation = null;
-    checkUrlChange();
-  }
-
-  function checkUrlChange() {
     if (lastBrowserUrl == self.url()) return;
 
     lastBrowserUrl = self.url();
@@ -247,7 +244,7 @@ function Browser(window, document, $log, $sniffer) {
    * Needs to be exported to be able to check for changes that have been done in sync,
    * as hashchange/popstate events fire in async.
    */
-  self.$$checkUrlChange = checkUrlChange;
+  self.$$checkUrlChange = fireUrlChange;
 
   //////////////////////////////////////////////////////////////
   // Misc API


### PR DESCRIPTION
Adds caching for url changes after a reload happens

Removes unnecessary caching from $browser, as IE-IE9 all allow to change `location.href` synchronously, i.e. after changing it (via property write or `location.replace) it can be read out immediately with the up to date value.
There was a wrong assumption in the previous version of this code
introduced by dca23173e25a32cb740245ca7f7b01a84805f43f and d70711481e6311c9cd283d650f07ca0cca72ecc2.

Adds more tests for #6976
Fixes #9235
