### PR TITLE
refactor($parse): new and faster $parse

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1309,7 +1309,10 @@ ASTInterpreter.prototype = {
       };
     case AST.MemberExpression:
       left = this.recurse(ast.object, false, !!create);
-      if (!ast.computed) ensureSafeMemberName(ast.property.name, self.expression);
+      if (!ast.computed) {
+        ensureSafeMemberName(ast.property.name, self.expression);
+        right = ast.property.name;
+      }
       if (ast.computed) right = this.recurse(ast.property);
       return ast.computed ?
         function(scope, locals, assign, inputs) {
@@ -1333,15 +1336,15 @@ ASTInterpreter.prototype = {
         } :
         function(scope, locals, assign, inputs) {
           var lhs = left(scope, locals, assign, inputs);
-          if (create && create !== 1 && lhs && !(ast.property.name in lhs)) {
-            lhs[ast.property.name] = {};
+          if (create && create !== 1 && lhs && !(right in lhs)) {
+            lhs[right] = {};
           }
-          var value = lhs != null ? lhs[ast.property.name] : undefined;
-          if (self.expensiveChecks || isPossiblyDangerousMemberName(ast.property.name)) {
+          var value = lhs != null ? lhs[right] : undefined;
+          if (self.expensiveChecks || isPossiblyDangerousMemberName(right)) {
             ensureSafeObject(value, self.expression);
           }
           if (context) {
-            return {context: lhs, name: ast.property.name, value: value};
+            return {context: lhs, name: right, value: value};
           } else {
             return value;
           }

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1764,21 +1764,23 @@ function $ParseProvider() {
       var lastResult;
 
       if (inputExpressions.length === 1) {
-        var oldInputValue = expressionInputDirtyCheck; // init to something unique so that equals check fails
+        var oldInputValueOf = expressionInputDirtyCheck; // init to something unique so that equals check fails
         inputExpressions = inputExpressions[0];
         return scope.$watch(function expressionInputWatch(scope) {
           var newInputValue = inputExpressions(scope);
-          if (!expressionInputDirtyCheck(newInputValue, oldInputValue)) {
+          if (!expressionInputDirtyCheck(newInputValue, oldInputValueOf)) {
             lastResult = parsedExpression(scope, undefined, undefined, [newInputValue]);
-            oldInputValue = newInputValue && getValueOf(newInputValue);
+            oldInputValueOf = newInputValue && getValueOf(newInputValue);
           }
           return lastResult;
         }, listener, objectEquality, prettyPrintExpression);
       }
 
       var oldInputValueOfValues = [];
+      var oldInputValues = [];
       for (var i = 0, ii = inputExpressions.length; i < ii; i++) {
         oldInputValueOfValues[i] = expressionInputDirtyCheck; // init to something unique so that equals check fails
+        oldInputValues[i] = null;
       }
 
       return scope.$watch(function expressionInputsWatch(scope) {
@@ -1787,12 +1789,13 @@ function $ParseProvider() {
         for (var i = 0, ii = inputExpressions.length; i < ii; i++) {
           var newInputValue = inputExpressions[i](scope);
           if (changed || (changed = !expressionInputDirtyCheck(newInputValue, oldInputValueOfValues[i]))) {
+            oldInputValues[i] = newInputValue;
             oldInputValueOfValues[i] = newInputValue && getValueOf(newInputValue);
           }
         }
 
         if (changed) {
-          lastResult = parsedExpression(scope, undefined, undefined, oldInputValueOfValues);
+          lastResult = parsedExpression(scope, undefined, undefined, oldInputValues);
         }
 
         return lastResult;

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -818,7 +818,7 @@ ASTCompiler.prototype = {
     var fns = this.state.inputs;
     var self = this;
     forEach(fns, function(name) {
-      result.push('var ' + name + '=' + self.generateFunction(name, 's,l'));
+      result.push('var ' + name + '=' + self.generateFunction(name, 's'));
     });
     if (fns.length) {
       result.push('fn.inputs=[' + fns.join(',') + '];');
@@ -835,7 +835,6 @@ ASTCompiler.prototype = {
 
   filterPrefix: function() {
     var parts = [];
-    var checks = [];
     var self = this;
     forEach(this.state.filters, function(id, filter) {
       parts.push(id + '=$filter(' + self.escape(filter) + ')');

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -872,7 +872,7 @@ ASTCompiler.prototype = {
       break;
     case AST.UnaryExpression:
       this.recurse(ast.argument, undefined, undefined, function(expr) { right = expr; });
-      expression = ast.operator + '(' + right + ')';
+      expression = ast.operator + '(' + this.ifDefined(right, 0) + ')';
       this.assign(intoId, expression);
       recursionFn(expression);
       break;
@@ -1436,8 +1436,10 @@ ASTInterpreter.prototype = {
   'unary+': function(argument, context) {
     return function(scope, locals, assign, inputs) {
       var arg = argument(scope, locals, assign, inputs);
-      if (arg != null) {
+      if (isDefined(arg)) {
         arg = +arg;
+      } else {
+        arg = 0;
       }
       return context ? {value: arg} : arg;
     };
@@ -1445,8 +1447,10 @@ ASTInterpreter.prototype = {
   'unary-': function(argument, context) {
     return function(scope, locals, assign, inputs) {
       var arg = argument(scope, locals, assign, inputs);
-      if (arg != null) {
+      if (isDefined(arg)) {
         arg = -arg;
+      } else {
+        arg = 0;
       }
       return context ? {value: arg} : arg;
     };

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1298,7 +1298,7 @@ ASTInterpreter.prototype = {
     case AST.Identifier:
       ensureSafeMemberName(ast.name);
       return function(scope, locals, assign, inputs) {
-        var base = locals && locals.hasOwnProperty(ast.name) ? locals : scope;
+        var base = locals && (ast.name in locals) ? locals : scope;
         if (self.expensiveChecks || isPossiblyDangerousMemberName(ast.name)) {
           ensureSafeObject(value, self.expression);
         }

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1655,7 +1655,7 @@ function $ParseProvider() {
         };
 
     return function $parse(exp, interceptorFn, expensiveChecks) {
-      var expressionFactory, parsedExpression, oneTime, cacheKey;
+      var parsedExpression, oneTime, cacheKey;
 
       switch (typeof exp) {
         case 'string':
@@ -1663,27 +1663,26 @@ function $ParseProvider() {
           cacheKey = exp;
 
           var cache = (expensiveChecks ? cacheExpensive : cacheDefault);
-          expressionFactory = cache[cacheKey];
+          parsedExpression = cache[cacheKey];
           if (exp.charAt(0) === ':' && exp.charAt(1) === ':') {
             oneTime = true;
             exp = exp.substring(2);
           }
 
-          if (!expressionFactory) {
+          if (!parsedExpression) {
             var parseOptions = expensiveChecks ? $parseOptionsExpensive : $parseOptions;
             var lexer = new Lexer(parseOptions);
             var parser = new Parser(lexer, $filter, parseOptions);
-            expressionFactory = parser.parse(exp);
-            cache[cacheKey] = expressionFactory;
-          }
-          parsedExpression = expressionFactory;
-          if (parsedExpression.constant) {
-            parsedExpression.$$watchDelegate = constantWatchDelegate;
-          } else if (oneTime) {
-            parsedExpression.$$watchDelegate = parsedExpression.literal ?
-                oneTimeLiteralWatchDelegate : oneTimeWatchDelegate;
-          } else if (parsedExpression.inputs) {
-            parsedExpression.$$watchDelegate = inputsWatchDelegate;
+            parsedExpression = parser.parse(exp);
+            if (parsedExpression.constant) {
+              parsedExpression.$$watchDelegate = constantWatchDelegate;
+            } else if (oneTime) {
+              parsedExpression.$$watchDelegate = parsedExpression.literal ?
+                  oneTimeLiteralWatchDelegate : oneTimeWatchDelegate;
+            } else if (parsedExpression.inputs) {
+              parsedExpression.$$watchDelegate = inputsWatchDelegate;
+            }
+            cache[cacheKey] = parsedExpression;
           }
           return addInterceptor(parsedExpression, interceptorFn);
 

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -657,7 +657,9 @@ function findConstantAndWatchExpressions(ast, $filter) {
     forEach(ast.arguments, function(expr) {
       findConstantAndWatchExpressions(expr, $filter);
       allConstants = allConstants && expr.constant;
-      argsToWatch.push.apply(argsToWatch, expr.toWatch);
+      if (!expr.constant) {
+        argsToWatch.push.apply(argsToWatch, expr.toWatch);
+      }
     });
     ast.constant = allConstants;
     ast.toWatch = ast.filter && isStateless($filter, ast.callee.name) ? argsToWatch : [ast];
@@ -674,7 +676,9 @@ function findConstantAndWatchExpressions(ast, $filter) {
     forEach(ast.elements, function(expr) {
       findConstantAndWatchExpressions(expr, $filter);
       allConstants = allConstants && expr.constant;
-      argsToWatch.push.apply(argsToWatch, expr.toWatch);
+      if (!expr.constant) {
+        argsToWatch.push.apply(argsToWatch, expr.toWatch);
+      }
     });
     ast.constant = allConstants;
     ast.toWatch = argsToWatch;
@@ -685,7 +689,9 @@ function findConstantAndWatchExpressions(ast, $filter) {
     forEach(ast.properties, function(property) {
       findConstantAndWatchExpressions(property.value, $filter);
       allConstants = allConstants && property.value.constant;
-      argsToWatch.push.apply(argsToWatch, property.value.toWatch);
+      if (!property.value.constant) {
+        argsToWatch.push.apply(argsToWatch, property.value.toWatch);
+      }
     });
     ast.constant = allConstants;
     ast.toWatch = argsToWatch;

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -607,9 +607,12 @@ function findConstantAndWatchExpressions(ast, $filter) {
   var argsToWatch;
   switch (ast.type) {
   case AST.Program:
+    allConstants = true;
     forEach(ast.body, function(expr) {
       findConstantAndWatchExpressions(expr.expression, $filter);
+      allConstants = allConstants && expr.expression.constant;
     });
+    ast.constant = allConstants;
     break;
   case AST.Literal:
     ast.constant = true;
@@ -722,14 +725,15 @@ function assignableAST(ast) {
 }
 
 function isLiteral(ast) {
-  return ast.body.length === 1 && (
+  return ast.body.length === 0 ||
+      ast.body.length === 1 && (
       ast.body[0].expression.type === AST.Literal ||
       ast.body[0].expression.type === AST.ArrayExpression ||
       ast.body[0].expression.type === AST.ObjectExpression);
 }
 
 function isConstant(ast) {
-  return ast.body.length === 1 && ast.body[0].expression.constant;
+  return ast.constant;
 }
 
 function ASTCompiler(astBuilder, $filter) {

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -907,7 +907,7 @@ ASTCompiler.prototype = {
         ensureSafeMemberName(ast.name);
         self.if(self.stage === 'inputs' || self.not(self.getHasOwnProperty('l', ast.name)),
           function() {
-            self.if('s', function() {
+            self.if(self.stage === 'inputs' || 's', function() {
               if (create && create !== 1) {
                 self.if(
                   self.not(self.getHasOwnProperty('s', ast.name)),

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -668,7 +668,7 @@ function findConstantAndWatchExpressions(ast, $filter) {
     findConstantAndWatchExpressions(ast.left, $filter);
     findConstantAndWatchExpressions(ast.right, $filter);
     ast.constant = ast.left.constant && ast.right.constant;
-    ast.toWatch = ast.right.toWatch;
+    ast.toWatch = [ast];
     break;
   case AST.ArrayExpression:
     allConstants = true;
@@ -704,8 +704,8 @@ function findConstantAndWatchExpressions(ast, $filter) {
 }
 
 function getInputs(body) {
-  if (!body.length) return;
-  var lastExpression = body[body.length - 1].expression;
+  if (body.length != 1) return;
+  var lastExpression = body[0].expression;
   var candidate = lastExpression.toWatch;
   if (candidate.length !== 1) return candidate;
   return candidate[0] !== lastExpression ? candidate : undefined;

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1286,7 +1286,7 @@ ASTInterpreter.prototype = {
         context
       );
     case AST.Identifier:
-      ensureSafeMemberName(ast.name);
+      ensureSafeMemberName(ast.name, self.expression);
       return self.identifier(ast.name,
                              self.expensiveChecks || isPossiblyDangerousMemberName(ast.name),
                              context, create, self.expression);
@@ -1336,7 +1336,7 @@ ASTInterpreter.prototype = {
       return function(scope, locals, assign, inputs) {
         var lhs = left(scope, locals, assign, inputs);
         var rhs = right(scope, locals, assign, inputs);
-        ensureSafeObject(lhs.value);
+        ensureSafeObject(lhs.value, self.expression);
         lhs.context[lhs.name] = rhs;
         return context ? {value: rhs} : rhs;
       };

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -356,11 +356,11 @@ function $RootScopeProvider() {
        *     comparing for reference equality.
        * @returns {function()} Returns a deregistration function for this listener.
        */
-      $watch: function(watchExp, listener, objectEquality) {
+      $watch: function(watchExp, listener, objectEquality, prettyPrintExpression) {
         var get = $parse(watchExp);
 
         if (get.$$watchDelegate) {
-          return get.$$watchDelegate(this, listener, objectEquality, get);
+          return get.$$watchDelegate(this, listener, objectEquality, get, watchExp);
         }
         var scope = this,
             array = scope.$$watchers,
@@ -368,7 +368,7 @@ function $RootScopeProvider() {
               fn: listener,
               last: initWatchVal,
               get: get,
-              exp: watchExp,
+              exp: prettyPrintExpression || watchExp,
               eq: !!objectEquality
             };
 

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1898,6 +1898,16 @@ describe('parser', function() {
         expect(scope.$eval('b')).toBeUndefined();
         expect(scope.$eval('a.x')).toBeUndefined();
         expect(scope.$eval('a.b.c.d')).toBeUndefined();
+        scope.a = undefined;
+        expect(scope.$eval('a - b')).toBe(0);
+        expect(scope.$eval('a + b')).toBe(undefined);
+        scope.a = 0;
+        expect(scope.$eval('a - b')).toBe(0);
+        expect(scope.$eval('a + b')).toBe(0);
+        scope.a = undefined;
+        scope.b = 0;
+        expect(scope.$eval('a - b')).toBe(0);
+        expect(scope.$eval('a + b')).toBe(0);
       });
 
       it('should support property names that collide with native object properties', function() {
@@ -2982,6 +2992,7 @@ describe('parser', function() {
             return v;
           }
           scope.$watch($parse("a", interceptor));
+          scope.$watch($parse("a + b", interceptor));
           scope.a = scope.b = 0;
           scope.$digest();
           expect(called).toBe(true);

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -2710,6 +2710,11 @@ describe('parser', function() {
       });
 
       describe('one-time binding', function() {
+        it('should always use the cache', inject(function($parse) {
+          expect($parse('foo')).toBe($parse('foo'));
+          expect($parse('::foo')).toBe($parse('::foo'));
+        }));
+
         it('should not affect calling the parseFn directly', inject(function($parse, $rootScope) {
           var fn = $parse('::foo');
           $rootScope.$watch(fn);

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3225,6 +3225,23 @@ describe('parser', function() {
           expect($parse('a[0][0].b')({a: [[{b: 'scope'}]]}, {b: 'locals'})).toBe('scope');
           expect($parse('a[0].b.c')({a: [{b: {c: 'scope'}}] }, {b: {c: 'locals'} })).toBe('scope');
         }));
+
+        it('should assign directly to locals when the local property exists', inject(function($parse) {
+          var s = {}, l = {};
+
+          $parse("a = 1")(s, l);
+          expect(s.a).toBe(1);
+          expect(l.a).toBeUndefined();
+
+          l.a = 2;
+          $parse("a = 0")(s, l);
+          expect(s.a).toBe(1);
+          expect(l.a).toBe(0);
+
+          $parse("toString = 1")(s, l);
+          expect(isFunction(s.toString)).toBe(true);
+          expect(l.toString).toBe(1);
+        }));
       });
 
       describe('literal', function() {

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -2804,6 +2804,13 @@ describe('parser', function() {
         }));
 
         describe('literal expressions', function() {
+          it('should mark an empty expressions as literal', inject(function($parse) {
+            expect($parse('').literal).toBe(true);
+            expect($parse('   ').literal).toBe(true);
+            expect($parse('::').literal).toBe(true);
+            expect($parse('::    ').literal).toBe(true);
+          }));
+
           it('should only become stable when all the properties of an object have defined values', inject(function($parse, $rootScope, log) {
             var fn = $parse('::{foo: foo, bar: bar}');
             $rootScope.$watch(fn, function(value) { log(value); }, true);
@@ -3274,6 +3281,13 @@ describe('parser', function() {
       });
 
       describe('constant', function() {
+        it('should mark an empty expressions as constant', inject(function($parse) {
+          expect($parse('').constant).toBe(true);
+          expect($parse('   ').constant).toBe(true);
+          expect($parse('::').constant).toBe(true);
+          expect($parse('::    ').constant).toBe(true);
+        }));
+
         it('should mark scalar value expressions as constant', inject(function($parse) {
           expect($parse('12.3').constant).toBe(true);
           expect($parse('"string"').constant).toBe(true);

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3089,10 +3089,11 @@ describe('parser', function() {
           var filterCalls = 0;
           $filterProvider.register('foo', valueFn(function(input) {
             filterCalls++;
+            expect(input instanceof Date).toBe(true);
             return input;
           }));
 
-          var parsed = $parse('date | foo');
+          var parsed = $parse('date | foo:a');
           var date = scope.date = new Date();
 
           var watcherCalls = 0;
@@ -3115,10 +3116,11 @@ describe('parser', function() {
           var filterCalls = 0;
           $filterProvider.register('foo', valueFn(function(input) {
             filterCalls++;
+            expect(input instanceof Date).toBe(true);
             return input;
           }));
 
-          var parsed = $parse('date | foo');
+          var parsed = $parse('date | foo:a');
           var date = scope.date = new Date();
 
           var watcherCalls = 0;

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3159,6 +3159,51 @@ describe('parser', function() {
           scope.$digest();
           expect(spy.calls.length).toEqual(5);
         }));
+
+        it('should invoke all statements in multi-statement expressions', inject(function($parse) {
+          var lastVal = NaN;
+          var listener = function(val) { lastVal = val; };
+
+          scope.setBarToOne = false;
+          scope.bar = 0;
+          scope.two = 2;
+          scope.foo = function() { if (scope.setBarToOne) scope.bar = 1; };
+          scope.$watch("foo(); bar + two", listener);
+
+          scope.$digest();
+          expect(lastVal).toBe(2);
+
+          scope.bar = 2;
+          scope.$digest();
+          expect(lastVal).toBe(4);
+
+          scope.setBarToOne = true;
+          scope.$digest();
+          expect(lastVal).toBe(3);
+        }));
+
+        it('should watch the left side of assignments', inject(function($parse) {
+          var lastVal = NaN;
+          var listener = function(val) { lastVal = val; };
+
+          var objA = {};
+          var objB = {};
+
+          scope.$watch("curObj.value = input", noop);
+
+          scope.curObj = objA;
+          scope.input = 1;
+          scope.$digest();
+          expect(objA.value).toBe(scope.input);
+
+          scope.curObj = objB;
+          scope.$digest();
+          expect(objB.value).toBe(scope.input);
+
+          scope.input = 2;
+          scope.$digest();
+          expect(objB.value).toBe(scope.input);
+        }));
       });
 
       describe('locals', function() {

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3127,6 +3127,23 @@ describe('parser', function() {
           scope.$digest();
           expect(called).toBe(true);
         }));
+
+        it('should continue with the evaluation of the expression without invoking computed parts',
+            inject(function($parse) {
+          var value = 'foo';
+          var spy = jasmine.createSpy();
+
+          spy.andCallFake(function() { return value; });
+          scope.foo = spy;
+          scope.$watch("foo() | uppercase");
+          scope.$digest();
+          expect(spy.calls.length).toEqual(2);
+          scope.$digest();
+          expect(spy.calls.length).toEqual(3);
+          value = 'bar';
+          scope.$digest();
+          expect(spy.calls.length).toEqual(5);
+        }));
       });
 
       describe('locals', function() {

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1701,6 +1701,21 @@ describe('parser', function() {
         expect(scope.$eval("1/2*3")).toEqual(1 / 2 * 3);
       });
 
+      it('should parse unary', function() {
+        expect(scope.$eval("+1")).toEqual(+1);
+        expect(scope.$eval("-1")).toEqual(-1);
+        expect(scope.$eval("+'1'")).toEqual(+'1');
+        expect(scope.$eval("-'1'")).toEqual(-'1');
+        expect(scope.$eval("+undefined")).toEqual(0);
+        expect(scope.$eval("-undefined")).toEqual(0);
+        expect(scope.$eval("+null")).toEqual(+null);
+        expect(scope.$eval("-null")).toEqual(-null);
+        expect(scope.$eval("+false")).toEqual(+false);
+        expect(scope.$eval("-false")).toEqual(-false);
+        expect(scope.$eval("+true")).toEqual(+true);
+        expect(scope.$eval("-true")).toEqual(-true);
+      });
+
       it('should parse comparison', function() {
         /* jshint -W041 */
         expect(scope.$eval("false")).toBeFalsy();


### PR DESCRIPTION
Change the way parse works from the old mechanism to a multiple stages
parsing and code generation. The new parse is a four stages parsing
- Lexer
- AST building
- AST processing
- Cacheing, one-time binding and `$watch` optimizations

The Lexer phase remains unchanged.

AST building phase follows Mozilla Parse API [1] and generates an AST that is compatible. The only exception was needed for `filters` as JavaScript does not support filters, in this case, a filter is transformed into a `CallExpression` that has an extra property named `filter` with the value of `true`. This phase is heavily based on the previous implementation of `$parse`.

The AST processing phase transforms the AST into a function that can be executed to evaluate the expression. The logic for expressions remains unchanged. The AST processing phase works in two different ways depending if csp is enabled or disabled. If csp is enabled, the processing phase returns pre-generated function that interpret specific parts of the AST.
When csp is disabled, then the entire expression is compiled into a single function that is later evaluated using `Function`. In both cases, the returning function has the properties `constant`, `literal` and `inputs` as in the previous implementation. These are used in the next phase to perform different optimizations.

The cacheing, one-time binding and `$watch` optimizations phase remains mostly unchanged.

[1] https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Parser_API
