### PR TITLE
fix($http): fix response headers with an empty value

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -26,7 +26,7 @@ function defaultHttpResponseTransform(data, headers) {
  * @returns {Object} Parsed headers as key value object
  */
 function parseHeaders(headers) {
-  var parsed = {}, key, val, i;
+  var parsed = createMap(), key, val, i;
 
   if (!headers) return parsed;
 
@@ -64,7 +64,7 @@ function headersGetter(headers) {
 
     if (name) {
       name = lowercase(name);
-      return Object.prototype.hasOwnProperty.call(headersObj, name) ? headersObj[name] : null;
+      return hasOwnProperty.call(headersObj, name) ? headersObj[name] : null;
     }
 
     return headersObj;

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -64,7 +64,7 @@ function headersGetter(headers) {
 
     if (name) {
       name = lowercase(name);
-      return headersObj.hasOwnProperty(name) ? headersObj[name] : null;
+      return Object.prototype.hasOwnProperty.call(headersObj, name) ? headersObj[name] : null;
     }
 
     return headersObj;

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -63,7 +63,8 @@ function headersGetter(headers) {
     if (!headersObj) headersObj =  parseHeaders(headers);
 
     if (name) {
-      return headersObj[lowercase(name)] || null;
+      name = lowercase(name);
+      return headersObj.hasOwnProperty(name) ? headersObj[name] : null;
     }
 
     return headersObj;

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -818,11 +818,13 @@ describe('$http', function() {
 
       it('should handle empty response header', function() {
        $httpBackend.expect('GET', '/url', undefined)
-           .respond(200, '', { 'Custom-Empty-Response-Header': '' });
+           .respond(200, '', { 'Custom-Empty-Response-Header': '', 'Constructor': '' });
        $http.get('/url').success(callback);
        $httpBackend.flush();
        expect(callback).toHaveBeenCalledOnce();
        expect(callback.mostRecentCall.args[2]('custom-empty-response-Header')).toBe('');
+       expect(callback.mostRecentCall.args[2]('ToString')).toBe(null);
+       expect(callback.mostRecentCall.args[2]('Constructor')).toBe('');
      });
 
       it('should have delete()', function() {

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -816,6 +816,15 @@ describe('$http', function() {
       });
 
 
+      it('should handle empty response header', function() {
+       $httpBackend.expect('GET', '/url', undefined)
+           .respond(200, '', { 'Custom-Empty-Response-Header': '' });
+       $http.get('/url').success(callback);
+       $httpBackend.flush();
+       expect(callback).toHaveBeenCalledOnce();
+       expect(callback.mostRecentCall.args[2]('custom-empty-response-Header')).toBe('');
+     });
+
       it('should have delete()', function() {
         $httpBackend.expect('DELETE', '/url').respond('');
         $http['delete']('/url');


### PR DESCRIPTION
Empty response header values are legal (http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html).
Return an empty string instead of null, which is returned when the header does not exist.

Closes #7779
