### PR TITLE
chore(docs): get rid of stable/unstable distinction in version selector

### DIFF
--- a/docs/app/src/versions.js
+++ b/docs/app/src/versions.js
@@ -2,20 +2,9 @@ angular.module('versions', [])
 
 .controller('DocsVersionsCtrl', ['$scope', '$location', '$window', 'NG_VERSIONS', function($scope, $location, $window, NG_VERSIONS) {
   $scope.docs_version  = NG_VERSIONS[0];
-
-  for(var i=0, minor = NaN; i < NG_VERSIONS.length; i++) {
-    var version = NG_VERSIONS[i];
-    // NaN will give false here
-    if (minor <= version.minor) {
-      continue;
-    }
-    version.isLatest = true;
-    minor = version.minor;
-  }
-
   $scope.docs_versions = NG_VERSIONS;
   $scope.getGroupName = function(v) {
-    return v.isLatest ? 'Latest' : (v.isStable ? 'Stable' : 'Unstable');
+    return 'v' + v.major + '.' + v.minor + '.x';
   };
 
   $scope.jumpToDocsVersion = function(version) {

--- a/lib/versions/version-info.js
+++ b/lib/versions/version-info.js
@@ -92,15 +92,6 @@ var getTaggedVersion = function() {
 };
 
 /**
- * Stable versions have an even minor version and have no prerelease
- * @param  {SemVer}  version The version to test
- * @return {Boolean}         True if the version is stable
- */
-var isStable = function(version) {
-  return semver.satisfies(version, '1.0 || 1.2') && version.prerelease.length === 0;
-};
-
-/**
  * Get a collection of all the previous versions sorted by semantic version
  * @return {Array.<SemVer>} The collection of previous versions
  */
@@ -119,8 +110,6 @@ var getPreviousVersions =  function() {
       })
       .filter()
       .map(function(version) {
-        version.isStable = isStable(version);
-
         version.docsUrl = 'http://code.angularjs.org/' + version.version + '/docs';
         // Versions before 1.0.2 had a different docs folder name
         if ( version.major < 1 || (version.major === 1 && version.minor === 0 && version.dot < 2 ) ) {


### PR DESCRIPTION
Let's replace this mess with option groups like **v1.3.x**, **v1.2.x** etc.
![image](https://cloud.githubusercontent.com/assets/94334/5039815/19314c06-6bad-11e4-9075-033f697ae3d9.png)
