### PR TITLE
fix($observe): check if the attribute is undefined

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1073,7 +1073,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
         listeners.push(fn);
         $rootScope.$evalAsync(function() {
-          if (!listeners.$$inter) {
+          if (!listeners.$$inter && attrs.hasOwnProperty(key)) {
             // no one registered attribute interpolation function, so lets call it manually
             fn(attrs[key]);
           }

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1331,6 +1331,11 @@ describe('input', function() {
     expect(scope.name).toEqual('adam');
   });
 
+  it('should not add the property to the scope if name is undefined', function() {
+    compileInput('<input type="text" ng-model="name" />');
+    expect(scope.form['undefined']).toBeUndefined();
+  });
+
   describe('compositionevents', function() {
     it('should not update the model between "compositionstart" and "compositionend" on non android', inject(function($sniffer) {
       $sniffer.android = false;


### PR DESCRIPTION
Check if the attribute is undefined before manually applying the function because if not an undefined
property is added to the scope of the form controller when the input control does not have a name.

Closes #9707

[#ngEurope](http://ngeurope.org/) /cc @rodyhaddad @vojtajina 
