### PR TITLE
chore(npm): Make require()-able as part of publish script

### DIFF
--- a/scripts/bower/publish.sh
+++ b/scripts/bower/publish.sh
@@ -75,6 +75,18 @@ function prepare {
     replaceJsonProp "bower.json" "angular.*" ".*" "$NEW_VERSION"
     replaceJsonProp "package.json" "version" ".*" "$NEW_VERSION"
     replaceJsonProp "package.json" "angular.*" ".*" "$NEW_VERSION"
+    deleteJsonProp "package.json" "main"
+
+    echo "-- Adding CommonJS index file"
+    if [ -f "index.js" ]
+    then
+      rm index.js
+    fi
+
+    touch index.js
+    echo "require('./$repo');" >> index.js
+    echo "" >> index.js
+    echo "module.exports = $repo;" >> index.js
 
     git add -A
 

--- a/scripts/bower/publish.sh
+++ b/scripts/bower/publish.sh
@@ -86,7 +86,7 @@ function prepare {
     touch index.js
     echo "require('./$repo');" >> index.js
     echo "" >> index.js
-    echo "module.exports = $repo;" >> index.js
+    echo "module.exports = '$repo';" >> index.js
 
     git add -A
 

--- a/scripts/utils.inc
+++ b/scripts/utils.inc
@@ -207,6 +207,12 @@ function replaceJsonProp {
   replaceInFile $1 '"('$2')"[ ]*:[ ]*"'$3'"' '"\1": "'$4'"'
 }
 
+# deleteJsonProp(jsonFile, property)
+# - restriction: property needs to be on a single line!
+function deleteJsonProp {
+  sed -i '' -e /\"$2\"\:/d $1
+}
+
 # replaceInFile(file, findPattern, replacePattern)
 function replaceInFile {
   sed -i .tmp -E "s/$2/$3/" $1


### PR DESCRIPTION
This brings back Ben's patch and just add the quotes to `module.exports`
