### PR TITLE
filter doesn't work when methods are added to Object.prototype

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -197,7 +197,7 @@ function filterFilter() {
         // jshint +W086
         for (var key in expression) {
           (function(path) {
-            if (typeof expression[path] === 'undefined') return;
+            if (typeof expression[path] === 'undefined' || !expression.hasOwnProperty(path)) return;
             predicates.push(function(value) {
               return search(path == '$' ? value : (value && value[path]), expression[path]);
             });


### PR DESCRIPTION
`$filter("filter")([{"name":"foo"}], "foo")` will return `[]` if properties/methods are added to Object.prototype because the check isn't done as it should. 

This simple change fixes that.
