### PR TITLE
docs(tutorial/4 - Two-way Data Binding): describe your change...

### DIFF
--- a/docs/content/tutorial/step_04.ngdoc
+++ b/docs/content/tutorial/step_04.ngdoc
@@ -32,7 +32,7 @@ __`app/index.html`:__
 
   <ul class="phones">
     <li ng-repeat="phone in phones | filter:query | orderBy:orderProp">
-      <span>{{phone.name}}</span>
+      <span class="name">{{phone.name}}</span>
       <p>{{phone.snippet}}</p>
     </li>
   </ul>
@@ -150,7 +150,7 @@ __`test/e2e/scenarios.js`:__
 ...
     it('should be possible to control phone order via the drop down select box', function() {
 
-      var phoneNameColumn = element.all(by.repeater('phone in phones').column('phone.name'));
+      var phoneNameColumn = element.all(by.css('.name'));
       var query = element(by.model('query'));
 
       function getNames() {


### PR DESCRIPTION
I have Nodejs v0.10.33, AngularJS v1.3.8, and protractor 1.0.0. The end-to-end test as written always failed with the following messages:

```
Expected [  ] to equal [ 'Motorola XOOM™ with Wi-Fi', 'MOTOROLA XOOM™' ].
```

After a great deal of head-scratching I discovered that for whatever reason, element.all(by.repeater('phone in phones').column('phone.name')) was returning this:

```
{"locator_":{},"parentElementFinder_":null}
```

However, if I added classes to the items I was going to be testing for, and built the array of names from those instead, my test would pass.

I think something must be wrong either with Angular or Protractor. It would make more sense for the code that's already in the tutorial to work.
