### PR TITLE
fix($emplateRequest): propagate rejection reason when ignoreRequestError...

### DIFF
--- a/src/ng/templateRequest.js
+++ b/src/ng/templateRequest.js
@@ -53,12 +53,12 @@ function $TemplateRequestProvider() {
           return html;
         }, handleError);
 
-      function handleError() {
+      function handleError(resp) {
         self.totalPendingRequests--;
         if (!ignoreRequestError) {
           throw $compileMinErr('tpload', 'Failed to load template: {0}', tpl);
         }
-        return $q.reject();
+        return $q.reject(resp);
       }
     }
 

--- a/test/ng/templateRequestSpec.js
+++ b/test/ng/templateRequestSpec.js
@@ -43,6 +43,20 @@ describe('$templateRequest', function() {
     }).toThrowMinErr('$compile', 'tpload', 'Failed to load template: tpl.html');
   }));
 
+  it('should not throw when the template is not found and ignoreRequestError is true',
+    inject(function($rootScope, $templateRequest, $httpBackend) {
+
+      $httpBackend.expectGET('tpl.html').respond(404);
+
+      var err;
+      $templateRequest('tpl.html', true).catch(function(reason) { err = reason; });
+
+      $rootScope.$digest();
+      $httpBackend.flush();
+
+      expect(err.status).toBe(404);
+  }));
+
   it('should not throw an error when the template is empty',
     inject(function($rootScope, $templateRequest, $httpBackend) {
 


### PR DESCRIPTION
... flag is set

We shouldn't swallow original rejection reason in the promise chain as people still might be interested in the root cause of the pb.
