### PR TITLE
feat($http): add X-Forwarded-* headers to requests

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -1056,14 +1056,25 @@ function $HttpProvider() {
       }
 
 
-      // if we won't have the response in cache, set the xsrf headers and
+      // if we won't have the response in cache, set the convenient headers and
       // send the request to the backend
       if (isUndefined(cachedResp)) {
         var xsrfValue = urlIsSameOrigin(config.url)
             ? $browser.cookies()[config.xsrfCookieName || defaults.xsrfCookieName]
             : undefined;
+
+           //TODO
         if (xsrfValue) {
           reqHeaders[(config.xsrfHeaderName || defaults.xsrfHeaderName)] = xsrfValue;
+        }
+
+        var target = document.createElement('a');
+        target.href = url;
+
+        var protocol = target.protocol.substring(0, target.protocol.length - 1);
+        reqHeaders['X-Forwarded-Proto'] = protocol;
+        if (protocol == 'https') {
+          reqHeaders['X-Forwarded-Ssl'] = 'on';
         }
 
         $httpBackend(config.method, url, reqData, done, reqHeaders, config.timeout,


### PR DESCRIPTION
.... for compatibility with RESTful backends (i.e. Spring MVC + HATEOAS) that are not beeing reversed proxied, and don't know for sure wich protocol they are beeing used.

I found that this could be an usefull thing to be done automatically by Angular as some frameworks (like Spring HATEOAS) rely in this information to generate absolute URLs (cause they expect a reverse proxy to set this headers for them). In a cloud environment (i.e. PaaS), or local environment, this frameworks are not likely to be reverse proxied (although they could) so currently there is no way other than hacking the framework itself, or creating a custom request interceptor in angular to provide this two headers so everything works .... 

I don't see any drawbacks (other than the little bit increased request size) in having this set automatically by angularjs. 

Also I have to change the 'should allow replacement of the headers object' spec as AFAIK $http could add other headers after the interceptor (as the ones I added or others like XSRF).

Would be glad to hear any feedbacks about the changes I made :-).
