### PR TITLE
using $window.angular so that we can put angular in no-conflict mode

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -788,8 +788,8 @@ function $LocationProvider() {
    * @param {string=} oldState History state object that was before it was changed.
    */
 
-  this.$get = ['$rootScope', '$browser', '$sniffer', '$rootElement',
-      function($rootScope, $browser, $sniffer, $rootElement) {
+  this.$get = ['$rootScope', '$browser', '$sniffer', '$rootElement', '$window',
+      function($rootScope, $browser, $sniffer, $rootElement, $window) {
     var $location,
         LocationMode,
         baseHref = $browser.baseHref(), // if base[href] is undefined, it defaults to ''
@@ -871,7 +871,7 @@ function $LocationProvider() {
           if ($location.absUrl() != $browser.url()) {
             $rootScope.$apply();
             // hack to work around FF6 bug 684208 when scenario runner clicks on links
-            window.angular['ff-684208-preventDefault'] = true;
+            $window.angular['ff-684208-preventDefault'] = true;
           }
         }
       }


### PR DESCRIPTION
we need to support multiple instances of angular on our page to support an enterprise rollout, where our instance is effectively 3rd party js. To do this we end up setting `$window.angular` to our instance of angular, but `window.angular` is undefined or their instance of angular if they have one. This will throw for us if they don't have their own instance of angular (`window.angular` is undefined.)  

In case you're wondering... we are also hijacking `$window` so that when we set `$window.angular` it doesn't set `window.angular`

``` javascript
.service('$window', function(){
            // angular isn't actually wrapping window - so if you set something it is available on window
            // this probably has side effects :(
            var $window = Object.create(window);

            // angular has some references to itself through window (search for $window.angular.callbacks)
            // we want it to use ours not the "real" one if there is another one later...
            $window.angular = angular;

            // this is sacrificing JSONP with $http but that is ok with us
            return $window;
        })
```
