### PR TITLE
fix(orderBy): Mantain order in array of objects when predicate is not provided

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -122,6 +122,7 @@ function orderByFilter($parse) {
     sortPredicate = isArray(sortPredicate) ? sortPredicate: [sortPredicate];
     if (sortPredicate.length === 0) { sortPredicate = ['+']; }
     sortPredicate = sortPredicate.map(function(predicate) {
+      predicate = predicate || '';
       var descending = false, get = predicate || identity;
       if (isString(predicate)) {
         if ((predicate.charAt(0) == '+' || predicate.charAt(0) == '-')) {
@@ -130,6 +131,12 @@ function orderByFilter($parse) {
         }
         if (predicate === '') {
           // Effectively no predicate was passed so we compare identity
+          if (array.some(isObject)) {
+            return function() {
+              return descending ? 1 : 0;
+            };
+          }
+
           return reverseComparator(function(a, b) {
             return compare(a, b);
           }, descending);

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -91,6 +91,20 @@ describe('Filter: orderBy', function() {
       .toEqualData([{"원": 31000}, {"원": 76000}, {"원": 156000}]);
   });
 
+  it('should maintain order in an array of objects when no predicate is provided', function() {
+    var array = [{a: 1}, {b: 2}, {c: 3}];
+
+    expect(orderBy(array)).toEqualData(array);
+    expect(orderBy(array, '')).toEqualData(array);
+    expect(orderBy(array, [])).toEqualData(array);
+    expect(orderBy(array, [''])).toEqualData(array);
+    expect(orderBy(array, ['+'])).toEqualData(array);
+  });
+
+  it('should inverse order in an array of objects when minus is provided without predicate', function() {
+    expect(orderBy([{a: 1}, {b: 2}, {c: 3}], ['-'])).toEqualData([{c: 3}, {b: 2}, {a: 1}]);
+  });
+
   it('should throw if quoted string predicate is quoted incorrectly', function() {
     /*jshint -W008 */
     expect(function() {


### PR DESCRIPTION
Fixes #9566
