### PR TITLE
Typo Fix

### DIFF
--- a/docs/content/api/index.ngdoc
+++ b/docs/content/api/index.ngdoc
@@ -128,7 +128,7 @@ Use ngRoute to enable URL routing to your application. The ngRoute module suppor
 
 ## {@link ngAnimate ngAnimate}
 
-Use ngAnimate to enable animation features into your application. Various core ng directives will provide
+Use ngAnimate to enable animation features within your application. Various core ng directives will provide
 animation hooks into your application when ngAnimate is included. Animations are defined by using CSS transitions/animations
 or JavaScript callbacks.
 


### PR DESCRIPTION
I changed the word "into" to "within".
Original description underneath ngAnimate reads: "Use ngAnimate to enable animation features into your application".
I changed the text to read: "Use ngAnimate to enable animation features within your application".
The change in wording makes the description read better and gives it a more professional feel.
