### PR TITLE
docs(ngModelOptions): Config objects cannot be shared among ngModelOptions instances.

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -1082,6 +1082,10 @@ var DEFAULT_REGEXP = /(\s+|^)default(\s+|$)/;
  * Any pending changes will take place immediately when an enclosing form is submitted via the
  * `submit` event. Note that `ngClick` events will occur before the model is updated. Use `ngSubmit`
  * to have access to the updated model.
+ * 
+ * Multiple `ngModelOptions` instances cannot share the same options Object. For example, supplying a 
+ * shared debouncing "config" Object among multiple input elements will not work; create a copy of the
+ * Object instead.
  *
  * `ngModelOptions` has an effect on the element it's declared on and its descendants.
  *


### PR DESCRIPTION
Just thought I'd add a note about this issue since it hit me during development and I cannot find any note about it in the documentation.  Looking at the source code, it seems that the changes to the object made in the block of https://github.com/angular/angular.js/blob/master/src/ng/directive/ngModel.js#L1223 are not idempotent, but I guess that's a design choice, not a bug?
