### PR TITLE
docs($templateCache): clarify inline template

### DIFF
--- a/src/ng/cacheFactory.js
+++ b/src/ng/cacheFactory.js
@@ -369,7 +369,8 @@ function $CacheFactoryProvider() {
  * ```
  *
  * **Note:** the `script` tag containing the template does not need to be included in the `head` of
- * the document, but it must be below the `ng-app` definition.
+ * the document, but it must be a descendent of the @{link ng.$rootElement $rootElement} (IE,
+ * element with ng-app attribute), otherwise the template will be ignored.
  *
  * Adding via the $templateCache service:
  *


### PR DESCRIPTION
Current doc doesn't state required tag location clear enough. It was [stack overflow|http://stackoverflow.com/a/16125138] where I've found that requirement
