### PR TITLE
fix(parse): dirty checking support for objects with null prototype

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -126,7 +126,6 @@ var VALIDITY_STATE_PROPERTY = 'validity';
  */
 var lowercase = function(string){return isString(string) ? string.toLowerCase() : string;};
 var hasOwnProperty = Object.prototype.hasOwnProperty;
-var valueOfObject = Object.prototype.valueOf;
 
 /**
  * @ngdoc function

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -126,6 +126,7 @@ var VALIDITY_STATE_PROPERTY = 'validity';
  */
 var lowercase = function(string){return isString(string) ? string.toLowerCase() : string;};
 var hasOwnProperty = Object.prototype.hasOwnProperty;
+var valueOfObject = Object.prototype.valueOf;
 
 /**
  * @ngdoc function

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -946,7 +946,7 @@ function getterFn(path, options, fullExp) {
   return fn;
 }
 
-var objectValueOf = Object.prototype.valueOf;
+var objectValueOf = Object.prototype.valueOf.call;
 
 function getValueOf(value) {
   return isFunction(value.valueOf) ? value.valueOf() : objectValueOf(value);

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1092,7 +1092,8 @@ function $ParseProvider() {
         // attempt to convert the value to a primitive type
         // TODO(docs): add a note to docs that by implementing valueOf even objects and arrays can
         //             be cheaply dirty-checked
-        newValue = newValue.valueOf();
+        typeof newValue.valueOf !== 'function' && (newValue = Object.valueOf.apply(newValue)) ||
+            (newValue = newValue.valueOf());
 
         if (typeof newValue === 'object') {
           // objects/arrays are not supported - deep-watching them would be too expensive
@@ -1119,7 +1120,8 @@ function $ParseProvider() {
           var newInputValue = inputExpressions(scope);
           if (!expressionInputDirtyCheck(newInputValue, oldInputValue)) {
             lastResult = parsedExpression(scope);
-            oldInputValue = newInputValue && newInputValue.valueOf();
+            oldInputValue = newInputValue && typeof newInputValue.valueOf !== 'function' &&
+                Object.valueOf.apply(newInputValue) || newInputValue.valueOf();
           }
           return lastResult;
         }, listener, objectEquality);
@@ -1136,7 +1138,8 @@ function $ParseProvider() {
         for (var i = 0, ii = inputExpressions.length; i < ii; i++) {
           var newInputValue = inputExpressions[i](scope);
           if (changed || (changed = !expressionInputDirtyCheck(newInputValue, oldInputValueOfValues[i]))) {
-            oldInputValueOfValues[i] = newInputValue && newInputValue.valueOf();
+            oldInputValueOfValues[i] = newInputValue && typeof newInputValue.valueOf !== 'function' &&
+                Object.valueOf.apply(newInputValue) || newInputValue.valueOf();
           }
         }
 

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1092,8 +1092,7 @@ function $ParseProvider() {
         // attempt to convert the value to a primitive type
         // TODO(docs): add a note to docs that by implementing valueOf even objects and arrays can
         //             be cheaply dirty-checked
-        typeof newValue.valueOf !== 'function' && (newValue = Object.valueOf.apply(newValue)) ||
-            (newValue = newValue.valueOf());
+        newValue = valueOfObject.call(newValue);
 
         if (typeof newValue === 'object') {
           // objects/arrays are not supported - deep-watching them would be too expensive
@@ -1120,8 +1119,7 @@ function $ParseProvider() {
           var newInputValue = inputExpressions(scope);
           if (!expressionInputDirtyCheck(newInputValue, oldInputValue)) {
             lastResult = parsedExpression(scope);
-            oldInputValue = newInputValue && typeof newInputValue.valueOf !== 'function' &&
-                Object.valueOf.apply(newInputValue) || newInputValue.valueOf();
+            oldInputValue = newInputValue && valueOfObject.call(newInputValue);
           }
           return lastResult;
         }, listener, objectEquality);
@@ -1138,8 +1136,7 @@ function $ParseProvider() {
         for (var i = 0, ii = inputExpressions.length; i < ii; i++) {
           var newInputValue = inputExpressions[i](scope);
           if (changed || (changed = !expressionInputDirtyCheck(newInputValue, oldInputValueOfValues[i]))) {
-            oldInputValueOfValues[i] = newInputValue && typeof newInputValue.valueOf !== 'function' &&
-                Object.valueOf.apply(newInputValue) || newInputValue.valueOf();
+            oldInputValueOfValues[i] = newInputValue && valueOfObject.call(newInputValue);
           }
         }
 

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -946,6 +946,13 @@ function getterFn(path, options, fullExp) {
   return fn;
 }
 
+function valueOfAgnostic(value){
+  if(typeof value.valueOf !== 'function'){
+    return Object.prototype.valueOf.call(value);
+  }
+  return value.valueOf();
+}
+
 ///////////////////////////////////
 
 /**
@@ -1092,7 +1099,7 @@ function $ParseProvider() {
         // attempt to convert the value to a primitive type
         // TODO(docs): add a note to docs that by implementing valueOf even objects and arrays can
         //             be cheaply dirty-checked
-        newValue = valueOfObject.call(newValue);
+        newValue = valueOfAgnostic(newValue);
 
         if (typeof newValue === 'object') {
           // objects/arrays are not supported - deep-watching them would be too expensive
@@ -1119,7 +1126,7 @@ function $ParseProvider() {
           var newInputValue = inputExpressions(scope);
           if (!expressionInputDirtyCheck(newInputValue, oldInputValue)) {
             lastResult = parsedExpression(scope);
-            oldInputValue = newInputValue && valueOfObject.call(newInputValue);
+            oldInputValue = newInputValue && valueOfAgnostic(newInputValue);
           }
           return lastResult;
         }, listener, objectEquality);
@@ -1136,7 +1143,7 @@ function $ParseProvider() {
         for (var i = 0, ii = inputExpressions.length; i < ii; i++) {
           var newInputValue = inputExpressions[i](scope);
           if (changed || (changed = !expressionInputDirtyCheck(newInputValue, oldInputValueOfValues[i]))) {
-            oldInputValueOfValues[i] = newInputValue && valueOfObject.call(newInputValue);
+            oldInputValueOfValues[i] = newInputValue && valueOfAgnostic(newInputValue);
           }
         }
 

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -946,11 +946,10 @@ function getterFn(path, options, fullExp) {
   return fn;
 }
 
-function valueOfAgnostic(value){
-  if(typeof value.valueOf !== 'function'){
-    return Object.prototype.valueOf.call(value);
-  }
-  return value.valueOf();
+var objectValueOf = Object.prototype.valueOf;
+
+function getValueOf(value) {
+  return isFunction(value.valueOf) ? value.valueOf() : objectValueOf(value);
 }
 
 ///////////////////////////////////
@@ -1099,7 +1098,7 @@ function $ParseProvider() {
         // attempt to convert the value to a primitive type
         // TODO(docs): add a note to docs that by implementing valueOf even objects and arrays can
         //             be cheaply dirty-checked
-        newValue = valueOfAgnostic(newValue);
+        newValue = getValueOf(newValue);
 
         if (typeof newValue === 'object') {
           // objects/arrays are not supported - deep-watching them would be too expensive
@@ -1126,7 +1125,7 @@ function $ParseProvider() {
           var newInputValue = inputExpressions(scope);
           if (!expressionInputDirtyCheck(newInputValue, oldInputValue)) {
             lastResult = parsedExpression(scope);
-            oldInputValue = newInputValue && valueOfAgnostic(newInputValue);
+            oldInputValue = newInputValue && getValueOf(newInputValue);
           }
           return lastResult;
         }, listener, objectEquality);
@@ -1143,7 +1142,7 @@ function $ParseProvider() {
         for (var i = 0, ii = inputExpressions.length; i < ii; i++) {
           var newInputValue = inputExpressions[i](scope);
           if (changed || (changed = !expressionInputDirtyCheck(newInputValue, oldInputValueOfValues[i]))) {
-            oldInputValueOfValues[i] = newInputValue && valueOfAgnostic(newInputValue);
+            oldInputValueOfValues[i] = newInputValue && getValueOf(newInputValue);
           }
         }
 

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -946,10 +946,10 @@ function getterFn(path, options, fullExp) {
   return fn;
 }
 
-var objectValueOf = Object.prototype.valueOf.call;
+var objectValueOf = Object.prototype.valueOf;
 
 function getValueOf(value) {
-  return isFunction(value.valueOf) ? value.valueOf() : objectValueOf(value);
+  return isFunction(value.valueOf) ? value.valueOf() : objectValueOf.call(value);
 }
 
 ///////////////////////////////////

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1460,7 +1460,7 @@ describe('parser', function() {
           expect(watcherCalls).toBe(1);
         }));
 
-        it("should always reevaluate filters with non-primitive input created with Object.create(null)",
+        it("should always reevaluate filters with non-primitive input created with null prototype",
             inject(function($parse) {
           var filterCalls = 0;
           $filterProvider.register('foo', valueFn(function(input) {

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1460,6 +1460,32 @@ describe('parser', function() {
           expect(watcherCalls).toBe(1);
         }));
 
+        it("should always reevaluate filters with non-primitive input created with Object.create(null)",
+            inject(function($parse) {
+          var filterCalls = 0;
+          $filterProvider.register('foo', valueFn(function(input) {
+            filterCalls++;
+            return input;
+          }));
+
+          var parsed = $parse('obj | foo');
+          var obj = scope.obj = Object.create(null);
+
+          var watcherCalls = 0;
+          scope.$watch(parsed, function(input) {
+            expect(input).toBe(obj);
+            watcherCalls++;
+          });
+
+          scope.$digest();
+          expect(filterCalls).toBe(2);
+          expect(watcherCalls).toBe(1);
+
+          scope.$digest();
+          expect(filterCalls).toBe(3);
+          expect(watcherCalls).toBe(1);
+        }));
+
         it("should not reevaluate filters with non-primitive input that does support valueOf()",
             inject(function($parse) {
           var filterCalls = 0;


### PR DESCRIPTION
With this changes, objects initially created with Object.create(null) can be bind to the view. This is because if the valueOf function is not available, it will use Object.valueOf.apply instead
