### PR TITLE
x5 optimization: do not run watchers on isolated scopes if their isolated bindings hasn't changed

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1896,7 +1896,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               case '@':
                 attrs.$observe(attrName, function(value) {
                   isolateBindingContext[scopeName] = value;
-				  isolateScope.$setDirty();
+                  isolateScope.$setDirty();
                 });
                 attrs.$$observers[attrName].$$scope = scope;
                 if (attrs[attrName]) {
@@ -1930,7 +1930,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                     if (!compare(parentValue, lastValue)) {
                       // parent changed and it has precedence
                       isolateBindingContext[scopeName] = parentValue;
-					  isolateScope.$setDirty();
+                      isolateScope.$setDirty();
                     } else {
                       // if the parent can be assigned then do so
                       parentSet(scope, parentValue = isolateBindingContext[scopeName]);

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1896,6 +1896,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               case '@':
                 attrs.$observe(attrName, function(value) {
                   isolateBindingContext[scopeName] = value;
+				  isolateScope.$setDirty();
                 });
                 attrs.$$observers[attrName].$$scope = scope;
                 if (attrs[attrName]) {
@@ -1929,6 +1930,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                     if (!compare(parentValue, lastValue)) {
                       // parent changed and it has precedence
                       isolateBindingContext[scopeName] = parentValue;
+					  isolateScope.$setDirty();
                     } else {
                       // if the parent can be assigned then do so
                       parentSet(scope, parentValue = isolateBindingContext[scopeName]);

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -731,6 +731,7 @@ function $RootScopeProvider() {
             next, current, target = this,
             watchLog = [],
             logIdx, logMsg, asyncTask;
+        this.$$dirty = true;
 
         beginPhase('$digest');
         // Check for changes to browser url that happened in sync before the call to $digest
@@ -1042,6 +1043,7 @@ function $RootScopeProvider() {
         } finally {
           clearPhase();
           try {
+            this.$$dirty = true;
             $rootScope.$digest();
           } catch (e) {
             $exceptionHandler(e);
@@ -1074,6 +1076,7 @@ function $RootScopeProvider() {
 
         function $applyAsyncExpression() {
           scope.$eval(expr);
+          this.$$dirty = true;
         }
       },
 

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -731,8 +731,8 @@ function $RootScopeProvider() {
             next, current, target = this,
             watchLog = [],
             logIdx, logMsg, asyncTask;
-        
-		this.$$dirty = true;
+
+        this.$$dirty = true;
 
         beginPhase('$digest');
         // Check for changes to browser url that happened in sync before the call to $digest

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -1076,7 +1076,7 @@ function $RootScopeProvider() {
 
         function $applyAsyncExpression() {
           scope.$eval(expr);
-          this.$$dirty = true;
+          scope.$$dirty = true;
         }
       },
 

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -731,7 +731,8 @@ function $RootScopeProvider() {
             next, current, target = this,
             watchLog = [],
             logIdx, logMsg, asyncTask;
-        this.$$dirty = true;
+        
+		this.$$dirty = true;
 
         beginPhase('$digest');
         // Check for changes to browser url that happened in sync before the call to $digest

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -731,7 +731,6 @@ function $RootScopeProvider() {
             next, current, target = this,
             watchLog = [],
             logIdx, logMsg, asyncTask;
-
         this.$$dirty = true;
 
         beginPhase('$digest');

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -137,7 +137,7 @@ function $RootScopeProvider() {
       this.$$listeners = {};
       this.$$listenerCount = {};
       this.$$isolateBindings = null;
-	  this.$$dirty = false;
+      this.$$dirty = false;
     }
 
     /**
@@ -203,7 +203,7 @@ function $RootScopeProvider() {
         if (isolate) {
           child = new Scope();
           child.$root = this.$root;
-		  child.$$dirty = true;
+          child.$$dirty = true;
         } else {
           // Only create a child scope class if somebody asks for one,
           // but cache it to allow the VM to optimize lookups.
@@ -242,12 +242,12 @@ function $RootScopeProvider() {
           child.$$destroyed = true;
         }
       },
-	  
-	  $setDirty: function() {
-      	if (!this.hasOwnProperty("$$isolateBindings"))
-      		throw 'Must be isolated scope.';
 
-      	this.$$dirty = true;
+      $setDirty: function() {
+        if (!this.hasOwnProperty("$$isolateBindings"))
+          throw 'Must be isolated scope.';
+
+        this.$$dirty = true;
       },
 
       /**
@@ -761,8 +761,8 @@ function $RootScopeProvider() {
 
           traverseScopesLoop:
           do { // "traverse the scopes" loop
-		    var skip = current.$$isolateBindings && !current.$$dirty && !current.$$transcluded;
-          	current.$$dirty = false;
+            var skip = current.$$isolateBindings && !current.$$dirty && !current.$$transcluded;
+            current.$$dirty = false;
             if (!skip && (watchers = current.$$watchers)) {
               // process our watches
               length = watchers.length;


### PR DESCRIPTION
This optimization reduces number of running watchers by x3 - x10 in apps with big number of isolated scopes.
#### How?

Do not run the isolated scope watchers if its scope definition bindings (e.g. `{label: '@'}`) hadn't changed.
#### Motivation

The common use case for  directives with isolate scope is to create kind of a widget. With isolate scope bindings it "connects" to its "public" interface and should implement its internal functionality using _ONLY_ these fields, model-wise. In other words, any inner watchers should entirely depend (directly or indirectly) on the "public" interface. Any direct watchers to parental scopes is discouraged.
Let's evaluate scenarios of what happens then:
- Templating: the mapped field is used inside a template, e.g. there is a mapping like `label: '@'` and somewhere in the template `{{label}}`. While the template is linked, it installs a watch that evaluates the expression. It's clear that if the outer `@label` is not changed it's useless to evaluate the expression since it's not changed. Consider that the expression can be more complex: `{{label}}: {{getFullName()}}`. Currently, all this runs several times during $digest cycle for nothing.
- Custom watches: the user installs a watch using a `function(){...}`. The function must return a value , in many cases the value is computed and the computation can be untrivial. The sad part is that if the isolated bindings hasn't changed, this computation should return the same value! So again, it will run for nothing...

Now consider an app that makes an intensive use of "widgets", like a typical LOB app. This optimization substantially boosts its performance (x5-x10).
#### Cons

Unfortunately this change can break an existing code. If the user creates watches to parental scopes, the system might behave abnormally: if the callback will change some scope values, the UI can be not updated.
- In the first place, this kind of watchers is discouraged and can be considered as a bug in user code
- I provide a method `scope.$setDirty()` that can be used to "fix" the problem

In any case, this issue makes this PR inappropriate for minor release. So there are 2 options:
1. The directive will mark somehow that a new isolated scope behavior can be used, in this case no old code will be broken and this can be merged.
2. Wait for a major release.

In my opinion (1) is better: like in Google [Guava](https://github.com/google/guava), there is a concept of `@Beta` features. This way the users might test the new functionality and provide feedback before it's released.

---

I created a demo app, which logs "skipped" scopes and # of watcher checks. In original angular number of checks is x3 - x10.

http://ngforms.azurewebsites.net/
