### PR TITLE
perf(Angular): only create new collection in getBlockNodes if the block has changed

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1638,22 +1638,24 @@ function getter(obj, path, bindFnToScope) {
 /**
  * Return the DOM siblings between the first and last node in the given array.
  * @param {Array} array like object
- * @returns {jqLite} jqLite collection containing the nodes
+ * @returns {Array} the inputted object or a jqLite collection containing the nodes
  */
 function getBlockNodes(nodes) {
-  // TODO(perf): just check if all items in `nodes` are siblings and if they are return the original
-  //             collection, otherwise update the original collection.
+  // TODO(perf): update `nodes` instead of creating a new object?
   var node = nodes[0];
   var endNode = nodes[nodes.length - 1];
-  var blockNodes = [node];
+  var blockNodes;
 
-  do {
-    node = node.nextSibling;
-    if (!node) break;
-    blockNodes.push(node);
-  } while (node !== endNode);
+  for (var i = 1; node !== endNode && (node = node.nextSibling); i++) {
+    if (blockNodes || nodes[i] !== node) {
+      if (!blockNodes) {
+        blockNodes = jqLite(slice.call(nodes, 0, i));
+      }
+      blockNodes.push(node);
+    }
+  }
 
-  return jqLite(blockNodes);
+  return blockNodes || nodes;
 }
 
 


### PR DESCRIPTION
Doing something such as...

```
var scope = $rootScope.$new();
$compile( $('<div ng-if="i"></div>').appendTo('body') )(scope);
while (loop forever) {
   scope.i = (0 === ++i%2);
   scope.digest()
}
```

The `getBlockNodes` goes from about 2.5% => 0.25%.  In any real test that diff would probably round down to zero though. But for only 3 extra lines (2 being `}`) I thought I'd at least throw it out there...
