### PR TITLE
fix(ngModel): use `$evalAsync` for blur events to safely `$apply`

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2416,7 +2416,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
      </file>
  * </example>
  */
-var ngModelDirective = function() {
+var ngModelDirective = ['$rootScope', function($rootScope) {
   return {
     restrict: 'A',
     require: ['ngModel', '^?form', '^?ngModelOptions'],
@@ -2459,7 +2459,8 @@ var ngModelDirective = function() {
 
           element.on('blur', function(ev) {
             if (modelCtrl.$touched) return;
-            if (scope.$$phase) {
+
+            if ($rootScope.$$phase) {
                 scope.$evalAsync(modelCtrl.$setTouched);
             } else {
                 scope.$apply(modelCtrl.$setTouched);
@@ -2469,7 +2470,7 @@ var ngModelDirective = function() {
       };
     }
   };
-};
+}];
 
 
 /**

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2460,9 +2460,14 @@ var ngModelDirective = function() {
           element.on('blur', function(ev) {
             if (modelCtrl.$touched) return;
 
-            scope.$apply(function() {
-              modelCtrl.$setTouched();
-            });
+            var onBlurSetTouched = function() {
+                modelCtrl.$setTouched();
+            };
+            if (scope.$$phase) {
+                scope.$evalAsync(onBlurSetTouched);
+            } else {
+                scope.$apply(onBlurSetTouched);
+            }
           });
         }
       };

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2459,14 +2459,10 @@ var ngModelDirective = function() {
 
           element.on('blur', function(ev) {
             if (modelCtrl.$touched) return;
-
-            var onBlurSetTouched = function() {
-                modelCtrl.$setTouched();
-            };
             if (scope.$$phase) {
-                scope.$evalAsync(onBlurSetTouched);
+                scope.$evalAsync(modelCtrl.$setTouched);
             } else {
-                scope.$apply(onBlurSetTouched);
+                scope.$apply(modelCtrl.$setTouched);
             }
           });
         }

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1144,6 +1144,32 @@ describe('ngModel', function() {
     dealoc(element);
   }));
 
+  it('should digest asynchronously on "blur" event if a apply is already in progress',
+      inject(function($compile, $rootScope) {
+
+    var element = $compile('<form name="myForm">' +
+                             '<input name="myControl" ng-model="value" >' +
+                           '</form>')($rootScope);
+    var inputElm = element.find('input');
+    var control = $rootScope.myForm.myControl;
+
+    $rootScope.$apply(function() {
+        expect(control.$touched).toBe(false);
+        expect(control.$untouched).toBe(true);
+
+        browserTrigger(inputElm, 'blur');
+
+        expect(control.$touched).toBe(false);
+        expect(control.$untouched).toBe(true);
+    });
+
+    expect(control.$touched).toBe(true);
+    expect(control.$untouched).toBe(false);
+
+    dealoc(element);
+  }));
+
+
   it('should register/deregister a nested ngModel with parent form when entering or leaving DOM',
       inject(function($compile, $rootScope) {
 


### PR DESCRIPTION
Set the `$touched` asynchronously using `$evalAsync` if the element is blurred during an `$apply`, otherwise it keeps the old behaviour.

Fixes https://github.com/angular/angular.js/issues/8762
