### PR TITLE
feat(injector): assign $inject field when annotating from an array

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -110,6 +110,7 @@ function annotate(fn, strictDi, name) {
     last = fn.length - 1;
     assertArgFn(fn[last], 'fn');
     $inject = fn.slice(0, last);
+    fn[last].$inject = $inject;
   } else {
     assertArgFn(fn, 'fn', true);
   }


### PR DESCRIPTION
When Angular annotates straight from function it adds `$inject` _static_ field to function itself. But when Angular annotates a function from an array it subsequently doesn't add the same. It would be advantageous if it did the same as client code may also use this field's value.
## Usage scenario

I'm following [John Papa's Angular guidelines](https://github.com/johnpapa/angularjs-styleguide) how to write better maintainable angular code. So I'm writing my controllers/services using actual prototypes and not anonymous functions. but instead of containing all behaviour within controller's constructor as John Papa does I'm actually writing prototypes. 

To work with prototypes we need all constructor injections on instantiated object so they can be accessed from other prototype functions. But to avoid tedious and error prone work of adding these manually one can write a function i.e. `injectParameters` that does it automatically. This specific function reads those either from `$inject` static field or it parses function similar as angular's annotation does. The problem happens with minified files where argument names may be different or even omitted from the ones provided in original source code. The same problem happens in Angular hence two possible injection scenarios:
- `angular.module("SomeModule").controller("SomeController", ["$scope",..., SomeController]);`
- `SomeController.$inject = ["$scope",...];`

So because Angular annotation doesn't add the `$inject` field when some controller/service was provided using the first method there is no possibility to get those names correctly in client code.

``` Javascript
function MyController($scope, someResource...) {
    injectParameters(this, arguments); // all injections accessible under i.e. this.injections...
    ...
}

MyController.prototype.doSomething() {
    // injections from constructor added by injectParameters to .injections object
    this.injections.someResource.get(...);
}
```
