### PR TITLE
Handle default or "no value supplied" case for the ng-maxlength directive

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2613,7 +2613,7 @@ var maxlengthDirective = function() {
         ctrl.$validate();
       });
       ctrl.$validators.maxlength = function(modelValue, viewValue) {
-        return ctrl.$isEmpty(modelValue) || viewValue.length <= maxlength;
+        return ctrl.$isEmpty(modelValue) || maxlength == 0 || viewValue.length <= maxlength;
       };
     }
   };


### PR DESCRIPTION
If one adds ng-maxlength="" to an input field, the default value of 0 for max length is used which results in an incorrect error being added to the input field. This fix checks for a value of 0 for the maxlength. If one uses this directive and purposefully supplies a value of 0 for the directive, that would make absolutely no sense in any scenario I can think of. By using this as the 'default' value (or the value used if a blank value is passed for this directive), and checking for that value and returning a result of 'valid' if that value is supplied, corrects this issue. This is not a problem for the ng-minlength directive as having a default value of 0 for the minimum length is actually a 'no-op' as you can't have a length less than 0.
