### PR TITLE
style(testability): throw a more informative error when getting testability

### DIFF
--- a/docs/content/error/ng/test.ngdoc
+++ b/docs/content/error/ng/test.ngdoc
@@ -1,0 +1,9 @@
+@ngdoc error
+@name ng:test
+@fullName Testability Not Found
+@description
+
+Angular's testability helper, getTestability, requires a root element to be
+passed in. This helps differentiate between different Angular apps on the same
+page. This error is thrown when no injector is found for root element. It is
+often because the root element is outside of the ng-app.

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1428,7 +1428,12 @@ function reloadWithDebugInfo() {
  * @param {DOMElement} element DOM element which is the root of angular application.
  */
 function getTestability(rootElement) {
-  return angular.element(rootElement).injector().get('$$testability');
+  var injector = angular.element(rootElement).injector();
+  if (!injector) {
+    throw ngMinErr('test',
+      'no injector found for element argument to getTestability');
+  }
+  return injector.get('$$testability');
 }
 
 var SNAKE_CASE_REGEXP = /[A-Z]/g;


### PR DESCRIPTION
The angular.getTestability method requires an element parameter to determine
which Angular application to use. Currently, if the element provided is
undefined or outside of an Angular app, the error message is 'cannot read
property get of undefined'. Improving to a more relevant error message.
