### PR TITLE
feat($logProvider): add additional control over what gets logged

### DIFF
--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -44,8 +44,76 @@
  * Use the `$logProvider` to configure how the application logs messages
  */
 function $LogProvider() {
-  var debug = true,
+  var log = true,
+      info = true,
+      warn = true,
+      error = true,
+      debug = true,
       self = this;
+
+  /**
+   * @ngdoc method
+   * @name $logProvider#logEnabled
+   * @description
+   * @param {boolean=} flag enable or disable log level messages
+   * @returns {*} current value if used as getter or itself (chaining) if used as setter
+   */
+  this.logEnabled = function(flag) {
+    if (isDefined(flag)) {
+      log = flag;
+      return this;
+    } else {
+      return log;
+    }
+  };
+
+  /**
+   * @ngdoc method
+   * @name $logProvider#infoEnabled
+   * @description
+   * @param {boolean=} flag enable or disable info level messages
+   * @returns {*} current value if used as getter or itself (chaining) if used as setter
+   */
+  this.infoEnabled = function(flag) {
+    if (isDefined(flag)) {
+      info = flag;
+      return this;
+    } else {
+      return info;
+    }
+  };
+
+  /**
+   * @ngdoc method
+   * @name $logProvider#warnEnabled
+   * @description
+   * @param {boolean=} flag enable or disable warn level messages
+   * @returns {*} current value if used as getter or itself (chaining) if used as setter
+   */
+  this.warnEnabled = function(flag) {
+    if (isDefined(flag)) {
+      warn = flag;
+      return this;
+    } else {
+      return warn;
+    }
+  };
+
+  /**
+   * @ngdoc method
+   * @name $logProvider#errorEnabled
+   * @description
+   * @param {boolean=} flag enable or disable error level messages
+   * @returns {*} current value if used as getter or itself (chaining) if used as setter
+   */
+  this.errorEnabled = function(flag) {
+    if (isDefined(flag)) {
+      error = flag;
+      return this;
+    } else {
+      return error;
+    }
+  };
 
   /**
    * @ngdoc method
@@ -57,7 +125,7 @@ function $LogProvider() {
   this.debugEnabled = function(flag) {
     if (isDefined(flag)) {
       debug = flag;
-    return this;
+      return this;
     } else {
       return debug;
     }
@@ -72,7 +140,15 @@ function $LogProvider() {
        * @description
        * Write a log message
        */
-      log: consoleLog('log'),
+      log: (function() {
+        var fn = consoleLog('log');
+
+        return function() {
+          if (log) {
+            fn.apply(self, arguments);
+          }
+        };
+      }()),
 
       /**
        * @ngdoc method
@@ -81,7 +157,15 @@ function $LogProvider() {
        * @description
        * Write an information message
        */
-      info: consoleLog('info'),
+      info: (function() {
+        var fn = consoleLog('info');
+
+        return function() {
+          if (info) {
+            fn.apply(self, arguments);
+          }
+        };
+      }()),
 
       /**
        * @ngdoc method
@@ -90,7 +174,15 @@ function $LogProvider() {
        * @description
        * Write a warning message
        */
-      warn: consoleLog('warn'),
+      warn: (function() {
+        var fn = consoleLog('warn');
+
+        return function() {
+          if (warn) {
+            fn.apply(self, arguments);
+          }
+        };
+      }()),
 
       /**
        * @ngdoc method
@@ -99,7 +191,15 @@ function $LogProvider() {
        * @description
        * Write an error message
        */
-      error: consoleLog('error'),
+      error: (function() {
+        var fn = consoleLog('error');
+
+        return function() {
+          if (error) {
+            fn.apply(self, arguments);
+          }
+        };
+      }()),
 
       /**
        * @ngdoc method

--- a/test/ng/logSpec.js
+++ b/test/ng/logSpec.js
@@ -117,6 +117,106 @@ describe('$log', function() {
     );
   });
 
+  describe("$log.log", function() {
+
+    beforeEach(module(function($logProvider) {
+      $logProvider.logEnabled(false);
+    }));
+
+    it("should skip log output if disabled", inject(function() {
+        $window.console = {log: log,
+                           warn: warn,
+                           info: info,
+                           error: error,
+                           debug: debug};
+      },
+      function($log) {
+        $log.log();
+        $log.warn();
+        $log.info();
+        $log.error();
+        $log.debug();
+        expect(logger).toEqual('warn;info;error;debug;');
+      }
+    ));
+
+  });
+
+  describe("$log.warn", function() {
+
+    beforeEach(module(function($logProvider) {
+      $logProvider.warnEnabled(false);
+    }));
+
+    it("should skip warn output if disabled", inject(function() {
+        $window.console = {log: log,
+                           warn: warn,
+                           info: info,
+                           error: error,
+                           debug: debug};
+      },
+      function($log) {
+        $log.log();
+        $log.warn();
+        $log.info();
+        $log.error();
+        $log.debug();
+        expect(logger).toEqual('log;info;error;debug;');
+      }
+    ));
+
+  });
+
+  describe("$log.info", function() {
+
+    beforeEach(module(function($logProvider) {
+      $logProvider.infoEnabled(false);
+    }));
+
+    it("should skip info output if disabled", inject(function() {
+        $window.console = {log: log,
+                           warn: warn,
+                           info: info,
+                           error: error,
+                           debug: debug};
+      },
+      function($log) {
+        $log.log();
+        $log.warn();
+        $log.info();
+        $log.error();
+        $log.debug();
+        expect(logger).toEqual('log;warn;error;debug;');
+      }
+    ));
+
+  });
+
+  describe("$log.error", function() {
+
+    beforeEach(module(function($logProvider) {
+      $logProvider.errorEnabled(false);
+    }));
+
+    it("should skip error output if disabled", inject(function() {
+        $window.console = {log: log,
+                           warn: warn,
+                           info: info,
+                           error: error,
+                           debug: debug};
+      },
+      function($log) {
+        $log.log();
+        $log.warn();
+        $log.info();
+        $log.error();
+        $log.debug();
+        expect(logger).toEqual('log;warn;info;debug;');
+      }
+    ));
+
+  });
+
   describe("$log.debug", function() {
 
     beforeEach(initService(false));


### PR DESCRIPTION
A simple addition that lets developers have greater control over what does and doesn't get logged. With this change you can disable log, info, warn and error messages, similar to how debug logs could be disable with $logProvider.debugEnabled in the past.

Closes #10560
