### PR TITLE
docs(tutorial/4 - Two-way Data Binding): Variable name typo

### DIFF
--- a/docs/content/tutorial/step_04.ngdoc
+++ b/docs/content/tutorial/step_04.ngdoc
@@ -150,7 +150,7 @@ __`test/e2e/scenarios.js`:__
 ...
     it('should be possible to control phone order via the drop down select box', function() {
 
-      var phoneNameColumn = element.all(by.repeater('phone in phones').column('{{phone.name}}'));
+      var phoneNameColumn = element.all(by.repeater('phone in phones').column('phone.name'));
       var query = element(by.model('query'));
 
       function getNames() {


### PR DESCRIPTION
This appears to be a typo in the tutorial as the protractor build fails when using the `{{phone.name}}` variable name.

Additionally, performing a `git checkout -f step-4` results in the `scenario.js` file using the `phone.name` variable name.
