### PR TITLE
docs(error/nobase): Added trailing slash for base path

### DIFF
--- a/docs/content/error/$location/nobase.ngdoc
+++ b/docs/content/error/$location/nobase.ngdoc
@@ -35,7 +35,7 @@ URL of the subcontext:
 
 ```html
 <head>
-  <base href="/subapp">
+  <base href="/subapp/">
   ...
 </head>
 ```


### PR DESCRIPTION
Trailing slash seems to be necessary, otherwise `$routeProvider` does not match routes correctly. Following is not matched:

URL: http://www.example.com/b/foo/1234

``` html
<base href="/b/foo">
```

``` javascript
$routeProvider.when('/:id', {
   templateUrl: '/view/path.html',
   controller: 'MyCtrl',
   reloadOnSearch: false
});
```
