### PR TITLE
perf(ngmodel/compile): improve ngmodel and general compile/controller performance (#9609)

### DIFF
--- a/benchmarks/largetable-bp/main.html
+++ b/benchmarks/largetable-bp/main.html
@@ -20,6 +20,7 @@
       <div>interpolation + fnInvocation: <input type="radio" ng-model="benchmarkType" value="interpolationFn"></div>
       <div>ngBind + filter: <input type="radio" ng-model="benchmarkType" value="ngBindFilter"></div>
       <div>interpolation + filter: <input type="radio" ng-model="benchmarkType" value="interpolationFilter"></div>
+      <div>ngModel: <input type="radio" ng-model="benchmarkType" value="ngModel"></div>
 
       <ng-switch on="benchmarkType">
         <baseline-binding-table ng-switch-when="baselineBinding">
@@ -82,6 +83,13 @@
           <h2>interpolation with filter</h2>
           <div ng-repeat="row in data">
             <span ng-repeat="column in row">{{column.i | noop}}:{{column.j | noop}}|</span>
+          </div>
+        </div>
+        <div ng-switch-when="ngModel">
+          <h2>ngModels</h2>
+          <div ng-repeat="row in data">
+            <input type="text" ng-model="row.i" name="constName" />
+            <input type="text" ng-model="row.j" />
           </div>
         </div>
       </ng-switch>

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1671,7 +1671,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
         if (!directive.templateUrl && directive.controller) {
           directiveValue = directive.controller;
-          controllerDirectives = controllerDirectives || {};
+          controllerDirectives = controllerDirectives || createMap();
           assertNoDuplicate("'" + directiveName + "' controller",
               controllerDirectives[directiveName], directive, $compileNode);
           controllerDirectives[directiveName] = directive;
@@ -1839,49 +1839,43 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
 
       function getControllers(directiveName, require, $element, elementControllers) {
-        var value, retrievalMethod = 'data', optional = false;
-        var $searchElement = $element;
-        var match;
-        if (isString(require)) {
-          match = require.match(REQUIRE_PREFIX_REGEXP);
-          require = require.substring(match[0].length);
+        var i, value;
 
-          if (match[3]) {
-            if (match[1]) match[3] = null;
-            else match[1] = match[3];
-          }
-          if (match[1] === '^') {
-            retrievalMethod = 'inheritedData';
-          } else if (match[1] === '^^') {
-            retrievalMethod = 'inheritedData';
-            $searchElement = $element.parent();
-          }
-          if (match[2] === '?') {
-            optional = true;
+        if (typeof require === 'string') {
+          var match = require.match(REQUIRE_PREFIX_REGEXP);
+          var name = require.substring(match[0].length);
+          var type = match[1] || match[3];
+
+          //If only parents then start at the parent element
+          //Otherwise attempt getting the controller from elementControllers to avoid .data
+          if (type === '^^') {
+            $element = $element.parent();
+          } else {
+            value = elementControllers && elementControllers[name];
+            value = value && value.instance;
           }
 
-          value = null;
-
-          if (elementControllers && retrievalMethod === 'data') {
-            if (value = elementControllers[require]) {
-              value = value.instance;
-            }
+          if (!value) {
+            var dataName = '$' + name + 'Controller';
+            value = type ? $element.inheritedData(dataName) : $element.data(dataName);
           }
-          value = value || $searchElement[retrievalMethod]('$' + require + 'Controller');
 
-          if (!value && !optional) {
+          if (!value && match[2] !== '?') {
             throw $compileMinErr('ctreq',
                 "Controller '{0}', required by directive '{1}', can't be found!",
-                require, directiveName);
+                name, directiveName);
           }
+
           return value || null;
-        } else if (isArray(require)) {
-          value = [];
-          forEach(require, function(require) {
-            value.push(getControllers(directiveName, require, $element, elementControllers));
-          });
         }
-        return value;
+
+        if (isArray(require)) {
+          value = new Array(i = require.length);
+          while (i--) {
+            value[i] = getControllers(directiveName, require[i], $element, elementControllers);
+          }
+          return value;
+        }
       }
 
 
@@ -1910,32 +1904,37 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         }
 
         if (controllerDirectives) {
-          elementControllers = {};
-          forEach(controllerDirectives, function(directive) {
+          elementControllers = createMap();
+
+          // For directives with element transclusion the element is a comment,
+          // but jQuery .data doesn't support attaching data to comment nodes as it's hard to
+          // clean up (http://bugs.jquery.com/ticket/8335).
+          // Instead, we save the controllers for the element in a local hash and attach to .data
+          // later, once we have the actual element.
+          var controllerData = !hasElementTranscludeDirective && $element.data();
+
+          for (var directiveName in controllerDirectives) {
+            var directive = controllerDirectives[directiveName];
+
             var locals = {
               $scope: directive === newIsolateScopeDirective || directive.$$isolateScope ? isolateScope : scope,
               $element: $element,
               $attrs: attrs,
               $transclude: transcludeFn
-            }, controllerInstance;
+            };
 
-            controller = directive.controller;
-            if (controller == '@') {
-              controller = attrs[directive.name];
+            var directiveController = directive.controller;
+            if (directiveController === '@') {
+              directiveController = attrs[directive.name];
             }
 
-            controllerInstance = $controller(controller, locals, true, directive.controllerAs);
+            var controllerInstance = $controller(directiveController, locals, true, directive.controllerAs);
 
-            // For directives with element transclusion the element is a comment,
-            // but jQuery .data doesn't support attaching data to comment nodes as it's hard to
-            // clean up (http://bugs.jquery.com/ticket/8335).
-            // Instead, we save the controllers for the element in a local hash and attach to .data
-            // later, once we have the actual element.
             elementControllers[directive.name] = controllerInstance;
-            if (!hasElementTranscludeDirective) {
-              $element.data('$' + directive.name + 'Controller', controllerInstance.instance);
+            if (controllerData) {
+              controllerData['$' + directive.name + 'Controller'] = controllerInstance.instance;
             }
-          });
+          }
         }
 
         if (newIsolateScopeDirective) {
@@ -1965,7 +1964,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                                               bindings, scopeDirective);
             }
           }
-          forEach(elementControllers, function(controller) {
+          // Initialize the controllers before linking
+          for (i in elementControllers) {
+            controller = elementControllers[i];
             var result = controller();
             if (result !== controller.instance &&
                 controller === controllerForBindings) {
@@ -1975,7 +1976,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                   initializeDirectiveBindings(scope, attrs, result,
                                               bindings, scopeDirective);
             }
-          });
+          }
         }
 
         // PRELINKING

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1614,7 +1614,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       var terminalPriority = -Number.MAX_VALUE,
           newScopeDirective,
           controllerDirectives = previousCompileContext.controllerDirectives,
-          controllers,
           newIsolateScopeDirective = previousCompileContext.newIsolateScopeDirective,
           templateDirective = previousCompileContext.templateDirective,
           nonTlbTranscludeDirective = previousCompileContext.nonTlbTranscludeDirective,
@@ -1911,8 +1910,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         }
 
         if (controllerDirectives) {
-          // TODO: merge `controllers` and `elementControllers` into single object.
-          controllers = {};
           elementControllers = {};
           forEach(controllerDirectives, function(directive) {
             var locals = {
@@ -1938,8 +1935,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             if (!hasElementTranscludeDirective) {
               $element.data('$' + directive.name + 'Controller', controllerInstance.instance);
             }
-
-            controllers[directive.name] = controllerInstance;
           });
         }
 
@@ -1954,14 +1949,14 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                                       isolateScope.$$isolateBindings,
                                       newIsolateScopeDirective, isolateScope);
         }
