### PR TITLE
feat($injector): print caller name in "unknown provider" errors (when available) #ngEurope

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -668,7 +668,7 @@ function createInjector(modulesToLoad, strictDi) {
 
   function enforceReturnValue(name, factory) {
     return function enforcedReturnValue() {
-      var result = instanceInjector.invoke(factory, this, undefined, name);
+      var result = instanceInjector.invoke(factory, this);
       if (isUndefined(result)) {
         throw $injectorMinErr('undef', "Provider '{0}' must return a value from $get factory method.", name);
       }

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -4,12 +4,14 @@ describe('injector', function() {
   var providers;
   var injector;
   var providerInjector;
+  var controllerProvider;
 
-  beforeEach(module(function($provide, $injector) {
+  beforeEach(module(function($provide, $injector, $controllerProvider) {
     providers = function(name, factory, annotations) {
       $provide.factory(name, extend(factory, annotations||{}));
     };
     providerInjector = $injector;
+    controllerProvider = $controllerProvider;
   }));
   beforeEach(inject(function($injector){
     injector = $injector;
@@ -71,6 +73,22 @@ describe('injector', function() {
     expect(function() {
       injector.get('idontexist');
     }).toThrowMinErr("$injector", "unpr", "Unknown provider: idontexistProvider <- idontexist");
+  });
+
+
+  it('should provide the caller name if given', function(done) {
+    expect(function() {
+      injector.get('idontexist', 'callerName');
+    }).toThrowMinErr("$injector", "unpr", "Unknown provider: idontexistProvider <- idontexist <- callerName");
+  });
+
+
+  it('should provide the caller name for controllers', function(done) {
+    controllerProvider.register('myCtrl', function(idontexist) {});
+    var $controller = injector.get('$controller');
+    expect(function() {
+      $controller('myCtrl', {$scope: {}});
+    }).toThrowMinErr("$injector", "unpr", "Unknown provider: idontexistProvider <- idontexist <- myCtrl");
   });
 
 


### PR DESCRIPTION
This will add the name of the service/controller/... to the error message so that we know where the error comes from.
For example, `Error: [$injector:unpr] Unknown provider: $timeuotProvider <- $timeuot` will print `Error: [$injector:unpr] Unknown provider: $timeuotProvider <- $timeuot <- AppCtrl`

This will not work in config/run block because propagating the module name would be difficult (you don't want to screw with invoke) but we could improve this later.

Also, I didn't add it to the directives because you already have an explicit message (something like `Error: [$injector:unpr] Unknown provider: $timeuotProvider <- $timeuot <- testDirective`).

Fixes #8135
