### PR TITLE
feat($log): add $log.snapshot() option to make angular.copy of console l...

### DIFF
--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -103,6 +103,25 @@ function $LogProvider() {
 
       /**
        * @ngdoc method
+       * @name $log#snapshot[(.log(..)/.info(..)/.warn(..)/.error(..)/.debug(..))]
+       *
+       * @description
+       * Make an angular.copy of arguments prior to logging; useful for logging a snapshot of nested or complex objects
+       * which may change later in your program, which would otherwise resulting in misleading console log output.
+       * Default $log.snapshot uses log level "log", or specify an optional .loglevel explicitly.
+       */
+      snapshot: (function() {
+        var snapshot = consoleLog('log', true); // define default snapshot function
+        snapshot.log = consoleLog('log', true);
+        snapshot.info = consoleLog('info',true);
+        snapshot.warn = consoleLog('warn', true);
+        snapshot.error = consoleLog('error', true);
+        snapshot.debug = consoleLog('debug', true);
+        return snapshot;
+      }()),
+
+      /**
+       * @ngdoc method
        * @name $log#debug
        *
        * @description
@@ -119,7 +138,7 @@ function $LogProvider() {
       }())
     };
 
-    function formatError(arg) {
+    function formatError(arg, copyFlag) {
       if (arg instanceof Error) {
         if (arg.stack) {
           arg = (arg.message && arg.stack.indexOf(arg.message) === -1)
@@ -128,11 +147,13 @@ function $LogProvider() {
         } else if (arg.sourceURL) {
           arg = arg.message + '\n' + arg.sourceURL + ':' + arg.line;
         }
+      } else if (copyFlag) {
+        return angular.copy(arg);
       }
       return arg;
     }
 
-    function consoleLog(type) {
+    function consoleLog(type, copyFlag) {
       var console = $window.console || {},
           logFn = console[type] || console.log || noop,
           hasApply = false;
@@ -147,7 +168,7 @@ function $LogProvider() {
         return function() {
           var args = [];
           forEach(arguments, function(arg) {
-            args.push(formatError(arg));
+            args.push(formatError(arg, copyFlag));
           });
           return logFn.apply(console, args);
         };
@@ -161,3 +182,4 @@ function $LogProvider() {
     }
   }];
 }
+

--- a/test/ng/logSpec.js
+++ b/test/ng/logSpec.js
@@ -117,6 +117,38 @@ describe('$log', function() {
     );
   });
 
+  describe("$log.snapshot", function() {
+
+    beforeEach(inject(
+      function() {
+        $window.console = {log: log,
+                           warn: warn,
+                           info: info,
+                           error: error,
+                           debug: debug};
+      }
+    ));
+
+    it ("should default to log level 'log' if no log level specifier provided", inject(
+      function($log) {
+        $log.snapshot();
+        expect(logger).toEqual('log;');
+      }
+    ));
+
+    it ("should apply log level if log level provided", inject(
+      function($log) {
+        $log.snapshot.log();
+        $log.snapshot.warn();
+        $log.snapshot.info();
+        $log.snapshot.error();
+        $log.snapshot.debug();
+        expect(logger).toEqual('log;warn;info;error;debug;');
+      }
+    ));
+
+  });
+
   describe("$log.debug", function() {
 
     beforeEach(initService(false));
@@ -179,3 +211,4 @@ describe('$log', function() {
     });
   });
 });
+


### PR DESCRIPTION
...og arguments

makes angular.copy of object before logging so mutating objects are still recorded accurately in log
(improves default behavior of browser log which otherwise contains live object references that
can provide misleading picture of complex objects that change after being logged).
$log.snapshot() is sugar method for $log.snapshot.log() Also can call $log.snapshot.warn(), $log.snapshot.info(), $log.snapshot.error(), $log.snapshot.debug()
