### PR TITLE
docs(angular.identity): Fixed ngdoc

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -401,6 +401,8 @@ noop.$inject = [];
        return (transformationFn || angular.identity)(value);
      };
    ```
+  * @param {*} value to be returned.
+  * @returns {*} the value passed in.
  */
 function identity($) {return $;}
 identity.$inject = [];


### PR DESCRIPTION
Added @param and @returns so identity documentation matches other function documentation.  This fix is for consistency across the documentation.
