### PR TITLE
fix(toDebugString): change replacement string

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -9,7 +9,7 @@ function serializeObject(obj) {
     val = toJsonReplacer(key, val);
     if (isObject(val)) {
 
-      if (seen.indexOf(val) >= 0) return '<<already seen>>';
+      if (seen.indexOf(val) >= 0) return '...';
 
       seen.push(val);
     }

--- a/test/minErrSpec.js
+++ b/test/minErrSpec.js
@@ -65,7 +65,7 @@ describe('minErr', function() {
     a.b.a = a;
 
     var myError = testError('26', 'a is {0}', a);
-    expect(myError.message).toMatch(/a is {"b":{"a":"<<already seen>>"}}/);
+    expect(myError.message).toMatch(/a is {"b":{"a":"..."}}/);
   });
 
   it('should preserve interpolation markers when fewer arguments than needed are provided', function() {

--- a/test/stringifySpec.js
+++ b/test/stringifySpec.js
@@ -9,7 +9,7 @@ describe('toDebugString', function() {
     expect(toDebugString()).toEqual('undefined');
     var a = { };
     a.a = a;
-    expect(toDebugString(a)).toEqual('{"a":"<<already seen>>"}');
-    expect(toDebugString([a,a])).toEqual('[{"a":"<<already seen>>"},"<<already seen>>"]');
+    expect(toDebugString(a)).toEqual('{"a":"..."}');
+    expect(toDebugString([a,a])).toEqual('[{"a":"..."},"..."]');
   });
 });


### PR DESCRIPTION
As discussed in #10085, the original replacement string can be treated as html when displayed by the browser so it replaces it with '...' string.

This PR has filtered that one fix from #10099 commit
