### PR TITLE
docs($routeProvider): describe your change...

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -139,6 +139,11 @@ function $RouteProvider() {
    *
    * @description
    * Adds a new route definition to the `$route` service.
+   * 
+   * Note:
+   * Purpose of "templateURL" option (as a string value) within "param" parameter when there also exists "path" parameter "in the API": 
+   * >>> "path" allows scenarios where same route URL is used with different "controller"s
+   * >>> "templateURL" allows scenarios where route URL is different for same "controller".
    */
   this.when = function(path, route) {
     //copy original route object to preserve params inherited from proto chain

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -141,9 +141,9 @@ function $RouteProvider() {
    * Adds a new route definition to the `$route` service.
    * 
    * Note:
-   * Purpose of "templateURL" option (as a string value) within "param" parameter when there also exists "path" parameter "in the API": 
-   * >>> "path" allows scenarios where same route URL is used with different "controller"s
-   * >>> "templateURL" allows scenarios where route URL is different for same "controller".
+   * Purpose of `templateUrl` option (as a string value) within `param` parameter when there also exists `path` parameter: 
+   *    - `path` allows scenarios where same route URL is used with different controllers
+   *    - `templateUrl` allows scenarios where route URL is different for same controller.
    */
   this.when = function(path, route) {
     //copy original route object to preserve params inherited from proto chain


### PR DESCRIPTION
Purpose of "templateUrl" option (as a string value) within "param" parameter when there also exists "path" parameter "in the API": 

> > > "path" allows scenarios where same route URL is used with different "controller"s
> > > "templateURL" allows scenarios where route URL is different for same "controller".
