### PR TITLE
fix(Angular): properly get node name for svg element wrapper

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -625,7 +625,7 @@ function makeMap(str) {
 
 
 function nodeName_(element) {
-  return lowercase(element.nodeName || element[0].nodeName);
+  return lowercase(element.nodeName || (element[0] && element[0].nodeName));
 }
 
 function includes(array, obj) {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1009,6 +1009,11 @@ describe('angular', function() {
       expect(nodeName_(div.childNodes[0])).toBe('ngtest:foo');
       expect(div.childNodes[0].getAttribute('ngtest:attr')).toBe('bar');
     });
+
+    it('should return undefined for elements without the .nodeName property', function() {
+      //some elements, like SVGElementInstance don't have .nodeName property
+      expect(nodeName_({})).toBeUndefined();
+    });
   });
 
 


### PR DESCRIPTION
Fixes #10078
