### PR TITLE
Add jscs jsdoc

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -1,4 +1,7 @@
 {
+  "additionalRules": [
+    "node_modules/jscs-jsdoc/lib/rules/*.js"
+  ],
   "excludeFiles": ["src/ngLocale/**"],
   "disallowKeywords": ["with"],
   "disallowMixedSpacesAndTabs": true,
@@ -21,6 +24,9 @@
   "disallowSpacesInsideParentheses": true,
   "disallowTrailingComma": true,
   "disallowTrailingWhitespace": true,
+  "jsDoc": {
+    "checkParamNames": true
+  },
   "requireCommaBeforeLineBreak": true,
   "requireLineFeedAtFileEnd": true,
   "requireSpaceAfterBinaryOperators": ["?", ":", "+", "-", "/", "*", "%", "==", "===", "!=", "!==", ">", ">=", "<", "<=", "&&", "||"],

--- a/.jscs.json
+++ b/.jscs.json
@@ -25,7 +25,8 @@
   "disallowTrailingComma": true,
   "disallowTrailingWhitespace": true,
   "jsDoc": {
-    "checkParamNames": true
+    "checkParamNames": true,
+    "requireParamTypes": true
   },
   "requireCommaBeforeLineBreak": true,
   "requireLineFeedAtFileEnd": true,

--- a/.jscs.json.todo
+++ b/.jscs.json.todo
@@ -9,7 +9,6 @@
   "disallowMultipleLineBreaks": true,
   "disallowKeywordsOnNewLine": ["else"],
   "validateJSDoc": {
-    "checkParamNames": true,
     "requireParamTypes": true
   }
 }

--- a/.jscs.json.todo
+++ b/.jscs.json.todo
@@ -7,8 +7,5 @@
   "requireCurlyBraces": ["if", "else", "for", "while", "do", "try", "catch"],
   "disallowImplicitTypeConversion": ["string"],
   "disallowMultipleLineBreaks": true,
