### PR TITLE
feat(ngAria): Announce ngMessages with aria-live

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -238,5 +238,16 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
 .directive('ngDisabled', ['$aria', function($aria) {
   return $aria.$$watchExpr('ngDisabled', 'aria-disabled');
 }])
+.directive('ngMessages', function() {
+  return {
+    restrict: 'A',
+    require: '?ngMessages',
+    link: function(scope, elem, attr, ngMessages) {
+      if (!elem.attr('aria-live')) {
+        elem.attr('aria-live', 'assertive');
+      }
+    }
+  };
+})
 .directive('ngClick', ngAriaTabindex)
 .directive('ngDblclick', ngAriaTabindex);

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -400,6 +400,16 @@ describe('$aria', function() {
     });
   });
 
+  describe('announcing ngMessages', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach aria-live', function() {
+      var element = [
+        $compile('<div ng-messages="myForm.myName.$error">')(scope)
+      ];
+      expectAriaAttrOnEachElement(element, 'aria-live', "assertive");
+    });
+  });
 
   describe('aria-value when disabled', function() {
     beforeEach(configAriaProvider({


### PR DESCRIPTION
To be accessible, error messages shown with `ngMessages` should be read aloud in a screen reader. This can be easily accomplished by adding `aria-live="assertive"` to the `ngMessages` directive via `ngAria`. 

Proof of concept in this Plunkr: http://plnkr.co/edit/6iFNWiSiRWz9y871v7oq
