### PR TITLE
fix($injector): ensure $get method invoked with provider context

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -664,7 +664,7 @@ function createInjector(modulesToLoad, strictDi) {
 
   function enforceReturnValue(name, factory) {
     return function enforcedReturnValue() {
-      var result = instanceInjector.invoke(factory);
+      var result = instanceInjector.invoke(factory, this, undefined, name);
       if (isUndefined(result)) {
         throw $injectorMinErr('undef', "Provider '{0}' must return a value from $get factory method.", name);
       }

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -993,4 +993,21 @@ describe('strict-di injector', function() {
       inject(function($test) {});
     }).toThrowMinErr('$injector', 'undef');
   });
+
+
+  it('should always use provider as `this` when invoking a factory', function() {
+    // jshint -W040
+    var called = false;
+    function factoryFn() {
+      called = true;
+      expect(typeof this.$get).toBe('function');
+      return this;
+    }
+    module(function($provide) {
+      $provide.factory('$test', factoryFn);
+    });
+    inject(function($test) {});
+    expect(called).toBe(true);
+    // jshint +W040
+  });
 });


### PR DESCRIPTION
0d3b69a5f27b41745b504c7ffd8d72653bac1f85 broke this by calling $get with an
undefined context, which in strict mode would be undefined. This fixes this by
ensuring that the provider is used as the context, as it was originally.

Closes #9511
