### PR TITLE
docs(guide/Directives): data from isolate to parent scope

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -751,9 +751,12 @@ own behavior to it.
     angular.module('docsIsoFnBindExample', [])
       .controller('Controller', ['$scope', '$timeout', function($scope, $timeout) {
         $scope.name = 'Tobias';
-        $scope.hideDialog = function () {
+        $scope.message = '';
+        $scope.hideDialog = function (message) {
+          $scope.message = message;
           $scope.dialogIsHidden = true;
           $timeout(function () {
+            $scope.message = '';
             $scope.dialogIsHidden = false;
           }, 2000);
         };
@@ -771,6 +774,7 @@ own behavior to it.
   </file>
   <file name="index.html">
     <div ng-controller="Controller">
+      {{message}}
       <my-dialog ng-hide="dialogIsHidden" on-close="hideDialog()">
         Check out the contents, {{name}}!
       </my-dialog>
@@ -778,7 +782,7 @@ own behavior to it.
   </file>
   <file name="my-dialog-close.html">
     <div class="alert">
-      <a href class="close" ng-click="close()">&times;</a>
+      <a href class="close" ng-click="close({message: 'closing for now'})">&times;</a>
       <div ng-transclude></div>
     </div>
   </file>
@@ -796,7 +800,10 @@ callback functions to directive behaviors.
 When the user clicks the `x` in the dialog, the directive's `close` function is called, thanks to
 `ng-click.`  This call to `close` on the isolated scope actually evaluates the expression
 `hideDialog()` in the context of the original scope, thus running `Controller`'s `hideDialog`
-function.
+function. Often it's desirable to pass data from the isolate scope via an expression and to the 
+parent scope, this can be done by passing a map of local variable names and values into the expression 
+wrapper fn. For example, the hideDialog function takes a message to display when the dialog is hidden.
+This is specified in the directive by calling `close({message: 'closing for now'})`.
 
 <div class="alert alert-success">
 **Best Practice:** use `&attr` in the `scope` option when you want your directive


### PR DESCRIPTION
It looks like this used to be in the Angular docs as per this thread: https://groups.google.com/d/msg/angular/3CHdR_THaNw/AxqKwUw5t0oJ I recently spent some time trying to get this to work and was very frustrated by lack of documentation. I tried to tie this into the existing &attr example but let me know if that is not desirable.
