### PR TITLE
docs(tutorial/7 - Routing

### DIFF
--- a/docs/content/tutorial/step_07.ngdoc
+++ b/docs/content/tutorial/step_07.ngdoc
@@ -37,13 +37,13 @@ We are using [Bower][bower] to install client side dependencies.  This step upda
     "angular-mocks": "~1.3.0",
     "jquery": "2.1.1",
     "bootstrap": "~3.1.1",
-    "angular-route": "~1.3.0"
+    "angular-route": "~1.2.0"
   }
 }
 ```
 
-The new dependency `"angular-route": "~1.3.0"` tells bower to install a version of the
-angular-route component that is compatible with version 1.3.x.  We must tell bower to download
+The new dependency `"angular-route": "~1.2.0"` tells bower to install a version of the
+angular-route component that is compatible with version 1.2.x.  We must tell bower to download
 and install this dependency.
 
 If you have bower installed globally then you can run `bower install` but for this project we have


### PR DESCRIPTION
 changed angular-route version to match the version that appears to be used by code checked into git. Perhaps the git code should instead be updated? Also, curiously the git diffs show the newer version number (even though the code I get from git shows the older version....)
