### PR TITLE
feat($templateRequest): trust url if it is already in cache

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2144,7 +2144,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
       $compileNode.empty();
 
-      $templateRequest($sce.getTrustedResourceUrl(templateUrl))
+      $templateRequest(templateUrl)
         .then(function(content) {
           var compileNode, tempTemplateAttrs, $template, childBoundTranscludeFn;
 

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -215,7 +215,7 @@ var ngIncludeDirective = ['$templateRequest', '$anchorScroll', '$animate', '$sce
           }
         };
 
-        scope.$watch($sce.parseAsResourceUrl(srcExp), function ngIncludeWatchAction(src) {
+        scope.$watch(srcExp, function ngIncludeWatchAction(src) {
           var afterAnimation = function() {
             if (isDefined(autoScrollExp) && (!autoScrollExp || scope.$eval(autoScrollExp))) {
               $anchorScroll();

--- a/src/ng/templateRequest.js
+++ b/src/ng/templateRequest.js
@@ -20,7 +20,7 @@ var $compileMinErr = minErr('$compile');
  * @property {number} totalPendingRequests total amount of pending template requests being downloaded.
  */
 function $TemplateRequestProvider() {
-  this.$get = ['$templateCache', '$http', '$q', function($templateCache, $http, $q) {
+  this.$get = ['$templateCache', '$http', '$q', '$sce', function($templateCache, $http, $q, $sce) {
     function handleRequestFn(tpl, ignoreRequestError) {
       var self = handleRequestFn;
       self.totalPendingRequests++;
@@ -40,7 +40,7 @@ function $TemplateRequestProvider() {
         transformResponse: transformResponse
       };
 
-      return $http.get(tpl, httpOptions)
+      return $http.get($sce.getTrustedResourceUrl(tpl), httpOptions)
         .then(function(response) {
           self.totalPendingRequests--;
           return response.data;

--- a/src/ng/templateRequest.js
+++ b/src/ng/templateRequest.js
@@ -40,7 +40,11 @@ function $TemplateRequestProvider() {
         transformResponse: transformResponse
       };
 
-      return $http.get($sce.getTrustedResourceUrl(tpl), httpOptions)
+      if (!isDefined($templateCache.get(tpl))) {
+        tpl = $sce.getTrustedResourceUrl(tpl);
+      }
+
+      return $http.get(tpl, httpOptions)
         .then(function(response) {
           self.totalPendingRequests--;
           return response.data;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1242,15 +1242,6 @@ describe('$compile', function() {
           }
         ));
 
-        it('should not load cross domain templates by default', inject(
-          function($compile, $rootScope, $templateCache, $sce) {
-            expect(function() {
-              $templateCache.put('http://example.com/should-not-load.html', 'Should not load even if in cache.');
-              $compile('<div class="crossDomainTemplate"></div>')($rootScope);
-            }).toThrowMinErr('$sce', 'insecurl', 'Blocked loading resource from url not allowed by $sceDelegate policy.  URL: http://example.com/should-not-load.html');
-          }
-        ));
-
         it('should load cross domain templates when trusted', inject(
           function($compile, $httpBackend, $rootScope, $sce) {
             $httpBackend.expect('GET', 'http://example.com/trusted-template.html').respond('<span>example.com/trusted_template_contents</span>');

--- a/test/ng/templateRequestSpec.js
+++ b/test/ng/templateRequestSpec.js
@@ -25,6 +25,19 @@ describe('$templateRequest', function() {
           /Blocked loading resource from url not allowed by \$sceDelegate policy.  URL: http:\/\/example.com\/tpl\.html.*/);
   }));
 
+  it('should fetch templates from cache even if url is untrusted',
+     inject(function($rootScope, $templateRequest, $httpBackend, $templateCache) {
+
+     $templateCache.put('http://example.com/tpl.html', '<div>abc</div>');
+
+     var content;
+     $templateRequest('http://example.com/tpl.html').then(function(html) { content = html; });
+
+     $rootScope.$digest();
+
+     expect(content).toBe('<div>abc</div>');
+  }));
+
   it('should cache the request to prevent extra downloads',
     inject(function($rootScope, $templateRequest, $httpBackend) {
 

--- a/test/ng/templateRequestSpec.js
+++ b/test/ng/templateRequestSpec.js
@@ -16,6 +16,15 @@ describe('$templateRequest', function() {
     expect(content).toBe('<div>abc</div>');
   }));
 
+  it('should not download templates from untrusted urls',
+    inject(function($templateRequest) {
+      expect(function() {
+        $templateRequest('http://example.com/tpl.html');
+      }).toThrowMinErr(
+          '$sce', 'insecurl',
+          /Blocked loading resource from url not allowed by \$sceDelegate policy.  URL: http:\/\/example.com\/tpl\.html.*/);
+  }));
+
   it('should cache the request to prevent extra downloads',
     inject(function($rootScope, $templateRequest, $httpBackend) {
 


### PR DESCRIPTION
This is a rehash of #4879. I've encountered this issue a long time ago and it is no longer relevant for me, but maybe it will help someone else... This bothered me when I used the base tag in some project to point to a domain different than the one the page was served from - it meant that any template that was preloaded using something like `<script type="text/ng-template" id="/tpl.html">` was blocked by `$sce` when I tried to load it since the domain in the base tag was not trusted by default.

So I'm thinking that it doesn't make much sense to block something that is already in the cache, but there was a test in`$compile` which explicitly tested that even cache will be blocked (which I had to remove), so I'm probably missing something.

Anyway, even if this is not really interesting, I think that the refactor in the first two commits might be relevant anyway....
