### PR TITLE
chore: add build into test unit task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -326,7 +326,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test:jquery', 'Run the jQuery unit tests with Karma', ['tests:jquery']);
   grunt.registerTask('test:modules', 'Run the Karma module tests with Karma', ['tests:modules']);
   grunt.registerTask('test:docs', 'Run the doc-page tests with Karma', ['package', 'tests:docs']);
-  grunt.registerTask('test:unit', 'Run unit, jQuery and Karma module tests with Karma', ['tests:jqlite', 'tests:jquery', 'tests:modules']);
+  grunt.registerTask('test:unit', 'Run unit, jQuery and Karma module tests with Karma', ['build', 'tests:jqlite', 'tests:jquery', 'tests:modules']);
   grunt.registerTask('test:protractor', 'Run the end to end tests with Protractor and keep a test server running in the background', ['webdriver', 'connect:testserver', 'protractor:normal']);
   grunt.registerTask('test:travis-protractor', 'Run the end to end tests with Protractor for Travis CI builds', ['connect:testserver', 'protractor:travis']);
   grunt.registerTask('test:ci-protractor', 'Run the end to end tests with Protractor for Jenkins CI builds', ['webdriver', 'connect:testserver', 'protractor:jenkins']);


### PR DESCRIPTION
While following setup document https://docs.angularjs.org/misc/contribute, and running 
$ grunt test:unit, it was showing "Uncaught ReferenceError: angular is not defined - AngularJS not working" error. 
So i added 'build' into test unit task and then it starts working.
