### PR TITLE
fix(jenkins): reset baseUrl in protractor conf

### DIFF
--- a/protractor-jenkins-conf.js
+++ b/protractor-jenkins-conf.js
@@ -13,7 +13,7 @@ exports.config = {
     'browserName': 'chrome'
   },
 
-  baseUrl: 'http://localhost:8000/build/docs/',
+  baseUrl: 'http://localhost:8000/',
 
   framework: 'jasmine',
 


### PR DESCRIPTION
(Tested before and after fix locally and manually on ci.angularjs.org)

Commit 22b817ec11f7ab1a81342a4b60acd644a3f2a8c3 changed the url
used by protractor in all docs tests to add build/docs, which
was already set to the baseUrl in protractor-jenkins.conf. This
commit just changes the protractor config's baseUrl to adapt
to the changes in the spec files.

Closes #9783
