### PR TITLE
chore(docs): Explains what the $q service does in the description, instead of origin document.

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -6,7 +6,11 @@
  * @requires $rootScope
  *
  * @description
- * A promise/deferred implementation inspired by [Kris Kowal's Q](https://github.com/kriskowal/q).
+ * A service that helps you run functions asynchronously, and use their return values (or exceptions) 
+ * when they are done processing. 
+ * 
+ * This is an implementation of promises/deferred objects inspired by 
+ * [Kris Kowal's Q](https://github.com/kriskowal/q).
  *
  * $q can be used in two fashions --- one which is more similar to Kris Kowal's Q or jQuery's Deferred
  * implementations, and the other which resembles ES6 promises to some degree.


### PR DESCRIPTION
Explain what the $q service does in the description. The original explanation was less accessible to people new to promises and JS in general.
