### PR TITLE
fix(browserTrigger): declare msie variable

### DIFF
--- a/src/ngScenario/browserTrigger.js
+++ b/src/ngScenario/browserTrigger.js
@@ -2,12 +2,6 @@
 
 (function() {
   /**
-   * documentMode is an IE-only property
-   * http://msdn.microsoft.com/en-us/library/ie/cc196988(v=vs.85).aspx
-   */
-  msie = document.documentMode;
-
-  /**
    * Triggers a browser event. Attempts to choose the right event if one is
    * not specified.
    *


### PR DESCRIPTION
The variable `msie` was used in strict mode without declaring it first,
causing both jshint and the module tests to fail. This change fixes the
problem.
