### PR TITLE
fix($parse): making unary +/- operators consistent

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -642,9 +642,7 @@ Parser.prototype = {
 
   unary: function() {
     var token;
-    if (this.expect('+')) {
-      return this.primary();
-    } else if ((token = this.expect('-'))) {
+    if ((token = this.expect('-', '+'))) {
       return this.binaryFn(Parser.ZERO, token.text, this.unary());
     } else if ((token = this.expect('!'))) {
       return this.unaryFn(token.text, this.unary());

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -247,7 +247,7 @@ describe('parser', function() {
       }));
 
       it('should parse expressions', function() {
-        /*jshint -W006, -W007 */
+        /*jshint -W006, -W007, -W018 */
         expect(scope.$eval("-1")).toEqual(-1);
         expect(scope.$eval("1 + 2.5")).toEqual(3.5);
         expect(scope.$eval("1 + -2.5")).toEqual(-1.5);
@@ -255,6 +255,12 @@ describe('parser', function() {
         expect(scope.$eval("0--1+1.5")).toEqual(0 - -1 + 1.5);
         expect(scope.$eval("-0--1++2*-3/-4")).toEqual(-0 - -1 + +2 * -3 / -4);
         expect(scope.$eval("1/2*3")).toEqual(1 / 2 * 3);
+        expect(scope.$eval("-+0")).toBe(-+0);
+        expect(scope.$eval("-!0")).toBe(-!0);
+        expect(scope.$eval("+!0")).toBe(+!0);
+        expect(scope.$eval("+-+-+-0")).toBe(+-+-+-0);
+        expect(scope.$eval("+(+1)")).toEqual(+(+1));
+        expect(scope.$eval("!+!-+-+!-!!!!0")).toBe(!+!-+-+!-!!!!0);
       });
 
       it('should parse comparison', function() {
@@ -659,6 +665,11 @@ describe('parser', function() {
       it('should evaluate sum with undefined', function() {
         expect(scope.$eval('1+undefined')).toEqual(1);
         expect(scope.$eval('undefined+1')).toEqual(1);
+      });
+
+      it('should evaluate unary negate/add of undefined', function() {
+        expect(scope.$eval('+undefined')).toEqual(0);
+        expect(scope.$eval('-undefined')).toEqual(0);
       });
 
       it('should throw exception on non-closed bracket', function() {


### PR DESCRIPTION
Fixes #10371
- makes `+undefined` evaluate as a numeric operator the same as `-undefined`
- allows `+` to be followed by another unary operator like `-` already does
- no longer parses `--i` or `---------i` which were previously parsed as a bunch of negates

That last one is a breaking change but I assume not many people use such things. If anyone it is probably people using `--i` and then spending far too much time trying to figure out why the decrement operator isn't working right...

I'm half tempted to do the opposite change to be more restrictive (make `-` more like `+`) but that would be a bigger breaking change.

EDIT: this has been changed to no longer be breaking and now only makes unary `+` the same as unary `-`. So everything above is out of date...
