### PR TITLE
Assign fn.$inject during annotation from array

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -110,6 +110,7 @@ function annotate(fn, strictDi, name) {
     last = fn.length - 1;
     assertArgFn(fn[last], 'fn');
     $inject = fn.slice(0, last);
+    fn.$inject = $inject;
   } else {
     assertArgFn(fn, 'fn', true);
   }


### PR DESCRIPTION
When Angular annotates straight from function it adds `$inject` _static_ field to function itself. But when Angular annotates a function from an array it subsequently doesn't add the same. It would be advantageous if it did the same as client code may also use this field's value.
## Usage example

I'm following John Papa's angular guidelines how to write better maintainable angular code. So I'm writing my controllers/services using actual prototypes (that's even better than containing all behaviour within controller's scope as John Papa does). To actually work with prototypes we need all constructor injections on instantiated object so they can be accessed from other prototype functions. But to avoid adding these manually one can write a function i.e. `injectParameters` that does it automatically. This specific function reads those either from `$inject` static field or it parses function similar as angular's annotation does. The problem happens with minified files where argument names may be different from the actual ones provided in original code. The same problem happens in Angular hence two possible injection scenarios. So because Angular annotation doesn't add the `$inject` field when some controller/service was provided using an array there is no possibility to get those names correctly.

``` Javascript
function MyController($scope, someResource...) {
    injectParameters(this, arguments); // will make all injections accessible under this.injections...
    ...
}

MyController.prototype.doSomething() {
    // use injections
    this.injections.someResource.get(...);
}
```
