### PR TITLE
<fix>(input): return original value from formatter if isEmpty, not ''

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1138,7 +1138,7 @@ function createDateInputType(type, regexp, parseDate, format) {
       } else {
         previousDate = null;
       }
-      return '';
+      return value;
     });
 
     if (isDefined(attr.min) || attr.ngMin) {


### PR DESCRIPTION
Fix the formatter on the input[type=date] to return the original value if the value
evaluates to falsey. It was previously returning an empty string with was causing
the underlying model to be modified upon binding.

Closes #9996
