### PR TITLE
fix($http): don't run transformData on HEAD methods

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -770,9 +770,12 @@ function $HttpProvider() {
 
       function transformResponse(response) {
         // make a copy since the response must be cacheable
-        var resp = extend({}, response, {
-          data: transformData(response.data, response.headers, config.transformResponse)
-        });
+        var resp = extend({}, response);
+        if(config.method === 'HEAD'){
+          resp.data = response.data;
+        } else {
+          resp.data = transformData(response.data, response.headers, config.transformResponse);
+        }
         return (isSuccess(response.status))
           ? resp
           : $q.reject(resp);

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1074,6 +1074,17 @@ describe('$http', function() {
           });
 
 
+          it('should deserialize json empty string when response header contains application/json',
+              function() {
+            $httpBackend.expect('GET', '/url').respond('""', {'Content-Type': 'application/json'});
+            $http({method: 'GET', url: '/url'}).success(callback);
+            $httpBackend.flush();
+
+            expect(callback).toHaveBeenCalledOnce();
+            expect(callback.mostRecentCall.args[0]).toEqual('');
+          });
+
+
           it('should deserialize json with security prefix', function() {
             $httpBackend.expect('GET', '/url').respond(')]}\',\n[1, "abc", {"foo":"bar"}]');
             $http({method: 'GET', url: '/url'}).success(callback);
@@ -1091,6 +1102,18 @@ describe('$http', function() {
 
             expect(callback).toHaveBeenCalledOnce();
             expect(callback.mostRecentCall.args[0]).toEqual([1, 'abc', {foo:'bar'}]);
+          });
+
+
+          it('should not attempt to deserialize json when HEAD request', function(){
+            //per http spec for Content-Type, HEAD request should return a Content-Type header
+            //set to what the content type would have been if a get was sent
+            $httpBackend.expect('HEAD', '/url').respond('', {'Content-Type': 'application/json'});
+            $http({method: 'HEAD', url: '/url'}).success(callback);
+            $httpBackend.flush();
+
+            expect(callback).toHaveBeenCalledOnce();
+            expect(callback.mostRecentCall.args[0]).toEqual('');
           });
 
 


### PR DESCRIPTION
7b6c1d0 created this issue by using `Content-Type` to
determine when to run `fromJson`.  Because `HEAD` methods do not contain
a body but are supposed to return the `Content-Type` header that would
have been returned if it was a `GET` this functionality fails.

Closes #9528 
