### PR TITLE
added ngContent directive

### DIFF
--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -160,7 +160,7 @@
  *
  * @description
  * Using Angular markup like `{{hash}}` in a `content` attribute doesn't
- * work right: The browser will fetch from the URL with the literal
+ * work right: bots will fetch from the URL with the literal
  * text `{{hash}}` until Angular replaces the expression inside
  * `{{hash}}`. The `ngContent` directive solves this problem.
  *

--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -154,6 +154,32 @@
 
 /**
  * @ngdoc directive
+ * @name ngContent
+ * @restrict META
+ * @priority 99
+ *
+ * @description
+ * Using Angular markup like `{{hash}}` in a `content` attribute doesn't
+ * work right: The browser will fetch from the URL with the literal
+ * text `{{hash}}` until Angular replaces the expression inside
+ * `{{hash}}`. The `ngContent` directive solves this problem.
+ *
+ * The buggy way to write it:
+ * ```html
+ * <meta property="og:url" content="https://docs.angularjs.org/{{hash}}"/>
+ * ```
+ *
+ * The correct way to write it:
+ * ```html
+ * <meta property="og:url" ng-content="https://docs.angularjs.org/{{hash}}"/>
+ * ```
+ *
+ * @element META
+ * @param {template} ngContent any string which can contain `{{}}` markup.
+ */
+
+/**
+ * @ngdoc directive
  * @name ngDisabled
  * @restrict A
  * @priority 100

--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -387,7 +387,7 @@ forEach(ALIASED_ATTR, function(htmlAttr, ngAttr) {
 });
 
 // ng-src, ng-srcset, ng-href are interpolated
-forEach(['src', 'srcset', 'href'], function(attrName) {
+forEach(['src', 'srcset', 'href', 'content'], function(attrName) {
   var normalized = directiveNormalize('ng-' + attrName);
   ngAttributeAliasDirectives[normalized] = function() {
     return {


### PR DESCRIPTION
The ngContent directive is useful when setting a URL in the `content` attribute of a `<meta>` tag. It ensures bots will not try to request the wrong URL.
