### PR TITLE
docs(ngModelOptions): minor grammer error

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2868,7 +2868,7 @@ var ngValueDirective = function() {
  * `ngModelOptions` has an effect on the element it's declared on and its descendants.
  *
  * @param {Object} ngModelOptions options to apply to the current model. Valid keys are:
- *   - `updateOn`: string specifying which event should be the input bound to. You can set several
+ *   - `updateOn`: string specifying which event should the input be bound to. You can set several
  *     events using an space delimited list. There is a special event called `default` that
  *     matches the default events belonging of the control.
  *   - `debounce`: integer value which contains the debounce model update value in milliseconds. A


### PR DESCRIPTION
On https://docs.angularjs.org/api/ng/directive/ngModelOptions, in Arguments block, in description of updateOn, it says “specifying which event should be the input bound to.” and should be “specifying which event should be the input be bound to.”.
