### PR TITLE
fix(ngAria): trigger digest on ng-click via keypress, pass $event to expression

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -297,21 +297,28 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
     }
   };
 })
-.directive('ngClick',['$aria', function($aria) {
+.directive('ngClick',['$aria', '$parse', function($aria, $parse) {
   return {
     restrict: 'A',
-    link: function(scope, elem, attr) {
-      if ($aria.config('tabindex') && !elem.attr('tabindex')) {
-        elem.attr('tabindex', 0);
-      }
+    compile: function(elem, attr) {
+      var fn = $parse(attr.ngClick, /* interceptorFn */ null, /* expensiveChecks */ true);
+      return function(scope, elem, attr) {
+        if ($aria.config('tabindex') && !elem.attr('tabindex')) {
+          elem.attr('tabindex', 0);
+        }
 
-      if ($aria.config('bindKeypress') && !elem.attr('ng-keypress')) {
-        elem.on('keypress', function(event) {
-          if (event.keyCode === 32 || event.keyCode === 13) {
-            scope.$eval(attr.ngClick);
-          }
-        });
-      }
+        if ($aria.config('bindKeypress') && !attr.ngKeypress) {
+          elem.on('keypress', function(event) {
+            if (event.keyCode === 32 || event.keyCode === 13) {
+              scope.$apply(callback);
+            }
+
+            function callback() {
+              fn(scope, { $event: event });
+            }
+          });
+        }
+      };
     }
   };
 }])

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -509,6 +509,23 @@ describe('$aria', function() {
       expect(clickFn).not.toHaveBeenCalled();
       expect(keypressFn).toHaveBeenCalled();
     });
+
+    it('should update bindings when keypress handled', function() {
+      compileInput('<div ng-click="text = \'clicked!\'">{{text}}</div>');
+      expect(element.text()).toBe('');
+      spyOn(scope.$root, '$digest').andCallThrough();
+      element.triggerHandler({ type: 'keypress', keyCode: 13 });
+      expect(element.text()).toBe('clicked!');
+      expect(scope.$root.$digest).toHaveBeenCalledOnce();
+    });
+
+    it('should pass $event to ng-click handler as local', function() {
+      compileInput('<div ng-click="event = $event">{{event.type}}' +
+                   '{{event.keyCode}}</div>');
+      expect(element.text()).toBe('');
+      element.triggerHandler({ type: 'keypress', keyCode: 13 });
+      expect(element.text()).toBe('keypress13');
+    });
   });
 
   describe('actions when bindKeypress set to false', function() {


### PR DESCRIPTION
Minor improvement to ng-click directive from ngAria. Now, if bindings are updated
during the click handler, the DOM will be updated as well. Additionally, the $event
object is passed in to the expression via locals, as is done for core event directives.

Closes #10442
