### PR TITLE
fix(filterFilter): correctly handle deep expression objects

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -125,7 +125,7 @@ function filterFilter() {
       case 'object':
         // Replace `{$: 'xyz'}` with `'xyz'` and fall through
         var keys = Object.keys(expression);
-        if ((keys.length === 1) && (keys[0] === '$')) expression  = expression.$;
+        if ((keys.length === 1) && (keys[0] === '$')) expression = expression.$;
         // jshint -W086
       case 'boolean':
       case 'number':

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -136,6 +136,17 @@ describe('Filter: filter', function() {
   });
 
 
+  it('should respect the depth level of a "$" property', function() {
+    var items = [{person: {name: 'Annet', email: 'annet@example.com'}},
+                 {person: {name: 'Billy', email: 'me@billy.com'}},
+                 {person: {name: 'Joan', email: {home: 'me@joan.com', work: 'joan@example.net'}}}];
+    var expr = {person: {$: 'net'}};
+
+    expect(filter(items, expr).length).toBe(1);
+    expect(filter(items, expr)).toEqual([items[0]]);
+  });
+
+
   it('should respect the nesting level of "$"', function() {
     var items = [{supervisor: 'me', person: {name: 'Annet', email: 'annet@example.com'}},
                  {supervisor: 'me', person: {name: 'Billy', email: 'me@billy.com'}},
@@ -314,6 +325,13 @@ describe('Filter: filter', function() {
 
   describe('should support comparator', function() {
 
+    it('not consider `object === "[object Object]"` in non-strict comparison', function() {
+      var items = [{test: {}}];
+      var expr = '[object';
+      expect(filter(items, expr).length).toBe(0);
+    });
+
+
     it('as equality when true', function() {
       var items = ['misko', 'adam', 'adamson'];
       var expr = 'adam';
@@ -395,7 +413,7 @@ describe('Filter: filter', function() {
         return isString(actual) && isString(expected) && (actual.indexOf(expected) === 0);
       };
 
-      expr = {details: {email: 'admin@example.com', role: 'admn'}};
+      expr = {details: {email: 'admin@example.com', role: 'min'}};
       expect(filter(items, expr, comp)).toEqual([]);
 
       expr = {details: {email: 'admin@example.com', role: 'adm'}};

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -156,6 +156,26 @@ describe('Filter: filter', function() {
   });
 
 
+  it('should not consider the expression\'s inherited properties', function() {
+    Object.prototype.noop = noop;
+
+    var items = [
+      {text: 'hello'},
+      {text: 'goodbye'},
+      {text: 'kittens'},
+      {text: 'puppies'}
+    ];
+
+    expect(filter(items, {text: 'hell'}).length).toBe(1);
+    expect(filter(items, {text: 'hell'})[0]).toBe(items[0]);
+
+    expect(filter(items, 'hell').length).toBe(1);
+    expect(filter(items, 'hell')[0]).toBe(items[0]);
+
+    delete(Object.prototype.noop);
+  });
+
+
   describe('should support comparator', function() {
 
     it('as equality when true', function() {


### PR DESCRIPTION
Previously, trying to use a deep expression object (i.e. an object whose properties can be objects themselves) did not work correctly. This commit refactors `filterFilter`, making it simpler and adding support for filtering collections of arbitrarily deep objects.

Closes #9698

---

<sub>
BTW, I used "non-IE8" stuff (like `Array.prototype.some/every`) for the sake of conciseness and clarity, so this is not directly back-portable to 1.2.x. If there is interest, I can create a IE8 compatible version (using `for-loops` etc).
</sub>
