### PR TITLE
refactor($parse): don't use bind-once interceptor for non-bind-once expressions

### DIFF
--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -301,7 +301,8 @@ function $InterpolateProvider() {
 
       function parseStringifyInterceptor(value) {
         try {
-          return stringify(getValue(value));
+          value = getValue(value);
+          return allOrNothing && !isDefined(value) ? value : stringify(value);
         } catch (err) {
           var newErr = $interpolateMinErr('interr', "Can't interpolate: {0}\n{1}", text,
             err.toString());


### PR DESCRIPTION
Side-effects:
- Logic for allOrNothing watches now lives in $interpolate rather than $parse

Closes #9958
