### PR TITLE
href attributes emptied when tag is disabled

### DIFF
--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -363,7 +363,7 @@ forEach(BOOLEAN_ATTR, function(propName, attrName) {
             return isEnabled;
           } else {
             isEnabled = !!newVal;
-            forEach(this.$listeners, function (f) { f(isEnabled); });
+            forEach(this.$listeners, function(f) { f(isEnabled); });
             $attrs.$set(attrName, isEnabled);
             return this;
           }
@@ -423,7 +423,7 @@ forEach(['src', 'srcset', 'href'], function(attrName) {
         attr.$observe(normalized, ngSrcSrcSetHrefWatchAttribute);
 
         if (ngDisabled) {
-          ngDisabled.$listeners.push(function (enabled) {
+          ngDisabled.$listeners.push(function(enabled) {
             ngSrcSrcSetHrefWatchAttribute(enabled ? attr["ngHref"] : false);
           });
         }

--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -408,7 +408,8 @@ forEach(['src', 'srcset', 'href'], function(attrName) {
   ngAttributeAliasDirectives[normalized] = function() {
     return {
       priority: 99, // it needs to run after the attributes are interpolated
-      link: function(scope, element, attr) {
+      require: '?ngDisabled',
+      link: function(scope, element, attr, ngDisabled) {
         var propName = attrName,
             name = attrName;
 
@@ -419,7 +420,15 @@ forEach(['src', 'srcset', 'href'], function(attrName) {
           propName = null;
         }
 
-        attr.$observe(normalized, function(value) {
+        attr.$observe(normalized, ngSrcSrcSetHrefWatchAttribute);
+
+        if (ngDisabled) {
+          ngDisabled.$listeners.push(function (enabled) {
+            ngSrcSrcSetHrefWatchAttribute(enabled ? attr["ngHref"] : false);
+          });
+        }
+
+        function ngSrcSrcSetHrefWatchAttribute(value) {
           if (!value) {
             if (attrName === 'href') {
               attr.$set(name, null);
@@ -434,7 +443,7 @@ forEach(['src', 'srcset', 'href'], function(attrName) {
           // to set the property as well to achieve the desired effect.
           // we use attr[attrName] value since $set can sanitize the url.
           if (msie && propName) element.prop(propName, attr[name]);
-        });
+        };
       }
     };
   };

--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -353,9 +353,25 @@ forEach(BOOLEAN_ATTR, function(propName, attrName) {
     return {
       restrict: 'A',
       priority: 100,
-      link: function(scope, element, attr) {
+      require: normalized,
+      controller: function ngBooleanController($attrs) {
+        var isEnabled;
+        this.$listeners = [];
+
+        this[attrName] = function(newVal) {
+          if (newVal === undefined) {
+            return value;
+          } else {
+            isEnabled = !!newVal;
+            forEach(this.$listeners, function (f) { f(isEnabled) });
+            $attrs.$set(attrName, isEnabled);
+            return this;
+          }
+        };
+      },
+      link: function(scope, element, attr, ctrl) {
         scope.$watch(attr[normalized], function ngBooleanAttrWatchAction(value) {
-          attr.$set(attrName, !!value);
+          ctrl[attrName](!!value);
         });
       }
     };

--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -360,10 +360,10 @@ forEach(BOOLEAN_ATTR, function(propName, attrName) {
 
         this[attrName] = function(newVal) {
           if (newVal === undefined) {
-            return value;
+            return isEnabled;
           } else {
             isEnabled = !!newVal;
-            forEach(this.$listeners, function (f) { f(isEnabled) });
+            forEach(this.$listeners, function (f) { f(isEnabled); });
             $attrs.$set(attrName, isEnabled);
             return this;
           }
@@ -443,7 +443,7 @@ forEach(['src', 'srcset', 'href'], function(attrName) {
           // to set the property as well to achieve the desired effect.
           // we use attr[attrName] value since $set can sanitize the url.
           if (msie && propName) element.prop(propName, attr[name]);
-        };
+        }
       }
     };
   };


### PR DESCRIPTION
Not merge ready due to lack of tests & docs; filing for opinions. Probably not the right way to do this, so suggestions appreciated.

When a `<button>` is set as `disabled`, clicking it doesn't trigger any event listeners. However, applying `disabled` to an `<a>` tag doesn't have the same effect as the browser follows a `href` regardless of the rest of the attributes.

This PR extends the boolean attribute directives to add a list of change listeners, and `ng-href` uses this to remove the `href` attribute when the element becomes disabled.
