### PR TITLE
fix($aria): pass $event in locals for ngClick

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -308,7 +308,7 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
       if ($aria.config('bindKeypress') && !elem.attr('ng-keypress')) {
         elem.on('keypress', function(event) {
           if (event.keyCode === 32 || event.keyCode === 13) {
-            scope.$eval(attr.ngClick);
+            scope.$eval(attr.ngClick, {$event: event});
           }
         });
       }


### PR DESCRIPTION
pass <code>event</code> in <code>locals</code> for <code>$eval</code>
This happens in <code>angular-bootstrap</code>'s repo for modals

``` javascript
ng-click="close($event)"
```

``` javascript
angular.module("template/modal/window.html", []).run(["$templateCache", function($templateCache) {
  $templateCache.put("template/modal/window.html",
    "<div tabindex=\"-1\" role=\"dialog\" class=\"modal fade\" ng-class=\"{in: animate}\" ng-style=\"{'z-index': 1050 + index*10, display: 'block'}\" ng-click=\"close($event)\">\n" +
    "    <div class=\"modal-dialog\" ng-class=\"{'modal-sm': size == 'sm', 'modal-lg': size == 'lg'}\"><div class=\"modal-content\" modal-transclude></div></div>\n" +
    "</div>");
}]);
```
