### PR TITLE
fix(dateFilter): ignore era format specifier "G"

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -321,7 +321,7 @@ var DATE_FORMATS = {
      w: weekGetter(1)
 };
 
-var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZEw']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|Z|w+))(.*)/,
+var DATE_FORMATS_SPLIT = /((?:[^yMdHhmsaZEwG']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|d+|H+|h+|m+|s+|a|Z|w+))(.*)/,
     NUMBER_STRING = /^\-?\d+$/;
 
 /**

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -293,6 +293,10 @@ describe('filters', function() {
 
       expect(date(earlyDate, "MMMM dd, y")).
                       toEqual('September 03, 1');
+
+      expect(date(earlyDate, "MMMM dd, G y")).
+                      toEqual('September 03,  1');
+
     });
 
     it('should accept negative numbers as strings', function() {


### PR DESCRIPTION
The era format specifier is not supported in our locale code and is being
passed through as the letter G in some long date formats, such as Thai (th-th).

It is not straightforward to provide locale specific era formatting since
the logic is calendar (locale) specific and not provided by the Google
closure library.

This commit simply ignores the G in format strings until we can work out
a better strategy for dealing with eras.

Closes #10503
