### PR TITLE
adds data to info so that it can be monitored from outside world

### DIFF
--- a/src/ng/cacheFactory.js
+++ b/src/ng/cacheFactory.js
@@ -278,7 +278,7 @@ function $CacheFactoryProvider() {
          *   </ul>
          */
         info: function() {
-          return extend({}, stats, {size: size});
+          return extend({}, stats, {size: size, data: data});
         }
       };
 


### PR DESCRIPTION
There's no way to see what's inside a $cacheFactory instance. Using `.info()` you can see the size but no way to see how big is the actual cache in terms of size.
