### PR TITLE
Remove sortedKeys()

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -28,7 +28,6 @@
     "manualUppercase": false,
     "isArrayLike": false,
     "forEach": false,
-    "sortedKeys": false,
     "forEachSorted": false,
     "reverseParams": false,
     "nextUid": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -22,7 +22,6 @@
   nodeName_: true,
   isArrayLike: true,
   forEach: true,
-  sortedKeys: true,
   forEachSorted: true,
   reverseParams: true,
   nextUid: true,
@@ -272,12 +271,8 @@ function forEach(obj, iterator, context) {
   return obj;
 }
 
-function sortedKeys(obj) {
-  return Object.keys(obj).sort();
-}
-
 function forEachSorted(obj, iterator, context) {
-  var keys = sortedKeys(obj);
+  var keys = Object.keys(obj).sort();
   for (var i = 0; i < keys.length; i++) {
     iterator.call(context, obj[keys[i]], keys[i]);
   }

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -26,7 +26,6 @@
     "manualUppercase": false,
     "isArrayLike": false,
     "forEach": false,
-    "sortedKeys": false,
     "reverseParams": false,
     "nextUid": false,
     "setHashKey": false,

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -699,13 +699,6 @@ describe('angular', function() {
   });
 
 
-  describe('sortedKeys', function() {
-    it('should collect keys from object', function() {
-      expect(sortedKeys({c:0, b:0, a:0})).toEqual(['a', 'b', 'c']);
-    });
-  });
-
-
   describe('encodeUriSegment', function() {
     it('should correctly encode uri segment and not encode chars defined as pchar set in rfc3986',
         function() {

--- a/test/helpers/testabilityPatch.js
+++ b/test/helpers/testabilityPatch.js
@@ -74,19 +74,9 @@ afterEach(function() {
 
 
   // copied from Angular.js
-  // we need these two methods here so that we can run module tests with wrapped angular.js
-  function sortedKeys(obj) {
-    var keys = [];
-    for (var key in obj) {
-      if (obj.hasOwnProperty(key)) {
-        keys.push(key);
-      }
-    }
-    return keys.sort();
-  }
-
+  // we need this method here so that we can run module tests with wrapped angular.js
   function forEachSorted(obj, iterator, context) {
-    var keys = sortedKeys(obj);
+    var keys = Object.keys(obj).sort();
     for (var i = 0; i < keys.length; i++) {
       iterator.call(context, obj[keys[i]], keys[i]);
     }


### PR DESCRIPTION
Since #10639 there's only one caller to `sortedKeys()` left, so it can be inlined to save some bytes.

Second commit applies #9704 and this change to `testabilityPatch.js` to keep it in sync.
