### PR TITLE
docs($browser): minor docs fixes

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -19,8 +19,7 @@
 /**
  * @param {object} window The global window object.
  * @param {object} document jQuery wrapped document.
- * @param {function()} XHR XMLHttpRequest constructor.
- * @param {object} $log console.log or an object with the same interface.
+ * @param {object} $log window.console or an object with the same interface.
  * @param {object} $sniffer $sniffer service
  */
 function Browser(window, document, $log, $sniffer) {


### PR DESCRIPTION
Remove obsolete `XHR` param from the docs and correct `$log` param description.
