### PR TITLE
Week formatter fix in date filter (Comply to ISO8601)

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -273,7 +273,8 @@ function getFirstThursdayOfYear(year) {
 function getThursdayThisWeek(datetime) {
     return new Date(datetime.getFullYear(), datetime.getMonth(),
       // 4 = index of Thursday
-      datetime.getDate() + (4 - datetime.getDay()));
+      //ISO8601 mandates that a week starts on Monday. Making Sunday 7 instead of 0.
+      datetime.getDate() + 4 - (datetime.getDay() || 7));
 }
 
 function weekGetter(size) {

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -235,7 +235,7 @@ describe('filters', function() {
     var noon =     new angular.mock.TzDate(+5, '2010-09-03T17:05:08.012Z'); //12pm
     var midnight = new angular.mock.TzDate(+5, '2010-09-03T05:05:08.123Z'); //12am
     var earlyDate = new angular.mock.TzDate(+5, '0001-09-03T05:05:08.000Z');
-    var secondWeek = new angular.mock.TzDate(+5, '2013-01-11T12:00:00.000Z'); //Friday Jan 11, 2012
+    var secondWeek = new angular.mock.TzDate(+5, '2013-01-13T12:00:00.000Z'); //Sunday Jan 13, 2013
     var date;
 
     beforeEach(inject(function($filter) {


### PR DESCRIPTION
ISO8601 mandates that a week starts on a Monday, and ends on a Sunday.

The test case was on a Friday, and did not show that W3 was returned instead of W2.
http://plnkr.co/edit/897MdGDME67aIQmLpzqZ
