### PR TITLE
feat($compile): allow using bindToController as object, support both new/isolate scopes

### DIFF
--- a/docs/content/error/$compile/noctrl.ngdoc
+++ b/docs/content/error/$compile/noctrl.ngdoc
@@ -4,65 +4,9 @@
 @description
 
 When using the `bindToController` feature of AngularJS, a directive is required
-to have a Controller, in addition to a controller identifier.
+to have a Controller. A controller may be specified by adding a "controller"
+property to the directive definition object. Its value should be either a
+string, or an invokable object (a function, or an array whose last element is a
+function).
 
-For example, the following directives are valid:
-
-```js
-// OKAY, because controller is a string with a label component.
-directive("okay", function() {
-  return {
-    bindToController: true,
-    controller: "myCtrl as $ctrl"
-    scope: {
-      text: "@text"
-    }
-  };
-});
-
-
-// OKAY, because the directive uses the controllerAs property to override
-// the controller identifier.
-directive("okay2", function() {
-  return {
-    bindToController: true,
-    controllerAs: "$ctrl",
-    controller: function() {
-
-    },
-    scope: {
-      text: "@text"
-    }
-  };
-});
-```
-
-While the following are invalid:
-
-```js
-// BAD, because the controller property is a string with no identifier.
-directive("bad", function() {
-  return {
-    bindToController: true,
-    controller: "unlabeledCtrl",
-    scope: {
-      text: "@text"
-    }
-  };
-});
-
-
-// BAD because the controller is not a string (therefore has no identifier),
-// and there is no controllerAs property.
-directive("bad2", function() {
-  return {
-    bindToController: true,
-    controller: function noControllerAs() {
-
-    },
-    scope: {
-      text: "@text"
-    }
-  };
-});
-```
+For more information, see the {@link guide/directive directives guide}.

--- a/docs/content/error/$compile/noctrl.ngdoc
+++ b/docs/content/error/$compile/noctrl.ngdoc
@@ -1,0 +1,68 @@
+@ngdoc error
+@name $compile:noctrl
+@fullName Controller is required.
+@description
+
+When using the `bindToController` feature of AngularJS, a directive is required
+to have a Controller, in addition to a controller identifier.
+
+For example, the following directives are valid:
+
+```js
+// OKAY, because controller is a string with a label component.
+directive("okay", function() {
+  return {
+    bindToController: true,
+    controller: "myCtrl as $ctrl"
+    scope: {
+      text: "@text"
+    }
+  };
+});
+
+
+// OKAY, because the directive uses the controllerAs property to override
+// the controller identifier.
+directive("okay2", function() {
+  return {
+    bindToController: true,
+    controllerAs: "$ctrl",
+    controller: function() {
+
+    },
+    scope: {
+      text: "@text"
+    }
+  };
+});
+```
+
+While the following are invalid:
+
+```js
+// BAD, because the controller property is a string with no identifier.
+directive("bad", function() {
+  return {
+    bindToController: true,
+    controller: "unlabeledCtrl",
+    scope: {
+      text: "@text"
+    }
+  };
+});
+
+
+// BAD because the controller is not a string (therefore has no identifier),
+// and there is no controllerAs property.
+directive("bad2", function() {
+  return {
+    bindToController: true,
+    controller: function noControllerAs() {
+
+    },
+    scope: {
+      text: "@text"
+    }
+  };
+});
+```

--- a/docs/content/error/$compile/noident.ngdoc
+++ b/docs/content/error/$compile/noident.ngdoc
@@ -1,0 +1,71 @@
+@ngdoc error
+@name $compile:noident
+@fullName Controller identifier is required.
+@description
+
+When using the `bindToController` feature of AngularJS, a directive is required
+to have a Controller identifier, which is initialized in scope with the value of
+the controller instance. This can be supplied using the "controllerAs" property
+of the directive object, or alternatively by adding " as IDENTIFIER" to the controller
+name.
+
+For example, the following directives are valid:
+
+```js
+// OKAY, because controller is a string with an identifier component.
+directive("okay", function() {
+  return {
+    bindToController: true,
+    controller: "myCtrl as $ctrl"
+    scope: {
+      text: "@text"
+    }
+  };
+});
+
+
+// OKAY, because the directive uses the controllerAs property to override
+// the controller identifier.
+directive("okay2", function() {
+  return {
+    bindToController: true,
+    controllerAs: "$ctrl",
+    controller: function() {
+
+    },
+    scope: {
+      text: "@text"
+    }
+  };
+});
+```
+
+While the following are invalid:
+
+```js
+// BAD, because the controller property is a string with no identifier.
+directive("bad", function() {
+  return {
+    bindToController: true,
+    controller: "noIdentCtrl",
+    scope: {
+      text: "@text"
+    }
+  };
+});
+
+
+// BAD because the controller is not a string (therefore has no identifier),
+// and there is no controllerAs property.
+directive("bad2", function() {
+  return {
+    bindToController: true,
+    controller: function noControllerAs() {
+
+    },
+    scope: {
+      text: "@text"
+    }
+  };
+});
+```

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -152,6 +152,9 @@
     "urlResolve": false,
     "urlIsSameOrigin": false,
 
