### PR TITLE
fix($location): allow empty string URLs to reset path, search, and hash

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -350,8 +350,8 @@ var locationPrototype = {
       return this.$$url;
 
     var match = PATH_MATCH.exec(url);
-    if (match[1]) this.path(decodeURIComponent(match[1]));
-    if (match[2] || match[1]) this.search(match[3] || '');
+    if (match[1] || url === '') this.path(decodeURIComponent(match[1]));
+    if (match[2] || match[1] || url === '') this.search(match[3] || '');
     this.hash(match[5] || '');
 
     return this;

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -304,6 +304,14 @@ describe('$location', function() {
       expect(url.hash()).toBe('');
     });
 
+    it('url() should change path when empty string specified', function() {
+      url.url('');
+
+      expect(url.path()).toBe('/');
+      expect(url.search()).toEqual({});
+      expect(url.hash()).toBe('');
+    });
+
 
     it('replace should set $$replace flag and return itself', function() {
       expect(url.$$replace).toBe(false);


### PR DESCRIPTION
Currently, providing '' to $location#url will only reset the hash, but otherwise has no effect. This
change brings the behaviour of $location#url more inline with window.location.href, which when
assigned to an empty string loads the page's base href.

Before:
$location.url() // http://www.example.com/path
$location.url('') // http://www.example.com/path

After:
$location.url() // http://www.example.com/path
$location.url('') // http://www.example.com

Fixes #10063
