### PR TITLE
fix($filter): add int support for negated strict comparison

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -134,6 +134,9 @@ function filterFilter() {
     if (comparatorType !== 'function') {
       if (comparatorType === 'boolean' && comparator) {
         comparator = function(obj, text) {
+          if (typeof obj === "number") {
+            text = parseInt(text);
+          }
           return angular.equals(obj, text);
         };
       } else {

--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -155,23 +155,11 @@ function filterFilter() {
 
     var search = function(obj, text) {
       if (typeof text === 'string' && text.charAt(0) === '!') {
-        if (typeof obj !== typeof text) {
-          text = text.substr(1);
-          switch (typeof obj) {
-            case 'number':
-              if (!isNaN(parseFloat(text))) {
-                text = parseFloat(text);
-              }
-              break;
-            case 'boolean':
-              if (text === 'true' || text === 'false') {
-                text = text == 'false' ? !text : !!text;
-              }
-            }
-            return !search(obj, text);
-        } else {
-          return !search(obj, text.substr(1));
+        text = text.substr(1);
+        if (typeof obj !== typeof text && typeof obj === 'number') {
+            text = parseFloat(text);
         }
+        return !search(obj, text);
       }
       switch (typeof obj) {
         case 'boolean':

--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -156,7 +156,7 @@ function filterFilter() {
     var search = function(obj, text) {
       if (typeof text === 'string' && text.charAt(0) === '!') {
         text = text.substr(1);
-        if (typeof obj !== typeof text && typeof obj === 'number') {
+        if (typeof obj !== typeof text && angular.isNumber(obj)) {
             text = parseFloat(text);
         }
         return !search(obj, text);

--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -134,9 +134,6 @@ function filterFilter() {
     if (comparatorType !== 'function') {
       if (comparatorType === 'boolean' && comparator) {
         comparator = function(obj, text) {
-          if (typeof obj === "number") {
-            text = parseInt(text);
-          }
           return angular.equals(obj, text);
         };
       } else {
@@ -158,7 +155,23 @@ function filterFilter() {
 
     var search = function(obj, text) {
       if (typeof text === 'string' && text.charAt(0) === '!') {
-        return !search(obj, text.substr(1));
+        if (typeof obj !== typeof text) {
+          text = text.substr(1);
+          switch (typeof obj) {
+            case 'number':
+              if (!isNaN(parseFloat(text))) {
+                text = parseFloat(text);
+              }
+              break;
+            case 'boolean':
+              if (text === 'true' || text === 'false') {
+                text = text == 'false' ? !text : !!text;
+              }
+            }
+            return !search(obj, text);
+        } else {
+          return !search(obj, text.substr(1));
+        }
       }
       switch (typeof obj) {
         case 'boolean':

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -168,6 +168,14 @@ describe('Filter: filter', function() {
       expect(filter(items, '!' + 1.123, true).length).toBe(2);
     });
 
+    it('should support negation operator on int wrapped as a string', function() {
+      var items = ['1', '11'];
+
+      expect(filter(items, '!1', true).length).toBe(1);
+      expect(filter(items, '!1', true)[0]).toEqual(items[1]);
+      expect(filter(items, '!1.123', true).length).toBe(2);
+    });
+
     it('and use the function given to compare values', function() {
       var items = [
         {key: 1, nonkey: 1},

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -160,6 +160,13 @@ describe('Filter: filter', function() {
       expect(filter(items, expr, true)).toEqual([items[2]]);
     });
 
+    it('should support negation operator on int with strict comparison', function() {
+      var items = [1, 11];
+
+      expect(filter(items, '!' + 1, true).length).toBe(1);
+      expect(filter(items, '!' + 1, true)[0]).toEqual(items[1]);
+    });
+
 
     it('and use the function given to compare values', function() {
       var items = [

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -165,6 +165,14 @@ describe('Filter: filter', function() {
 
       expect(filter(items, '!' + 1, true).length).toBe(1);
       expect(filter(items, '!' + 1, true)[0]).toEqual(items[1]);
+      expect(filter(items, '!' + 1.123, true).length).toBe(2);
+    });
+
+    it('should support negation operator on boolean with strict comparison', function() {
+      var items = [true, false];
+
+      expect(filter(items, '!' + true, true).length).toBe(1);
+      expect(filter(items, '!' + true, true)[0]).toEqual(items[1]);
     });
 
 

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -168,14 +168,6 @@ describe('Filter: filter', function() {
       expect(filter(items, '!' + 1.123, true).length).toBe(2);
     });
 
-    it('should support negation operator on boolean with strict comparison', function() {
-      var items = [true, false];
-
-      expect(filter(items, '!' + true, true).length).toBe(1);
-      expect(filter(items, '!' + true, true)[0]).toEqual(items[1]);
-    });
-
-
     it('and use the function given to compare values', function() {
       var items = [
         {key: 1, nonkey: 1},


### PR DESCRIPTION
- negation is achieved by adding '!' which fails if key is a integer and strict comparison is set to true.
- This commit fixes it by checking typeof and parsing accordingly

Closes #10141
