### PR TITLE
fix($http): allow empty json response

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -771,7 +771,7 @@ function $HttpProvider() {
       function transformResponse(response) {
         // make a copy since the response must be cacheable
         var resp = extend({}, response);
-        if(config.method === 'HEAD'){
+        if (!response.data) {
           resp.data = response.data;
         } else {
           resp.data = transformData(response.data, response.headers, config.transformResponse);

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1116,6 +1116,16 @@ describe('$http', function() {
             expect(callback.mostRecentCall.args[0]).toEqual('');
           });
 
+          it('should not attempt to deserialize json for an empty response whose header contains application/json', function(){
+            //per http spec for Content-Type, HEAD request should return a Content-Type header
+            //set to what the content type would have been if a get was sent
+            $httpBackend.expect('GET', '/url').respond('', {'Content-Type': 'application/json'});
+            $http({method: 'GET', url: '/url'}).success(callback);
+            $httpBackend.flush();
+
+            expect(callback).toHaveBeenCalledOnce();
+            expect(callback.mostRecentCall.args[0]).toEqual('');
+          });
 
           it('should not deserialize tpl beginning with ng expression', function() {
             $httpBackend.expect('GET', '/url').respond('{{some}}');


### PR DESCRIPTION
When a response contains an `application/json` header and
the response is empty the response should be left as is.

Fixes #9532
