### PR TITLE
docs(design): highlight source button when focused

### DIFF
--- a/docs/app/assets/css/docs.css
+++ b/docs/app/assets/css/docs.css
@@ -546,10 +546,10 @@ h4 {
   margin-left:10px;
 }
 
-.btn:hover {
-  color:black!important;
+.btn:hover, .btn:focus {
+  color: black!important;
   border: 1px solid #ddd!important;
-  background:white!important;
+  background: white!important;
 }
 
 .view-source, .improve-docs {


### PR DESCRIPTION
The 'view source' and 'improve this Doc' buttons become unreadable when get focus:
![btn-focus](https://cloud.githubusercontent.com/assets/1024920/5702103/129d1220-9a4d-11e4-9ba4-f03721d22120.png)
