### PR TITLE
Update jscs

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -20,6 +20,11 @@
     "beforeOpeningRoundBrace": true
   },
   "disallowSpacesInsideArrayBrackets": true,
+  "requireSpaceBeforeKeywords": [
+    "else",
+    "while",
+    "catch"
+  ],
   "disallowSpacesInsideParentheses": true,
   "disallowTrailingComma": true,
   "disallowTrailingWhitespace": true,

--- a/.jscs.json
+++ b/.jscs.json
@@ -12,6 +12,7 @@
   "disallowSpacesInAnonymousFunctionExpression": {
     "beforeOpeningRoundBrace": true
   },
+  "disallowSpacesInCallExpression": true,
   "disallowSpacesInFunctionDeclaration": {
     "beforeOpeningRoundBrace": true
   },

--- a/.jscs.json
+++ b/.jscs.json
@@ -35,6 +35,7 @@
     "afterConsequent": true,
     "beforeAlternate": true
   },
+  "requireSpacesInForStatement": true,
   "requireSpacesInFunction": {
     "beforeOpeningCurlyBrace": true
   },

--- a/.jscs.json
+++ b/.jscs.json
@@ -1,6 +1,7 @@
 {
   "excludeFiles": ["src/ngLocale/**"],
   "disallowKeywords": ["with"],
+  "disallowKeywordsOnNewLine": ["else"],
   "disallowMixedSpacesAndTabs": true,
   "disallowMultipleLineStrings": true,
   "disallowNewlineBeforeBlockStatements": true,

--- a/.jscs.json.todo
+++ b/.jscs.json.todo
@@ -7,7 +7,6 @@
   "requireCurlyBraces": ["if", "else", "for", "while", "do", "try", "catch"],
   "disallowImplicitTypeConversion": ["string"],
   "disallowMultipleLineBreaks": true,
-  "disallowKeywordsOnNewLine": ["else"],
   "validateJSDoc": {
     "checkParamNames": true,
     "requireParamTypes": true

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2346,22 +2346,28 @@
       "resolved": "git://github.com/vojtajina/grunt-jasmine-node.git#ced17cbe52c1412b2ada53160432a5b681f37cd7"
     },
     "grunt-jscs": {
-      "version": "0.7.1",
+      "version": "1.2.0",
       "dependencies": {
         "hooker": {
           "version": "0.2.3"
         },
         "jscs": {
-          "version": "1.6.2",
+          "version": "1.10.0",
           "dependencies": {
             "colors": {
-              "version": "0.6.2"
+              "version": "1.0.3"
             },
             "commander": {
-              "version": "2.3.0"
+              "version": "2.5.1"
             },
             "esprima": {
               "version": "1.2.2"
+            },
+            "esprima-harmony-jscs": {
+              "version": "1.1.0-regex-token-fix"
+            },
+            "estraverse": {
+              "version": "1.9.1"
             },
             "exit": {
               "version": "0.1.2"
@@ -2370,10 +2376,21 @@
               "version": "4.0.6",
               "dependencies": {
                 "graceful-fs": {
-                  "version": "3.0.4"
+                  "version": "3.0.5"
                 },
                 "inherits": {
                   "version": "2.0.1"
+                },
+                "minimatch": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0"
+                    }
+                  }
                 },
                 "once": {
                   "version": "1.3.1",
@@ -2386,54 +2403,61 @@
               }
             },
             "minimatch": {
-              "version": "1.0.0",
+              "version": "2.0.1",
               "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0"
-                },
-                "sigmund": {
-                  "version": "1.0.0"
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1"
+                    }
+                  }
                 }
               }
             },
             "strip-json-comments": {
-              "version": "1.0.1"
+              "version": "1.0.2"
             },
             "vow-fs": {
-              "version": "0.3.2",
+              "version": "0.3.4",
               "dependencies": {
                 "node-uuid": {
-                  "version": "1.4.0"
-                },
-                "vow": {
-                  "version": "0.4.4"
+                  "version": "1.4.2"
                 },
                 "vow-queue": {
-                  "version": "0.3.1"
+                  "version": "0.4.1"
                 },
                 "glob": {
-                  "version": "3.2.8",
+                  "version": "4.3.5",
                   "dependencies": {
-                    "minimatch": {
-                      "version": "0.2.14",
+                    "inflight": {
+                      "version": "1.0.4",
                       "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0"
+                        "wrappy": {
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1"
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1"
+                        }
+                      }
                     }
                   }
                 }
               }
             },
             "xmlbuilder": {
-              "version": "2.4.4",
+              "version": "2.4.5",
               "dependencies": {
                 "lodash-node": {
                   "version": "2.4.1"
@@ -2441,12 +2465,12 @@
               }
             },
             "supports-color": {
-              "version": "1.1.0"
+              "version": "1.2.0"
             }
           }
         },
         "vow": {
-          "version": "0.4.5"
+          "version": "0.4.7"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-ddescribe-iit": "~0.0.1",
     "grunt-jasmine-node": "git://github.com/vojtajina/grunt-jasmine-node.git#fix-grunt-exit-code",
-    "grunt-jscs": "~0.7.1",
+    "grunt-jscs": "~1.2.0",
     "grunt-merge-conflict": "~0.0.1",
     "grunt-shell": "~1.1.1",
     "gulp": "~3.8.0",

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -317,8 +317,7 @@ function nextUid() {
 function setHashKey(obj, h) {
   if (h) {
     obj.$$hashKey = h;
-  }
-  else {
+  } else {
     delete obj.$$hashKey;
   }
 }

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -627,7 +627,7 @@ function isElement(node) {
 function makeMap(str) {
   var obj = {}, items = str.split(","), i;
   for (i = 0; i < items.length; i++)
-    obj[ items[i] ] = true;
+    obj[items[i]] = true;
   return obj;
 }
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -887,8 +887,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
   this.$get = [
             '$injector', '$interpolate', '$exceptionHandler', '$templateRequest', '$parse',
             '$controller', '$rootScope', '$document', '$sce', '$animate', '$$sanitizeUri',
-    function($injector,   $interpolate,   $exceptionHandler,   $templateRequest,   $parse,
-             $controller,   $rootScope,   $document,   $sce,   $animate,   $$sanitizeUri) {
+    function($injector, $interpolate, $exceptionHandler, $templateRequest, $parse,
+             $controller, $rootScope, $document, $sce, $animate, $$sanitizeUri) {
 
     var Attributes = function(element, attributesToCopy) {
       if (attributesToCopy) {

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -179,7 +179,7 @@
  * @param {String} src URL of content to load.
  */
 var ngIncludeDirective = ['$templateRequest', '$anchorScroll', '$animate', '$sce',
-                  function($templateRequest,   $anchorScroll,   $animate,   $sce) {
+                  function($templateRequest, $anchorScroll, $animate, $sce) {
   return {
     restrict: 'ECA',
     priority: 400,

--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -3,7 +3,7 @@
 
 function $IntervalProvider() {
   this.$get = ['$rootScope', '$window', '$q', '$$q',
-       function($rootScope,   $window,   $q,   $$q) {
+       function($rootScope, $window, $q, $$q) {
     var intervals = {};
 
 

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -347,8 +347,7 @@ function qFactory(nextTick, exceptionHandler) {
           'qcycle',
           "Expected promise to be resolved with value other than itself '{0}'",
           val));
-      }
-      else {
+      } else {
         this.$$resolve(val);
       }
 

--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -719,7 +719,7 @@ function $SceProvider() {
    */
 
   this.$get = ['$parse', '$sceDelegate', function(
-                $parse,   $sceDelegate) {
+                $parse, $sceDelegate) {
     // Prereq: Ensure that we're not running in IE<11 quirks mode.  In that mode, IE < 11 allow
     // the "expression(javascript expression)" syntax which is insecure.
     if (enabled && msie < 8) {

--- a/src/ng/testability.js
+++ b/src/ng/testability.js
@@ -3,7 +3,7 @@
 
 function $$TestabilityProvider() {
   this.$get = ['$rootScope', '$browser', '$location',
-       function($rootScope,   $browser,   $location) {
+       function($rootScope, $browser, $location) {
 
     /**
      * @name $testability

--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -3,7 +3,7 @@
 
 function $TimeoutProvider() {
   this.$get = ['$rootScope', '$browser', '$q', '$$q', '$exceptionHandler',
-       function($rootScope,   $browser,   $q,   $$q,   $exceptionHandler) {
+       function($rootScope, $browser, $q, $$q, $exceptionHandler) {
 
     var deferreds = {};
 

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -1327,8 +1327,7 @@ angular.module('ngAnimate', ['ng'])
           } else if (lastAnimation.event == 'setClass') {
             animationsToCancel.push(lastAnimation);
             cleanup(element, className);
-          }
-          else if (runningAnimations[className]) {
+          } else if (runningAnimations[className]) {
             var current = runningAnimations[className];
             if (current.event == animationEvent) {
               skipAnimation = true;

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -476,7 +476,7 @@ angular.module('ngAnimate', ['ng'])
     var $$jqLite;
     $provide.decorator('$animate',
         ['$delegate', '$$q', '$injector', '$sniffer', '$rootElement', '$$asyncCallback', '$rootScope', '$document', '$templateRequest', '$$jqLite',
- function($delegate,   $$q,   $injector,   $sniffer,   $rootElement,   $$asyncCallback,   $rootScope,   $document,   $templateRequest,   $$$jqLite) {
+ function($delegate, $$q, $injector, $sniffer, $rootElement, $$asyncCallback, $rootScope, $document, $templateRequest, $$$jqLite) {
 
       $$jqLite = $$$jqLite;
       $rootElement.data(NG_ANIMATE_STATE, rootAnimateState);
@@ -1579,7 +1579,7 @@ angular.module('ngAnimate', ['ng'])
     }]);
 
     $animateProvider.register('', ['$window', '$sniffer', '$timeout', '$$animateReflow',
-                           function($window,   $sniffer,   $timeout,   $$animateReflow) {
+                           function($window, $sniffer, $timeout, $$animateReflow) {
       // Detect proper transitionend/animationend event names.
       var CSS_PREFIX = '', TRANSITION_PROP, TRANSITIONEND_EVENT, ANIMATION_PROP, ANIMATIONEND_EVENT;
 

--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -229,7 +229,7 @@ angular.module('ngMessages', [])
     * </example>
     */
   .directive('ngMessages', ['$compile', '$animate', '$templateRequest',
-                   function($compile,    $animate,   $templateRequest) {
+                   function($compile, $animate, $templateRequest) {
     var ACTIVE_CLASS = 'ng-active';
     var INACTIVE_CLASS = 'ng-inactive';
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -455,7 +455,7 @@ angular.mock.$LogProvider = function() {
  */
 angular.mock.$IntervalProvider = function() {
   this.$get = ['$browser', '$rootScope', '$q', '$$q',
-       function($browser,   $rootScope,   $q,   $$q) {
+       function($browser, $rootScope, $q, $$q) {
     var repeatFns = [],
         nextRepeatId = 0,
         now = 0;
@@ -783,7 +783,7 @@ angular.mock.animate = angular.module('ngAnimateMock', ['ng'])
     });
 
     $provide.decorator('$animate', ['$delegate', '$$asyncCallback', '$timeout', '$browser',
-                            function($delegate,   $$asyncCallback,   $timeout,   $browser) {
+                            function($delegate, $$asyncCallback, $timeout, $browser) {
       var animate = {
         queue: [],
         cancel: $delegate.cancel,

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -490,8 +490,7 @@ function $RouteProvider() {
               newParams = angular.extend({}, this.current.params, newParams);
               $location.path(interpolate(this.current.$$route.originalPath, newParams));
               $location.search(angular.extend({}, $location.search(), searchParams));
-            }
-            else {
+            } else {
               throw $routeMinErr('norout', 'Tried updating route when with no current route');
             }
           }

--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -271,14 +271,14 @@ function htmlParser(html, handler) {
     }
   }
   var index, chars, match, stack = [], last = html, text;
-  stack.last = function() { return stack[ stack.length - 1 ]; };
+  stack.last = function() { return stack[stack.length - 1]; };
 
   while (html) {
     text = '';
     chars = true;
 
     // Make sure we're not in a script or style element
-    if (!stack.last() || !specialElements[ stack.last() ]) {
+    if (!stack.last() || !specialElements[stack.last()]) {
 
       // Comment
       if (html.indexOf("<!--") === 0) {
@@ -360,17 +360,17 @@ function htmlParser(html, handler) {
 
   function parseStartTag(tag, tagName, rest, unary) {
     tagName = angular.lowercase(tagName);
-    if (blockElements[ tagName ]) {
-      while (stack.last() && inlineElements[ stack.last() ]) {
+    if (blockElements[tagName]) {
+      while (stack.last() && inlineElements[stack.last()]) {
         parseEndTag("", stack.last());
       }
     }
 
-    if (optionalEndTagElements[ tagName ] && stack.last() == tagName) {
+    if (optionalEndTagElements[tagName] && stack.last() == tagName) {
       parseEndTag("", tagName);
     }
 
-    unary = voidElements[ tagName ] || !!unary;
+    unary = voidElements[tagName] || !!unary;
 
     if (!unary)
       stack.push(tagName);
@@ -395,13 +395,13 @@ function htmlParser(html, handler) {
     if (tagName)
       // Find the closest opened tag of the same type
       for (pos = stack.length - 1; pos >= 0; pos--)
-        if (stack[ pos ] == tagName)
+        if (stack[pos] == tagName)
           break;
 
     if (pos >= 0) {
       // Close all the open elements, up the stack
       for (i = stack.length - 1; i >= pos; i--)
-        if (handler.end) handler.end(stack[ i ]);
+        if (handler.end) handler.end(stack[i]);
 
       // Remove the open elements from the stack
       stack.length = pos;

--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -304,7 +304,7 @@ _jQuery.fn.bindings = function(windowJquery, bindExp) {
     var element = windowJquery(this),
         bindings;
     if (bindings = element.data('$binding')) {
-      for (var expressions = [], binding, j=0, jj=bindings.length;  j < jj; j++) {
+      for (var expressions = [], binding, j=0, jj=bindings.length; j < jj; j++) {
         binding = bindings[j];
 
         if (binding.expressions) {

--- a/src/ngScenario/browserTrigger.js
+++ b/src/ngScenario/browserTrigger.js
@@ -55,8 +55,7 @@
       if (window.WebKitTransitionEvent) {
         evnt = new WebKitTransitionEvent(eventType, eventData);
         evnt.initEvent(eventType, false, true);
-      }
-      else {
+      } else {
         try {
           evnt = new TransitionEvent(eventType, eventData);
         }
@@ -65,13 +64,11 @@
           evnt.initTransitionEvent(eventType, null, null, null, eventData.elapsedTime || 0);
         }
       }
-    }
-    else if (/animationend/.test(eventType)) {
+    } else if (/animationend/.test(eventType)) {
       if (window.WebKitAnimationEvent) {
         evnt = new WebKitAnimationEvent(eventType, eventData);
         evnt.initEvent(eventType, false, true);
-      }
-      else {
+      } else {
         try {
           evnt = new AnimationEvent(eventType, eventData);
         }
@@ -80,8 +77,7 @@
           evnt.initAnimationEvent(eventType, null, null, null, eventData.elapsedTime || 0);
         }
       }
-    }
-    else {
+    } else {
       evnt = document.createEvent('MouseEvents');
       x = x || 0;
       y = y || 0;

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -972,7 +972,7 @@ describe('strict-di injector', function() {
       });
     });
     inject(function($injector) {
-      expect (function() {
+      expect(function() {
         $injector.invoke(function($test2) {});
       }).toThrowMinErr('$injector', 'strictdi');
     });
@@ -986,7 +986,7 @@ describe('strict-di injector', function() {
       });
     });
     inject(function($injector) {
-      expect (function() {
+      expect(function() {
         $injector.invoke(['$test', function($test) {}]);
       }).toThrowMinErr('$injector', 'strictdi');
     });

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -395,7 +395,7 @@ describe('browser', function() {
       });
 
 
-      it ('should return a value for an existing cookie', function() {
+      it('should return a value for an existing cookie', function() {
         document.cookie = "foo=bar=baz;path=/";
         expect(browser.cookies().foo).toEqual('bar=baz');
       });
@@ -408,7 +408,7 @@ describe('browser', function() {
         expect(browser.cookies()['foo']).toBe('"first"');
       });
 
-      it ('should decode cookie values that were encoded by puts', function() {
+      it('should decode cookie values that were encoded by puts', function() {
         document.cookie = "cookie2%3Dbar%3Bbaz=val%3Due;path=/";
         expect(browser.cookies()['cookie2=bar;baz']).toEqual('val=ue');
       });

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -423,8 +423,7 @@ describe('$compile', function() {
     describe('multiple directives per element', function() {
       it('should allow multiple directives per element', inject(function($compile, $rootScope, log) {
         element = $compile(
-          '<span greet="angular" log="L" x-high-log="H" data-medium-log="M"></span>')
-          ($rootScope);
+          '<span greet="angular" log="L" x-high-log="H" data-medium-log="M"></span>')($rootScope);
         expect(element.text()).toEqual('Hello angular');
         expect(log).toEqual('L; M; H');
       }));
@@ -607,8 +606,7 @@ describe('$compile', function() {
       describe('priority', function() {
         it('should honor priority', inject(function($compile, $rootScope, log) {
           element = $compile(
-            '<span log="L" x-high-log="H" data-medium-log="M"></span>')
-            ($rootScope);
+            '<span log="L" x-high-log="H" data-medium-log="M"></span>')($rootScope);
           expect(log).toEqual('L; M; H');
         }));
       });
@@ -809,8 +807,7 @@ describe('$compile', function() {
 
 
         it('should compile template when replacing', inject(function($compile, $rootScope, log) {
-          element = $compile('<div><div replace medium-log>ignore</div><div>')
-            ($rootScope);
+          element = $compile('<div><div replace medium-log>ignore</div><div>')($rootScope);
           $rootScope.$digest();
           expect(element.text()).toEqual('Replace!');
           expect(log).toEqual('LOG; HIGH; MEDIUM');
@@ -818,8 +815,7 @@ describe('$compile', function() {
 
 
         it('should compile template when appending', inject(function($compile, $rootScope, log) {
-          element = $compile('<div><div append medium-log>ignore</div><div>')
-            ($rootScope);
+          element = $compile('<div><div append medium-log>ignore</div><div>')($rootScope);
           $rootScope.$digest();
           expect(element.text()).toEqual('Append!');
           expect(log).toEqual('LOG; HIGH; MEDIUM');
@@ -828,8 +824,7 @@ describe('$compile', function() {
 
         it('should merge attributes including style attr', inject(function($compile, $rootScope) {
           element = $compile(
-            '<div><div replace class="medium-log" style="height: 20px" ></div><div>')
-            ($rootScope);
+            '<div><div replace class="medium-log" style="height: 20px" ></div><div>')($rootScope);
           var div = element.find('div');
           expect(div.hasClass('medium-log')).toBe(true);
           expect(div.hasClass('log')).toBe(true);
@@ -841,8 +836,7 @@ describe('$compile', function() {
 
         it('should not merge attributes if they are the same', inject(function($compile, $rootScope) {
           element = $compile(
-            '<div><div nomerge class="medium-log" id="myid"></div><div>')
-            ($rootScope);
+            '<div><div nomerge class="medium-log" id="myid"></div><div>')($rootScope);
           var div = element.find('div');
           expect(div.hasClass('medium-log')).toBe(true);
           expect(div.hasClass('log')).toBe(true);
@@ -4610,8 +4604,7 @@ describe('$compile', function() {
           });
         });
         inject(function(log, $rootScope, $compile) {
-          element = $compile('<div><div trans>T:{{x}}-{{$parent.$id}}-{{$id}}<span>;</span></div></div>')
-              ($rootScope);
+          element = $compile('<div><div trans>T:{{x}}-{{$parent.$id}}-{{$id}}<span>;</span></div></div>')($rootScope);
           $rootScope.x = 'root';
           $rootScope.$apply();
           expect(element.text()).toEqual('W:iso-1-2;T:root-2-3;');
@@ -4896,8 +4889,7 @@ describe('$compile', function() {
           });
         });
         inject(function(log, $rootScope, $compile) {
-          element = $compile('<div><div trans>T:{{$$transcluded}}</div></div>')
-              ($rootScope);
+          element = $compile('<div><div trans>T:{{$$transcluded}}</div></div>')($rootScope);
           $rootScope.$apply();
           expect(jqLite(element.find('span')[0]).text()).toEqual('I:');
           expect(jqLite(element.find('span')[1]).text()).toEqual('T:true');
@@ -5728,8 +5720,7 @@ describe('$compile', function() {
           });
         });
         inject(function(log, $rootScope, $compile) {
-          element = $compile('<div><div high-log trans="text" log>{{$parent.$id}}-{{$id}};</div></div>')
-              ($rootScope);
+          element = $compile('<div><div high-log trans="text" log>{{$parent.$id}}-{{$id}};</div></div>')($rootScope);
           $rootScope.$apply();
           expect(log).toEqual('compile: <!-- trans: text -->; link; LOG; LOG; HIGH');
           expect(element.text()).toEqual('1-2;1-3;');

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -6065,7 +6065,7 @@ describe('$compile', function() {
             link: function(scope, element, attrs, ctrl, transclude) {
 
               // We use timeout here to simulate how ng-if works
-              $timeout(function()  {
+              $timeout(function() {
                 transclude(function(child) { element.append(child); });
               });
             }

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1641,9 +1641,9 @@ describe('input', function() {
       });
     });
 
-    describe('max', function()  {
+    describe('max', function() {
 
-      it('should invalidate', function()  {
+      it('should invalidate', function() {
         var inputElm = helper.compileInput('<input type="date" ng-model="value" name="alias" max="2019-01-01" />');
         helper.changeInputValueTo('2019-12-31');
         expect(inputElm).toBeInvalid();

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1323,7 +1323,7 @@ describe('$location', function() {
     });
 
 
-    it ('should not rewrite links when rewriting links is disabled', function() {
+    it('should not rewrite links when rewriting links is disabled', function() {
       configureService({linkHref: 'link?a#b', html5Mode: {enabled: true, rewriteLinks:false}, supportHist: true});
       inject(
         initBrowser(),
@@ -1847,7 +1847,7 @@ describe('$location', function() {
       })
     );
 
-    it ('should fire $locationChangeSuccess event when change from browser location bar',
+    it('should fire $locationChangeSuccess event when change from browser location bar',
       inject(function($log, $location, $browser, $rootScope) {
         $rootScope.$apply(); // clear initial $locationChangeStart
 

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -957,7 +957,7 @@ describe('$location', function() {
       initService({html5Mode:true,hashPrefix: '!!',supportHistory: false});
       inject(
         initBrowser({url:'http://domain.com/base/index.html#!!/a/b',basePath: '/base/index.html'}),
-        function($rootScope, $location,  $browser) {
+        function($rootScope, $location, $browser) {
           expect($browser.url()).toBe('http://domain.com/base/index.html#!!/a/b');
           $location.path('/new');
           $location.search({a: true});

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -87,11 +87,9 @@ describe('$sniffer', function() {
         var ua = $window.navigator.userAgent.toLowerCase();
         if (/chrome/i.test(ua) || /safari/i.test(ua) || /webkit/i.test(ua)) {
           expectedPrefix = 'Webkit';
-        }
-        else if (/firefox/i.test(ua)) {
+        } else if (/firefox/i.test(ua)) {
           expectedPrefix = 'Moz';
-        }
-        else if (/ie/i.test(ua) || /trident/i.test(ua)) {
+        } else if (/ie/i.test(ua) || /trident/i.test(ua)) {
           expectedPrefix = 'Ms';
         }
         expect($sniffer.vendorPrefix).toBe(expectedPrefix);

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1193,7 +1193,7 @@ describe('ngMock', function() {
       });
 
 
-      it ('should throw exception when only headers differs from expectation', function() {
+      it('should throw exception when only headers differs from expectation', function() {
         hb.when('GET').respond(200, '', {});
         hb.expect('GET', '/match', undefined, {'Content-Type': 'application/json'});
 
@@ -1204,7 +1204,7 @@ describe('ngMock', function() {
       });
 
 
-      it ('should throw exception when only data differs from expectation', function() {
+      it('should throw exception when only data differs from expectation', function() {
         hb.when('GET').respond(200, '', {});
         hb.expect('GET', '/match', 'some-data');
 
@@ -1215,7 +1215,7 @@ describe('ngMock', function() {
       });
 
 
-      it ('should not throw an exception when parsed body is equal to expected body object', function() {
+      it('should not throw an exception when parsed body is equal to expected body object', function() {
         hb.when('GET').respond(200, '', {});
 
         hb.expect('GET', '/match', {a: 1, b: 2});
@@ -1230,7 +1230,7 @@ describe('ngMock', function() {
       });
 
 
-      it ('should throw exception when only parsed body differs from expected body object', function() {
+      it('should throw exception when only parsed body differs from expected body object', function() {
         hb.when('GET').respond(200, '', {});
         hb.expect('GET', '/match', {a: 1, b: 2});
 


### PR DESCRIPTION
Updates jscs to latest (1.10.0) by updating grunt-jscs to 1.2.0

add rule disallowKeywordsOnNewLine: "else" ~ 10 changes

``` js
// Valid
if (x) {
} else {
}
// Invalid
if (x) {
}
else {
}
```

add rule disallowSpacesInCallExpression ~ 19 changes

``` js
// Valid
functionCall()
// Invalid
functionCall ()
```

add rule requireSpacesInForStatement ~ 1 change

``` js
// Valid
for (var i=0; i < length; i++)
// Invalid
for (var i=0;i < length;i++)
for (var i=0;  i < length;  i++)
```

add rule requireSpaceBeforeKeywords ~ 0 changes

``` js
// Valid
} else {
// Invalid
}else {
```

Others that could be added:
~32 changes: "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
"requireSpaceBetweenArguments": true,
"disallowMultipleLineBreaks": true

@caitp 
