### PR TITLE
fix(ngRepeat): don't clone DOM for holes in sparse arrays

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -348,17 +348,28 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
           collectionLength = collectionKeys.length;
           nextBlockOrder = new Array(collectionLength);
 
+          var k = 0;
+          var keyIndex;
           // locate existing items
           for (index = 0; index < collectionLength; index++) {
-            key = (collection === collectionKeys) ? index : collectionKeys[index];
+            if (collection === collectionKeys) {
+              // Do not iterate over holes in arrays or array-like values
+              if (!(index in collection)) continue;
+              key = index;
+              keyIndex = k++;
+            } else {
+              key = collectionKeys[index];
+              keyIndex = index;
+            }
+
             value = collection[key];
-            trackById = trackByIdFn(key, value, index);
+            trackById = trackByIdFn(key, value, keyIndex);
             if (lastBlockMap[trackById]) {
               // found previously seen block
               block = lastBlockMap[trackById];
               delete lastBlockMap[trackById];
               nextBlockMap[trackById] = block;
-              nextBlockOrder[index] = block;
+              nextBlockOrder[keyIndex] = block;
             } else if (nextBlockMap[trackById]) {
               // if collision detected. restore lastBlockMap and throw an error
               forEach(nextBlockOrder, function(block) {
@@ -369,7 +380,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
                   expression, trackById, value);
             } else {
               // new never before seen block
-              nextBlockOrder[index] = {id: trackById, scope: undefined, clone: undefined};
+              nextBlockOrder[keyIndex] = {id: trackById, scope: undefined, clone: undefined};
               nextBlockMap[trackById] = true;
             }
           }
@@ -389,11 +400,22 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
             block.scope.$destroy();
           }
 
+          k = 0;
           // we are not using forEach for perf reasons (trying to avoid #call)
           for (index = 0; index < collectionLength; index++) {
-            key = (collection === collectionKeys) ? index : collectionKeys[index];
+            if (collection === collectionKeys) {
+              // Do not iterate over holes in arrays or array-like values
+              if (!(index in collection)) continue;
+              key = index;
+              keyIndex = k++;
+            } else {
+              key = collectionKeys[index];
+              keyIndex = index;
+            }
+
             value = collection[key];
-            block = nextBlockOrder[index];
+            block = nextBlockOrder[keyIndex];
+            if (!block) continue;
 
             if (block.scope) {
               // if we have already seen this object, then we need to reuse the
@@ -411,7 +433,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
                 $animate.move(getBlockNodes(block.clone), null, jqLite(previousNode));
               }
               previousNode = getBlockEnd(block);
-              updateScope(block.scope, index, valueIdentifier, value, keyIdentifier, key, collectionLength);
+              updateScope(block.scope, keyIndex, valueIdentifier, value, keyIdentifier, key, collectionLength);
             } else {
               // new item which we don't know about
               $transclude(function ngRepeatTransclude(clone, scope) {
@@ -428,7 +450,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
                 // by a directive with templateUrl when its template arrives.
                 block.clone = clone;
                 nextBlockMap[block.id] = block;
-                updateScope(block.scope, index, valueIdentifier, value, keyIdentifier, key, collectionLength);
+                updateScope(block.scope, keyIndex, valueIdentifier, value, keyIdentifier, key, collectionLength);
               });
             }
           }
@@ -438,4 +460,3 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
     }
   };
 }];
-

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -607,8 +607,8 @@ function $RouteProvider() {
               return $q.all(locals);
             }
           }).
-          // after route change
           then(function(locals) {
+            // after route change
             if (nextRoute == $route.current) {
               if (nextRoute) {
                 nextRoute.locals = locals;

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -759,14 +759,23 @@ describe('ngRepeat', function() {
   });
 
 
-  it('should iterate over non-existent elements of a sparse array', function() {
+  it('should not iterate over non-existent elements of a sparse array', function() {
     element = $compile('<ul><li ng-repeat="item in array track by $index">{{item}}|</li></ul>')(scope);
-    scope.array = ['a', 'b'];
-    scope.array[4] = 'c';
-    scope.array[6] = 'd';
+    // jscs: disable
+    scope.array = ['a', 'b', , , 'c', , 'd'];
+    // jscs: enable
     scope.$digest();
 
-    expect(element.text()).toBe('a|b|||c||d|');
+    expect(element.text()).toBe('a|b|c|d|');
+  });
+
+
+  it('should not iterate over non-existent elements of a sparse array-like', function() {
+    element = $compile('<ul><li ng-repeat="item in array track by $index">{{item}}|</li></ul>')(scope);
+    scope.array = { '0': 'a', '1': 'b', '4': 'c', '6': 'd', 'length': 7 };
+    scope.$digest();
+
+    expect(element.text()).toBe('a|b|c|d|');
   });
 
 


### PR DESCRIPTION
Previously, ngRepeat would clone DOM for holes in sparse arrays. Now, holes are ignored. The $index
is translated to the index of the repeated clone, rather than the original array $index, so that
$even and $odd still work correctly.

Closes #10544
