### PR TITLE
fix(minErr/ngRepeat/$rootScope): serialization of error objects

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -5,6 +5,7 @@ var angularFiles = {
     'src/minErr.js',
     'src/Angular.js',
     'src/loader.js',
+    'src/stringify.js',
     'src/AngularPublic.js',
     'src/jqLite.js',
     'src/apis.js',
@@ -73,6 +74,7 @@ var angularFiles = {
   ],
 
   'angularLoader': [
+    'stringify.js',
     'src/minErr.js',
     'src/loader.js'
   ],

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -19,6 +19,7 @@
     "angularModule": false,
     "nodeName_": false,
     "uid": false,
+    "toDebugString": false,
 
     "REGEX_STRING_REGEXP" : false,
     "lowercase": false,

--- a/src/minErr.js
+++ b/src/minErr.js
@@ -37,31 +37,14 @@ function minErr(module, ErrorConstructor) {
       prefix = '[' + (module ? module + ':' : '') + code + '] ',
       template = arguments[1],
       templateArgs = arguments,
-      stringify = function(obj) {
-        if (typeof obj === 'function') {
-          return obj.toString().replace(/ \{[\s\S]*$/, '');
-        } else if (typeof obj === 'undefined') {
-          return 'undefined';
-        } else if (typeof obj !== 'string') {
-          return JSON.stringify(obj);
-        }
-        return obj;
-      },
+
       message, i;
 
     message = prefix + template.replace(/\{\d+\}/g, function(match) {
       var index = +match.slice(1, -1), arg;
 
       if (index + 2 < templateArgs.length) {
-        arg = templateArgs[index + 2];
-        if (typeof arg === 'function') {
-          return arg.toString().replace(/ ?\{[\s\S]*$/, '');
-        } else if (typeof arg === 'undefined') {
-          return 'undefined';
-        } else if (typeof arg !== 'string') {
-          return toJson(arg);
-        }
-        return arg;
+        return toDebugString(templateArgs[index + 2]);
       }
       return match;
     });
@@ -70,7 +53,7 @@ function minErr(module, ErrorConstructor) {
       (module ? module + '/' : '') + code;
     for (i = 2; i < arguments.length; i++) {
       message = message + (i == 2 ? '?' : '&') + 'p' + (i - 2) + '=' +
-        encodeURIComponent(stringify(arguments[i]));
+        encodeURIComponent(toDebugString(arguments[i]));
     }
     return new ErrorConstructor(message);
   };

--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -366,7 +366,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
               });
               throw ngRepeatMinErr('dupes',
                   "Duplicates in a repeater are not allowed. Use 'track by' expression to specify unique keys. Repeater: {0}, Duplicate key: {1}, Duplicate value: {2}",
-                  expression, trackById, toJson(value));
+                  expression, trackById, value);
             } else {
               // new never before seen block
               nextBlockOrder[index] = {id: trackById, scope: undefined, clone: undefined};

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -773,11 +773,11 @@ function $RootScopeProvider() {
                       if (ttl < 5) {
                         logIdx = 4 - ttl;
                         if (!watchLog[logIdx]) watchLog[logIdx] = [];
-                        logMsg = (isFunction(watch.exp))
-                            ? 'fn: ' + (watch.exp.name || watch.exp.toString())
-                            : watch.exp;
-                        logMsg += '; newVal: ' + toJson(value) + '; oldVal: ' + toJson(last);
-                        watchLog[logIdx].push(logMsg);
+                        watchLog[logIdx].push({
+                          msg: isFunction(watch.exp) ? 'fn: ' + (watch.exp.name || watch.exp.toString()) : watch.exp,
+                          newVal: value,
+                          oldVal: last
+                        });
                       }
                     } else if (watch === lastDirtyWatch) {
                       // If the most recently dirty watcher is now clean, short circuit since the remaining watchers
@@ -810,7 +810,7 @@ function $RootScopeProvider() {
             throw $rootScopeMinErr('infdig',
                 '{0} $digest() iterations reached. Aborting!\n' +
                 'Watchers fired in the last 5 iterations: {1}',
-                TTL, toJson(watchLog));
+                TTL, watchLog);
           }
 
         } while (dirty || asyncQueue.length);

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/* global: toDebugString: true */
+
+function serializeObject(obj) {
+  var seen = [];
+
+  return JSON.stringify(obj, function(key, val) {
+    val = toJsonReplacer(key, val);
+    if (isObject(val)) {
+
+      if (seen.indexOf(val) >= 0) return '<<already seen>>';
+
+      seen.push(val);
+    }
+    return val;
+  });
+}
+
+function toDebugString(obj) {
+  if (typeof obj === 'function') {
+    return obj.toString().replace(/ \{[\s\S]*$/, '');
+  } else if (typeof obj === 'undefined') {
+    return 'undefined';
+  } else if (typeof obj !== 'string') {
+    return serializeObject(obj);
+  }
+  return obj;
+}

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -18,6 +18,7 @@
     "angularModule": false,
     "nodeName_": false,
     "uid": false,
+    "toDebugString": false,
 
     "lowercase": false,
     "uppercase": false,

--- a/test/minErrSpec.js
+++ b/test/minErrSpec.js
@@ -60,6 +60,13 @@ describe('minErr', function() {
         toMatch(/^\[test:26\] false: false; zero: 0; null: null; undefined: undefined; emptyStr: /);
   });
 
+  it('should handle arguments that are objects with cyclic references', function() {
+    var a = { b: { } };
+    a.b.a = a;
+
+    var myError = testError('26', 'a is {0}', a);
+    expect(myError.message).toMatch(/a is {"b":{"a":"<<already seen>>"}}/);
+  });
 
   it('should preserve interpolation markers when fewer arguments than needed are provided', function() {
     // this way we can easily see if we are passing fewer args than needed

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -298,11 +298,11 @@ describe('Scope', function() {
           $rootScope.$digest();
         }).toThrowMinErr('$rootScope', 'infdig', '100 $digest() iterations reached. Aborting!\n' +
             'Watchers fired in the last 5 iterations: ' +
-            '[["a; newVal: 96; oldVal: 95","b; newVal: 97; oldVal: 96"],' +
-            '["a; newVal: 97; oldVal: 96","b; newVal: 98; oldVal: 97"],' +
-            '["a; newVal: 98; oldVal: 97","b; newVal: 99; oldVal: 98"],' +
-            '["a; newVal: 99; oldVal: 98","b; newVal: 100; oldVal: 99"],' +
-            '["a; newVal: 100; oldVal: 99","b; newVal: 101; oldVal: 100"]]');
+            '[[{"msg":"a","newVal":96,"oldVal":95},{"msg":"b","newVal":97,"oldVal":96}],' +
+            '[{"msg":"a","newVal":97,"oldVal":96},{"msg":"b","newVal":98,"oldVal":97}],' +
+            '[{"msg":"a","newVal":98,"oldVal":97},{"msg":"b","newVal":99,"oldVal":98}],' +
+            '[{"msg":"a","newVal":99,"oldVal":98},{"msg":"b","newVal":100,"oldVal":99}],' +
+            '[{"msg":"a","newVal":100,"oldVal":99},{"msg":"b","newVal":101,"oldVal":100}]]');
 
         expect($rootScope.$$phase).toBeNull();
       });

