### PR TITLE
fix($rootScope): ignore properties beginning with `$` in $watchCollection object mode

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -599,6 +599,12 @@ function $RootScopeProvider() {
             // copy the items to oldValue and look for changes.
             newLength = 0;
             for (key in newValue) {
+              // Emulate angular.equals(), which ignores keys beginning with
+              // a single dollar sign.
+              if (key.charAt(0) === '$') {
+                continue;
+              }
+
               if (newValue.hasOwnProperty(key)) {
                 newLength++;
                 newItem = newValue[key];

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -764,6 +764,17 @@ describe('Scope', function() {
           expect(log.empty()).toEqual([{newVal: {b: {}, c: 'B'}, oldVal: {a: [], b: {}, c: 'B'}}]);
         });
 
+
+        it('should ignore properties beginning with $', function() {
+          $rootScope.obj = {};
+          $rootScope.$digest();
+          expect(log.empty()).toEqual([{newVal: {}, oldVal: {}, identical: true}]);
+          $rootScope.obj = {$private: "private"};
+          $rootScope.$digest();
+          expect(log.empty()).toEqual([]);
+        });
+
+
         it('should not infinitely digest when current value is NaN', function() {
           $rootScope.obj = {a: NaN};
           expect(function() {


### PR DESCRIPTION
I'm not too keen on this, I think we want to fix angular.equals() to only ignore double-dollar-signs $$, which would make a lot more sense to do in $watchCollection. Up to you @petebacondarwin.

---

Make behaviour of $watchCollection (for non-ArrayLike objects) consistent with angular.equals, used by $watch when objectEquality flag is set to true.

BREAKING CHANGE:

Previously, enumerable properties beginning with `$` would be taken into consideration. Now, they are simply ignored.

Closes #10426
