### PR TITLE
docs(angular.extend): explanation of deep copy.

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -340,6 +340,7 @@ function setHashKey(obj, h) {
  * Extends the destination object `dst` by copying own enumerable properties from the `src` object(s)
  * to `dst`. You can specify multiple `src` objects. If you want to preserve original objects, you can do so
  * by passing an empty object as the target: `var object = angular.extend({}, object1, object2)`.
+ * Note: Keep in mind that `angular.extend` does not support recursive merge (deep copy).
  *
  * @param {Object} dst Destination object.
  * @param {...Object} src Source object(s).


### PR DESCRIPTION
It is very common to see many developers confused about it.
