### PR TITLE
docs($httpBackend): add module declaration for best understanding purposes

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -996,7 +996,7 @@ angular.mock.dump = function(object) {
   ```js
   // The module code
   angular
-    .module('MyApp')
+    .module('MyApp', [])
     .controller('MyController', MyController);
   
   // The controller code

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -994,6 +994,11 @@ angular.mock.dump = function(object) {
  * First we create the controller under test:
  *
   ```js
+  // The module code
+  angular
+    .module('MyApp')
+    .controller('MyController', MyController);
+  
   // The controller code
   function MyController($scope, $http) {
     var authToken;
@@ -1022,6 +1027,9 @@ angular.mock.dump = function(object) {
     // testing controller
     describe('MyController', function() {
        var $httpBackend, $rootScope, createController, authRequestHandler;
+       
+       // Set up the module
+       beforeEach(module('MyApp'));
 
        beforeEach(inject(function($injector) {
          // Set up the mock http service responses


### PR DESCRIPTION
According with the Issue #9537. This module declaration in the test is very important. When I started to test in angular I copy and paste this code to see how it works, and I get this `module undefined error`, and just after read some blog posts I figure out that this line is essential for testing your module. So, for best understanding of begginers this can be very helpful.
