### PR TITLE
feat(ngModelController.$focused): add $focused / $unfocused to ngModelController

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2602,7 +2602,7 @@ var ngModelDirective = ['$rootScope', function($rootScope) {
                 }
               });
             } else {
-              scope.$apply(function () {
+              scope.$apply(function() {
                 modelCtrl.$setUnfocused();
                 if (modelCtrl.$untouched) {
                   modelCtrl.$setTouched();

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1532,7 +1532,9 @@ var VALID_CLASS = 'ng-valid',
     DIRTY_CLASS = 'ng-dirty',
     UNTOUCHED_CLASS = 'ng-untouched',
     TOUCHED_CLASS = 'ng-touched',
-    PENDING_CLASS = 'ng-pending';
+    PENDING_CLASS = 'ng-pending',
+    UNFOCUSED_CLASS = 'ng-unfocused',
+    FOCUSED_CLASS = 'ng-focused';
 
 /**
  * @ngdoc type
@@ -1620,6 +1622,8 @@ is set to `true`. The parse error is stored in `ngModel.$error.parse`.
  *
  * @property {boolean} $untouched True if control has not lost focus yet.
  * @property {boolean} $touched True if control has lost focus.
+ * @property {boolean} $unfocused True if control is not actively focused on.
+ * @property {boolean} $focused True if control is actively focused on.
  * @property {boolean} $pristine True if user has not interacted with the control yet.
  * @property {boolean} $dirty True if user has already interacted with the control.
  * @property {boolean} $valid True if there is no error.
@@ -1744,6 +1748,8 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
   this.$viewChangeListeners = [];
   this.$untouched = true;
   this.$touched = false;
+  this.$focused = false;
+  this.$unfocused = true;
   this.$pristine = true;
   this.$dirty = false;
   this.$valid = true;
@@ -1939,6 +1945,41 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
     ctrl.$touched = true;
     ctrl.$untouched = false;
     $animate.setClass($element, TOUCHED_CLASS, UNTOUCHED_CLASS);
+  };
+
+  /**
+   * @ngdoc method
+   * @name ngModel.NgModelController#$setUnfocused
+   *
+   * @description
+   * Sets the control to its unfocused state.
+   *
+   * This method can be called to remove the `ng-focused` class and set the control to its
+   * unfocused state (`ng-unfocused` class). Upon compilation, a model is set as unfocused
+   * by default, however this function can be used to restore that state if the model has
+   * already been focused by the user.
+   */
+  this.$setUnfocused = function() {
+    ctrl.$focused = false;
+    ctrl.$unfocused = true;
+    $animate.setClass($element, UNFOCUSED_CLASS, FOCUSED_CLASS);
+  };
+
+  /**
+   * @ngdoc method
+   * @name ngModel.NgModelController#$setFocused
+   *
+   * @description
+   * Sets the control to its focused state.
+   *
+   * This method can be called to remove the `ng-unfocused` class and set the control to its
+   * focused state (`ng-focused` class). A model is considered to be focused when the user is
+   * actively focusing on the control element.
+   */
+  this.$setFocused = function() {
+    ctrl.$focused = true;
+    ctrl.$unfocused = false;
+    $animate.setClass($element, FOCUSED_CLASS, UNFOCUSED_CLASS);
   };
 
   /**
@@ -2363,8 +2404,8 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
  * - Binding the view into the model, which other directives such as `input`, `textarea` or `select`
  *   require.
  * - Providing validation behavior (i.e. required, number, email, url).
- * - Keeping the state of the control (valid/invalid, dirty/pristine, touched/untouched, validation errors).
- * - Setting related css classes on the element (`ng-valid`, `ng-invalid`, `ng-dirty`, `ng-pristine`, `ng-touched`, `ng-untouched`) including animations.
+ * - Keeping the state of the control (valid/invalid, dirty/pristine, touched/untouched, focused/unfocused, validation errors).
+ * - Setting related css classes on the element (`ng-valid`, `ng-invalid`, `ng-dirty`, `ng-pristine`, `ng-touched`, `ng-untouched`, `ng-focused`, `ng-unfocused`) including animations.
  * - Registering the control with its parent {@link ng.directive:form form}.
  *
  * Note: `ngModel` will try to bind to the property given by evaluating the expression on the
@@ -2404,6 +2445,8 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
  *  - `ng-dirty`: the control has been interacted with
  *  - `ng-touched`: the control has been blurred
  *  - `ng-untouched`: the control hasn't been blurred
+ *  - `ng-focused`: the control has been focused on
+ *  - `ng-unfocused`: the control isn't currently focused on
  *  - `ng-pending`: any `$asyncValidators` are unfulfilled
  *
  * Keep in mind that ngAnimate can detect each of these classes when added and removed.
@@ -2551,12 +2594,28 @@ var ngModelDirective = ['$rootScope', function($rootScope) {
           }
 
           element.on('blur', function(ev) {
-            if (modelCtrl.$touched) return;
-
             if ($rootScope.$$phase) {
-              scope.$evalAsync(modelCtrl.$setTouched);
+              scope.$evalAsync(function() {
+                modelCtrl.$setUnfocused();
+                if (modelCtrl.$untouched) {
+                  modelCtrl.$setTouched();
+                }
+              });
             } else {
-              scope.$apply(modelCtrl.$setTouched);
+              scope.$apply(function () {
+                modelCtrl.$setUnfocused();
+                if (modelCtrl.$untouched) {
+                  modelCtrl.$setTouched();
+                }
+              });
+            }
+          });
+
+          element.on('focus', function(ev) {
+            if ($rootScope.$$phase) {
+              scope.$evalAsync(modelCtrl.$setFocused);
+            } else {
+              scope.$apply(modelCtrl.$setFocused);
             }
           });
         }

--- a/test/helpers/matchers.js
+++ b/test/helpers/matchers.js
@@ -43,6 +43,8 @@ beforeEach(function() {
     toBePristine: cssMatcher('ng-pristine', 'ng-dirty'),
     toBeUntouched: cssMatcher('ng-untouched', 'ng-touched'),
     toBeTouched: cssMatcher('ng-touched', 'ng-untouched'),
+    toBeUnfocused: cssMatcher('ng-unfocused', 'ng-focused'),
+    toBeFocused: cssMatcher('ng-focused', 'ng-unfocused'),
     toBeAPromise: function() {
       this.message = valueFn(
           "Expected object " + (this.isNot ? "not " : "") + "to be a promise");

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2606,6 +2606,47 @@ describe('input', function() {
       expect(inputElm).toBeValid();
     });
 
+    it('should only accept empty values when maxlength is 0', function() {
+      compileInput('<input type="text" ng-model="value" ng-maxlength="0" />');
+
+      changeInputValueTo('');
+      expect(inputElm).toBeValid();
+
+      changeInputValueTo('a');
+      expect(inputElm).toBeInvalid();
+    });
+
+    it('should accept values of any length when maxlength is negative', function() {
+      compileInput('<input type="text" ng-model="value" ng-maxlength="-1" />');
+
+      changeInputValueTo('');
+      expect(inputElm).toBeValid();
+
+      changeInputValueTo('aaaaaaaaaa');
+      expect(inputElm).toBeValid();
+    });
+
+    it('should accept values of any length when maxlength is non-numeric', function() {
+      compileInput('<input type="text" ng-model="value" ng-maxlength="{{maxlength}}" />');
+      changeInputValueTo('aaaaaaaaaa');
+
+      scope.$apply('maxlength = "5"');
+      expect(inputElm).toBeInvalid();
+
+      scope.$apply('maxlength = "abc"');
+      expect(inputElm).toBeValid();
+
+      scope.$apply('maxlength = ""');
+      expect(inputElm).toBeValid();
+
+      scope.$apply('maxlength = null');
+      expect(inputElm).toBeValid();
+
+      scope.someObj = {};
+      scope.$apply('maxlength = someObj');
+      expect(inputElm).toBeValid();
+    });
+
     it('should listen on ng-maxlength when maxlength is observed', function() {
       var value = 0;
       compileInput('<input type="text" ng-model="value" ng-maxlength="max" attr-capture />');

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -178,6 +178,28 @@ describe('NgModelController', function() {
     });
   });
 
+  describe('setUnfocused', function() {
+
+    it('should set control to its unfocused state', function() {
+      ctrl.$setFocused();
+
+      ctrl.$setUnfocused();
+      expect(ctrl.$focused).toBe(false);
+      expect(ctrl.$unfocused).toBe(true);
+    });
+  });
+
+  describe('setFocused', function() {
+
+    it('should set control to its focused state', function() {
+      ctrl.$setUnfocused();
+
+      ctrl.$setFocused();
+      expect(ctrl.$focused).toBe(true);
+      expect(ctrl.$unfocused).toBe(false);
+    });
+  });
+
   describe('view -> model', function() {
 
     it('should set the value to $viewValue', function() {
@@ -1073,7 +1095,7 @@ describe('NgModelController', function() {
 describe('ngModel', function() {
   var EMAIL_REGEXP = /^[a-z0-9!#$%&'*+\/=?^_`{|}~.-]+@[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i;
 
-  it('should set css classes (ng-valid, ng-invalid, ng-pristine, ng-dirty, ng-untouched, ng-touched)',
+  it('should set css classes (ng-valid, ng-invalid, ng-pristine, ng-dirty, ng-untouched, ng-touched, ng-unfocused, ng-focused)',
       inject(function($compile, $rootScope, $sniffer) {
     var element = $compile('<input type="email" ng-model="value" />')($rootScope);
 
@@ -1104,8 +1126,12 @@ describe('ngModel', function() {
     expect(element.hasClass('ng-valid-email')).toBe(true);
     expect(element.hasClass('ng-invalid-email')).toBe(false);
 
+    browserTrigger(element, 'focus');
+    expect(element).toBeFocused();
+
     browserTrigger(element, 'blur');
     expect(element).toBeTouched();
+    expect(element).toBeUnfocused();
 
     dealoc(element);
   }));
@@ -1262,7 +1288,7 @@ describe('ngModel', function() {
     dealoc(element);
   }));
 
-  it('should not cause a digest on "blur" event if control is already touched',
+  it('should not call $setTouched on "blur" event if control is already touched',
       inject(function($compile, $rootScope) {
 
     var element = $compile('<form name="myForm">' +
@@ -1272,10 +1298,10 @@ describe('ngModel', function() {
     var control = $rootScope.myForm.myControl;
 
     control.$setTouched();
-    spyOn($rootScope, '$apply');
+    spyOn(control, '$setTouched');
     browserTrigger(inputElm, 'blur');
 
-    expect($rootScope.$apply).not.toHaveBeenCalled();
+    expect(control.$setTouched).not.toHaveBeenCalled();
 
     dealoc(element);
   }));
@@ -1301,6 +1327,40 @@ describe('ngModel', function() {
 
     expect(control.$touched).toBe(true);
     expect(control.$untouched).toBe(false);
+
+    dealoc(element);
+  }));
+
+  it('should call $setUnfocused on "blur" event',
+      inject(function($compile, $rootScope) {
+
+    var element = $compile('<form name="myForm">' +
+                             '<input name="myControl" ng-model="value" >' +
+                           '</form>')($rootScope);
+    var inputElm = element.find('input');
+    var control = $rootScope.myForm.myControl;
+
+    spyOn(control, '$setUnfocused');
+    browserTrigger(inputElm, 'blur');
+
+    expect(control.$setUnfocused).toHaveBeenCalled();
+
+    dealoc(element);
+  }));
+
+  it('should call $setFocused on "focus" event',
+      inject(function($compile, $rootScope) {
+
+    var element = $compile('<form name="myForm">' +
+                             '<input name="myControl" ng-model="value" >' +
+                           '</form>')($rootScope);
+    var inputElm = element.find('input');
+    var control = $rootScope.myForm.myControl;
+
+    spyOn(control, '$setFocused');
+    browserTrigger(inputElm, 'focus');
+
+    expect(control.$setFocused).toHaveBeenCalled();
 
     dealoc(element);
   }));
@@ -2543,47 +2603,6 @@ describe('input', function() {
       expect(inputElm).toBeInvalid();
 
       changeInputValueTo('aaa');
-      expect(inputElm).toBeValid();
-    });
-
-    it('should only accept empty values when maxlength is 0', function() {
-      compileInput('<input type="text" ng-model="value" ng-maxlength="0" />');
-
-      changeInputValueTo('');
-      expect(inputElm).toBeValid();
-
-      changeInputValueTo('a');
-      expect(inputElm).toBeInvalid();
-    });
-
-    it('should accept values of any length when maxlength is negative', function() {
-      compileInput('<input type="text" ng-model="value" ng-maxlength="-1" />');
-
-      changeInputValueTo('');
-      expect(inputElm).toBeValid();
-
-      changeInputValueTo('aaaaaaaaaa');
-      expect(inputElm).toBeValid();
-    });
-
-    it('should accept values of any length when maxlength is non-numeric', function() {
-      compileInput('<input type="text" ng-model="value" ng-maxlength="{{maxlength}}" />');
-      changeInputValueTo('aaaaaaaaaa');
-
-      scope.$apply('maxlength = "5"');
-      expect(inputElm).toBeInvalid();
-
-      scope.$apply('maxlength = "abc"');
-      expect(inputElm).toBeValid();
-
-      scope.$apply('maxlength = ""');
-      expect(inputElm).toBeValid();
-
-      scope.$apply('maxlength = null');
-      expect(inputElm).toBeValid();
-
-      scope.someObj = {};
-      scope.$apply('maxlength = someObj');
       expect(inputElm).toBeValid();
     });
 


### PR DESCRIPTION
- set ngModelController.$focused when an input is actively focused
- set ngModelController.$unfocused on blur
- useful for things like hiding error messages when the user is actively focused on an input

No breaking changes
