### PR TITLE
refactor(*): rename internal function `int` to `toInt`

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -34,7 +34,7 @@
     "nextUid": false,
     "setHashKey": false,
     "extend": false,
-    "int": false,
+    "toInt": false,
     "inherit": false,
     "noop": false,
     "identity": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -28,7 +28,7 @@
   nextUid: true,
   setHashKey: true,
   extend: true,
-  int: true,
+  toInt: true,
   inherit: true,
   noop: true,
   identity: true,
@@ -357,7 +357,7 @@ function extend(dst) {
   return dst;
 }
 
-function int(str) {
+function toInt(str) {
   return parseInt(str, 10);
 }
 

--- a/src/ng/directive/validators.js
+++ b/src/ng/directive/validators.js
@@ -60,7 +60,7 @@ var maxlengthDirective = function() {
 
       var maxlength = -1;
       attr.$observe('maxlength', function(value) {
-        var intVal = int(value);
+        var intVal = toInt(value);
         maxlength = isNaN(intVal) ? -1 : intVal;
         ctrl.$validate();
       });
@@ -80,7 +80,7 @@ var minlengthDirective = function() {
 
       var minlength = 0;
       attr.$observe('minlength', function(value) {
-        minlength = int(value) || 0;
+        minlength = toInt(value) || 0;
         ctrl.$validate();
       });
       ctrl.$validators.minlength = function(modelValue, viewValue) {

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -429,13 +429,13 @@ function dateFilter($locale) {
           timeSetter = match[8] ? date.setUTCHours : date.setHours;
 
       if (match[9]) {
-        tzHour = int(match[9] + match[10]);
-        tzMin = int(match[9] + match[11]);
+        tzHour = toInt(match[9] + match[10]);
+        tzMin = toInt(match[9] + match[11]);
       }
-      dateSetter.call(date, int(match[1]), int(match[2]) - 1, int(match[3]));
-      var h = int(match[4] || 0) - tzHour;
-      var m = int(match[5] || 0) - tzMin;
-      var s = int(match[6] || 0);
+      dateSetter.call(date, toInt(match[1]), toInt(match[2]) - 1, toInt(match[3]));
+      var h = toInt(match[4] || 0) - tzHour;
+      var m = toInt(match[5] || 0) - tzMin;
+      var s = toInt(match[6] || 0);
       var ms = Math.round(parseFloat('0.' + (match[7] || 0)) * 1000);
       timeSetter.call(date, h, m, s, ms);
       return date;
@@ -452,7 +452,7 @@ function dateFilter($locale) {
     format = format || 'mediumDate';
     format = $locale.DATETIME_FORMATS[format] || format;
     if (isString(date)) {
-      date = NUMBER_STRING.test(date) ? int(date) : jsonStringToDate(date);
+      date = NUMBER_STRING.test(date) ? toInt(date) : jsonStringToDate(date);
     }
 
     if (isNumber(date)) {

--- a/src/ng/filter/limitTo.js
+++ b/src/ng/filter/limitTo.js
@@ -92,7 +92,7 @@ function limitToFilter() {
     if (Math.abs(Number(limit)) === Infinity) {
       limit = Number(limit);
     } else {
-      limit = int(limit);
+      limit = toInt(limit);
     }
     if (isNaN(limit)) return input;
 

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -27,7 +27,7 @@ function parseAbsoluteUrl(absoluteUrl, locationObj) {
 
   locationObj.$$protocol = parsedUrl.protocol;
   locationObj.$$host = parsedUrl.hostname;
-  locationObj.$$port = int(parsedUrl.port) || DEFAULT_PORTS[parsedUrl.protocol] || null;
+  locationObj.$$port = toInt(parsedUrl.port) || DEFAULT_PORTS[parsedUrl.protocol] || null;
 }
 
 

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -18,7 +18,7 @@ function $SnifferProvider() {
   this.$get = ['$window', '$document', function($window, $document) {
     var eventSupport = {},
         android =
-          int((/android (\d+)/.exec(lowercase(($window.navigator || {}).userAgent)) || [])[1]),
+          toInt((/android (\d+)/.exec(lowercase(($window.navigator || {}).userAgent)) || [])[1]),
         boxee = /Boxee/i.test(($window.navigator || {}).userAgent),
         document = $document[0] || {},
         vendorPrefix,

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -574,20 +574,20 @@ function jsonStringToDate(string) {
         tzHour = 0,
         tzMin  = 0;
     if (match[9]) {
-      tzHour = int(match[9] + match[10]);
-      tzMin = int(match[9] + match[11]);
+      tzHour = toInt(match[9] + match[10]);
+      tzMin = toInt(match[9] + match[11]);
     }
-    date.setUTCFullYear(int(match[1]), int(match[2]) - 1, int(match[3]));
-    date.setUTCHours(int(match[4] || 0) - tzHour,
-                     int(match[5] || 0) - tzMin,
-                     int(match[6] || 0),
-                     int(match[7] || 0));
+    date.setUTCFullYear(toInt(match[1]), toInt(match[2]) - 1, toInt(match[3]));
+    date.setUTCHours(toInt(match[4] || 0) - tzHour,
+                     toInt(match[5] || 0) - tzMin,
+                     toInt(match[6] || 0),
+                     toInt(match[7] || 0));
     return date;
   }
   return string;
 }
 
-function int(str) {
+function toInt(str) {
   return parseInt(str, 10);
 }
 

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -31,7 +31,7 @@
     "nextUid": false,
     "setHashKey": false,
     "extend": false,
-    "int": false,
+    "toInt": false,
     "inherit": false,
     "noop": false,
     "identity": false,

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2169,7 +2169,7 @@ describe('input', function() {
         var value = 0;
         var inputElm = helper.compileInput('<input type="number" ng-model="value" ng-minlength="min" attr-capture />');
         helper.attrs.$observe('minlength', function(v) {
-          value = int(helper.attrs.minlength);
+          value = toInt(helper.attrs.minlength);
         });
 
         $rootScope.$apply(function() {
@@ -2215,7 +2215,7 @@ describe('input', function() {
         var value = 0;
         var inputElm = helper.compileInput('<input type="number" ng-model="value" ng-maxlength="max" attr-capture />');
         helper.attrs.$observe('maxlength', function(v) {
-          value = int(helper.attrs.maxlength);
+          value = toInt(helper.attrs.maxlength);
         });
 
         $rootScope.$apply(function() {

--- a/test/ng/directive/validatorsSpec.js
+++ b/test/ng/directive/validatorsSpec.js
@@ -224,7 +224,7 @@ describe('validators', function() {
       var value = 0;
       var inputElm = helper.compileInput('<input type="text" ng-model="value" ng-minlength="min" attr-capture />');
       helper.attrs.$observe('minlength', function(v) {
-        value = int(helper.attrs.minlength);
+        value = toInt(helper.attrs.minlength);
       });
 
       $rootScope.$apply('min = 5');
@@ -318,7 +318,7 @@ describe('validators', function() {
       var value = 0;
       var inputElm = helper.compileInput('<input type="text" ng-model="value" ng-maxlength="max" attr-capture />');
       helper.attrs.$observe('maxlength', function(v) {
-        value = int(helper.attrs.maxlength);
+        value = toInt(helper.attrs.maxlength);
       });
 
       $rootScope.$apply('max = 10');


### PR DESCRIPTION
Renamed the internal function `int` to `toInt` as `int` is a reserved word

Closes #7768
