### PR TITLE
fix(ngRoute): dont duplicate optional params into query

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -481,15 +481,10 @@ function $RouteProvider() {
            */
           updateParams: function(newParams) {
             if (this.current && this.current.$$route) {
-              var searchParams = {}, self=this;
-
-              angular.forEach(Object.keys(newParams), function(key) {
-                if (!self.current.pathParams[key]) searchParams[key] = newParams[key];
-              });
-
               newParams = angular.extend({}, this.current.params, newParams);
               $location.path(interpolate(this.current.$$route.originalPath, newParams));
-              $location.search(angular.extend({}, $location.search(), searchParams));
+              // interpolate modifies newParams, only query params are left
+              $location.search(newParams);
             }
             else {
               throw $routeMinErr('norout', 'Tried updating route when with no current route');

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -1341,6 +1341,30 @@ describe('$route', function() {
       });
     });
 
+    it('should not update query params when an optional property was previously not in path', function() {
+      var routeChangeSpy = jasmine.createSpy('route change');
+
+      module(function($routeProvider) {
+        $routeProvider.when('/bar/:barId/:fooId/:spamId/:eggId?', {controller: angular.noop});
+      });
+
+      inject(function($route, $routeParams, $location, $rootScope) {
+        $rootScope.$on('$routeChangeSuccess', routeChangeSpy);
+
+        $location.path('/bar/1/2/3');
+        $location.search({initial: 'true'});
+        $rootScope.$digest();
+        routeChangeSpy.reset();
+
+        $route.updateParams({barId: '5', fooId: '6', eggId: '4'});
+        $rootScope.$digest();
+
+        expect($routeParams).toEqual({barId: '5', fooId: '6', spamId: '3', eggId: '4', initial: 'true'});
+        expect(routeChangeSpy).toHaveBeenCalledOnce();
+        expect($location.path()).toEqual('/bar/5/6/3/4');
+        expect($location.search()).toEqual({initial: 'true'});
+      });
+    });
 
     it('should complain if called without an existing route', inject(function($route) {
       expect($route.updateParams).toThrowMinErr('ngRoute', 'norout');


### PR DESCRIPTION
When calling updateParams with properties which were optional, but
previously undefined, they would be duplicated into the query params as
well as into the path.

[jsfiddle reproduction](http://jsfiddle.net/cryqss2z/)

From `#updateParams` docs:

> Provided property names that match the route's path segment definitions will be interpolated into the location's path, while remaining properties will be treated as query params.

In the actual [implementation of updateParams](https://github.com/angular/angular.js/blob/e24d96827628285976526c7e8d91090a90e36322/src/ngRoute/route.js#L487) the "remaining properties" are determined prior to interpolation by checking if the `pathParam` for the given `key` has a value; however, optional parameters may not exist in `pathParams`.

Alternative fixes might include
-  (probably better) running `interpolate` before separating `searchParams`, since it will remove matched keys from the passed in `newParams` object.
-  (maybe more correct?) include undefined optional params in the `pathParams` object (switchRouteMatcher L536, `if (key && val)` -> `if(key)`) and then check for the property as opposed to truthiness
