### PR TITLE
Fix(ngRepeat) do not allow `$id` and `$root` as aliases

### DIFF
--- a/docs/content/error/ngRepeat/badident.ngdoc
+++ b/docs/content/error/ngRepeat/badident.ngdoc
@@ -16,6 +16,8 @@ Reserved names include:
   - `this`
   - `undefined`
   - `$parent`
+  - `$id`
+  - `$root`
   - `$even`
   - `$odd`
   - `$first`

--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -267,7 +267,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
       var keyIdentifier = match[2];
 
       if (aliasAs && (!/^[$a-zA-Z_][$a-zA-Z0-9_]*$/.test(aliasAs) ||
-          /^(null|undefined|this|\$index|\$first|\$middle|\$last|\$even|\$odd|\$parent)$/.test(aliasAs))) {
+          /^(null|undefined|this|\$index|\$first|\$middle|\$last|\$even|\$odd|\$parent|\$root|\$id)$/.test(aliasAs))) {
         throw ngRepeatMinErr('badident', "alias '{0}' is invalid --- must be a valid JS identifier which is not a reserved name.",
           aliasAs);
       }

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -474,6 +474,8 @@ describe('ngRepeat', function() {
         'this',
         'undefined',
         '$parent',
+        '$root',
+        '$id',
         '$index',
         '$first',
         '$middle',


### PR DESCRIPTION
Currently user can use `$id` or `$root` as alias in ng-repeat directive that leads to rewriting these scope-related variables. This commit fixes this behavior by throwing an error when user try to use these values.
