### PR TITLE
docs(ngEventDirs): update remarks on behavior

### DIFF
--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -33,10 +33,8 @@
    </example>
  */
 /*
- * A directive that allows creation of custom onclick handlers that are defined as angular
- * expressions and are compiled and executed within the current scope.
- *
- * Events that are handled via these handler are always configured not to propagate further.
+ * A collection of directives that allows creation of custom event handlers that are defined as
+ * angular expressions and are compiled and executed within the current scope.
  */
 var ngEventDirectives = {};
 


### PR DESCRIPTION
This comment states that events are configured not to propagate, but that hasn't been the case since 1752c8c4, over 2.5 years ago(!). This is a minor tweak to the block, also removing the part that's too specific to `onclick`.
