### PR TITLE
Update dgeni config to free up paths to protractor tests

### DIFF
--- a/docs/app/e2e/api-docs/api-pages.scenario.js
+++ b/docs/app/e2e/api-docs/api-pages.scenario.js
@@ -5,15 +5,15 @@ describe("doc.angularjs.org", function() {
   describe("API pages", function() {
 
     it("should display links to code on GitHub", function() {
-      browser.get('index-debug.html#!/api/ng/service/$http');
+      browser.get('build/docs/index.html#!/api/ng/service/$http');
       expect(element(by.css('.improve-docs')).getAttribute('href')).toMatch(/https?:\/\/github\.com\/angular\/angular\.js\/edit\/.+\/src\/ng\/http\.js/);
 
-      browser.get('index-debug.html#!/api/ng/service/$http');
+      browser.get('build/docs/index.html#!/api/ng/service/$http');
       expect(element(by.css('.view-source')).getAttribute('href')).toMatch(/https?:\/\/github\.com\/angular\/angular\.js\/tree\/.+\/src\/ng\/http\.js#L\d+/);
     });
 
     it('should change the page content when clicking a link to a service', function () {
-      browser.get('');
+      browser.get('build/docs/index.html');
 
       var ngBindLink = element(by.css('.definition-table td a[href="api/ng/directive/ngClick"]'));
       ngBindLink.click();
@@ -24,7 +24,7 @@ describe("doc.angularjs.org", function() {
 
 
     it('should show the functioning input directive example', function () {
-      browser.get('index-debug.html#!/api/ng/directive/input');
+      browser.get('build/docs/index.html#!/api/ng/directive/input');
 
       // Ensure that the page is loaded before trying to switch frames.
       browser.waitForAngular();
@@ -39,7 +39,7 @@ describe("doc.angularjs.org", function() {
     });
 
     it("should trim indentation from code blocks", function() {
-      browser.get('index-debug.html#!/api/ng/type/$rootScope.Scope');
+      browser.get('build/docs/index.html#!/api/ng/type/$rootScope.Scope');
 
       var codeBlocks = element.all(by.css('pre > code.lang-js'));
       codeBlocks.each(function(codeBlock) {

--- a/docs/app/e2e/api-docs/provider-pages.scenario.js
+++ b/docs/app/e2e/api-docs/provider-pages.scenario.js
@@ -3,7 +3,7 @@
 describe("provider pages", function() {
 
   it("should show the related service", function() {
-    browser.get('index-debug.html#!/api/ng/provider/$compileProvider');
+    browser.get('build/docs/index.html#!/api/ng/provider/$compileProvider');
     var serviceLink = element.all(by.css('ol.api-profile-header-structure li a')).first();
     expect(serviceLink.getText()).toEqual('- $compile');
     expect(serviceLink.getAttribute('href')).toMatch(/api\/ng\/service\/\$compile/);

--- a/docs/app/e2e/api-docs/service-pages.scenario.js
+++ b/docs/app/e2e/api-docs/service-pages.scenario.js
@@ -3,19 +3,19 @@
 describe("service pages", function() {
 
   it("should show the related provider if there is one", function() {
-    browser.get('index-debug.html#!/api/ng/service/$compile');
+    browser.get('build/docs/index.html#!/api/ng/service/$compile');
     var providerLink = element.all(by.css('ol.api-profile-header-structure li a')).first();
     expect(providerLink.getText()).toEqual('- $compileProvider');
     expect(providerLink.getAttribute('href')).toMatch(/api\/ng\/provider\/\$compileProvider/);
 
-    browser.get('index-debug.html#!/api/ng/service/$q');
+    browser.get('build/docs/index.html#!/api/ng/service/$q');
     providerLink = element.all(by.css('ol.api-profile-header-structure li a')).first();
     expect(providerLink.getText()).not.toEqual('- $qProvider');
     expect(providerLink.getAttribute('href')).not.toMatch(/api\/ng\/provider\/\$compileProvider/);
   });
 
   it("should show parameter defaults", function() {
-    browser.get('index-debug.html#!/api/ng/service/$timeout');
+    browser.get('build/docs/index.html#!/api/ng/service/$timeout');
     expect(element.all(by.css('.input-arguments p em')).first().getText()).toContain('(default: 0)');
   });
 

--- a/docs/app/e2e/app.scenario.js
+++ b/docs/app/e2e/app.scenario.js
@@ -39,7 +39,7 @@ describe('docs.angularjs.org', function () {
 
 
     it('should change the page content when clicking a link to a service', function () {
-      browser.get('');
+      browser.get('build/docs/index.html');
 
       var ngBindLink = element(by.css('.definition-table td a[href="api/ng/directive/ngClick"]'));
       ngBindLink.click();
@@ -51,33 +51,33 @@ describe('docs.angularjs.org', function () {
 
 
     it('should be resilient to trailing slashes', function() {
-      browser.get('index-debug.html#!/api/ng/function/angular.noop/');
+      browser.get('build/docs/index.html#!/api/ng/function/angular.noop/');
       var pageBody = element(by.css('h1'));
       expect(pageBody.getText()).toEqual('angular.noop');
     });
 
 
     it('should be resilient to trailing "index"', function() {
-      browser.get('index-debug.html#!/api/ng/function/angular.noop/index');
+      browser.get('build/docs/index.html#!/api/ng/function/angular.noop/index');
       var pageBody = element(by.css('h1'));
       expect(pageBody.getText()).toEqual('angular.noop');
     });
 
 
     it('should be resilient to trailing "index/"', function() {
-      browser.get('index-debug.html#!/api/ng/function/angular.noop/index/');
+      browser.get('build/docs/index.html#!/api/ng/function/angular.noop/index/');
       var pageBody = element(by.css('h1'));
       expect(pageBody.getText()).toEqual('angular.noop');
     });
 
 
     it('should display formatted error messages on error doc pages', function() {
-      browser.get('index-debug.html#!error/ng/areq?p0=Missing&p1=not%20a%20function,%20got%20undefined');
+      browser.get('build/docs/index.html#!error/ng/areq?p0=Missing&p1=not%20a%20function,%20got%20undefined');
       expect(element(by.css('.minerr-errmsg')).getText()).toEqual("Argument 'Missing' is not a function, got undefined");
     });
 
     it("should display an error if the page does not exist", function() {
-      browser.get('index-debug.html#!/api/does/not/exist');
+      browser.get('build/docs/index.html#!/api/does/not/exist');
       expect(element(by.css('h1')).getText()).toBe('Oops!');
     });
 

--- a/docs/config/index.js
+++ b/docs/config/index.js
@@ -157,6 +157,8 @@ module.exports = new Package('angularjs', [
     jqueryDeployment
   ];
 
+  generateProtractorTestsProcessor.basePath = 'build/docs/';
+
   generateExamplesProcessor.deployments = [
     debugDeployment,
     defaultDeployment,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1329,7 +1329,7 @@
       }
     },
     "dgeni-packages": {
-      "version": "0.10.3",
+      "version": "0.10.5",
       "dependencies": {
         "catharsis": {
           "version": "0.7.1"

--- a/protractor-shared-conf.js
+++ b/protractor-shared-conf.js
@@ -3,7 +3,7 @@
 exports.config = {
   allScriptsTimeout: 11000,
 
-  baseUrl: 'http://localhost:8000/build/docs/',
+  baseUrl: 'http://localhost:8000/',
 
   framework: 'jasmine',
 


### PR DESCRIPTION
There are two commits:

The first updates the base path for protractor tests.
The second fixes some manual e2e tests that needed their path changing
