### PR TITLE
fix(ngRepeat): Track By function conflict

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -289,7 +289,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
       return function ngRepeatLink($scope, $element, $attr, ctrl, $transclude) {
 
         if (trackByExpGetter) {
-          trackByIdExpFn = function(key, value, index) {
+          var trackByIdExpFn = function(key, value, index) {
             // assign key, value, and $index to the locals so that they can be used in hash functions
             if (keyIdentifier) hashFnLocals[keyIdentifier] = key;
             hashFnLocals[valueIdentifier] = value;

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -607,8 +607,8 @@ function $RouteProvider() {
               return $q.all(locals);
             }
           }).
-          // after route change
           then(function(locals) {
+            // after route change
             if (nextRoute == $route.current) {
               if (nextRoute) {
                 nextRoute.locals = locals;


### PR DESCRIPTION
Added 'var' to make sure the Track By function/closure is attached to each instance.
Otherwise all directives of the same type call the same Track By function, with the same arguments/closure. (the last one created).
This problem might affect other types of track by expressions variables, as they are declared in the compile method. (line 275)
