### PR TITLE
fix($compile): use createMap() for $$observe listeners when initialized ...

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2359,7 +2359,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         compile: function() {
             return {
               pre: function attrInterpolatePreLinkFn(scope, element, attr) {
-                var $$observers = (attr.$$observers || (attr.$$observers = {}));
+                var $$observers = (attr.$$observers || (attr.$$observers = createMap()));
 
                 if (EVENT_HANDLER_ATTR_REGEXP.test(name)) {
                   throw $compileMinErr('nodomevents',

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3274,6 +3274,22 @@ describe('$compile', function() {
       });
     });
 
+    it('should be able to interpolate attribute names which are present in Object.prototype', function() {
+      var attrs;
+      module(function() {
+        directive('attrExposer', valueFn({
+          link: function($scope, $element, $attrs) {
+            attrs = $attrs;
+          }
+        }));
+      });
+      inject(function($compile, $rootScope) {
+        $compile('<div attr-exposer to-string="{{1 + 1}}">')($rootScope);
+        $rootScope.$apply();
+        expect(attrs.toString).toBe('2');
+      });
+    });
+
 
     it('should not initialize scope value if optional expression binding is not passed', inject(function($compile) {
       compile('<div my-component></div>');


### PR DESCRIPTION
...from attr interpolation

This alternate initialization of `$$observers` was missed in a27d827c22b0b6b3ba6b7495cf4fc338c6934b37.
