### PR TITLE
fix(select): respect tracking expression when shallow watching arrays of...

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -414,7 +414,23 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
 
         ctrl.$render = render;
 
-        scope.$watchCollection(valuesFn, scheduleRendering);
+        if (trackFn) {
+          scope.$watchCollection(function() {
+            var locals = {},
+                values = valuesFn(scope);
+            if (values) {
+              var trackers = new Array(values.length);
+              for (var i = 0, ii = values.length; i < ii; i++) {
+                trackers[i] = trackFn(scope, locals);
+              }
+
+              return trackers;
+            }
+          }, scheduleRendering);
+        } else {
+          scope.$watchCollection(valuesFn, scheduleRendering);
+        }
+
         scope.$watchCollection(function () {
           var locals = {},
               values = valuesFn(scope);

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1162,6 +1162,29 @@ describe('select', function() {
         expect(element.val()).toEqual('?');
         expect(element.find('option').eq(0).attr('selected')).toEqual('selected');
       });
+
+      it('should respect trackexpr when working with arrays of objects', function() {
+        var elementCount = 5;
+
+        createSelect({
+          'ng-model':'selected',
+          'ng-options':'v as v.label for v in makeValues() track by v.code'
+        });
+
+        scope.$apply(function() {
+          scope.makeValues = function() {
+            var values = [];
+            for (var i = 0; i < elementCount; i++) {
+              values.push({label: 'Value = ' + i, code: i});
+            }
+
+            return values;
+          };
+          scope.selected = {label: 'Value = 1', code: 1};
+        });
+
+        expect(element.find('option').length).toEqual(elementCount);
+      });
     });
 
 


### PR DESCRIPTION
... objects in ngOptions

ngOptions does not use the tracking expression when shallow watching array elements passed in to ngOptions. This is a problem if the elements passed in to ngOptions are generated on the fly and while the array elements identical in value, they are different instances; this leads to infinite digest loops. This change attempts to rectify the situation by shallow watching an array of trackFn(values) rather than the array of values themselves.

Closes #9464
