### PR TITLE
docs($templateRequest): remove duplicate "the" in return description

### DIFF
--- a/src/ng/templateRequest.js
+++ b/src/ng/templateRequest.js
@@ -15,7 +15,7 @@ var $compileMinErr = minErr('$compile');
  * @param {string} tpl The HTTP request template URL
  * @param {boolean=} ignoreRequestError Whether or not to ignore the exception when the request fails or the template is empty
  *
- * @return {Promise} a promise for the the HTTP response data of the given URL.
+ * @return {Promise} a promise for the HTTP response data of the given URL.
  *
  * @property {number} totalPendingRequests total amount of pending template requests being downloaded.
  */


### PR DESCRIPTION
Introduced with: https://github.com/angular/angular.js/commit/1e5e527c84e2e5e9ed83ceb8e8c9c340c150b960
Reported: https://github.com/angular/angular.js/commit/1e5e527c84e2e5e9ed83ceb8e8c9c340c150b960#commitcomment-9123344
