### PR TITLE
fix(isArrayLike): Correct logic in isArrayLike to screen out objects

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -201,7 +201,7 @@ function isArrayLike(obj) {
     return true;
   }
 
-  return isString(obj) || isArray(obj) || length === 0 ||
+  return isString(obj) || isArray(obj) || (length === 0 && Object.keys(obj).length <= 1) ||
          typeof length === 'number' && length > 0 && (length - 1) in obj;
 }
 

--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -344,7 +344,6 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
             }
             collectionKeys.sort();
           }
-
           collectionLength = collectionKeys.length;
           nextBlockOrder = new Array(collectionLength);
 
@@ -438,4 +437,3 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
     }
   };
 }];
-

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -580,6 +580,16 @@ describe('ngRepeat', function() {
     expect(element.text()).toEqual('frodo:f:0|misko:m:1|shyam:s:2|');
   });
 
+  it('should expose iterator offset as $index when iterating over objects with length key value 0', function() {
+    element = $compile(
+      '<ul>' +
+        '<li ng-repeat="(key, val) in items">{{key}}:{{val}}:{{$index}}|</li>' +
+      '</ul>')(scope);
+    scope.items = {'misko':'m', 'shyam':'s', 'frodo':'f', 'length':0};
+    scope.$digest();
+    expect(element.text()).toEqual('frodo:f:0|length:0:1|misko:m:2|shyam:s:3|');
+  });
+
 
   it('should expose iterator position as $first, $middle and $last when iterating over arrays',
       function() {


### PR DESCRIPTION
- Fix ngRepeat check via isArrayLike check to prevent objects from
  accidentally passing as array-like

This addresses #8000 & #4751.
