### PR TITLE
refactor($sce): don't depend on $document

### DIFF
--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -718,8 +718,8 @@ function $SceProvider() {
    * sce.js and sceSpecs.js would need to be aware of this detail.
    */
 
-  this.$get = ['$document', '$parse', '$sceDelegate', function(
-                $document,   $parse,   $sceDelegate) {
+  this.$get = ['$parse', '$sceDelegate', function(
+                $parse,   $sceDelegate) {
     // Prereq: Ensure that we're not running in IE<11 quirks mode.  In that mode, IE < 11 allow
     // the "expression(javascript expression)" syntax which is insecure.
     if (enabled && msie < 8) {


### PR DESCRIPTION
The $sce dependency on $document was added in 64241a5 because it was thought
it's not possible to easiy use the msie variable in this module. This was
changed in 45252c3, though so it's no longer needed to depend on $document.
