### PR TITLE
Make templates consistent

### DIFF
--- a/docs/content/tutorial/step_02.ngdoc
+++ b/docs/content/tutorial/step_02.ngdoc
@@ -40,7 +40,7 @@ __`app/index.html`:__
 
   <ul>
     <li ng-repeat="phone in phones">
-      {{phone.name}}
+      <span>{{phone.name}}</span>
       <p>{{phone.snippet}}</p>
     </li>
   </ul>


### PR DESCRIPTION
In Lession 1 template has phone names within `span` element, while in lession 2 the name is directly within the wrapper `div`
