### PR TITLE
chore(CHANGELOG): add an extra new line after each item in the "Breaking Changes" list

### DIFF
--- a/changelog.js
+++ b/changelog.js
@@ -112,7 +112,7 @@ var printSection = function(stream, title, section, printCommitLinks) {
         }
         stream.write(')\n');
       } else {
-        stream.write(util.format('%s %s', prefix, commit.subject));
+        stream.write(util.format('%s %s\n', prefix, commit.subject));
       }
     });
   });
@@ -188,6 +188,7 @@ var getPreviousTag = function() {
 
 
 var generate = function(version, file) {
+
   getPreviousTag().then(function(tag) {
     console.log('Reading git log since', tag);
     readGitLog('^fix|^feat|^perf|BREAKING', tag).then(function(commits) {


### PR DESCRIPTION
This ensures that the next item will appear on a new line and be properly
parsed as new list item (and not as the continuation of the current item),
even if the current item does not end with a newline character.
Currently, it would result is something like this:

```
- **item 1**: due to ...
  blah1 blah1 blah1- **item 2**: due to...
  blah2 blah2 blah2
```

instead of the intended:

```
- **item 1**: due to ...
  ...
- **item 2**: due to ...
  ...
```
## 

For example, this was the case with the 1.3.0-rc.5 [CHANGELOG](https://github.com/angular/angular.js/blob/v1.3.0-rc.5/CHANGELOG.md#user-content-breaking-changes) (see the last `ngAnimate` breaking change).
