### PR TITLE
docs(ngClass): fix formatting

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -142,6 +142,7 @@ function classDirective(name, selector) {
  *
  * @animations
  * add - happens just before the class is applied to the element
+ * 
  * remove - happens just before the class is removed from the element
  *
  * @element ANY


### PR DESCRIPTION
adds line break between add/remove in animations. Previously showing up on one line like this: "add - happens just before the class is applied to the element remove - happens just before the class is removed from the element"
