### PR TITLE
fix(ngClass): handle multi-class definitions as an element of an array

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -97,7 +97,7 @@ function classDirective(name, selector) {
 
     function arrayClasses(classVal) {
       if (isArray(classVal)) {
-        return classVal;
+        return classVal.join(' ').split(' ');
       } else if (isString(classVal)) {
         return classVal.split(' ');
       } else if (isObject(classVal)) {

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -88,6 +88,16 @@ describe('ngClass', function() {
   }));
 
 
+  it('should support adding multiple classes via a space delimited string inside an array', inject(function($rootScope, $compile) {
+    element = $compile('<div class="existing" ng-class="[\'A B\', \'C\']"></div>')($rootScope);
+    $rootScope.$digest();
+    expect(element.hasClass('existing')).toBeTruthy();
+    expect(element.hasClass('A')).toBeTruthy();
+    expect(element.hasClass('B')).toBeTruthy();
+    expect(element.hasClass('C')).toBeTruthy();
+  }));
+
+
   it('should preserve class added post compilation with pre-existing classes', inject(function($rootScope, $compile) {
     element = $compile('<div class="existing" ng-class="dynClass"></div>')($rootScope);
     $rootScope.dynClass = 'A';


### PR DESCRIPTION
Handles multi-class definition as an element of an array

Closes #8578
