### PR TITLE
Feature hooks for ng events

### DIFF
--- a/test/ng/directive/ngEventDirsSpec.js
+++ b/test/ng/directive/ngEventDirsSpec.js
@@ -169,6 +169,41 @@ describe('event directives', function() {
           });
         });
       });
+
+      describe('cancellation', function() {
+        beforeEach(function() {
+          var that = this;
+          module(function($compileProvider) {
+            that.spy = jasmine.createSpy('interceptor').andCallFake(function(e) {
+              return false;
+            });
+
+            $compileProvider.directive('testInterceptor', function() {
+              return {
+                restrict: 'A',
+                require: 'ngClick',
+                link: function(scope, element, attrs, ngClick) {
+                  ngClick.$interceptors.push(that.spy);
+                }
+              };
+            });
+          });
+        });
+
+        it('should only cancel calling event handler by returning false', function() {
+          var that = this;
+          inject(function($rootScope, $compile) {
+            var element = $compile('<button test-interceptor ng-click="call()">Click</button>')($rootScope);
+            $rootScope.call = jasmine.createSpy('call').andCallFake(function() {
+              $rootScope.value = 'newValue';
+            });
+
+            element.triggerHandler('click');
+            expect(that.spy).toHaveBeenCalled();
+            expect($rootScope.call).not.toHaveBeenCalled();
+          });
+        });
+      });
     });
   });
 

--- a/test/ng/directive/ngEventDirsSpec.js
+++ b/test/ng/directive/ngEventDirsSpec.js
@@ -131,4 +131,45 @@ describe('event directives', function() {
     }));
 
   });
+
+  describe('hooks', function() {
+
+    describe('interceptor hook', function() {
+
+      describe('execution', function() {
+        beforeEach(function() {
+          var that = this;
+          module(function($compileProvider) {
+            that.spy = jasmine.createSpy('interceptor').andCallFake(function(e) {
+            });
+
+            $compileProvider.directive('testInterceptor', function() {
+              return {
+                restrict: 'A',
+                require: 'ngClick',
+                link: function(scope, element, attrs, ngClick) {
+                  ngClick.$interceptors.push(that.spy);
+                }
+              };
+            });
+          });
+        });
+
+        it('should be called before the event handler', function() {
+          var that = this;
+          inject(function($rootScope, $compile) {
+            var element = $compile('<button test-interceptor ng-click="call()">Click</button>')($rootScope);
+            $rootScope.call = jasmine.createSpy('call').andCallFake(function() {
+              $rootScope.value = 'newValue';
+            });
+
+            element.triggerHandler('click');
+            expect(that.spy).toHaveBeenCalled();
+            expect($rootScope.call).toHaveBeenCalled();
+          });
+        });
+      });
+    });
+  });
+
 });

--- a/test/ng/directive/ngEventDirsSpec.js
+++ b/test/ng/directive/ngEventDirsSpec.js
@@ -240,6 +240,42 @@ describe('event directives', function() {
         });
       });
     });
+
+    describe('result watch hook', function() {
+      describe('handler function', function() {
+        beforeEach(function() {
+          var that = this;
+          module(function($compileProvider) {
+            that.spy = jasmine.createSpy('resultWatcher');
+            $compileProvider.directive('testResultWatcher', function() {
+              return {
+                restrict: 'A',
+                require: 'ngClick',
+                link: function(scope, element, attrs, ngClick) {
+                  ngClick.$callResultWatchers.push(that.spy);
+                }
+              };
+            });
+          });
+        });
+
+        it('should be called with the return value of the event handler', function() {
+          var that = this;
+          inject(function($rootScope, $compile) {
+            var element = $compile('<button test-result-watcher ng-click="call()">Click</button>')($rootScope);
+            $rootScope.call = jasmine.createSpy('call').andCallFake(function() {
+              return 'cake';
+            });
+
+            element.triggerHandler('click');
+
+            expect(that.spy).toHaveBeenCalled();
+            expect($rootScope.call).toHaveBeenCalled();
+            expect(that.spy.calls[0].args[0]).toEqual('cake');
+          });
+        });
+      });
+    });
   });
 
 });

--- a/test/ng/directive/ngEventDirsSpec.js
+++ b/test/ng/directive/ngEventDirsSpec.js
@@ -204,6 +204,41 @@ describe('event directives', function() {
           });
         });
       });
+
+      describe('handler function', function() {
+        beforeEach(function() {
+          var that = this;
+          module(function($compileProvider) {
+            that.spy = jasmine.createSpy('interceptor');
+            $compileProvider.directive('testInterceptor', function() {
+              return {
+                restrict: 'A',
+                require: 'ngClick',
+                link: function(scope, element, attrs, ngClick) {
+                  ngClick.$interceptors.push(that.spy);
+                }
+              };
+            });
+          });
+        });
+
+        it('should have access to the event', function() {
+          var that = this;
+          inject(function($rootScope, $compile) {
+            var element = $compile('<button test-interceptor ng-click="call()">Click</button>')($rootScope);
+            $rootScope.call = jasmine.createSpy('call').andCallFake(function() {
+              $rootScope.value = 'newValue';
+            });
+
+            element.triggerHandler('click');
+
+            expect(that.spy).toHaveBeenCalled();
+            var arg = that.spy.calls[0].args[0];
+            expect(arg).not.toBeUndefined();
+            expect(arg.target).toEqual(element[0]);
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Review needed/ not merge ready (due to lack of docs).

This adds a mechanism for hooking into ngClick/Touch/Mouseover etc. events, so that directives can cancel events or view the result of the handler call.

My use case: I wanted to create a `button` directive which disables the button/changes it to a loading state if the ng-click handler returns a promise.

This can be achieved now by `require`ing `ngClick` in the directive, and hooking the state changes into a function pushed to `$callResultWatchers`.

`$interceptors` hold functions which are called before the handler, and can cancel the event with exactly and only a `return false;`.

Would love feedback on the design & implementation.

Thanks!
