### PR TITLE
Get rid of unused variable

### DIFF
--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -380,7 +380,7 @@ angular.module('ngMessages', [])
               });
             }
           },
-          detach: function(now) {
+          detach: function() {
             if (element) {
               $animate.leave(element);
               element = null;


### PR DESCRIPTION
It may not cause a large problem for the project, but in the long-term, it might disrupt the ng-messages module, which is quite popular (All my angular apps have them), so I cleaned it up.
