### PR TITLE
Update index.ngdoc fix grammar

### DIFF
--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -7,7 +7,7 @@
 
 A great way to get introduced to AngularJS is to work through this tutorial, which walks you through
 the construction of an AngularJS web app. The app you will build is a catalog that displays a list
-of Android devices, lets you filter the list to see only devices that interest you, and then view
+of Android devices, lets you filter the list to see only devices that interest you, and then presents
 details for any device.
 
 <img class="diagram" src="img/tutorial/catalog_screen.png" width="488" height="413" alt="demo


### PR DESCRIPTION
Update index.ngdoc to fix grammar for parallelism. Expressions separated by commas should be structured similarly, and in this case the verbs of each of those expressions refer to "catalog". The catalog does not view details, but presents them.

BEFORE: "... catalog that displays a list of Android devices, lets you filter the list to see only devices that interest you, and then view details..."
AFTER: "... catalog that displays a list of Android devices, lets you filter the list to see only devices that interest you, and then presents details..."
