### PR TITLE
docs(guide/Scopes): (fix) gramatical error line 248

### DIFF
--- a/docs/content/guide/scope.ngdoc
+++ b/docs/content/guide/scope.ngdoc
@@ -245,7 +245,7 @@ of the `$watch` expressions and compares them with the previous value. This dirt
 asynchronously. This means that assignment such as `$scope.username="angular"` will not
 immediately cause a `$watch` to be notified, instead the `$watch` notification is delayed until
 the `$digest` phase. This delay is desirable, since it coalesces multiple model updates into one
-`$watch` notification as well as it guarantees that during the `$watch` notification no other
+`$watch` notification, and guarantees that during the `$watch` notification no other
 `$watch`es are running. If a `$watch` changes the value of the model, it will force additional
 `$digest` cycle.
 


### PR DESCRIPTION
changed "as well as it guarantees"    to   ", and guarantees"

![screen shot 2014-10-29 at 11 44 23 am](https://cloud.githubusercontent.com/assets/4251807/4832425/0beb8740-5f9c-11e4-9e2c-ccad1d76050d.png)

before:

![screen shot 2014-10-29 at 11 48 12 am](https://cloud.githubusercontent.com/assets/4251807/4832451/43f6f46c-5f9c-11e4-83d0-708e9bbe9793.png)
