### PR TITLE
docs(tutorial/5 - XHRs

### DIFF
--- a/docs/content/tutorial/step_05.ngdoc
+++ b/docs/content/tutorial/step_05.ngdoc
@@ -209,8 +209,7 @@ isolated from the work done in other tests.
 * We called the injected `$controller` function passing the name of the `PhoneListCtrl` controller
 and the created scope as parameters.
 
-Because our code now uses the `$http` service to fetch the phone list data in our controller, before
-we create the `PhoneListCtrl` child scope, we need to tell the testing harness to expect an
+Because our code now uses the `$http` service to fetch the phone list data in our controller, we also need to tell the testing harness to expect an
 incoming request from the controller. To do this we:
 
 * Request `$httpBackend` service to be injected into our `beforeEach` function. This is a mock


### PR DESCRIPTION
The documentation describes the code to be written in a different order than the code is actually written. I'm not an angular expert, but I found that putting the scope creation and controller creation BEFORE the httpBackend setup code doesn't cause problems (at least the tests still pass).  I also reordered the parameters passed into inject(function( to match the order that we use them in the function).  Here's the resulting code that is consistent with my suggested doc modification: 

```
beforeEach(inject(function($rootScope, $controller, _$httpBackend_) {
  scope = $rootScope.$new();
  ctrl = $controller('PhoneListCtrl', {$scope: scope});

  $httpBackend = _$httpBackend_;
  $httpBackend.expectGET('phones/phones.json').
      respond([{name: 'Nexus S'}, {name: 'Motorola DROID'}]);
}));
```
