### PR TITLE
docs($http): patch method is not exists

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -284,7 +284,6 @@ function $HttpProvider() {
      * - {@link ng.$http#put $http.put}
      * - {@link ng.$http#delete $http.delete}
      * - {@link ng.$http#jsonp $http.jsonp}
-     * - {@link ng.$http#patch $http.patch}
      *
      *
      * # Setting HTTP Headers


### PR DESCRIPTION
The link here brings nowhere.
On the 1.2.6 the patch method seems not exists / not working.

You can observe the error here:
http://plnkr.co/edit/cwJ1pgoqbBUzjSoApg5S
`TypeError: undefined is not a function`

If you just change the version of angular with 1.3.0 the request will work.
