### PR TITLE
docs(tutorial/0 - Bootstrapping): Remind users to refresh page

### DIFF
--- a/docs/content/tutorial/step_00.ngdoc
+++ b/docs/content/tutorial/step_00.ngdoc
@@ -33,6 +33,9 @@ To see the app running in a browser, open a *separate* terminal/command line tab
 run `npm start` to start the web server. Now, open a browser window for the app and navigate to
 <a href="http://localhost:8000/app/" target="_blank">`http://localhost:8000/app/`</a>
 
+Note that if you already ran the master branch app prior to checking out step-0, you may see the cached
+master version of the app in your browser window at this point. Just hit refresh to re-load the page.
+
 You can now see the page in your browser. It's not very exciting, but that's OK.
 
 The HTML page that displays "Nothing here yet!" was constructed with the HTML code shown below.


### PR DESCRIPTION
On line 32-34 after reverting to step-0 and starting the webserver, the browser may have already cached the master branch of the app and the user will see the master version in their browser. I just added a reminder to tell them to refresh the page if this happens!
