### PR TITLE
fix($filter): add int support for negated strict comparison

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -134,6 +134,9 @@ function filterFilter() {
     if (comparatorType !== 'function') {
       if (comparatorType === 'boolean' && comparator) {
         comparator = function(obj, text) {
+          if (typeof obj === "number") {
+            text = parseInt(text);
+          }
           return angular.equals(obj, text);
         };
       } else {

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -160,6 +160,13 @@ describe('Filter: filter', function() {
       expect(filter(items, expr, true)).toEqual([items[2]]);
     });
 
+    it('should support negation operator on int with strict comparison', function() {
+      var items = [1, 11];
+
+      expect(filter(items, '!' + 1, true).length).toBe(1);
+      expect(filter(items, '!' + 1, true)[0]).toEqual(items[1]);
+    });
+
 
     it('and use the function given to compare values', function() {
       var items = [


### PR DESCRIPTION
- negation is achieved by adding '!' which fails if key is a integer and strict comparison is set to true.
- This commit fixes it by checking typeof and parsing accordingly

Closes #10141
