### PR TITLE
fix($http): Prevent calling undefined in defaultHttpResponseTransform

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -119,7 +119,7 @@ function $HttpProvider() {
       if (isString(data)) {
         // strip json vulnerability protection prefix
         data = data.replace(PROTECTION_PREFIX, '');
-        var contentType = headers('Content-Type');
+        var contentType = isFunction(headers) && headers('Content-Type');
         if ((contentType && contentType.indexOf(APPLICATION_JSON) === 0) ||
             (JSON_START.test(data) && JSON_END.test(data))) {
           data = fromJson(data);


### PR DESCRIPTION
The `defaultHttpResponseTransform` accepts a second parameter, `headers`, which when not passed it throws `TypeError: undefined is not a function`.
