### PR TITLE
Include an important sentence into the @description

### DIFF
--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -11,9 +11,8 @@
  * make the link go to the wrong URL if the user clicks it before
  * Angular has a chance to replace the `{{hash}}` markup with its
  * value. Until Angular replaces the markup the link will be broken
- * and will most likely return a 404 error.
- *
- * The `ngHref` directive solves this problem.
+ * and will most likely return a 404 error. The `ngHref` directive 
+ * solves this problem.
  *
  * The wrong way to write it:
  * ```html


### PR DESCRIPTION
Improve Docs: The inclusion of the last sentence would help define `ngHref` well.
