### PR TITLE
fix(loader): fix double spaces

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -296,7 +296,7 @@ function setupModuleLoader(window) {
           config(configFn);
         }
 
-        return  moduleInstance;
+        return moduleInstance;
 
         /**
          * @param {string} provider


### PR DESCRIPTION
Fix double spaces in return statement. Double spaces between return and
returned value brake minification process of some minifiers (bug found on JSMin
https://github.com/mrclay/jsmin-php).
