### PR TITLE
docs(app): fixes material build

### DIFF
--- a/docs/bower.json
+++ b/docs/bower.json
@@ -4,7 +4,7 @@
     "jquery": "2.1.1",
     "lunr.js": "0.4.3",
     "google-code-prettify": "1.0.1",
-    "angular-material": "master",
+    "angular-material": "0.6.x",
     "angular-sanitize": "1.3.x"
   }
 }


### PR DESCRIPTION
The theme css files were reorganized at some point in Angular Material 0.7.x and the build is now failing because the files are missing. The styles on the site do not work correctly now with 0.7.x because the css is missing. This change will keep us on 0.6.x until we can update the theme issue.
