### PR TITLE
chore(testing): bump protractor to version 1.6.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1528,7 +1528,7 @@
               "dependencies": {
                 "fsevents": {
                   "version": "0.2.1",
-                  "from": "git://github.com/pipobscure/fsevents#7dcdf9fa3f8956610fd6f69f72c67bace2de7138",
+                  "from": "fsevents@git://github.com/pipobscure/fsevents#7dcdf9fa3f8956610fd6f69f72c67bace2de7138",
                   "resolved": "git://github.com/pipobscure/fsevents#7dcdf9fa3f8956610fd6f69f72c67bace2de7138",
                   "dependencies": {
                     "nan": {
@@ -2452,17 +2452,6 @@
     },
     "grunt-merge-conflict": {
       "version": "0.0.2"
-    },
-    "grunt-parallel": {
-      "version": "0.3.1",
-      "dependencies": {
-        "q": {
-          "version": "0.8.12"
-        },
-        "lpad": {
-          "version": "0.1.0"
-        }
-      }
     },
     "grunt-shell": {
       "version": "1.1.1",
@@ -4810,7 +4799,7 @@
       }
     },
     "protractor": {
-      "version": "1.4.0",
+      "version": "1.6.0",
       "dependencies": {
         "request": {
           "version": "2.36.0",
@@ -4828,7 +4817,7 @@
               "version": "0.5.2"
             },
             "node-uuid": {
-              "version": "1.4.1"
+              "version": "1.4.2"
             },
             "tough-cookie": {
               "version": "0.12.1",
@@ -4858,16 +4847,16 @@
               "version": "0.4.0"
             },
             "http-signature": {
-              "version": "0.10.0",
+              "version": "0.10.1",
               "dependencies": {
                 "assert-plus": {
-                  "version": "0.1.2"
+                  "version": "0.1.5"
                 },
                 "asn1": {
                   "version": "0.1.11"
                 },
                 "ctype": {
-                  "version": "0.5.2"
+                  "version": "0.5.3"
                 }
               }
             },
@@ -4909,7 +4898,7 @@
                   "version": "0.6.1"
                 },
                 "xmlbuilder": {
-                  "version": "2.4.4",
+                  "version": "2.4.5",
                   "dependencies": {
                     "lodash-node": {
                       "version": "2.4.1"
@@ -4925,6 +4914,17 @@
         },
         "jasminewd": {
           "version": "1.1.0"
+        },
+        "jasminewd2": {
+          "version": "0.0.2"
+        },
+        "jasmine": {
+          "version": "2.1.1",
+          "dependencies": {
+            "jasmine-core": {
+              "version": "2.1.3"
+            }
+          }
         },
         "saucelabs": {
           "version": "0.1.1"
@@ -4966,7 +4966,7 @@
           "version": "1.0.0"
         },
         "source-map-support": {
-          "version": "0.2.8",
+          "version": "0.2.9",
           "dependencies": {
             "source-map": {
               "version": "0.1.32",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bower": "~1.3.9",
     "browserstacktunnel-wrapper": "~1.3.1",
     "canonical-path": "0.0.2",
+    "cheerio": "^0.17.0",
     "dgeni": "^0.4.0",
     "dgeni-packages": "^0.10.0",
     "event-stream": "~3.1.0",
@@ -51,7 +52,7 @@
     "marked": "~0.3.0",
     "node-html-encoder": "0.0.2",
     "promises-aplus-tests": "~2.1.0",
-    "protractor": "1.4.0",
+    "protractor": "^1.6.0",
     "q": "~1.0.0",
     "q-io": "^1.10.9",
     "qq": "^0.3.5",
@@ -59,8 +60,7 @@
     "semver": "~4.0.3",
     "shelljs": "~0.3.0",
     "sorted-object": "^1.0.0",
-    "stringmap": "^0.2.2",
-    "cheerio": "^0.17.0"
+    "stringmap": "^0.2.2"
   },
   "licenses": [
     {


### PR DESCRIPTION
This will also be cherry-picked to 1.3 and 1.2
