### PR TITLE
fix(select): remove unknown option when value is set to correct one

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -624,7 +624,9 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
             index++; // increment since the existingOptions[0] is parent element not OPTION
             while(existingOptions.length > index) {
               option = existingOptions.pop();
-              selectCtrl.removeOption(option.label);
+              if(keys.indexOf(option.label) === -1) {
+                selectCtrl.removeOption(option.label);
+              }
               option.element.remove();
             }
           }

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -406,6 +406,58 @@ describe('select', function() {
           expect(scope.robot).toBe('r2d2');
         });
 
+        it('should remove unknown option when option is again known', function() {
+          var getValues = function() {
+            var result = [];
+
+            forEach(element.find('option'), function(option) {
+              result.push(option.getAttribute('value'));
+            });
+
+            return result;
+          }, getLabels = function() {
+            var result = [];
+
+            forEach(element.find('option'), function(option) {
+              result.push(option.innerHTML);
+            });
+
+            return result;
+          };
+
+          scope.robots = [
+            'c3p0',
+            'r2d2'
+          ];
+
+          scope.robot = 'r2d2';
+
+          scope.$apply();
+
+          compile('<select ng-model="robot" ' +
+          'ng-options="item for item in robots">' +
+          '</select>');
+
+          scope.$apply();
+
+          expect(getValues()).toEqual(['0', '1']);
+          expect(getLabels()).toEqual(['c3p0', 'r2d2']);
+
+          scope.$apply(function() {
+            delete scope.robot;
+          });
+
+          expect(getValues()).toEqual(['?', '0', '1']);
+          expect(getLabels()).toEqual(['', 'c3p0', 'r2d2']);
+
+          scope.$apply(function() {
+            scope.robot = 'r2d2';
+          });
+
+          expect(getValues()).toEqual(['0', '1']);
+          expect(getLabels()).toEqual(['c3p0', 'r2d2']);
+        });
+
         describe('selectController.hasOption', function() {
           it('should return true for options added via ngOptions', function() {
             scope.robots = [

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -432,13 +432,9 @@ describe('select', function() {
 
           scope.robot = 'r2d2';
 
-          scope.$apply();
-
           compile('<select ng-model="robot" ' +
           'ng-options="item for item in robots">' +
           '</select>');
-
-          scope.$apply();
 
           expect(getValues()).toEqual(['0', '1']);
           expect(getLabels()).toEqual(['c3p0', 'r2d2']);


### PR DESCRIPTION
When selected option goes from unknown to the last in list, not by `change` event, unknown option is also removed and correct option is selected.

Closes #9490
