### PR TITLE
`inject` function in `angular-mocks` does not forward result

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2224,6 +2224,7 @@ if (window.jasmine || window.mocha) {
     function workFn() {
       var modules = currentSpec.$modules || [];
       var strictDi = !!currentSpec.$injectorStrict;
+      var result;
       modules.unshift('ngMock');
       modules.unshift('ng');
       var injector = currentSpec.$injector;
@@ -2247,7 +2248,7 @@ if (window.jasmine || window.mocha) {
         }
         try {
           /* jshint -W040 *//* Jasmine explicitly provides a `this` object when calling functions */
-          injector.invoke(blockFns[i] || angular.noop, this);
+          result = injector.invoke(blockFns[i] || angular.noop, this);
           /* jshint +W040 */
         } catch (e) {
           if (e.stack && errorForStack) {
@@ -2258,6 +2259,7 @@ if (window.jasmine || window.mocha) {
           errorForStack = null;
         }
       }
+      return result;
     }
   };
 


### PR DESCRIPTION
This code returns no result ([angular-mocks.js#L2250](https://github.com/angular/angular.js/blob/master/src/ngMock/angular-mocks.js#L2250)):

``` js
injector.invoke(blockFns[i] || angular.noop, this);
```

Therefore promises don't reach the `mocha` and I can't use `chai-as-promised` within `inject`:

``` js
it('should run', inject(function(myService) {
        return myService.save().should.be.fulfilled;
    }));
```
