### PR TITLE
feat($http): pass response status code to data transform functions

### DIFF
--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1232,6 +1232,19 @@ describe('$http', function() {
           expect(callback.mostRecentCall.args[0]).toBe('header1');
         });
 
+        it('should have access to response status', function() {
+          $httpBackend.expect('GET', '/url').respond(200, 'response', {h1: 'header1'});
+          $http.get('/url', {
+            transformResponse: function(data, headers, status) {
+              return status;
+            }
+          }).success(callback);
+          $httpBackend.flush();
+
+          expect(callback).toHaveBeenCalledOnce();
+          expect(callback.mostRecentCall.args[0]).toBe(200);
+        });
+
 
         it('should pipeline more functions', function() {
           function first(d, h) {return d + '-first' + ':' + h('h1');}


### PR DESCRIPTION
Fixes #10324
Closes #6734

@caitp this is an alternative to #6734 discussed today. I'm still not sure what it the best: to pass status code or just success / error flag (like in #6734). The first approach is more flexible but people will have to duplicate the `isSuccess` "logic".
