### PR TITLE
fix(filter): throw error if not used with an array

### DIFF
--- a/docs/content/error/filter/notarray.ngdoc
+++ b/docs/content/error/filter/notarray.ngdoc
@@ -1,0 +1,8 @@
+@ngdoc error
+@name filter:notarray
+@fullName Not an array
+@description
+
+This error occurs when {@link ng.filter filter} is not used with an array.
+Filter must be used with an array so a subset of items can be returned.
+The array can be initialized asynchronously so null or undefined won't throw this error.

--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -117,7 +117,13 @@
  */
 function filterFilter() {
   return function(array, expression, comparator) {
-    if (!isArray(array)) return array;
+    if (!isArray(array)) {
+      if (array == null) {
+        return array;
+      } else {
+        throw minErr('filter')('notarray', 'Expected array but received: {0}', array);
+      }
+    }
 
     var predicateFn;
     var matchAgainstAnyProp;

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -195,7 +195,7 @@ describe('Filter: filter', function() {
     expect(filter(items, expr, true).length).toBe(1);
     expect(filter(items, expr, true)[0]).toBe(items[0]);
 
-    // Inherited function proprties
+    // Inherited function properties
     function Item(text) {
         this.text = text;
     }
@@ -320,6 +320,35 @@ describe('Filter: filter', function() {
     expect(filter(items, 'll')[0]).toBe(items[0]);
 
     delete Object.prototype.someProp;
+  });
+
+
+  it('should throw an error when is not used with an array', function() {
+    var item = {'not': 'array'};
+    expect(function() { filter(item, {}); }).
+      toThrowMinErr('filter', 'notarray', 'Expected array but received: {"not":"array"}');
+
+    item = Object.create(null);
+    expect(function() { filter(item, {}); }).
+      toThrowMinErr('filter', 'notarray', 'Expected array but received: {}');
+
+    item = {
+      toString: null,
+      valueOf: null
+    };
+    expect(function() { filter(item, {}); }).
+      toThrowMinErr('filter', 'notarray', 'Expected array but received: {"toString":null,"valueOf":null}');
+  });
+
+
+  it('should return undefined when the array is undefined', function() {
+    expect(filter(undefined, {})).toBeUndefined();
+  });
+
+
+  it('should return null when the value of the array is null', function() {
+    var item = null;
+    expect(filter(item, {})).toBe(null);
   });
 
 

--- a/test/ngScenario/dslSpec.js
+++ b/test/ngScenario/dslSpec.js
@@ -624,7 +624,7 @@ describe("angular.scenario.dsl", function() {
       });
 
       it('should match bindings by substring match', function() {
-        compile('<pre ng-bind="foo.bar | filter"></pre>', 'binding value');
+        compile('<pre ng-bind="foo.bar | lowercase"></pre>', 'binding value');
         $root.dsl.binding('foo . bar');
         expect($root.futureResult).toEqual('binding value');
       });


### PR DESCRIPTION
Throw error if filter is not used with an array.

Closes #9992

BREAKING CHANGE: Previously, the filter was not applied if used with a non array.
Now, it throws an error.
