### PR TITLE
fix($parse): stabilize one-time literal expressions correctly

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1168,16 +1168,17 @@ function $ParseProvider() {
     }
 
     function oneTimeLiteralWatchDelegate(scope, listener, objectEquality, parsedExpression) {
-      var unwatch;
+      var unwatch, lastValue;
       return unwatch = scope.$watch(function oneTimeWatch(scope) {
         return parsedExpression(scope);
       }, function oneTimeListener(value, old, scope) {
+        lastValue = value;
         if (isFunction(listener)) {
           listener.call(this, value, old, scope);
         }
         if (isAllDefined(value)) {
           scope.$$postDigest(function () {
-            if(isAllDefined(value)) unwatch();
+            if(isAllDefined(lastValue)) unwatch();
           });
         }
       }, objectEquality);

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1301,6 +1301,28 @@ describe('parser', function() {
             expect($rootScope.$$watchers.length).toBe(0);
             expect(log.empty()).toEqual([]);
           }));
+
+          it('should only become stable when all the elements of an array have defined values at the end of a $digest', inject(function($parse, $rootScope, log) {
+            var fn = $parse('::[foo]');
+            $rootScope.$watch(fn, function(value) { log(value); }, true);
+            $rootScope.$watch('foo', function() { if ($rootScope.foo === 'bar') {$rootScope.foo = undefined; } });
+
+            $rootScope.foo = 'bar';
+            $rootScope.$digest();
+            expect($rootScope.$$watchers.length).toBe(2);
+            expect(log.empty()).toEqual([['bar'], [undefined]]);
+
+            $rootScope.foo = 'baz';
+            $rootScope.$digest();
+            expect($rootScope.$$watchers.length).toBe(1);
+            expect(log.empty()).toEqual([['baz']]);
+
+            $rootScope.bar = 'qux';
+            $rootScope.$digest();
+            expect($rootScope.$$watchers.length).toBe(1);
+            expect(log).toEqual([]);
+          }));
+
         });
       });
 


### PR DESCRIPTION
Change `oneTimeLiteralWatchDelegate` (introduced in c024f28) so that it implements the stabilization algorithm described in the expression docs, like `oneTimeWatchDelegate` does.

At the end of the digest, the delegate must look at the _last_ value seen by the expression. Otherwise the expression becomes stable even when the array/object members go back to `undefined` during the digest.
