### PR TITLE
fix(toJson): add ability to suppress exceptions

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -967,8 +967,20 @@ function toJsonReplacer(key, value) {
  * @param {boolean=} pretty If set to true, the JSON output will contain newlines and whitespace.
  * @returns {string|undefined} JSON-ified string representing `obj`.
  */
-function toJson(obj, pretty) {
+function toJson(obj, pretty, options) {
   if (typeof obj === 'undefined') return undefined;
+
+  if (!options) options = {};
+
+  if (options.suppressExceptions) {
+    try {
+      return JSON.stringify(obj, toJsonReplacer, pretty ? '  ' : null);
+    } catch (e) {
+      // in case JSON.stringify throws, suppress error and return undefined
+      return undefined;
+    }
+  }
+
   return JSON.stringify(obj, toJsonReplacer, pretty ? '  ' : null);
 }
 

--- a/src/minErr.js
+++ b/src/minErr.js
@@ -59,7 +59,7 @@ function minErr(module, ErrorConstructor) {
         } else if (typeof arg === 'undefined') {
           return 'undefined';
         } else if (typeof arg !== 'string') {
-          return toJson(arg);
+          return toJson(arg, false, {suppressExceptions: true});
         }
         return arg;
       }

--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -366,7 +366,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
               });
               throw ngRepeatMinErr('dupes',
                   "Duplicates in a repeater are not allowed. Use 'track by' expression to specify unique keys. Repeater: {0}, Duplicate key: {1}, Duplicate value: {2}",
-                  expression, trackById, toJson(value));
+                  expression, trackById, toJson(value, false, {suppressExceptions: true}));
             } else {
               // new never before seen block
               nextBlockOrder[index] = {id: trackById, scope: undefined, clone: undefined};

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -776,7 +776,8 @@ function $RootScopeProvider() {
                         logMsg = (isFunction(watch.exp))
                             ? 'fn: ' + (watch.exp.name || watch.exp.toString())
                             : watch.exp;
-                        logMsg += '; newVal: ' + toJson(value) + '; oldVal: ' + toJson(last);
+                        logMsg += '; newVal: ' + toJson(value, false, {suppressExceptions: true}) +
+                            '; oldVal: ' + toJson(last, false, {suppressExceptions: true});
                         watchLog[logIdx].push(logMsg);
                       }
                     } else if (watch === lastDirtyWatch) {
@@ -810,7 +811,7 @@ function $RootScopeProvider() {
             throw $rootScopeMinErr('infdig',
                 '{0} $digest() iterations reached. Aborting!\n' +
                 'Watchers fired in the last 5 iterations: {1}',
-                TTL, toJson(watchLog));
+                TTL, toJson(watchLog, false, {suppressExceptions: true}));
           }
 
         } while (dirty || asyncQueue.length);

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1219,6 +1219,33 @@ describe('angular', function() {
     it('should serialize undefined as undefined', function() {
       expect(toJson(undefined)).toEqual(undefined);
     });
+
+    it('should allow JSON.stringify to throw exceptions by default', function() {
+      // create objects with references to each other (circular reference)
+      // passing such object to JSON.stringify throws a TypeError
+      var a = {}, b = {test: a};
+      a.test = b;
+
+      // prepare toJson function with correct arguments for this test
+      var toJsonSuppressedTest = toJson.bind(undefined, a);
+
+      // it should throw a TypeError
+      expect(toJsonSuppressedTest).toThrow();
+    });
+
+    it('should not throw exceptions if suppressExceptions option is passed', function() {
+      // create objects with references to each other (circular reference)
+      // passing such object to JSON.stringify throws a TypeError
+      var a = {}, b = {test: a};
+      a.test = b;
+
+      // prepare toJson function with correct arguments for this test
+      var toJsonSuppressedTest = toJson.bind(undefined, a, false, {suppressExceptions: true});
+
+      // it shouldn't throw a TypeError and it should return undefined
+      expect(toJsonSuppressedTest).not.toThrow();
+      expect(toJsonSuppressedTest()).toBeUndefined();
+    });
   });
 
   describe('isElement', function() {


### PR DESCRIPTION
This is a pull request prepared for issue #9838 

I have implemented solution discussed in #9838 and applied it in places that I was sure of.
There are several places left where toJson is used but I wasn't certain if exceptions should be suppressed there:

https://github.com/angular/angular.js/blob/master/src/ng/http.js#L135
https://github.com/angular/angular.js/blob/master/src/ng/http.js#L1098
https://github.com/angular/angular.js/blob/master/src/ng/interpolate.js#L257
https://github.com/angular/angular.js/blob/master/src/ng/filter/filters.js#L524
https://github.com/angular/angular.js/blob/master/src/ngCookies/cookies.js#L181
https://github.com/angular/angular.js/blob/master/src/ngMock/angular-mocks.js#L871
https://github.com/angular/angular.js/blob/master/src/ngMock/angular-mocks.js#L885
https://github.com/angular/angular.js/blob/master/src/ngMock/angular-mocks.js#L1158
https://github.com/angular/angular.js/blob/master/src/ngMock/angular-mocks.js#L1637
https://github.com/angular/angular.js/blob/master/src/ngScenario/Scenario.js#L80
https://github.com/angular/angular.js/blob/master/src/ngScenario/Scenario.js#L89
https://github.com/angular/angular.js/blob/master/src/ngScenario/Scenario.js#L298
https://github.com/angular/angular.js/blob/master/src/ngScenario/output/Json.js#L8

ps. yeah I know I did copy&paste on one line there and it looks awful but I didn't know if I could create new function in global angular scope like `toJsonReplacer` just to throw that line there.
