### PR TITLE
chore(ngScenario): make jshint happy

### DIFF
--- a/src/ngScenario/browserTrigger.js
+++ b/src/ngScenario/browserTrigger.js
@@ -5,7 +5,7 @@
    * documentMode is an IE-only property
    * http://msdn.microsoft.com/en-us/library/ie/cc196988(v=vs.85).aspx
    */
-  msie = document.documentMode;
+  var msie = document.documentMode;
 
   /**
    * Triggers a browser event. Attempts to choose the right event if one is


### PR DESCRIPTION
Someone accidentally removed an important keyword which prevented a variable
from being added to the global object
