### PR TITLE
fix(filterFilter): filter deep object by string

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -169,17 +169,18 @@ function createPredicateFn(expression, comparator, matchAgainstAnyProp) {
   return predicateFn;
 }
 
-function deepCompare(actual, expected, comparator, matchAgainstAnyProp) {
+function deepCompare(actual, expected, comparator, matchAgainstAnyProp, temporaryAnyProp) {
   var actualType = typeof actual;
   var expectedType = typeof expected;
+  var nextMatchAgainstAnyProp = matchAgainstAnyProp && !temporaryAnyProp;
 
   if ((expectedType === 'string') && (expected.charAt(0) === '!')) {
-    return !deepCompare(actual, expected.substring(1), comparator, matchAgainstAnyProp);
+    return !deepCompare(actual, expected.substring(1), comparator, nextMatchAgainstAnyProp);
   } else if (actualType === 'array') {
     // In case `actual` is an array, consider it a match
     // if ANY of it's items matches `expected`
     return actual.some(function(item) {
-      return deepCompare(item, expected, comparator, matchAgainstAnyProp);
+      return deepCompare(item, expected, comparator, nextMatchAgainstAnyProp);
     });
   }
 
@@ -188,7 +189,7 @@ function deepCompare(actual, expected, comparator, matchAgainstAnyProp) {
       var key;
       if (matchAgainstAnyProp) {
         for (key in actual) {
-          if ((key.charAt(0) !== '$') && deepCompare(actual[key], expected, comparator)) {
+          if ((key.charAt(0) !== '$') && deepCompare(actual[key], expected, comparator, nextMatchAgainstAnyProp)) {
             return true;
           }
         }
@@ -202,7 +203,7 @@ function deepCompare(actual, expected, comparator, matchAgainstAnyProp) {
 
           var keyIsDollar = key === '$';
           var actualVal = keyIsDollar ? actual : actual[key];
-          if (!deepCompare(actualVal, expectedVal, comparator, keyIsDollar)) {
+          if (!deepCompare(actualVal, expectedVal, comparator, keyIsDollar, keyIsDollar)) {
             return false;
           }
         }

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -28,6 +28,13 @@ describe('Filter: filter', function() {
     expect(filter(items, "I don't exist").length).toBe(0);
   });
 
+  it('should filter deep object by string', function() {
+    var items = [{person: {name: 'Annet', email: 'annet@example.com'}},
+                 {person: {name: 'Billy', email: 'me@billy.com'}},
+                 {person: {name: 'Joan', email: {home: 'me@joan.com', work: 'joan@example.net'}}}];
+    expect(filter(items, 'me@joan').length).toBe(1);
+    expect(filter(items, 'joan@example').length).toBe(1);
+  });
 
   it('should not read $ properties', function() {
     expect(''.charAt(0)).toBe(''); // assumption

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -143,14 +143,14 @@ describe('Filter: filter', function() {
   });
 
 
-  it('should respect the depth level of a "$" property', function() {
+  it('should match the same level and deeper of a "$" property', function() {
     var items = [{person: {name: 'Annet', email: 'annet@example.com'}},
                  {person: {name: 'Billy', email: 'me@billy.com'}},
                  {person: {name: 'Joan', email: {home: 'me@joan.com', work: 'joan@example.net'}}}];
     var expr = {person: {$: 'net'}};
 
-    expect(filter(items, expr).length).toBe(1);
-    expect(filter(items, expr)).toEqual([items[0]]);
+    expect(filter(items, expr).length).toBe(2);
+    expect(filter(items, expr)).toEqual([items[0], items[2]]);
   });
 
 


### PR DESCRIPTION
Before #9757 and 1.3.6, filterFilter with string expression used to check object's properties recursively. Now it checks only object's top level properties, which is a breaking change to existing applications.

Here is a test that this pull request makes passable.

``` js
  it('should filter deep object by string', function() {
    var items = [{person: {name: 'Annet', email: 'annet@example.com'}},
                 {person: {name: 'Billy', email: 'me@billy.com'}},
                 {person: {name: 'Joan', email: {home: 'me@joan.com', work: 'joan@example.net'}}}];
    expect(filter(items, 'me@joan').length).toBe(1);
    expect(filter(items, 'joan@example').length).toBe(1);
  });
```
