### PR TITLE
fix($parse): Follow Javascript context for unbound functions

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -709,7 +709,7 @@ Parser.prototype = {
     var args = argsFn.length ? [] : null;
 
     return function $parseFunctionCall(scope, locals) {
-      var context = contextGetter ? contextGetter(scope, locals) : scope;
+      var context = contextGetter ? contextGetter(scope, locals) : isDefined(contextGetter) ? undefined : scope;
       var fn = fnGetter(scope, locals, context) || noop;
 
       if (args) {

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -508,10 +508,17 @@ describe('parser', function() {
       });
 
       it('should evaluate function call from a return value', function() {
-        scope.val = 33;
-        scope.getter = function() { return function() { return this.val; }; };
+        scope.getter = function() { return function() { return 33; }; };
         expect(scope.$eval("getter()()")).toBe(33);
       });
+
+      // There is no "strict mode" in IE9
+      if (!msie || msie > 9) {
+        it('should set no context to functions returned by other functions', function() {
+          scope.getter = function() { return function() { expect(this).toBeUndefined(); }; };
+          scope.$eval("getter()()");
+        });
+      }
 
       it('should evaluate multiplication and division', function() {
         scope.taxRate =  8;


### PR DESCRIPTION
Use `undefined` as the context when a function is ounbound.
E.g. when executing `foo()()`, then `foo()` is executed using the scope as the context, the function returned by `foo()` will have an `undefined` context
