### PR TITLE
docs($templateRequest): Fixed run-on sentence

### DIFF
--- a/src/ng/templateRequest.js
+++ b/src/ng/templateRequest.js
@@ -9,7 +9,7 @@ var $compileMinErr = minErr('$compile');
  * @description
  * The `$templateRequest` service downloads the provided template using `$http` and, upon success,
  * stores the contents inside of `$templateCache`. If the HTTP request fails or the response data
- * of the HTTP request is empty then a `$compile` error will be thrown (the exception can be thwarted
+ * of the HTTP request is empty, a `$compile` error will be thrown (the exception can be thwarted
  * by setting the 2nd parameter of the function to true).
  *
  * @param {string} tpl The HTTP request template URL


### PR DESCRIPTION
The description of $templateRequest contains a run-on sentence that makes it confusing to understand.

ORGINAL: If the HTTP request fails or the response data of the HTTP request is empty then a `$compile` error will be thrown (the exception can be thwarted by setting the 2nd parameter of the function to true).

NEW: If the HTTP request fails or the response data of the HTTP request is empty, a `$compile` error will be thrown (the exception can be thwarted by setting the 2nd parameter of the function to true).
