### PR TITLE
fix(ngPluralize): Use "other" pluralization key as a fallback

### DIFF
--- a/src/ng/directive/ngPluralize.js
+++ b/src/ng/directive/ngPluralize.js
@@ -216,7 +216,7 @@ var ngPluralizeDirective = ['$locale', '$interpolate', function($locale, $interp
         // In JS `NaN !== NaN`, so we have to exlicitly check.
         if ((count !== lastCount) && !(countIsNaN && isNaN(lastCount))) {
           watchRemover();
-          watchRemover = scope.$watch(whensExpFns[count], updateElementText);
+          watchRemover = scope.$watch(whensExpFns[count] || whensExpFns['other'], updateElementText);
           lastCount = count;
         }
       });


### PR DESCRIPTION
With languages having optional keys like `few` or `many` it's handy to use `other` as a fallback instead of defining all of the translation keys (in which some may be repeated) in `when` attribute of `ng-pluralize`.

Refs #7774
