### PR TITLE
fix(orderBy): gracefully compare null values

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -161,6 +161,7 @@ function orderByFilter($parse) {
           : comp;
     }
     function compare(v1, v2) {
+      if (v1 === null && v2 === null) return 0;
       var t1 = typeof v1;
       var t2 = typeof v2;
       // Prepare values for Abstract Relational Comparison

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -175,6 +175,7 @@ describe('Filter: orderBy', function() {
       expect(orderBy([{a:15, b:1}, {a:2, b:1}], ['a', 'b'])).toEqualData([{a:2, b:1}, {a:15, b:1}]);
       expect(orderBy([{a:15, b:1}, {a:2, b:1}], ['b', 'a'])).toEqualData([{a:2, b:1}, {a:15, b:1}]);
       expect(orderBy([{a:15, b:1}, {a:2, b:1}], ['+b', '-a'])).toEqualData([{a:15, b:1}, {a:2, b:1}]);
+      expect(orderBy([{a:15, b:null}, {a:2, b:null}], ['-b'])).toEqualData([{a:15, b:null}, {a:2, b:null}]);
     });
 
 


### PR DESCRIPTION
v1.3.6 introduces a bug in the compare function.
When values of the used predicate are null valueOf is called on null.
