### PR TITLE
refactor($location): remove special case for adding a `#` at end of url

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -168,6 +168,11 @@ function Browser(window, document, $log, $sniffer) {
       } else {
         if (!sameBase) {
           reloadLocation = url;
+        } else if (url.indexOf('#') === -1) {
+          // prevent page reload when navigating from a url with hash to the
+          // same url without a hash, e.g.
+          // from http://server/#asdf to http://server/
+          url += '#';
         }
         if (replace) {
           location.replace(url);
@@ -181,7 +186,9 @@ function Browser(window, document, $log, $sniffer) {
       // - reloadLocation is needed as browsers don't allow to read out
       //   the new location.href if a reload happened.
       // - the replacement is a workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=407172
-      return reloadLocation || location.href.replace(/%27/g,"'");
+      var result = reloadLocation || location.href.replace(/%27/g,"'");
+      // remove trailing hashes
+      return result.replace(/#$/, '');
     }
   };
 

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -291,15 +291,6 @@ function LocationHashbangInHtml5Url(appBase, hashPrefix) {
     return !!rewrittenUrl;
   };
 
-  this.$$compose = function() {
-    var search = toKeyValue(this.$$search),
-        hash = this.$$hash ? '#' + encodeUriSegment(this.$$hash) : '';
-
-    this.$$url = encodePath(this.$$path) + (search ? '?' + search : '') + hash;
-    // include hashPrefix in $$absUrl when $$url is empty so IE8 & 9 do not reload page because of removal of '#'
-    this.$$absUrl = appBase + hashPrefix + this.$$url;
-  };
-
 }
 
 

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -410,6 +410,11 @@ describe('browser', function() {
       expect(browser.url()).toEqual('https://another.com');
     });
 
+    it('should ignore a trailing hash when reading', function() {
+      fakeWindow.location.href = 'http://server/#';
+      expect(browser.url()).toBe('http://server/');
+    });
+
     it('should use history.pushState when available', function() {
       sniffer.history = true;
       browser.url('http://new.org');
@@ -494,6 +499,12 @@ describe('browser', function() {
       fakeWindow.location.href = 'dontchange';
       browser.url(current);
       expect(fakeWindow.location.href).toBe('dontchange');
+    });
+
+    it('should add a trailing hash when a hash was present before to prevent page reload', function() {
+      browser.url('http://server/#asdf');
+      browser.url('http://server/');
+      expect(fakeWindow.location.href).toBe('http://server/#');
     });
 
     it('should not read out location.href if a reload was triggered but still allow to change the url', function() {

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1842,13 +1842,13 @@ describe('$location', function() {
 
     it('should rewrite URL', function() {
       expect(parseLinkAndReturn(location, 'http://other')).toEqual(undefined);
-      expect(parseLinkAndReturn(location, 'http://server/pre')).toEqual('http://server/pre/#!');
-      expect(parseLinkAndReturn(location, 'http://server/pre/')).toEqual('http://server/pre/#!');
+      expect(parseLinkAndReturn(location, 'http://server/pre')).toEqual('http://server/pre/');
+      expect(parseLinkAndReturn(location, 'http://server/pre/')).toEqual('http://server/pre/');
       expect(parseLinkAndReturn(location, 'http://server/pre/otherPath')).toEqual('http://server/pre/#!/otherPath');
       // Note: relies on the previous state!
       expect(parseLinkAndReturn(location, 'someIgnoredAbsoluteHref', '#test')).toEqual('http://server/pre/#!/otherPath#test');
 
-      expect(parseLinkAndReturn(locationIndex, 'http://server/pre')).toEqual('http://server/pre/index.html#!');
+      expect(parseLinkAndReturn(locationIndex, 'http://server/pre')).toEqual('http://server/pre/index.html');
       expect(parseLinkAndReturn(locationIndex, 'http://server/pre/')).toEqual(undefined);
       expect(parseLinkAndReturn(locationIndex, 'http://server/pre/otherPath')).toEqual('http://server/pre/index.html#!/otherPath');
       // Note: relies on the previous state!


### PR DESCRIPTION
Previously, `LocationHashbangInHtml5Url` always added a trailing `#`
to the absolute url that was given to `$browser.url` to prevent page reloads
when the hash fragment was empty.

This refactoring adds a general mechanism in `$browser` to ignore
a trailing `#` during read and add a trailing `#` when the hash fragment
is removed.
