### PR TITLE
fix(orderBy): maintain order in array of objects when predicate is not provided

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -164,12 +164,12 @@ function orderByFilter($parse) {
       var t1 = typeof v1;
       var t2 = typeof v2;
       if (t1 === t2 && t1 === "object") {
-        t1 = typeof (v1 = v1.valueOf());
-        t2 = typeof (v2 = v2.valueOf());
+        t1 = typeof (v1.valueOf ? v1 = v1.valueOf() : v1);
+        t2 = typeof (v2.valueOf ? v2 = v2.valueOf() : v2);
         if (t1 === t2 && t1 === "object") {
-          t1 = typeof (v1 = v1.toString());
-          t2 = typeof (v2 = v2.toString());
-          if (t1 === t2 && v1 === v2) return 0;
+          t1 = typeof (v1.toString ? v1 = v1.toString() : v1);
+          t2 = typeof (v2.toString ? v2 = v2.toString() : v2);
+          if (t1 === t2 && v1 === v2 || t1 === "object") return 0;
         }
       }
       if (t1 === t2) {

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -163,12 +163,17 @@ function orderByFilter($parse) {
     function compare(v1, v2) {
       var t1 = typeof v1;
       var t2 = typeof v2;
-      if (t1 == t2) {
-        if (isDate(v1) && isDate(v2)) {
-          v1 = v1.valueOf();
-          v2 = v2.valueOf();
+      if (t1 === t2 && t1 === "object") {
+        t1 = typeof (v1 = v1.valueOf());
+        t2 = typeof (v2 = v2.valueOf());
+        if (t1 === t2 && t1 === "object") {
+          t1 = typeof (v1 = v1.toString());
+          t2 = typeof (v2 = v2.toString());
+          if (t1 === t2 && v1 === v2) return 0;
         }
-        if (t1 == "string") {
+      }
+      if (t1 === t2) {
+        if (t1 === "string") {
            v1 = v1.toLowerCase();
            v2 = v2.toLowerCase();
         }

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -115,6 +115,16 @@ describe('Filter: orderBy', function() {
       ];
       expect(orderBy(array)).toEqualData(array);
     });
+
+
+    it('should not reverse array of objects with null prototype and no predicate', function() {
+      var array = [2,1,4,3].map(function(id) {
+        var obj = Object.create(null);
+        obj.id = id;
+        return obj;
+      });
+      expect(orderBy(array)).toEqualData(array);
+    });
   });
 
 
@@ -230,6 +240,16 @@ describe('Filter: orderBy', function() {
         { id: 4 },
         { id: 3 }
       ];
+      expect(orderBy(array)).toEqualData(array);
+    });
+
+
+    it('should not reverse array of objects with null prototype and no predicate', function() {
+      var array = [2,1,4,3].map(function(id) {
+        var obj = Object.create(null);
+        obj.id = id;
+        return obj;
+      });
       expect(orderBy(array)).toEqualData(array);
     });
   });

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -104,6 +104,17 @@ describe('Filter: orderBy', function() {
         return orderBy([{"Tip %": .15}, {"Tip %": .25}, {"Tip %": .40}], '"Tip %\'');
       }).toThrow();
     });
+
+
+    it('should not reverse array of objects with no predicate', function() {
+      var array = [
+        { id: 2 },
+        { id: 1 },
+        { id: 4 },
+        { id: 3 }
+      ];
+      expect(orderBy(array)).toEqualData(array);
+    });
   });
 
 
@@ -209,6 +220,17 @@ describe('Filter: orderBy', function() {
       expect(function() {
         return orderBy([{"Tip %": .15}, {"Tip %": .25}, {"Tip %": .40}], '"Tip %\'');
       }).toThrow();
+    });
+
+
+    it('should not reverse array of objects with no predicate', function() {
+      var array = [
+        { id: 2 },
+        { id: 1 },
+        { id: 4 },
+        { id: 3 }
+      ];
+      expect(orderBy(array)).toEqualData(array);
     });
   });
 });


### PR DESCRIPTION
In ES262, there are two properties which are used to get a primitive value from an Object:
- valueOf() -- a method which returns a primitive value represented by the Object
- toString() -- a method which returns a string value representing the Object.

When comparing objects using relational operators, the abstract operation ToPrimitive(O, TypeHint) is used,
which will use these methods to retrieve a value.

This CL emulates the behaviour of ToPrimitive(), and ensures that no ordering occurs if the retrieved value
is identical.

This behaviour was previously used for Date objects, however it can be safely made generic as it applies to
all objects.

Closes #9566
Closes #9747
