### PR TITLE
fix(input): $render input even if $modelValue is empty

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1029,7 +1029,7 @@ function baseInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   element.on('change', listener);
 
   ctrl.$render = function() {
-    element.val(ctrl.$isEmpty(ctrl.$modelValue) ? '' : ctrl.$viewValue);
+    element.val(ctrl.$viewValue || '');
   };
 }
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -484,6 +484,7 @@ describe('NgModelController', function() {
 
   });
 
+
   describe('validations pipeline', function() {
 
     it('should perform validations when $validate() is called', function() {
@@ -2073,6 +2074,21 @@ describe('input', function() {
     scope.$apply('value = 0');
 
     expect(inputElm.val()).toBe('0');
+  });
+
+  it('should render the $viewValue when $modelValue is empty', function() {
+    compileInput('<input type="text" ng-model="value" />');
+
+    var ctrl = inputElm.controller('ngModel');
+
+    ctrl.$modelValue = null;
+
+    expect(ctrl.$isEmpty(ctrl.$modelValue)).toBe(true);
+
+    ctrl.$viewValue = 'abc';
+    ctrl.$render();
+
+    expect(inputElm.val()).toBe('abc');
   });
 
 


### PR DESCRIPTION
$render should only be concerned if there is a $viewValue present.
When we check $isEmpty($modelValue), we assume $render is used in
context of a model -> view update. But since it is part of the public
API, it needs to work independent of internal usage.

Fixes #9156

In the end, the formatters are responsible for providing a correct value to the $render function in a model -> update. If someone uses $render manually, they are obviously responsible.
