### PR TITLE
fix(parse): fix operators associativity

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -598,8 +598,8 @@ Parser.prototype = {
   logicalAND: function() {
     var left = this.equality();
     var token;
-    if ((token = this.expect('&&'))) {
-      left = this.binaryFn(left, token.text, this.logicalAND(), true);
+    while ((token = this.expect('&&'))) {
+      left = this.binaryFn(left, token.text, this.equality(), true);
     }
     return left;
   },
@@ -607,8 +607,8 @@ Parser.prototype = {
   equality: function() {
     var left = this.relational();
     var token;
-    if ((token = this.expect('==','!=','===','!=='))) {
-      left = this.binaryFn(left, token.text, this.equality());
+    while ((token = this.expect('==','!=','===','!=='))) {
+      left = this.binaryFn(left, token.text, this.relational());
     }
     return left;
   },
@@ -616,8 +616,8 @@ Parser.prototype = {
   relational: function() {
     var left = this.additive();
     var token;
-    if ((token = this.expect('<', '>', '<=', '>='))) {
-      left = this.binaryFn(left, token.text, this.relational());
+    while ((token = this.expect('<', '>', '<=', '>='))) {
+      left = this.binaryFn(left, token.text, this.additive());
     }
     return left;
   },

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -276,6 +276,10 @@ describe('parser', function() {
         expect(scope.$eval("2>=1")).toEqual(2 >= 1);
         expect(scope.$eval("true==2<3")).toEqual(true == 2 < 3);
         expect(scope.$eval("true===2<3")).toEqual(true === 2 < 3);
+
+        expect(scope.$eval("true===3===3")).toEqual(true === 3 === 3);
+        expect(scope.$eval("3===3===true")).toEqual(3 === 3 === true);
+        expect(scope.$eval("3 >= 3 > 2")).toEqual(3 >= 3 > 2);
       });
 
       it('should parse logical', function() {
@@ -696,6 +700,7 @@ describe('parser', function() {
           throw "IT SHOULD NOT HAVE RUN";
         };
         expect(scope.$eval('false && run()')).toBe(false);
+        expect(scope.$eval('false && true && run()')).toBe(false);
       });
 
       it('should short-circuit OR operator', function() {
@@ -703,6 +708,7 @@ describe('parser', function() {
           throw "IT SHOULD NOT HAVE RUN";
         };
         expect(scope.$eval('true || run()')).toBe(true);
+        expect(scope.$eval('true || false || run()')).toBe(true);
       });
 
 


### PR DESCRIPTION
Make the operators `&&`, `==`, `!=`, `===`, `!==`, `<`, `>`, `<=`, `>=` follow Javascript left-to-right associativity
