### PR TITLE
Why should watchExpression should be idempotent?

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -250,9 +250,10 @@ function $RootScopeProvider() {
        * Registers a `listener` callback to be executed whenever the `watchExpression` changes.
        *
        * - The `watchExpression` is called on every call to {@link ng.$rootScope.Scope#$digest
-       *   $digest()} and should return the value that will be watched. (`watchExpression` should be idempontent
-       *   because it may be executed multiple times per {@link ng.$rootScope.Scope#$digest $digest()}.
-       *   {@link ng.$rootScope.Scope#$digest $digest()} and should be idempotent.)
+       *   $digest()} and should return the value that will be watched. (`watchExpression` should not change
+       *   its value when executed multiple times with the same input because it may be executed multiple 
+       *   times by {@link ng.$rootScope.Scope#$digest $digest()}. That is, `watchExpression` should be
+       *   [idempotent](http://en.wikipedia.org/wiki/Idempotence).
        * - The `listener` is called only when the value from the current `watchExpression` and the
        *   previous call to `watchExpression` are not equal (with the exception of the initial run,
        *   see below). Inequality is determined according to reference inequality,

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -250,9 +250,8 @@ function $RootScopeProvider() {
        * Registers a `listener` callback to be executed whenever the `watchExpression` changes.
        *
        * - The `watchExpression` is called on every call to {@link ng.$rootScope.Scope#$digest
-       *   $digest()} and should return the value that will be watched. (Since
-       *   {@link ng.$rootScope.Scope#$digest $digest()} reruns when it detects changes the
-       *   `watchExpression` can execute multiple times per
+       *   $digest()} and should return the value that will be watched. (`watchExpression` should be idempontent
+       *   because it may be executed multiple times per {@link ng.$rootScope.Scope#$digest $digest()}.
        *   {@link ng.$rootScope.Scope#$digest $digest()} and should be idempotent.)
        * - The `listener` is called only when the value from the current `watchExpression` and the
        *   previous call to `watchExpression` are not equal (with the exception of the initial run,


### PR DESCRIPTION
This attempts to clarify the rationale. The Previous sentence was a bit ambiguous. If this new explanation does not reflect the intent, please use its active voice (as opposed to passive voice) as a template to clarify the existing sentence.
