### PR TITLE
fix(ngPattern): match behaviour of native HTML pattern attribute

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2577,7 +2577,7 @@ var patternDirective = function() {
       var regexp, patternExp = attr.ngPattern || attr.pattern;
       attr.$observe('pattern', function(regex) {
         if (isString(regex) && regex.length > 0) {
-          regex = new RegExp(regex);
+          regex = new RegExp('^' + regex + '$');
         }
 
         if (regex && !regex.test) {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2224,6 +2224,21 @@ describe('input', function() {
         });
       }).toThrowMatching(/^\[ngPattern:noregexp\] Expected fooRegexp to be a RegExp but was/);
     });
+
+    it('should be invalid if entire string does not match pattern', function() {
+      compileInput('<input type="text" name="test" ng-model="value" pattern="\\d{4}">');
+      changeInputValueTo('1234');
+      expect(scope.form.test.$error.pattern).not.toBe(true);
+      expect(inputElm).toBeValid();
+
+      changeInputValueTo('123');
+      expect(scope.form.test.$error.pattern).toBe(true);
+      expect(inputElm).not.toBeValid();
+
+      changeInputValueTo('12345');
+      expect(scope.form.test.$error.pattern).toBe(true);
+      expect(inputElm).not.toBeValid();
+    });
   });
 
 


### PR DESCRIPTION
From https://html.spec.whatwg.org/multipage/forms.html#attr-input-pattern

> The compiled pattern regular expression, when matched against a string, must have its start
> anchored to the start of the string and its end anchored to the end of the string.

/CC @matsko please review

Closes #9881
