### PR TITLE
fix(ngResource): Can't write to the response object in Google Chrome 38+

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -604,6 +604,10 @@ angular.module('ngResource', ['ng']).
 
               value.$resolved = true;
 
+			  if (typeof response === "string") {
+				response = {};
+			  }
+
               response.resource = value;
 
               return response;


### PR DESCRIPTION
 Can't write to the response object in Google Chrome 38+ if it's an empty string. (#9802)

In Chrome v. 38 the response object might come back as an empty string instead of as an object. If this happens, the variable gets overwritten with an empty object in this fix.
