### PR TITLE
Correct grammatical error

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1174,7 +1174,7 @@ function getNgAttribute(element, ngAttr) {
  * document would not be compiled, the `AppController` would not be instantiated and the `{{ a+b }}`
  * would not be resolved to `3`.
  *
- * `ngApp` is the easiest, and most common, way to bootstrap an application.
+ * `ngApp` is the easiest, and most common way to bootstrap an application.
  *
  <example module="ngAppDemo">
    <file name="index.html">


### PR DESCRIPTION
The sentence was broken up. Deleted superfluous comma.
