### PR TITLE
fix($browser): account for IE deserializing history.state on each read

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -850,9 +850,10 @@ function $LocationProvider(){
       var oldUrl = $browser.url();
       var oldState = $browser.state();
       var currentReplace = $location.$$replace;
+      var urlOrStateChanged = oldUrl !== $location.absUrl() ||
+        ($location.$$html5 && $sniffer.history && oldState !== $location.$$state);
 
-      if (initializing || oldUrl !== $location.absUrl() ||
-          ($location.$$html5 && $sniffer.history && oldState !== $location.$$state)) {
+      if (initializing || urlOrStateChanged) {
         initializing = false;
 
         $rootScope.$evalAsync(function() {
@@ -861,8 +862,10 @@ function $LocationProvider(){
             $location.$$parse(oldUrl);
             $location.$$state = oldState;
           } else {
-            setBrowserUrlWithFallback($location.absUrl(), currentReplace,
-                                      oldState === $location.$$state ? null : $location.$$state);
+            if (urlOrStateChanged) {
+              setBrowserUrlWithFallback($location.absUrl(), currentReplace,
+                                        oldState === $location.$$state ? null : $location.$$state);
+            }
             afterLocationChange(oldUrl, oldState);
           }
         });


### PR DESCRIPTION
fix($browser): account for IE deserializing history.state on each read

IE 10-11+ deserialize history.state on every read, causing simple comparisons
against history.state always return false. Account for that caching
`history.state` on every hashchange or popstate event.

Also:
1. Prevent firing onUrlChange callbacks twice if both popstate and hashchange
event were fired.
2. Fix the issue of routes sometimes not firing the URL change in all browsers.

Closes #9587
Fixes #9545
