### PR TITLE
style: enforce spaces after keywords, add spaces

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -2,5 +2,6 @@
   "disallowKeywords": ["with"],
   "disallowTrailingWhitespace": true,
   "disallowSpaceAfterPrefixUnaryOperators": ["!"],
-  "disallowSpaceBeforeBinaryOperators": [","]
+  "disallowSpaceBeforeBinaryOperators": [","],
+  "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "try", "catch"]
 }

--- a/.jscs.json.todo
+++ b/.jscs.json.todo
@@ -5,7 +5,6 @@
 
 {
   "requireCurlyBraces": ["if", "else", "for", "while", "do", "try", "catch"],
-  "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "try", "catch"],
   "requireSpaceAfterBinaryOperators": ["?", ":", "+", "-", "/", "*", "%", "==", "===", "!=", "!==", ">", ">=", "<", "<=", "&&", "||"],
   "requireSpaceBeforeBinaryOperators": ["?", ":", "+", "-", "/", "*", "%", "==", "===", "!=", "!==", ">", ">=", "<", "<=", "&&", "||"],
   "disallowImplicitTypeConversion": ["string"],

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -801,7 +801,7 @@ function copy(source, destination, stackSource, stackDest) {
         });
       }
       for ( var key in source) {
-        if(source.hasOwnProperty(key)) {
+        if (source.hasOwnProperty(key)) {
           result = copy(source[key], null, stackSource, stackDest);
           if (isObject(source[key])) {
             stackSource.push(source[key]);
@@ -882,7 +882,7 @@ function equals(o1, o2) {
       if (isArray(o1)) {
         if (!isArray(o2)) return false;
         if ((length = o1.length) == o2.length) {
-          for(key=0; key<length; key++) {
+          for (key=0; key<length; key++) {
             if (!equals(o1[key], o2[key])) return false;
           }
           return true;
@@ -895,12 +895,12 @@ function equals(o1, o2) {
       } else {
         if (isScope(o1) || isScope(o2) || isWindow(o1) || isWindow(o2) || isArray(o2)) return false;
         keySet = {};
-        for(key in o1) {
+        for (key in o1) {
           if (key.charAt(0) === '$' || isFunction(o1[key])) continue;
           if (!equals(o1[key], o2[key])) return false;
           keySet[key] = true;
         }
-        for(key in o2) {
+        for (key in o2) {
           if (!keySet.hasOwnProperty(key) &&
               key.charAt(0) !== '$' &&
               o2[key] !== undefined &&
@@ -1048,14 +1048,14 @@ function startingTag(element) {
     // turns out IE does not let you set .html() on elements which
     // are not allowed to have children. So we just ignore it.
     element.empty();
-  } catch(e) {}
+  } catch (e) {}
   var elemHtml = jqLite('<div>').append(element).html();
   try {
     return element[0].nodeType === NODE_TYPE_TEXT ? lowercase(elemHtml) :
         elemHtml.
           match(/^(<[^>]+>)/)[1].
           replace(/^<([\w\-]+)/, function(match, nodeName) { return '<' + lowercase(nodeName); });
-  } catch(e) {
+  } catch (e) {
     return lowercase(elemHtml);
   }
 
@@ -1075,7 +1075,7 @@ function startingTag(element) {
 function tryDecodeURIComponent(value) {
   try {
     return decodeURIComponent(value);
-  } catch(e) {
+  } catch (e) {
     // Ignore any invalid uri component
   }
 }
@@ -1095,7 +1095,7 @@ function parseKeyValue(/**string*/keyValue) {
         var val = isDefined(key_value[1]) ? tryDecodeURIComponent(key_value[1]) : true;
         if (!hasOwnProperty.call(obj, key)) {
           obj[key] = val;
-        } else if(isArray(obj[key])) {
+        } else if (isArray(obj[key])) {
           obj[key].push(val);
         } else {
           obj[key] = [obj[key],val];

--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -713,7 +713,7 @@ function createInjector(modulesToLoad, strictDi) {
 
       function runInvokeQueue(queue) {
         var i, ii;
-        for(i = 0, ii = queue.length; i < ii; i++) {
+        for (i = 0, ii = queue.length; i < ii; i++) {
           var invokeArgs = queue[i],
               provider = providerInjector.get(invokeArgs[0]);
 
@@ -793,7 +793,7 @@ function createInjector(modulesToLoad, strictDi) {
           length, i,
           key;
 
-      for(i = 0, length = $inject.length; i < length; i++) {
+      for (i = 0, length = $inject.length; i < length; i++) {
         key = $inject[i];
         if (typeof key !== 'string') {
           throw $injectorMinErr('itkn',

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -423,7 +423,7 @@ function jqLiteController(element, name) {
 function jqLiteInheritedData(element, name, value) {
   // if element is the document object work with the html element instead
   // this makes $(document).scope() possible
-  if(element.nodeType == NODE_TYPE_DOCUMENT) {
+  if (element.nodeType == NODE_TYPE_DOCUMENT) {
     element = element.documentElement;
   }
   var names = isArray(name) ? name : [name];
@@ -983,7 +983,7 @@ forEach({
   JQLite.prototype[name] = function(arg1, arg2, arg3) {
     var value;
 
-    for(var i = 0, ii = this.length; i < ii; i++) {
+    for (var i = 0, ii = this.length; i < ii; i++) {
       if (isUndefined(value)) {
         value = fn(this[i], arg1, arg2, arg3);
         if (isDefined(value)) {

--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -75,7 +75,7 @@ var $AnimateProvider = ['$provide', function($provide) {
    * @return {RegExp} The current CSS className expression value. If null then there is no expression value
    */
   this.classNameFilter = function(expression) {
-    if(arguments.length === 1) {
+    if (arguments.length === 1) {
       this.$$classNameFilter = (expression instanceof RegExp) ? expression : null;
     }
     return this.$$classNameFilter;

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -51,7 +51,7 @@ function Browser(window, document, $log, $sniffer) {
     } finally {
       outstandingRequestCount--;
       if (outstandingRequestCount === 0) {
-        while(outstandingRequestCallbacks.length) {
+        while (outstandingRequestCallbacks.length) {
           try {
             outstandingRequestCallbacks.pop()();
           } catch (e) {

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -854,7 +854,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    */
   var debugInfoEnabled = true;
   this.debugInfoEnabled = function(enabled) {
-    if(isDefined(enabled)) {
+    if (isDefined(enabled)) {
       debugInfoEnabled = enabled;
       return this;
     }
@@ -899,7 +899,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
        * @param {string} classVal The className value that will be added to the element
        */
       $addClass : function(classVal) {
-        if(classVal && classVal.length > 0) {
+        if (classVal && classVal.length > 0) {
           $animate.addClass(this.$$element, classVal);
         }
       },
@@ -916,7 +916,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
        * @param {string} classVal The className value that will be removed from the element
        */
       $removeClass : function(classVal) {
-        if(classVal && classVal.length > 0) {
+        if (classVal && classVal.length > 0) {
           $animate.removeClass(this.$$element, classVal);
         }
       },
@@ -969,7 +969,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         if (booleanKey) {
           this.$$element.prop(key, value);
           attrName = booleanKey;
-        } else if(aliasedKey) {
+        } else if (aliasedKey) {
           this[aliasedKey] = value;
           observer = aliasedKey;
         }
@@ -1022,7 +1022,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           result += $$sanitizeUri(trim(lastTuple[0]), true);
 
           // and add the last descriptor if any
-          if( lastTuple.length === 2) {
+          if (lastTuple.length === 2) {
             result += (" " + trim(lastTuple[1]));
           }
           this[key] = value = result;
@@ -1089,7 +1089,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     function safeAddClass($element, className) {
       try {
         $element.addClass(className);
-      } catch(e) {
+      } catch (e) {
         // ignore, since it means that we are trying to set class on
         // SVG element, where class name is read-only.
       }
@@ -1278,7 +1278,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           stableNodeList = nodeList;
         }
 
-        for(i = 0, ii = linkFns.length; i < ii;) {
+        for (i = 0, ii = linkFns.length; i < ii;) {
           node = stableNodeList[linkFns[i++]];
           nodeLinkFn = linkFns[i++];
           childLinkFn = linkFns[i++];
@@ -1346,7 +1346,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           match,
           className;
 
-      switch(nodeType) {
+      switch (nodeType) {
         case NODE_TYPE_ELEMENT: /* Element */
           // use the node name: <directive>
           addDirective(directives,
@@ -1522,7 +1522,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           directiveValue;
 
       // executes all directives on the current element
-      for(var i = 0, ii = directives.length; i < ii; i++) {
+      for (var i = 0, ii = directives.length; i < ii; i++) {
         directive = directives[i];
         var attrStart = directive.$$start;
         var attrEnd = directive.$$end;
@@ -1855,7 +1855,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                   isolateBindingContext[scopeName] = value;
                 });
                 attrs.$$observers[attrName].$$scope = scope;
-                if( attrs[attrName] ) {
+                if ( attrs[attrName] ) {
                   // If the attribute has been provided then we trigger an interpolation to ensure
                   // the value is there for use in the link fn
                   isolateBindingContext[scopeName] = $interpolate(attrs[attrName])(scope);
@@ -1915,7 +1915,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         }
 
         // PRELINKING
-        for(i = 0, ii = preLinkFns.length; i < ii; i++) {
+        for (i = 0, ii = preLinkFns.length; i < ii; i++) {
           linkFn = preLinkFns[i];
           invokeLinkFn(linkFn,
               linkFn.isolateScope ? isolateScope : scope,
@@ -1936,7 +1936,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         childLinkFn && childLinkFn(scopeToChild, linkNode.childNodes, undefined, boundTranscludeFn);
 
         // POSTLINKING
-        for(i = postLinkFns.length - 1; i >= 0; i--) {
+        for (i = postLinkFns.length - 1; i >= 0; i--) {
           linkFn = postLinkFns[i];
           invokeLinkFn(linkFn,
               linkFn.isolateScope ? isolateScope : scope,
@@ -1996,7 +1996,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       if (name === ignoreDirective) return null;
       var match = null;
       if (hasDirectives.hasOwnProperty(name)) {
-        for(var directive, directives = $injector.get(name + Suffix),
+        for (var directive, directives = $injector.get(name + Suffix),
             i = 0, ii = directives.length; i<ii; i++) {
           try {
             directive = directives[i];
@@ -2008,7 +2008,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               tDirectives.push(directive);
               match = directive;
             }
-          } catch(e) { $exceptionHandler(e); }
+          } catch (e) { $exceptionHandler(e); }
         }
       }
       return match;
@@ -2025,7 +2025,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
      */
     function directiveIsMultiElement(name) {
       if (hasDirectives.hasOwnProperty(name)) {
-        for(var directive, directives = $injector.get(name + Suffix),
+        for (var directive, directives = $injector.get(name + Suffix),
             i = 0, ii = directives.length; i<ii; i++) {
           directive = directives[i];
           if (directive.multiElement) {
@@ -2142,7 +2142,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           });
           afterTemplateChildLinkFn = compileNodes($compileNode[0].childNodes, childTranscludeFn);
 
-          while(linkQueue.length) {
+          while (linkQueue.length) {
             var scope = linkQueue.shift(),
                 beforeTemplateLinkNode = linkQueue.shift(),
                 linkRootElement = linkQueue.shift(),
@@ -2241,7 +2241,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
     function wrapTemplate(type, template) {
       type = lowercase(type || 'html');
-      switch(type) {
+      switch (type) {
       case 'svg':
       case 'math':
         var wrapper = document.createElement('div');
@@ -2322,7 +2322,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                     //skip animations when the first digest occurs (when
                     //both the new and the old values are the same) since
                     //the CSS classes are the non-interpolated values
-                    if(name === 'class' && newValue != oldValue) {
+                    if (name === 'class' && newValue != oldValue) {
                       attr.$updateClass(newValue, oldValue);
                     } else {
                       attr.$set(name, newValue);
@@ -2352,7 +2352,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           i, ii;
 
       if ($rootElement) {
-        for(i = 0, ii = $rootElement.length; i < ii; i++) {
+        for (i = 0, ii = $rootElement.length; i < ii; i++) {
           if ($rootElement[i] == firstElementToRemove) {
             $rootElement[i++] = newNode;
             for (var j = i, j2 = j + removeCount - 1,
@@ -2427,7 +2427,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     function invokeLinkFn(linkFn, scope, $element, attrs, controllers, transcludeFn) {
       try {
         linkFn(scope, $element, attrs, controllers, transcludeFn);
-      } catch(e) {
+      } catch (e) {
         $exceptionHandler(e, startingTag($element));
       }
     }
@@ -2516,10 +2516,10 @@ function tokenDifference(str1, str2) {
       tokens2 = str2.split(/\s+/);
 
   outer:
-  for(var i = 0; i < tokens1.length; i++) {
+  for (var i = 0; i < tokens1.length; i++) {
     var token = tokens1[i];
-    for(var j = 0; j < tokens2.length; j++) {
-      if(token == tokens2[j]) continue outer;
+    for (var j = 0; j < tokens2.length; j++) {
+      if (token == tokens2[j]) continue outer;
     }
     values += (values.length > 0 ? ' ' : '') + token;
   }

--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -82,7 +82,7 @@ function $ControllerProvider() {
         identifier = ident;
       }
 
-      if(isString(expression)) {
+      if (isString(expression)) {
         match = expression.match(CNTRL_REG),
         constructor = match[1],
         identifier = identifier || match[3];

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2107,7 +2107,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
     var parserValid = isUndefined(modelValue) ? undefined : true;
 
     if (parserValid) {
-      for(var i = 0; i < ctrl.$parsers.length; i++) {
+      for (var i = 0; i < ctrl.$parsers.length; i++) {
         modelValue = ctrl.$parsers[i](modelValue);
         if (isUndefined(modelValue)) {
           parserValid = false;
@@ -2148,7 +2148,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
     forEach(ctrl.$viewChangeListeners, function(listener) {
       try {
         listener();
-      } catch(e) {
+      } catch (e) {
         $exceptionHandler(e);
       }
     });
@@ -2251,7 +2251,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
           idx = formatters.length;
 
       var viewValue = modelValue;
-      while(idx--) {
+      while (idx--) {
         viewValue = formatters[idx](viewValue);
       }
       if (ctrl.$viewValue !== viewValue) {

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -85,10 +85,10 @@ function classDirective(name, selector) {
       var values = [];
 
       outer:
-      for(var i = 0; i < tokens1.length; i++) {
+      for (var i = 0; i < tokens1.length; i++) {
         var token = tokens1[i];
-        for(var j = 0; j < tokens2.length; j++) {
-          if(token == tokens2[j]) continue outer;
+        for (var j = 0; j < tokens2.length; j++) {
+          if (token == tokens2[j]) continue outer;
         }
         values.push(token);
       }

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -198,15 +198,15 @@ var ngIncludeDirective = ['$templateRequest', '$anchorScroll', '$animate', '$sce
             currentElement;
 
         var cleanupLastIncludeContent = function() {
-          if(previousElement) {
+          if (previousElement) {
             previousElement.remove();
             previousElement = null;
           }
-          if(currentScope) {
+          if (currentScope) {
             currentScope.$destroy();
             currentScope = null;
           }
-          if(currentElement) {
+          if (currentElement) {
             $animate.leave(currentElement).then(function() {
               previousElement = null;
             });

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -253,7 +253,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
           unknownOption = optionTemplate.clone();
 
       // find "null" option
-      for(var i = 0, children = element.children(), ii = children.length; i < ii; i++) {
+      for (var i = 0, children = element.children(), ii = children.length; i < ii; i++) {
         if (children[i].value === '') {
           emptyOption = nullOption = children.eq(i);
           break;
@@ -603,7 +603,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
             }
 
             lastElement = null;  // start at the beginning
-            for(index = 0, length = optionGroup.length; index < length; index++) {
+            for (index = 0, length = optionGroup.length; index < length; index++) {
               option = optionGroup[index];
               if ((existingOption = existingOptions[index+1])) {
                 // reuse elements
@@ -661,7 +661,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
             }
             // remove any excessive OPTIONs in a group
             index++; // increment since the existingOptions[0] is parent element not OPTION
-            while(existingOptions.length > index) {
+            while (existingOptions.length > index) {
               option = existingOptions.pop();
               updateLabelMap(labelMap, option.label, false);
               option.element.remove();
@@ -675,7 +675,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
             });
           }
           // remove any excessive OPTGROUPs from select
-          while(optionGroupsCache.length > groupIndex) {
+          while (optionGroupsCache.length > groupIndex) {
             optionGroupsCache.pop()[0].element.remove();
           }
         }

--- a/src/ng/filter.js
+++ b/src/ng/filter.js
@@ -105,7 +105,7 @@ function $FilterProvider($provide) {
    *    of the registered filter instances.
    */
   function register(name, factory) {
-    if(isObject(name)) {
+    if (isObject(name)) {
       var filters = {};
       forEach(name, function(filter, key) {
         filters[key] = register(key, filter);

--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -124,7 +124,7 @@ function filterFilter() {
 
     predicates.check = function(value, index) {
       for (var j = 0; j < predicates.length; j++) {
-        if(!predicates[j](value, index)) {
+        if (!predicates[j](value, index)) {
           return false;
         }
       }

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -202,7 +202,7 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
     }
 
     // format fraction part.
-    while(fraction.length < fractionSize) {
+    while (fraction.length < fractionSize) {
       fraction += '0';
     }
 
@@ -227,7 +227,7 @@ function padNumber(num, digits, trim) {
     num = -num;
   }
   num = '' + num;
-  while(num.length < digits) num = '0' + num;
+  while (num.length < digits) num = '0' + num;
   if (trim)
     num = num.substr(num.length - digits);
   return neg + num;
@@ -465,7 +465,7 @@ function dateFilter($locale) {
       return date;
     }
 
-    while(format) {
+    while (format) {
       match = DATE_FORMATS_SPLIT.exec(format);
       if (match) {
         parts = concat(parts, match, 1);

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -747,7 +747,7 @@ function $HttpProvider() {
         }
       });
 
-      while(chain.length) {
+      while (chain.length) {
         var thenFn = chain.shift();
         var rejectFn = chain.shift();
 
@@ -1093,7 +1093,7 @@ function $HttpProvider() {
                      encodeUriQuery(v));
         });
       });
-      if(parts.length > 0) {
+      if (parts.length > 0) {
         url += ((url.indexOf('?') == -1) ? '?' : '&') + parts.join('&');
       }
       return url;

--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -194,7 +194,7 @@ function $InterpolateProvider() {
           concat = [],
           expressionPositions = [];
 
-      while(index < textLength) {
+      while (index < textLength) {
         if ( ((startIndex = text.indexOf(startSymbol, index)) != -1) &&
              ((endIndex = text.indexOf(endSymbol, startIndex + startSymbolLength)) != -1) ) {
           if (index !== startIndex) {
@@ -230,7 +230,7 @@ function $InterpolateProvider() {
 
       if (!mustHaveExpression || expressions.length) {
         var compute = function(values) {
-          for(var i = 0, ii = expressions.length; i < ii; i++) {
+          for (var i = 0, ii = expressions.length; i < ii; i++) {
             if (allOrNothing && isUndefined(values[i])) return;
             concat[expressionPositions[i]] = values[i];
           }
@@ -271,7 +271,7 @@ function $InterpolateProvider() {
               }
 
               return compute(values);
-            } catch(err) {
+            } catch (err) {
               var newErr = $interpolateMinErr('interr', "Can't interpolate: {0}\n{1}", text,
                   err.toString());
               $exceptionHandler(newErr);
@@ -302,7 +302,7 @@ function $InterpolateProvider() {
       function parseStringifyInterceptor(value) {
         try {
           return stringify(getValue(value));
-        } catch(err) {
+        } catch (err) {
           var newErr = $interpolateMinErr('interr', "Can't interpolate: {0}\n{1}", text,
             err.toString());
           $exceptionHandler(newErr);

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -243,7 +243,7 @@ function LocationHashbangUrl(appBase, hashPrefix) {
   };
 
   this.$$parseLinkUrl = function(url, relHref) {
-    if(stripHash(appBase) == stripHash(url)) {
+    if (stripHash(appBase) == stripHash(url)) {
       this.$$parse(url);
       return true;
     }

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1184,7 +1184,7 @@ function $ParseProvider() {
         }
         if (isAllDefined(value)) {
           scope.$$postDigest(function () {
-            if(isAllDefined(lastValue)) unwatch();
+            if (isAllDefined(lastValue)) unwatch();
           });
         }
       }, objectEquality);

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -318,7 +318,7 @@ function qFactory(nextTick, exceptionHandler) {
         } else {
           promise.reject(state.value);
         }
-      } catch(e) {
+      } catch (e) {
         promise.reject(e);
         exceptionHandler(e);
       }
@@ -368,7 +368,7 @@ function qFactory(nextTick, exceptionHandler) {
           this.promise.$$state.status = 1;
           scheduleProcessQueue(this.promise.$$state);
         }
-      } catch(e) {
+      } catch (e) {
         fns[1](e);
         exceptionHandler(e);
       }
@@ -396,7 +396,7 @@ function qFactory(nextTick, exceptionHandler) {
             callback = callbacks[i][3];
             try {
               result.notify(isFunction(callback) ? callback(progress) : progress);
-            } catch(e) {
+            } catch (e) {
               exceptionHandler(e);
             }
           }
@@ -461,7 +461,7 @@ function qFactory(nextTick, exceptionHandler) {
     var callbackOutput = null;
     try {
       if (isFunction(callback)) callbackOutput = callback();
-    } catch(e) {
+    } catch (e) {
       return makePromise(e, false);
     }
     if (isPromiseLike(callbackOutput)) {

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -613,7 +613,7 @@ function $RootScopeProvider(){
             if (oldLength > newLength) {
               // we used to have more keys, need to find them and destroy them.
               changeDetected++;
-              for(key in oldValue) {
+              for (key in oldValue) {
                 if (!newValue.hasOwnProperty(key)) {
                   oldLength--;
                   delete oldValue[key];
@@ -733,7 +733,7 @@ function $RootScopeProvider(){
           dirty = false;
           current = target;
 
-          while(asyncQueue.length) {
+          while (asyncQueue.length) {
             try {
               asyncTask = asyncQueue.shift();
               asyncTask.scope.$eval(asyncTask.expression);
@@ -790,7 +790,7 @@ function $RootScopeProvider(){
             // this piece should be kept in sync with the traversal in $broadcast
             if (!(next = (current.$$childHead ||
                 (current !== target && current.$$nextSibling)))) {
-              while(current !== target && !(next = current.$$nextSibling)) {
+              while (current !== target && !(next = current.$$nextSibling)) {
                 current = current.$parent;
               }
             }
@@ -798,7 +798,7 @@ function $RootScopeProvider(){
 
           // `break traverseScopesLoop;` takes us to here
 
-          if((dirty || asyncQueue.length) && !(ttl--)) {
+          if ((dirty || asyncQueue.length) && !(ttl--)) {
             clearPhase();
             throw $rootScopeMinErr('infdig',
                 '{0} $digest() iterations reached. Aborting!\n' +
@@ -810,7 +810,7 @@ function $RootScopeProvider(){
 
         clearPhase();
 
-        while(postDigestQueue.length) {
+        while (postDigestQueue.length) {
           try {
             postDigestQueue.shift()();
           } catch (e) {
@@ -1236,7 +1236,7 @@ function $RootScopeProvider(){
 
             try {
               listeners[i].apply(null, listenerArgs);
-            } catch(e) {
+            } catch (e) {
               $exceptionHandler(e);
             }
           }
@@ -1247,7 +1247,7 @@ function $RootScopeProvider(){
           // (though it differs due to having the extra check for $$listenerCount)
           if (!(next = ((current.$$listenerCount[name] && current.$$childHead) ||
               (current !== target && current.$$nextSibling)))) {
-            while(current !== target && !(next = current.$$nextSibling)) {
+            while (current !== target && !(next = current.$$nextSibling)) {
               current = current.$parent;
             }
           }
@@ -1301,7 +1301,7 @@ function $RootScopeProvider(){
       while (applyAsyncQueue.length) {
         try {
           applyAsyncQueue.shift()();
-        } catch(e) {
+        } catch (e) {
           $exceptionHandler(e);
         }
       }

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -29,15 +29,15 @@ function $SnifferProvider() {
         match;
 
     if (bodyStyle) {
-      for(var prop in bodyStyle) {
-        if(match = vendorRegex.exec(prop)) {
+      for (var prop in bodyStyle) {
+        if (match = vendorRegex.exec(prop)) {
           vendorPrefix = match[0];
           vendorPrefix = vendorPrefix.substr(0, 1).toUpperCase() + vendorPrefix.substr(1);
           break;
         }
       }
 
-      if(!vendorPrefix) {
+      if (!vendorPrefix) {
         vendorPrefix = ('WebkitOpacity' in bodyStyle) && 'webkit';
       }
 

--- a/src/ng/templateRequest.js
+++ b/src/ng/templateRequest.js
@@ -49,7 +49,7 @@ function $TemplateRequestProvider() {
       return $http.get(tpl, httpOptions)
         .then(function(response) {
           var html = response.data;
-          if(!html || html.length === 0) {
+          if (!html || html.length === 0) {
             return handleError();
           }
 

--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -41,7 +41,7 @@ function $TimeoutProvider() {
       timeoutId = $browser.defer(function() {
         try {
           deferred.resolve(fn());
-        } catch(e) {
+        } catch (e) {
           deferred.reject(e);
           $exceptionHandler(e);
         }

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -430,7 +430,7 @@ angular.module('ngAnimate', ['ng'])
     var rootAnimateState = {running: true};
 
     function extractElementNode(element) {
-      for(var i = 0; i < element.length; i++) {
+      for (var i = 0; i < element.length; i++) {
         var elm = element[i];
         if (elm.nodeType == ELEMENT_NODE) {
           return elm;
@@ -586,7 +586,7 @@ angular.module('ngAnimate', ['ng'])
             matches.push($injector.get(selectors['']));
           }
 
-          for(var i=0; i < classes.length; i++) {
+          for (var i=0; i < classes.length; i++) {
             var klass = classes[i],
                 selectorFactoryName = selectors[klass];
             if (selectorFactoryName && !flagMap[klass]) {
@@ -697,7 +697,7 @@ angular.module('ngAnimate', ['ng'])
             var progress = function() {
               afterAnimationComplete(index);
             };
-            switch(animation.event) {
+            switch (animation.event) {
               case 'setClass':
                 cancellations.push(animation.fn(element, classNameAdd, classNameRemove, progress, options));
                 break;
@@ -1217,7 +1217,7 @@ angular.module('ngAnimate', ['ng'])
          *
         */
         enabled : function(value, element) {
-          switch(arguments.length) {
+          switch (arguments.length) {
             case 2:
               if (value) {
                 cleanup(element);
@@ -1292,7 +1292,7 @@ angular.module('ngAnimate', ['ng'])
               skipAnimation = true;
             } else {
               //cancel all animations when a structural animation takes place
-              for(var klass in runningAnimations) {
+              for (var klass in runningAnimations) {
                 animationsToCancel.push(runningAnimations[klass]);
               }
               ngAnimateState = {};
@@ -1546,7 +1546,7 @@ angular.module('ngAnimate', ['ng'])
                                    state.running ||
                                    (state.last && !state.last.isClassBased);
         }
-        while(parentElement = parentElement.parent());
+        while (parentElement = parentElement.parent());
 
         return !hasParent || (!allowChildAnimations && parentRunningAnimation);
       }

--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -90,7 +90,7 @@ angular.module('ngCookies', ['ng']).
         }
 
         //update all cookies updated in $cookies
-        for(name in cookies) {
+        for (name in cookies) {
           value = cookies[name];
           if (!angular.isString(value)) {
             value = '' + value;

--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -240,12 +240,12 @@ angular.module('ngMessages', [])
 
         var messages = [];
         this.registerMessage = function(index, message) {
-          for(var i = 0; i < messages.length; i++) {
-            if(messages[i].type == message.type) {
-              if(index != i) {
+          for (var i = 0; i < messages.length; i++) {
+            if (messages[i].type == message.type) {
+              if (index != i) {
                 var temp = messages[index];
                 messages[index] = messages[i];
-                if(index < messages.length) {
+                if (index < messages.length) {
                   messages[i] = temp;
                 } else {
                   messages.splice(0, i); //remove the old one (and shift left)
@@ -262,7 +262,7 @@ angular.module('ngMessages', [])
 
           var found;
           angular.forEach(messages, function(message) {
-            if((!found || multiple) && truthyVal(values[message.type])) {
+            if ((!found || multiple) && truthyVal(values[message.type])) {
               message.attach();
               found = true;
             } else {
@@ -295,7 +295,7 @@ angular.module('ngMessages', [])
         });
 
         var tpl = $attrs.ngMessagesInclude || $attrs.include;
-        if(tpl) {
+        if (tpl) {
           $templateRequest(tpl)
             .then(function processTemplate(html) {
               var after, container = angular.element('<div/>').html(html);
@@ -359,10 +359,10 @@ angular.module('ngMessages', [])
 
         var commentNode = $element[0];
         var parentNode = commentNode.parentNode;
-        for(var i = 0, j = 0; i < parentNode.childNodes.length; i++) {
+        for (var i = 0, j = 0; i < parentNode.childNodes.length; i++) {
           var node = parentNode.childNodes[i];
-          if(node.nodeType == COMMENT_NODE && node.nodeValue.indexOf('ngMessage') >= 0) {
-            if(node === commentNode) {
+          if (node.nodeType == COMMENT_NODE && node.nodeValue.indexOf('ngMessage') >= 0) {
+            if (node === commentNode) {
               index = j;
               break;
             }
@@ -373,7 +373,7 @@ angular.module('ngMessages', [])
         ngMessages.registerMessage(index, {
           type : $attrs.ngMessage || $attrs.when,
           attach : function() {
-            if(!element) {
+            if (!element) {
               $transclude($scope, function(clone) {
                 $animate.enter(clone, null, $element);
                 element = clone;
@@ -381,7 +381,7 @@ angular.module('ngMessages', [])
             }
           },
           detach : function(now) {
-            if(element) {
+            if (element) {
               $animate.leave(element);
               element = null;
             }

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -251,7 +251,7 @@ angular.mock.$ExceptionHandlerProvider = function() {
    *            {@link ngMock.$log#reset reset()}
    */
   this.mode = function(mode) {
-    switch(mode) {
+    switch (mode) {
       case 'rethrow':
         handler = function(e) {
           throw e;
@@ -513,7 +513,7 @@ angular.mock.$IntervalProvider = function() {
      * @returns {boolean} Returns `true` if the task was successfully cancelled.
      */
     $interval.cancel = function(promise) {
-      if(!promise) return false;
+      if (!promise) return false;
       var fnIndex;
 
       angular.forEach(repeatFns, function(fn, index) {
@@ -594,7 +594,7 @@ function padNumber(num, digits, trim) {
     num = -num;
   }
   num = '' + num;
-  while(num.length < digits) num = '0' + num;
+  while (num.length < digits) num = '0' + num;
   if (trim)
     num = num.substr(num.length - digits);
   return neg + num;
@@ -882,7 +882,7 @@ angular.mock.dump = function(object) {
       }
     }
     var child = scope.$$childHead;
-    while(child) {
+    while (child) {
       log.push(serializeScope(child, offset + '  '));
       child = child.$$nextSibling;
     }
@@ -1756,12 +1756,12 @@ angular.mock.$RAFDecorator = ['$delegate', function($delegate) {
   rafFn.supported = $delegate.supported;
 
   rafFn.flush = function() {
-    if(queue.length === 0) {
+    if (queue.length === 0) {
       throw new Error('No rAF callbacks present');
     }
 
     var length = queue.length;
-    for(var i=0;i<length;i++) {
+    for (var i=0;i<length;i++) {
       queue[i]();
     }
 
@@ -2029,7 +2029,7 @@ angular.mock.e2e.$httpBackendDecorator =
   ['$rootScope', '$delegate', '$browser', createHttpBackendMock];
 
 
-if(window.jasmine || window.mocha) {
+if (window.jasmine || window.mocha) {
 
   var currentSpec = null,
       isSpecRunning = function() {
@@ -2237,7 +2237,7 @@ if(window.jasmine || window.mocha) {
         injector = currentSpec.$injector = angular.injector(modules, strictDi);
         currentSpec.$injectorStrict = strictDi;
       }
-      for(var i = 0, ii = blockFns.length; i < ii; i++) {
+      for (var i = 0, ii = blockFns.length; i < ii; i++) {
         if (currentSpec.$injectorStrict) {
           // If the injector is strict / strictDi, and the spec wants to inject using automatic
           // annotation, then annotate the function here.

--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -196,16 +196,16 @@ function ngViewFactory(   $route,   $anchorScroll,   $animate) {
         update();
 
         function cleanupLastView() {
-          if(previousLeaveAnimation) {
+          if (previousLeaveAnimation) {
             $animate.cancel(previousLeaveAnimation);
             previousLeaveAnimation = null;
           }
 
-          if(currentScope) {
+          if (currentScope) {
             currentScope.$destroy();
             currentScope = null;
           }
-          if(currentElement) {
+          if (currentElement) {
             previousLeaveAnimation = $animate.leave(currentElement);
             previousLeaveAnimation.then(function() {
               previousLeaveAnimation = null;

--- a/src/ngScenario/Future.js
+++ b/src/ngScenario/Future.js
@@ -28,7 +28,7 @@ angular.scenario.Future.prototype.execute = function(doneFn) {
     if (result) {
       try {
         result = self.parser(result);
-      } catch(e) {
+      } catch (e) {
         error = e;
       }
     }

--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -304,7 +304,7 @@ _jQuery.fn.bindings = function(windowJquery, bindExp) {
     var element = windowJquery(this),
         bindings;
     if (bindings = element.data('$binding')) {
-      for(var expressions = [], binding, j=0, jj=bindings.length;  j<jj; j++) {
+      for (var expressions = [], binding, j=0, jj=bindings.length;  j<jj; j++) {
         binding = bindings[j];
 
         if (binding.expressions) {
@@ -314,7 +314,7 @@ _jQuery.fn.bindings = function(windowJquery, bindExp) {
         }
         for (var scope, expression, i = 0, ii = expressions.length; i < ii; i++) {
           expression = expressions[i];
-          if(match(expression)) {
+          if (match(expression)) {
             scope = scope || element.scope();
             push(scope.$eval(expression));
           }

--- a/src/ngScenario/SpecRunner.js
+++ b/src/ngScenario/SpecRunner.js
@@ -136,7 +136,7 @@ angular.scenario.SpecRunner.prototype.addFutureAction = function(name, behavior,
 
       try {
         behavior.call(self, $window, $document, done);
-      } catch(e) {
+      } catch (e) {
         if (e.type && e.type === 'selector') {
           done(e.message);
         } else {

--- a/src/ngScenario/angular-bootstrap.js
+++ b/src/ngScenario/angular-bootstrap.js
@@ -6,7 +6,7 @@
   var prefix = (function() {
     var filename = /(.*\/)angular-bootstrap.js(#(.*))?/;
     var scripts = document.getElementsByTagName("script");
-    for(var j = 0; j < scripts.length; j++) {
+    for (var j = 0; j < scripts.length; j++) {
       var src = scripts[j].src;
       if (src && src.match(filename)) {
         var parts = src.match(filename);
@@ -26,7 +26,7 @@
   window.onload = function() {
     try {
       if (previousOnLoad) previousOnLoad();
-    } catch(e) {}
+    } catch (e) {}
     angular.scenario.setUpAndRun({});
   };
 

--- a/src/ngScenario/browserTrigger.js
+++ b/src/ngScenario/browserTrigger.js
@@ -51,8 +51,8 @@
     }
 
     var evnt;
-    if(/transitionend/.test(eventType)) {
-      if(window.WebKitTransitionEvent) {
+    if (/transitionend/.test(eventType)) {
+      if (window.WebKitTransitionEvent) {
         evnt = new WebKitTransitionEvent(eventType, eventData);
         evnt.initEvent(eventType, false, true);
       }
@@ -60,14 +60,14 @@
         try {
           evnt = new TransitionEvent(eventType, eventData);
         }
-        catch(e) {
+        catch (e) {
           evnt = document.createEvent('TransitionEvent');
           evnt.initTransitionEvent(eventType, null, null, null, eventData.elapsedTime || 0);
         }
       }
     }
-    else if(/animationend/.test(eventType)) {
-      if(window.WebKitAnimationEvent) {
+    else if (/animationend/.test(eventType)) {
+      if (window.WebKitAnimationEvent) {
         evnt = new WebKitAnimationEvent(eventType, eventData);
         evnt.initEvent(eventType, false, true);
       }
@@ -75,7 +75,7 @@
         try {
           evnt = new AnimationEvent(eventType, eventData);
         }
-        catch(e) {
+        catch (e) {
           evnt = document.createEvent('AnimationEvent');
           evnt.initAnimationEvent(eventType, null, null, null, eventData.elapsedTime || 0);
         }
@@ -94,7 +94,7 @@
      * read */
     evnt.$manualTimeStamp = eventData.timeStamp;
 
-    if(!evnt) return;
+    if (!evnt) return;
 
     var originalPreventDefault = evnt.preventDefault,
         appWindow = element.ownerDocument.defaultView,

--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -213,7 +213,7 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
       tapping = true;
       tapElement = event.target ? event.target : event.srcElement; // IE uses srcElement.
       // Hack for Safari, which can target text nodes instead of containers.
-      if(tapElement.nodeType == 3) {
+      if (tapElement.nodeType == 3) {
         tapElement = tapElement.parentNode;
       }
 

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1045,7 +1045,7 @@ describe('angular', function() {
       var seen = {};
       var count = 100;
 
-      while(count--) {
+      while (count--) {
         var current = nextUid();
         expect(typeof current).toBe('number');
         expect(seen[current]).toBeFalsy();

--- a/test/helpers/matchers.js
+++ b/test/helpers/matchers.js
@@ -195,7 +195,7 @@ beforeEach(function() {
         regex = jasmine.isA_("RegExp", content) ? content :
                   angular.isDefined(content) ? new RegExp(escapeRegexp(content)) : undefined;
 
-      if(!angular.isFunction(this.actual)) {
+      if (!angular.isFunction(this.actual)) {
         throw new Error('Actual is not a function');
       }
 

--- a/test/helpers/privateMocks.js
+++ b/test/helpers/privateMocks.js
@@ -15,11 +15,11 @@ function createMockStyleSheet(doc, wind) {
       try {
         ss.insertRule(selector + '{ ' + styles + '}', 0);
       }
-      catch(e) {
+      catch (e) {
         try {
           ss.addRule(selector, styles);
         }
-        catch(e2) {}
+        catch (e2) {}
       }
     },
 

--- a/test/helpers/testabilityPatch.js
+++ b/test/helpers/testabilityPatch.js
@@ -169,12 +169,12 @@ function sortedHtml(element, showNgClass) {
       if (className) {
         attrs.push(' class="' + className + '"');
       }
-      for(var i=0; i<attributes.length; i++) {
+      for (var i=0; i<attributes.length; i++) {
         if (i>0 && attributes[i] == attributes[i-1])
           continue; //IE9 creates dupes. Ignore them!
 
         var attr = attributes[i];
-        if(attr.name.match(/^ng[\:\-]/) ||
+        if (attr.name.match(/^ng[\:\-]/) ||
             (attr.value || attr.value === '') &&
             attr.value !='null' &&
             attr.value !='auto' &&
@@ -218,7 +218,7 @@ function sortedHtml(element, showNgClass) {
             }
           });
         }
-        for(var css in node.style){
+        for (var css in node.style){
           var value = node.style[css];
           if (isString(value) && isString(css) && css != 'cssText' && value && (1*css != css)) {
             var text = lowercase(css + ': ' + value);
@@ -240,7 +240,7 @@ function sortedHtml(element, showNgClass) {
       }
       html += '>';
       var children = node.childNodes;
-      for(var j=0; j<children.length; j++) {
+      for (var j=0; j<children.length; j++) {
         toString(children[j]);
       }
       html += '</' + node.nodeName.toLowerCase() + '>';

--- a/test/ng/animateSpec.js
+++ b/test/ng/animateSpec.js
@@ -22,7 +22,7 @@ describe("$animate", function() {
     it("should enter the element to the start of the parent container",
       inject(function($animate, $compile, $rootScope) {
 
-      for(var i = 0; i < 5; i++) {
+      for (var i = 0; i < 5; i++) {
         element.append(jqLite('<div> ' + i + '</div>'));
       }
 

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -337,7 +337,7 @@ describe('browser', function() {
       it('should log warnings when 4kb per cookie storage limit is reached', function() {
         var i, longVal = '', cookieStr;
 
-        for(i=0; i<4083; i++) {
+        for (i=0; i<4083; i++) {
           longVal += 'x';
         }
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -394,7 +394,7 @@ describe('$compile', function() {
 
       try {
         element[0].childNodes[1] = {nodeType: 3, nodeName: 'OBJECT', textContent: 'fake node'};
-      } catch(e) {
+      } catch (e) {
       } finally {
         if (!element[0].childNodes[1]) return; //browser doesn't support this kind of mocking
       }
@@ -831,7 +831,7 @@ describe('$compile', function() {
           try {
             $compile('<div><span replace class="replace"></span></div>');
             this.fail(new Error('should have thrown Multiple directives error'));
-          } catch(e) {
+          } catch (e) {
             expect(e.message).toMatch(/Multiple directives .* asking for template/);
           }
         }));
@@ -4795,7 +4795,7 @@ describe('$compile', function() {
           // we need to do this because different browsers print empty attributes differently
           try {
             $compile('<div><div ng-transclude></div></div>')($rootScope);
-          } catch(e) {
+          } catch (e) {
             expect(e.message).toMatch(new RegExp(
                 '^\\[ngTransclude:orphan\\] ' +
                     'Illegal use of ngTransclude directive in the template! ' +

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2382,7 +2382,7 @@ describe('input', function() {
       try {
         //set to text for browsers with datetime-local validation.
         inputElm[0].setAttribute('type', 'text');
-      } catch(e) {
+      } catch (e) {
         //for IE8
       }
 
@@ -2576,7 +2576,7 @@ describe('input', function() {
       try {
         //set to text for browsers with datetime-local validation.
         inputElm[0].setAttribute('type', 'text');
-      } catch(e) {
+      } catch (e) {
         //for IE8
       }
 
@@ -2745,7 +2745,7 @@ describe('input', function() {
       try {
         //set to text for browsers with datetime-local validation.
         inputElm[0].setAttribute('type', 'text');
-      } catch(e) {
+      } catch (e) {
         //for IE8
       }
 
@@ -3020,7 +3020,7 @@ describe('input', function() {
       try {
         //set to text for browsers with time validation.
         inputElm[0].setAttribute('type', 'text');
-      } catch(e) {
+      } catch (e) {
         //for IE8
       }
 
@@ -3284,7 +3284,7 @@ describe('input', function() {
       try {
         //set to text for browsers with date validation.
         inputElm[0].setAttribute('type', 'text');
-      } catch(e) {
+      } catch (e) {
         //for IE8
       }
 
@@ -4676,9 +4676,9 @@ describe('NgModel animations', function() {
   function findElementAnimations(element, queue) {
     var node = element[0];
     var animations = [];
-    for(var i = 0; i < queue.length; i++) {
+    for (var i = 0; i < queue.length; i++) {
       var animation = queue[i];
-      if(animation.element[0] == node) {
+      if (animation.element[0] == node) {
         animations.push(animation);
       }
     }
@@ -4688,7 +4688,7 @@ describe('NgModel animations', function() {
   function assertValidAnimation(animation, event, classNameA, classNameB) {
     expect(animation.event).toBe(event);
     expect(animation.args[1]).toBe(classNameA);
-    if(classNameB) expect(animation.args[2]).toBe(classNameB);
+    if (classNameB) expect(animation.args[2]).toBe(classNameB);
   }
 
   var doc, input, scope, model;

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1055,7 +1055,7 @@ describe('$location', function() {
           if (!relLink) {
             if (linkHref[0] == '/') {
               linkHref = 'http://host.com' + linkHref;
-            } else if(!linkHref.match(/:\/\//)) {
+            } else if (!linkHref.match(/:\/\//)) {
               // fake the behavior of <base> tag
               linkHref = 'http://host.com/base/' + linkHref;
             }

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -170,7 +170,7 @@ describe('q', function() {
         forEach(queue, function(task) {
           try {
             task();
-          } catch(e) {
+          } catch (e) {
             if ( mockNextTick.logExceptions ) {
               dump('exception in mockNextTick:', e, e.name, e.message, task);
             }

--- a/test/ng/rafSpec.js
+++ b/test/ng/rafSpec.js
@@ -2,7 +2,7 @@
 
 describe('$$rAF', function() {
   it('should queue and block animation frames', inject(function($$rAF) {
-    if(!$$rAF.supported) return;
+    if (!$$rAF.supported) return;
 
     var message;
     $$rAF(function() {
@@ -15,7 +15,7 @@ describe('$$rAF', function() {
   }));
 
   it('should provide a cancellation method', inject(function($$rAF) {
-    if(!$$rAF.supported) return;
+    if (!$$rAF.supported) return;
 
     var present = true;
     var cancel = $$rAF(function() {
@@ -27,7 +27,7 @@ describe('$$rAF', function() {
 
     try {
       $$rAF.flush();
-    } catch(e) {}
+    } catch (e) {}
     expect(present).toBe(true);
   }));
 
@@ -62,11 +62,11 @@ describe('$$rAF', function() {
 
   describe('mocks', function() {
     it('should throw an error if no frames are present', inject(function($$rAF) {
-      if($$rAF.supported) {
+      if ($$rAF.supported) {
         var failed = false;
         try {
           $$rAF.flush();
-        } catch(e) {
+        } catch (e) {
           failed = true;
         }
         expect(failed).toBe(true);
@@ -94,7 +94,7 @@ describe('$$rAF', function() {
 
       try {
         cancel();
-      } catch(e) {}
+      } catch (e) {}
 
       expect($window.webkitCancelRequestAnimationFrame).toHaveBeenCalled();
     });

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -318,7 +318,7 @@ describe('Scope', function() {
       try {
         $rootScope.$digest();
         throw new Error('Should have thrown exception');
-      } catch(e) {
+      } catch (e) {
         expect(e.message.match(/"fn: (watcherA|function)/g).length).toBe(10);
       }
     }));

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -84,13 +84,13 @@ describe('$sniffer', function() {
       inject(function($sniffer, $window) {
         var expectedPrefix;
         var ua = $window.navigator.userAgent.toLowerCase();
-        if(/chrome/i.test(ua) || /safari/i.test(ua) || /webkit/i.test(ua)) {
+        if (/chrome/i.test(ua) || /safari/i.test(ua) || /webkit/i.test(ua)) {
           expectedPrefix = 'Webkit';
         }
-        else if(/firefox/i.test(ua)) {
+        else if (/firefox/i.test(ua)) {
           expectedPrefix = 'Moz';
         }
-        else if(/ie/i.test(ua) || /trident/i.test(ua)) {
+        else if (/ie/i.test(ua) || /trident/i.test(ua)) {
           expectedPrefix = 'Ms';
         }
         expect($sniffer.vendorPrefix).toBe(expectedPrefix);

--- a/test/ng/templateRequestSpec.js
+++ b/test/ng/templateRequestSpec.js
@@ -81,7 +81,7 @@ describe('$templateRequest', function() {
 
     try {
       $httpBackend.flush();
-    } catch(e) {}
+    } catch (e) {}
 
     expect($templateRequest.totalPendingRequests).toBe(0);
   }));

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -111,14 +111,14 @@ describe("ngAnimate", function() {
         ss = createMockStyleSheet($document, $window);
         try {
           $timeout.flush();
-        } catch(e) {}
+        } catch (e) {}
         $animate.enabled(true);
         $rootScope.$digest();
       };
     }));
 
     afterEach(function(){
-      if(ss) {
+      if (ss) {
         ss.destroy();
       }
       dealoc(body);
@@ -353,7 +353,7 @@ describe("ngAnimate", function() {
           $animate.enter(child, element);
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             expect(child.hasClass('ng-enter')).toBe(true);
             expect(child.hasClass('ng-enter-active')).toBe(true);
@@ -371,7 +371,7 @@ describe("ngAnimate", function() {
           $animate.enter(child[0], element[0]);
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             expect(child.hasClass('ng-enter')).toBe(true);
             expect(child.hasClass('ng-enter-active')).toBe(true);
@@ -389,7 +389,7 @@ describe("ngAnimate", function() {
           $animate.leave(child);
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             expect(child.hasClass('ng-leave')).toBe(true);
             expect(child.hasClass('ng-leave-active')).toBe(true);
@@ -406,7 +406,7 @@ describe("ngAnimate", function() {
           $animate.leave(child[0]);
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             expect(child.hasClass('ng-leave')).toBe(true);
             expect(child.hasClass('ng-leave-active')).toBe(true);
@@ -429,7 +429,7 @@ describe("ngAnimate", function() {
           expect(element.text()).toBe('12');
           $animate.move(child1, element, child2);
           $rootScope.$digest();
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
           }
           expect(element.text()).toBe('21');
@@ -448,7 +448,7 @@ describe("ngAnimate", function() {
           expect(element.text()).toBe('12');
           $animate.move(child1[0], element[0], child2[0]);
           $rootScope.$digest();
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
           }
           expect(element.text()).toBe('21');
@@ -461,7 +461,7 @@ describe("ngAnimate", function() {
           $animate.animate(element, { color: 'rgb(255, 0, 0)' }, { color: 'rgb(0, 0, 255)' }, 'animated');
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             expect(element.css('color')).toBe('rgb(255, 0, 0)');
             $animate.triggerReflow();
           }
@@ -476,7 +476,7 @@ describe("ngAnimate", function() {
           expect(child).toBeHidden();
           $animate.removeClass(child, 'ng-hide');
           $rootScope.$digest();
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             expect(child.hasClass('ng-hide-remove')).toBe(true);
             expect(child.hasClass('ng-hide-remove-active')).toBe(true);
@@ -494,7 +494,7 @@ describe("ngAnimate", function() {
           expect(child).toBeShown();
           $animate.addClass(child, 'ng-hide');
           $rootScope.$digest();
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             expect(child.hasClass('ng-hide-add')).toBe(true);
             expect(child.hasClass('ng-hide-add-active')).toBe(true);
@@ -803,7 +803,7 @@ describe("ngAnimate", function() {
           element.addClass('ng-hide');
           $animate.removeClass(element, 'ng-hide');
           $rootScope.$digest();
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
           }
           expect(element.text()).toBe('memento');
@@ -819,13 +819,13 @@ describe("ngAnimate", function() {
           expect(element).toBeShown();
           $animate.addClass(child, 'ng-hide');
           $rootScope.$digest();
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             expect(child).toBeShown();
           }
 
           $animate.leave(child);
           $rootScope.$digest();
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
           }
           expect(child).toBeHidden(); //hides instantly
@@ -834,7 +834,7 @@ describe("ngAnimate", function() {
           child.css('display','block');
           child.removeClass('ng-hide');
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             expect(element.children().length).toBe(1); //still animating
             browserTrigger(child,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
           }
@@ -858,7 +858,7 @@ describe("ngAnimate", function() {
           $animate.leave(child);
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
 
             //this is to verify that the existing style is appended with a semicolon automatically
@@ -878,7 +878,7 @@ describe("ngAnimate", function() {
           child.addClass('custom-delay ng-hide');
           $animate.removeClass(child, 'ng-hide');
           $rootScope.$digest();
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             browserTrigger(child,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
           }
@@ -948,7 +948,7 @@ describe("ngAnimate", function() {
           expect(element.hasClass('green'));
 
           expect(completed).toBe(false);
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             browserTrigger(child,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
           }
@@ -1047,7 +1047,7 @@ describe("ngAnimate", function() {
           $animate.removeClass(element, 'ng-hide');
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             browserTrigger(element,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
           }
           $timeout.flush(2000);
@@ -1212,7 +1212,7 @@ describe("ngAnimate", function() {
             });
           });
           inject(function($animate, $rootScope, $compile, $sniffer) {
-            if(!$sniffer.transitions) return;
+            if (!$sniffer.transitions) return;
 
             element = $compile(html('<div class="js-animation"></div>'))($rootScope);
             $animate.leave(element);
@@ -1335,7 +1335,7 @@ describe("ngAnimate", function() {
               $animate.removeClass(element, 'ng-hide');
               $rootScope.$digest();
 
-              if($sniffer.animations) {
+              if ($sniffer.animations) {
                 $animate.triggerReflow();
                 expect(element.hasClass('ng-hide-remove')).toBe(true);
                 expect(element.hasClass('ng-hide-remove-active')).toBe(true);
@@ -1347,7 +1347,7 @@ describe("ngAnimate", function() {
 
               expect(element.hasClass('ng-hide-remove')).toBe(false); //added right away
 
-              if($sniffer.animations) { //cleanup some pending animations
+              if ($sniffer.animations) { //cleanup some pending animations
                 $animate.triggerReflow();
                 expect(element.hasClass('ng-hide-add')).toBe(true);
                 expect(element.hasClass('ng-hide-add-active')).toBe(true);
@@ -1384,7 +1384,7 @@ describe("ngAnimate", function() {
           it("should pause the playstate when performing a stagger animation",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout) {
 
-            if(!$sniffer.animations) return;
+            if (!$sniffer.animations) return;
 
             $animate.enabled(true);
 
@@ -1407,7 +1407,7 @@ describe("ngAnimate", function() {
             var container = $compile(html('<div></div>'))($rootScope);
 
             var newScope, element, elements = [];
-            for(var i = 0; i < 5; i++) {
+            for (var i = 0; i < 5; i++) {
               newScope = $rootScope.$new();
               element = $compile('<div class="real-animation"></div>')(newScope);
               $animate.enter(element, container);
@@ -1418,14 +1418,14 @@ describe("ngAnimate", function() {
             $animate.triggerReflow();
 
             expect(elements[0].attr('style')).toBeFalsy();
-            for(i = 1; i < 5; i++) {
+            for (i = 1; i < 5; i++) {
               expect(elements[i].attr('style')).toMatch(/animation-play-state:\s*paused/);
             }
 
             //final closing timeout
             $timeout.flush();
 
-            for(i = 0; i < 5; i++) {
+            for (i = 0; i < 5; i++) {
               dealoc(elements[i]);
               newScope = $rootScope.$new();
               element = $compile('<div class="fake-animation"></div>')(newScope);
@@ -1439,7 +1439,7 @@ describe("ngAnimate", function() {
             $timeout.verifyNoPendingTasks();
 
             expect(elements[0].attr('style')).toBeFalsy();
-            for(i=1;i<5;i++) {
+            for (i=1;i<5;i++) {
               expect(elements[i].attr('style')).not.toMatch(/animation-play-state:\s*paused/);
             }
           }));
@@ -1448,7 +1448,7 @@ describe("ngAnimate", function() {
           it("should block and unblock keyframe animations when a stagger animation kicks in while skipping the first element",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout) {
 
-            if(!$sniffer.animations) return;
+            if (!$sniffer.animations) return;
 
             $animate.enabled(true);
 
@@ -1463,7 +1463,7 @@ describe("ngAnimate", function() {
             var container = $compile(html('<div></div>'))($rootScope);
 
             var elements = [];
-            for(var i = 0; i < 4; i++) {
+            for (var i = 0; i < 4; i++) {
               var newScope = $rootScope.$new();
               var element = $compile('<div class="blocked-animation"></div>')(newScope);
               $animate.enter(element, container);
@@ -1473,20 +1473,20 @@ describe("ngAnimate", function() {
             $rootScope.$digest();
 
             expect(elements[0].attr('style')).toBeUndefined();
-            for(i = 1; i < 4; i++) {
+            for (i = 1; i < 4; i++) {
               expect(elements[i].attr('style')).toMatch(/animation-play-state:\s*paused/);
             }
 
             $animate.triggerReflow();
 
             expect(elements[0].attr('style')).toBeUndefined();
-            for(i = 1; i < 4; i++) {
+            for (i = 1; i < 4; i++) {
               expect(elements[i].attr('style')).toMatch(/animation-play-state:\s*paused/);
             }
 
             $timeout.flush(800);
 
-            for(i = 1; i < 4; i++) {
+            for (i = 1; i < 4; i++) {
               expect(elements[i].attr('style')).not.toMatch(/animation-play-state/);
             }
           }));
@@ -1494,7 +1494,7 @@ describe("ngAnimate", function() {
           it("should stagger items when multiple animation durations/delays are defined",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout, $document, $rootElement, $window) {
 
-            if(!$sniffer.transitions) return;
+            if (!$sniffer.transitions) return;
 
             $animate.enabled(true);
 
@@ -1509,7 +1509,7 @@ describe("ngAnimate", function() {
             var container = $compile(html('<div></div>'))($rootScope);
 
             var elements = [];
-            for(var i = 0; i < 4; i++) {
+            for (var i = 0; i < 4; i++) {
               var newScope = $rootScope.$new();
               var element = $compile('<div class="stagger-animation"></div>')(newScope);
               $animate.enter(element, container);
@@ -1519,7 +1519,7 @@ describe("ngAnimate", function() {
             $rootScope.$digest();
             $animate.triggerReflow();
 
-            for(i = 1; i < 4; i++) {
+            for (i = 1; i < 4; i++) {
               expect(elements[i]).not.toHaveClass('ng-enter-active');
               expect(elements[i]).toHaveClass('ng-enter-pending');
               expect(getMaxValue('animationDelay', elements[i], $window)).toBe(2);
@@ -1527,7 +1527,7 @@ describe("ngAnimate", function() {
 
             $timeout.flush(300);
 
-            for(i = 1; i < 4; i++) {
+            for (i = 1; i < 4; i++) {
               expect(elements[i]).toHaveClass('ng-enter-active');
               expect(elements[i]).not.toHaveClass('ng-enter-pending');
               expect(getMaxValue('animationDelay', elements[i], $window)).toBe(2);
@@ -1537,7 +1537,7 @@ describe("ngAnimate", function() {
           it("should stagger items and apply the transition + directive styles the right time when piggy-back styles are used",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout, $document, $rootElement, $window) {
 
-            if(!$sniffer.transitions) return;
+            if (!$sniffer.transitions) return;
 
             $animate.enabled(true);
 
@@ -1556,7 +1556,7 @@ describe("ngAnimate", function() {
             var container = $compile(html('<div></div>'))($rootScope);
 
             var elements = [];
-            for(var i = 0; i < 4; i++) {
+            for (var i = 0; i < 4; i++) {
               var newScope = $rootScope.$new();
               var element = $compile('<div class="stagger-animation"></div>')(newScope);
               $animate.enter(element, container, null, styles);
@@ -1565,7 +1565,7 @@ describe("ngAnimate", function() {
 
             $rootScope.$digest();
 
-            for(i = 0; i < 4; i++) {
+            for (i = 0; i < 4; i++) {
               expect(elements[i]).toHaveClass('ng-enter');
               assertTransitionDuration(elements[i], '2', true);
               assertLeftStyle(elements[i], '50');
@@ -1577,7 +1577,7 @@ describe("ngAnimate", function() {
             assertLeftStyle(elements[0], '100');
             assertTransitionDuration(elements[0], '1');
 
-            for(i = 1; i < 4; i++) {
+            for (i = 1; i < 4; i++) {
               expect(elements[i]).not.toHaveClass('ng-enter-active');
               assertTransitionDuration(elements[i], '1', true);
               assertLeftStyle(elements[i], '100', true);
@@ -1585,7 +1585,7 @@ describe("ngAnimate", function() {
 
             $timeout.flush(300);
 
-            for(i = 1; i < 4; i++) {
+            for (i = 1; i < 4; i++) {
               expect(elements[i]).toHaveClass('ng-enter-active');
               assertTransitionDuration(elements[i], '1');
               assertLeftStyle(elements[i], '100');
@@ -1593,7 +1593,7 @@ describe("ngAnimate", function() {
 
             $timeout.flush();
 
-            for(i = 0; i < 4; i++) {
+            for (i = 0; i < 4; i++) {
               expect(elements[i]).not.toHaveClass('ng-enter');
               expect(elements[i]).not.toHaveClass('ng-enter-active');
               assertTransitionDuration(elements[i], '1', true);
@@ -1723,7 +1723,7 @@ describe("ngAnimate", function() {
           it("should NOT overwrite styles with outdated values when animation completes",
             inject(function($animate, $rootScope, $compile, $sniffer) {
 
-              if(!$sniffer.transitions) return;
+              if (!$sniffer.transitions) return;
 
               var style = '-webkit-transition-duration: 1s, 2000ms, 1s;' +
                           '-webkit-transition-property: height, left, opacity;' +
@@ -1753,7 +1753,7 @@ describe("ngAnimate", function() {
           it("should NOT overwrite styles when a transition with a specific property is used",
             inject(function($animate, $rootScope, $compile, $sniffer) {
 
-            if(!$sniffer.transitions) return;
+            if (!$sniffer.transitions) return;
 
             var style = '-webkit-transition: border linear .2s;' +
                                 'transition: border linear .2s;';
@@ -1815,7 +1815,7 @@ describe("ngAnimate", function() {
               $animate.removeClass(element, 'ng-hide');
               $rootScope.$digest();
 
-              if($sniffer.transitions) {
+              if ($sniffer.transitions) {
                 $animate.triggerReflow();
                 expect(element.hasClass('ng-hide-remove')).toBe(true);
                 expect(element.hasClass('ng-hide-remove-active')).toBe(true);
@@ -1828,7 +1828,7 @@ describe("ngAnimate", function() {
               $animate.addClass(element, 'ng-hide');
               $rootScope.$digest();
 
-              if($sniffer.transitions) {
+              if ($sniffer.transitions) {
                 $animate.triggerReflow();
                 expect(element.hasClass('ng-hide-add')).toBe(true);
                 expect(element.hasClass('ng-hide-add-active')).toBe(true);
@@ -1839,7 +1839,7 @@ describe("ngAnimate", function() {
           it("should place a hard block when a structural CSS transition is run",
             inject(function($animate, $rootScope, $compile, $sniffer) {
 
-            if(!$sniffer.transitions) return;
+            if (!$sniffer.transitions) return;
 
             ss.addRule('.leave-animation.ng-leave',
               '-webkit-transition:5s linear all;' +
@@ -1863,7 +1863,7 @@ describe("ngAnimate", function() {
           it("should not place a hard block when a class-based CSS transition is run",
             inject(function($animate, $rootScope, $compile, $sniffer) {
 
-            if(!$sniffer.transitions) return;
+            if (!$sniffer.transitions) return;
 
             ss.addRule('.my-class', '-webkit-transition:5s linear all;' +
                                     'transition:5s linear all;');
@@ -1889,7 +1889,7 @@ describe("ngAnimate", function() {
           it("should stagger the items when the correct CSS class is provided",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout, $document, $rootElement, $browser) {
 
-            if(!$sniffer.transitions) return;
+            if (!$sniffer.transitions) return;
 
             $animate.enabled(true);
 
@@ -1912,7 +1912,7 @@ describe("ngAnimate", function() {
             var container = $compile(html('<div></div>'))($rootScope);
 
             var newScope, element, elements = [];
-            for(var i = 0; i < 5; i++) {
+            for (var i = 0; i < 5; i++) {
               newScope = $rootScope.$new();
               element = $compile('<div class="real-animation"></div>')(newScope);
               $animate.enter(element, container);
@@ -1925,7 +1925,7 @@ describe("ngAnimate", function() {
             expect($browser.deferredFns.length).toEqual(5); //4 staggers + 1 combined timeout
             $timeout.flush();
 
-            for(i = 0; i < 5; i++) {
+            for (i = 0; i < 5; i++) {
               dealoc(elements[i]);
               newScope = $rootScope.$new();
               element = $compile('<div class="fake-animation"></div>')(newScope);
@@ -1943,7 +1943,7 @@ describe("ngAnimate", function() {
           it("should stagger items when multiple transition durations/delays are defined",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout, $document, $rootElement, $window) {
 
-            if(!$sniffer.transitions) return;
+            if (!$sniffer.transitions) return;
 
             $animate.enabled(true);
 
@@ -1958,7 +1958,7 @@ describe("ngAnimate", function() {
             var container = $compile(html('<div></div>'))($rootScope);
 
             var elements = [];
-            for(var i = 0; i < 4; i++) {
+            for (var i = 0; i < 4; i++) {
               var newScope = $rootScope.$new();
               var element = $compile('<div class="stagger-animation"></div>')(newScope);
               $animate.enter(element, container);
@@ -1968,7 +1968,7 @@ describe("ngAnimate", function() {
             $rootScope.$digest();
             $animate.triggerReflow();
 
-            for(i = 1; i < 4; i++) {
+            for (i = 1; i < 4; i++) {
               expect(elements[i]).not.toHaveClass('ng-enter-active');
               expect(elements[i]).toHaveClass('ng-enter-pending');
               expect(getMaxValue('transitionDelay', elements[i], $window)).toBe(4);
@@ -1976,7 +1976,7 @@ describe("ngAnimate", function() {
 
             $timeout.flush(300);
 
-            for(i = 1; i < 4; i++) {
+            for (i = 1; i < 4; i++) {
               expect(elements[i]).toHaveClass('ng-enter-active');
               expect(elements[i]).not.toHaveClass('ng-enter-pending');
               expect(getMaxValue('transitionDelay', elements[i], $window)).toBe(4);
@@ -1986,7 +1986,7 @@ describe("ngAnimate", function() {
           it("should stagger items, apply directive styles but not apply a transition style when the stagger step kicks in",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout, $document, $rootElement, $window) {
 
-            if(!$sniffer.transitions) return;
+            if (!$sniffer.transitions) return;
 
             $animate.enabled(true);
 
@@ -2005,7 +2005,7 @@ describe("ngAnimate", function() {
             var container = $compile(html('<div></div>'))($rootScope);
 
             var elements = [];
-            for(var i = 0; i < 4; i++) {
+            for (var i = 0; i < 4; i++) {
               var newScope = $rootScope.$new();
               var element = $compile('<div class="stagger-animation"></div>')(newScope);
               $animate.enter(element, container, null, styles);
@@ -2014,7 +2014,7 @@ describe("ngAnimate", function() {
 
             $rootScope.$digest();
 
-            for(i = 0; i < 4; i++) {
+            for (i = 0; i < 4; i++) {
               expect(elements[i]).toHaveClass('ng-enter');
               assertLeftStyle(elements[i], '155');
             }
@@ -2025,14 +2025,14 @@ describe("ngAnimate", function() {
             assertLeftStyle(elements[0], '255');
             assertNoTransitionDuration(elements[0]);
 
-            for(i = 1; i < 4; i++) {
+            for (i = 1; i < 4; i++) {
               expect(elements[i]).not.toHaveClass('ng-enter-active');
               assertLeftStyle(elements[i], '255', true);
             }
 
             $timeout.flush(300);
 
-            for(i = 1; i < 4; i++) {
+            for (i = 1; i < 4; i++) {
               expect(elements[i]).toHaveClass('ng-enter-active');
               assertNoTransitionDuration(elements[i]);
               assertLeftStyle(elements[i], '255');
@@ -2040,7 +2040,7 @@ describe("ngAnimate", function() {
 
             $timeout.flush();
 
-            for(i = 0; i < 4; i++) {
+            for (i = 0; i < 4; i++) {
               expect(elements[i]).not.toHaveClass('ng-enter');
               expect(elements[i]).not.toHaveClass('ng-enter-active');
               assertNoTransitionDuration(elements[i]);
@@ -2086,7 +2086,7 @@ describe("ngAnimate", function() {
               $provide.decorator('$timeout', function($delegate) {
                 var _cancel = $delegate.cancel;
                 $delegate.cancel = function(timer) {
-                  if(timer) {
+                  if (timer) {
                     cancellations++;
                     return _cancel.apply($delegate, arguments);
                   }
@@ -2095,7 +2095,7 @@ describe("ngAnimate", function() {
               });
 
               return function($sniffer) {
-                if($sniffer.transitions) {
+                if ($sniffer.transitions) {
                   currentTimestamp = Date.now();
                   spyOn(Date,'now').andCallFake(function() {
                     return currentTimestamp;
@@ -2188,7 +2188,7 @@ describe("ngAnimate", function() {
 
             element = $compile(html('<div></div>'))($rootScope);
             var kids = [];
-            for(var i = 0; i < 5; i++) {
+            for (var i = 0; i < 5; i++) {
               kids.push(angular.element('<div class="entering-element"></div>'));
               $animate.enter(kids[i], element);
             }
@@ -2197,14 +2197,14 @@ describe("ngAnimate", function() {
             $animate.triggerReflow(); //reflow
             expect(element.children().length).toBe(5);
 
-            for(i = 1; i < 5; i++) {
+            for (i = 1; i < 5; i++) {
               expect(kids[i]).not.toHaveClass('ng-enter-active');
               expect(kids[i]).toHaveClass('ng-enter-pending');
             }
 
             $timeout.flush(2000);
 
-            for(i = 1; i < 5; i++) {
+            for (i = 1; i < 5; i++) {
               expect(kids[i]).toHaveClass('ng-enter-active');
               expect(kids[i]).not.toHaveClass('ng-enter-pending');
             }
@@ -2214,13 +2214,13 @@ describe("ngAnimate", function() {
             //9500 - 2000 - 7499 = 1
             $timeout.flush(7499);
 
-            for(i = 0; i < 5; i++) {
+            for (i = 0; i < 5; i++) {
               expect(kids[i].hasClass('ng-enter-active')).toBe(true);
             }
 
             $timeout.flush(1); //up to 2000ms
 
-            for(i = 0; i < 5; i++) {
+            for (i = 0; i < 5; i++) {
               expect(kids[i].hasClass('ng-enter-active')).toBe(false);
             }
           }));
@@ -2241,7 +2241,7 @@ describe("ngAnimate", function() {
             var cancellations = [];
             element = $compile(html('<div></div>'))($rootScope);
             var kids = [];
-            for(var i = 0; i < 5; i++) {
+            for (var i = 0; i < 5; i++) {
               kids.push(angular.element('<div class="entering-element"></div>'));
               cancellations.push($animate.enter(kids[i], element));
             }
@@ -2250,7 +2250,7 @@ describe("ngAnimate", function() {
             $animate.triggerReflow(); //reflow
             expect(element.children().length).toBe(5);
 
-            for(i = 1; i < 5; i++) {
+            for (i = 1; i < 5; i++) {
               expect(kids[i]).not.toHaveClass('ng-enter-active');
               expect(kids[i]).toHaveClass('ng-enter-pending');
             }
@@ -2261,7 +2261,7 @@ describe("ngAnimate", function() {
               $animate.cancel(promise);
             });
 
-            for(i = 1; i < 5; i++) {
+            for (i = 1; i < 5; i++) {
               expect(kids[i]).not.toHaveClass('ng-enter');
               expect(kids[i]).not.toHaveClass('ng-enter-active');
               expect(kids[i]).not.toHaveClass('ng-enter-pending');
@@ -2309,7 +2309,7 @@ describe("ngAnimate", function() {
         it("should apply staggering to both transitions and keyframe animations when used within the same animation",
           inject(function($animate, $rootScope, $compile, $sniffer, $timeout, $document, $rootElement, $browser) {
 
-          if(!$sniffer.transitions) return;
+          if (!$sniffer.transitions) return;
 
           $animate.enabled(true);
 
@@ -2328,7 +2328,7 @@ describe("ngAnimate", function() {
           var container = $compile(html('<div></div>'))($rootScope);
 
           var elements = [];
-          for(var i = 0; i < 3; i++) {
+          for (var i = 0; i < 3; i++) {
             var newScope = $rootScope.$new();
             var element = $compile('<div class="stagger-animation"></div>')(newScope);
             $animate.enter(element, container);
@@ -2343,19 +2343,19 @@ describe("ngAnimate", function() {
           expect(elements[1].attr('style')).toMatch(/animation-play-state:\s*paused/);
           expect(elements[2].attr('style')).toMatch(/animation-play-state:\s*paused/);
 
-          for(i = 1; i < 3; i++) {
+          for (i = 1; i < 3; i++) {
             expect(elements[i]).not.toHaveClass('ng-enter-active');
             expect(elements[i]).toHaveClass('ng-enter-pending');
           }
 
           $timeout.flush(0.4 * 1000);
 
-          for(i = 1; i < 3; i++) {
+          for (i = 1; i < 3; i++) {
             expect(elements[i]).toHaveClass('ng-enter-active');
             expect(elements[i]).not.toHaveClass('ng-enter-pending');
           }
 
-          for(i = 0; i < 3; i++) {
+          for (i = 0; i < 3; i++) {
             browserTrigger(elements[i],'transitionend', { timeStamp: Date.now() + 22000, elapsedTime: 22000 });
             expect(elements[i].attr('style')).toBeFalsy();
           }
@@ -2447,7 +2447,7 @@ describe("ngAnimate", function() {
           $animate.enter(element, parent);
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             expect(element.hasClass('one')).toBe(true);
             expect(element.hasClass('two')).toBe(true);
@@ -2604,7 +2604,7 @@ describe("ngAnimate", function() {
         it('should fire DOM callbacks on the element being animated',
           inject(function($animate, $rootScope, $compile, $sniffer, $rootElement) {
 
-          if(!$sniffer.transitions) return;
+          if (!$sniffer.transitions) return;
 
           $animate.enabled(true);
 
@@ -2735,7 +2735,7 @@ describe("ngAnimate", function() {
           });
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             browserTrigger(element,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
           }
@@ -2788,7 +2788,7 @@ describe("ngAnimate", function() {
           $rootScope.$digest();
 
           $animate.addClass(element, 'ng-hide'); //earlier animation cancelled
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             browserTrigger(element,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 9 });
           }
@@ -3054,7 +3054,7 @@ describe("ngAnimate", function() {
           });
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             expect(element.hasClass('klass-add')).toBe(true);
             $animate.triggerReflow();
             expect(element.hasClass('klass')).toBe(true);
@@ -3070,7 +3070,7 @@ describe("ngAnimate", function() {
           });
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             expect(element.hasClass('klass-remove')).toBe(true);
 
             $animate.triggerReflow();
@@ -3176,7 +3176,7 @@ describe("ngAnimate", function() {
           });
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             expect(element.hasClass('klass-add')).toBe(true);
             expect(element.hasClass('klass-add-active')).toBe(true);
@@ -3193,7 +3193,7 @@ describe("ngAnimate", function() {
           });
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             expect(element.hasClass('klass-remove')).toBe(true);
             expect(element.hasClass('klass-remove-active')).toBe(true);
@@ -3229,7 +3229,7 @@ describe("ngAnimate", function() {
 
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             expect(element.hasClass('one-add')).toBe(true);
             expect(element.hasClass('two-add')).toBe(true);
@@ -3276,7 +3276,7 @@ describe("ngAnimate", function() {
           });
           $rootScope.$digest();
 
-          if($sniffer.transitions) {
+          if ($sniffer.transitions) {
             $animate.triggerReflow();
             expect(element.hasClass('one-remove')).toBe(true);
             expect(element.hasClass('two-remove')).toBe(true);
@@ -3330,7 +3330,7 @@ describe("ngAnimate", function() {
       $animate.enter(child, element);
       $rootScope.$digest();
 
-      if($sniffer.transitions) {
+      if ($sniffer.transitions) {
         $animate.triggerReflow();
         expect(child.hasClass('ng-enter')).toBe(true);
         expect(child.hasClass('ng-enter-active')).toBe(true);
@@ -3354,7 +3354,7 @@ describe("ngAnimate", function() {
       $animate.enter(child, element);
       $rootScope.$digest();
 
-      if($sniffer.transitions) {
+      if ($sniffer.transitions) {
         $animate.triggerReflow();
         expect(child.hasClass('ng-enter')).toBe(true);
         expect(child.hasClass('ng-enter-active')).toBe(true);
@@ -3409,7 +3409,7 @@ describe("ngAnimate", function() {
         $animate.enter(child, element);
         $rootScope.$digest();
 
-        if($sniffer.transitions) {
+        if ($sniffer.transitions) {
           $animate.triggerReflow();
           browserTrigger(child,'transitionend', { timeStamp: Date.now() + 1000, elapsedTime: 1 });
         }
@@ -3443,7 +3443,7 @@ describe("ngAnimate", function() {
         $rootScope.$digest();
 
         //this is added/removed right away otherwise
-        if($sniffer.transitions) {
+        if ($sniffer.transitions) {
           $animate.triggerReflow();
           expect(child.hasClass('ng-enter')).toBe(true);
           expect(child.hasClass('ng-enter-active')).toBe(true);
@@ -3468,7 +3468,7 @@ describe("ngAnimate", function() {
 
     it("should not perform the active class animation if the animation has been cancelled before the reflow occurs", function() {
       inject(function($compile, $rootScope, $animate, $sniffer) {
-        if(!$sniffer.transitions) return;
+        if (!$sniffer.transitions) return;
 
         ss.addRule('.animated.ng-enter', '-webkit-transition: 2s linear all;' +
                                                  'transition: 2s linear all;');
@@ -3668,7 +3668,7 @@ describe("ngAnimate", function() {
 
     it("should not skip ngAnimate animations when any pre-existing CSS transitions are present on the element", function() {
       inject(function($compile, $rootScope, $animate, $timeout, $sniffer) {
-        if(!$sniffer.transitions) return;
+        if (!$sniffer.transitions) return;
 
         var element = html($compile('<div class="animated parent"></div>')($rootScope));
         var child   = html($compile('<div class="animated child"></div>')($rootScope));
@@ -3688,7 +3688,7 @@ describe("ngAnimate", function() {
           $animate.triggerReflow();
           empty = false;
         }
-        catch(e) {}
+        catch (e) {}
 
         expect(empty).toBe(false);
       });
@@ -3698,7 +3698,7 @@ describe("ngAnimate", function() {
     it("should wait until both the duration and delay are complete to close off the animation",
       inject(function($compile, $rootScope, $animate, $timeout, $sniffer) {
 
-      if(!$sniffer.transitions) return;
+      if (!$sniffer.transitions) return;
 
       var element = html($compile('<div class="animated parent"></div>')($rootScope));
       var child   = html($compile('<div class="animated child"></div>')($rootScope));
@@ -3769,14 +3769,14 @@ describe("ngAnimate", function() {
         $rootScope.$digest();
 
         expect(animationState).toBe('enter');
-        if($sniffer.transitions) {
+        if ($sniffer.transitions) {
           expect(child.hasClass('ng-enter')).toBe(true);
           $animate.triggerReflow();
           expect(child.hasClass('ng-enter-active')).toBe(true);
         }
 
         $animate.move(element, container);
-        if($sniffer.transitions) {
+        if ($sniffer.transitions) {
           expect(child.hasClass('ng-enter')).toBe(false);
           expect(child.hasClass('ng-enter-active')).toBe(false);
         }
@@ -3788,18 +3788,18 @@ describe("ngAnimate", function() {
 
         $animate.addClass(child, 'something');
         $rootScope.$digest();
-        if($sniffer.transitions) {
+        if ($sniffer.transitions) {
           $animate.triggerReflow();
         }
         expect(animationState).toBe('addClass');
-        if($sniffer.transitions) {
+        if ($sniffer.transitions) {
           expect(child.hasClass('something-add')).toBe(true);
           expect(child.hasClass('something-add-active')).toBe(true);
         }
 
         $animate.leave(container);
         expect(animationState).toBe('addClass-cancel');
-        if($sniffer.transitions) {
+        if ($sniffer.transitions) {
           expect(child.hasClass('something-add')).toBe(false);
           expect(child.hasClass('something-add-active')).toBe(false);
         }
@@ -4077,7 +4077,7 @@ describe("ngAnimate", function() {
     it("should wait until a queue of animations are complete before performing a reflow",
       inject(function($rootScope, $compile, $timeout, $sniffer, $animate) {
 
-      if(!$sniffer.transitions) return;
+      if (!$sniffer.transitions) return;
 
       $rootScope.items = [1,2,3,4,5];
       var element = html($compile('<div><div class="animated" ng-repeat="item in items"></div></div>')($rootScope));
@@ -4280,7 +4280,7 @@ describe("ngAnimate", function() {
       });
 
       inject(function($animate, $rootScope, $compile, $rootElement, $timeout, $document, $sniffer) {
-        if(!$sniffer.transitions) return;
+        if (!$sniffer.transitions) return;
 
         $animate.enabled(true);
 
@@ -4288,7 +4288,7 @@ describe("ngAnimate", function() {
         $rootElement.append(element);
         jqLite($document[0].body).append($rootElement);
 
-        for(var i=0;i<20;i++) {
+        for (var i=0;i<20;i++) {
           kid = $compile('<div class="kid"></div>')($rootScope);
           $animate.enter(kid, element);
         }
@@ -4300,7 +4300,7 @@ describe("ngAnimate", function() {
         dealoc(element);
         count = 0;
 
-        for(i=0;i<20;i++) {
+        for (i=0;i<20;i++) {
           kid = $compile('<div class="kid c-'+i+'"></div>')($rootScope);
           $animate.enter(kid, element);
         }
@@ -4677,7 +4677,7 @@ describe("ngAnimate", function() {
       var node = element[0];
       node._setAttribute = node.setAttribute;
       node.setAttribute = function(prop, val) {
-        if(prop == 'class' && val.indexOf('trigger-class') >= 0) {
+        if (prop == 'class' && val.indexOf('trigger-class') >= 0) {
           var propertyKey = ($sniffer.vendorPrefix == 'Webkit' ? '-webkit-' : '') + 'transition-property';
           capturedProperty = element.css(propertyKey);
         }
@@ -4809,7 +4809,7 @@ describe("ngAnimate", function() {
         });
       });
       inject(function($rootScope, $compile, $rootElement, $document, $timeout, $templateCache, $sniffer, $animate) {
-        if(!$sniffer.transitions) return;
+        if (!$sniffer.transitions) return;
 
         $templateCache.put('item-template', 'item: #{{ item }} ');
         var element = $compile('<div>' +
@@ -4864,7 +4864,7 @@ describe("ngAnimate", function() {
         });
       });
       inject(function($rootScope, $compile, $rootElement, $document, $timeout, $templateCache, $sniffer, $animate) {
-        if(!$sniffer.transitions) return;
+        if (!$sniffer.transitions) return;
 
         var element = $compile('<div class="capture"></div>')($rootScope);
         $rootElement.append(element);
@@ -4915,7 +4915,7 @@ describe("ngAnimate", function() {
         });
       });
       inject(function($rootScope, $compile, $rootElement, $document, $sniffer, $animate) {
-        if(!$sniffer.transitions) return;
+        if (!$sniffer.transitions) return;
 
         var upperElement = $compile('<div><div ng-if=1><span class="capture prefixed-animation"></span></div></div>')($rootScope);
         $rootElement.append(upperElement);
@@ -5286,7 +5286,7 @@ describe("ngAnimate", function() {
           $rootScope.$watch('bool', function(bool) {
             if (bool) {
               $animate.enter(element, $rootElement);
-            } else if(element.parent().length) {
+            } else if (element.parent().length) {
               $animate.leave(element);
             }
           });
@@ -5316,7 +5316,7 @@ describe("ngAnimate", function() {
         //jQuery doesn't handle SVG elements natively. Instead, an add-on library
         //is required which is called jquery.svg.js. Therefore, when jQuery is
         //active here there is no point to test this since it won't work by default.
-        if(!$sniffer.transitions || !_jqLiteMode) return;
+        if (!$sniffer.transitions || !_jqLiteMode) return;
 
         ss.addRule('circle.ng-enter', '-webkit-transition:1s linear all;' +
                                               'transition:1s linear all;');

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -528,10 +528,10 @@ describe('ngView', function() {
       $rootScope.$digest();
 
       angular.forEach(element.contents(), function(node) {
-        if(node.nodeType == 3 /* text node */) {
+        if (node.nodeType == 3 /* text node */) {
           expect(angular.element(node).scope()).not.toBe($route.current.scope);
           expect(angular.element(node).controller()).not.toBeDefined();
-        } else if(node.nodeType == 8 /* comment node */) {
+        } else if (node.nodeType == 8 /* comment node */) {
           expect(angular.element(node).scope()).toBe(element.scope());
           expect(angular.element(node).controller()).toBe(element.controller());
         } else {


### PR DESCRIPTION
Moving the `requireSpaceAfterKeywords` rule to jscs with associated changes.

Is it preferred to explicitly specify the keywords in an array?

Or use `requireSpaceAfterKeywords = true`
which is equivalent to `requireSpaceAfterKeywords = [ 'do', 'for', 'if', 'else', 'switch', 'case', 'try', 'catch', 'void', 'while', 'with', 'return', 'typeof', 'function'];`

Although it doesn't make sense for `function`.

cc: @caitp
