### PR TITLE
Add warning message when a module is reset/replaced

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -87,6 +87,10 @@ function setupModuleLoader(window) {
 
       assertNotHasOwnProperty(name, 'module');
       if (requires && modules.hasOwnProperty(name)) {
+        if (modules[name] && window.console) {
+            //logProvider is not available at this place
+            window.console.log('The module \'' + name + '\' already exists and has been redefined.');
+        }
         modules[name] = null;
       }
       return ensure(modules, name, function() {

--- a/test/helpers/testabilityPatch.js
+++ b/test/helpers/testabilityPatch.js
@@ -14,14 +14,6 @@ if (window.bindJQuery) bindJQuery();
 beforeEach(function() {
   // all this stuff is not needed for module tests, where jqlite and publishExternalAPI and jqLite are not global vars
   if (window.publishExternalAPI) {
-    publishExternalAPI(angular);
-
-    // workaround for IE bug https://plus.google.com/104744871076396904202/posts/Kqjuj6RSbbT
-    // IE overwrite window.jQuery with undefined because of empty jQuery var statement, so we have to
-    // correct this, but only if we are not running in jqLite mode
-    if (!_jqLiteMode && _jQuery !== jQuery) {
-      jQuery = _jQuery;
-    }
 
     // This resets global id counter;
     uid = 0;

--- a/test/loaderSpec.js
+++ b/test/loaderSpec.js
@@ -4,10 +4,13 @@ describe('module loader', function() {
   var window;
 
   beforeEach(function () {
-    window = {};
+    window = {
+        console: {
+            log: function() {}
+        }
+    };
     setupModuleLoader(window);
   });
-
 
   it('should set up namespace', function() {
     expect(window.angular).toBeDefined();
@@ -61,13 +64,27 @@ describe('module loader', function() {
     expect(myModule._runBlocks).toEqual(['runBlock']);
   });
 
-
   it('should allow module redefinition', function() {
-    expect(window.angular.module('a', [])).not.toBe(window.angular.module('a', []));
+    var module1 = window.angular.module('module1', []);
+    var module2 = window.angular.module('module1', []);
+
+    expect(window.angular.module('module1')).not.toBe(module1);
+    expect(window.angular.module('module1')).toBe(module2);
   });
 
+  it('should inform about redefined module', function() {
+    var module1 = window.angular.module('module1', []);
 
-  it('should complain of no module', function() {
+
+    spyOn(window.console, 'log');
+    var module2 = window.angular.module('module1', []);
+
+    expect(window.angular.module('module1')).not.toBe(module1);
+    expect(window.angular.module('module1')).toBe(module2);
+    expect(window.console.log).toHaveBeenCalled();
+  });
+
+   it('should complain of no module', function() {
     expect(function() {
       window.angular.module('dontExist');
     }).toThrowMinErr("$injector", "nomod", "Module 'dontExist' is not available! You either misspelled the module name " +

--- a/test/loaderSpec.js
+++ b/test/loaderSpec.js
@@ -12,6 +12,7 @@ describe('module loader', function() {
     setupModuleLoader(window);
   });
 
+
   it('should set up namespace', function() {
     expect(window.angular).toBeDefined();
     expect(window.angular.module).toBeDefined();
@@ -64,27 +65,13 @@ describe('module loader', function() {
     expect(myModule._runBlocks).toEqual(['runBlock']);
   });
 
+
   it('should allow module redefinition', function() {
-    var module1 = window.angular.module('module1', []);
-    var module2 = window.angular.module('module1', []);
-
-    expect(window.angular.module('module1')).not.toBe(module1);
-    expect(window.angular.module('module1')).toBe(module2);
+    expect(window.angular.module('a', [])).not.toBe(window.angular.module('a', []));
   });
 
-  it('should inform about redefined module', function() {
-    var module1 = window.angular.module('module1', []);
 
-
-    spyOn(window.console, 'log');
-    var module2 = window.angular.module('module1', []);
-
-    expect(window.angular.module('module1')).not.toBe(module1);
-    expect(window.angular.module('module1')).toBe(module2);
-    expect(window.console.log).toHaveBeenCalled();
-  });
-
-   it('should complain of no module', function() {
+  it('should complain of no module', function() {
     expect(function() {
       window.angular.module('dontExist');
     }).toThrowMinErr("$injector", "nomod", "Module 'dontExist' is not available! You either misspelled the module name " +
@@ -100,5 +87,14 @@ describe('module loader', function() {
 
   it('should expose `$$minErr` on the `angular` object', function() {
     expect(window.angular.$$minErr).toEqual(jasmine.any(Function));
+  });
+
+  it('should inform about redefined module', function() {
+    window.angular.module('module1', []);
+
+    spyOn(window.console, 'log');
+    window.angular.module('module1', []);
+
+    expect(window.console.log).toHaveBeenCalledWith( 'The module \'module1\' already exists and has been redefined.');
   });
 });


### PR DESCRIPTION
- Add log to loader.js in case module with the same name is loaded again. The logProvider is not available at this point and after discussion on ng-europe we decided to use console.log.
- The result of the fix was tons of messages 
  LOG: 'The module 'ng' already exists and has been redefined.'
  because publishExternalAPI was called twice for EVERY test. Therefore  publishExternalAPI(angular); could be removed from testabilityPatch.js.

Fix for #6034 
