### PR TITLE
Minor fixes in $location

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -659,8 +659,8 @@ function $LocationProvider(){
    *     whether or not a <base> tag is required to be present. If `enabled` and `requireBase` are
    *     true, and a base tag is not present, an error will be thrown when `$location` is injected.
    *     See the {@link guide/$location $location guide for more information}
-   *   - **rewriteLinks** - `{boolean}` - (default: `false`) When html5Mode is enabled, disables
-   *     url rewriting for relative linksTurns off url rewriting for relative links.
+   *   - **rewriteLinks** - `{boolean}` - (default: `true`) When html5Mode is enabled,
+   *     enables/disables url rewriting for relative links.
    *
    * @returns {Object} html5Mode object if used as getter or itself (chaining) if used as setter
    */

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -671,7 +671,7 @@ function $LocationProvider(){
     } else if (isObject(mode)) {
 
       if (isBoolean(mode.enabled)) {
-        html5Mode.enabled =  mode.enabled;
+        html5Mode.enabled = mode.enabled;
       }
 
       if (isBoolean(mode.requireBase)) {
@@ -679,7 +679,7 @@ function $LocationProvider(){
       }
 
       if (isBoolean(mode.rewriteLinks)) {
-        html5Mode.rewriteLinks =  mode.rewriteLinks;
+        html5Mode.rewriteLinks = mode.rewriteLinks;
       }
 
       return this;


### PR DESCRIPTION
Fixes the description of `rewriteLinks` and removes two redundant spaces.

Related to #9487.
