### PR TITLE
test($rootScope) test the correct setting of the constructor in IE 11

### DIFF
--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -14,7 +14,7 @@ describe('Scope', function() {
 
     it('should expose the constructor', inject(function($rootScope) {
       /* jshint -W103 */
-      if (msie) return;
+      if (msie < 11) return;
       expect($rootScope.__proto__).toBe($rootScope.constructor.prototype);
     }));
 


### PR DESCRIPTION
Note: Not actually tested, as I don't have a Windows machine handy. Hoping for CI to do the testing for me ;)
