### PR TITLE
docs($cookieStore#get): Clarified that undefined is returned if no cookie exists

### DIFF
--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -160,7 +160,7 @@ angular.module('ngCookies', ['ng']).
          * Returns the value of given cookie key
          *
          * @param {string} key Id to use for lookup.
-         * @returns {Object} Deserialized cookie value.
+         * @returns {Object} Deserialized cookie value, undefined if the cookie does not exist.
          */
         get: function(key) {
           var value = $cookies[key];


### PR DESCRIPTION
Simply clarified that `undefined` is the return value if no cookie exists.
