### PR TITLE
docs($q): missing finally notifyCallback API

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -142,7 +142,7 @@
  *
  * - `catch(errorCallback)` – shorthand for `promise.then(null, errorCallback)`
  *
- * - `finally(callback)` – allows you to observe either the fulfillment or rejection of a promise,
+ * - `finally(callback, notifyCallback)` – allows you to observe either the fulfillment or rejection of a promise,
  *   but to do so without modifying the final value. This is useful to release resources or do some
  *   clean-up that needs to be done whether the promise was rejected or resolved. See the [full
  *   specification](https://github.com/kriskowal/q/wiki/API-Reference#promisefinallycallback) for


### PR DESCRIPTION
finally allows for notifyCallback and is missing in the Docs
https://github.com/angular/angular.js/blob/v1.3.2/src/ng/q.js#L288
