### PR TITLE
fix(ngModel): don't run parsers when executing $validate

### DIFF
--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -484,72 +484,75 @@ describe('NgModelController', function() {
 
   });
 
-  describe('validations pipeline', function() {
+  describe('validation', function() {
 
-    it('should perform validations when $validate() is called', function() {
-      scope.$apply('value = ""');
+    describe('$validate', function() {
+      it('should perform validations when $validate() is called', function() {
+        scope.$apply('value = ""');
 
-      var validatorResult = false;
-      ctrl.$validators.someValidator = function(value) {
-        return validatorResult;
-      };
+        var validatorResult = false;
+        ctrl.$validators.someValidator = function(value) {
+          return validatorResult;
+        };
 
-      ctrl.$validate();
+        ctrl.$validate();
 
-      expect(ctrl.$valid).toBe(false);
+        expect(ctrl.$valid).toBe(false);
 
-      validatorResult = true;
-      ctrl.$validate();
+        validatorResult = true;
+        ctrl.$validate();
 
-      expect(ctrl.$valid).toBe(true);
-    });
-
-    it('should always perform validations using the parsed model value', function() {
-      var captures;
-      ctrl.$validators.raw = function() {
-        captures = arguments;
-        return captures[0];
-      };
-
-      ctrl.$parsers.push(function(value) {
-        return value.toUpperCase();
+        expect(ctrl.$valid).toBe(true);
       });
 
-      ctrl.$setViewValue('my-value');
+    describe('view -> model update', function() {
+      it('should always perform validations using the parsed model value', function() {
+        var captures;
+        ctrl.$validators.raw = function() {
+          captures = arguments;
+          return captures[0];
+        };
 
-      expect(captures).toEqual(['MY-VALUE', 'my-value']);
-    });
+        ctrl.$parsers.push(function(value) {
+          return value.toUpperCase();
+        });
 
-    it('should always perform validations using the formatted view value', function() {
-      var captures;
-      ctrl.$validators.raw = function() {
-        captures = arguments;
-        return captures[0];
-      };
+        ctrl.$setViewValue('my-value');
 
-      ctrl.$formatters.push(function(value) {
-        return value + '...';
+        expect(captures).toEqual(['MY-VALUE', 'my-value']);
       });
 
-      scope.$apply('value = "matias"');
+      it('should always perform validations using the formatted view value', function() {
+        var captures;
+        ctrl.$validators.raw = function() {
+          captures = arguments;
+          return captures[0];
+        };
 
-      expect(captures).toEqual(['matias', 'matias...']);
-    });
+        ctrl.$formatters.push(function(value) {
+          return value + '...';
+        });
 
-    it('should only perform validations if the view value is different', function() {
-      var count = 0;
-      ctrl.$validators.countMe = function() {
-        count++;
-      };
+        scope.$apply('value = "matias"');
 
-      ctrl.$setViewValue('my-value');
-      expect(count).toBe(1);
+        expect(captures).toEqual(['matias', 'matias...']);
+      });
 
-      ctrl.$setViewValue('my-value');
-      expect(count).toBe(1);
+      it('should only perform validations if the view value is different', function() {
+        var count = 0;
+        ctrl.$validators.countMe = function() {
+          count++;
+        };
 
-      ctrl.$setViewValue('your-value');
-      expect(count).toBe(2);
+        ctrl.$setViewValue('my-value');
+        expect(count).toBe(1);
+
+        ctrl.$setViewValue('my-value');
+        expect(count).toBe(1);
+
+        ctrl.$setViewValue('your-value');
+        expect(count).toBe(2);
+      });
     });
 
     it('should perform validations twice each time the model value changes within a digest', function() {


### PR DESCRIPTION
Previously, $validate would execute the parsers to obtain a
modelValue for validation. This was necessary, because a validator
that is called outside of model / view update (e.g. from an observer)
otherwise might only an undefined modelValue, because a previous
view update has found a validation $error and set the model
to undefined (as is tradition in angular)

This is problematic as validators that are run immediately after
the ngModelController initializes would parse the modelValue
and replace the model, even though there had been no user input.

The solution is to go back to an older design: the ngModelController
will now internally record the $$rawModelValue. This means a model
or view update will store the set / parsed modelValue regardless
of validity, that is, it will never set it to undefined because of
validation errors.

When $validate is called, the $$rawModelValue will passed to the
validators. If the validity has changed, the usual behavior is kept:
if it became invalid, set the model to undefined, if valid,
restore the last available modelValue - the $$rawModelValue.

Additionally, $validate will only update the model when the validity
changed. This is to prevent setting initially invalid models other
than undefined to undefined (see #9063)

Fixes: #9063
Fixes: #9959
Fixes: #9996
Fixes: #10025

Closes: #9890
Closes: #9913
Closes: #9997 

Bonus: the commit which introduced parsing when validating (I actually wanted $$invalidModelValue to be removed, oh well): https://github.com/angular/angular.js/commit/9ad7d745ab5f6f8f43b51cacd7a238df9562246f

@caitp @petebacondarwin @lgalfaso 
