### PR TITLE
fix($location): Allow urlencoded slashes to remain encoded

### DIFF
--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -2226,7 +2226,6 @@ describe('$location', function() {
     });
   });
 
-
   describe('LocationHashbangInHtml5Url', function() {
     /* global LocationHashbangInHtml5Url: false */
     var location, locationIndex;
@@ -2253,6 +2252,71 @@ describe('$location', function() {
 
     it('should throw on url(urlString, stateObject)', function() {
       throwOnState(location);
+    });
+  });
+
+  describe('urlencoding behavior', function() {
+    function testDecodeEntities(LocationType, expectedPath, options) {
+      var baseUrl = 'http://example.com/';
+      var parsePath = '/path%2Fwithslash';
+      var hashPrefix = '#';
+      var opts = options || {};
+      var path;
+
+      var url = new LocationType(baseUrl, hashPrefix, opts);
+      url.$$opts = options || {};
+      url.$$parse(baseUrl + hashPrefix + parsePath);
+
+      path = LocationType === LocationHtml5Url ? url.hash() : url.path();
+      expect(path).toBe(expectedPath);
+    }
+
+    describe('LocationHashbangUrl', function() {
+      var type = LocationHashbangUrl;
+
+      it('should decode all entities if leaveSlashesEncoded is not set', function() {
+        testDecodeEntities(type, '/path/withslash');
+      });
+
+      it('should leave slashes encoded if leaveSlashesEncoded is true', function() {
+        testDecodeEntities(type, '/path%2Fwithslash', {leaveSlashesEncoded: true});
+      });
+
+      it('should decode all entities if leaveSlashesEncoded is false', function() {
+        testDecodeEntities(type, '/path/withslash', {leaveSlashesEncoded: false});
+      });
+    });
+
+    describe('LocationHashbangInHtml5Url', function() {
+      var type = LocationHashbangInHtml5Url;
+
+      it('should decode all entities if leaveSlashesEncoded is not set', function() {
+        testDecodeEntities(type, '/path/withslash');
+      });
+
+      it('should leave slashes encoded if leaveSlashesEncoded is true', function() {
+        testDecodeEntities(type, '/path%2Fwithslash', {leaveSlashesEncoded: true});
+      });
+
+      it('should decode all entities if leaveSlashesEncoded is false', function() {
+        testDecodeEntities(type, '/path/withslash', {leaveSlashesEncoded: false});
+      });
+    });
+
+    describe('LocationHtml5Url', function() {
+      var type = LocationHtml5Url;
+
+      it('should decode all entities if leaveSlashesEncoded is not set', function() {
+        testDecodeEntities(type, '/path/withslash');
+      });
+
+      it('should leave slashes encoded if leaveSlashesEncoded is true', function() {
+        testDecodeEntities(type, '/path%2Fwithslash', {leaveSlashesEncoded: true});
+      });
+
+      it('should decode all entities if leaveSlashesEncoded is false', function() {
+        testDecodeEntities(type, '/path/withslash', {leaveSlashesEncoded: false});
+      });
     });
   });
 });

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -366,6 +366,36 @@ describe('$route', function() {
     });
   });
 
+  describe('urlencoded slashes', function() {
+
+    function initProviders(opts) {
+      return module(function($routeProvider, $locationProvider) {
+        $routeProvider.when('/:path/:subresource', {templateUrl: 'bar.html'});
+        $routeProvider.when('/path%2Fwithslash', {templateUrl: 'foo.html'});
+        $locationProvider.leaveSlashesEncoded(opts.leaveSlashesEncoded);
+      });
+    }
+
+    describe ('with leaveSlashesEncoded = false', function() {
+      beforeEach(initProviders({leaveSlashesEncoded: false}));
+
+      it('should be split into multiple route params if url contains encoded slash', inject(function($route, $location, $rootScope) {
+        $location.url('/path%2Fwithslash');
+        $rootScope.$digest();
+        expect($route.current.loadedTemplateUrl).toBe('bar.html');
+      }));
+    });
+
+    describe ('with leaveSlashesEncoded = true', function() {
+      beforeEach(initProviders({leaveSlashesEncoded: true}));
+
+      it('should NOT be split into multiple route params if url contains encoded slash', inject(function($route, $location, $rootScope) {
+        $location.url('/path%2Fwithslash');
+        $rootScope.$digest();
+        expect($route.current.loadedTemplateUrl).toBe('foo.html');
+      }));
+    });
+  });
 
   describe('should match a route that contains optional params in the path', function() {
     beforeEach(module(function($routeProvider) {


### PR DESCRIPTION
Encoded slashes passed to $location.url() may now stay encoded if
$locationProvider.leaveSlashesEncoded(true) is called in the config
block. Other encoded entities continue to be decoded as before,
regardless of leaveSlashesEncoded value. Previously all entities,
including slashes, were decoded, which caused a problem when trying
to capture route params, which are slash-delimited.

Closes #10479