+    /* ng/controller.js */
+    "identifierForController": false,
+
     /* ng/compile.js */
     "directiveNormalize": false,
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -64,7 +64,7 @@
  *       templateNamespace: 'html',
  *       scope: false,
  *       controller: function($scope, $element, $attrs, $transclude, otherInjectables) { ... },
- *       controllerAs: 'stringAlias',
+ *       controllerAs: 'stringIdentifier',
  *       require: 'siblingDirectiveName', // or // ['^parentDirectiveName', '?optionalDirectiveName', '?^optionalParent'],
  *       compile: function compile(tElement, tAttrs, transclude) {
  *         return {
@@ -224,9 +224,10 @@
  *
  *
  * #### `controllerAs`
- * Controller alias at the directive scope. An alias for the controller so it
- * can be referenced at the directive template. The directive needs to define a scope for this
- * configuration to be used. Useful in the case when directive is used as component.
+ * Identifier name for a reference to the controller in the directive's scope.
+ * This allows the controller to be referenced from the directive template. The directive
+ * needs to define a scope for this configuration to be used. Useful in the case when
+ * directive is used as component.
  *
  *
  * #### `restrict`

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -762,9 +762,15 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     if (isObject(bindings.bindToController)) {
       var controller = directive.controller;
       var controllerAs = directive.controllerAs;
-      if (!directive.controller || !identifierForController(controller, controllerAs)) {
+      if (!controller) {
+        // There is no controller, there may or may not be a controllerAs property
         throw $compileMinErr('noctrl',
               "Cannot bind to controller without directive '{0}'s controller.",
+              directiveName);
+      } else if (!identifierForController(controller, controllerAs)) {
+        // There is a controller, but no identifier or controllerAs property
+        throw $compileMinErr('noident',
+              "Cannot bind to controller without identifier for directive '{0}'.",
               directiveName);
       }
     }

--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -2,6 +2,17 @@
 
 var $controllerMinErr = minErr('$controller');
 
+
+var CNTRL_REG = /^(\S+)(\s+as\s+(\w+))?$/;
+function identifierForController(controller, ident) {
+  if (ident && isString(ident)) return ident;
+  if (isString(controller)) {
+    var match = CNTRL_REG.exec(controller);
+    if (match) return match[3];
+  }
+}
+
+
 /**
  * @ngdoc provider
  * @name $controllerProvider
@@ -14,9 +25,7 @@ var $controllerMinErr = minErr('$controller');
  */
 function $ControllerProvider() {
   var controllers = {},
-      globals = false,
-      CNTRL_REG = /^(\S+)(\s+as\s+(\w+))?$/;
-
+      globals = false;
 
   /**
    * @ngdoc method

--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -133,8 +133,16 @@ function $ControllerProvider() {
           addIdentifier(locals, identifier, instance, constructor || expression.name);
         }
 
-        return extend(function() {
-          $injector.invoke(expression, instance, locals, constructor);
+        var instantiate;
+        return instantiate = extend(function() {
+          var result = $injector.invoke(expression, instance, locals, constructor);
+          if (result !== instance && (isObject(result) || isFunction(result))) {
+            instance = result;
+            if (identifier) {
+              // If result changed, re-assign controllerAs value to scope.
+              addIdentifier(locals, identifier, instance, constructor || expression.name);
+            }
+          }
           return instance;
         }, {
           instance: instance,

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -73,8 +73,8 @@ function $RouteProvider() {
    *    - `controller` – `{(string|function()=}` – Controller fn that should be associated with
    *      newly created scope or the name of a {@link angular.Module#controller registered
    *      controller} if passed as a string.
-   *    - `controllerAs` – `{string=}` – A controller alias name. If present the controller will be
-   *      published to scope under the `controllerAs` name.
+   *    - `controllerAs` – `{string=}` – An identifier name for a reference to the controller.
+   *      If present, the controller will be published to scope under the `controllerAs` name.
    *    - `template` – `{string=|function()=}` – html template as a string or a function that
    *      returns an html template as a string which should be used by {@link
    *      ngRoute.directive:ngView ngView} or {@link ng.directive:ngInclude ngInclude} directives.

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3833,9 +3833,9 @@ describe('$compile', function() {
     });
 
 
-    it('should throw noctrl when missing controllerAs label', function() {
+    it('should throw noident when missing controllerAs directive property', function() {
       module(function($compileProvider) {
-        $compileProvider.directive('noCtrl', valueFn({
+        $compileProvider.directive('noIdent', valueFn({
           templateUrl: 'test.html',
           scope: {
             'data': '=dirData',
@@ -3848,17 +3848,17 @@ describe('$compile', function() {
       });
       inject(function($compile, $rootScope) {
         expect(function() {
-          $compile('<div no-ctrl>')($rootScope);
-        }).toThrowMinErr('$compile', 'noctrl',
-        'Cannot bind to controller without directive \'noCtrl\'s controller.');
+          $compile('<div no-ident>')($rootScope);
+        }).toThrowMinErr('$compile', 'noident',
+        'Cannot bind to controller without identifier for directive \'noIdent\'.');
       });
     });
 
 
-    it('should throw noctrl when missing controller label', function() {
+    it('should throw noident when missing controller identifier', function() {
       module(function($compileProvider, $controllerProvider) {
         $controllerProvider.register('myCtrl', function() {});
-        $compileProvider.directive('noCtrl', valueFn({
+        $compileProvider.directive('noIdent', valueFn({
           templateUrl: 'test.html',
           scope: {
             'data': '=dirData',
@@ -3871,9 +3871,9 @@ describe('$compile', function() {
       });
       inject(function($compile, $rootScope) {
         expect(function() {
-          $compile('<div no-ctrl>')($rootScope);
-        }).toThrowMinErr('$compile', 'noctrl',
-        'Cannot bind to controller without directive \'noCtrl\'s controller.');
+          $compile('<div no-ident>')($rootScope);
+        }).toThrowMinErr('$compile', 'noident',
+        'Cannot bind to controller without identifier for directive \'noIdent\'.');
       });
     });
 
@@ -3958,7 +3958,7 @@ describe('$compile', function() {
     });
 
 
-    it('should put controller in scope when labelled but not using controllerAs', function() {
+    it('should put controller in scope when controller identifier present but not using controllerAs', function() {
       var controllerCalled = false;
       var myCtrl;
       module(function($compileProvider, $controllerProvider) {
@@ -3998,7 +3998,7 @@ describe('$compile', function() {
         });
         expect(this.str).toBe('Hello, world!');
         expect(this.fn()).toBe('called!');
-      }
+      };
 
       module(function($compileProvider, $controllerProvider) {
         $controllerProvider.register('myCtrl', function() {
@@ -4052,7 +4052,7 @@ describe('$compile', function() {
         });
         expect(this.str).toBe('Hello, world!');
         expect(this.fn()).toBe('called!');
-      }
+      };
 
       module(function($compileProvider, $controllerProvider) {
         $controllerProvider.register('myCtrl', function() {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3910,8 +3910,8 @@ describe('$compile', function() {
           'baz': 'biz'
         };
         element = $compile('<div foo-dir dir-data="remoteData" ' +
-        'dir-str="Hello, {{whom}}!" ' +
-        'dir-fn="fn()"></div>')($rootScope);
+                           'dir-str="Hello, {{whom}}!" ' +
+                           'dir-fn="fn()"></div>')($rootScope);
         $rootScope.$digest();
         expect(controllerCalled).toBe(true);
       });
@@ -3950,8 +3950,8 @@ describe('$compile', function() {
           'baz': 'biz'
         };
         element = $compile('<div foo-dir dir-data="remoteData" ' +
-        'dir-str="Hello, {{whom}}!" ' +
-        'dir-fn="fn()"></div>')($rootScope);
+                           'dir-str="Hello, {{whom}}!" ' +
+                           'dir-fn="fn()"></div>')($rootScope);
         $rootScope.$digest();
         expect(controllerCalled).toBe(true);
       });
@@ -3981,6 +3981,114 @@ describe('$compile', function() {
         var childScope = element.children().scope();
         expect(childScope).not.toBe($rootScope);
         expect(childScope.theCtrl).toBe(myCtrl);
+      });
+    });
+
+
+    it('should re-install controllerAs and bindings for returned value from controller (new scope)', function() {
+      var controllerCalled = false;
+      var myCtrl;
+
+      function MyCtrl() {
+      }
+      MyCtrl.prototype.test = function() {
+        expect(this.data).toEqualData({
+          'foo': 'bar',
+          'baz': 'biz'
+        });
+        expect(this.str).toBe('Hello, world!');
+        expect(this.fn()).toBe('called!');
+      }
+
+      module(function($compileProvider, $controllerProvider) {
+        $controllerProvider.register('myCtrl', function() {
+          controllerCalled = true;
+          myCtrl = this;
+          return new MyCtrl();
+        });
+        $compileProvider.directive('fooDir', valueFn({
+          templateUrl: 'test.html',
+          bindToController: {
+            'data': '=dirData',
+            'str': '@dirStr',
+            'fn': '&dirFn'
+          },
+          scope: true,
+          controller: 'myCtrl as theCtrl'
+        }));
+      });
+      inject(function($compile, $rootScope, $templateCache) {
+        $templateCache.put('test.html', '<p>isolate</p>');
+        $rootScope.fn = valueFn('called!');
+        $rootScope.whom = 'world';
+        $rootScope.remoteData = {
+          'foo': 'bar',
+          'baz': 'biz'
+        };
+        element = $compile('<div foo-dir dir-data="remoteData" ' +
+                           'dir-str="Hello, {{whom}}!" ' +
+                           'dir-fn="fn()"></div>')($rootScope);
+        $rootScope.$digest();
+        expect(controllerCalled).toBe(true);
+        var childScope = element.children().scope();
+        expect(childScope).not.toBe($rootScope);
+        expect(childScope.theCtrl).not.toBe(myCtrl);
+        expect(childScope.theCtrl.constructor).toBe(MyCtrl);
+        childScope.theCtrl.test();
+      });
+    });
+
+
+    it('should re-install controllerAs and bindings for returned value from controller (isolate scope)', function() {
+      var controllerCalled = false;
+      var myCtrl;
+
+      function MyCtrl() {
+      }
+      MyCtrl.prototype.test = function() {
+        expect(this.data).toEqualData({
+          'foo': 'bar',
+          'baz': 'biz'
+        });
+        expect(this.str).toBe('Hello, world!');
+        expect(this.fn()).toBe('called!');
+      }
+
+      module(function($compileProvider, $controllerProvider) {
+        $controllerProvider.register('myCtrl', function() {
+          controllerCalled = true;
+          myCtrl = this;
+          return new MyCtrl();
+        });
+        $compileProvider.directive('fooDir', valueFn({
+          templateUrl: 'test.html',
+          bindToController: true,
+          scope: {
+            'data': '=dirData',
+            'str': '@dirStr',
+            'fn': '&dirFn'
+          },
+          controller: 'myCtrl as theCtrl'
+        }));
+      });
+      inject(function($compile, $rootScope, $templateCache) {
+        $templateCache.put('test.html', '<p>isolate</p>');
+        $rootScope.fn = valueFn('called!');
+        $rootScope.whom = 'world';
+        $rootScope.remoteData = {
+          'foo': 'bar',
+          'baz': 'biz'
+        };
+        element = $compile('<div foo-dir dir-data="remoteData" ' +
+        'dir-str="Hello, {{whom}}!" ' +
+        'dir-fn="fn()"></div>')($rootScope);
+        $rootScope.$digest();
+        expect(controllerCalled).toBe(true);
+        var childScope = element.children().scope();
+        expect(childScope).not.toBe($rootScope);
+        expect(childScope.theCtrl).not.toBe(myCtrl);
+        expect(childScope.theCtrl.constructor).toBe(MyCtrl);
+        childScope.theCtrl.test();
       });
     });
   });


### PR DESCRIPTION
bindToController is now able to be specified as a convenient object notation:

```
bindToController: {
  text: '@text',
  obj: '=obj',
  expr: '&expr'
},
scope: {
  notBoundToCtrl: '@someOtherAttr'
}
```

It can also be used in conjunction with new scopes, rather than exclusively isolate scopes:

```
bindToController: {
  text: '@text',
  obj: '=obj',
  expr: '&expr'
},
scope: true
```

PING @petebacondarwin / @johnlindquist

I am not super keen on this, because it makes things much crazier than they used to be. That said:
- Currently, `bindToController` does not automatically imply an isolate scope --- maybe it should (I hate this though)
- It could probably do with more errors being thrown when people use it wrong
- The errors it does throw could be better
- The errors it throws are potentially breaking changes :(

Closes #10420
