### PR TITLE
docs($compile) fix a typo

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -477,7 +477,7 @@
  *
  * <div class="alert alert-info">
  * **Best Practice**: if you intend to add and remove transcluded content manually in your directive
- * (by calling the transclude function to get the DOM and and calling `element.remove()` to remove it),
+ * (by calling the transclude function to get the DOM and calling `element.remove()` to remove it),
  * then you are also responsible for calling `$destroy` on the transclusion scope.
  * </div>
  *


### PR DESCRIPTION
Remove unnecessary 'and' in $compile docs.