-  "disallowKeywordsOnNewLine": ["else"],
-  "validateJSDoc": {
-    "requireParamTypes": true
-  }
+  "disallowKeywordsOnNewLine": ["else"]
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2346,107 +2346,13 @@
       "resolved": "git://github.com/vojtajina/grunt-jasmine-node.git#ced17cbe52c1412b2ada53160432a5b681f37cd7"
     },
     "grunt-jscs": {
-      "version": "0.7.1",
+      "version": "1.0.0",
       "dependencies": {
         "hooker": {
           "version": "0.2.3"
         },
-        "jscs": {
-          "version": "1.6.2",
-          "dependencies": {
-            "colors": {
-              "version": "0.6.2"
-            },
-            "commander": {
-              "version": "2.3.0"
-            },
-            "esprima": {
-              "version": "1.2.2"
-            },
-            "exit": {
-              "version": "0.1.2"
-            },
-            "glob": {
-              "version": "4.0.6",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "3.0.4"
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                },
-                "once": {
-                  "version": "1.3.1",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "minimatch": {
-              "version": "1.0.0",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0"
-                },
-                "sigmund": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "strip-json-comments": {
-              "version": "1.0.1"
-            },
-            "vow-fs": {
-              "version": "0.3.2",
-              "dependencies": {
-                "node-uuid": {
-                  "version": "1.4.0"
-                },
-                "vow": {
-                  "version": "0.4.4"
-                },
-                "vow-queue": {
-                  "version": "0.3.1"
-                },
-                "glob": {
-                  "version": "3.2.8",
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "0.2.14",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "xmlbuilder": {
-              "version": "2.4.4",
-              "dependencies": {
-                "lodash-node": {
-                  "version": "2.4.1"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "1.1.0"
-            }
-          }
-        },
         "vow": {
-          "version": "0.4.5"
+          "version": "0.4.7"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3951,6 +3951,119 @@
         }
       }
     },
+    "jscs": {
+      "version": "1.8.1",
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3"
+        },
+        "commander": {
+          "version": "2.5.0"
+        },
+        "esprima": {
+          "version": "1.2.2"
+        },
+        "esprima-harmony-jscs": {
+          "version": "1.1.0-dev-harmony"
+        },
+        "exit": {
+          "version": "0.1.2"
+        },
+        "glob": {
+          "version": "4.0.6",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.4"
+            },
+            "inherits": {
+              "version": "2.0.1"
+            },
+            "once": {
+              "version": "1.3.1",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1"
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "1.0.0",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0"
+            },
+            "sigmund": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.2"
+        },
+        "vow": {
+          "version": "0.4.7"
+        },
+        "vow-fs": {
+          "version": "0.3.3",
+          "dependencies": {
+            "node-uuid": {
+              "version": "1.4.0"
+            },
+            "vow": {
+              "version": "0.4.4"
+            },
+            "vow-queue": {
+              "version": "0.4.1"
+            },
+            "glob": {
+              "version": "3.2.8",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.2.14",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1"
+                }
+              }
+            }
+          }
+        },
+        "xmlbuilder": {
+          "version": "2.4.5",
+          "dependencies": {
+            "lodash-node": {
+              "version": "2.4.1"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "1.2.0"
+        }
+      }
+    },
+    "jscs-jsdoc": {
+      "version": "0.1.0",
+      "dependencies": {
+        "comment-parser": {
+          "version": "0.2.2",
+          "from": "git://github.com/zxqfox/comment-parser#jscs-jsdoc",
+          "resolved": "git://github.com/zxqfox/comment-parser#d99a658dd9e28501ecc823b1f8ded730d1e6539d"
+        },
+        "jsdoctypeparser": {
+          "version": "1.1.3"
+        }
+      }
+    },
     "jshint-stylish": {
       "version": "1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-ddescribe-iit": "~0.0.1",
     "grunt-jasmine-node": "git://github.com/vojtajina/grunt-jasmine-node.git#fix-grunt-exit-code",
-    "grunt-jscs": "~0.7.1",
+    "grunt-jscs": "~1.0.0",
     "grunt-merge-conflict": "~0.0.1",
     "grunt-parallel": "~0.3.1",
     "grunt-shell": "~1.1.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bower": "~1.3.9",
     "browserstacktunnel-wrapper": "~1.3.1",
     "canonical-path": "0.0.2",
+    "cheerio": "^0.17.0",
     "dgeni": "^0.4.0",
     "dgeni-packages": "^0.10.0",
     "event-stream": "~3.1.0",
@@ -37,6 +38,8 @@
     "gulp-util": "^3.0.1",
     "jasmine-node": "~1.14.5",
     "jasmine-reporters": "~1.0.1",
+    "jscs": "^1.8.1",
+    "jscs-jsdoc": "^0.1.0",
     "jshint-stylish": "~1.0.0",
     "karma": "^0.12.0",
     "karma-browserstack-launcher": "0.1.1",
@@ -60,8 +63,7 @@
     "semver": "~4.0.3",
     "shelljs": "~0.3.0",
     "sorted-object": "^1.0.0",
-    "stringmap": "^0.2.2",
-    "cheerio": "^0.17.0"
+    "stringmap": "^0.2.2"
   },
   "licenses": [
     {

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -310,8 +310,8 @@ function nextUid() {
 
 /**
  * Set or clear the hashkey for an object.
- * @param obj object
- * @param h the hashkey (!truthy to delete the hashkey)
+ * @param {Object} obj
+ * @param {String} h the hashkey (!truthy to delete the hashkey)
  */
 function setHashKey(obj, h) {
   if (h) {
@@ -613,7 +613,7 @@ function isElement(node) {
 }
 
 /**
- * @param str 'key1,key2,...'
+ * @param {String} str 'key1,key2,...'
  * @returns {object} in the form of {key1:true, key2:true, ...}
  */
 function makeMap(str) {

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -603,7 +603,7 @@ var escapeForRegexp = function(s) {
  * @description
  * Determines if a reference is a DOM element (or wrapped jQuery element).
  *
- * @param {*} value Reference to check.
+ * @param {*} node Reference to check.
  * @returns {boolean} True if `value` is a DOM element (or wrapped jQuery element).
  */
 function isElement(node) {
@@ -1021,7 +1021,7 @@ function startingTag(element) {
  * Tries to decode the URI component without throwing an exception.
  *
  * @private
- * @param str value potential URI component to check.
+ * @param {string} value potential URI component to check.
  * @returns {boolean} True if `value` can be decoded
  * with the decodeURIComponent function.
  */
@@ -1421,7 +1421,7 @@ function reloadWithDebugInfo() {
  * @description
  * Get the testability service for the instance of Angular on the given
  * element.
- * @param {DOMElement} element DOM element which is the root of angular application.
+ * @param {DOMElement} rootElement DOM element which is the root of angular application.
  */
 function getTestability(rootElement) {
   return angular.element(rootElement).injector().get('$$testability');
@@ -1548,7 +1548,7 @@ function getter(obj, path, bindFnToScope) {
 
 /**
  * Return the DOM siblings between the first and last node in the given array.
- * @param {Array} array like object
+ * @param {Array} nodes array like object
  * @returns {jqLite} jqLite collection containing the nodes
  */
 function getBlockNodes(nodes) {

--- a/src/apis.js
+++ b/src/apis.js
@@ -9,7 +9,7 @@
  *  object is either result of calling $$hashKey function on the object or uniquely generated id,
  *         that is also assigned to the $$hashKey property of the object.
  *
- * @param obj
+ * @param {String|Number|Object|Function} obj
  * @returns {string} hash string such that the same input will have the same hash string.
  *         The resulting string key is in 'type:hashKey' format.
  */
@@ -48,15 +48,15 @@ function HashMap(array, isolatedUid) {
 HashMap.prototype = {
   /**
    * Store key value pair
-   * @param key key to store can be any type
-   * @param value value to store can be any type
+   * @param {*} key to store can be any type
+   * @param {*} value to store can be any type
    */
   put: function(key, value) {
     this[hashKey(key, this.nextUid)] = value;
   },
 
   /**
-   * @param key
+   * @param {*} key
    * @returns {Object} the value for the key
    */
   get: function(key) {
@@ -65,7 +65,7 @@ HashMap.prototype = {
 
   /**
    * Remove the key/value pair
-   * @param key
+   * @param {*} key
    */
   remove: function(key) {
     var value = this[key = hashKey(key, this.nextUid)];

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -130,7 +130,7 @@ var jqLiteMinErr = minErr('jqLite');
 /**
  * Converts snake_case to camelCase.
  * Also there is special case for Moz prefix starting with upper case letter.
- * @param name Name to normalize
+ * @param {String} name Name to normalize
  */
 function camelCase(name) {
   return name.

--- a/src/loader.js
+++ b/src/loader.js
@@ -286,8 +286,8 @@ function setupModuleLoader(window) {
            * Use this method to register work which should be performed when the injector is done
            * loading all modules.
            */
-          run: function(block) {
-            runBlocks.push(block);
+          run: function(initializationFn) {
+            runBlocks.push(initializationFn);
             return this;
           }
         };

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -270,7 +270,7 @@ function Browser(window, document, $log, $sniffer) {
    * NOTE: this api is intended for use only by the $location service. Please use the
    * {@link ng.$location $location service} to monitor url changes in angular apps.
    *
-   * @param {function(string)} listener Listener function to be called when url changes.
+   * @param {function(string)} callback Listener function to be called when url changes.
    * @return {function(string)} Returns the registered listener fn - handy if the fn is anonymous.
    */
   self.onUrlChange = function(callback) {

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1374,10 +1374,10 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
      * Looks for directives on the given node and adds them to the directive collection which is
      * sorted.
      *
-     * @param node Node to search.
-     * @param directives An array to which the directives are added to. This array is sorted before
+     * @param {Node} node Node to search.
+     * @param {Array} directives An array to which the directives are added to. This array is sorted before
      *        the function returns.
-     * @param attrs The shared attrs object which is used to populate the normalized attributes.
+     * @param {Object} attrs The shared attrs object which is used to populate the normalized attributes.
      * @param {number=} maxPriority Max directive priority.
      */
     function collectDirectives(node, directives, attrs, maxPriority, ignoreDirective) {
@@ -1469,9 +1469,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     /**
      * Given a node with an directive-start it collects all of the siblings until it finds
      * directive-end.
-     * @param node
-     * @param attrStart
-     * @param attrEnd
+     * @param {Node} node
+     * @param {String} attrStart
+     * @param {String} attrEnd
      * @returns {*}
      */
     function groupScan(node, attrStart, attrEnd) {
@@ -1501,9 +1501,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     /**
      * Wrapper for linking function which converts normal linking function into a grouped
      * linking function.
-     * @param linkFn
-     * @param attrStart
-     * @param attrEnd
+     * @param {Function} linkFn
+     * @param {String} attrStart
+     * @param {String} attrEnd
      * @returns {Function}
      */
     function groupElementsLinkFnWrapper(linkFn, attrStart, attrEnd) {
@@ -2493,7 +2493,7 @@ var PREFIX_REGEXP = /^((?:x|data)[\:\-_])/i;
  *   data-my:directive
  *
  * Also there is special case for Moz prefix starting with upper case letter.
- * @param name Name to normalize
+ * @param {String} name Name to normalize
  */
 function directiveNormalize(name) {
   return camelCase(name.replace(PREFIX_REGEXP, ''));

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2029,6 +2029,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
      * looks up the directive and decorates it with exception handling and proper parameters. We
      * call this the boundDirective.
      *
+     * @param {array} tDirectives
      * @param {string} name name of the directive to look up.
      * @param {string} location The directive must be found in specific format.
      *   String containing any of theses characters:

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -887,8 +887,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
   this.$get = [
             '$injector', '$interpolate', '$exceptionHandler', '$templateRequest', '$parse',
             '$controller', '$rootScope', '$document', '$sce', '$animate', '$$sanitizeUri',
-    function($injector,   $interpolate,   $exceptionHandler,   $templateRequest,   $parse,
-             $controller,   $rootScope,   $document,   $sce,   $animate,   $$sanitizeUri) {
+    function($injector, $interpolate, $exceptionHandler, $templateRequest, $parse,
+             $controller, $rootScope, $document, $sce, $animate, $$sanitizeUri) {
 
     var Attributes = function(element, attributesToCopy) {
       if (attributesToCopy) {

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -179,7 +179,7 @@
  * @param {String} src URL of content to load.
  */
 var ngIncludeDirective = ['$templateRequest', '$anchorScroll', '$animate', '$sce',
-                  function($templateRequest,   $anchorScroll,   $animate,   $sce) {
+                  function($templateRequest, $anchorScroll, $animate, $sce) {
   return {
     restrict: 'ECA',
     priority: 400,

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -165,7 +165,7 @@ var ngOptionsDirective = valueFn({
 });
 
 // jshint maxlen: false
-var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
+var selectDirective = ['$compile', '$parse', function($compile, $parse) {
                          //000011111111110000000000022222222220000000000000000000003333333333000000000000004444444444444440000000005555555555555550000000666666666666666000000000000000777777777700000000000000000008888888888
   var NG_OPTIONS_REGEXP = /^\s*([\s\S]+?)(?:\s+as\s+([\s\S]+?))?(?:\s+group\s+by\s+([\s\S]+?))?\s+for\s+(?:([\$\w][\$\w]*)|(?:\(\s*([\$\w][\$\w]*)\s*,\s*([\$\w][\$\w]*)\s*\)))\s+in\s+([\s\S]+?)(?:\s+track\s+by\s+([\s\S]+?))?$/,
       nullModelCtrl = {$setViewValue: noop};

--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -3,7 +3,7 @@
 
 function $IntervalProvider() {
   this.$get = ['$rootScope', '$window', '$q', '$$q',
-       function($rootScope,   $window,   $q,   $$q) {
+       function($rootScope, $window, $q, $$q) {
     var intervals = {};
 
 

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -923,6 +923,11 @@ function $RootScopeProvider() {
        *    - `string`: execute using the rules as defined in  {@link guide/expression expression}.
        *    - `function(scope)`: execute the function with the current `scope` parameter.
        *
+       * @param {(string|function())=} expr An angular expression to be executed.
+       *
+       *    - `string`: execute using the rules as defined in {@link guide/expression expression}.
+       *    - `function(scope)`: execute the function with current `scope` parameter.
+       *
        * @param {(object)=} locals Local variables object, useful for overriding values in scope.
        * @returns {*} The result of evaluating the expression.
        */
@@ -953,7 +958,7 @@ function $RootScopeProvider() {
        * will be scheduled. However, it is encouraged to always call code that changes the model
        * from within an `$apply` call. That includes code evaluated via `$evalAsync`.
        *
-       * @param {(string|function())=} expression An angular expression to be executed.
+       * @param {(string|function())=} expr An angular expression to be executed.
        *
        *    - `string`: execute using the rules as defined in {@link guide/expression expression}.
        *    - `function(scope)`: execute the function with the current `scope` parameter.
@@ -1015,7 +1020,7 @@ function $RootScopeProvider() {
        *    expression was executed using the {@link ng.$rootScope.Scope#$digest $digest()} method.
        *
        *
-       * @param {(string|function())=} exp An angular expression to be executed.
+       * @param {(string|function())=} expr An angular expression to be executed.
        *
        *    - `string`: execute using the rules as defined in {@link guide/expression expression}.
        *    - `function(scope)`: execute the function with current `scope` parameter.
@@ -1051,7 +1056,7 @@ function $RootScopeProvider() {
        * This can be used to queue up multiple expressions which need to be evaluated in the same
        * digest.
        *
-       * @param {(string|function())=} exp An angular expression to be executed.
+       * @param {(string|function())=} expr An angular expression to be executed.
        *
        *    - `string`: execute using the rules as defined in {@link guide/expression expression}.
        *    - `function(scope)`: execute the function with current `scope` parameter.

--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -149,9 +149,9 @@ function $SceDelegateProvider() {
    * @description
    * Sets/Gets the whitelist of trusted resource URLs.
    */
-  this.resourceUrlWhitelist = function(value) {
+  this.resourceUrlWhitelist = function(whitelist) {
     if (arguments.length) {
-      resourceUrlWhitelist = adjustMatchers(value);
+      resourceUrlWhitelist = adjustMatchers(whitelist);
     }
     return resourceUrlWhitelist;
   };
@@ -272,7 +272,7 @@ function $SceDelegateProvider() {
      *
      * @param {string} type The kind of context in which this value is safe for use.  e.g. url,
      *   resourceUrl, html, js and css.
-     * @param {*} value The value that that should be considered trusted/safe.
+     * @param {*} trustedValue The value that that should be considered trusted/safe.
      * @returns {*} A value that can be used to stand in for the provided `value` in places
      * where Angular expects a $sce.trustAs() return value.
      */
@@ -308,7 +308,7 @@ function $SceDelegateProvider() {
      * If the passed parameter is not a value that had been returned by {@link
      * ng.$sceDelegate#trustAs `$sceDelegate.trustAs`}, returns it as-is.
      *
-     * @param {*} value The result of a prior {@link ng.$sceDelegate#trustAs `$sceDelegate.trustAs`}
+     * @param {*} maybeTrusted The result of a prior {@link ng.$sceDelegate#trustAs `$sceDelegate.trustAs`}
      *      call or anything else.
      * @returns {*} The `value` that was originally provided to {@link ng.$sceDelegate#trustAs
      *     `$sceDelegate.trustAs`} if `value` is the result of such a call.  Otherwise, returns
@@ -765,7 +765,7 @@ function $SceProvider() {
      * *result*)}
      *
      * @param {string} type The kind of SCE context in which this result will be used.
-     * @param {string} expression String expression to compile.
+     * @param {string} expr String expression to compile.
      * @returns {function(context, locals)} a function which represents the compiled expression:
      *
      *    * `context` – `{object}` – an object against which any expressions embedded in the strings

--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -719,7 +719,7 @@ function $SceProvider() {
    */
 
   this.$get = ['$parse', '$sceDelegate', function(
-                $parse,   $sceDelegate) {
+                $parse, $sceDelegate) {
     // Prereq: Ensure that we're not running in IE<11 quirks mode.  In that mode, IE < 11 allow
     // the "expression(javascript expression)" syntax which is insecure.
     if (enabled && msie < 8) {

--- a/src/ng/testability.js
+++ b/src/ng/testability.js
@@ -3,7 +3,7 @@
 
 function $$TestabilityProvider() {
   this.$get = ['$rootScope', '$browser', '$location',
-       function($rootScope,   $browser,   $location) {
+       function($rootScope, $browser, $location) {
 
     /**
      * @name $testability

--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -3,7 +3,7 @@
 
 function $TimeoutProvider() {
   this.$get = ['$rootScope', '$browser', '$q', '$$q', '$exceptionHandler',
-       function($rootScope,   $browser,   $q,   $$q,   $exceptionHandler) {
+       function($rootScope, $browser, $q, $$q, $exceptionHandler) {
     var deferreds = {};
 
 

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -1218,7 +1218,7 @@ angular.module('ngAnimate', ['ng'])
          * @name $animate#cancel
          * @kind function
          *
-         * @param {Promise} animationPromise The animation promise that is returned when an animation is started.
+         * @param {Promise} promise The animation promise that is returned when an animation is started.
          *
          * @description
          * Cancels the provided animation.

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -476,7 +476,7 @@ angular.module('ngAnimate', ['ng'])
 
     $provide.decorator('$animate',
         ['$delegate', '$$q', '$injector', '$sniffer', '$rootElement', '$$asyncCallback', '$rootScope', '$document', '$templateRequest',
- function($delegate,   $$q,   $injector,   $sniffer,   $rootElement,   $$asyncCallback,   $rootScope,   $document,   $templateRequest) {
+ function($delegate, $$q, $injector, $sniffer, $rootElement, $$asyncCallback, $rootScope, $document, $templateRequest) {
 
       $rootElement.data(NG_ANIMATE_STATE, rootAnimateState);
 
@@ -1577,7 +1577,7 @@ angular.module('ngAnimate', ['ng'])
     }]);
 
     $animateProvider.register('', ['$window', '$sniffer', '$timeout', '$$animateReflow',
-                           function($window,   $sniffer,   $timeout,   $$animateReflow) {
+                           function($window, $sniffer, $timeout, $$animateReflow) {
       // Detect proper transitionend/animationend event names.
       var CSS_PREFIX = '', TRANSITION_PROP, TRANSITIONEND_EVENT, ANIMATION_PROP, ANIMATIONEND_EVENT;
 

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -89,7 +89,7 @@ function $AriaProvider() {
    * @ngdoc method
    * @name $ariaProvider#config
    *
-   * @param {object} config object to enable/disable specific ARIA attributes
+   * @param {object} newConfig object to enable/disable specific ARIA attributes
    *
    *  - **ariaHidden** – `{boolean}` – Enables/disables aria-hidden tags
    *  - **ariaChecked** – `{boolean}` – Enables/disables aria-checked tags

--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -1,4 +1,5 @@
 'use strict';
+// jscs:disable jsDoc
 
 /**
  * @ngdoc module

--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -229,7 +229,7 @@ angular.module('ngMessages', [])
     * </example>
     */
   .directive('ngMessages', ['$compile', '$animate', '$templateRequest',
-                   function($compile,    $animate,   $templateRequest) {
+                   function($compile, $animate, $templateRequest) {
     var ACTIVE_CLASS = 'ng-active';
     var INACTIVE_CLASS = 'ng-inactive';
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -455,7 +455,7 @@ angular.mock.$LogProvider = function() {
  */
 angular.mock.$IntervalProvider = function() {
   this.$get = ['$browser', '$rootScope', '$q', '$$q',
-       function($browser,   $rootScope,   $q,   $$q) {
+       function($browser, $rootScope, $q, $$q) {
     var repeatFns = [],
         nextRepeatId = 0,
         now = 0;
@@ -783,7 +783,7 @@ angular.mock.animate = angular.module('ngAnimateMock', ['ng'])
     });
 
     $provide.decorator('$animate', ['$delegate', '$$asyncCallback', '$timeout', '$browser',
-                            function($delegate,   $$asyncCallback,   $timeout,   $browser) {
+                            function($delegate, $$asyncCallback, $timeout, $browser) {
       var animate = {
         queue: [],
         cancel: $delegate.cancel,

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -103,7 +103,7 @@ angular.mock.$Browser = function() {
    * @description
    * Flushes all pending requests and executes the defer callbacks.
    *
-   * @param {number=} number of milliseconds to flush. See {@link #defer.now}
+   * @param {number=} delay number of milliseconds to flush. See {@link #defer.now}
    */
   self.defer.flush = function(delay) {
     if (angular.isDefined(delay)) {
@@ -1125,6 +1125,7 @@ angular.mock.$HttpBackendProvider = function() {
  *   - passing through (delegating request to real backend) is enabled
  *   - auto flushing is enabled
  *
+ * @param {Object=} $rootScope
  * @param {Object=} $delegate Real $httpBackend instance (allow passing through if specified)
  * @param {Object=} $browser Auto-flushing enabled if specified
  * @return {Object} Instance of $httpBackend mock

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -181,8 +181,8 @@ function $RouteProvider() {
   this.caseInsensitiveMatch = false;
 
    /**
-    * @param path {string} path
-    * @param opts {Object} options
+    * @param {string} path
+    * @param {Object} opts
     * @return {?Object}
     *
     * @description
@@ -505,8 +505,8 @@ function $RouteProvider() {
     /////////////////////////////////////////////////////
 
     /**
-     * @param on {string} current url
-     * @param route {Object} route regexp to match the url against
+     * @param {string} on current url
+     * @param {Object} route route regexp to match the url against
      * @return {?Object}
      *
      * @description

--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -413,7 +413,7 @@ var hiddenPre=document.createElement("pre");
 var spaceRe = /^(\s*)([\s\S]*?)(\s*)$/;
 /**
  * decodes all entities into regular string
- * @param value
+ * @param {string} value
  * @returns {string} A string with decoded entities.
  */
 function decodeEntities(value) {
@@ -441,7 +441,7 @@ function decodeEntities(value) {
  * Escapes all potentially dangerous characters, so that the
  * resulting string can be safely inserted into attribute or
  * element text.
- * @param value
+ * @param {string} value
  * @returns {string} escaped text
  */
 function encodeEntities(value) {

--- a/src/ngScenario/ObjectModel.js
+++ b/src/ngScenario/ObjectModel.js
@@ -155,7 +155,7 @@ angular.scenario.ObjectModel.prototype.emit = function(eventName) {
  * Computes the path of definition describe blocks that wrap around
  * this spec.
  *
- * @param spec Spec to compute the path for.
+ * @param {Object} spec to compute the path for.
  * @return {Array<Describe>} The describe block path
  */
 angular.scenario.ObjectModel.prototype.getDefinitionPath = function(spec) {

--- a/src/ngScenario/Runner.js
+++ b/src/ngScenario/Runner.js
@@ -127,7 +127,7 @@ angular.scenario.Runner.prototype.iit = function(name, body) {
  *
  * @see Describe.js
  *
- * @param {function()} Callback to execute
+ * @param {function()} body Callback to execute
  */
 angular.scenario.Runner.prototype.beforeEach = function(body) {
   this.currentDescribe.beforeEach(body);
@@ -139,7 +139,7 @@ angular.scenario.Runner.prototype.beforeEach = function(body) {
  *
  * @see Describe.js
  *
- * @param {function()} Callback to execute
+ * @param {function()} body Callback to execute
  */
 angular.scenario.Runner.prototype.afterEach = function(body) {
   this.currentDescribe.afterEach(body);

--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -260,6 +260,7 @@ function callerFile(offset) {
  * Finds all bindings with the substring match of name and returns an
  * array of their values.
  *
+ * @param {Object} windowJquery
  * @param {string} bindExp The name to match
  * @return {Array.<string>} String of binding values
  */

--- a/src/ngScenario/output/Html.js
+++ b/src/ngScenario/output/Html.js
@@ -123,7 +123,7 @@ angular.scenario.output('html', function(context, runner, model) {
   /**
    * Finds the context of a spec block defined by the passed definition.
    *
-   * @param {Object} The definition created by the Describe object.
+   * @param {Object} spec The definition created by the Describe object.
    */
   function findContext(spec) {
     var currentContext = context.find('#specs');
@@ -147,7 +147,7 @@ angular.scenario.output('html', function(context, runner, model) {
   /**
    * Updates the test counter for the status.
    *
-   * @param {string} the status.
+   * @param {string} status the status.
    */
   function updateTotals(status) {
     var legend = context.find('#status-legend .status-' + status);
@@ -159,9 +159,9 @@ angular.scenario.output('html', function(context, runner, model) {
   /**
    * Add an error to a step.
    *
-   * @param {Object} The JQuery wrapped context
-   * @param {function()} fn() that should return the file/line number of the error
-   * @param {Object} the error.
+   * @param {Object} context The JQuery wrapped context
+   * @param {function()} line fn() that should return the file/line number of the error
+   * @param {Object} error the error.
    */
   function addError(context, line, error) {
     context.find('.test-title').append('<pre></pre>');

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -931,7 +931,7 @@ describe('$location', function() {
       initService({html5Mode:true,hashPrefix: '!!',supportHistory: false});
       inject(
         initBrowser({url:'http://domain.com/base/index.html#!!/a/b',basePath: '/base/index.html'}),
-        function($rootScope, $location,  $browser) {
+        function($rootScope, $location, $browser) {
           expect($browser.url()).toBe('http://domain.com/base/index.html#!!/a/b');
           $location.path('/new');
           $location.search({a: true});


### PR DESCRIPTION
WIP

Don't know if we still want to add jsdoc checks but if we do... [jscs-jsdoc](https://github.com/jscs-dev/jscs-jsdoc).
Added `jscs-jsdoc`, updated `grunt-jscs` to `1.0.0` and `jscs` to `1.8.1`.

I know Ngdoc is a bit different so not sure if it will work consistently. However `@param` should be the same?

Not sure if I should remove the fsevents from `npm-shrinkwrap.json`.

I did
`npm install jscs-jsdoc`
`npm shrinkwrap --dev`
`./scripts/clean-shrinkwrap.js`

Adding jscs rules:
- `checkParamNames` to match the docs parameter names.  
  - Could also standardize parameter names like `expression` vs `expr` that are used a lot.
- `requireParamTypes` to make sure there is a {TYPE}.  
  - can also look at some of the different types used - https://gist.github.com/hzoo/1c9c8443b7e495f63a8d

No extra errors with jscs (fixed ~25 style errors for each rule).

---

There was a problem with `src/ngMessages/messages.js`  line 349
where jscs had a problem with
`* @param {string} ngMessage a string value corresponding to the message key.`
since the parameter is the parameter of the directive and not a function so just did
`// jscs:disable jsDoc` for now.

Not sure why it didn't have a problem with directive `ngMessages` but had one with `ngMessage` - maybe have to check some of these manually.

cc: @caitp  
