### PR TITLE
docs(API Reference): Fixed missing punctuation

### DIFF
--- a/docs/content/api/index.ngdoc
+++ b/docs/content/api/index.ngdoc
@@ -273,7 +273,7 @@ Use ngSanitize to securely parse and manipulate HTML data in your application.
 
 ## {@link ngMock ngMock}
 
-Use ngMock to inject and mock modules, factories, services and providers within your unit tests
+Use ngMock to inject and mock modules, factories, services and providers within your unit tests.
 
 <div class="alert alert-info">Include the **angular-mocks.js** file into your test runner for this to work.</div>
 


### PR DESCRIPTION
Added a period that was missing from the end of the ngMock description.

Before: 
Use ngMock to inject and mock modules, factories, services and providers within your unit tests

After:
Use ngMock to inject and mock modules, factories, services and providers within your unit tests.
