### PR TITLE
fix(ngAria): handle non-string model values

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -228,13 +228,13 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
         if (needsTabIndex) {
           needsTabIndex = false;
           return function ngAriaRadioReaction(newVal) {
-            var boolVal = newVal === attr.value;
+            var boolVal = (angular.isUndefined(newVal) ? newVal : newVal.toString()) === attr.value;
             elem.attr('aria-checked', boolVal);
             elem.attr('tabindex', 0 - !boolVal);
           };
         } else {
           return function ngAriaRadioReaction(newVal) {
-            elem.attr('aria-checked', newVal === attr.value);
+            elem.attr('aria-checked', (angular.isUndefined(newVal) ? newVal : newVal.toString()) === attr.value);
           };
         }
       }

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -98,6 +98,19 @@ describe('$aria', function() {
       expect(element.eq(1).attr('aria-checked')).toBe('true');
     });
 
+    it('should handle non-string model values', function() {
+      var element = $compile('<input type="radio" ng-model="val" value="0">' +
+          '<input type="radio" ng-model="val" value="1">')(scope);
+
+      scope.$apply("val=0");
+      expect(element.eq(0).attr('aria-checked')).toBe('true');
+      expect(element.eq(1).attr('aria-checked')).toBe('false');
+
+      scope.$apply("val=1");
+      expect(element.eq(0).attr('aria-checked')).toBe('false');
+      expect(element.eq(1).attr('aria-checked')).toBe('true');
+    });
+
     it('should attach itself to role="radio"', function() {
       scope.$apply("val = 'one'");
       compileInput('<div role="radio" ng-model="val" value="{{val}}"></div>');


### PR DESCRIPTION
Fix for #10212. Compare the string value of the model
so that aria-checked will be properly applied to
type=radio in the case where the model is a number

Closes #10212
