### PR TITLE
feat(ngRoute): screening colon in given path

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -191,35 +191,39 @@ function $RouteProvider() {
     *
     * Inspired by pathRexp in visionmedia/express/lib/utils.js.
     */
-  function pathRegExp(path, opts) {
-    var insensitive = opts.caseInsensitiveMatch,
-        ret = {
-          originalPath: path,
-          regexp: path
-        },
-        keys = ret.keys = [];
+   function pathRegExp(path, opts) {
+     var insensitive = opts.caseInsensitiveMatch,
+       ret = {
+         originalPath: path,
+         regexp: path
+       },
+       keys = ret.keys = [];
 
-    path = path
-      .replace(/([().])/g, '\\$1')
-      .replace(/(\/)?:(\w+)([\?\*])?/g, function(_, slash, key, option) {
-        var optional = option === '?' ? option : null;
-        var star = option === '*' ? option : null;
-        keys.push({ name: key, optional: !!optional });
-        slash = slash || '';
-        return ''
-          + (optional ? '' : slash)
-          + '(?:'
-          + (optional ? slash : '')
-          + (star && '(.+?)' || '([^/]+)')
-          + (optional || '')
-          + ')'
-          + (optional || '');
-      })
-      .replace(/([\/$\*])/g, '\\$1');
+     path = path
+       .replace(/([().])/g, '\\$1')
+       .replace(/(\/)?(\\)?:(\w+)([\?\*])?/g, function (_, slash, screening, key, option) {
+         if (screening === '\\') {
+           return _.replace(/\\/g, '');
+         }
 
-    ret.regexp = new RegExp('^' + path + '$', insensitive ? 'i' : '');
-    return ret;
-  }
+         var optional = option === '?' ? option : null;
+         var star = option === '*' ? option : null;
+         keys.push({ name: key, optional: !!optional });
+         slash = slash || '';
+         return ''
+           + (optional ? '' : slash)
+           + '(?:'
+           + (optional ? slash : '')
+           + (star && '(.+?)' || '([^/]+)')
+           + (optional || '')
+           + ')'
+           + (optional || '');
+       })
+       .replace(/([\/$\*])/g, '\\$1');
+
+     ret.regexp = new RegExp('^' + path + '$', insensitive ? 'i' : '');
+     return ret;
+   }
 
   /**
    * @ngdoc method

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -201,7 +201,7 @@ function $RouteProvider() {
 
      path = path
        .replace(/([().])/g, '\\$1')
-       .replace(/(\/)?(\\)?:(\w+)([\?\*])?/g, function (_, slash, screening, key, option) {
+       .replace(/(\/)?(\\)?:(\w+)([\?\*])?/g, function(_, slash, screening, key, option) {
          if (screening === '\\') {
            return _.replace(/\\/g, '');
          }

--- a/test/ngRoute/routeParamsSpec.js
+++ b/test/ngRoute/routeParamsSpec.js
@@ -22,6 +22,18 @@ describe('$routeParams', function() {
     });
   });
 
+  it('should not publish screened param into a service', function () {
+    module(function ($routeProvider) {
+      $routeProvider.when('/bar/\\:barId', {});
+    });
+
+    inject(function ($rootScope, $route, $location, $routeParams) {
+      $location.path('/bar/123');
+      $rootScope.$digest();
+      expect($routeParams).toEqual({barId: undefined});
+    });
+  });
+
   it('should correctly extract the params when a param name is part of the route',  function() {
     module(function($routeProvider) {
       $routeProvider.when('/bar/:foo/:bar', {});

--- a/test/ngRoute/routeParamsSpec.js
+++ b/test/ngRoute/routeParamsSpec.js
@@ -22,12 +22,12 @@ describe('$routeParams', function() {
     });
   });
 
-  it('should not publish screened param into a service', function () {
-    module(function ($routeProvider) {
+  it('should not publish screened param into a service', function() {
+    module(function($routeProvider) {
       $routeProvider.when('/bar/\\:barId', {});
     });
 
-    inject(function ($rootScope, $route, $location, $routeParams) {
+    inject(function($rootScope, $route, $location, $routeParams) {
       $location.path('/bar/123');
       $rootScope.$digest();
       expect($routeParams).toEqual({barId: undefined});


### PR DESCRIPTION
Use backslash symbol before colon to prevent it interpretation as variable.
For example: path "/\:foo/:bar" returns only "bar" variable
