### PR TITLE
chore($cache): do not add entry to LRU hash when value is undefined

### DIFF
--- a/src/ng/cacheFactory.js
+++ b/src/ng/cacheFactory.js
@@ -159,13 +159,13 @@ function $CacheFactoryProvider() {
          * @returns {*} the value stored.
          */
         put: function(key, value) {
+          if (isUndefined(value)) return;
           if (capacity < Number.MAX_VALUE) {
             var lruEntry = lruHash[key] || (lruHash[key] = {key: key});
 
             refresh(lruEntry);
           }
 
-          if (isUndefined(value)) return;
           if (!(key in data)) size++;
           data[key] = value;
 


### PR DESCRIPTION
When adding entries to the cache and the `value` is `undefined`, no entry should be added to the `lruHash`

There is no way to create a unit test as we do not expose these inner structures
