### PR TITLE
feat($scope): propose and implement $when method

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -658,6 +658,45 @@ function $RootScopeProvider(){
 
       /**
        * @ngdoc method
+       * @name $rootScope.Scope#$when
+       * @kind function
+       *
+       * @description
+       * Executes a function when some condition has been met.  If the `condition` expression
+       * evaluates to a truthy value at the time `$when` is called, `action` is executed
+       * immediately.  Otherwise, a {@link ng.$rootScope.Scope#$watch watcher} is created so that
+       * the `action` is called as soon as the `condition` becomes true.  This watcher is
+       * unregistered after the `action` has been completed.
+       * 
+       * @param {string|function(scope)} condition An angular {@link guide/expression expression} to be evaluated. 
+       *
+       *    - `string`: execute using the rules as defined in {@link guide/expression expression}.
+       *    - `function(scope)`: execute the function with current `scope` parameter.
+       * @param {function()} action A callback that is executed when the `condition` evaluates to a truthy value.  
+       */
+      $when: function(condition, action) {
+        if (this.$eval(condition)) {
+          try {
+            action();
+          } catch (e) {
+            $exceptionHandler(e);
+          }
+        } else {
+          var deregister = this.$watch(condition, function(newValue) {
+            if (newValue) {
+              try {
+                action();
+              } catch (e) {
+                $exceptionHandler(e);
+              }
+              deregister();
+            }
+          });
+        }
+      },
+
+      /**
+       * @ngdoc method
        * @name $rootScope.Scope#$digest
        * @kind function
        *

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -943,6 +943,30 @@ describe('Scope', function() {
 
   });
 
+  describe('$when', function() {
+    it('should execute the action when the condition becomes true', inject(function($rootScope) {
+      $rootScope.value = 0;
+      $rootScope.$when('value > 1', function() {
+        $rootScope.message = 'greater';
+      });
+      expect($rootScope.message).toBeUndefined();
+      $rootScope.value = 1;
+      $rootScope.$digest();
+      expect($rootScope.message).toBeUndefined();
+      $rootScope.value = 2;
+      $rootScope.$digest();
+      expect($rootScope.message).toEqual('greater');
+    }));
+
+    it('should execute the action immediately if the condition is already true', inject(function($rootScope) {
+      $rootScope.value = 2;
+      $rootScope.$when('value > 1', function() {
+        $rootScope.message = 'greater';
+      });
+      expect($rootScope.message).toEqual('greater');
+    }));
+  });
+
   describe('$destroy', function() {
     var first = null, middle = null, last = null, log = null;
 


### PR DESCRIPTION
I have noticed that following pattern occurs in many of my AngularJS controllers
when I need to do initialization based on an asynchronously loaded resource:

```
if ($scope.someCondition == true) {
  doSomething();
} else {
  var unwatch = $scope.$watch('someCondition == true', function(newValue) {
    if (newValue) {
      doSomething();
      unwatch();
    }
  });
}
```

I propose adding a $when() method to $scope to simplify handing of such cases:

```
$scope.$when('someCondition == true', doSomething);
```

This commit provides an initial implementation of the $when() method.
