### PR TITLE
fix(ngModelOptions): Allow sharing ngModelOptions objects between multiple directive instances, even when they specify default behavior.

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -1218,7 +1218,7 @@ var ngModelOptionsDirective = function() {
       this.$options = $scope.$eval($attrs.ngModelOptions);
       // Allow adding/overriding bound events
       if (this.$options.updateOn !== undefined) {
-        this.$options.updateOnDefault = false;
+        this.$options.updateOnDefault = this.$options.updateOnDefault || false;
         // extract "default" pseudo-event from list of events that can trigger a model update
         this.$options.updateOn = trim(this.$options.updateOn.replace(DEFAULT_REGEXP, function() {
           that.$options.updateOnDefault = true;

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -1733,6 +1733,31 @@ describe('ngModelOptions attributes', function() {
   });
 
 
+  it('should allow options object with default update behavior to be shared between instances', function() {
+    $rootScope.sharedModelOptions = {
+        updateOn: 'default blur'
+    };
+
+    var inputElm = helper.compileInput(
+        '<input type="text" ng-model="nameA" name="aliasA" ' +
+          'ng-model-options="sharedModelOptions"' +
+        '/>' +
+        '<input type="text" ng-model="nameB" name="aliasB" ' +
+          'ng-model-options="sharedModelOptions"' +
+        '/>'),
+        inputA = jqLite(inputElm[0]),
+        inputB = jqLite(inputElm[1]);
+
+    expect($rootScope.sharedModelOptions.updateOnDefault).toBe(true);
+    helper.changeGivenInputTo(inputA, 'a');
+    expect($rootScope.nameA).toEqual('a');
+    helper.changeGivenInputTo(inputB, 'b');
+    expect($rootScope.nameB).toEqual('b');
+
+    delete $rootScope.sharedModelOptions;
+  });
+
+
   it('should allow overriding the model update trigger event on checkboxes', function() {
     var inputElm = helper.compileInput(
         '<input type="checkbox" ng-model="checkbox" ' +


### PR DESCRIPTION
Fixes #10667.
