### PR TITLE
test(currencyFilter): fix disambiguous locator warning in e2e tests

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -27,15 +27,15 @@
        <div ng-controller="ExampleController">
          <input type="number" ng-model="amount"> <br>
          default currency symbol ($): <span id="currency-default">{{amount | currency}}</span><br>
-         custom currency identifier (USD$): <span>{{amount | currency:"USD$"}}</span>
-         no fractions (0): <span>{{amount | currency:"USD$":0}}</span>
+         custom currency identifier (USD$): <span id="currency-custom">{{amount | currency:"USD$"}}</span>
+         no fractions (0): <span id="currency-no-fractions">{{amount | currency:"USD$":0}}</span>
        </div>
      </file>
      <file name="protractor.js" type="protractor">
        it('should init with 1234.56', function() {
          expect(element(by.id('currency-default')).getText()).toBe('$1,234.56');
-         expect(element(by.binding('amount | currency:"USD$"')).getText()).toBe('USD$1,234.56');
-         expect(element(by.binding('amount | currency:"USD$":0')).getText()).toBe('USD$1,235');
+         expect(element(by.id('currency-custom')).getText()).toBe('USD$1,234.56');
+         expect(element(by.id('currency-no-fractions')).getText()).toBe('USD$1,235');
        });
        it('should update', function() {
          if (browser.params.browser == 'safari') {
@@ -46,8 +46,8 @@
          element(by.model('amount')).clear();
          element(by.model('amount')).sendKeys('-1234');
          expect(element(by.id('currency-default')).getText()).toBe('($1,234.00)');
-         expect(element(by.binding('amount | currency:"USD$"')).getText()).toBe('(USD$1,234.00)');
-         expect(element(by.binding('amount | currency:"USD$":0')).getText()).toBe('(USD$1,234)');
+         expect(element(by.id('currency-custom')).getText()).toBe('(USD$1,234.00)');
+         expect(element(by.id('currency-no-fractions')).getText()).toBe('(USD$1,234)');
        });
      </file>
    </example>


### PR DESCRIPTION
The e2e tests for the `currencyFilter` issued the following warnings:

> warning: more than one element found for locator by.binding("amount | currency:"USD$"")

This commit removes the warnings by locating the elements by ID and not by binding.
