### PR TITLE
docs(ngView): remove duplicate CSS

### DIFF
--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -79,7 +79,6 @@ ngRouteModule.directive('ngView', ngViewFillContentFactory);
         .view-animate-container {
           position:relative;
           height:100px!important;
-          position:relative;
           background:white;
           border:1px solid black;
           height:40px;


### PR DESCRIPTION
The CSS had `position: relative` twice. Now it only has it once.
