### PR TITLE
docs($http): adds missing markdown formatter (backtick)

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -347,7 +347,7 @@ function $HttpProvider() {
      * To add or overwrite these defaults, simply add or remove a property from these configuration
      * objects. To add headers for an HTTP method other than POST or PUT, simply add a new object
      * with the lowercased HTTP method name as the key, e.g.
-     * `$httpProvider.defaults.headers.get = { 'My-Header' : 'value' }.
+     * `$httpProvider.defaults.headers.get = { 'My-Header' : 'value' }`.
      *
      * The defaults can also be set at runtime via the `$http.defaults` object in the same
      * fashion. For example:


### PR DESCRIPTION
adds missing markdown formatter (backtick)
