### PR TITLE
docs($http): Fix typo

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -381,7 +381,7 @@ function $HttpProvider() {
      *
      * Both requests and responses can be transformed using transformation functions: `transformRequest`
      * and `transformResponse`. These properties can be a single function that returns
-     * the transformed value (`{function(data, headersGetter, status)`) or an array of such transformation functions,
+     * the transformed value (`function(data, headersGetter, status)`) or an array of such transformation functions,
      * which allows you to `push` or `unshift` a new transformation function into the transformation chain.
      *
      * ### Default Transformations


### PR DESCRIPTION
Fix a small typo in the description of request and response transformers
