### PR TITLE
Caret restoring after recompiling the inputs with ng-model

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1015,7 +1015,16 @@ function baseInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   element.on('change', listener);
 
   ctrl.$render = function() {
-    element.val(ctrl.$isEmpty(ctrl.$modelValue) ? '' : ctrl.$viewValue);
+    if (/text/.test(element[0].type)) {
+      var start = element[0].selectionStart;
+      var end = element[0].selectionEnd;
+
+      element.val(ctrl.$isEmpty(ctrl.$modelValue) ? '' : ctrl.$viewValue);
+
+      element[0].setSelectionRange(start, end);
+    } else {
+      element.val(ctrl.$isEmpty(ctrl.$modelValue) ? '' : ctrl.$viewValue);
+    }
   };
 }
 


### PR DESCRIPTION
Hello, after upgrading to 1.3.0 I have an issue with caret on recompiled inputs. After enter the value caret jumps to the end of input. 
![123](https://cloud.githubusercontent.com/assets/3543513/4896179/aa3709a8-63f5-11e4-888e-e5db02b27256.gif)

**Reproducable:** always
**Angular Version**: >1.3.0
**Browsers:** Chrome 38 and IE 11
**Operating system:** Windows 8.1
**Plnkr:** http://plnkr.co/edit/BMumov7W1t4xp1PYeL1K?p=preview
