### PR TITLE
feat($compile): add one way (one-off) binding to isolate scope

### DIFF
--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3392,6 +3392,72 @@ describe('$compile', function() {
         });
       });
 
+      describe('isolateScope one way data binding', function() {
+        it('should not throw if the one way binding is optional', function() {
+          module(function() {
+            directive('hello', function() {
+              return {
+                scope: {
+                  oneWay: '>?'
+                }
+              };
+            });
+          });
+
+          inject(function($compile, $rootScope) {
+            compile('<div hello></div>');
+
+            var isolateScope = element.isolateScope();
+            expect(isolateScope.oneWay).toBe(undefined);
+          });
+        });
+
+        it('should not update isolate scope when parent scope changes a ":" binding', function() {
+          module(function() {
+            directive('hello', function() {
+              return {
+                scope: {
+                  oneWay: '>'
+                }
+              };
+            });
+          });
+
+          inject(function($compile, $rootScope) {
+            $rootScope.name = 'jack';
+            compile('<div hello one-way="name"></div>');
+
+            var isolateScope = element.isolateScope();
+            expect(isolateScope.oneWay).toBe('jack');
+
+            $rootScope.$apply(function() { $rootScope.name = 'igor'; });
+            expect(isolateScope.oneWay).toBe('jack');
+          });
+        });
+
+        it('should not update parent scope when isolate scope changes a ":" binding', function() {
+          module(function() {
+            directive('hello', function() {
+              return {
+                scope: {
+                  oneWay: '>'
+                }
+              };
+            });
+          });
+
+          inject(function($compile, $rootScope) {
+            $rootScope.name = 'jack';
+            compile('<div hello one-way="name"></div>');
+
+            var isolateScope = element.isolateScope();
+            expect(isolateScope.oneWay).toBe('jack');
+
+            isolateScope.$apply(function(scope) { scope.oneWay = 'igor'; });
+            expect($rootScope.name).toBe('jack');
+          });
+        });
+      });
     });
 
 


### PR DESCRIPTION
Adds the ability to define a directive that has a one way data binding
variable:

``` js
directive('foo', function() {
  return {
    scope: { oneWay: '>' }
  };
});

<foo one-way="name"></foo>
```

Given the above code, if `name` changes on the parent, that change will
not propagate through to foo, as it would if the binding was "=".
Similarly, if foo updates `oneWay`, that change will not be reflected on
the parent.

There wasn't an open issue for this, but discussed this in person with @IgorMinar before starting (ng-fixit-1 :tada:).
