### PR TITLE
refactor($browser): wrap Get(history.state) in try/catch

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -235,10 +235,22 @@ function Browser(window, document, $log, $sniffer) {
 
   // This variable should be used *only* inside the cacheState function.
   var lastCachedState = null;
+  function getCurrentState() {
+    try {
+      var state = history.state;
+      if (state === void 0) {
+        state = null;
+      }
+      return state;
+    } catch (e) {
+      // MSIE can reportedly throw when there is no state (UNCONFIRMED).
+      return null;
+    }
+  }
+
   function cacheState() {
     // This should be the only place in $browser where `history.state` is read.
-    cachedState = window.history.state;
-    cachedState = isUndefined(cachedState) ? null : cachedState;
+    cachedState = getCurrentState();
 
     // Prevent callbacks fo fire twice if both hashchange & popstate were fired.
     if (equals(cachedState, lastCachedState)) {


### PR DESCRIPTION
Reportedly, MSIE can throw under certain conditions when fetching this attribute.

Will confirm before landing.

Fixes #10367
