### PR TITLE
style: disallow space after object keys, other rules

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -1,7 +1,11 @@
 {
   "disallowKeywords": ["with"],
+  "disallowMixedSpacesAndTabs": true,
+  "disallowMultipleLineStrings": true,
+  "disallowNewlineBeforeBlockStatements": true,
   "disallowTrailingWhitespace": true,
   "disallowSpaceAfterPrefixUnaryOperators": ["!"],
   "disallowSpaceBeforeBinaryOperators": [","],
+  "disallowSpaceAfterObjectKeys": true,
   "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "try", "catch"]
 }

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -236,7 +236,7 @@ function publishExternalAPI(angular){
         $timeout: $TimeoutProvider,
         $window: $WindowProvider,
         $$rAF: $$RAFProvider,
-        $$asyncCallback : $$AsyncCallbackProvider
+        $$asyncCallback: $$AsyncCallbackProvider
       });
     }
   ]);

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -122,7 +122,7 @@ function jqNextId() { return ++jqId; }
 
 var SPECIAL_CHARS_REGEXP = /([\:\-\_]+(.))/g;
 var MOZ_HACK_REGEXP = /^moz([A-Z])/;
-var MOUSE_EVENT_MAP= { mouseleave : "mouseout", mouseenter : "mouseover"};
+var MOUSE_EVENT_MAP= { mouseleave: "mouseout", mouseenter: "mouseover"};
 var jqLiteMinErr = minErr('jqLite');
 
 /**
@@ -521,11 +521,11 @@ forEach('input,select,option,textarea,button,form,details'.split(','), function(
   BOOLEAN_ELEMENTS[value] = true;
 });
 var ALIASED_ATTR = {
-  'ngMinlength' : 'minlength',
-  'ngMaxlength' : 'maxlength',
-  'ngMin' : 'min',
-  'ngMax' : 'max',
-  'ngPattern' : 'pattern'
+  'ngMinlength': 'minlength',
+  'ngMaxlength': 'maxlength',
+  'ngMin': 'min',
+  'ngMax': 'max',
+  'ngPattern': 'pattern'
 };
 
 function getBooleanAttrName(element, name) {

--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -170,7 +170,7 @@ var $AnimateProvider = ['$provide', function($provide) {
      * page}.
      */
     return {
-      animate : function(element, from, to) {
+      animate: function(element, from, to) {
         applyStyles(element, { from: from, to: to });
         return asyncPromise();
       },
@@ -191,7 +191,7 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @param {object=} options an optional collection of styles that will be applied to the element.
        * @return {Promise} the animation callback promise
        */
-      enter : function(element, parent, after, options) {
+      enter: function(element, parent, after, options) {
         applyStyles(element, options);
         after ? after.after(element)
               : parent.prepend(element);
@@ -209,7 +209,7 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @param {object=} options an optional collection of options that will be applied to the element.
        * @return {Promise} the animation callback promise
        */
-      leave : function(element, options) {
+      leave: function(element, options) {
         element.remove();
         return asyncPromise();
       },
@@ -232,7 +232,7 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @param {object=} options an optional collection of options that will be applied to the element.
        * @return {Promise} the animation callback promise
        */
-      move : function(element, parent, after, options) {
+      move: function(element, parent, after, options) {
         // Do not remove element before insert. Removing will cause data associated with the
         // element to be dropped. Insert will implicitly do the remove.
         return this.enter(element, parent, after, options);
@@ -251,11 +251,11 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @param {object=} options an optional collection of options that will be applied to the element.
        * @return {Promise} the animation callback promise
        */
-      addClass : function(element, className, options) {
+      addClass: function(element, className, options) {
         return this.setClass(element, className, [], options);
       },
 
-      $$addClassImmediately : function(element, className, options) {
+      $$addClassImmediately: function(element, className, options) {
         element = jqLite(element);
         className = !isString(className)
                         ? (isArray(className) ? className.join(' ') : '')
@@ -280,11 +280,11 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @param {object=} options an optional collection of options that will be applied to the element.
        * @return {Promise} the animation callback promise
        */
-      removeClass : function(element, className, options) {
+      removeClass: function(element, className, options) {
         return this.setClass(element, [], className, options);
       },
 
-      $$removeClassImmediately : function(element, className, options) {
+      $$removeClassImmediately: function(element, className, options) {
         element = jqLite(element);
         className = !isString(className)
                         ? (isArray(className) ? className.join(' ') : '')
@@ -310,7 +310,7 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @param {object=} options an optional collection of options that will be applied to the element.
        * @return {Promise} the animation callback promise
        */
-      setClass : function(element, add, remove, options) {
+      setClass: function(element, add, remove, options) {
         var self = this;
         var STORAGE_KEY = '$$animateClasses';
         var createdCache = false;
@@ -320,7 +320,7 @@ var $AnimateProvider = ['$provide', function($provide) {
         if (!cache) {
           cache = {
             classes: {},
-            options : options
+            options: options
           };
           createdCache = true;
         } else if (options && cache.options) {
@@ -357,15 +357,15 @@ var $AnimateProvider = ['$provide', function($provide) {
         return cache.promise;
       },
 
-      $$setClassImmediately : function(element, add, remove, options) {
+      $$setClassImmediately: function(element, add, remove, options) {
         add && this.$$addClassImmediately(element, add);
         remove && this.$$removeClassImmediately(element, remove);
         applyStyles(element, options);
         return asyncPromise();
       },
 
-      enabled : noop,
-      cancel : noop
+      enabled: noop,
+      cancel: noop
     };
   }];
 }];

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -898,7 +898,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
        *
        * @param {string} classVal The className value that will be added to the element
        */
-      $addClass : function(classVal) {
+      $addClass: function(classVal) {
         if (classVal && classVal.length > 0) {
           $animate.addClass(this.$$element, classVal);
         }
@@ -915,7 +915,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
        *
        * @param {string} classVal The className value that will be removed from the element
        */
-      $removeClass : function(classVal) {
+      $removeClass: function(classVal) {
         if (classVal && classVal.length > 0) {
           $animate.removeClass(this.$$element, classVal);
         }
@@ -933,7 +933,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
        * @param {string} newClasses The current CSS className value
        * @param {string} oldClasses The former CSS className value
        */
-      $updateClass : function(newClasses, oldClasses) {
+      $updateClass: function(newClasses, oldClasses) {
         var toAdd = tokenDifference(newClasses, oldClasses);
         if (toAdd && toAdd.length) {
           $animate.addClass(this.$$element, toAdd);

--- a/src/ng/directive/ngShowHide.js
+++ b/src/ng/directive/ngShowHide.js
@@ -168,7 +168,7 @@ var ngShowDirective = ['$animate', function($animate) {
         // to have a global/greedy CSS selector that breaks when other animations are run.
         // Read: https://github.com/angular/angular.js/issues/9103#issuecomment-58335845
         $animate[value ? 'removeClass' : 'addClass'](element, NG_HIDE_CLASS, {
-          tempClasses : NG_HIDE_IN_PROGRESS_CLASS
+          tempClasses: NG_HIDE_IN_PROGRESS_CLASS
         });
       });
     }
@@ -327,7 +327,7 @@ var ngHideDirective = ['$animate', function($animate) {
         // The comment inside of the ngShowDirective explains why we add and
         // remove a temporary class for the show/hide animation
         $animate[value ? 'addClass' : 'removeClass'](element,NG_HIDE_CLASS, {
-          tempClasses : NG_HIDE_IN_PROGRESS_CLASS
+          tempClasses: NG_HIDE_IN_PROGRESS_CLASS
         });
       });
     }

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -1062,7 +1062,7 @@ function $HttpProvider() {
           status: status,
           headers: headersGetter(headers),
           config: config,
-          statusText : statusText
+          statusText: statusText
         });
       }
 

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -966,7 +966,7 @@ function $RootScopeProvider(){
         asyncQueue.push({scope: this, expression: expr});
       },
 
-      $$postDigest : function(fn) {
+      $$postDigest: function(fn) {
         postDigestQueue.push(fn);
       },
 

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -78,8 +78,8 @@ function $SnifferProvider() {
       },
       csp: csp(),
       vendorPrefix: vendorPrefix,
-      transitions : transitions,
-      animations : animations,
+      transitions: transitions,
+      animations: animations,
       android: android
     };
   }];

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -665,10 +665,10 @@ angular.module('ngAnimate', ['ng'])
               afterFn = null;
             }
             after.push({
-              event : event, fn : afterFn
+              event: event, fn: afterFn
             });
             before.push({
-              event : event, fn : beforeFn
+              event: event, fn: beforeFn
             });
             return true;
           }
@@ -722,31 +722,31 @@ angular.module('ngAnimate', ['ng'])
         }
 
         return {
-          node : node,
-          event : animationEvent,
-          className : className,
-          isClassBased : isClassBased,
-          isSetClassOperation : isSetClassOperation,
-          applyStyles : function() {
+          node: node,
+          event: animationEvent,
+          className: className,
+          isClassBased: isClassBased,
+          isSetClassOperation: isSetClassOperation,
+          applyStyles: function() {
             if (options) {
               element.css(angular.extend(options.from || {}, options.to || {}));
             }
           },
-          before : function(allCompleteFn) {
+          before: function(allCompleteFn) {
             beforeComplete = allCompleteFn;
             run(before, beforeCancel, function() {
               beforeComplete = noop;
               allCompleteFn();
             });
           },
-          after : function(allCompleteFn) {
+          after: function(allCompleteFn) {
             afterComplete = allCompleteFn;
             run(after, afterCancel, function() {
               afterComplete = noop;
               allCompleteFn();
             });
           },
-          cancel : function() {
+          cancel: function() {
             if (beforeCancel) {
               forEach(beforeCancel, function(cancelFn) {
                 (cancelFn || noop)(true);
@@ -871,7 +871,7 @@ angular.module('ngAnimate', ['ng'])
          * @param {object=} options an optional collection of options that will be picked up by the CSS transition/animation
          * @return {Promise} the animation callback promise
         */
-        animate : function(element, from, to, className, options) {
+        animate: function(element, from, to, className, options) {
           className = className || 'ng-inline-animate';
           options = parseAnimateOptions(options) || {};
           options.from = to ? from : null;
@@ -915,7 +915,7 @@ angular.module('ngAnimate', ['ng'])
          * @param {object=} options an optional collection of options that will be picked up by the CSS transition/animation
          * @return {Promise} the animation callback promise
         */
-        enter : function(element, parentElement, afterElement, options) {
+        enter: function(element, parentElement, afterElement, options) {
           options = parseAnimateOptions(options);
           element = angular.element(element);
           parentElement = prepareElement(parentElement);
@@ -959,7 +959,7 @@ angular.module('ngAnimate', ['ng'])
          * @param {object=} options an optional collection of styles that will be picked up by the CSS transition/animation
          * @return {Promise} the animation callback promise
         */
-        leave : function(element, options) {
+        leave: function(element, options) {
           options = parseAnimateOptions(options);
           element = angular.element(element);
 
@@ -1006,7 +1006,7 @@ angular.module('ngAnimate', ['ng'])
          * @param {object=} options an optional collection of styles that will be picked up by the CSS transition/animation
          * @return {Promise} the animation callback promise
         */
-        move : function(element, parentElement, afterElement, options) {
+        move: function(element, parentElement, afterElement, options) {
           options = parseAnimateOptions(options);
           element = angular.element(element);
           parentElement = prepareElement(parentElement);
@@ -1050,7 +1050,7 @@ angular.module('ngAnimate', ['ng'])
          * @param {object=} options an optional collection of styles that will be picked up by the CSS transition/animation
          * @return {Promise} the animation callback promise
         */
-        addClass : function(element, className, options) {
+        addClass: function(element, className, options) {
           return this.setClass(element, className, [], options);
         },
 
@@ -1084,7 +1084,7 @@ angular.module('ngAnimate', ['ng'])
          * @param {object=} options an optional collection of styles that will be picked up by the CSS transition/animation
          * @return {Promise} the animation callback promise
         */
-        removeClass : function(element, className, options) {
+        removeClass: function(element, className, options) {
           return this.setClass(element, [], className, options);
         },
 
@@ -1116,7 +1116,7 @@ angular.module('ngAnimate', ['ng'])
          * @param {object=} options an optional collection of styles that will be picked up by the CSS transition/animation
          * @return {Promise} the animation callback promise
          */
-        setClass : function(element, add, remove, options) {
+        setClass: function(element, add, remove, options) {
           options = parseAnimateOptions(options);
 
           var STORAGE_KEY = '$$animateClasses';
@@ -1160,8 +1160,8 @@ angular.module('ngAnimate', ['ng'])
             return cache.promise;
           } else {
             element.data(STORAGE_KEY, cache = {
-              classes : classes,
-              options : options
+              classes: classes,
+              options: options
             });
           }
 
@@ -1199,7 +1199,7 @@ angular.module('ngAnimate', ['ng'])
          * @description
          * Cancels the provided animation.
         */
-        cancel : function(promise) {
+        cancel: function(promise) {
           promise.$$cancelFn();
         },
 
@@ -1216,7 +1216,7 @@ angular.module('ngAnimate', ['ng'])
          * Globally enables/disables animations.
          *
         */
-        enabled : function(value, element) {
+        enabled: function(value, element) {
           switch (arguments.length) {
             case 2:
               if (value) {
@@ -1368,10 +1368,10 @@ angular.module('ngAnimate', ['ng'])
         runningAnimations[className] = runner;
 
         element.data(NG_ANIMATE_STATE, {
-          last : runner,
-          active : runningAnimations,
-          index : localAnimationCount,
-          totalActive : totalActiveAnimations
+          last: runner,
+          active: runningAnimations,
+          index: localAnimationCount,
+          totalActive: totalActiveAnimations
         });
 
         //first we run the before animations and when all of those are complete
@@ -1399,8 +1399,8 @@ angular.module('ngAnimate', ['ng'])
           if (elementEvents && elementEvents[eventName] && elementEvents[eventName].length > 0) {
             $$asyncCallback(function() {
               element.triggerHandler(eventName, {
-                event : animationEvent,
-                className : className
+                event: animationEvent,
+                className: className
               });
             });
           }
@@ -1693,7 +1693,7 @@ angular.module('ngAnimate', ['ng'])
             }
           });
           data = {
-            total : 0,
+            total: 0,
             transitionDelay: transitionDelay,
             transitionDuration: transitionDuration,
             animationDelay: animationDelay,
@@ -1766,12 +1766,12 @@ angular.module('ngAnimate', ['ng'])
 
         var closeAnimationFns = formerData.closeAnimationFns || [];
         element.data(NG_ANIMATE_CSS_DATA_KEY, {
-          stagger : stagger,
-          cacheKey : eventCacheKey,
-          running : formerData.running || 0,
-          itemIndex : itemIndex,
-          blockTransition : blockTransition,
-          closeAnimationFns : closeAnimationFns
+          stagger: stagger,
+          cacheKey: eventCacheKey,
+          running: formerData.running || 0,
+          itemIndex: itemIndex,
+          blockTransition: blockTransition,
+          closeAnimationFns: closeAnimationFns
         });
 
         var node = extractElementNode(element);
@@ -2013,29 +2013,29 @@ angular.module('ngAnimate', ['ng'])
       }
 
       return {
-        animate : function(element, className, from, to, animationCompleted, options) {
+        animate: function(element, className, from, to, animationCompleted, options) {
           options = options || {};
           options.from = from;
           options.to = to;
           return animate('animate', element, className, animationCompleted, options);
         },
 
-        enter : function(element, animationCompleted, options) {
+        enter: function(element, animationCompleted, options) {
           options = options || {};
           return animate('enter', element, 'ng-enter', animationCompleted, options);
         },
 
-        leave : function(element, animationCompleted, options) {
+        leave: function(element, animationCompleted, options) {
           options = options || {};
           return animate('leave', element, 'ng-leave', animationCompleted, options);
         },
 
-        move : function(element, animationCompleted, options) {
+        move: function(element, animationCompleted, options) {
           options = options || {};
           return animate('move', element, 'ng-move', animationCompleted, options);
         },
 
-        beforeSetClass : function(element, add, remove, animationCompleted, options) {
+        beforeSetClass: function(element, add, remove, animationCompleted, options) {
           options = options || {};
           var className = suffixClasses(remove, '-remove') + ' ' +
                           suffixClasses(add, '-add');
@@ -2048,7 +2048,7 @@ angular.module('ngAnimate', ['ng'])
           animationCompleted();
         },
 
-        beforeAddClass : function(element, className, animationCompleted, options) {
+        beforeAddClass: function(element, className, animationCompleted, options) {
           options = options || {};
           var cancellationMethod = animateBefore('addClass', element, suffixClasses(className, '-add'), options.from);
           if (cancellationMethod) {
@@ -2059,7 +2059,7 @@ angular.module('ngAnimate', ['ng'])
           animationCompleted();
         },
 
-        beforeRemoveClass : function(element, className, animationCompleted, options) {
+        beforeRemoveClass: function(element, className, animationCompleted, options) {
           options = options || {};
           var cancellationMethod = animateBefore('removeClass', element, suffixClasses(className, '-remove'), options.from);
           if (cancellationMethod) {
@@ -2070,7 +2070,7 @@ angular.module('ngAnimate', ['ng'])
           animationCompleted();
         },
 
-        setClass : function(element, add, remove, animationCompleted, options) {
+        setClass: function(element, add, remove, animationCompleted, options) {
           options = options || {};
           remove = suffixClasses(remove, '-remove');
           add = suffixClasses(add, '-add');
@@ -2078,12 +2078,12 @@ angular.module('ngAnimate', ['ng'])
           return animateAfter('setClass', element, className, animationCompleted, options.to);
         },
 
-        addClass : function(element, className, animationCompleted, options) {
+        addClass: function(element, className, animationCompleted, options) {
           options = options || {};
           return animateAfter('addClass', element, suffixClasses(className, '-add'), animationCompleted, options.to);
         },
 
-        removeClass : function(element, className, animationCompleted, options) {
+        removeClass: function(element, className, animationCompleted, options) {
           options = options || {};
           return animateAfter('removeClass', element, suffixClasses(className, '-remove'), animationCompleted, options.to);
         }

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -49,7 +49,7 @@ var ngAriaModule = angular.module('ngAria', ['ng']).
  */
 function $AriaProvider() {
   var config = {
-    ariaHidden : true,
+    ariaHidden: true,
     ariaChecked: true,
     ariaDisabled: true,
     ariaRequired: true,

--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -371,8 +371,8 @@ angular.module('ngMessages', [])
         }
 
         ngMessages.registerMessage(index, {
-          type : $attrs.ngMessage || $attrs.when,
-          attach : function() {
+          type: $attrs.ngMessage || $attrs.when,
+          attach: function() {
             if (!element) {
               $transclude($scope, function(clone) {
                 $animate.enter(clone, null, $element);
@@ -380,7 +380,7 @@ angular.module('ngMessages', [])
               });
             }
           },
-          detach : function(now) {
+          detach: function(now) {
             if (element) {
               $animate.leave(element);
               element = null;

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -781,20 +781,20 @@ angular.mock.animate = angular.module('ngAnimateMock', ['ng'])
     $provide.decorator('$animate', ['$delegate', '$$asyncCallback', '$timeout', '$browser',
                             function($delegate,   $$asyncCallback,   $timeout,   $browser) {
       var animate = {
-        queue : [],
-        cancel : $delegate.cancel,
-        enabled : $delegate.enabled,
-        triggerCallbackEvents : function() {
+        queue: [],
+        cancel: $delegate.cancel,
+        enabled: $delegate.enabled,
+        triggerCallbackEvents: function() {
           $$asyncCallback.flush();
         },
-        triggerCallbackPromise : function() {
+        triggerCallbackPromise: function() {
           $timeout.flush(0);
         },
-        triggerCallbacks : function() {
+        triggerCallbacks: function() {
           this.triggerCallbackEvents();
           this.triggerCallbackPromise();
         },
-        triggerReflow : function() {
+        triggerReflow: function() {
           angular.forEach(reflowQueue, function(fn) {
             fn();
           });
@@ -806,10 +806,10 @@ angular.mock.animate = angular.module('ngAnimateMock', ['ng'])
         ['animate','enter','leave','move','addClass','removeClass','setClass'], function(method) {
         animate[method] = function() {
           animate.queue.push({
-            event : method,
-            element : arguments[0],
-            options : arguments[arguments.length-1],
-            args : arguments
+            event: method,
+            element: arguments[0],
+            options: arguments[arguments.length-1],
+            args: arguments
           });
           return $delegate[method].apply($delegate, arguments);
         };

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -623,7 +623,7 @@ describe('angular', function() {
 
     it('should handle objects with length property as objects', function() {
       var obj = {
-          'foo' : 'bar',
+          'foo': 'bar',
           'length': 2
         },
         log = [];

--- a/test/helpers/privateMocks.js
+++ b/test/helpers/privateMocks.js
@@ -11,7 +11,7 @@ function createMockStyleSheet(doc, wind) {
   var ss = doc.styleSheets[doc.styleSheets.length - 1];
 
   return {
-    addRule : function(selector, styles) {
+    addRule: function(selector, styles) {
       try {
         ss.insertRule(selector + '{ ' + styles + '}', 0);
       }
@@ -23,7 +23,7 @@ function createMockStyleSheet(doc, wind) {
       }
     },
 
-    destroy : function() {
+    destroy: function() {
       head.removeChild(node);
     }
   };

--- a/test/ng/animateSpec.js
+++ b/test/ng/animateSpec.js
@@ -121,35 +121,35 @@ describe("$animate", function() {
       $animate.enabled(true);
 
       $animate.enter(element, parent, null, {
-        to: { color : 'red' }
+        to: { color: 'red' }
       });
       assertColor('red');
 
       $animate.move(element, null, other, {
-        to: { color : 'yellow' }
+        to: { color: 'yellow' }
       });
       assertColor('yellow');
 
       $animate.addClass(element, 'on', {
-        to: { color : 'green' }
+        to: { color: 'green' }
       });
       $rootScope.$digest();
       assertColor('green');
 
       $animate.setClass(element, 'off', 'on', {
-        to: { color : 'black' }
+        to: { color: 'black' }
       });
       $rootScope.$digest();
       assertColor('black');
 
       $animate.removeClass(element, 'off', {
-        to: { color : 'blue' }
+        to: { color: 'blue' }
       });
       $rootScope.$digest();
       assertColor('blue');
 
       $animate.leave(element, 'off', {
-        to: { color : 'blue' }
+        to: { color: 'blue' }
       });
       assertColor('blue'); //nothing should happen the element is gone anyway
 
@@ -165,8 +165,8 @@ describe("$animate", function() {
 
       element.css('color', 'red');
       $animate.addClass(element, 'on', {
-        from : { color : 'green' },
-        to : { borderColor : 'purple' }
+        from: { color: 'green' },
+        to: { borderColor: 'purple' }
       });
       $rootScope.$digest();
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4252,7 +4252,7 @@ describe('$compile', function() {
           return {
             require: '^parentDirective',
             templateUrl: 'childDirective.html',
-            controller : function(log) { log('childController'); }
+            controller: function(log) { log('childController'); }
           };
         });
       });
@@ -4343,14 +4343,14 @@ describe('$compile', function() {
             transclude: true,
             replace: true,
             templateUrl: 'childDirective.html',
-            controller : function(log) { log('childController'); }
+            controller: function(log) { log('childController'); }
           };
         });
         directive('babyDirective', function() {
           return {
             require: '^childDirective',
             templateUrl: 'babyDirective.html',
-            controller : function(log) { log('babyController'); }
+            controller: function(log) { log('babyController'); }
           };
         });
       });

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -283,7 +283,7 @@ describe('NgModelController', function() {
       a = b = true;
 
       ctrl.$setViewValue('3');
-      expect(ctrl.$error).toEqual({ high : true, even : true });
+      expect(ctrl.$error).toEqual({ high: true, even: true });
 
       ctrl.$setViewValue('10');
       expect(ctrl.$error).toEqual({});
@@ -308,14 +308,14 @@ describe('NgModelController', function() {
       a = b = false; //not undefined
 
       ctrl.$setViewValue('2');
-      expect(ctrl.$error).toEqual({ high : true });
+      expect(ctrl.$error).toEqual({ high: true });
     });
 
     it('should not remove external validators when a parser failed', function() {
       ctrl.$parsers.push(function(v) { return undefined; });
       ctrl.$setValidity('externalError', false);
       ctrl.$setViewValue('someValue');
-      expect(ctrl.$error).toEqual({ externalError : true, parse: true });
+      expect(ctrl.$error).toEqual({ externalError: true, parse: true });
     });
 
     it('should remove all non-parse-related CSS classes from the form when a parser fails',
@@ -658,7 +658,7 @@ describe('NgModelController', function() {
 
       var stages = {};
 
-      stages.sync = { status1 : false, status2: false, count : 0 };
+      stages.sync = { status1: false, status2: false, count: 0 };
       ctrl.$validators.syncValidator1 = function(modelValue, viewValue) {
         stages.sync.count++;
         return stages.sync.status1;
@@ -669,7 +669,7 @@ describe('NgModelController', function() {
         return stages.sync.status2;
       };
 
-      stages.async = { defer : null, count : 0 };
+      stages.async = { defer: null, count: 0 };
       ctrl.$asyncValidators.asyncValidator = function(modelValue, viewValue) {
         stages.async.defer = $q.defer();
         stages.async.count++;
@@ -4465,7 +4465,7 @@ describe('input', function() {
 
 
     it('should consider bad input as an error before any other errors are considered', function() {
-      compileInput('<input type="text" ng-model="value" required />', { badInput : true });
+      compileInput('<input type="text" ng-model="value" required />', { badInput: true });
       var ctrl = inputElm.controller('ngModel');
       ctrl.$parsers.push(function() {
         return undefined;

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -415,7 +415,7 @@ describe('ngClass animations', function() {
     module(function($animateProvider) {
       $animateProvider.register('.crazy', function() {
         return {
-          enter : function(element, done) {
+          enter: function(element, done) {
             element.data('state', 'crazy-enter');
             done();
           }

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -285,7 +285,7 @@ describe('ngInclude', function() {
     $httpBackend.expect('GET', 'myUrl2').respond('<div>{{logger("url2")}}</div>');
     $httpBackend.flush(); // now that we have two requests pending, flush!
 
-    expect(log).toEqual({ url2 : true });
+    expect(log).toEqual({ url2: true });
   }));
 
 

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -372,12 +372,12 @@ describe('ngRepeat', function() {
         '<div ng-repeat="item in items | filter:x as results track by $index">{{item.name}}/</div>')(scope);
 
       scope.items = [
-        { name : 'red' },
-        { name : 'blue' },
-        { name : 'green' },
-        { name : 'black' },
-        { name : 'orange' },
-        { name : 'blonde' }
+        { name: 'red' },
+        { name: 'blue' },
+        { name: 'green' },
+        { name: 'black' },
+        { name: 'orange' },
+        { name: 'blonde' }
       ];
 
       expect(scope.results).toBeUndefined();
@@ -387,9 +387,9 @@ describe('ngRepeat', function() {
       scope.$digest();
 
       expect(scope.results).toEqual([
-        { name : 'blue' },
-        { name : 'black' },
-        { name : 'blonde' }
+        { name: 'blue' },
+        { name: 'black' },
+        { name: 'blonde' }
       ]);
 
       scope.items = [];
@@ -421,12 +421,12 @@ describe('ngRepeat', function() {
     it('should support alias identifiers containing reserved words', inject(function($exceptionHandler) {
       scope.x = 'bl';
       scope.items = [
-        { name : 'red' },
-        { name : 'blue' },
-        { name : 'green' },
-        { name : 'black' },
-        { name : 'orange' },
-        { name : 'blonde' }
+        { name: 'red' },
+        { name: 'blue' },
+        { name: 'green' },
+        { name: 'black' },
+        { name: 'orange' },
+        { name: 'blonde' }
       ];
       forEach([
         'null2',
@@ -451,12 +451,12 @@ describe('ngRepeat', function() {
     it('should throw if alias identifier is not a simple identifier', inject(function($exceptionHandler) {
       scope.x = 'bl';
       scope.items = [
-        { name : 'red' },
-        { name : 'blue' },
-        { name : 'green' },
-        { name : 'black' },
-        { name : 'orange' },
-        { name : 'blonde' }
+        { name: 'red' },
+        { name: 'blue' },
+        { name: 'green' },
+        { name: 'black' },
+        { name: 'orange' },
+        { name: 'blonde' }
       ];
 
       forEach([

--- a/test/ng/directive/ngSwitchSpec.js
+++ b/test/ng/directive/ngSwitchSpec.js
@@ -330,7 +330,7 @@ describe('ngSwitch animation', function() {
       module(function($animateProvider) {
         $animateProvider.register('.long-leave', function() {
           return {
-            leave : function(element, done) {
+            leave: function(element, done) {
               //do nothing at all
             }
           };

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -415,14 +415,14 @@ describe('$httpBackend', function() {
 
       //temporarily overriding the DOM element to pretend that the test runs origin with file:// protocol
       urlParsingNode = {
-        hash : "#/C:/",
-        host : "",
-        hostname : "",
-        href : "file:///C:/base#!/C:/foo",
-        pathname : "/C:/foo",
-        port : "",
-        protocol : "file:",
-        search : "",
+        hash: "#/C:/",
+        host: "",
+        hostname: "",
+        href: "file:///C:/base#!/C:/foo",
+        pathname: "/C:/foo",
+        port: "",
+        protocol: "file:",
+        search: "",
         setAttribute: angular.noop
       };
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -711,15 +711,15 @@ describe('$http', function() {
       });
 
       it('should NOT delete Content-Type header if request data/body is set by request transform', function() {
-        $httpBackend.expect('POST', '/url', {'one' : 'two'}, function(headers) {
+        $httpBackend.expect('POST', '/url', {'one': 'two'}, function(headers) {
           return headers['Content-Type'] == 'application/json;charset=utf-8';
         }).respond('');
 
         $http({
           url: '/url',
           method: 'POST',
-          transformRequest : function(data) {
-            data = {'one' : 'two'};
+          transformRequest: function(data) {
+            data = {'one': 'two'};
             return data;
           }
         });

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -25,14 +25,14 @@ describe('$location', function() {
       //temporarily overriding the DOM element
       //with output from IE, if not in IE
       urlParsingNode = {
-        hash : "#/C:/",
-        host : "",
-        hostname : "",
-        href : "file:///C:/base#!/C:/foo",
-        pathname : "/C:/foo",
-        port : "",
-        protocol : "file:",
-        search : "",
+        hash: "#/C:/",
+        host: "",
+        hostname: "",
+        href: "file:///C:/base#!/C:/foo",
+        pathname: "/C:/foo",
+        port: "",
+        protocol: "file:",
+        search: "",
         setAttribute: angular.noop
       };
     }));

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1600,10 +1600,10 @@ describe('parser', function() {
         }));
 
         it('should not use locals to resolve object properties', inject(function($parse) {
-          expect($parse('a[0].b')({a: [ {b : 'scope'} ]}, {b : 'locals'})).toBe('scope');
-          expect($parse('a[0]["b"]')({a: [ {b : 'scope'} ]}, {b : 'locals'})).toBe('scope');
-          expect($parse('a[0][0].b')({a: [[{b : 'scope'}]]}, {b : 'locals'})).toBe('scope');
-          expect($parse('a[0].b.c')({a: [ {b: {c: 'scope'}}] }, {b : {c: 'locals'} })).toBe('scope');
+          expect($parse('a[0].b')({a: [ {b: 'scope'} ]}, {b: 'locals'})).toBe('scope');
+          expect($parse('a[0]["b"]')({a: [ {b: 'scope'} ]}, {b: 'locals'})).toBe('scope');
+          expect($parse('a[0][0].b')({a: [[{b: 'scope'}]]}, {b: 'locals'})).toBe('scope');
+          expect($parse('a[0].b.c')({a: [ {b: {c: 'scope'}}] }, {b: {c: 'locals'} })).toBe('scope');
         }));
       });
 

--- a/test/ng/rafSpec.js
+++ b/test/ng/rafSpec.js
@@ -39,7 +39,7 @@ describe('$$rAF', function() {
       var injector = createInjector(['ng', function($provide) {
         $provide.value('$timeout', timeoutSpy);
         $provide.value('$window', {
-          location : window.location,
+          location: window.location,
         });
       }]);
 

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -566,7 +566,7 @@ describe('Scope', function() {
 
       it('should not trigger if nothing change', inject(function($rootScope) {
         $rootScope.$digest();
-        expect(log).toEqual([{ newVal : undefined, oldVal : undefined, identical : true }]);
+        expect(log).toEqual([{ newVal: undefined, oldVal: undefined, identical: true }]);
         log.reset();
 
         $rootScope.$digest();

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -100,8 +100,8 @@ describe('$sniffer', function() {
     it('should still work for an older version of Webkit', function() {
       module(function($provide) {
         var doc = {
-          body : {
-            style : {
+          body: {
+            style: {
               WebkitOpacity: '0'
             }
           }
@@ -125,8 +125,8 @@ describe('$sniffer', function() {
     it('should be false when there is no animation style', function() {
       module(function($provide) {
         var doc = {
-          body : {
-            style : {}
+          body: {
+            style: {}
           }
         };
         $provide.value('$document', jqLite(doc));
@@ -140,11 +140,11 @@ describe('$sniffer', function() {
       module(function($provide) {
         var animationStyle = 'some_animation 2s linear';
         var doc = {
-          body : {
-            style : {
-              WebkitAnimation : animationStyle,
-              MozAnimation : animationStyle,
-              OAnimation : animationStyle
+          body: {
+            style: {
+              WebkitAnimation: animationStyle,
+              MozAnimation: animationStyle,
+              OAnimation: animationStyle
             }
           }
         };
@@ -158,9 +158,9 @@ describe('$sniffer', function() {
     it('should be true with w3c-style animations', function() {
       module(function($provide) {
         var doc = {
-          body : {
-            style : {
-              animation : 'some_animation 2s linear'
+          body: {
+            style: {
+              animation: 'some_animation 2s linear'
             }
           }
         };
@@ -174,8 +174,8 @@ describe('$sniffer', function() {
     it('should be true on android with older body style properties', function() {
       module(function($provide) {
         var doc = {
-          body : {
-            style : {
+          body: {
+            style: {
               webkitAnimation: ''
             }
           }
@@ -196,8 +196,8 @@ describe('$sniffer', function() {
     it('should be true when an older version of Webkit is used', function() {
       module(function($provide) {
         var doc = {
-          body : {
-            style : {
+          body: {
+            style: {
               WebkitOpacity: '0'
             }
           }
@@ -222,8 +222,8 @@ describe('$sniffer', function() {
     it('should be false when there is no transition style', function() {
       module(function($provide) {
         var doc = {
-          body : {
-            style : {}
+          body: {
+            style: {}
           }
         };
         $provide.value('$document', jqLite(doc));
@@ -237,11 +237,11 @@ describe('$sniffer', function() {
       module(function($provide) {
         var transitionStyle = '1s linear all';
         var doc = {
-          body : {
-            style : {
-              WebkitTransition : transitionStyle,
-              MozTransition : transitionStyle,
-              OTransition : transitionStyle
+          body: {
+            style: {
+              WebkitTransition: transitionStyle,
+              MozTransition: transitionStyle,
+              OTransition: transitionStyle
             }
           }
         };
@@ -255,9 +255,9 @@ describe('$sniffer', function() {
     it('should be true with w3c-style transitions', function() {
       module(function($provide) {
         var doc = {
-          body : {
-            style : {
-              transition : '1s linear all'
+          body: {
+            style: {
+              transition: '1s linear all'
             }
           }
         };
@@ -271,8 +271,8 @@ describe('$sniffer', function() {
     it('should be true on android with older body style properties', function() {
       module(function($provide) {
         var doc = {
-          body : {
-            style : {
+          body: {
+            style: {
               webkitTransition: ''
             }
           }
@@ -297,8 +297,8 @@ describe('$sniffer', function() {
     it('should be true on Boxee box with an older version of Webkit', function() {
       module(function($provide) {
         var doc = {
-          body : {
-            style : {}
+          body: {
+            style: {}
           }
         };
         var win = {

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -28,11 +28,11 @@ describe("ngAnimate", function() {
     module(function($animateProvider) {
       $animateProvider.register('.my-structrual-animation', function() {
         return {
-          enter : function(element, done) {
+          enter: function(element, done) {
             hasBeenAnimated = true;
             done();
           },
-          leave : function(element, done) {
+          leave: function(element, done) {
             hasBeenAnimated = true;
             done();
           }
@@ -61,13 +61,13 @@ describe("ngAnimate", function() {
     module(function($animateProvider, $compileProvider) {
       $compileProvider.directive('myRemoteDirective', function() {
         return {
-          templateUrl : 'remote.html'
+          templateUrl: 'remote.html'
         };
       });
       $animateProvider.register('.my-structrual-animation', function() {
         return {
-          enter : animateSpy,
-          leave : animateSpy
+          enter: animateSpy,
+          leave: animateSpy
         };
       });
     });
@@ -155,7 +155,7 @@ describe("ngAnimate", function() {
           module(function($animateProvider) {
             $animateProvider.register('.animated', function() {
               return {
-                addClass : function(element, className, done) {
+                addClass: function(element, className, done) {
                   count++;
                   done();
                 }
@@ -213,7 +213,7 @@ describe("ngAnimate", function() {
           module(function($animateProvider) {
             $animateProvider.register('.animated', function() {
               return {
-                addClass : function(element, className, done) {
+                addClass: function(element, className, done) {
                   count++;
                   done();
                 }
@@ -240,7 +240,7 @@ describe("ngAnimate", function() {
             $provide.value('$rootElement', rootElm);
             $animateProvider.register('.capture-animation', function() {
               return {
-                addClass : function(element, className, done) {
+                addClass: function(element, className, done) {
                   captured = true;
                   done();
                 }
@@ -299,9 +299,9 @@ describe("ngAnimate", function() {
                 };
               }
               return {
-                leave : animate,
-                addClass : animate,
-                removeClass : animate
+                leave: animate,
+                addClass: animate,
+                removeClass: animate
               };
             });
             $animateProvider.register('.custom-long-delay', function($timeout) {
@@ -313,9 +313,9 @@ describe("ngAnimate", function() {
                 };
               }
               return {
-                leave : animate,
-                addClass : animate,
-                removeClass : animate
+                leave: animate,
+                addClass: animate,
+                removeClass: animate
               };
             });
             $animateProvider.register('.setup-memo', function() {
@@ -509,18 +509,18 @@ describe("ngAnimate", function() {
           module(function($animateProvider) {
             $animateProvider.register('.classify', function() {
               return {
-                beforeAddClass : fallback,
-                addClass : fallback,
-                beforeRemoveClass : fallback,
-                removeClass : fallback,
+                beforeAddClass: fallback,
+                addClass: fallback,
+                beforeRemoveClass: fallback,
+                removeClass: fallback,
 
-                beforeSetClass : function(element, add, remove, done) {
+                beforeSetClass: function(element, add, remove, done) {
                   count++;
                   expect(add).toBe('yes');
                   expect(remove).toBe('no');
                   done();
                 },
-                setClass : function(element, add, remove, done) {
+                setClass: function(element, add, remove, done) {
                   count++;
                   expect(add).toBe('yes');
                   expect(remove).toBe('no');
@@ -548,18 +548,18 @@ describe("ngAnimate", function() {
           module(function($animateProvider) {
             $animateProvider.register('.classify', function() {
               return {
-                beforeAddClass : fallback,
-                addClass : fallback,
-                beforeRemoveClass : fallback,
-                removeClass : fallback,
+                beforeAddClass: fallback,
+                addClass: fallback,
+                beforeRemoveClass: fallback,
+                removeClass: fallback,
 
-                beforeSetClass : function(element, add, remove, done) {
+                beforeSetClass: function(element, add, remove, done) {
                   count++;
                   expect(add).toBe('yes');
                   expect(remove).toBe('no');
                   done();
                 },
-                setClass : function(element, add, remove, done) {
+                setClass: function(element, add, remove, done) {
                   count++;
                   expect(add).toBe('yes');
                   expect(remove).toBe('no');
@@ -587,22 +587,22 @@ describe("ngAnimate", function() {
           module(function($animateProvider) {
             $animateProvider.register('.classify', function() {
               return {
-                beforeAddClass : function(element, className, done) {
+                beforeAddClass: function(element, className, done) {
                   count++;
                   expect(className).toBe('yes');
                   done();
                 },
-                addClass : function(element, className, done) {
+                addClass: function(element, className, done) {
                   count++;
                   expect(className).toBe('yes');
                   done();
                 },
-                beforeRemoveClass : function(element, className, done) {
+                beforeRemoveClass: function(element, className, done) {
                   count++;
                   expect(className).toBe('no');
                   done();
                 },
-                removeClass : function(element, className, done) {
+                removeClass: function(element, className, done) {
                   count++;
                   expect(className).toBe('no');
                   done();
@@ -693,12 +693,12 @@ describe("ngAnimate", function() {
           module(function($animateProvider) {
             $animateProvider.register('.track-me', function() {
               return {
-                enter       : track('enter'),
-                leave       : track('leave'),
-                move        : track('move'),
-                addClass    : track('addClass'),
-                removeClass : track('removeClass'),
-                setClass    : track('setClass')
+                enter: track('enter'),
+                leave: track('leave'),
+                move: track('move'),
+                addClass: track('addClass'),
+                removeClass: track('removeClass'),
+                setClass: track('setClass')
               };
 
               function track(type) {
@@ -897,11 +897,11 @@ describe("ngAnimate", function() {
           module(function($animateProvider) {
             $animateProvider.register('.hide', function() {
               return {
-                addClass : function(element, className, done) {
+                addClass: function(element, className, done) {
                   addClassDone = done;
                   return addClassDoneSpy;
                 },
-                removeClass : function(element, className, done) {
+                removeClass: function(element, className, done) {
                   removeClassDone = done;
                   return removeClassDoneSpy;
                 }
@@ -962,7 +962,7 @@ describe("ngAnimate", function() {
           module(function($animateProvider) {
             $animateProvider.register('.capture', function() {
               return {
-                addClass : function(element, className, done) {
+                addClass: function(element, className, done) {
                   capture = true;
                   done();
                 }
@@ -1073,12 +1073,12 @@ describe("ngAnimate", function() {
           module(function($animateProvider) {
             $animateProvider.register('.capture', function() {
               return {
-                enter : proxyAnimation,
-                leave : proxyAnimation,
-                move : proxyAnimation,
-                addClass : proxyAnimation,
-                removeClass : proxyAnimation,
-                setClass : proxyAnimation
+                enter: proxyAnimation,
+                leave: proxyAnimation,
+                move: proxyAnimation,
+                addClass: proxyAnimation,
+                removeClass: proxyAnimation,
+                setClass: proxyAnimation
               };
             });
           });
@@ -1167,7 +1167,7 @@ describe("ngAnimate", function() {
         element = $compile('<div class="fake-animation"></div>')($rootScope);
 
         $animate.enter(element, $rootElement, null, {
-          to : {borderColor: 'red'}
+          to: {borderColor: 'red'}
         });
 
         $rootScope.$digest();
@@ -1201,13 +1201,13 @@ describe("ngAnimate", function() {
             //CSS animation handler
             $animateProvider.register('', function() {
               return {
-                leave : function() { log.push('css'); }
+                leave: function() { log.push('css'); }
               };
             });
             //custom JS animation handler
             $animateProvider.register('.js-animation', function() {
               return {
-                leave : function() { log.push('js'); }
+                leave: function() { log.push('js'); }
               };
             });
           });
@@ -1297,7 +1297,7 @@ describe("ngAnimate", function() {
             $rootScope.$digest();
             if ($sniffer.transitions) {
               $animate.triggerReflow();
-              browserTrigger(element,'animationend', { timeStamp : Date.now() + 20000, elapsedTime: 10 });
+              browserTrigger(element,'animationend', { timeStamp: Date.now() + 20000, elapsedTime: 10 });
             }
             expect(element).toBeShown();
           }));
@@ -1550,8 +1550,8 @@ describe("ngAnimate", function() {
               'animation-delay:0.1s;');
 
             var styles = {
-              from : { left : '50px' },
-              to : { left : '100px' }
+              from: { left: '50px' },
+              to: { left: '100px' }
             };
             var container = $compile(html('<div></div>'))($rootScope);
 
@@ -1999,8 +1999,8 @@ describe("ngAnimate", function() {
               'transition-delay:0.1s;');
 
             var styles = {
-              from : { left : '155px' },
-              to : { left : '255px' }
+              from: { left: '155px' },
+              to: { left: '255px' }
             };
             var container = $compile(html('<div></div>'))($rootScope);
 
@@ -2470,14 +2470,14 @@ describe("ngAnimate", function() {
           module(function($animateProvider) {
             $animateProvider.register('.custom', function($timeout) {
               return {
-                removeClass : function(element, className, done) {
+                removeClass: function(element, className, done) {
                   $timeout(done, 2000);
                 }
               };
             });
             $animateProvider.register('.other', function($timeout) {
               return {
-                enter : function(element, done) {
+                enter: function(element, done) {
                   $timeout(done, 10000);
                 }
               };
@@ -2804,12 +2804,12 @@ describe("ngAnimate", function() {
           module(function($animateProvider) {
             $animateProvider.register('.capture', function() {
               return {
-                enter : capture('enter'),
-                leave : capture('leave'),
-                move : capture('move'),
-                addClass : capture('addClass'),
-                removeClass : capture('removeClass'),
-                setClass : capture('setClass')
+                enter: capture('enter'),
+                leave: capture('leave'),
+                move: capture('move'),
+                addClass: capture('addClass'),
+                removeClass: capture('removeClass'),
+                setClass: capture('setClass')
               };
 
               function capture(event) {
@@ -2889,11 +2889,11 @@ describe("ngAnimate", function() {
           module(function($animateProvider) {
             $animateProvider.register('.klassy', function($timeout) {
               return {
-                addClass : function(element, className, done) {
+                addClass: function(element, className, done) {
                   captured = 'addClass-' + className;
                   $timeout(done, 500, false);
                 },
-                removeClass : function(element, className, done) {
+                removeClass: function(element, className, done) {
                   captured = 'removeClass-' + className;
                   $timeout(done, 3000, false);
                 }
@@ -3388,7 +3388,7 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.custom', function($timeout) {
           return {
-            enter : function(element, done) {
+            enter: function(element, done) {
               element.addClass('i-was-animated');
               $timeout(done, 10, false);
             }
@@ -3423,7 +3423,7 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.usurper', function($timeout) {
           return {
-            leave : function(element, done) {
+            leave: function(element, done) {
               element.addClass('this-is-mine-now');
               $timeout(done, 55, false);
             }
@@ -3597,7 +3597,7 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.three', function() {
           return {
-            move : function(element, done) {
+            move: function(element, done) {
               fn = function() {
                 done();
               };
@@ -3634,11 +3634,11 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.classify', function() {
           return {
-            removeClass : function(element, className, done) {
+            removeClass: function(element, className, done) {
               element.data('classify','remove-' + className);
               done();
             },
-            addClass : function(element, className, done) {
+            addClass: function(element, className, done) {
               element.data('classify','add-' + className);
               done();
             }
@@ -3736,14 +3736,14 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.animan', function() {
           return {
-            enter : function(element, done) {
+            enter: function(element, done) {
               animationState = 'enter';
               step = done;
               return function(cancelled) {
                 animationState = cancelled ? 'enter-cancel' : animationState;
               };
             },
-            addClass : function(element, className, done) {
+            addClass: function(element, className, done) {
               animationState = 'addClass';
               step = done;
               return function(cancelled) {
@@ -3811,14 +3811,14 @@ describe("ngAnimate", function() {
       var log = [];
       var track = function(name) {
         return function() {
-          log.push({ name : name, className : arguments[1] });
+          log.push({ name: name, className: arguments[1] });
         };
       };
       module(function($animateProvider) {
         $animateProvider.register('.animate', function() {
           return {
-            addClass    : track('addClass'),
-            removeClass : track('removeClass')
+            addClass: track('addClass'),
+            removeClass: track('removeClass')
           };
         });
       });
@@ -3839,8 +3839,8 @@ describe("ngAnimate", function() {
         $animate.triggerReflow();
 
         expect(log.length).toBe(2);
-        expect(log[0]).toEqual({ name : 'addClass', className : 'one four five' });
-        expect(log[1]).toEqual({ name : 'removeClass', className : 'three' });
+        expect(log[0]).toEqual({ name: 'addClass', className: 'one four five' });
+        expect(log[1]).toEqual({ name: 'removeClass', className: 'three' });
       });
     });
 
@@ -3848,14 +3848,14 @@ describe("ngAnimate", function() {
       var log = [];
       var track = function(name) {
         return function() {
-          log.push({ name : name, className : arguments[1] });
+          log.push({ name: name, className: arguments[1] });
         };
       };
       module(function($animateProvider) {
         $animateProvider.register('.animate', function() {
           return {
-            addClass    : track('addClass'),
-            removeClass : track('removeClass')
+            addClass: track('addClass'),
+            removeClass: track('removeClass')
           };
         });
       });
@@ -3894,7 +3894,7 @@ describe("ngAnimate", function() {
         $animate.triggerReflow();
         expect(log.length).toBe(1);
         $animate.triggerCallbacks();
-        expect(log[0]).toEqual({ name : 'removeClass', className : 'four' });
+        expect(log[0]).toEqual({ name: 'removeClass', className: 'four' });
 
         $animate.addClass(element, 'five');
         $animate.addClass(element, 'five');
@@ -3905,7 +3905,7 @@ describe("ngAnimate", function() {
         $animate.triggerReflow();
         expect(log.length).toBe(2);
         $animate.triggerCallbacks();
-        expect(log[1]).toEqual({ name : 'addClass', className : 'five' });
+        expect(log[1]).toEqual({ name: 'addClass', className: 'five' });
       });
     });
 
@@ -3914,9 +3914,9 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.animated', function() {
           return {
-            beforeAddClass : spy,
-            beforeRemoveClass : spy,
-            beforeSetClass : spy
+            beforeAddClass: spy,
+            beforeRemoveClass: spy,
+            beforeSetClass: spy
           };
         });
       });
@@ -3962,9 +3962,9 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.animated', function() {
           return {
-            beforeAddClass : spy,
-            beforeRemoveClass : spy,
-            beforeSetClass : spy
+            beforeAddClass: spy,
+            beforeRemoveClass: spy,
+            beforeSetClass: spy
           };
         });
       });
@@ -4009,7 +4009,7 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.animate', function() {
           return {
-            addClass : function(element, className, done) {
+            addClass: function(element, className, done) {
               continueAnimation = done;
             }
           };
@@ -4046,8 +4046,8 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.animate', function() {
           return {
-            addClass : spy,
-            removeClass : spy
+            addClass: spy,
+            removeClass: spy
           };
         });
       });
@@ -4104,7 +4104,7 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.child', function() {
           return {
-            addClass : function(element, className, done) {
+            addClass: function(element, className, done) {
               childAnimated = true;
               done();
             }
@@ -4112,7 +4112,7 @@ describe("ngAnimate", function() {
         });
         $animateProvider.register('.container', function() {
           return {
-            leave : function(element, done) {
+            leave: function(element, done) {
               containerAnimated = true;
               done();
             }
@@ -4158,11 +4158,11 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.animated', function() {
           return {
-            enter : ani('enter'),
-            leave : ani('leave'),
-            move : ani('move'),
-            addClass : ani('addClass'),
-            removeClass : ani('removeClass')
+            enter: ani('enter'),
+            leave: ani('leave'),
+            move: ani('move'),
+            addClass: ani('addClass'),
+            removeClass: ani('removeClass')
           };
 
           function ani(type) {
@@ -4244,7 +4244,7 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.animated', function() {
           return {
-            enter : function(element, done) {
+            enter: function(element, done) {
               intercepted = true;
               done();
             }
@@ -4271,7 +4271,7 @@ describe("ngAnimate", function() {
       var count = 0;
       module(function($provide) {
         $provide.value('$window', {
-          document : jqLite(window.document),
+          document: jqLite(window.document),
           getComputedStyle: function(element) {
             count++;
             return window.getComputedStyle(element);
@@ -4488,14 +4488,14 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.on', function() {
           return {
-            beforeAddClass : function(element, className, done) {
+            beforeAddClass: function(element, className, done) {
               currentAnimation = 'addClass';
               currentFn = done;
               return function(cancelled) {
                 currentAnimation = cancelled ? null : currentAnimation;
               };
             },
-            beforeRemoveClass : function(element, className, done) {
+            beforeRemoveClass: function(element, className, done) {
               currentAnimation = 'removeClass';
               currentFn = done;
               return function(cancelled) {
@@ -4532,7 +4532,7 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.animated', function() {
           return {
-            addClass : function(element, className, done) {
+            addClass: function(element, className, done) {
               count++;
               done();
             }
@@ -4562,11 +4562,11 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.class-animate', function() {
           return {
-            beforeAddClass : function(element, className, done) {
+            beforeAddClass: function(element, className, done) {
               steps.push('before');
               done();
             },
-            addClass : function(element, className, done) {
+            addClass: function(element, className, done) {
               steps.push('after');
               done();
             }
@@ -4594,11 +4594,11 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.animate', function() {
           return {
-            beforeLeave : function(element, done) {
+            beforeLeave: function(element, done) {
               steps.push('before');
               done();
             },
-            leave : function(element, done) {
+            leave: function(element, done) {
               parentID = element.parent().attr('id');
               steps.push('after');
               done();
@@ -4731,12 +4731,12 @@ describe("ngAnimate", function() {
         $animateProvider.register('.special', function($sniffer, $window) {
           var prop = $sniffer.vendorPrefix == 'Webkit' ? 'WebkitAnimation' : 'animation';
           return {
-            beforeAddClass : function(element, className, done) {
+            beforeAddClass: function(element, className, done) {
               expect(element[0].style[prop]).not.toContain('none');
               expect($window.getComputedStyle(element[0])[prop + 'Duration']).toBe('1s');
               done();
             },
-            addClass : function(element, className, done) {
+            addClass: function(element, className, done) {
               expect(element[0].style[prop]).not.toContain('none');
               expect($window.getComputedStyle(element[0])[prop + 'Duration']).toBe('1s');
               done();
@@ -4797,11 +4797,11 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.special', function() {
           return {
-            enter : function(element, done) {
+            enter: function(element, done) {
               capturedAnimation = 'enter';
               done();
             },
-            leave : function(element, done) {
+            leave: function(element, done) {
               capturedAnimation = 'leave';
               done();
             }
@@ -4851,8 +4851,8 @@ describe("ngAnimate", function() {
         $animateProvider.classNameFilter(/prefixed-animation/);
         $animateProvider.register('.capture', function() {
           return {
-            enter : buildFn('enter'),
-            leave : buildFn('leave')
+            enter: buildFn('enter'),
+            leave: buildFn('leave')
           };
 
           function buildFn(key) {
@@ -4902,8 +4902,8 @@ describe("ngAnimate", function() {
         $animateProvider.classNameFilter(/prefixed-animation/);
         $animateProvider.register('.capture', function() {
           return {
-            enter : buildFn('enter'),
-            leave : buildFn('leave')
+            enter: buildFn('enter'),
+            leave: buildFn('leave')
           };
 
           function buildFn(key) {
@@ -5080,7 +5080,7 @@ describe("ngAnimate", function() {
       module(function($animateProvider) {
         $animateProvider.register('.going', function() {
           return {
-            leave : function() {
+            leave: function() {
               //left blank so it hangs
               stat = 'leaving';
               return function(cancelled) {
@@ -5160,10 +5160,10 @@ describe("ngAnimate", function() {
 
         function mockAnimate() {
           return {
-            enter : spy,
-            leave : spy,
-            addClass : spy,
-            removeClass : spy
+            enter: spy,
+            leave: spy,
+            addClass: spy,
+            removeClass: spy
           };
         }
       }));
@@ -5258,11 +5258,11 @@ describe("ngAnimate", function() {
           module(function($animateProvider) {
             $animateProvider.register('.inner', function() {
               return {
-                beforeAddClass : function(element, className, done) {
+                beforeAddClass: function(element, className, done) {
                   spy();
                   done();
                 },
-                beforeRemoveClass : function(element, className, done) {
+                beforeRemoveClass: function(element, className, done) {
                   spy();
                   done();
                 }

--- a/test/ngMessages/messagesSpec.js
+++ b/test/ngMessages/messagesSpec.js
@@ -35,7 +35,7 @@ describe('ngMessages', function() {
     expect(element.text()).not.toContain('Message is set');
 
     $rootScope.$apply(function() {
-      $rootScope.col = { val : true };
+      $rootScope.col = { val: true };
     });
 
     expect(element.text()).toContain('Message is set');
@@ -52,7 +52,7 @@ describe('ngMessages', function() {
     expect(element.text()).not.toContain('Message is set');
 
     $rootScope.$apply(function() {
-      $rootScope.col = { val : true };
+      $rootScope.col = { val: true };
     });
 
     expect(element.text()).toContain('Message is set');
@@ -65,7 +65,7 @@ describe('ngMessages', function() {
       '[]': [],
       '[{}]': [{}],
       '': '',
-      '{ val2 : true }': { val2 : true } },
+      '{ val2 : true }': { val2: true } },
   function(prop) {
     inject(function($rootScope, $compile) {
       element = $compile('<div ng-messages="col">' +
@@ -103,8 +103,8 @@ describe('ngMessages', function() {
 
       $rootScope.$apply(function() {
         $rootScope.col = {
-          blue : true,
-          red : false
+          blue: true,
+          red: false
         };
       });
 
@@ -113,7 +113,7 @@ describe('ngMessages', function() {
 
       $rootScope.$apply(function() {
         $rootScope.col = {
-          red : prop
+          red: prop
         };
       });
 
@@ -129,8 +129,8 @@ describe('ngMessages', function() {
 
       $rootScope.$apply(function() {
         $rootScope.col = {
-          blue : 0,
-          red : null
+          blue: 0,
+          red: null
         };
       });
 
@@ -150,9 +150,9 @@ describe('ngMessages', function() {
 
     $rootScope.$apply(function() {
       $rootScope.col = {
-        three : true,
-        one : true,
-        two : true
+        three: true,
+        one: true,
+        two: true
       };
     });
 
@@ -182,7 +182,7 @@ describe('ngMessages', function() {
     expect(element.hasClass('ng-inactive')).toBe(true);
 
     $rootScope.$apply(function() {
-      $rootScope.col = { ready : true };
+      $rootScope.col = { ready: true };
     });
 
     expect(element.hasClass('ng-active')).toBe(true);
@@ -207,7 +207,7 @@ describe('ngMessages', function() {
       expect(event.args[2]).toBe('ng-active');
 
       $rootScope.$apply(function() {
-        $rootScope.col = { ready : true };
+        $rootScope.col = { ready: true };
       });
 
       event = $animate.queue.pop();
@@ -221,7 +221,7 @@ describe('ngMessages', function() {
     they('should load a remote template using $prop',
       {'<div ng-messages ng-messages-include="...">':
           '<div ng-messages="data" ng-messages-include="abc.html"></div>',
-       '<ng-messages include="...">' :
+       '<ng-messages include="...">':
           '<ng-messages for="data" include="abc.html"></ng-messages>'},
     function(html) {
       inject(function($compile, $rootScope, $templateCache) {
@@ -277,8 +277,8 @@ describe('ngMessages', function() {
                          '</div>')($rootScope);
 
       $rootScope.data = {
-        required : true,
-        failed : true
+        required: true,
+        failed: true
       };
 
       $rootScope.$digest();
@@ -382,8 +382,8 @@ describe('ngMessages', function() {
 
   describe('when multiple', function() {
     they('should show all truthy messages when the $prop attr is present',
-      { 'multiple' : 'multiple',
-        'ng-messages-multiple' : 'ng-messages-multiple' },
+      { 'multiple': 'multiple',
+        'ng-messages-multiple': 'ng-messages-multiple' },
     function(prop) {
       inject(function($rootScope, $compile) {
         element = $compile('<div ng-messages="data" ' + prop + '>' +

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -314,7 +314,7 @@ describe("resource", function() {
   it('should handle + in url params', function () {
     var R = $resource('/api/myapp/:myresource?from=:from&to=:to&histlen=:histlen');
     $httpBackend.expect('GET', '/api/myapp/pear+apple?from=2012-04-01&to=2012-04-29&histlen=3').respond('{}');
-    R.get({ myresource: 'pear+apple', from : '2012-04-01', to : '2012-04-29', histlen : 3  });
+    R.get({ myresource: 'pear+apple', from: '2012-04-01', to: '2012-04-29', histlen: 3  });
   });
 
 

--- a/test/ngTouch/directive/ngSwipeSpec.js
+++ b/test/ngTouch/directive/ngSwipeSpec.js
@@ -28,11 +28,11 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBeUndefined();
 
       browserTrigger(element, startEvent, {
-        keys : [],
-        x : 100,
-        y : 20
+        keys: [],
+        x: 100,
+        y: 20
       });
-      browserTrigger(element, endEvent,{
+      browserTrigger(element, endEvent, {
         keys: [],
         x: 20,
         y: 20
@@ -45,12 +45,12 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       $rootScope.$digest();
       expect($rootScope.swiped).toBeUndefined();
 
-      browserTrigger(element, startEvent,{
+      browserTrigger(element, startEvent, {
         keys: [],
         x: 20,
         y: 20
       });
-      browserTrigger(element, endEvent,{
+      browserTrigger(element, endEvent, {
         keys: [],
         x: 90,
         y: 20
@@ -64,11 +64,11 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       expect($rootScope.swiped).toBeUndefined();
 
       browserTrigger(element, startEvent, {
-        keys : [],
-        x : 100,
-        y : 20
+        keys: [],
+        x: 100,
+        y: 20
       });
-      browserTrigger(element, endEvent,{
+      browserTrigger(element, endEvent, {
         keys: [],
         x: 20,
         y: 20
@@ -81,11 +81,11 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
       $rootScope.$digest();
 
       browserTrigger(element, startEvent, {
-        keys : [],
-        x : 100,
-        y : 20
+        keys: [],
+        x: 100,
+        y: 20
       });
-      browserTrigger(element, endEvent,{
+      browserTrigger(element, endEvent, {
         keys: [],
         x: 20,
         y: 20
@@ -100,17 +100,17 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
 
       expect($rootScope.swiped).toBeUndefined();
 
-      browserTrigger(element, startEvent,{
+      browserTrigger(element, startEvent, {
         keys: [],
         x: 90,
         y: 20
       });
-      browserTrigger(element, moveEvent,{
+      browserTrigger(element, moveEvent, {
         keys: [],
         x: 70,
         y: 200
       });
-      browserTrigger(element, endEvent,{
+      browserTrigger(element, endEvent, {
         keys: [],
         x: 20,
         y: 20
@@ -126,12 +126,12 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
 
       expect($rootScope.swiped).toBeUndefined();
 
-      browserTrigger(element, startEvent,{
+      browserTrigger(element, startEvent, {
         keys: [],
         x: 90,
         y: 20
       });
-      browserTrigger(element, endEvent,{
+      browserTrigger(element, endEvent, {
         keys: [],
         x: 80,
         y: 20
@@ -147,12 +147,12 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
 
       expect($rootScope.swiped).toBeUndefined();
 
-      browserTrigger(element, startEvent,{
+      browserTrigger(element, startEvent, {
         keys: [],
         x: 20,
         y: 20
       });
-      browserTrigger(element, moveEvent,{
+      browserTrigger(element, moveEvent, {
         keys: [],
         x: 40,
         y: 20
@@ -168,12 +168,12 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
 
       expect($rootScope.swiped).toBeUndefined();
 
-      browserTrigger(element, moveEvent,{
+      browserTrigger(element, moveEvent, {
         keys: [],
         x: 10,
         y: 20
       });
-      browserTrigger(element, endEvent,{
+      browserTrigger(element, endEvent, {
         keys: [],
         x: 90,
         y: 20
@@ -193,12 +193,12 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
         eventFired = true;
       });
 
-      browserTrigger(element, startEvent,{
+      browserTrigger(element, startEvent, {
         keys: [],
         x: 100,
         y: 20
       });
-      browserTrigger(element, endEvent,{
+      browserTrigger(element, endEvent, {
         keys: [],
         x: 20,
         y: 20
@@ -217,12 +217,12 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
         eventFired = true;
       });
 
-      browserTrigger(element, startEvent,{
+      browserTrigger(element, startEvent, {
         keys: [],
         x: 20,
         y: 20
       });
-      browserTrigger(element, endEvent,{
+      browserTrigger(element, endEvent, {
         keys: [],
         x: 100,
         y: 20
@@ -233,5 +233,5 @@ var swipeTests = function(description, restrictBrowsers, startEvent, moveEvent, 
 };
 
 swipeTests('touch', /* restrictBrowers */ true, 'touchstart', 'touchmove', 'touchend');
-swipeTests('mouse', /* restrictBrowers */ false, 'mousedown',  'mousemove', 'mouseup');
+swipeTests('mouse', /* restrictBrowers */ false, 'mousedown', 'mousemove', 'mouseup');
 


### PR DESCRIPTION
add `disallowSpaceAfterObjectKeys` and associated changes.

add `disallowMixedSpacesAndTabs` (no files changed)
add `disallowMultipleLineStrings` (no files changed)
add `disallowNewlineBeforeBlockStatements` (no files changed)

Feel free to remove the other rules if not needed.

cc: @caitp 
