### PR TITLE
docs(guide/css-styling): form controls are not always input elements

### DIFF
--- a/docs/content/guide/css-styling.ngdoc
+++ b/docs/content/guide/css-styling.ngdoc
@@ -21,17 +21,17 @@ Angular sets these CSS classes. It is up to your application to provide useful s
     `{{}}` curly braces, for example. (see {@link guide/databinding databinding} guide)
 
 * `ng-invalid`, `ng-valid`
-  - **Usage:** angular applies this class to an input widget element if that element's input does
+  - **Usage:** angular applies this class to a form control widget element if that element's input does
     not pass validation. (see {@link ng.directive:input input} directive)
 
 * `ng-pristine`, `ng-dirty`
-  - **Usage:** angular {@link ng.directive:input input} directive applies `ng-pristine` class
-    to a new input widget element which did not have user interaction. Once the user interacts with
-    the input widget the class is changed to `ng-dirty`.
+  - **Usage:** angular {@link ng.directive:ngModel ngModel} directive applies `ng-pristine` class
+    to a new form control widget which did not have user interaction. Once the user interacts with
+    the form control, the class is changed to `ng-dirty`.
 
 * `ng-touched`, `ng-untouched`
   - **Usage:** angular {@link ng.directive:ngModel ngModel} directive applies `ng-untouched` class
-    to a new input widget element which has not been blurred. Once the user blurs the input widget
+    to a new form control widget which has not been blurred. Once the user blurs the form control,
     the class is changed to `ng-touched`.
 
 

--- a/docs/content/guide/css-styling.ngdoc
+++ b/docs/content/guide/css-styling.ngdoc
@@ -13,8 +13,8 @@ Angular sets these CSS classes. It is up to your application to provide useful s
     is defined. (see {@link guide/scope scope} guide for more information about scopes)
 
 * `ng-isolate-scope`
-  - **Usage:** angular applies this class to any element for which a new 
-    {@link guide/directive#isolating-the-scope-of-a-directive isolate scope} is defined. 
+  - **Usage:** angular applies this class to any element for which a new
+    {@link guide/directive#isolating-the-scope-of-a-directive isolate scope} is defined.
 
 * `ng-binding`
   - **Usage:** angular applies this class to any element that is attached to a data binding, via `ng-bind` or
@@ -28,7 +28,7 @@ Angular sets these CSS classes. It is up to your application to provide useful s
   - **Usage:** angular {@link ng.directive:input input} directive applies `ng-pristine` class
     to a new input widget element which did not have user interaction. Once the user interacts with
     the input widget the class is changed to `ng-dirty`.
-    
+
 * `ng-touched`, `ng-untouched`
   - **Usage:** angular {@link ng.directive:ngModel ngModel} directive applies `ng-untouched` class
     to a new input widget element which has not been blurred. Once the user blurs the input widget


### PR DESCRIPTION
People frequently write custom form controls using the `ngModel` directive,
this just refactors the text to be more clear that this is possible (imho).

(Feel free to go over this and decide if you like this text better or not)
