### PR TITLE
fix(location): throw a MinErr when base path has the wrong case #4082

### DIFF
--- a/docs/content/error/$location/wrgcase.ngdoc
+++ b/docs/content/error/$location/wrgcase.ngdoc
@@ -1,0 +1,7 @@
+@ngdoc error
+@name $location:wrgcase
+@fullName base path in $location has to be used with correct case
+@description
+
+While using {@link ng.$location `$location`}, you need to make sure, that the base href of an URL handed to the application
+matches the case of the base path of the application.

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -59,6 +59,8 @@ function parseAppUrl(relativeUrl, locationObj, appBase) {
 function beginsWith(begin, whole) {
   if (whole.indexOf(begin) === 0) {
     return whole.substr(begin.length);
+  } else if (whole.toLowerCase().indexOf(begin.toLowerCase()) === 0) {
+      throw $locationMinErr('wrgcase', 'Invalid url "{0}", base path is expected case sensitive', whole);
   }
 }
 

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -397,6 +397,12 @@ describe('$location', function() {
       }).toThrowMinErr('$location', 'ipthprfx', 'Invalid url "http://server.org/path#/path", missing path prefix "http://server.org/base/".');
     });
 
+    it('should throw error when base url given with wrong case', function() {
+      url = new LocationHtml5Url('http://server.org/base/abc', '/base');
+      expect(function() {
+        url.$$parse('http://server.org/Base/efg');
+      }).toThrowMinErr('$location', 'wrgcase', 'Invalid url "http://server.org/Base/efg", base path is expected case sensitive');
+    });
 
     describe('state', function () {
       it('should set $$state and return itself', function() {
@@ -552,6 +558,13 @@ describe('$location', function() {
       }).toThrowMinErr('$location', 'ihshprfx', 'Invalid url "http://www.server.org:1234/base#/path", missing hash prefix "#!".');
     });
 
+    it('should throw error when base of hashbang url given with wrong case', function() {
+      url = new LocationHashbangUrl('http://www.server.org:1234/base', '#!');
+      expect(function() {
+        url.$$parse('http://www.server.org:1234/Base#!/path?a=b&c#hash');
+      }).toThrowMinErr('$location', 'wrgcase',
+        'Invalid url "http://www.server.org:1234/Base#!/path?a=b&c#hash", base path is expected case sensitive');
+    });
 
     describe('encoding', function() {
 
@@ -643,7 +656,6 @@ describe('$location', function() {
 
     beforeEach(initService({html5Mode:false,hashPrefix: '!',supportHistory: true}));
     beforeEach(inject(initBrowser({url:'http://new.com/a/b#!',basePath: 'http://new.com/a/b'})));
-
 
     it('should update $location when browser url changes', inject(function($browser, $location) {
       spyOn($location, '$$parse').andCallThrough();
@@ -758,6 +770,15 @@ describe('$location', function() {
 
       $rootScope.$digest();
       expect($browser.url()).toBe('http://new.com/a/b#!/changed');
+    }));
+
+    it('should throw error when case of base url is not matched', inject(function($browser, $location) {
+      spyOn($location, '$$parse').andCallThrough();
+      expect(function() {
+        $browser.url('http://new.com/A/b#!/aaa');
+        $browser.poll();
+      }).toThrowMinErr('$location', 'wrgcase',
+        'Invalid url "http://new.com/A/b#!/aaa", base path is expected case sensitive');
     }));
   });
 
@@ -1938,6 +1959,13 @@ describe('$location', function() {
     it('should support state', function() {
       expect(location.state({a: 2}).state()).toEqual({a: 2});
     });
+
+    iit('should throw error when case of base url is not matched',
+          function() {
+      expect(function () {
+        location.$$parse('http://server/Pre/index.html');
+      }).toThrowMinErr('$location', 'wrgcase', 'Invalid url "http://server/Pre/index.html", base path is expected case sensitive');
+    });
   });
 
 
@@ -2007,6 +2035,14 @@ describe('$location', function() {
     it('should throw on url(urlString, stateObject)', function () {
       throwOnState(location);
     });
+
+    iit('should throw error when case of base url is not matched',
+        function() {
+      location = new LocationHashbangUrl('http://server/pre/index.html', '#');
+      expect(function () {
+        location.$$parse('http://server/Pre/index.html');
+      }).toThrowMinErr('$location', 'wrgcase', 'Invalid url "http://server/Pre/index.html", base path is expected case sensitive');
+    });
   });
 
 
@@ -2036,6 +2072,13 @@ describe('$location', function() {
 
     it('should throw on url(urlString, stateObject)', function () {
       throwOnState(location);
+    });
+
+    iit('should throw error when case of base url is not matched',
+      function() {
+        expect(function () {
+            location.$$parse('http://server/Pre/index.html');
+        }).toThrowMinErr('$location', 'wrgcase', 'Invalid url "http://server/Pre/index.html", base path is expected case sensitive');
     });
   });
 });


### PR DESCRIPTION
If the user inputs a url where the base path has the wrong case, an MinErr is now thrown instead of a stack trace.

From the issue:
This issue is common when serving files from a case-insensitive filesystem, where the files may serve from /Base/ and /base/ but the href is set as /base/. This behavior is preferable because it encourages developers to follow the best practice of treating their files and URLs as case-sensitive.

Fixes #4082 #ng-europe
