### PR TITLE
Support Windows Phone 8 and Browser with MOVE_TOLERANCE.

### DIFF
--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -185,7 +185,9 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
         tapElement,  // Used to blur the element after a tap.
         startTime,   // Used to check if the tap was held too long.
         touchStartX,
-        touchStartY;
+        touchStartY,
+        clickStartX,
+        clickStartY;
 
     function resetState() {
       tapping = false;
@@ -258,6 +260,15 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     // - But the browser's follow-up slow click will be "busted" before it reaches this handler.
     // Therefore it's safe to use this directive on both mobile and desktop.
     element.on('click', function(event, touchend) {
+      if (!touchend) {
+        // If we have no touchend event, we should still check MOVE_TOLERANCE
+        // for standard browser clicks. Otherwise if we create directives that
+        // use the `swipe` service, the element will still receive clicks.
+        var x = event.clientX;
+        var y = event.clientY;
+        var dist = Math.sqrt( Math.pow(x - clickStartX, 2) + Math.pow(y - clickStartY, 2) );
+        if (dist >= MOVE_TOLERANCE) return;
+      }
       scope.$apply(function() {
         clickHandler(scope, {$event: (touchend || event)});
       });
@@ -265,6 +276,8 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
 
     element.on('mousedown', function(event) {
       element.addClass(ACTIVE_CLASS_NAME);
+      clickStartX = event.clientX;
+      clickStartY = event.clientY;
     });
 
     element.on('mousemove mouseup', function(event) {

--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -266,7 +266,7 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
         // use the `swipe` service, the element will still receive clicks.
         var x = event.clientX;
         var y = event.clientY;
-        var dist = Math.sqrt( Math.pow(x - clickStartX, 2) + Math.pow(y - clickStartY, 2) );
+        var dist = Math.sqrt(Math.pow(x - clickStartX, 2) + Math.pow(y - clickStartY, 2));
         if (dist >= MOVE_TOLERANCE) return;
       }
       scope.$apply(function() {

--- a/test/ngTouch/directive/ngClickSpec.js
+++ b/test/ngTouch/directive/ngClickSpec.js
@@ -408,6 +408,26 @@ describe('ngClick (touch)', function() {
 
 
   describe('click fallback', function() {
+    it('should not click if the click is too far away', inject(function($rootScope, $compile, $rootElement) {
+      element = $compile('<div ng-click="tapped = true"></div>')($rootScope);
+      $rootElement.append(element);
+      $rootScope.$digest();
+
+      expect($rootScope.tapped).toBeUndefined();
+
+      browserTrigger(element, 'mousedown',{
+        keys: [],
+        x: 10,
+        y: 10
+      });
+      browserTrigger(element, 'click',{
+        keys: [],
+        x: 400,
+        y: 400
+      });
+
+      expect($rootScope.tapped).toBeUndefined();
+    }));
 
     it('should treat a click as a tap on desktop', inject(function($rootScope, $compile) {
       element = $compile('<div ng-click="tapped = true"></div>')($rootScope);


### PR DESCRIPTION
If an element has ngClick applied, it will still fire the `click` event after dragging the element or any children of the element that has ngClick. It is particularly buggy when combined with the `$swipe` service.

This change moves the `mouse` and `pointer` events to coexist with touch events logic and incorporate MOVE_TOLERANCE.
