### PR TITLE
fix($route): fix redirection with optional/eager params

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -652,7 +652,7 @@ function $RouteProvider() {
         if (i === 0) {
           result.push(segment);
         } else {
-          var segmentMatch = segment.match(/(\w+)(.*)/);
+          var segmentMatch = segment.match(/(\w+)(?:[?*])?(.*)/);
           var key = segmentMatch[1];
           result.push(params[key]);
           result.push(segmentMatch[2] || '');

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -974,6 +974,29 @@ describe('$route', function() {
     });
 
 
+    it('should properly interpolate optional and eager route vars ' +
+       'when redirecting from path with trailing slash', function() {
+      module(function($routeProvider) {
+        $routeProvider.when('/foo/:id?/:subid?', {templateUrl: 'foo.html'});
+        $routeProvider.when('/bar/:id*/:subid', {templateUrl: 'bar.html'});
+      });
+
+      inject(function($location, $rootScope, $route) {
+        $location.path('/foo/id1/subid2/');
+        $rootScope.$digest();
+
+        expect($location.path()).toEqual('/foo/id1/subid2');
+        expect($route.current.templateUrl).toEqual('foo.html');
+
+        $location.path('/bar/id1/extra/subid2/');
+        $rootScope.$digest();
+
+        expect($location.path()).toEqual('/bar/id1/extra/subid2');
+        expect($route.current.templateUrl).toEqual('bar.html');
+      });
+    });
+
+
     it('should allow custom redirectTo function to be used', function() {
       function customRedirectFn(routePathParams, path, search) {
         expect(routePathParams).toEqual({id: 'id3'});

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -326,13 +326,13 @@ describe('$route', function() {
       expect($route.current).toBeUndefined();
     }));
 
-    it('matches literal *', inject(function($route, $location, $rootScope) {
+    it('matches literal .', inject(function($route, $location, $rootScope) {
       $location.path('/$testX23/foo*(bar)/222');
       $rootScope.$digest();
       expect($route.current).toBeUndefined();
     }));
 
-    it('matches literal .', inject(function($route, $location, $rootScope) {
+    it('matches literal *', inject(function($route, $location, $rootScope) {
       $location.path('/$test.23/foooo(bar)/222');
       $rootScope.$digest();
       expect($route.current).toBeUndefined();


### PR DESCRIPTION
Previously, when (automatically) redirecting from path that fetured a trailing slash and optional or "eager" parameters, the resulting path would (incorrectly) contain the special characters (`?`,`*`) along with the parameter values.
(There is also a first (unrelated) commit, that fixes the names of 2 tests in `routeSpec`.)

Closes #9819