-        if (controllers) {
+        if (elementControllers) {
           // Initialize bindToController bindings for new/isolate scopes
           var scopeDirective = newIsolateScopeDirective || newScopeDirective;
           var bindings;
           var controllerForBindings;
-          if (scopeDirective && controllers[scopeDirective.name]) {
+          if (scopeDirective && elementControllers[scopeDirective.name]) {
             bindings = scopeDirective.$$bindings.bindToController;
-            controller = controllers[scopeDirective.name];
+            controller = elementControllers[scopeDirective.name];
 
             if (controller && controller.identifier && bindings) {
               controllerForBindings = controller;
@@ -1970,7 +1965,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                                               bindings, scopeDirective);
             }
           }
-          forEach(controllers, function(controller) {
+          forEach(elementControllers, function(controller) {
             var result = controller();
             if (result !== controller.instance &&
                 controller === controllerForBindings) {
@@ -1981,7 +1976,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                                               bindings, scopeDirective);
             }
           });
-          controllers = null;
         }
 
         // PRELINKING


### PR DESCRIPTION
This was mainly focused around #9609 - bringing 1.3 up to speed with 1.2 with an ng-repeated ng-model, at least when not using jQuery.

Overall these changes make the added benchmark (and the jsfiddle in #9609) 2-3x faster and seem to be faster then 1.2 now.

The last 3 commits (refactoring controller stuff in $compile) can probably be squashed but I left them separate for now for nicer diffs.

The only functional change (that I know of) is that the NgModelController `$name` is now initialized by the directive (pre-link) instead of within the controller. I'm not sure if this an issue or considered breaking? This was already the case for the `$options` field...
