### PR TITLE
docs(ngInit): fix code block not being displayed in the note section

### DIFF
--- a/src/ng/directive/ngInit.js
+++ b/src/ng/directive/ngInit.js
@@ -19,7 +19,7 @@
  * **Note**: If you have assignment in `ngInit` along with {@link ng.$filter `$filter`}, make
  * sure you have parenthesis for correct precedence:
  * <pre class="prettyprint">
- *   <div ng-init="test1 = (data | orderBy:'name')"></div>
+ * `<div ng-init="test1 = (data | orderBy:'name')"></div>`
  * </pre>
  * </div>
  *


### PR DESCRIPTION
The note section is blank in https://docs.angularjs.org/api/ng/directive/ngInit
