### PR TITLE
fix($parse): Handle the empty string as an object key

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -806,7 +806,7 @@ Parser.prototype = {
           break;
         }
         var token = this.expect();
-        keys.push(token.string || token.text);
+        keys.push(isDefined(token.string) ? token.string : token.text);
         this.consume(':');
         var value = this.expression();
         valueFns.push(value);

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -511,6 +511,7 @@ describe('parser', function() {
         expect(toJson(scope.$eval("{a:'b',}"))).toEqual('{"a":"b"}');
         expect(toJson(scope.$eval("{'a':'b',}"))).toEqual('{"a":"b"}');
         expect(toJson(scope.$eval("{\"a\":'b',}"))).toEqual('{"a":"b"}');
+        expect(toJson(scope.$eval('{"":"b",}'))).toEqual('{"":"b"}');
       });
 
       it('should evaluate object access', function() {


### PR DESCRIPTION
When rebuilding an object literal key, use `isDefined` to decide if this is a string token or an identifier

Closes #9893
