### PR TITLE
docs(guide/E2E Testing): Added '-' to 'end-to-end'

### DIFF
--- a/docs/content/guide/e2e-testing.ngdoc
+++ b/docs/content/guide/e2e-testing.ngdoc
@@ -6,7 +6,7 @@
 # E2E Testing
 
 <div class="alert alert-danger">
-**Note:** In the past, end to end testing could be done with a deprecated tool called
+**Note:** In the past, end-to-end testing could be done with a deprecated tool called
 [Angular Scenario Runner](http://code.angularjs.org/1.2.16/docs/guide/e2e-testing). That tool
 is now in maintenance mode.
 </div>
@@ -14,7 +14,7 @@ is now in maintenance mode.
 As applications grow in size and complexity, it becomes unrealistic to rely on manual testing to
 verify the correctness of new features, catch bugs and notice regressions. Unit tests
 are the first line of defense for catching bugs, but sometimes issues come up with integration
-between components which can't be captured in a unit test. End to end tests are made to find
+between components which can't be captured in a unit test. End-to-end tests are made to find
 these problems.
 
 We have built [Protractor](https://github.com/angular/protractor), an end
@@ -23,7 +23,7 @@ Angular application.
 
 ## Using Protractor
 
-Protractor is a [Node.js](http://nodejs.org) program, and runs end to end tests that are also
+Protractor is a [Node.js](http://nodejs.org) program, and runs end-to-end tests that are also
 written in JavaScript and run with node. Protractor uses [WebDriver](https://code.google.com/p/selenium/wiki/GettingStarted)
 to control browsers and simulate user actions.
 
@@ -77,7 +77,7 @@ filter the list of items.
 ## Example
 See the [angular-seed](https://github.com/angular/angular-seed) project for more examples, or look
 at the embedded examples in the Angular documentation (For example, {@link $http $http}
-has an end to end test in the example under the `protractor.js` tag).
+has an end-to-end test in the example under the `protractor.js` tag).
 
 ## Caveats
 


### PR DESCRIPTION
E2E Testing is generally spelled out as End-to-end testing in the community, but is referred to as end to end testing in the documentation. I have updated all instances of 'end to end' to 'end-to-end'. This should align the documentation with what's generally accepted in the community.

CHANGES 1: In the past, <i>end-to-end</i> testing could be done with a...
CHANGES 2: <i>End-to-end</i> tests are made to find these problems.
CHANGES 3: Protractor is a [Node.js](http://nodejs.org) program, and runs <i>end-to-end</i> tests that are...
CHANGES 4: (For example, {@link $http $http} has an <i>end-to-end</i> test in the example under the `protractor.js` tag)
