### PR TITLE
docs(ngModel.NgModelController): use $evalAsync instead of $apply for events

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1643,7 +1643,7 @@ var VALID_CLASS = 'ng-valid',
 
               // Listen for change events to enable binding
               element.on('blur keyup change', function() {
-                scope.$apply(read);
+                scope.$evalAsync(read);
               });
               read(); // initialize
 


### PR DESCRIPTION
Have the apply called safely during events by using `$evalAsync` rather than `$apply`.
This will help ensure that an apply for a user directive is not called during a digest cycle.
