### PR TITLE
docs($rootElement): 3 minor grammatical errors

### DIFF
--- a/src/ng/rootElement.js
+++ b/src/ng/rootElement.js
@@ -7,9 +7,9 @@
  * @description
  * The root element of Angular application. This is either the element where {@link
  * ng.directive:ngApp ngApp} was declared or the element passed into
- * {@link angular.bootstrap}. The element represent the root element of application. It is also the
- * location where the applications {@link auto.$injector $injector} service gets
- * published, it can be retrieved using `$rootElement.injector()`.
+ * {@link angular.bootstrap}. The element represents the root element of application. It is also the
+ * location where the application's {@link auto.$injector $injector} service gets
+ * published, and can be retrieved using `$rootElement.injector()`.
  */
 
 


### PR DESCRIPTION
The third edit (the last sentence) fixed a run-on. You could also break it up into two sentences: "It is also the location where the application's {@link auto.$injector $injector} service gets published. It can be retrieved using `$rootElement.injector()`."
