### PR TITLE
docs(ngAnimate): Fix typo

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -239,7 +239,7 @@
  * You then configure `$animate` to enforce this prefix:
  *
  * ```js
- * $animateProvider.classNamePrefix(/animate-/);
+ * $animateProvider.classNameFilter(/animate-/);
  * ```
  * </div>
  *


### PR DESCRIPTION
The ngAnimate makes reference to a function `$animateProvider.classNamePrefix` that does not exist, the correct function is `$animateProvider.classNameFilter`

Closes #10142
