### PR TITLE
docs(ngRoute): clarify JSDoc for caseInsensitiveMatch

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -175,7 +175,7 @@ function $RouteProvider() {
    * @description
    *
    * A boolean property indicating if routes defined
-   * using this provider should be matched using a case sensitive
+   * using this provider should be matched using a case insensitive
    * algorithm. Defaults to `false`.
    */
   this.caseInsensitiveMatch = false;


### PR DESCRIPTION
I found the mismatch between the property name+semantics and the description a bit confusing.  This change aligns the two.
