### PR TITLE
refactor($http): avoid using closure vars in serverRequest fn

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -738,23 +738,22 @@ function $HttpProvider() {
 </example>
      */
     function $http(requestConfig) {
-      var config = {
-        method: 'get',
-        transformRequest: defaults.transformRequest,
-        transformResponse: defaults.transformResponse
-      };
-      var headers = mergeHeaders(requestConfig);
 
       if (!angular.isObject(requestConfig)) {
         throw minErr('$http')('badreq', 'Http request configuration must be an object.  Received: {0}', requestConfig);
       }
 
-      extend(config, requestConfig);
-      config.headers = headers;
+      var config = extend({
+        method: 'get',
+        transformRequest: defaults.transformRequest,
+        transformResponse: defaults.transformResponse
+      }, requestConfig);
+
+      config.headers = mergeHeaders(requestConfig);
       config.method = uppercase(config.method);
 
       var serverRequest = function(config) {
-        headers = config.headers;
+        var headers = config.headers;
         var reqData = transformData(config.data, headersGetter(headers), config.transformRequest);
 
         // strip content-type if data is undefined


### PR DESCRIPTION
The `serverRequest` function was accessing the `headers` var defined in a closure and "reusing" it as a local variable thus making the closure scope bigger and using the same name for 2 different purposes. Hopefully this version of the code is easier to follow.
