### PR TITLE
refactor($http): avoid re-creating execHeaders function

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -823,6 +823,23 @@ function $HttpProvider() {
           : $q.reject(resp);
       }
 
+      function executeHeaderFns(headers) {
+        var headerContent, processedHeaders = {};
+
+        forEach(headers, function(headerFn, header) {
+          if (isFunction(headerFn)) {
+            headerContent = headerFn();
+            if (headerContent != null) {
+              processedHeaders[header] = headerContent;
+            }
+          } else {
+            processedHeaders[header] = headerFn;
+          }
+        });
+
+        return processedHeaders;
+      }
+
       function mergeHeaders(config) {
         var defHeaders = defaults.headers,
             reqHeaders = extend({}, config.headers),
@@ -845,23 +862,7 @@ function $HttpProvider() {
         }
 
         // execute if header value is a function for merged headers
-        execHeaders(reqHeaders);
-        return reqHeaders;
-
-        function execHeaders(headers) {
-          var headerContent;
-
-          forEach(headers, function(headerFn, header) {
-            if (isFunction(headerFn)) {
-              headerContent = headerFn();
-              if (headerContent != null) {
-                headers[header] = headerContent;
-              } else {
-                delete headers[header];
-              }
-            }
-          });
-        }
+        return executeHeaderFns(reqHeaders);
       }
     }
 


### PR DESCRIPTION
The execHeaders function was being re-defined inside mergeHeaders
function. Additionally it was mutating its arguments thus making code 
harder to read / reason about.

There are some other problems with this function (inconsistent treatment for null / undefined headers coming from an object value as compared to being result of a function execution) but let's tackle those one by one. 
