### PR TITLE
orderBy should not reverse an array of objects

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -175,9 +175,9 @@ function orderByFilter($parse){
            v2 = v2.toLowerCase();
         }
         if (v1 === v2) return 0;
-        return v1 < v2 ? -1 : 1;
+        return v1 > v2 ? 1 : -1;
       } else {
-        return t1 < t2 ? -1 : 1;
+        return t1 > t2 ? 1 : -1;
       }
     }
   };

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -20,6 +20,13 @@ describe('Filter: orderBy', function() {
     expect(orderBy([2, 1, 3], ['-'])).toEqual([3, 2, 1]);
   });
 
+  it('should maintain order in an array of objects if no predicate is provided', function() {
+    expect(orderBy([{a: 1}, {b: 2}, {c: 3}])).toEqualData([{a: 1}, {b: 2}, {c: 3}]);
+	expect(orderBy([{a: 1}, {b: 2}, {c: 3}], '')).toEqualData([{a: 1}, {b: 2}, {c: 3}]);
+	expect(orderBy([{a: 1}, {b: 2}, {c: 3}], [])).toEqualData([{a: 1}, {b: 2}, {c: 3}]);
+	expect(orderBy([{a: 1}, {b: 2}, {c: 3}], [''])).toEqualData([{a: 1}, {b: 2}, {c: 3}]);
+  });
+
   it('shouldSortArrayInReverse', function() {
     expect(orderBy([{a:15}, {a:2}], 'a', true)).toEqualData([{a:15}, {a:2}]);
     expect(orderBy([{a:15}, {a:2}], 'a', "T")).toEqualData([{a:15}, {a:2}]);


### PR DESCRIPTION
When no predicate is provided, orderBy will reverse an array of objects.
This isn't ideal. It should err on the side of preserving the order.

It happens because, for objects, in the compare() function, v1 < v2 is
false, so the comparator function returns 1 (effectively moving v2
before v1).
