### PR TITLE
docs(angular.copy): Grammar correction

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -655,7 +655,7 @@ function arrayRemove(array, value) {
  * Creates a deep copy of `source`, which should be an object or an array.
  *
  * * If no destination is supplied, a copy of the object or array is created.
- * * If a destination is provided, all of its elements (for array) or properties (for objects)
+ * * If a destination is provided, all of its elements (for arrays) or properties (for objects)
  *   are deleted and then all elements/properties from the source are copied to it.
  * * If `source` is not an object or array (inc. `null` and `undefined`), `source` is returned.
  * * If `source` is identical to 'destination' an exception will be thrown.


### PR DESCRIPTION
Add a "s" after "for array" in parentheses 

Before: If a destination is provided, all of its elements (for array) or properties (for objects)

After: If a destination is provided, all of its elements (for arrays) or properties (for objects)
