### PR TITLE
fix($http): return empty headers, ignore properties in Object prototype

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -26,7 +26,7 @@ function defaultHttpResponseTransform(data, headers) {
  * @returns {Object} Parsed headers as key value object
  */
 function parseHeaders(headers) {
-  var parsed = {}, key, val, i;
+  var parsed = createMap(), key, val, i;
 
   if (!headers) return parsed;
 
@@ -63,7 +63,11 @@ function headersGetter(headers) {
     if (!headersObj) headersObj =  parseHeaders(headers);
 
     if (name) {
-      return headersObj[lowercase(name)] || null;
+      var value = headersObj[lowercase(name)];
+      if (value === void 0) {
+        value = null;
+      }
+      return value;
     }
 
     return headersObj;

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -816,6 +816,17 @@ describe('$http', function() {
       });
 
 
+      it('should handle empty response header', function() {
+       $httpBackend.expect('GET', '/url', undefined)
+           .respond(200, '', { 'Custom-Empty-Response-Header': '', 'Constructor': '' });
+       $http.get('/url').success(callback);
+       $httpBackend.flush();
+       expect(callback).toHaveBeenCalledOnce();
+       expect(callback.mostRecentCall.args[2]('custom-empty-response-Header')).toBe('');
+       expect(callback.mostRecentCall.args[2]('ToString')).toBe(null);
+       expect(callback.mostRecentCall.args[2]('Constructor')).toBe('');
+     });
+
       it('should have delete()', function() {
         $httpBackend.expect('DELETE', '/url').respond('');
         $http['delete']('/url');


### PR DESCRIPTION
(TESTING FOR MERGE)

Fix response headers with an empty value Empty response header values are legal
(http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html).

The headers getter fn will now only return null if the header property is not an own property.

Closes #7779
