### PR TITLE
feat(ngMaxlength): disable maxlength when not set to a non-negative integer

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -41,7 +41,8 @@ var inputType = {
    * @param {number=} ngMinlength Sets `minlength` validation error key if the value is shorter than
    *    minlength.
    * @param {number=} ngMaxlength Sets `maxlength` validation error key if the value is longer than
-   *    maxlength.
+   *    maxlength. Setting the attribute to a negative or non-numeric value, allows view values of
+   *    any length.
    * @param {string=} pattern Similar to `ngPattern` except that the attribute value is the actual string
    *    that contains the regular expression body that will be converted to a regular expression
    *    as in the ngPattern directive.
@@ -589,7 +590,8 @@ var inputType = {
    * @param {number=} ngMinlength Sets `minlength` validation error key if the value is shorter than
    *    minlength.
    * @param {number=} ngMaxlength Sets `maxlength` validation error key if the value is longer than
-   *    maxlength.
+   *    maxlength. Setting the attribute to a negative or non-numeric value, allows view values of
+   *    any length.
    * @param {string=} pattern Similar to `ngPattern` except that the attribute value is the actual string
    *    that contains the regular expression body that will be converted to a regular expression
    *    as in the ngPattern directive.
@@ -676,7 +678,8 @@ var inputType = {
    * @param {number=} ngMinlength Sets `minlength` validation error key if the value is shorter than
    *    minlength.
    * @param {number=} ngMaxlength Sets `maxlength` validation error key if the value is longer than
-   *    maxlength.
+   *    maxlength. Setting the attribute to a negative or non-numeric value, allows view values of
+   *    any length.
    * @param {string=} pattern Similar to `ngPattern` except that the attribute value is the actual string
    *    that contains the regular expression body that will be converted to a regular expression
    *    as in the ngPattern directive.
@@ -764,7 +767,8 @@ var inputType = {
    * @param {number=} ngMinlength Sets `minlength` validation error key if the value is shorter than
    *    minlength.
    * @param {number=} ngMaxlength Sets `maxlength` validation error key if the value is longer than
-   *    maxlength.
+   *    maxlength. Setting the attribute to a negative or non-numeric value, allows view values of
+   *    any length.
    * @param {string=} pattern Similar to `ngPattern` except that the attribute value is the actual string
    *    that contains the regular expression body that will be converted to a regular expression
    *    as in the ngPattern directive.
@@ -1370,7 +1374,8 @@ function checkboxInputType(scope, element, attr, ctrl, $sniffer, $browser, $filt
  * @param {number=} ngMinlength Sets `minlength` validation error key if the value is shorter than
  *    minlength.
  * @param {number=} ngMaxlength Sets `maxlength` validation error key if the value is longer than
- *    maxlength.
+ *    maxlength. Setting the attribute to a negative or non-numeric value, allows view values of any
+ *    length.
  * @param {string=} ngPattern Sets `pattern` validation error key if the value does not match the
  *    RegExp pattern expression. Expected value is `/regexp/` for inline patterns or `regexp` for
  *    patterns defined as scope expressions.
@@ -1402,7 +1407,8 @@ function checkboxInputType(scope, element, attr, ctrl, $sniffer, $browser, $filt
  * @param {number=} ngMinlength Sets `minlength` validation error key if the value is shorter than
  *    minlength.
  * @param {number=} ngMaxlength Sets `maxlength` validation error key if the value is longer than
- *    maxlength.
+ *    maxlength. Setting the attribute to a negative or non-numeric value, allows view values of any
+ *    length.
  * @param {string=} ngPattern Sets `pattern` validation error key if the value does not match the
  *    RegExp pattern expression. Expected value is `/regexp/` for inline patterns or `regexp` for
  *    patterns defined as scope expressions.

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2696,7 +2696,7 @@ var maxlengthDirective = function() {
         ctrl.$validate();
       });
       ctrl.$validators.maxlength = function(modelValue, viewValue) {
-        return ctrl.$isEmpty(modelValue) || viewValue.length <= maxlength;
+        return (maxlength < 0) || ctrl.$isEmpty(modelValue) || (viewValue.length <= maxlength);
       };
     }
   };

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2690,9 +2690,10 @@ var maxlengthDirective = function() {
     link: function(scope, elm, attr, ctrl) {
       if (!ctrl) return;
 
-      var maxlength = 0;
+      var maxlength = -1;
       attr.$observe('maxlength', function(value) {
-        maxlength = int(value) || 0;
+        var intVal = int(value);
+        maxlength = isNaN(intVal) ? -1 : intVal;
         ctrl.$validate();
       });
       ctrl.$validators.maxlength = function(modelValue, viewValue) {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2495,6 +2495,16 @@ describe('input', function() {
       expect(inputElm).toBeValid();
     });
 
+    it('should only accept empty values when maxlength is 0', function() {
+      compileInput('<input type="text" ng-model="value" ng-maxlength="0" />');
+
+      changeInputValueTo('');
+      expect(inputElm).toBeValid();
+
+      changeInputValueTo('a');
+      expect(inputElm).toBeInvalid();
+    });
+
     it('should accept values of any length when maxlength is negative', function() {
       compileInput('<input type="text" ng-model="value" ng-maxlength="-1" />');
 
@@ -2502,6 +2512,27 @@ describe('input', function() {
       expect(inputElm).toBeValid();
 
       changeInputValueTo('aaaaaaaaaa');
+      expect(inputElm).toBeValid();
+    });
+
+    it('should accept values of any length when maxlength is non-numeric', function() {
+      compileInput('<input type="text" ng-model="value" ng-maxlength="{{maxlength}}" />');
+      changeInputValueTo('aaaaaaaaaa');
+
+      scope.$apply('maxlength = "5"');
+      expect(inputElm).toBeInvalid();
+
+      scope.$apply('maxlength = "abc"');
+      expect(inputElm).toBeValid();
+
+      scope.$apply('maxlength = ""');
+      expect(inputElm).toBeValid();
+
+      scope.$apply('maxlength = null');
+      expect(inputElm).toBeValid();
+
+      scope.someObj = {};
+      scope.$apply('maxlength = someObj');
       expect(inputElm).toBeValid();
     });
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2495,6 +2495,16 @@ describe('input', function() {
       expect(inputElm).toBeValid();
     });
 
+    it('should accept values of any length when maxlength is negative', function() {
+      compileInput('<input type="text" ng-model="value" ng-maxlength="-1" />');
+
+      changeInputValueTo('');
+      expect(inputElm).toBeValid();
+
+      changeInputValueTo('aaaaaaaaaa');
+      expect(inputElm).toBeValid();
+    });
+
     it('should listen on ng-maxlength when maxlength is observed', function() {
       var value = 0;
       compileInput('<input type="text" ng-model="value" ng-maxlength="max" attr-capture />');


### PR DESCRIPTION
1. Previously, setting the maxlength to a negative number, would make all input values invalid (since their length should be less than maxlength, which is impossible).
2. Furthermore, supplying a non-numeric value would set maxlength to 0 (effectively only allowing empty values - although this is not very likely the intended behaviour).

The 1st commit fixes (1): Adds support for disabling the max length limit by setting maxlength to a negative number.

The 2nd commit "fixes" (2): When specifying a non-numeric value for maxlength (e.g. `""`, `null`, `"abc"`), the max length limit is disabled (i.e. the validator will return `true` for any input).

Note that the behaviour implemented in these 2 commits is more inline with how the HTML5 `maxlength` attribute works (both in browsers and according to [the spec](http://dev.w3.org/html5/spec-preview/attributes-common-to-form-controls.html#attr-fe-maxlength)).

Closes #9874
Closes #9995
