### PR TITLE
refactor(minErr): code cleanup

### DIFF
--- a/src/minErr.js
+++ b/src/minErr.js
@@ -33,28 +33,33 @@
 function minErr(module, ErrorConstructor) {
   ErrorConstructor = ErrorConstructor || Error;
   return function() {
-    var code = arguments[0],
-      prefix = '[' + (module ? module + ':' : '') + code + '] ',
-      template = arguments[1],
-      templateArgs = arguments,
+    var SKIP_INDEXES = 2;
 
-      message, i;
+    var templateArgs = arguments,
+      code = templateArgs[0],
+      message = '[' + (module ? module + ':' : '') + code + '] ',
+      template = templateArgs[1],
+      paramPrefix, i;
 
-    message = prefix + template.replace(/\{\d+\}/g, function(match) {
-      var index = +match.slice(1, -1), arg;
+    message += template.replace(/\{\d+\}/g, function(match) {
+      var index = +match.slice(1, -1),
+        shiftedIndex = index + SKIP_INDEXES;
 
-      if (index + 2 < templateArgs.length) {
-        return toDebugString(templateArgs[index + 2]);
+      if (shiftedIndex < templateArgs.length) {
+        return toDebugString(templateArgs[shiftedIndex]);
       }
+
       return match;
     });
 
-    message = message + '\nhttp://errors.angularjs.org/"NG_VERSION_FULL"/' +
+    message += '\nhttp://errors.angularjs.org/"NG_VERSION_FULL"/' +
       (module ? module + '/' : '') + code;
-    for (i = 2; i < arguments.length; i++) {
-      message = message + (i == 2 ? '?' : '&') + 'p' + (i - 2) + '=' +
-        encodeURIComponent(toDebugString(arguments[i]));
+
+    for (i = SKIP_INDEXES, paramPrefix = '?'; i < templateArgs.length; i++, paramPrefix = '&') {
+      message += paramPrefix + 'p' + (i - SKIP_INDEXES) + '=' +
+        encodeURIComponent(toDebugString(templateArgs[i]));
     }
+
     return new ErrorConstructor(message);
   };
 }

--- a/test/minErrSpec.js
+++ b/test/minErrSpec.js
@@ -97,4 +97,11 @@ describe('minErr', function() {
     var typeMinErr = minErr('type', TypeError);
     expect(typeMinErr('acode', 'aproblem') instanceof TypeError).toBe(true);
   });
+
+
+  it('should include a properly formatted error reference URL in the message', function() {
+    // to avoid maintaining the root URL in two locations, we only validate the parameters
+    expect(testError('acode', 'aproblem', 'a', 'b', 'value with space').message)
+      .toMatch(/^[\s\S]*\?p0=a&p1=b&p2=value%20with%20space$/);
+  });
 });


### PR DESCRIPTION
Removes a "magic number" (2) used multiple times in the code.
Removes unnecessary variables "arg" and "prefix".
Removed a condition within the "for" loop that generates query string parameters.
Adds a test case to ensure URL parameters are generated as expected.
