### PR TITLE
fix(numberFilter): properly format small number expressed with e notation

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -148,13 +148,13 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
 
   var hasExponent = false;
   if (numStr.indexOf('e') !== -1) {
+    hasExponent = true;
     var match = numStr.match(/([\d\.]+)e(-?)(\d+)/);
-    if (match && match[2] == '-' && match[3] > fractionSize + 1) {
+    if (match && match[2] == '-' && match[3] > (fractionSize || pattern.maxFrac) + 1) {
       numStr = '0';
       number = 0;
     } else {
       formatedText = numStr;
-      hasExponent = true;
     }
   }
 
@@ -170,10 +170,6 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
     // inspired by:
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
     number = +(Math.round(+(number.toString() + 'e' + fractionSize)).toString() + 'e' + -fractionSize);
-
-    if (number === 0) {
-      isNegative = false;
-    }
 
     var fraction = ('' + number).split(DECIMAL_SEP);
     var whole = fraction[0];
@@ -207,10 +203,14 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
 
     if (fractionSize && fractionSize !== "0") formatedText += decimalSep + fraction.substr(0, fractionSize);
   } else {
-
-    if (fractionSize > 0 && number > -1 && number < 1) {
+    fractionSize = isUndefined(fractionSize) ? pattern.maxFrac : fractionSize;
+    if (number > -1 && number < 1) {
       formatedText = number.toFixed(fractionSize);
     }
+  }
+
+  if (number === 0) {
+    isNegative = false;
   }
 
   parts.push(isNegative ? pattern.negPre : pattern.posPre,

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -200,6 +200,14 @@ describe('filters', function() {
       expect(number(-1e-6, 6)).toEqual('-0.000001');
       expect(number(-1e-7, 6)).toEqual('-0.000000');
     });
+
+    it('should filter exponentially small numbers when no fraction specified', function() {
+      expect(number(1e-10)).toEqual('0.000');
+      expect(number(0.0000000001)).toEqual('0.000');
+
+      expect(number(-1e-10)).toEqual('0.000');
+      expect(number(-0.0000000001)).toEqual('0.000');
+    });
   });
 
   describe('json', function() {


### PR DESCRIPTION
Fixes #10246
