### PR TITLE
feat($interval): pass arguments in callback

### DIFF
--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -39,6 +39,7 @@ function $IntervalProvider() {
       *   indefinitely.
       * @param {boolean=} [invokeApply=true] If set to `false` skips model dirty checking, otherwise
       *   will invoke `fn` within the {@link ng.$rootScope.Scope#$apply $apply} block.
+      * @param {...*=} Pass additional parameters to the executed function.
       * @returns {promise} A promise which will be notified on each iteration.
       *
       * @example
@@ -132,7 +133,9 @@ function $IntervalProvider() {
       * </example>
       */
     function interval(fn, delay, count, invokeApply) {
-      var setInterval = $window.setInterval,
+      var hasParams = arguments.length > 4,
+          args = hasParams ? sliceArgs(arguments, 4) : [],
+          setInterval = $window.setInterval,
           clearInterval = $window.clearInterval,
           iteration = 0,
           skipApply = (isDefined(invokeApply) && !invokeApply),
@@ -141,7 +144,9 @@ function $IntervalProvider() {
 
       count = isDefined(count) ? count : 0;
 
-      promise.then(null, null, fn);
+      promise.then(null, null, (!hasParams) ? fn : function() {
+        fn.apply(null, args);
+      });
 
       promise.$$intervalId = setInterval(function tick() {
         deferred.notify(iteration++);

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -451,6 +451,7 @@ angular.mock.$LogProvider = function() {
  *   indefinitely.
  * @param {boolean=} [invokeApply=true] If set to `false` skips model dirty checking, otherwise
  *   will invoke `fn` within the {@link ng.$rootScope.Scope#$apply $apply} block.
+ * @param {...*=} Pass additional parameters to the executed function.
  * @returns {promise} A promise which will be notified on each iteration.
  */
 angular.mock.$IntervalProvider = function() {
@@ -461,13 +462,17 @@ angular.mock.$IntervalProvider = function() {
         now = 0;
 
     var $interval = function(fn, delay, count, invokeApply) {
-      var iteration = 0,
+      var hasParams = arguments.length > 4,
+          args = hasParams ? Array.prototype.slice.call(arguments, 4) : [],
+          iteration = 0,
           skipApply = (angular.isDefined(invokeApply) && !invokeApply),
           deferred = (skipApply ? $$q : $q).defer(),
           promise = deferred.promise;
 
       count = (angular.isDefined(count)) ? count : 0;
-      promise.then(null, null, fn);
+      promise.then(null, null, (!hasParams) ? fn : function() {
+        fn.apply(null, args);
+      });
 
       promise.$$intervalId = nextRepeatId;
 

--- a/test/ng/intervalSpec.js
+++ b/test/ng/intervalSpec.js
@@ -142,6 +142,31 @@ describe('$interval', function() {
   }));
 
 
+  it('should allow you to specify a number of arguments', inject(function($interval, $window) {
+    var task1 = jasmine.createSpy('task1'),
+        task2 = jasmine.createSpy('task2'),
+        task3 = jasmine.createSpy('task3');
+    $interval(task1, 1000, 2, true, 'Task1');
+    $interval(task2, 1000, 2, true, 'Task2');
+    $interval(task3, 1000, 2, true, 'I', 'am', 'a', 'Task3', 'spy');
+
+    $window.flush(1000);
+    expect(task1).toHaveBeenCalledWith('Task1');
+    expect(task2).toHaveBeenCalledWith('Task2');
+    expect(task3).toHaveBeenCalledWith('I', 'am', 'a', 'Task3', 'spy');
+
+    task1.reset();
+    task2.reset();
+    task3.reset();
+
+    $window.flush(1000);
+    expect(task1).toHaveBeenCalledWith('Task1');
+    expect(task2).toHaveBeenCalledWith('Task2');
+    expect(task3).toHaveBeenCalledWith('I', 'am', 'a', 'Task3', 'spy');
+
+  }));
+
+
   it('should return a promise which will be updated with the count on each iteration',
       inject(function($interval, $window) {
     var log = [],


### PR DESCRIPTION
PR has updated Docs and Tests
`setInterval` allows you to pass arguments into the callback function
in
the …3rd argument. Since that’s taken I added it to the …5th
http://mdn.io/setInterval#Syntax

similar pull request https://github.com/angular/angular.js/pull/10631
