### PR TITLE
chore($sniffer): Remove $sniffer.hashchange

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -256,9 +256,7 @@ function Browser(window, document, $log, $sniffer) {
       // html5 history api - popstate event
       if ($sniffer.history) jqLite(window).on('popstate', fireUrlChange);
       // hashchange event
-      if ($sniffer.hashchange) jqLite(window).on('hashchange', fireUrlChange);
-      // polling
-      else self.addPollFn(fireUrlChange);
+      jqLite(window).on('hashchange', fireUrlChange);
 
       urlChangeInit = true;
     }

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -8,7 +8,6 @@
  * @requires $document
  *
  * @property {boolean} history Does the browser support html5 history api ?
- * @property {boolean} hashchange Does the browser support hashchange event ?
  * @property {boolean} transitions Does the browser support CSS transition events ?
  * @property {boolean} animations Does the browser support CSS animation events ?
  *
@@ -65,9 +64,6 @@ function $SnifferProvider() {
       // jshint -W018
       history: !!($window.history && $window.history.pushState && !(android < 4) && !boxee),
       // jshint +W018
-      hashchange: 'onhashchange' in $window &&
-                  // IE8 compatible mode lies
-                  (!documentMode || documentMode > 7),
       hasEvent: function(event) {
         // IE9 implements 'input' event it's so fubared that we rather pretend that it doesn't have
         // it. In particular the event is not fired when backspace or delete key are pressed or

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -100,7 +100,7 @@ describe('browser', function() {
   beforeEach(function() {
     scripts = [];
     removedScripts = [];
-    sniffer = {history: true, hashchange: true};
+    sniffer = {history: true};
     fakeWindow = new MockWindow();
     fakeDocument = new MockDocument();
 
@@ -597,7 +597,7 @@ describe('browser', function() {
     var currentHref;
 
     beforeEach(function() {
-      sniffer = {history: true, hashchange: true};
+      sniffer = {history: true};
       currentHref = fakeWindow.location.href;
     });
 
@@ -683,9 +683,8 @@ describe('browser', function() {
       expect(callback).toHaveBeenCalledOnce();
     });
 
-    it('should forward only popstate event when both history and hashchange supported', function() {
+    it('should forward only popstate event when history supported', function() {
       sniffer.history = true;
-      sniffer.hashchange = true;
       browser.onUrlChange(callback);
       fakeWindow.location.href = 'http://server/new';
 
@@ -697,9 +696,8 @@ describe('browser', function() {
       expect(callback).toHaveBeenCalledOnce();
     });
 
-    it('should forward hashchange event with new url when only hashchange supported', function() {
+    it('should forward hashchange event with new url when history not supported', function() {
       sniffer.history = false;
-      sniffer.hashchange = true;
       browser.onUrlChange(callback);
       fakeWindow.location.href = 'http://server/new';
 
@@ -711,56 +709,8 @@ describe('browser', function() {
       expect(callback).toHaveBeenCalledOnce();
     });
 
-    it('should use polling when neither history nor hashchange supported', function() {
+    it('should not fire urlChange if changed by browser.url method', function() {
       sniffer.history = false;
-      sniffer.hashchange = false;
-      browser.onUrlChange(callback);
-
-      fakeWindow.location.href = 'http://server.new';
-      fakeWindow.setTimeout.flush();
-      expect(callback).toHaveBeenCalledWith('http://server.new', null);
-
-      callback.reset();
-
-      fakeWindow.fire('popstate');
-      fakeWindow.fire('hashchange');
-      expect(callback).not.toHaveBeenCalled();
-    });
-
-    describe('after an initial location change by browser.url method when neither history nor hashchange supported', function() {
-      beforeEach(function() {
-        sniffer.history = false;
-        sniffer.hashchange = false;
-        browser.url("http://server/#current");
-      });
-
-      it('should fire callback with the correct URL on location change outside of angular', function() {
-        browser.onUrlChange(callback);
-
-        fakeWindow.location.href = 'http://server/#new';
-        fakeWindow.setTimeout.flush();
-        expect(callback).toHaveBeenCalledWith('http://server/#new', null);
-
-        fakeWindow.fire('popstate');
-        fakeWindow.fire('hashchange');
-        expect(callback).toHaveBeenCalledOnce();
-      });
-
-    });
-
-    it('should not fire urlChange if changed by browser.url method (polling)', function() {
-      sniffer.history = false;
-      sniffer.hashchange = false;
-      browser.onUrlChange(callback);
-      browser.url('http://new.com');
-
-      fakeWindow.setTimeout.flush();
-      expect(callback).not.toHaveBeenCalled();
-    });
-
-    it('should not fire urlChange if changed by browser.url method (hashchange)', function() {
-      sniffer.history = false;
-      sniffer.hashchange = true;
       browser.onUrlChange(callback);
       browser.url('http://new.com');
 

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -90,7 +90,7 @@ describe('$location', function() {
         };
       };
       $browserProvider.$get = function($document, $window) {
-        var sniffer = {history: true, hashchange: false};
+        var sniffer = {history: true};
         var logs = {log:[], warn:[], info:[], error:[]};
         var fakeLog = {log: function() { logs.log.push(slice.call(arguments)); },
                    warn: function() { logs.warn.push(slice.call(arguments)); },

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -23,20 +23,6 @@ describe('$sniffer', function() {
     });
   });
 
-  describe('hashchange', function() {
-    it('should be true if onhashchange property defined', function() {
-      expect(sniffer({onhashchange: true}).hashchange).toBe(true);
-    });
-
-    it('should be false if onhashchange property not defined', function() {
-      expect(sniffer({}).hashchange).toBe(false);
-    });
-
-    it('should be false if documentMode is 7 (IE8 comp mode)', function() {
-      expect(sniffer({onhashchange: true}, {documentMode: 7}).hashchange).toBe(false);
-    });
-  });
-
 
   describe('hasEvent', function() {
     var mockDocument, mockDivElement, $sniffer;


### PR DESCRIPTION
The hashchange event is not supported only in ancient browsers like Android<2.2
and IE<8. Angular never really supported IE7 and in 1.3 where support for IE8
is dropped it makes even less sense to check for hashchange support.
