### PR TITLE
fix(testability): findBindings should escape binding expressions before ...

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -54,6 +54,7 @@
     "isBoolean": false,
     "isPromiseLike": false,
     "trim": false,
+    "escapeForRegexp": true,
     "isElement": false,
     "makeMap": false,
     "size": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -49,6 +49,7 @@
   isBoolean: true,
   isPromiseLike: true,
   trim: true,
+  escapeForRegexp: true,
   isElement: true,
   makeMap: true,
   size: true,
@@ -584,6 +585,14 @@ function isPromiseLike(obj) {
 
 var trim = function(value) {
   return isString(value) ? value.trim() : value;
+};
+
+// Copied from:
+// http://docs.closure-library.googlecode.com/git/local_closure_goog_string_string.js.source.html#line1021
+// Prereq: s is a string.
+var escapeForRegexp = function(s) {
+  return s.replace(/([-()\[\]{}+?*.$\^|,:#<!\\])/g, '\\$1').
+           replace(/\x08/g, '\\x08');
 };
 
 

--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -14,15 +14,6 @@ var SCE_CONTEXTS = {
 
 // Helper functions follow.
 
-// Copied from:
-// http://docs.closure-library.googlecode.com/git/closure_goog_string_string.js.source.html#line962
-// Prereq: s is a string.
-function escapeForRegexp(s) {
-  return s.replace(/([-()\[\]{}+?*.$\^|,:#<!\\])/g, '\\$1').
-           replace(/\x08/g, '\\x08');
-}
-
-
 function adjustMatcher(matcher) {
   if (matcher === 'self') {
     return matcher;

--- a/src/ng/testability.js
+++ b/src/ng/testability.js
@@ -34,7 +34,7 @@ function $$TestabilityProvider() {
         if (dataBinding) {
           forEach(dataBinding, function(bindingName) {
             if (opt_exactMatch) {
-              var matcher = new RegExp('(^|\\s)' + expression + '(\\s|\\||$)');
+              var matcher = new RegExp('(^|\\s)' + escapeForRegexp(expression) + '(\\s|\\||$)');
               if (matcher.test(bindingName)) {
                 matches.push(binding);
               }

--- a/test/ng/testabilitySpec.js
+++ b/test/ng/testabilitySpec.js
@@ -88,6 +88,23 @@ describe('$$testability', function() {
       expect(names[0]).toBe(element.find('li')[0]);
     });
 
+    it('should find bindings with allowed special characters', function() {
+      element =
+          '<div>' +
+          '  <span>{{$index}}</span>' +
+          '  <span>{{foo.bar}}</span>' +
+          '  <span>{{foonbar}}</span>' +
+          '</div>';
+      element = $compile(element)(scope);
+      var indexes = $$testability.findBindings(element[0], '$index', true);
+      expect(indexes.length).toBe(1);
+      expect(indexes[0]).toBe(element.find('span')[0]);
+
+      var foobars = $$testability.findBindings(element[0], 'foo.bar', true);
+      expect(foobars.length).toBe(1); // it should not match {{foonbar}}
+      expect(foobars[0]).toBe(element.find('span')[1]);
+    });
+
     it('should find partial models', function() {
       element =
           '<div>' +


### PR DESCRIPTION
...performing regexp

Move the function to escape regexps to Angular.js, fix the link, and use it in
the $$testability service.

See #9595
