### PR TITLE
Add a helpful warning msg about case sensitivity on isolated scope variable names

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -388,7 +388,10 @@ element as a customer component.
 
 
 ### Isolating the Scope of a Directive
-
+<div class="alert alert-warning">
+**Note:** Keep in mind that there are rules around case sensitivity for parameter names. If you find yourself with undefined 
+variable values try to make the variable name all lower case.
+</div>
 Our `myCustomer` directive above is great, but it has a fatal flaw. We can only use it once within a
 given scope.
 


### PR DESCRIPTION
I just spent several hours banging my head because of an undefined value with isolating scope. I talked to another engineer who had the same problem and he just gave up after wasting 1/2 a day. I eventually guessed that it might be a case sensitivity issue. I just want to pay it forward and help people from giving up on this!!!!
