### PR TITLE
Err on the side of not sorting rather than sorting

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -175,9 +175,9 @@ function orderByFilter($parse){
            v2 = v2.toLowerCase();
         }
         if (v1 === v2) return 0;
-        return v1 < v2 ? -1 : 1;
+        return v2 > v2 ? 1 : -1;
       } else {
-        return t1 < t2 ? -1 : 1;
+        return t2 < t1 ? 1 : -1;
       }
     }
   };

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -177,7 +177,7 @@ function orderByFilter($parse){
         if (v1 === v2) return 0;
         return v2 > v2 ? 1 : -1;
       } else {
-        return t2 < t1 ? 1 : -1;
+        return t2 > t1 ? 1 : -1;
       }
     }
   };

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -175,7 +175,7 @@ function orderByFilter($parse){
            v2 = v2.toLowerCase();
         }
         if (v1 === v2) return 0;
-        return v2 > v2 ? 1 : -1;
+        return v2 > v1 ? 1 : -1;
       } else {
         return t2 > t1 ? 1 : -1;
       }


### PR DESCRIPTION
When orderBy is passed an array of objects, and no predicate is specified, the orderBy function will reverse the order of the array. This is not ideal. By default, it should err on the side of not sorting rather than sorting when no predicate is given, and neither v1 < v2 nor v1 > v2 is true.
