### PR TITLE
fix($httpBackend): compare timeoutId with undefined in completeRequest

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -126,7 +126,9 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
 
     function completeRequest(callback, status, response, headersString, statusText) {
       // cancel timeout and subsequent timeout promise resolution
-      timeoutId && $browserDefer.cancel(timeoutId);
+      if (timeoutId !== undefined) {
+        $browserDefer.cancel(timeoutId);
+      }
       jsonpDone = xhr = null;
 
       callback(status, response, headersString, statusText);


### PR DESCRIPTION
fix($httpBackend): compare timeoutId with undefined in completeRequest
httpBackend with ngMock browser.defer can never cancel the first deferredFn because the timeoutId returned by defer for the first fn is a zero value.
Compare timeoutId with undefined fix this issue. Replace fakeTimeout with defer mock to test this fix.
