### PR TITLE
perf(ngModel,form): avoid invoking $interpolate for empty/unset values

### DIFF
--- a/benchmarks/largetable-bp/main.html
+++ b/benchmarks/largetable-bp/main.html
@@ -19,6 +19,7 @@
       <div>interpolation + fnInvocation: <input type="radio" ng-model="benchmarkType" value="interpolationFn"></div>
       <div>ngBind + filter: <input type="radio" ng-model="benchmarkType" value="ngBindFilter"></div>
       <div>interpolation + filter: <input type="radio" ng-model="benchmarkType" value="interpolationFilter"></div>
+      <div>ngModel: <input type="radio" ng-model="benchmarkType" value="ngModel"></div>
 
       <ng-switch on="benchmarkType">
         <baseline-binding-table ng-switch-when="baselineBinding">
@@ -75,6 +76,13 @@
           <h2>interpolation with filter</h2>
           <div ng-repeat="row in data">
             <span ng-repeat="column in row">{{column.i | noop}}:{{column.j | noop}}|</span>
+          </div>
+        </div>
+        <div ng-switch-when="ngModel">
+          <h2>ngModels</h2>
+          <div ng-repeat="row in data">
+            <input type="text" ng-model="row.i" name="constName" />
+            <input type="text" ng-model="row.j" />
           </div>
         </div>
       </ng-switch>

--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -125,6 +125,28 @@ describe('$interpolate', function() {
 
       expect($rootScope.$countWatchers()).toBe(0);
     }));
+
+    it('should stop watching strings with no expressions after first execution',
+      inject(function($interpolate, $rootScope) {
+        var spy = jasmine.createSpy();
+        $rootScope.$watch($interpolate('foo'), spy);
+        $rootScope.$digest();
+        expect(($rootScope.$$watchers || []).length).toBe(0);
+        expect(spy).toHaveBeenCalledWith('foo', 'foo', $rootScope);
+        expect(spy.calls.length).toBe(1);
+      })
+    );
+
+    it('should stop watching strings with only constant expressions after first execution',
+      inject(function($interpolate, $rootScope) {
+        var spy = jasmine.createSpy();
+        $rootScope.$watch($interpolate('foo {{42}}'), spy);
+        $rootScope.$digest();
+        expect(($rootScope.$$watchers || []).length).toBe(0);
+        expect(spy).toHaveBeenCalledWith('foo 42', 'foo 42', $rootScope);
+        expect(spy.calls.length).toBe(1);
+      })
+    );
   });
 
   describe('interpolation escaping', function() {
@@ -135,6 +157,7 @@ describe('$interpolate', function() {
 
 
     it('should support escaping interpolation signs', inject(function($interpolate) {
+      expect($interpolate('\\{\\{')(obj)).toBe('{{');
       expect($interpolate('{{foo}} \\{\\{bar\\}\\}')(obj)).toBe('Hello {{bar}}');
       expect($interpolate('\\{\\{foo\\}\\} {{bar}}')(obj)).toBe('{{foo}} World');
     }));


### PR DESCRIPTION
This reduces GC (KB) by ~10% in the added benchmark create step.

I'm tempted to add a helper such as `$interpolate.$$eval(exp, scope)` to avoid the ugly duplication. A helper could also be used for spots such as https://github.com/angular/angular.js/blob/master/src/ng/compile.js#L1922 (the helper can pass `mustHaveExpression=true` to avoid creating the interp result function even though it has no interpolation...). Worth it?
