### PR TITLE
Fix merging of two ngIfs in replace mode.

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2119,7 +2119,14 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       forEach(dst, function(value, key) {
         if (key.charAt(0) != '$') {
           if (src[key] && src[key] !== value) {
-            value += (key === 'style' ? ';' : ' ') + src[key];
+            var concatString = ' ';
+            if(key === 'style') {
+              concatString = ';'
+            }
+            if(key === 'ngIf'){ //if ngIf is merged both conditions need to be taken into account
+              concatString = ' && ';
+            }
+            value += concatString + src[key];
           }
           dst.$set(key, value, true, srcAttr[key]);
         }

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2120,10 +2120,10 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         if (key.charAt(0) != '$') {
           if (src[key] && src[key] !== value) {
             var concatString = ' ';
-            if(key === 'style') {
-              concatString = ';'
+            if (key === 'style') {
+              concatString = ';';
             }
-            if(key === 'ngIf'){ //if ngIf is merged both conditions need to be taken into account
+            if (key === 'ngIf') { //if ngIf is merged both conditions need to be taken into account
               concatString = ' && ';
             }
             value += concatString + src[key];

--- a/test/ng/directive/ngIfSpec.js
+++ b/test/ng/directive/ngIfSpec.js
@@ -212,6 +212,23 @@ describe('ngIf and transcludes', function() {
     });
   });
 
+  it('should allow using ngIf on the target element and on the root element of the directive template when used in a replace mode', function() {
+    module(function($compileProvider) {
+      var directive = $compileProvider.directive;
+      directive('example', valueFn({
+        template: '<div ng-if="innerCondition">guacamole</div>',
+        replace: true
+      }));
+    });
+    inject(function($compile, $rootScope) {
+      $rootScope.innerCondition = true;
+      $rootScope.outerCondition = true;
+      var element = $compile('<div><example ng-if="outerCondition"></example></div>')($rootScope);
+      $rootScope.$apply();
+      expect(element.text()).toBe('guacamole');
+      dealoc(element);
+    });
+  });
 
   it('should use the correct transcluded scope', function() {
     module(function($compileProvider) {


### PR DESCRIPTION
I noticed an error while working with ngIf in my project. It is reproduced here: http://codepen.io/kubawalinski/pen/EaWjxe?editors=101. In short, when 2 ngIfs need to be merged the merge is done incorrectly (it just concatenates the conditions with a space character). This is an attempt to fix this by concatenating with the ' && ' string, so that both conditions are checked and both need to be true for the ngIf to kick in.
