### PR TITLE
docs($animate): misleading $animate.cancel example

### DIFF
--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -833,7 +833,8 @@ angular.module('ngAnimate', ['ng'])
        * promise that was returned when the animation was started.
        *
        * ```js
-       * var promise = $animate.addClass(element, 'super-long-animation').then(function() {
+       * var promise = $animate.addClass(element, 'super-long-animation');
+       * promise.then(function() {
        *   //this will still be called even if cancelled
        * });
        *


### PR DESCRIPTION
The given example is wrong, you can't cancel promise returned by "then" but you can do it for promise returned by "addClass".
