### PR TITLE
docs($location): location#hash example

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -555,7 +555,7 @@ var locationPrototype = {
    *
    *
    * ```js
-   * // given url http://example.com/some/path?foo=bar&baz=xoxo#hashValue
+   * // given url http://example.com/some/path?foo=bar&baz=xoxo#/#hashValue
    * var hash = $location.hash();
    * // => "hashValue"
    * ```

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -555,7 +555,7 @@ var locationPrototype = {
    *
    *
    * ```js
-   * // given url http://example.com/some/path?foo=bar&baz=xoxo#/#hashValue
+   * // given url http://example.com/#/some/path?foo=bar&baz=xoxo#hashValue
    * var hash = $location.hash();
    * // => "hashValue"
    * ```


### PR DESCRIPTION
The given example is slightly different then functionality. location.hash() only returns the value after a slash and a second hash.
