### PR TITLE
Fix memory leak with $setValidity

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -163,6 +163,9 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
     forEach(form.$error, function(value, name) {
       form.$setValidity(name, null, control);
     });
+    forEach(form.$$success, function(value, name) {
+      form.$setValidity(name, null, control);
+    });
 
     arrayRemove(controls, control);
   };

--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -1247,22 +1247,22 @@ function addSetValidityMethod(context) {
 
   ctrl.$setValidity = setValidity;
 
-  function setValidity(validationErrorKey, state, options) {
+  function setValidity(validationErrorKey, state, control) {
     if (state === undefined) {
-      createAndSet('$pending', validationErrorKey, options);
+      createAndSet('$pending', validationErrorKey, control);
     } else {
-      unsetAndCleanup('$pending', validationErrorKey, options);
+      unsetAndCleanup('$pending', validationErrorKey, control);
     }
     if (!isBoolean(state)) {
-      unset(ctrl.$error, validationErrorKey, options);
-      unset(ctrl.$$success, validationErrorKey, options);
+      unset(ctrl.$error, validationErrorKey, control);
+      unset(ctrl.$$success, validationErrorKey, control);
     } else {
       if (state) {
-        unset(ctrl.$error, validationErrorKey, options);
-        set(ctrl.$$success, validationErrorKey, options);
+        unset(ctrl.$error, validationErrorKey, control);
+        set(ctrl.$$success, validationErrorKey, control);
       } else {
-        set(ctrl.$error, validationErrorKey, options);
-        unset(ctrl.$$success, validationErrorKey, options);
+        set(ctrl.$error, validationErrorKey, control);
+        unset(ctrl.$$success, validationErrorKey, control);
       }
     }
     if (ctrl.$pending) {
@@ -1290,20 +1290,21 @@ function addSetValidityMethod(context) {
     } else {
       combinedState = null;
     }
+
     toggleValidationCss(validationErrorKey, combinedState);
     parentForm.$setValidity(validationErrorKey, combinedState, ctrl);
   }
 
-  function createAndSet(name, value, options) {
+  function createAndSet(name, value, control) {
     if (!ctrl[name]) {
       ctrl[name] = {};
     }
-    set(ctrl[name], value, options);
+    set(ctrl[name], value, control);
   }
 
-  function unsetAndCleanup(name, value, options) {
+  function unsetAndCleanup(name, value, control) {
     if (ctrl[name]) {
-      unset(ctrl[name], value, options);
+      unset(ctrl[name], value, control);
     }
     if (isObjectEmpty(ctrl[name])) {
       ctrl[name] = undefined;

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -512,6 +512,41 @@ describe('form', function() {
       expect(doc.find('div').hasClass('ng-invalid-maxlength')).toBe(false);
     });
 
+    it('should deregister a input that is $pending when it is removed from DOM', function() {
+      doc = jqLite(
+        '<form name="parent">' +
+          '<div class="ng-form" name="child">' +
+            '<input ng-if="inputPresent" ng-model="modelA" name="inputA">' +
+          '</div>' +
+        '</form>');
+      $compile(doc)(scope);
+      scope.$apply('inputPresent = true');
+
+      var parent = scope.parent;
+      var child = scope.child;
+      var input = child.inputA;
+
+      scope.$apply(child.inputA.$setValidity('fake', undefined));
+
+      expect(parent).toBeDefined();
+      expect(child).toBeDefined();
+
+      expect(parent.$pending.fake).toEqual([child]);
+      expect(child.$pending.fake).toEqual([input]);
+
+      expect(doc.hasClass('ng-pending')).toBe(true);
+      expect(doc.find('div').hasClass('ng-pending')).toBe(true);
+
+      //remove child input
+      scope.$apply('inputPresent = false');
+
+      expect(parent.$pending).toBeUndefined();
+      expect(child.$pending).toBeUndefined();
+
+      expect(doc.hasClass('ng-pending')).toBe(false);
+      expect(doc.find('div').hasClass('ng-pending')).toBe(false);
+    });
+
   it('should leave the parent form invalid when deregister a removed input', function() {
     doc = jqLite(
       '<form name="parent">' +

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -463,7 +463,7 @@ describe('form', function() {
       doc = jqLite(
         '<form name="parent">' +
           '<div class="ng-form" name="child">' +
-            '<input ng-if="inputPresent" ng-model="modelA" name="inputA" required>' +
+            '<input ng-if="inputPresent" ng-model="modelA" name="inputA" required maxlength="10">' +
           '</div>' +
         '</form>');
       $compile(doc)(scope);
@@ -476,23 +476,40 @@ describe('form', function() {
 
       expect(parent).toBeDefined();
       expect(child).toBeDefined();
+
       expect(parent.$error.required).toEqual([child]);
+      expect(parent.$$success.maxlength).toEqual([child]);
+
       expect(child.$error.required).toEqual([input]);
+      expect(child.$$success.maxlength).toEqual([input]);
+
       expect(doc.hasClass('ng-invalid')).toBe(true);
       expect(doc.hasClass('ng-invalid-required')).toBe(true);
+      expect(doc.hasClass('ng-valid-maxlength')).toBe(true);
       expect(doc.find('div').hasClass('ng-invalid')).toBe(true);
       expect(doc.find('div').hasClass('ng-invalid-required')).toBe(true);
+      expect(doc.find('div').hasClass('ng-valid-maxlength')).toBe(true);
 
       //remove child input
-      scope.inputPresent = false;
-      scope.$apply();
+      scope.$apply('inputPresent = false');
 
       expect(parent.$error.required).toBeFalsy();
+      expect(parent.$$success.maxlength).toBeFalsy();
+
       expect(child.$error.required).toBeFalsy();
+      expect(child.$$success.maxlength).toBeFalsy();
+
       expect(doc.hasClass('ng-valid')).toBe(true);
       expect(doc.hasClass('ng-valid-required')).toBe(false);
+      expect(doc.hasClass('ng-invalid-required')).toBe(false);
+      expect(doc.hasClass('ng-valid-maxlength')).toBe(false);
+      expect(doc.hasClass('ng-invalid-maxlength')).toBe(false);
+
       expect(doc.find('div').hasClass('ng-valid')).toBe(true);
       expect(doc.find('div').hasClass('ng-valid-required')).toBe(false);
+      expect(doc.find('div').hasClass('ng-invalid-required')).toBe(false);
+      expect(doc.find('div').hasClass('ng-valid-maxlength')).toBe(false);
+      expect(doc.find('div').hasClass('ng-invalid-maxlength')).toBe(false);
     });
 
   it('should leave the parent form invalid when deregister a removed input', function() {


### PR DESCRIPTION
This PR includes:
- commit that correctly cleans up references to input controls in forms after they have been removed
- commit that renames an argument to better reflect its purpose
- commit which tests the form clean-up behavior for $pending inputs
