### PR TITLE
docs(tutorial/6 - Templating Links

### DIFF
--- a/docs/content/tutorial/step_06.ngdoc
+++ b/docs/content/tutorial/step_06.ngdoc
@@ -75,7 +75,7 @@ __`test/e2e/scenarios.js`__:
       query.sendKeys('nexus');
       element.all(by.css('.phones li a')).first().click();
       browser.getLocationAbsUrl().then(function(url) {
-        expect(url.split('#')[1]).toBe('/phones/nexus-s');
+        expect(url.split('#')[0]).toBe('/phones/nexus-s');
       });
     });
 ...


### PR DESCRIPTION
Using expect(url.split('#')[1]).toBe('/phones/nexus-s') gives an error when you run e2e test. But works well when expect(url.split('#')[0]).toBe('/phones/nexus-s'); is used
