### PR TITLE
(cherry-pick) fix($browser): prevent infinite digests when clearing the hash of a url

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -62,6 +62,11 @@ function Browser(window, document, $log, $sniffer) {
     }
   }
 
+  function getHash(url) {
+    var index = url.indexOf('#');
+    return index === -1 ? '' : url.substr(index + 1);
+  }
+
   /**
    * @private
    * Note: this method is used only by scenario runner
@@ -173,8 +178,10 @@ function Browser(window, document, $log, $sniffer) {
         }
         if (replace) {
           location.replace(url);
-        } else {
+        } else if (!sameBase) {
           location.href = url;
+        } else {
+          location.hash = getHash(url);
         }
       }
       return self;


### PR DESCRIPTION
By using `location.hash` to update the current browser location when only
the hash has changed, we prevent the browser from attempting to reload.

Closes #9629
Closes #9635
Closes #10228
Closes #10308
