### PR TITLE
fix($animate): applyStyles from options on leave

### DIFF
--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -210,6 +210,7 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @return {Promise} the animation callback promise
        */
       leave: function(element, options) {
+        applyStyles(element, options);
         element.remove();
         return asyncPromise();
       },

--- a/test/ng/animateSpec.js
+++ b/test/ng/animateSpec.js
@@ -148,10 +148,11 @@ describe("$animate", function() {
       $rootScope.$digest();
       assertColor('blue');
 
-      $animate.leave(element, 'off', {
-        to: { color: 'blue' }
+      $animate.leave(element, {
+        to: { color: 'yellow' }
       });
-      assertColor('blue'); //nothing should happen the element is gone anyway
+      $rootScope.$digest();
+      assertColor('yellow');
 
       function assertColor(color) {
         expect(element[0].style.color).toBe(color);


### PR DESCRIPTION
missing <code>[options]</code> API that should either be removed from the docs or added in the code

@param {object=} options an optional collection of options that will be applied to the element.

the tests weren't working for this feature 

``` javascript
      $animate.leave(element, 'off', {
        to: { color: 'blue' }
      });
      assertColor('blue'); //nothing should happen the element is gone anyway
```

you can view the docs here https://ng-click.com/$animate#leave
