### PR TITLE
docs(ngBindHtml): fix awkward wording

### DIFF
--- a/src/ng/directive/ngBind.js
+++ b/src/ng/directive/ngBind.js
@@ -141,12 +141,13 @@ var ngBindTemplateDirective = ['$interpolate', '$compile', function($interpolate
  * @name ngBindHtml
  *
  * @description
- * Creates a binding that will innerHTML the result of evaluating the `expression` into the current
- * element in a secure way.  By default, the innerHTML-ed content will be sanitized using the {@link
- * ngSanitize.$sanitize $sanitize} service.  To utilize this functionality, ensure that `$sanitize`
- * is available, for example, by including {@link ngSanitize} in your module's dependencies (not in
- * core Angular). In order to use {@link ngSanitize} in your module's dependencies, you need to
- * include "angular-sanitize.js" in your application.
+ * The ngBindHtml attribute tells Angular to replace the inner HTML content of the specified HTML 
+ * element with the value of a given expression, and to update the inner HTML content when the value 
+ * of that expression changes in a secure way.  By default, the innerHTML-ed content will be sanitized 
+ * using the {@link ngSanitize.$sanitize $sanitize} service.  To utilize this functionality, ensure 
+ * that `$sanitize` is available, for example, by including {@link ngSanitize} in your module's 
+ * dependencies (not in core Angular). In order to use {@link ngSanitize} in your module's dependencies, 
+ * you need to include "angular-sanitize.js" in your application.
  *
  * You may also bypass sanitization for values you know are safe. To do so, bind to
  * an explicitly trusted value via {@link ng.$sce#trustAsHtml $sce.trustAsHtml}.  See the example


### PR DESCRIPTION
for issue #10097

changes: 
- @ngdoc directive
- @name ngBindHtml
  *
- @description
- Creates a binding that will innerHTML the result of evaluating the `expression` into the current
- element in a secure way.  By default, the innerHTML-ed content will be sanitized using the {@link
- ngSanitize.$sanitize $sanitize} service.  To utilize this functionality, ensure that `$sanitize`
- is available, for example, by including {@link ngSanitize} in your module's dependencies (not in
- core Angular). In order to use {@link ngSanitize} in your module's dependencies, you need to
- include "angular-sanitize.js" in your application.

to this:
/**
- @ngdoc directive
- @name ngBindHtml
  *
- @description
- The ngBindHtml attribute tells Angular to replace the inner HTML content of the specified HTML 
- element with the value of a given expression, and to update the inner HTML content when the value 
- of that expression changes in a secure way.  By default, the innerHTML-ed content will be sanitized 
- using the {@link ngSanitize.$sanitize $sanitize} service.  To utilize this functionality, ensure 
- that `$sanitize` is available, for example, by including {@link ngSanitize} in your module's 
- dependencies (not in core Angular). In order to use {@link ngSanitize} in your module's dependencies, 
- you need to include "angular-sanitize.js" in your application.
