### PR TITLE
Remove more bits and pieces of Internet Explorer 8 support

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -254,9 +254,7 @@ function forEach(obj, iterator, context) {
   if (obj) {
     if (isFunction(obj)) {
       for (key in obj) {
-        // Need to check if hasOwnProperty exists,
-        // as on IE8 the result of querySelectorAll is an object without a hasOwnProperty function
-        if (key != 'prototype' && key != 'length' && key != 'name' && (!obj.hasOwnProperty || obj.hasOwnProperty(key))) {
+        if (key != 'prototype' && key != 'length' && key != 'name' && obj.hasOwnProperty(key)) {
           iterator.call(context, obj[key], key, obj);
         }
       }

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -274,11 +274,9 @@ function jqLiteClone(element) {
 function jqLiteDealoc(element, onlyDescendants) {
   if (!onlyDescendants) jqLiteRemoveData(element);
 
-  if (element.querySelectorAll) {
-    var descendants = element.querySelectorAll('*');
-    for (var i = 0, l = descendants.length; i < l; i++) {
-      jqLiteRemoveData(descendants[i]);
-    }
+  var descendants = element.querySelectorAll('*');
+  for (var i = 0, l = descendants.length; i < l; i++) {
+    jqLiteRemoveData(descendants[i]);
   }
 }
 

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -58,7 +58,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
       xhr.onload = function requestLoaded() {
         var statusText = xhr.statusText || '';
 
-        // responseText is the old-school way of retrieving response (supported by IE8 & 9)
+        // responseText is the old-school way of retrieving response (supported by IE9)
         // response/responseType properties were introduced in XHR Level2 spec (supported by IE10)
         var response = ('response' in xhr) ? xhr.response : xhr.responseText;
 

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -316,7 +316,7 @@ function LocationHashbangInHtml5Url(appBase, appBaseNoFile, hashPrefix) {
         hash = this.$$hash ? '#' + encodeUriSegment(this.$$hash) : '';
 
     this.$$url = encodePath(this.$$path) + (search ? '?' + search : '') + hash;
-    // include hashPrefix in $$absUrl when $$url is empty so IE8 & 9 do not reload page because of removal of '#'
+    // include hashPrefix in $$absUrl when $$url is empty so IE9 do not reload page because of removal of '#'
     this.$$absUrl = appBase + hashPrefix + this.$$url;
   };
 

--- a/src/ng/urlUtils.js
+++ b/src/ng/urlUtils.js
@@ -24,19 +24,12 @@ var originUrl = urlResolve(window.location.href);
  *
  * Implementation Notes for IE
  * ---------------------------
- * IE >= 8 and <= 10 normalizes the URL when assigned to the anchor node similar to the other
+ * IE <= 11 normalizes the URL when assigned to the anchor node similar to the other
  * browsers.  However, the parsed components will not be set if the URL assigned did not specify
  * them.  (e.g. if you assign a.href = "foo", then a.protocol, a.host, etc. will be empty.)  We
  * work around that by performing the parsing in a 2nd step by taking a previously normalized
  * URL (e.g. by assigning to a.href) and assigning it a.href again.  This correctly populates the
  * properties such as protocol, hostname, port, etc.
- *
- * IE7 does not normalize the URL when assigned to an anchor node.  (Apparently, it does, if one
- * uses the inner HTML approach to assign the URL as part of an HTML snippet -
- * http://stackoverflow.com/a/472729)  However, setting img[src] does normalize the URL.
- * Unfortunately, setting img[src] to something like "javascript:foo" on IE throws an exception.
- * Since the primary usage for normalizing URLs is to sanitize such URLs, we can't use that
- * method and IE < 8 is unsupported.
  *
  * References:
  *   http://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1072,22 +1072,6 @@ describe('angular', function() {
       expect(log).toEqual(['0:a', '1:c']);
     });
 
-    if (document.querySelectorAll) {
-      it('should handle the result of querySelectorAll in IE8 as it has no hasOwnProperty function', function() {
-        document.body.innerHTML = "<p>" +
-          "<a name='x'>a</a>" +
-          "<a name='y'>b</a>" +
-          "<a name='x'>c</a>" +
-          "</p>";
-
-        var htmlCollection = document.querySelectorAll('[name="x"]'),
-          log = [];
-
-        forEach(htmlCollection, function(value, key) { log.push(key + ':' + value.innerHTML); });
-        expect(log).toEqual(['0:a', '1:c']);
-      });
-    }
-
     it('should handle arguments objects like arrays', function() {
       var args,
           log = [];

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -252,7 +252,7 @@ describe('$httpBackend', function() {
 
 
     it('should read responseText if response was not defined', function() {
-      //  old browsers like IE8, don't support responseType, so they always respond with responseText
+      //  old browsers like IE9, don't support responseType, so they always respond with responseText
 
       $backend('GET', '/whatever', null, callback, {}, null, null, 'blob');
 

--- a/test/ng/sceSpecs.js
+++ b/test/ng/sceSpecs.js
@@ -2,12 +2,6 @@
 
 describe('SCE', function() {
 
-  // Work around an IE8 bug.  Though window.inject === angular.mock.inject, if it's invoked the
-  // window scope, IE8 loses the exception object that bubbles up and replaces it with a TypeError.
-  // By using a local alias, it gets invoked on the global scope instead of window.
-  // Ref: https://github.com/angular/angular.js/pull/4221#/issuecomment-25515813
-  var inject = angular.mock.inject;
-
   describe('when disabled', function() {
     beforeEach(function() {
       module(function($sceProvider) {

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -719,8 +719,6 @@ describe('ngMock', function() {
 
     it('should serialize scope that has overridden "hasOwnProperty"', inject(function($rootScope, $sniffer) {
       /* jshint -W001 */
-      // MS IE8 just doesn't work for this kind of thing, since "for ... in" doesn't return
-      // things like hasOwnProperty even if it is explicitly defined on the actual object!
       $rootScope.hasOwnProperty = 'X';
       expect(d($rootScope)).toMatch(/Scope\(.*\): \{/);
       expect(d($rootScope)).toMatch(/hasOwnProperty: "X"/);
@@ -904,11 +902,6 @@ describe('ngMock', function() {
           expect(tested).toBe(true);
         });
       });
-
-
-      // We don't run the following tests on IE8.
-      // IE8 throws "Object does not support this property or method." error,
-      // when thrown from a function defined on window (which `inject` is).
 
       it('should not change thrown Errors', inject(function($sniffer) {
         expect(function() {


### PR DESCRIPTION
Some of these are just comments that were explaining code removed in e843ae7a4cfb746760e1d8c3578d9ec613c3e2ee. The most relevant (functional) change is the one to ngSanitize.

I've also removed adjusted some comments referring to IE8 and IE9 to only mention IE9.
