### PR TITLE
feat(openPlunkr): enable ctrl+click

### DIFF
--- a/docs/app/src/examples.js
+++ b/docs/app/src/examples.js
@@ -1,13 +1,16 @@
 angular.module('examples', [])
 
 .factory('formPostData', ['$document', function($document) {
-  return function(url, fields) {
+  return function(url, newWindow, fields) {
     /**
-     * Form previously posted to target="_blank", but pop-up blockers were causing this to not work.
-     * If a user chose to bypass pop-up blocker one time and click the link, they would arrive at
-     * a new default plnkr, not a plnkr with the desired template.
+     * If the form posts to target="_blank", pop-up blockers can cause it not to work.
+     * If a user choses to bypass pop-up blocker one time and click the link, they will arrive at
+     * a new default plnkr, not a plnkr with the desired template.  Given this undesired behavior,
+     * some may still want to open the plnk in a new window by opting-in via ctrl+click.  The
+     * newWindow param allows for this possibility.
      */
-    var form = angular.element('<form style="display: none;" method="post" action="' + url + '"></form>');
+    var target = newWindow ? '_blank' : '_self';
+    var form = angular.element('<form style="display: none;" method="post" action="' + url + '" target="' + target + '"></form>');
     angular.forEach(fields, function(value, name) {
       var input = angular.element('<input type="hidden" name="' +  name + '">');
       input.attr('value', value);
@@ -21,9 +24,10 @@ angular.module('examples', [])
 
 
 .factory('openPlunkr', ['formPostData', '$http', '$q', function(formPostData, $http, $q) {
-  return function(exampleFolder) {
+  return function(exampleFolder, clickEvent) {
 
     var exampleName = 'AngularJS Example';
+    var newWindow = clickEvent.ctrlKey;
 
     // Load the manifest for the example
     $http.get(exampleFolder + '/manifest.json')
@@ -71,7 +75,7 @@ angular.module('examples', [])
         postData.private = true;
         postData.description = exampleName;
 
-        formPostData('http://plnkr.co/edit/?p=preview', postData);
+        formPostData('http://plnkr.co/edit/?p=preview', newWindow, postData);
       });
   };
 }]);

--- a/docs/config/templates/runnableExample.template.html
+++ b/docs/config/templates/runnableExample.template.html
@@ -2,7 +2,7 @@
    is HTML and wrap each line in a <p> - thus breaking the HTML #}
 
 <div>
-  <a ng-click="openPlunkr('{$ doc.path $}')" class="btn pull-right">
+  <a ng-click="openPlunkr('{$ doc.path $}', $event)" class="btn pull-right">
     <i class="glyphicon glyphicon-edit">&nbsp;</i>
     Edit in Plunker</a>
 


### PR DESCRIPTION
This is an initial suggestion for dealing with the problem described in #10641.  To summarize, the problem is:
- The "Edit in Plunkr" anchor tag has an ng-click attribute
- The `openPlunkr` function is fired on click which calls `formPostData`
- `formPostData` creates a new form element, adds it to the page, posts it, and removes the form element
- The form, when posted, opens in the same page (`target="_self"`)
- This can be unhelpful for people who want to stay on the AngularJS documentation site.
- Changing the target attribute to `"_blank"`, however, can trigger the popup blocker.
- If a user chose to bypass pop-up blocker one time and click the link, they would arrive at a new default plnkr, not a plnkr with the desired template.

To resolve, the following steps were taken:
- Pass the `$event` object into the `openPlunkr` function
- Check if the ctrl button was pressed during click
  - If true, set `target="_blank"`
  - If false, set `target="_self"`

This enables a user to "opt-in" to the new window functionality, and the assumption is that they will whitelist the AngularJS docs page so their popup blocker doesn't block the popup.  However, for the users who do not ctrl+click, they will continue experiencing the default functionality and not experience the undesired behavior described above.
