### PR TITLE
docs(Courses): Fix syntax issue in Developer Guide

### DIFF
--- a/docs/content/guide/index.ngdoc
+++ b/docs/content/guide/index.ngdoc
@@ -117,12 +117,12 @@ This is a short list of libraries with specific support and documentation for wo
 ### Courses
 * **Free online:**
   [thinkster.io](http://thinkster.io),
-  [CodeAcademy](http://www.codecademy.com/courses/javascript-advanced-en-2hJ3J/0/1)
+  [CodeAcademy](http://www.codecademy.com/courses/javascript-advanced-en-2hJ3J/0/1),
   [CodeSchool](https://www.codeschool.com/courses/shaping-up-with-angular-js)
 * **Paid online:**
   [Pluralsite (3 courses)](http://www.pluralsight.com/training/Courses/Find?highlight=true&searchTerm=angularjs),
   [Tuts+](https://tutsplus.com/course/easier-js-apps-with-angular/),
-  [lynda.com](http://www.lynda.com/AngularJS-tutorials/Up-Running-AngularJS/133318-2.html)
+  [lynda.com](http://www.lynda.com/AngularJS-tutorials/Up-Running-AngularJS/133318-2.html),
   [WintellectNOW (4 lessons)](http://www.wintellectnow.com/Course/Detail/mastering-angularjs)
 * **Paid onsite:**
   [angularbootcamp.com](http://angularbootcamp.com/)


### PR DESCRIPTION
The courses section should use commas between links to differentiate the instances of each link.  This improves the clarity of the docs by denoting that there are two separate links on each line.

![image](https://cloud.githubusercontent.com/assets/6476956/5426166/32049166-82f5-11e4-9e4e-3ffbbc65af70.png)
