### PR TITLE
fix($q): correctly set constructor on prototypes

### DIFF
--- a/lib/promises-aplus/promises-aplus-test-adapter.js
+++ b/lib/promises-aplus/promises-aplus-test-adapter.js
@@ -10,6 +10,31 @@ var minErr = function minErr (module, constructor) {
     throw new ErrorConstructor(module + arguments[0] + arguments[1]);
   };
 };
+var setHashKey = function setHashKey(obj, h) {
+  if (h) {
+    obj.$$hashKey = h;
+  }
+  else {
+    delete obj.$$hashKey;
+  }
+}
+var extend = function extend(dst) {
+  var h = dst.$$hashKey;
+
+  for (var i = 1, ii = arguments.length; i < ii; i++) {
+    var obj = arguments[i];
+    if (obj) {
+      var keys = Object.keys(obj);
+      for (var j = 0, jj = keys.length; j < jj; j++) {
+        var key = keys[j];
+        dst[key] = obj[key];
+      }
+    }
+  }
+
+  setHashKey(dst, h);
+  return dst;
+}
 
 var $q = qFactory(process.nextTick, function noopExceptionHandler() {});
 

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -270,7 +270,7 @@ function qFactory(nextTick, exceptionHandler) {
     this.$$state = { status: 0 };
   }
 
-  Promise.prototype = {
+  extend(Promise.prototype, {
     constructor: Promise,
     
     then: function(onFulfilled, onRejected, progressBack) {
@@ -294,7 +294,7 @@ function qFactory(nextTick, exceptionHandler) {
         return handleCallback(error, false, callback);
       }, progressBack);
     }
-  };
+  });
 
   //Faster, more basic than angular.bind http://jsperf.com/angular-bind-vs-custom-vs-native
   function simpleBind(context, fn) {
@@ -341,9 +341,7 @@ function qFactory(nextTick, exceptionHandler) {
     this.notify = simpleBind(this, this.notify);
   }
 
-  Deferred.prototype = {
-    constructor: Deferred,
-    
+  extend(Deferred.prototype, {
     resolve: function(val) {
       if (this.promise.$$state.status) return;
       if (val === this.promise) {
@@ -407,7 +405,7 @@ function qFactory(nextTick, exceptionHandler) {
         });
       }
     }
-  };
+  });
 
   /**
    * @ngdoc method

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -271,6 +271,8 @@ function qFactory(nextTick, exceptionHandler) {
   }
 
   Promise.prototype = {
+    constructor: Promise,
+    
     then: function(onFulfilled, onRejected, progressBack) {
       var result = new Deferred();
 
@@ -340,6 +342,8 @@ function qFactory(nextTick, exceptionHandler) {
   }
 
   Deferred.prototype = {
+    constructor: Deferred,
+    
     resolve: function(val) {
       if (this.promise.$$state.status) return;
       if (val === this.promise) {


### PR DESCRIPTION
This patch will correctly set `Promise.prototype.constructor` and `Deferred.prototype.constructor`.

When prototype is set in the form `Foo.prototype = {x: y};`, the constructor will not be set correctly (as opposed to in the form `Foo.prototype.x = y;`.

As such, it is necessary to manually add the constructor to the prototype in these cases.
