### PR TITLE
docs(error/badname): Fixed Grammatical Error

### DIFF
--- a/docs/content/error/ng/badname.ngdoc
+++ b/docs/content/error/ng/badname.ngdoc
@@ -3,6 +3,6 @@
 @fullName Bad `hasOwnProperty` Name
 @description
 
-Occurs when you try to use the name `hasOwnProperty` in a context where it is not allow.
+Occurs when you try to use the name `hasOwnProperty` in a context where it is not allowed.
 Generally, a name cannot be `hasOwnProperty` because it is used, internally, on a object
 and allowing such a name would break lookups on this object.


### PR DESCRIPTION
In badname.ngdoc, the phrase 'in a context where it is not allow' is changed to 'in a context where it is not allowed'. The grammatical error made this document slightly confusing.

FIX:  Occurs when you try to use the name `hasOwnProperty` in a context where it is not allowed.
