### PR TITLE
perf($compile): only re-$interpolate attribute values at link time if changed since compile

### DIFF
--- a/benchmarks/largetable-bp/main.html
+++ b/benchmarks/largetable-bp/main.html
@@ -14,6 +14,7 @@
       <div>ngBind: <input type="radio" ng-model="benchmarkType" value="ngBind"></div>
       <div>ngBindOnce: <input type="radio" ng-model="benchmarkType" value="ngBindOnce"></div>
       <div>interpolation: <input type="radio" ng-model="benchmarkType" value="interpolation"></div>
+      <div>attribute interpolation: <input type="radio" ng-model="benchmarkType" value="interpolationAttr"></div>
       <div>ngBind + fnInvocation: <input type="radio" ng-model="benchmarkType" value="ngBindFn"></div>
       <div>interpolation + fnInvocation: <input type="radio" ng-model="benchmarkType" value="interpolationFn"></div>
       <div>ngBind + filter: <input type="radio" ng-model="benchmarkType" value="ngBindFilter"></div>
@@ -44,6 +45,12 @@
           <h2>baseline interpolation</h2>
           <div ng-repeat="row in data">
             <span ng-repeat="column in row">{{column.i}}:{{column.j}}|</span>
+          </div>
+        </div>
+        <div ng-switch-when="interpolationAttr">
+          <h2>attribute interpolation</h2>
+          <div ng-repeat="row in data">
+            <span ng-repeat="column in row" i="{{column.i}}" j="{{column.j}}">i,j attrs</span>
           </div>
         </div>
         <div ng-switch-when="ngBindFn">


### PR DESCRIPTION
This makes the added benchmark case
- create step ~3x faster
- create step consumes half the memory (and half the garbage collected on destroy step)
- GC times in all 3 steps are about 30-50% less
