### PR TITLE
docs(tutorial/10 - Event Handlers): Added missing semicolon in tutorial documentation

### DIFF
--- a/docs/content/tutorial/step_10.ngdoc
+++ b/docs/content/tutorial/step_10.ngdoc
@@ -31,7 +31,7 @@ phonecatControllers.controller('PhoneDetailCtrl', ['$scope', '$routeParams', '$h
 
     $scope.setImage = function(imageUrl) {
       $scope.mainImageUrl = imageUrl;
-    }
+    };
   }]);
 ```
 


### PR DESCRIPTION
Added a missing semicolon in definition of $scope.setImage in tutorial documentation step 10.
