### PR TITLE
refactor($compile): use createMap() rather than Object.create(null)

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1066,7 +1066,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
        */
       $observe: function(key, fn) {
         var attrs = this,
-            $$observers = (attrs.$$observers || (attrs.$$observers = Object.create(null))),
+            $$observers = (attrs.$$observers || (attrs.$$observers = createMap())),
             listeners = ($$observers[key] || ($$observers[key] = []));
 
         listeners.push(fn);


### PR DESCRIPTION
I didn't know we had a helper for this previously, but I guess we do :>
