### PR TITLE
fix(:http): Fix error message on calls to $http without an object

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -717,7 +717,7 @@ function $HttpProvider() {
         transformResponse: defaults.transformResponse
       };
 
-      if (angular.isArray(requestConfig) || !angular.isObject(requestConfig)) {
+      if (!isObject(requestConfig)) {
           throw minErr('$http')('argument','Invalid argument, expected object, received {0}', requestConfig);
       }
 

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -716,6 +716,13 @@ function $HttpProvider() {
         transformRequest: defaults.transformRequest,
         transformResponse: defaults.transformResponse
       };
+
+      if (angular.isString(requestConfig)) {
+          requestConfig = {url: requestConfig};
+      } else if (angular.isArray(requestConfig) || !angular.isObject(requestConfig)) {
+          throw minErr('$http')('argument','Invalid argument, expected object, received {0}', requestConfig);
+      }
+
       var headers = mergeHeaders(requestConfig);
 
       extend(config, requestConfig);

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -717,9 +717,7 @@ function $HttpProvider() {
         transformResponse: defaults.transformResponse
       };
 
-      if (angular.isString(requestConfig)) {
-          requestConfig = {url: requestConfig};
-      } else if (angular.isArray(requestConfig) || !angular.isObject(requestConfig)) {
+      if (angular.isArray(requestConfig) || !angular.isObject(requestConfig)) {
           throw minErr('$http')('argument','Invalid argument, expected object, received {0}', requestConfig);
       }
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -292,7 +292,7 @@ describe('$http', function() {
 
     it('should throw error if its not a string or not an object supplied', inject(function($httpBackend, $http) {
         expect(function() {
-            $http(['/url'])
+            $http(['/url']);
         }).toThrowMinErr('$http','argument');
     }));
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -285,17 +285,12 @@ describe('$http', function() {
       $http = $h;
     }]));
 
-    it('should throw error if a string is supplied', inject(function($httpBackend, $http) {
+    it('should throw error if a non object is supplied', inject(function($httpBackend, $http) {
         expect(function() {
             $http('/url');
         }).toThrowMinErr('$http','argument');
     }));
 
-    it('should throw error if an array is supplied', inject(function($httpBackend, $http) {
-        expect(function() {
-            $http(['/url']);
-        }).toThrowMinErr('$http','argument');
-    }));
 
     it('should send GET requests if no method specified', inject(function($httpBackend, $http) {
       $httpBackend.expect('GET', '/url').respond('');

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -285,6 +285,17 @@ describe('$http', function() {
       $http = $h;
     }]));
 
+    it('should send GET request if string is supplied', inject(function($httpBackend, $http) {
+        $httpBackend.expect('GET', '/url').respond('');
+        $http('/url');
+    }));
+
+    it('should throw error if its not a string or not an object supplied', inject(function($httpBackend, $http) {
+        expect(function() {
+            $http(['/url'])
+        }).toThrowMinErr('$http','argument');
+    }));
+
     it('should send GET requests if no method specified', inject(function($httpBackend, $http) {
       $httpBackend.expect('GET', '/url').respond('');
       $http({url: '/url'});

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -285,12 +285,13 @@ describe('$http', function() {
       $http = $h;
     }]));
 
-    it('should send GET request if string is supplied', inject(function($httpBackend, $http) {
-        $httpBackend.expect('GET', '/url').respond('');
-        $http('/url');
+    it('should throw error if a string is supplied', inject(function($httpBackend, $http) {
+        expect(function() {
+            $http('/url');
+        }).toThrowMinErr('$http','argument');
     }));
 
-    it('should throw error if its not a string or not an object supplied', inject(function($httpBackend, $http) {
+    it('should throw error if an array is supplied', inject(function($httpBackend, $http) {
         expect(function() {
             $http(['/url']);
         }).toThrowMinErr('$http','argument');


### PR DESCRIPTION
Checks on $http calls and validates it received an object, if it receives a string, automatically wraps it in an object containing only url.
If an array or any non object/string is passed, will throw an error.

Closes #10016
