### PR TITLE
docs(guide/Conceptual Overview): change "a" to "an" before ng-controller

### DIFF
--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -154,7 +154,7 @@ First, there is a new JavaScript file that contains a so called <a name="control
 More exactly, the file contains a constructor function that creates the actual controller instance.
 The purpose of controllers is to expose variables and functionality to expressions and directives.
 
-Besides the new file that contains the controller code we also added a
+Besides the new file that contains the controller code we also added an
 {@link ng.directive:ngController `ng-controller`} directive to the HTML.
 This directive tells angular that the new `InvoiceController` is responsible for the element with the directive
 and all of the element's children.


### PR DESCRIPTION
The article matches how a word is pronounced. Since "en-gee"-controller begins with a vowel, the article used should be "an" and not "a": _we added an ng-controller_
