### PR TITLE
fix(ngModel): fix issues when parserName is same as validator key

### DIFF
--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -1222,77 +1222,93 @@ describe('ngModel', function() {
         expect(ctrl.$validators.mock.calls.length).toEqual(2);
       });
 
-      it('should validate correctly when $parser name equals $validator key', function() {
+      iit('should validate correctly when $parser name equals $validator key', function() {
 
-        var testValid, otherValid, parseValid;
-
-        ctrl.$validators.test = function(value) {
-          return testValid;
+        ctrl.$validators.parserOrValidator = function(value) {
+          switch (value) {
+            case 'allInvalid':
+            case 'parseValid-validatorsInvalid':
+            case 'stillParseValid-validatorsInvalid':
+              return false;
+            default:
+              return true;
+          }
         };
 
-        ctrl.$validators.other = function(value) {
-          return otherValid;
+        ctrl.$validators.validator = function(value) {
+          switch (value) {
+            case 'allInvalid':
+            case 'parseValid-validatorsInvalid':
+            case 'stillParseValid-validatorsInvalid':
+              return false;
+            default:
+              return true;
+          }
         };
 
-        ctrl.$$parserName = 'test';
+        ctrl.$$parserName = 'parserOrValidator';
         ctrl.$parsers.push(function(value) {
-          return parseValid ? true : undefined;
+          switch (value) {
+            case 'allInvalid':
+            case 'stillAllInvalid':
+            case 'parseInvalid-validatorsValid':
+            case 'stillParseInvalid-validatorsValid':
+              return undefined;
+            default:
+              return value;
+          }
         });
 
-
-        testValid = otherValid = parseValid = false;
+        //Parser and validators are invalid
         scope.$apply('value = "allInvalid"');
         expect(scope.value).toBe('allInvalid');
-        expect(ctrl.$error).toEqual({test: true, other: true});
+        expect(ctrl.$error).toEqual({parserOrValidator: true, validator: true});
 
         ctrl.$validate();
-        expect(scope.value).toBe('allInvalid');
-        expect(ctrl.$error).toEqual({test: true, other: true});
+        expect(scope.value).toEqual('allInvalid');
+        expect(ctrl.$error).toEqual({parserOrValidator: true, validator: true});
 
         ctrl.$setViewValue('stillAllInvalid');
         expect(scope.value).toBeUndefined();
-        expect(ctrl.$error).toEqual({test: true});
+        expect(ctrl.$error).toEqual({parserOrValidator: true});
 
         ctrl.$validate();
         expect(scope.value).toBeUndefined();
-        expect(ctrl.$error).toEqual({test: true});
+        expect(ctrl.$error).toEqual({parserOrValidator: true});
 
-
-        parseValid = true;
-        scope.$apply('value = "parseValidAndValidatorInvalid"');
-        expect(scope.value).toBe('parseValidAndValidatorInvalid');
-        expect(ctrl.$error).toEqual({test: true, other: true});
-
-        ctrl.$validate();
-        expect(scope.value).toBe('parseValidAndValidatorInvalid');
-        expect(ctrl.$error).toEqual({test: true, other: true});
-
-        ctrl.$setViewValue('stillParseValidAndValidatorInvalid');
-        expect(scope.value).toBeUndefined();
-        expect(ctrl.$error).toEqual({test: true, other: true});
+        //Parser is valid, validators are invalid
+        scope.$apply('value = "parseValid-validatorsInvalid"');
+        expect(scope.value).toBe('parseValid-validatorsInvalid');
+        expect(ctrl.$error).toEqual({parserOrValidator: true, validator: true});
 
         ctrl.$validate();
+        expect(scope.value).toBe('parseValid-validatorsInvalid');
+        expect(ctrl.$error).toEqual({parserOrValidator: true, validator: true});
+
+        ctrl.$setViewValue('stillParseValid-validatorsInvalid');
         expect(scope.value).toBeUndefined();
-        expect(ctrl.$error).toEqual({test: true, other: true});
+        expect(ctrl.$error).toEqual({parserOrValidator: true, validator: true});
 
+        ctrl.$validate();
+        expect(scope.value).toBeUndefined();
+        expect(ctrl.$error).toEqual({parserOrValidator: true, validator: true});
 
-        parseValid = false;
-        testValid = otherValid = true;
-        scope.$apply('value = "parseInvalidAndValidatorValid"');
-        expect(scope.value).toBe('parseInvalidAndValidatorValid');
+        //Parser is invalid, validators are valid
+        scope.$apply('value = "parseInvalid-validatorsValid"');
+        expect(scope.value).toBe('parseInvalid-validatorsValid');
         expect(ctrl.$error).toEqual({});
 
         ctrl.$validate();
-        expect(scope.value).toBe('parseInvalidAndValidatorValid');
+        expect(scope.value).toBe('parseInvalid-validatorsValid');
         expect(ctrl.$error).toEqual({});
 
-        ctrl.$setViewValue('stillParseInvalidAndValidatorValid');
+        ctrl.$setViewValue('stillParseInvalid-validatorsValid');
         expect(scope.value).toBeUndefined();
-        expect(ctrl.$error).toEqual({test: true});
+        expect(ctrl.$error).toEqual({parserOrValidator: true});
 
         ctrl.$validate();
         expect(scope.value).toBeUndefined();
-        expect(ctrl.$error).toEqual({test: true});
+        expect(ctrl.$error).toEqual({parserOrValidator: true});
       });
 
     });

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -1221,6 +1221,80 @@ describe('ngModel', function() {
         expect(ctrl.$validators.mock).toHaveBeenCalledWith('a', 'ab');
         expect(ctrl.$validators.mock.calls.length).toEqual(2);
       });
+
+      it('should validate correctly when $parser name equals $validator key', function() {
+
+        var testValid, otherValid, parseValid;
+
+        ctrl.$validators.test = function(value) {
+          return testValid;
+        };
+
+        ctrl.$validators.other = function(value) {
+          return otherValid;
+        };
+
+        ctrl.$$parserName = 'test';
+        ctrl.$parsers.push(function(value) {
+          return parseValid ? true : undefined;
+        });
+
+
+        testValid = otherValid = parseValid = false;
+        scope.$apply('value = "allInvalid"');
+        expect(scope.value).toBe('allInvalid');
+        expect(ctrl.$error).toEqual({test: true, other: true});
+
+        ctrl.$validate();
+        expect(scope.value).toBe('allInvalid');
+        expect(ctrl.$error).toEqual({test: true, other: true});
+
+        ctrl.$setViewValue('stillAllInvalid');
+        expect(scope.value).toBeUndefined();
+        expect(ctrl.$error).toEqual({test: true});
+
+        ctrl.$validate();
+        expect(scope.value).toBeUndefined();
+        expect(ctrl.$error).toEqual({test: true});
+
+
+        parseValid = true;
+        scope.$apply('value = "parseValidAndValidatorInvalid"');
+        expect(scope.value).toBe('parseValidAndValidatorInvalid');
+        expect(ctrl.$error).toEqual({test: true, other: true});
+
+        ctrl.$validate();
+        expect(scope.value).toBe('parseValidAndValidatorInvalid');
+        expect(ctrl.$error).toEqual({test: true, other: true});
+
+        ctrl.$setViewValue('stillParseValidAndValidatorInvalid');
+        expect(scope.value).toBeUndefined();
+        expect(ctrl.$error).toEqual({test: true, other: true});
+
+        ctrl.$validate();
+        expect(scope.value).toBeUndefined();
+        expect(ctrl.$error).toEqual({test: true, other: true});
+
+
+        parseValid = false;
+        testValid = otherValid = true;
+        scope.$apply('value = "parseInvalidAndValidatorValid"');
+        expect(scope.value).toBe('parseInvalidAndValidatorValid');
+        expect(ctrl.$error).toEqual({});
+
+        ctrl.$validate();
+        expect(scope.value).toBe('parseInvalidAndValidatorValid');
+        expect(ctrl.$error).toEqual({});
+
+        ctrl.$setViewValue('stillParseInvalidAndValidatorValid');
+        expect(scope.value).toBeUndefined();
+        expect(ctrl.$error).toEqual({test: true});
+
+        ctrl.$validate();
+        expect(scope.value).toBeUndefined();
+        expect(ctrl.$error).toEqual({test: true});
+      });
+
     });
   });
 


### PR DESCRIPTION
For $validate(), it is necessary to store the parseError state
in the controller. Otherwise, if the parser name equals a validator
key, $validate() will assume a parse error occured if the validator
is invalid.

Also, setting the validity for the parser now happens after setting
validity for the validator key. Otherwise, the parse key is set,
and then immediately afterwards the validator key is unset
(because parse errors remove all other validations).

Fixes #10698
Closes #10828
