### PR TITLE
docs(guide/e2e-testing): fix outdated link to Protractor API

### DIFF
--- a/docs/content/guide/e2e-testing.ngdoc
+++ b/docs/content/guide/e2e-testing.ngdoc
@@ -28,7 +28,7 @@ written in JavaScript and run with node. Protractor uses [WebDriver](https://cod
 to control browsers and simulate user actions.
 
 For more information on Protractor, view [getting started](https://github.com/angular/protractor/blob/master/docs/getting-started.md)
-or the [api docs](https://github.com/angular/protractor/blob/master/docs/api.md).
+or the [api docs](http://angular.github.io/protractor/#/api).
 
 Protractor uses [Jasmine](http://jasmine.github.io/1.3/introduction.html) for its test syntax.
 As in unit testing, a test file is comprised of one or


### PR DESCRIPTION
The link to Protractor API points to an outdated document, replaced it with the correct URL.

https://docs.angularjs.org/guide/e2e-testing -> Using Protractor -> "api docs" link.
