### PR TITLE
fix(ngModel): fix issues when parserName is same as validator key

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -563,7 +563,6 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
       if (parseValid === undefined) {
         setValidity(errorKey, null);
       } else {
-        setValidity(errorKey, parseValid);
         if (!parseValid) {
           forEach(ctrl.$validators, function(v, name) {
             setValidity(name, null);
@@ -571,8 +570,10 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
           forEach(ctrl.$asyncValidators, function(v, name) {
             setValidity(name, null);
           });
-          return false;
         }
+        // Set the parse error last, to prevent unsetting it, should a $validators key == parserName
+        setValidity(errorKey, parseValid);
+        return parseValid;
       }
       return true;
     }

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -1221,6 +1221,85 @@ describe('ngModel', function() {
         expect(ctrl.$validators.mock).toHaveBeenCalledWith('a', 'ab');
         expect(ctrl.$validators.mock.calls.length).toEqual(2);
       });
+
+      it('should validate correctly when parserName is same as $validator key', function() {
+        ctrl.$validators.test = function(value) {
+          return ['valid', 'parseInvalidAndValidatorValid'].indexOf(value) !== -1;
+        };
+
+        ctrl.$$parserName = 'test';
+        ctrl.$parsers.push(function(value) {
+          var result = ['valid', 'parseValidAndValidatorInvalid'].indexOf(value) !== -1 ? value : undefined;
+          return result;
+        });
+
+        //model to view updates
+        scope.$apply('value = "valid"');
+        expect(scope.value).toBe('valid');
+        expect(ctrl.$error).toEqual({});
+
+        ctrl.$validate();
+        expect(scope.value).toBe('valid');
+        expect(ctrl.$error).toEqual({});
+
+        scope.$apply('value = "invalid"');
+        expect(scope.value).toBe('invalid');
+        expect(ctrl.$error).toEqual({test: true});
+
+        ctrl.$validate();
+        expect(scope.value).toBe('invalid');
+        expect(ctrl.$error).toEqual({test: true});
+
+        scope.$apply('value = "parseValidAndValidatorInvalid"');
+        expect(scope.value).toBe('parseValidAndValidatorInvalid');
+        expect(ctrl.$error).toEqual({test: true});
+
+        ctrl.$validate();
+        expect(scope.value).toBe('parseValidAndValidatorInvalid');
+        expect(ctrl.$error).toEqual({test: true});
+
+        scope.$apply('value = "parseInvalidAndValidatorValid"');
+        expect(scope.value).toBe('parseInvalidAndValidatorValid');
+        expect(ctrl.$error).toEqual({});
+
+        ctrl.$validate();
+        expect(scope.value).toBe('parseInvalidAndValidatorValid');
+        expect(ctrl.$error).toEqual({});
+
+        //view to model update
+        ctrl.$setViewValue('valid');
+        expect(scope.value).toBe('valid');
+        expect(ctrl.$error).toEqual({});
+
+        ctrl.$validate();
+        expect(scope.value).toBe('valid');
+        expect(ctrl.$error).toEqual({});
+
+        ctrl.$setViewValue('invalid');
+        expect(scope.value).toBeUndefined();
+        expect(ctrl.$error).toEqual({test: true});
+
+        ctrl.$validate();
+        expect(scope.value).toBeUndefined();
+        expect(ctrl.$error).toEqual({test: true});
+
+        ctrl.$setViewValue('parseValidAndValidatorInvalid');
+        expect(scope.value).toBeUndefined();
+        expect(ctrl.$error).toEqual({test: true});
+
+        ctrl.$validate();
+        expect(scope.value).toBeUndefined();
+        expect(ctrl.$error).toEqual({test: true});
+
+        ctrl.$setViewValue('parseInvalidAndValidatorValid');
+        expect(scope.value).toBeUndefined();
+        expect(ctrl.$error).toEqual({test: true});
+
+        ctrl.$validate();
+        expect(scope.value).toBeUndefined();
+        expect(ctrl.$error).toEqual({test: true});
+      });
+
     });
   });
 


### PR DESCRIPTION
When a parser has the same name as a validator key, and a parse error
occurs, set validity for parser name after setting validity for the
validator key.

Otherwise, the parse key is set, and then immediately afterwards the
validator key is unset (because parse errors remove all other
validations).
