### PR TITLE
fix($http): won't parse single space response

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -11,7 +11,7 @@ function defaultHttpResponseTransform(data, headers) {
     // strip json vulnerability protection prefix
     data = data.replace(JSON_PROTECTION_PREFIX, '');
     var contentType = headers('Content-Type');
-    if ((contentType && contentType.indexOf(APPLICATION_JSON) === 0) ||
+    if ((contentType && contentType.indexOf(APPLICATION_JSON) === 0 && data.trim()) ||
         (JSON_START.test(data) && JSON_END.test(data))) {
       data = fromJson(data);
     }
@@ -782,7 +782,7 @@ function $HttpProvider() {
       function transformResponse(response) {
         // make a copy since the response must be cacheable
         var resp = extend({}, response);
-        if (!response.data || response.data === ' ') {
+        if (!response.data) {
           resp.data = response.data;
         } else {
           resp.data = transformData(response.data, response.headers, config.transformResponse);

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -782,7 +782,7 @@ function $HttpProvider() {
       function transformResponse(response) {
         // make a copy since the response must be cacheable
         var resp = extend({}, response);
-        if (!response.data) {
+        if (!response.data || response.data === ' ') {
           resp.data = response.data;
         } else {
           resp.data = transformData(response.data, response.headers, config.transformResponse);

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1133,6 +1133,17 @@ describe('$http', function() {
             expect(callback.mostRecentCall.args[0]).toEqual('');
           });
 
+          it('should not attempt to deserialize json for a blank response whose header contains application/json', function() {
+            //per http spec for Content-Type, HEAD request should return a Content-Type header
+            //set to what the content type would have been if a get was sent
+            $httpBackend.expect('GET', '/url').respond(' ', {'Content-Type': 'application/json'});
+            $http({method: 'GET', url: '/url'}).success(callback);
+            $httpBackend.flush();
+
+            expect(callback).toHaveBeenCalledOnce();
+            expect(callback.mostRecentCall.args[0]).toEqual(' ');
+          });
+
           it('should not deserialize tpl beginning with ng expression', function() {
             $httpBackend.expect('GET', '/url').respond('{{some}}');
             $http.get('/url').success(callback);


### PR DESCRIPTION
According to [this question](http://stackoverflow.com/questions/3351247/how-to-return-truly-empty-body-in-rails-i-e-content-length-0), Rails in order to patch a bug in Safari, returns a single space when calling `head :ok`, which is the standard for POST requests.

Angular since [9ba24c54d](https://github.com/angular/angular.js/commit/9ba24c54d60e643b1450cc5cfa8f990bd524c130) checks if the body is empty before calling JSON parse, but this still breaks in this case, since the body isn't empty, but contains a single space. 

We are hitting this issue when trying to upgrade from Angular 1.2.10. This PR should help in that case.
