### PR TITLE
chore($sniffer): Remove remnants of separate documentMode handling

### DIFF
--- a/docs/content/error/$sce/iequirks.ngdoc
+++ b/docs/content/error/$sce/iequirks.ngdoc
@@ -1,13 +1,13 @@
 @ngdoc error
 @name $sce:iequirks
-@fullName IE8 in quirks mode is unsupported
+@fullName IE<11 in quirks mode is unsupported
 @description
 
-This error occurs when you are using AngularJS with {@link ng.$sce Strict Contextual Escaping (SCE)} mode enabled (the default) on IE8 or lower in quirks mode.
+This error occurs when you are using AngularJS with {@link ng.$sce Strict Contextual Escaping (SCE)} mode enabled (the default) on IE10 or lower in quirks mode.
 
-In this mode, IE8 allows one to execute arbitrary javascript by the use of the `expression()` syntax and is not supported.
+In this mode, IE<11 allow one to execute arbitrary javascript by the use of the `expression()` syntax and is not supported.
 Refer
-[MSDN Blogs > IEBlog > Ending Expressions](http://blogs.msdn.com/b/ie/archive/2008/10/16/ending-expressions.aspx)
+[CSS expressions no longer supported for the Internet zone](http://msdn.microsoft.com/en-us/library/ie/dn384050(v=vs.85).aspx)
 to learn more about them.
 
 To resolve this error please specify the proper doctype at the top of your main html document:

--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -410,7 +410,7 @@ function $SceDelegateProvider() {
  *
  * As of version 1.2, Angular ships with SCE enabled by default.
  *
- * Note:  When enabled (the default), IE8 in quirks mode is not supported.  In this mode, IE8 allows
+ * Note:  When enabled (the default), IE<11 in quirks mode is not supported.  In this mode, IE<11 allow
  * one to execute arbitrary javascript by the use of the expression() syntax.  Refer
  * <http://blogs.msdn.com/b/ie/archive/2008/10/16/ending-expressions.aspx> to learn more about them.
  * You can ensure your document is in standards mode and not quirks mode by adding `<!doctype html>`
@@ -727,13 +727,13 @@ function $SceProvider() {
    * sce.js and sceSpecs.js would need to be aware of this detail.
    */
 
-  this.$get = ['$parse', '$sniffer', '$sceDelegate', function(
-                $parse,   $sniffer,   $sceDelegate) {
-    // Prereq: Ensure that we're not running in IE8 quirks mode.  In that mode, IE allows
+  this.$get = ['$document', '$parse', '$sceDelegate', function(
+                $document,   $parse,   $sceDelegate) {
+    // Prereq: Ensure that we're not running in IE<11 quirks mode.  In that mode, IE < 11 allow
     // the "expression(javascript expression)" syntax which is insecure.
-    if (enabled && $sniffer.msie && $sniffer.msieDocumentMode < 8) {
+    if (enabled && $document[0].documentMode < 8) {
       throw $sceMinErr('iequirks',
-        'Strict Contextual Escaping does not support Internet Explorer version < 9 in quirks ' +
+        'Strict Contextual Escaping does not support Internet Explorer version < 11 in quirks ' +
         'mode.  You can fix this by adding the text <!doctype html> to the top of your HTML ' +
         'document.  See http://docs.angularjs.org/api/ng.$sce for more information.');
     }

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -21,7 +21,6 @@ function $SnifferProvider() {
           int((/android (\d+)/.exec(lowercase(($window.navigator || {}).userAgent)) || [])[1]),
         boxee = /Boxee/i.test(($window.navigator || {}).userAgent),
         document = $document[0] || {},
-        documentMode = document.documentMode,
         vendorPrefix,
         vendorRegex = /^(Moz|webkit|O|ms)(?=[A-Z])/,
         bodyStyle = document.body && document.body.style,
@@ -81,9 +80,7 @@ function $SnifferProvider() {
       vendorPrefix: vendorPrefix,
       transitions : transitions,
       animations : animations,
-      android: android,
-      msie : msie,
-      msieDocumentMode: documentMode
+      android: android
     };
   }];
 }

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -18,7 +18,7 @@ describe('$location', function() {
     var urlParsingNodePlaceholder;
 
     beforeEach(inject(function ($sniffer) {
-      if ($sniffer.msie) return;
+      if (msie) return;
 
       urlParsingNodePlaceholder = urlParsingNode;
 
@@ -38,7 +38,7 @@ describe('$location', function() {
     }));
 
     afterEach(inject(function ($sniffer) {
-      if ($sniffer.msie) return;
+      if (msie) return;
       //reset urlParsingNode
       urlParsingNode = urlParsingNodePlaceholder;
     }));

--- a/test/ng/sceSpecs.js
+++ b/test/ng/sceSpecs.js
@@ -26,13 +26,12 @@ describe('SCE', function() {
     }));
   });
 
-  describe('IE8 quirks mode', function() {
+  describe('IE<11 quirks mode', function() {
     function runTest(enabled, documentMode, expectException) {
       module(function($provide) {
-        $provide.value('$sniffer', {
-          msie: documentMode,
-          msieDocumentMode: documentMode
-        });
+        $provide.value('$document', [{
+          documentMode: documentMode
+        }]);
         $provide.value('$sceDelegate', {trustAs: null, valueOf: null, getTrusted: null});
       });
 
@@ -47,7 +46,7 @@ describe('SCE', function() {
         if (expectException) {
           expect(constructSce).toThrowMinErr(
             '$sce', 'iequirks', 'Strict Contextual Escaping does not support Internet Explorer ' +
-              'version < 9 in quirks mode.  You can fix this by adding the text <!doctype html> to ' +
+              'version < 11 in quirks mode.  You can fix this by adding the text <!doctype html> to ' +
               'the top of your HTML document.  See http://docs.angularjs.org/api/ng.$sce for more ' +
               'information.');
         } else {

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -332,16 +332,4 @@ describe('$sniffer', function() {
       expect($sniffer.android).toBe(2);
     });
   });
-
-  it('should return the internal msie flag', inject(function($sniffer) {
-    expect(isNaN($sniffer.msie)).toBe(isNaN(msie));
-    if (msie) {
-      expect($sniffer.msie).toBe(msie);
-    }
-  }));
-
-  it('should return document.documentMode as msieDocumentMode', function() {
-    var someDocumentMode = 123;
-    expect(sniffer({}, {documentMode: someDocumentMode}).msieDocumentMode).toBe(someDocumentMode);
-  });
 });


### PR DESCRIPTION
Since msie is now set to document.documentMode, it's not necessary to keep
the documentMode in a separate property.
