### PR TITLE
feat(input): add $setDirty method to the controller of ng-model directive

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1851,6 +1851,25 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
 
   /**
    * @ngdoc method
+   * @name ngModel.NgModelController#$setDirty
+   *
+   * @description
+   * Sets the control to its dirty state.
+   *
+   * This method can be called to remove the 'ng-pristine' class and set the control to its dirty
+   * state (ng-dirty class). A model is considered to be dirty when the model has been changed
+   * from when first compiled within then form.
+   */
+  this.$setDirty = function() {
+    ctrl.$dirty = true;
+    ctrl.$pristine = false;
+    $animate.removeClass($element, PRISTINE_CLASS);
+    $animate.addClass($element, DIRTY_CLASS);
+    parentForm.$setDirty();
+  };
+
+  /**
+   * @ngdoc method
    * @name ngModel.NgModelController#$setUntouched
    *
    * @description
@@ -2081,11 +2100,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
 
     // change to dirty
     if (ctrl.$pristine) {
-      ctrl.$dirty = true;
-      ctrl.$pristine = false;
-      $animate.removeClass($element, PRISTINE_CLASS);
-      $animate.addClass($element, DIRTY_CLASS);
-      parentForm.$setDirty();
+      this.$setDirty();
     }
     this.$$parseAndValidate();
   };

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -139,6 +139,23 @@ describe('NgModelController', function() {
     });
   });
 
+  describe('setDirty', function() {
+
+    it('should set control to its dirty state', function() {
+      expect(ctrl.$pristine).toBe(true);
+      expect(ctrl.$dirty).toBe(false);
+
+      ctrl.$setDirty();
+      expect(ctrl.$pristine).toBe(false);
+      expect(ctrl.$dirty).toBe(true);
+    });
+
+    it('should set parent form to its dirty state', function() {
+      ctrl.$setDirty();
+      expect(parentFormCtrl.$setDirty).toHaveBeenCalled();
+    });
+  });
+
   describe('setUntouched', function() {
 
     it('should set control to its untouched state', function() {


### PR DESCRIPTION
- extract existing functionality to public method: $setDirty
- add tests to corresponding changes
- refactor code to use extracted method

Closes #10038
