### PR TITLE
chore(travis): split out the docs e2e tests into their own travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ branches:
 env:
   matrix:
     - JOB=unit BROWSER_PROVIDER=saucelabs
+    - JOB=docs-e2e BROWSER_PROVIDER=saucelabs
     - JOB=e2e TEST_TARGET=jqlite BROWSER_PROVIDER=saucelabs
     - JOB=e2e TEST_TARGET=jquery BROWSER_PROVIDER=saucelabs
     - JOB=unit BROWSER_PROVIDER=browserstack
+    - JOB=docs-e2e BROWSER_PROVIDER=browserstack
     - JOB=e2e TEST_TARGET=jqlite BROWSER_PROVIDER=browserstack
     - JOB=e2e TEST_TARGET=jquery BROWSER_PROVIDER=browserstack
   global:

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -16,6 +16,7 @@ if [ $JOB = "unit" ]; then
   grunt test:unit --browsers $BROWSERS --reporters dots
   grunt ci-checks
   grunt tests:docs --browsers $BROWSERS --reporters dots
+elif [ $JOB = "docs-e2e" ]; then
   grunt test:travis-protractor --specs "docs/app/e2e/**/*.scenario.js"
 elif [ $JOB = "e2e" ]; then
   if [ $TEST_TARGET = "jquery" ]; then


### PR DESCRIPTION
Previously, they were in the 'unit' job to save travis VMs, but this
was confusing and made it more difficult to track down errors easily.
