### PR TITLE
docs(ngTransclude): example markup consistency

### DIFF
--- a/src/ng/directive/ngTransclude.js
+++ b/src/ng/directive/ngTransclude.js
@@ -34,7 +34,7 @@
          }]);
        </script>
        <div ng-controller="ExampleController">
-         <input ng-model="title"><br>
+         <input ng-model="title"> <br/>
          <textarea ng-model="text"></textarea> <br/>
          <pane title="{{title}}">{{text}}</pane>
        </div>


### PR DESCRIPTION
The second of the `<br>` tags used in the example HTML is self-closed but the first is not.
