### PR TITLE
docs($route): fix description of the caseInsensitiveMatch property

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -172,9 +172,11 @@ function $RouteProvider() {
   /**
    * @ngdoc property
    * @name $routeProvider#caseInsensitiveMatch
+   * @description
    *
-   * @property {boolean} caseInsensitiveMatch Value of the `caseInsensitiveMatch` property
-   *  for newly defined routes. Defaults to `false`.
+   * A boolean property indicating if routes defined
+   * using this provider should be matched using a case sensitive
+   * algorithm. Defaults to `false`.
    */
   this.caseInsensitiveMatch = false;
 


### PR DESCRIPTION
It looks like I've messed up docs while preparing 0db573b7493f76abd94ff65ce660017d617e865b...
