### PR TITLE
Fixed grammar in compile.js (ngDoc)

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -870,7 +870,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    * * `ng-binding` CSS class
    * * `$binding` data property containing an array of the binding expressions
    *
-   * You may want disable this in production for a significant performance boost. See
+   * You may want to disable this in production for a significant performance boost. See
    * {@link guide/production#disabling-debug-data Disabling Debug Data} for more.
    *
    * The default value is true.

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -870,7 +870,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    * * `ng-binding` CSS class
    * * `$binding` data property containing an array of the binding expressions
    *
-   * You may want to use this in production for a significant performance boost. See
+   * You may want disable this in production for a significant performance boost. See
    * {@link guide/production#disabling-debug-data Disabling Debug Data} for more.
    *
    * The default value is true.


### PR DESCRIPTION
Changed "You may want to use this in production" to "You may want disable this in production". The phrase "to use" implies enabling where as it should be _disabled_ in production.
