### PR TITLE
fix(inputs): improve "input" event emulation for legacy browsers

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -994,14 +994,25 @@ function baseInputType(scope, element, attr, ctrl, $sniffer, $browser) {
       }
     };
 
+    element.on('keypress', function(event) {
+      var key = event.keyCode,
+          multiline = event.target.nodeName.toLowerCase() === 'textarea';
+
+      // ignore
+      //    escape          enter
+      if (key === 27 || (key === 13 && !multiline)) return;
+
+      deferListener(event);
+    });
+
     element.on('keydown', function(event) {
       var key = event.keyCode;
 
-      // ignore
-      //    command            modifiers                   arrows
-      if (key === 91 || (15 < key && key < 19) || (37 <= key && key <= 40)) return;
-
-      deferListener(event);
+      // only fire listener for a few extra keys not captured by "keypress"
+      //  backspace      delete
+      if (key === 8 || key === 46) {
+        deferListener(event);
+      }
     });
 
     // if user modifies input value using context menu in IE, we need "paste" and "cut" events to catch it

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -70,8 +70,8 @@ function $SnifferProvider() {
         if (event == 'input' && msie == 9) return false;
 
         if (isUndefined(eventSupport[event])) {
-          var divElm = document.createElement('div');
-          eventSupport[event] = 'on' + event in divElm;
+          var elm = document.createElement('input');
+          eventSupport[event] = 'on' + event in elm;
         }
 
         return eventSupport[event];

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1495,7 +1495,7 @@ describe('input', function() {
     }
   });
 
-  describe('"paste" and "cut" events', function() {
+  describe('legacy events', function() {
     beforeEach(function() {
       // Force browser to report a lack of an 'input' event
       $sniffer.hasEvent = function(eventName) {
@@ -1521,8 +1521,23 @@ describe('input', function() {
       expect(scope.name).toEqual('john');
     });
 
-  });
+    it('should update the model on "keypress" event', function() {
+      compileInput('<input type="text" ng-model="name" name="alias" ng-change="change()" />');
 
+      inputElm.val('cassius');
+      browserTrigger(inputElm, 'keypress');
+      $browser.defer.flush();
+      expect(scope.name).toEqual('cassius');
+    });
+
+    it('should not dirty the model on "keydown" event', function() {
+      compileInput('<input type="text" ng-model="name" name="alias" ng-change="change()" />');
+
+      browserTrigger(inputElm, 'keydown');
+      $browser.defer.flush();
+      expect(inputElm).toBePristine();
+    });
+  });
 
   it('should update the model and trim the value', function() {
     compileInput('<input type="text" ng-model="name" name="alias" ng-change="change()" />');

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -25,12 +25,12 @@ describe('$sniffer', function() {
 
 
   describe('hasEvent', function() {
-    var mockDocument, mockDivElement, $sniffer;
+    var mockDocument, mockElement, $sniffer;
 
     beforeEach(function() {
       mockDocument = {createElement: jasmine.createSpy('createElement')};
       mockDocument.createElement.andCallFake(function(elm) {
-        if (elm === 'div') return mockDivElement;
+        if (elm === 'input') return mockElement;
       });
 
       $sniffer = sniffer({}, mockDocument);
@@ -38,21 +38,21 @@ describe('$sniffer', function() {
 
 
     it('should return true if "onchange" is present in a div element', function() {
-      mockDivElement = {onchange: noop};
+      mockElement = {onchange: noop};
 
       expect($sniffer.hasEvent('change')).toBe(true);
     });
 
 
     it('should return false if "oninput" is not present in a div element', function() {
-      mockDivElement = {};
+      mockElement = {};
 
       expect($sniffer.hasEvent('input')).toBe(false);
     });
 
 
     it('should only create the element once', function() {
-      mockDivElement = {};
+      mockElement = {};
 
       $sniffer.hasEvent('change');
       $sniffer.hasEvent('change');
@@ -64,7 +64,7 @@ describe('$sniffer', function() {
 
     it('should claim that IE9 doesn\'t have support for "oninput"', function() {
       // IE9 implementation is fubared, so it's better to pretend that it doesn't have the support
-      mockDivElement = {oninput: noop};
+      mockElement = {oninput: noop};
 
       expect($sniffer.hasEvent('input')).toBe((msie == 9) ? false : true);
     });


### PR DESCRIPTION
Hello,

In IE versions that use the keydown handler to check for changes to an input, there is a bug when pressing the tab key that will update the input after the change and blur events.

This PR fixes this behavior ~~by cancelling the keydown handler, and updating immediately on change/blur~~.

See a demo of the bug here (only affects IE8/IE9): http://codepen.io/cvn/full/lvjJr/

Here is a fixed demo with the changes from this PR applied to angular.js: http://codepen.io/cvn/full/cgLns/

Currently, this bug only impacts IE8 & 9, but if PR https://github.com/angular/angular.js/pull/9265 lands, it will affect all versions of IE.

Issue https://github.com/angular/angular.js/issues/1206 may be related, but I'm not sure about this.

I'm submitting this PR to master, but I think it makes sense to include in both 1.2 and 1.3 branches.

Please let me know what you think.
