### PR TITLE
fix($parse): stateful interceptors override an `undefined` expression

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1218,7 +1218,7 @@ function $ParseProvider() {
         var result = interceptorFn(value, scope, locals);
         // we only return the interceptor's result if the
         // initial value is defined (for bind-once)
-        return isDefined(value) ? result : value;
+        return isDefined(value) || interceptorFn.$stateful ? result : value;
       };
 
       // Propagate $$watchDelegates other then inputsWatchDelegate

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -551,6 +551,9 @@ function $RootScopeProvider(){
           newValue = _value;
           var newLength, key, bothNaN, newItem, oldItem;
 
+          // If the new value is undefined, then return undefined as the watch may be a one-time watch
+          if (isUndefined(newValue)) return;
+
           if (!isObject(newValue)) { // if primitive
             if (oldValue !== newValue) {
               oldValue = newValue;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3354,6 +3354,31 @@ describe('$compile', function() {
         });
       });
 
+      it('should continue with a digets cycle when there is a two-way binding from the child to the parent', function() {
+        module(function() {
+          directive('hello', function() {
+            return {
+              restrict: 'E',
+              scope: { greeting: '=' },
+              template: '<button ng-click="setGreeting()">Say hi!</button>',
+              link: function(scope) {
+                scope.setGreeting = function() { scope.greeting = 'Hello!'; };
+              }
+            };
+          });
+        });
+
+        inject(function($rootScope) {
+          compile('<div>' +
+                    '<p>{{greeting}}</p>' +
+                    '<div><hello greeting="greeting"></hello></div>' +
+                  '</div>');
+          $rootScope.$digest();
+          browserTrigger(element.find('button'), 'click');
+          expect(element.find('p').text()).toBe('Hello!');
+        });
+      });
+
     });
 
 


### PR DESCRIPTION
When using `$parse` with a stateful interceptor and the expression is `undefined`, then return the result from the interceptor

Closes #9821
