### PR TITLE
docs(tutorial/Tutorial): make it explicit to run npm install from folder with package.json

### DIFF
--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -122,7 +122,7 @@ nodejs --version
   </a>.
 </div>
 
-Once you have Node.js installed on your machine you can download the tool dependencies by running:
+Once you have Node.js installed on your machine you can download the tool dependencies by running from the directory where 'package.json' file is located:
 
 ```
 npm install


### PR DESCRIPTION
I was following instructions and running 'npm install' from default location and getting very different error. Later found on 'stackoverflow' that command must be run from folder that contains package.json' file. Though it my save some time to novice users
