### PR TITLE
WIP: perf(ngInclude): cache linkFns for each template

### DIFF
--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -180,14 +180,15 @@
  */
 var ngIncludeDirective = ['$templateRequest', '$anchorScroll', '$animate', '$sce', '$compile',
                   function($templateRequest,   $anchorScroll,   $animate,   $sce, $compile) {
+
+  var linkFns = {};
+
   return {
     restrict: 'ECA',
     priority: 400,
     terminal: true,
     transclude: 'element',
-    controller: function() {
-      this.linkFns = {};
-    },
+    controller: noop,
     compile: function(element, attr) {
       var srcExp = attr.ngInclude || attr.src,
           onloadExp = attr.onload || '',
@@ -234,7 +235,7 @@ var ngIncludeDirective = ['$templateRequest', '$anchorScroll', '$animate', '$sce
               ctrl.template = response;
 
               // Compile and cache the template
-              ctrl.linkFn = ctrl.linkFns[src] = ctrl.linkFns[src] || $compile(jqLiteBuildFragment(ctrl.template, document).childNodes);
+              ctrl.linkFn = linkFns[src] = linkFns[src] || $compile(jqLiteBuildFragment(ctrl.template, document).childNodes);
 
               // Note: This will also link all children of ng-include that were contained in the original
               // html. If that content contains controllers, ... they could pollute/change the scope.

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -233,6 +233,37 @@ describe('ngInclude', function() {
     dealoc($rootScope);
   }));
 
+  it('should only compile each template once', function() {
+
+    module(function($provide) {
+      $provide.decorator('$compile', function($delegate) {
+        return jasmine.createSpy('$compile').andCallFake($delegate);
+      });
+    });
+    inject(function($rootScope, $httpBackend, $compile) {
+      element = $compile('<div><ng:include src="url"></ng:include></div>')($rootScope);
+      $compile.reset();
+      $httpBackend.expect('GET', 'myUrl').respond('my partial');
+
+      $rootScope.url = 'myUrl';
+      $rootScope.$digest();
+      $httpBackend.flush();
+      expect(element.text()).toEqual('my partial');
+
+      $rootScope.url = null;
+      $rootScope.$digest();
+      expect(element.text()).toEqual('');
+
+      $rootScope.url = 'myUrl';
+      $rootScope.$digest();
+      expect(element.text()).toEqual('my partial');
+      expect($compile.calls.length).toEqual(1);
+
+      dealoc($rootScope);
+    });
+  });
+
+
 
   it('should clear content when error during xhr request',
       inject(function($httpBackend, $compile, $rootScope) {


### PR DESCRIPTION
This is probably not the best way to do this but here is a working Proof of Concept.

See http://www.bennadel.com/blog/2738-using-ngrepeat-with-nginclude-hurts-performance-in-angularjs.htm

Here is demo: http://plnkr.co/edit/Pf9DVKxNEAZQavcGm7Bu?p=preview
