### PR TITLE
refactor($templateRequest): avoid double calls to $templateCache.put

### DIFF
--- a/src/ng/templateRequest.js
+++ b/src/ng/templateRequest.js
@@ -47,10 +47,8 @@ function $TemplateRequestProvider() {
 
       return $http.get(tpl, httpOptions)
         .then(function(response) {
-          var html = response.data;
           self.totalPendingRequests--;
-          $templateCache.put(tpl, html);
-          return html;
+          return response.data;
         }, handleError);
 
       function handleError() {

--- a/test/ng/templateRequestSpec.js
+++ b/test/ng/templateRequestSpec.js
@@ -16,16 +16,24 @@ describe('$templateRequest', function() {
     expect(content).toBe('<div>abc</div>');
   }));
 
-  it('should cache the request using $templateCache to prevent extra downloads',
-    inject(function($rootScope, $templateRequest, $templateCache) {
+  it('should cache the request to prevent extra downloads',
+    inject(function($rootScope, $templateRequest, $httpBackend) {
 
-    $templateCache.put('tpl.html', 'matias');
+    $httpBackend.expectGET('tpl.html').respond('matias');
 
-    var content;
-    $templateRequest('tpl.html').then(function(html) { content = html; });
+    var content = [];
+    function tplRequestCb(html) {
+      content.push(html);
+    }
 
+    $templateRequest('tpl.html').then(tplRequestCb);
+    $httpBackend.flush();
+
+    $templateRequest('tpl.html').then(tplRequestCb);
     $rootScope.$digest();
-    expect(content).toBe('matias');
+
+    expect(content[0]).toBe('matias');
+    expect(content[1]).toBe('matias');
   }));
 
   it('should throw an error when the template is not found',


### PR DESCRIPTION
Passing a $templateCache instance as part of the config (as [here](https://github.com/angular/angular.js/blob/d0351c4803c289b66468f693c93d33ab0b8d85ee/src/ng/templateRequest.js#L44) is enough to have the cache filled correctly, we don't need explicit calls to `$templateCache.put`.

We've got a test that proves that things work correctly after this change:
https://github.com/angular/angular.js/blob/d0351c4803c289b66468f693c93d33ab0b8d85ee/test/ng/templateRequestSpec.js#L19-L29 
