### PR TITLE
fix(jqLite): properly handle dash-delimited node names in `jqLiteBuildFragment`

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -142,7 +142,7 @@ function camelCase(name) {
 
 var SINGLE_TAG_REGEXP = /^<(\w+)\s*\/?>(?:<\/\1>|)$/;
 var HTML_REGEXP = /<|&#?\w+;/;
-var TAG_NAME_REGEXP = /<([\w:]+)/;
+var TAG_NAME_REGEXP = /<([\w:-]+)/;
 var XHTML_TAG_REGEXP = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>]*)\/>/gi;
 
 var wrapMap = {

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -78,6 +78,19 @@ describe('jqLite', function() {
     });
 
 
+    it('should properly handle dash-delimited node names', function() {
+      var nodes = jqLite('<custom-element>Hello, world !</custom-element>');
+      expect(nodes.length).toBe(1);
+      expect(nodeName_(nodes)).toBe('custom-element');
+      expect(nodes.html()).toBe('Hello, world !');
+
+      nodes = jqLite('<tr-custom>Hello, world !</tr-custom>');
+      expect(nodes.length).toBe(1);
+      expect(nodeName_(nodes)).toBe('tr-custom');
+      expect(nodes.html()).toBe('Hello, world !');
+    });
+
+
     it('should allow creation of comment tags', function() {
       var nodes = jqLite('<!-- foo -->');
       expect(nodes.length).toBe(1);


### PR DESCRIPTION
Closes #10617
