### PR TITLE
fix($sce): do not assume $document[0] exists

### DIFF
--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -722,7 +722,7 @@ function $SceProvider() {
                 $document,   $parse,   $sceDelegate) {
     // Prereq: Ensure that we're not running in IE<11 quirks mode.  In that mode, IE < 11 allow
     // the "expression(javascript expression)" syntax which is insecure.
-    if (enabled && $document[0].documentMode < 8) {
+    if (enabled && msie < 8) {
       throw $sceMinErr('iequirks',
         'Strict Contextual Escaping does not support Internet Explorer version < 11 in quirks ' +
         'mode.  You can fix this by adding the text <!doctype html> to the top of your HTML ' +

--- a/src/ngScenario/browserTrigger.js
+++ b/src/ngScenario/browserTrigger.js
@@ -2,12 +2,6 @@
 
 (function() {
   /**
-   * documentMode is an IE-only property
-   * http://msdn.microsoft.com/en-us/library/ie/cc196988(v=vs.85).aspx
-   */
-  var msie = document.documentMode;
-
-  /**
    * Triggers a browser event. Attempts to choose the right event if one is
    * not specified.
    *

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1249,21 +1249,6 @@ describe('angular', function() {
     });
   });
 
-  describe('msie UA parsing', function() {
-    if (/ Trident\/.*; rv:/.test(window.navigator.userAgent)) {
-      it('should fail when the Trident and the rv versions disagree for IE11+', function() {
-        // When this test fails, we can think about whether we want to use the version from the
-        // Trident token in the UA string or stick with the version from rv: as we currently do.
-        // Refer https://github.com/angular/angular.js/pull/3758#issuecomment-23529245 for the
-        // discussion.
-        var UA = window.navigator.userAgent;
-        var tridentVersion = parseInt((/Trident\/(\d+)/.exec(UA) || [])[1], 10) + 4;
-        var rvVersion = parseInt((/Trident\/.*; rv:(\d+)/.exec(UA) || [])[1], 10);
-        expect(tridentVersion).toBe(rvVersion);
-      });
-    }
-  });
-
   describe('isElement', function() {
     it('should return a boolean value', inject(function($compile, $document, $rootScope) {
       var element = $compile('<p>Hello, world!</p>')($rootScope),

--- a/test/ng/sceSpecs.js
+++ b/test/ng/sceSpecs.js
@@ -27,11 +27,20 @@ describe('SCE', function() {
   });
 
   describe('IE<11 quirks mode', function() {
+    /* global msie: true */
+    var msieBackup;
+
+    beforeEach(function() {
+      msieBackup = msie;
+    });
+
+    afterEach(function() {
+      msie = msieBackup;
+    });
+
     function runTest(enabled, documentMode, expectException) {
+      msie = documentMode;
       module(function($provide) {
-        $provide.value('$document', [{
-          documentMode: documentMode
-        }]);
         $provide.value('$sceDelegate', {trustAs: null, valueOf: null, getTrusted: null});
       });
 

--- a/test/ng/windowSpec.js
+++ b/test/ng/windowSpec.js
@@ -4,4 +4,9 @@ describe('$window', function() {
   it("should inject $window", inject(function($window) {
     expect($window).toBe(window);
   }));
+
+  it('should be able to mock $window without errors', function() {
+    module({$window: {}});
+    inject(['$sce', angular.noop]);
+  });
 });


### PR DESCRIPTION
this is important so that people can mock $window without having to add stuff that angular uses internally into it

Closes #9661
