### PR TITLE
fix(ng-options): support one-time binding on the options

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -414,7 +414,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
         ctrl.$render = render;
 
         scope.$watchCollection(valuesFn, scheduleRendering);
-        scope.$watchCollection(getLabels, scheduleRendering);
+        scope.$watchCollection($parse(valuesFn, getLabels), scheduleRendering);
 
         if (multiple) {
           scope.$watchCollection(function() { return ctrl.$modelValue; }, scheduleRendering);
@@ -458,8 +458,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
           }
         }
 
-        function getLabels() {
-          var values = valuesFn(scope);
+        function getLabels(values) {
           var toDisplay;
           if (values && isArray(values)) {
             toDisplay = new Array(values.length);

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -212,6 +212,32 @@ describe('select', function() {
     });
 
 
+    it('should be possible to use one-time binding on the expression', function() {
+      var options;
+
+      compile('<select ng-model="someModel" ng-options="o as o for o in ::arr"></select>');
+      options = element.find('option');
+      expect(options.length).toEqual(1);
+
+      scope.arr = ['a','b','c'];
+      scope.$digest();
+      options = element.find('option');
+      expect(options.length).toEqual(4);
+      expect(options.eq(0)).toEqualOption('?', '');
+      expect(options.eq(1)).toEqualOption('0', 'a');
+      expect(options.eq(2)).toEqualOption('1', 'b');
+      expect(options.eq(3)).toEqualOption('2', 'c');
+
+      scope.arr = ['w', 'x', 'y', 'z'];
+      scope.$digest();
+      options = element.find('option');
+      expect(options.length).toEqual(4);
+      expect(options.eq(0)).toEqualOption('?', '');
+      expect(options.eq(1)).toEqualOption('0', 'a');
+      expect(options.eq(2)).toEqualOption('1', 'b');
+      expect(options.eq(3)).toEqualOption('2', 'c');
+    });
+
     describe('empty option', function() {
 
       it('should select the empty option when model is undefined', function() {


### PR DESCRIPTION
Preserve the $watchDelegate on the watcher used to detect changes on the labels

Closes #10687
