### PR TITLE
fix($parse): ensuring shared sub expressions do not use full expression text

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -830,14 +830,14 @@ function isPossiblyDangerousMemberName(name) {
  * - http://jsperf.com/angularjs-parse-getter/4
  * - http://jsperf.com/path-evaluation-simplified/7
  */
-function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, expensiveChecks) {
+function cspSafeGetterFn(key0, key1, key2, key3, key4, path, fullExp, expensiveChecks) {
   ensureSafeMemberName(key0, fullExp);
   ensureSafeMemberName(key1, fullExp);
   ensureSafeMemberName(key2, fullExp);
   ensureSafeMemberName(key3, fullExp);
   ensureSafeMemberName(key4, fullExp);
   var eso = function(o) {
-    return ensureSafeObject(o, fullExp);
+    return ensureSafeObject(o, path);
   };
   var eso0 = (expensiveChecks || isPossiblyDangerousMemberName(key0)) ? eso : identity;
   var eso1 = (expensiveChecks || isPossiblyDangerousMemberName(key1)) ? eso : identity;
@@ -871,9 +871,9 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, expensiveChecks)
   };
 }
 
-function getterFnWithEnsureSafeObject(fn, fullExpression) {
+function getterFnWithEnsureSafeObject(fn, path) {
   return function(s, l) {
-    return fn(s, l, ensureSafeObject, fullExpression);
+    return fn(s, l, ensureSafeObject, path);
   };
 }
 
@@ -890,13 +890,13 @@ function getterFn(path, options, fullExp) {
   // http://jsperf.com/angularjs-parse-getter/6
   if (options.csp) {
     if (pathKeysLength < 6) {
-      fn = cspSafeGetterFn(pathKeys[0], pathKeys[1], pathKeys[2], pathKeys[3], pathKeys[4], fullExp, expensiveChecks);
+      fn = cspSafeGetterFn(pathKeys[0], pathKeys[1], pathKeys[2], pathKeys[3], pathKeys[4], path, fullExp, expensiveChecks);
     } else {
       fn = function cspSafeGetter(scope, locals) {
         var i = 0, val;
         do {
           val = cspSafeGetterFn(pathKeys[i++], pathKeys[i++], pathKeys[i++], pathKeys[i++],
-                                pathKeys[i++], fullExp, expensiveChecks)(scope, locals);
+                                pathKeys[i++], path, fullExp, expensiveChecks)(scope, locals);
 
           locals = undefined; // clear after first iteration
           scope = val;
@@ -907,7 +907,7 @@ function getterFn(path, options, fullExp) {
   } else {
     var code = '';
     if (expensiveChecks) {
-      code += 's = eso(s, fe);\nl = eso(l, fe);\n';
+      code += 's = eso(s, p);\nl = eso(l, p);\n';
     }
     var needsEnsureSafeObject = expensiveChecks;
     forEach(pathKeys, function(key, index) {
@@ -918,7 +918,7 @@ function getterFn(path, options, fullExp) {
                       // but if we are first then we check locals first, and if so read it first
                       : '((l&&l.hasOwnProperty("' + key + '"))?l:s)') + '.' + key;
       if (expensiveChecks || isPossiblyDangerousMemberName(key)) {
-        lookupJs = 'eso(' + lookupJs + ', fe)';
+        lookupJs = 'eso(' + lookupJs + ', p)';
         needsEnsureSafeObject = true;
       }
       code += 'if(s == null) return undefined;\n' +
@@ -927,11 +927,11 @@ function getterFn(path, options, fullExp) {
     code += 'return s;';
 
     /* jshint -W054 */
-    var evaledFnGetter = new Function('s', 'l', 'eso', 'fe', code); // s=scope, l=locals, eso=ensureSafeObject
+    var evaledFnGetter = new Function('s', 'l', 'eso', 'p', code); // s=scope, l=locals, eso=ensureSafeObject, p=path
     /* jshint +W054 */
     evaledFnGetter.toString = valueFn(code);
     if (needsEnsureSafeObject) {
-      evaledFnGetter = getterFnWithEnsureSafeObject(evaledFnGetter, fullExp);
+      evaledFnGetter = getterFnWithEnsureSafeObject(evaledFnGetter, path);
     }
     fn = evaledFnGetter;
   }

--- a/test/ng/directive/ngEventDirsSpec.js
+++ b/test/ng/directive/ngEventDirsSpec.js
@@ -105,7 +105,7 @@ describe('event directives', function() {
         element.triggerHandler('click');
       }).toThrowMinErr(
               '$parse', 'isecdom', 'Referencing DOM nodes in Angular expressions is disallowed! ' +
-              'Expression: e = $event.target');
+              'Expression: $event.target');
     }));
   });
 

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -742,7 +742,7 @@ describe('parser', function() {
               scope.$eval('{}.toString.constructor');
             }).toThrowMinErr(
                     '$parse', 'isecfn', 'Referencing Function in Angular expressions is disallowed! ' +
-                    'Expression: {}.toString.constructor');
+                    'Expression: toString.constructor');
 
           });
 
@@ -761,7 +761,7 @@ describe('parser', function() {
               scope.$eval('{}.toString.constructor("alert(1)")');
             }).toThrowMinErr(
                     '$parse', 'isecfn', 'Referencing Function in Angular expressions is disallowed! ' +
-                    'Expression: {}.toString.constructor("alert(1)")');
+                    'Expression: constructor');
 
           });
 
@@ -1141,6 +1141,20 @@ describe('parser', function() {
               ')()' +
               '');
           }).toThrow();
+        });
+
+        it('should not output another expression when throwing from shared sub expressions', function() {
+          expect(function() { scope.$eval('1 + {}.toString.constructor'); })
+            .toThrowMinErr(
+              '$parse', 'isecfn', 'Referencing Function in Angular expressions is disallowed! ' +
+              'Expression: toString.constructor'
+            );
+
+          expect(function() { scope.$eval('2 + {}.toString.constructor'); })
+            .toThrowMinErr(
+              '$parse', 'isecfn', 'Referencing Function in Angular expressions is disallowed! ' +
+              'Expression: toString.constructor'
+            );
         });
       });
 


### PR DESCRIPTION
This depends on #10351 otherwise some of the changed error messages would be even shorter (tests will probably fail for now showing why...).

I guess this is debatable but I don't think anything shared (just `getterFn`s really...) should reference the `fullExp` which created it when it might be used by other expressions. For example (without this patch):

```
$rootScope.$eval('foo.constructor + 123')  => 123
$rootScope.$eval('foo.constructor.foo()', {foo: Function}) => 
   [$parse:isecfn] Referencing Function in Angular expressions is disallowed! Expression: foo.constructor + 123
```

This patch changes it so the shared `getterFn` only references the shared path itself. While seeing the full expression would be nicer at least for now it won't be wrong.

This was caused by e676d642f5feb8d3ba88944634afb479ba525c36 and also exists in 1.2 from the same security fix.
