### PR TITLE
feat(limitTo): ignore limit when undefined

### DIFF
--- a/src/ng/filter/limitTo.js
+++ b/src/ng/filter/limitTo.js
@@ -15,7 +15,8 @@
  * @param {string|number} limit The length of the returned array or string. If the `limit` number
  *     is positive, `limit` number of items from the beginning of the source array/string are copied.
  *     If the number is negative, `limit` number  of items from the end of the source array/string
- *     are copied. The `limit` will be trimmed if it exceeds `array.length`
+ *     are copied. The `limit` will be trimmed if it exceeds `array.length`. If `limit` is undefined,
+ *     the input will be returned unchanged.
  * @returns {Array|string} A new sub-array or substring of length `limit` or less if input array
  *     had less than `limit` elements.
  *
@@ -97,13 +98,10 @@ function limitToFilter() {
       limit = int(limit);
     }
 
+    if (isNaN(limit)) return input;
+
     if (isString(input)) {
-      //NaN check on limit
-      if (limit) {
-        return limit >= 0 ? input.slice(0, limit) : input.slice(limit, input.length);
-      } else {
-        return "";
-      }
+      return limit >= 0 ? input.slice(0, limit) : input.slice(limit, input.length);
     }
 
     var i, n;
@@ -118,7 +116,7 @@ function limitToFilter() {
       i = 0;
       n = limit;
     } else {
-      // zero and NaN check on limit - return empty array
+      // zero check on limit - return empty array
       if (!limit) return [];
 
       i = input.length + limit;

--- a/test/ng/filter/limitToSpec.js
+++ b/test/ng/filter/limitToSpec.js
@@ -34,20 +34,30 @@ describe('Filter: limitTo', function() {
   });
 
 
-  it('should return an empty array when X cannot be parsed', function() {
-    expect(limitTo(items, 'bogus')).toEqual([]);
-    expect(limitTo(items, 'null')).toEqual([]);
-    expect(limitTo(items, 'undefined')).toEqual([]);
-    expect(limitTo(items, null)).toEqual([]);
-    expect(limitTo(items, undefined)).toEqual([]);
+  it('should return an empty array when X = 0', function() {
+    expect(limitTo(items, 0)).toEqual([]);
+    expect(limitTo(items, '0')).toEqual([]);
   });
 
-  it('should return an empty string when X cannot be parsed', function() {
-    expect(limitTo(str, 'bogus')).toEqual("");
-    expect(limitTo(str, 'null')).toEqual("");
-    expect(limitTo(str, 'undefined')).toEqual("");
-    expect(limitTo(str, null)).toEqual("");
-    expect(limitTo(str, undefined)).toEqual("");
+  it('should return entire array when X cannot be parsed', function() {
+    expect(limitTo(items, 'bogus')).toEqual(items);
+    expect(limitTo(items, 'null')).toEqual(items);
+    expect(limitTo(items, 'undefined')).toEqual(items);
+    expect(limitTo(items, null)).toEqual(items);
+    expect(limitTo(items, undefined)).toEqual(items);
+  });
+
+  it('should return an empty string when X = 0', function() {
+    expect(limitTo(str, 0)).toEqual("");
+    expect(limitTo(str, '0')).toEqual("");
+  });
+
+  it('should return entire string when X cannot be parsed', function() {
+    expect(limitTo(str, 'bogus')).toEqual(str);
+    expect(limitTo(str, 'null')).toEqual(str);
+    expect(limitTo(str, 'undefined')).toEqual(str);
+    expect(limitTo(str, null)).toEqual(str);
+    expect(limitTo(str, undefined)).toEqual(str);
   });
 
 


### PR DESCRIPTION
BREAKING CHANGE: limitTo changed behavoir when limit value is undefined.
Instead of returning empty object/array it returns non-changed input.

Closes #10484