--- a/test/stringifySpec.js
+++ b/test/stringifySpec.js
@@ -1,0 +1,15 @@
+'use strict';
+
+describe('toDebugString', function() {
+  it('should convert its argument to a string', function() {
+    expect(toDebugString('string')).toEqual('string');
+    expect(toDebugString(123)).toEqual('123');
+    expect(toDebugString({a:{b:'c'}})).toEqual('{"a":{"b":"c"}}');
+    expect(toDebugString(function fn() { var a = 10; })).toEqual('function fn()');
+    expect(toDebugString()).toEqual('undefined');
+    var a = { };
+    a.a = a;
+    expect(toDebugString(a)).toEqual('{"a":"<<already seen>>"}');
+    expect(toDebugString([a,a])).toEqual('[{"a":"<<already seen>>"},"<<already seen>>"]');
+  });
+});


### PR DESCRIPTION
This is my preferred solution to #9838.
`toJson` should throw errors on cyclic object references. JSON is not really designed to handle this out of the box and we should not be hiding the error from the developer.
Adding a hidden parameter is just making this method convoluted and slowing it down.

Instead we should consider that for error messages, we do not high fidelity serialization of objects but instead a readable string that is useful for debugging. Returning `undefined` for broken JSON stringification is not helpful.

This fix provides a new function `stringify` which is available within the `angular.js` file and also within the `angular-loader.js` file. This function is then used inside `minErr` and `$rootScope` to provide nice string forms of objects.

Places that were using `toJson` to create error messages (i.e. `ngRepeat` and `$rootScope`) no either pass the object directly to `minErr` or they use the `stringify` method directly.

This solution ensures that we don't confuse the point of `toJson` - it is not a generic stringification tool, it is designed for converting to and from valid JSON. The new method `stringify` also provides us with a single future improvement point if we wished to make the stringification of objects to strings more comprehensive.
