### PR TITLE
chore(docs): mark builds >= 1.3.0 as stable

### DIFF
--- a/lib/versions/version-info.js
+++ b/lib/versions/version-info.js
@@ -97,7 +97,7 @@ var getTaggedVersion = function() {
  * @return {Boolean}         True if the version is stable
  */
 var isStable = function(version) {
-  return semver.satisfies(version, '1.0 || 1.2') && version.prerelease.length === 0;
+  return semver.satisfies(version, '1.0 || 1.2 || >=1.3') && version.prerelease.length === 0;
 };
 
 /**


### PR DESCRIPTION
Update isStable() to add builds >= 1.3.0 marked as stable. Previously, only builds with an even minor version number (1.0.x, 1.2.x) were marked as stable, while odd minor numbers (1.3.x) were marked as unstable. Now, 1.0.x, 1.2.x and 1.3+ will all be marked as stable. Prereleases remain marked as unstable, regardless of minor version.

As noted [here](http://angularjs.blogspot.com/2013/12/angularjs-13-new-release-approaches.html), odd minor versions are no longer considered unstable.

See screenshot of the current (incorrect) behavior:
![angular versions](https://cloud.githubusercontent.com/assets/1669397/5099577/c8a1b7d0-6f5d-11e4-9257-542cf80cd99a.png)
