### PR TITLE
chore($$raf) Remove support for moz prefixed requestAnimationFrame

### DIFF
--- a/src/ng/raf.js
+++ b/src/ng/raf.js
@@ -3,12 +3,10 @@
 function $$RAFProvider() { //rAF
   this.$get = ['$window', '$timeout', function($window, $timeout) {
     var requestAnimationFrame = $window.requestAnimationFrame ||
-                                $window.webkitRequestAnimationFrame ||
-                                $window.mozRequestAnimationFrame;
+                                $window.webkitRequestAnimationFrame;
 
     var cancelAnimationFrame = $window.cancelAnimationFrame ||
                                $window.webkitCancelAnimationFrame ||
-                               $window.mozCancelAnimationFrame ||
                                $window.webkitCancelRequestAnimationFrame;
 
     var rafSupported = !!requestAnimationFrame;


### PR DESCRIPTION
According to [can I use](http://caniuse.com/#feat=requestanimationframe) this would drop support for the following browsers:
- Firefox 22
- Chrome 23
- Safari 6
- iOS 6.1

Note, they don't have data on Blackberry 10.1 (where it's prefixed) and 10.2 (where it's unprefixed).

This is also the same level of support as provided by [jQuery](https://github.com/jquery/jquery/blob/10399ddcf8a239acc27bdec9231b996b178224d3/src/effects.js#L649).
