### PR TITLE
docs(tutorial/0 - Bootstrapping): The url http://localhost:8000/app/ 

### DIFF
--- a/docs/content/tutorial/step_00.ngdoc
+++ b/docs/content/tutorial/step_00.ngdoc
@@ -31,7 +31,7 @@ npm install
 
 To see the app running in a browser, open a *separate* terminal/command line tab or window, then
 run `npm start` to start the web server. Now, open a browser window for the app and navigate to
-<a href="http://localhost:8000/app/" target="_blank">`http://localhost:8000/app/`</a>
+<a href="http://localhost:8000/app/index.html" target="_blank">`http://localhost:8000/app/index.html`</a>
 
 You can now see the page in your browser. It's not very exciting, but that's OK.
 


### PR DESCRIPTION
does not resolve to index.html. In stead, it goes to http://localhost:8000/app/#/phones, which is the app. If we explicitly point it at index.html, the behavior is as described in the tutorial.
