### PR TITLE
Add jscs rule requireCurlyBraces and disallowKeywordsOnNewLine

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -1,6 +1,7 @@
 {
   "excludeFiles": ["src/ngLocale/**"],
   "disallowKeywords": ["with"],
+  "disallowKeywordsOnNewLine": ["else"],
   "disallowMixedSpacesAndTabs": true,
   "disallowMultipleLineStrings": true,
   "disallowNewlineBeforeBlockStatements": true,

--- a/.jscs.json
+++ b/.jscs.json
@@ -22,6 +22,7 @@
   "disallowTrailingComma": true,
   "disallowTrailingWhitespace": true,
   "requireCommaBeforeLineBreak": true,
+  "requireCurlyBraces": ["if", "else", "for", "while", "do", "try", "catch"],
   "requireLineFeedAtFileEnd": true,
   "requireSpaceAfterBinaryOperators": ["?", ":", "+", "-", "/", "*", "%", "==", "===", "!=", "!==", ">", ">=", "<", "<=", "&&", "||"],
   "requireSpaceBeforeBinaryOperators": ["?", ":", "+", "-", "/", "*", "%", "==", "===", "!=", "!==", ">", ">=", "<", "<=", "&&", "||"],

--- a/.jscs.json.todo
+++ b/.jscs.json.todo
@@ -6,7 +6,6 @@
 {
   "disallowImplicitTypeConversion": ["string"],
   "disallowMultipleLineBreaks": true,
-  "disallowKeywordsOnNewLine": ["else"],
   "validateJSDoc": {
     "checkParamNames": true,
     "requireParamTypes": true

--- a/.jscs.json.todo
+++ b/.jscs.json.todo
@@ -4,7 +4,6 @@
 // that correct the existing code base issues and make the new check pass.
 
 {
-  "requireCurlyBraces": ["if", "else", "for", "while", "do", "try", "catch"],
   "disallowImplicitTypeConversion": ["string"],
   "disallowMultipleLineBreaks": true,
   "disallowKeywordsOnNewLine": ["else"],

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -312,8 +312,7 @@ function nextUid() {
 function setHashKey(obj, h) {
   if (h) {
     obj.$$hashKey = h;
-  }
-  else {
+  } else {
     delete obj.$$hashKey;
   }
 }

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1346,7 +1346,9 @@ function angularInit(element, bootstrap) {
  * @returns {auto.$injector} Returns the newly created injector for this app.
  */
 function bootstrap(element, modules, config) {
-  if (!isObject(config)) config = {};
+  if (!isObject(config)) {
+    config = {};
+  }
   var defaultConfig = {
     strictDi: false
   };

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -724,15 +724,18 @@ function copy(source, destination, stackSource, stackDest) {
       }
     }
   } else {
-    if (source === destination) throw ngMinErr('cpi',
-      "Can't copy! Source and destination are identical.");
+    if (source === destination) {
+      throw ngMinErr('cpi', "Can't copy! Source and destination are identical.");
+    }
 
     stackSource = stackSource || [];
     stackDest = stackDest || [];
 
     if (isObject(source)) {
       var index = stackSource.indexOf(source);
-      if (index !== -1) return stackDest[index];
+      if (index !== -1) {
+        return stackDest[index];
+      }
 
       stackSource.push(source);
       stackDest.push(destination);
@@ -831,38 +834,58 @@ function shallowCopy(src, dst) {
  * @returns {boolean} True if arguments are equal.
  */
 function equals(o1, o2) {
-  if (o1 === o2) return true;
-  if (o1 === null || o2 === null) return false;
-  if (o1 !== o1 && o2 !== o2) return true; // NaN === NaN
+  if (o1 === o2) {
+    return true;
+  }
+  if (o1 === null || o2 === null) {
+    return false;
+  }
+  if (o1 !== o1 && o2 !== o2) { // NaN === NaN
+    return true;
+  }
   var t1 = typeof o1, t2 = typeof o2, length, key, keySet;
   if (t1 == t2) {
     if (t1 == 'object') {
       if (isArray(o1)) {
-        if (!isArray(o2)) return false;
+        if (!isArray(o2)) {
+          return false;
+        }
         if ((length = o1.length) == o2.length) {
           for (key = 0; key < length; key++) {
-            if (!equals(o1[key], o2[key])) return false;
+            if (!equals(o1[key], o2[key])) {
+              return false;
+            }
           }
           return true;
         }
       } else if (isDate(o1)) {
-        if (!isDate(o2)) return false;
+        if (!isDate(o2)) {
+          return false;
+        }
         return equals(o1.getTime(), o2.getTime());
       } else if (isRegExp(o1) && isRegExp(o2)) {
         return o1.toString() == o2.toString();
       } else {
-        if (isScope(o1) || isScope(o2) || isWindow(o1) || isWindow(o2) || isArray(o2)) return false;
+        if (isScope(o1) || isScope(o2) || isWindow(o1) || isWindow(o2) || isArray(o2)) {
+          return false;
+        }
         keySet = {};
         for (key in o1) {
-          if (key.charAt(0) === '$' || isFunction(o1[key])) continue;
-          if (!equals(o1[key], o2[key])) return false;
+          if (key.charAt(0) === '$' || isFunction(o1[key])) {
+            continue;
+          }
+          if (!equals(o1[key], o2[key])) {
+            return false;
+          }
           keySet[key] = true;
         }
         for (key in o2) {
           if (!keySet.hasOwnProperty(key) &&
               key.charAt(0) !== '$' &&
               o2[key] !== undefined &&
-              !isFunction(o2[key])) return false;
+              !isFunction(o2[key])) {
+            return false;
+          }
         }
         return true;
       }
@@ -872,7 +895,9 @@ function equals(o1, o2) {
 }
 
 var csp = function() {
-  if (isDefined(csp.isActive_)) return csp.isActive_;
+  if (isDefined(csp.isActive_)) {
+    return csp.isActive_;
+  }
 
   var active = !!(document.querySelector('[ng-csp]') ||
                   document.querySelector('[data-ng-csp]'));
@@ -974,7 +999,9 @@ function toJsonReplacer(key, value) {
  * @returns {string|undefined} JSON-ified string representing `obj`.
  */
 function toJson(obj, pretty) {
-  if (typeof obj === 'undefined') return undefined;
+  if (typeof obj === 'undefined') {
+    return undefined;
+  }
   if (!isNumber(pretty)) {
     pretty = pretty ? 2 : null;
   }
@@ -1544,7 +1571,9 @@ function assertNotHasOwnProperty(name, context) {
  */
 //TODO(misko): this function needs to be removed
 function getter(obj, path, bindFnToScope) {
-  if (!path) return obj;
+  if (!path) {
+    return obj;
+  }
   var keys = path.split('.');
   var key;
   var lastInstance = obj;
@@ -1576,7 +1605,9 @@ function getBlockNodes(nodes) {
 
   do {
     node = node.nextSibling;
-    if (!node) break;
+    if (!node) {
+      break;
+    }
     blockNodes.push(node);
   } while (node !== endNode);
 

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -621,8 +621,9 @@ function isElement(node) {
  */
 function makeMap(str) {
   var obj = {}, items = str.split(","), i;
-  for (i = 0; i < items.length; i++)
+  for (i = 0; i < items.length; i++) {
     obj[ items[i] ] = true;
+  }
   return obj;
 }
 
@@ -637,8 +638,9 @@ function includes(array, obj) {
 
 function arrayRemove(array, value) {
   var index = array.indexOf(value);
-  if (index >= 0)
+  if (index >= 0) {
     array.splice(index, 1);
+  }
   return value;
 }
 

--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -719,7 +719,9 @@ function createInjector(modulesToLoad, strictDi) {
   function loadModules(modulesToLoad) {
     var runBlocks = [], moduleFn;
     forEach(modulesToLoad, function(module) {
-      if (loadedModules.get(module)) return;
+      if (loadedModules.get(module)) {
+        return;
+      }
       loadedModules.put(module, true);
 
       function runInvokeQueue(queue) {

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -851,8 +851,9 @@ forEach({
   children: function(element) {
     var children = [];
     forEach(element.childNodes, function(element) {
-      if (element.nodeType === NODE_TYPE_ELEMENT)
+      if (element.nodeType === NODE_TYPE_ELEMENT) {
         children.push(element);
+      }
     });
     return children;
   },

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -254,7 +254,9 @@ function jqLiteClone(element) {
 }
 
 function jqLiteDealoc(element, onlyDescendants) {
-  if (!onlyDescendants) jqLiteRemoveData(element);
+  if (!onlyDescendants) {
+    jqLiteRemoveData(element);
+  }
 
   if (element.querySelectorAll) {
     var descendants = element.querySelectorAll('*');
@@ -450,9 +452,13 @@ function jqLiteEmpty(element) {
 }
 
 function jqLiteRemove(element, keepData) {
-  if (!keepData) jqLiteDealoc(element);
+  if (!keepData) {
+    jqLiteDealoc(element);
+  }
   var parent = element.parentNode;
-  if (parent) parent.removeChild(element);
+  if (parent) {
+    parent.removeChild(element);
+  }
 }
 
 
@@ -1011,15 +1017,21 @@ function $$jqLiteProvider() {
   this.$get = function $$jqLite() {
     return extend(JQLite, {
       hasClass: function(node, classes) {
-        if (node.attr) node = node[0];
+        if (node.attr) {
+          node = node[0];
+        }
         return jqLiteHasClass(node, classes);
       },
       addClass: function(node, classes) {
-        if (node.attr) node = node[0];
+        if (node.attr) {
+          node = node[0];
+        }
         return jqLiteAddClass(node, classes);
       },
       removeClass: function(node, classes) {
-        if (node.attr) node = node[0];
+        if (node.attr) {
+          node = node[0];
+        }
         return jqLiteRemoveClass(node, classes);
       }
     });

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -267,13 +267,18 @@ function jqLiteDealoc(element, onlyDescendants) {
 }
 
 function jqLiteOff(element, type, fn, unsupported) {
-  if (isDefined(unsupported)) throw jqLiteMinErr('offargs', 'jqLite#off() does not support the `selector` argument');
+  if (isDefined(unsupported)) {
+    throw jqLiteMinErr('offargs', 'jqLite#off() does not support the `selector` argument');
+  }
 
   var expandoStore = jqLiteExpandoStore(element);
   var events = expandoStore && expandoStore.events;
   var handle = expandoStore && expandoStore.handle;
 
-  if (!handle) return; //no listeners registered
+  if (!handle) {
+    //no listeners registered
+    return;
+  }
 
   if (!type) {
     for (type in events) {
@@ -360,7 +365,9 @@ function jqLiteData(element, key, value) {
 }
 
 function jqLiteHasClass(element, selector) {
-  if (!element.getAttribute) return false;
+  if (!element.getAttribute) {
+    return false;
+  }
   return ((" " + (element.getAttribute('class') || '') + " ").replace(/[\n\t]/g, " ").
       indexOf(" " + selector + " ") > -1);
 }
@@ -434,7 +441,9 @@ function jqLiteInheritedData(element, name, value) {
 
   while (element) {
     for (var i = 0, ii = names.length; i < ii; i++) {
-      if ((value = jqLite.data(element, names[i])) !== undefined) return value;
+      if ((value = jqLite.data(element, names[i])) !== undefined) {
+        return value;
+      }
     }
 
     // If dealing with a document fragment node with a host element, and no parent, use the host
@@ -483,7 +492,9 @@ var JQLitePrototype = JQLite.prototype = {
     var fired = false;
 
     function trigger() {
-      if (fired) return;
+      if (fired) {
+        return;
+      }
       fired = true;
       fn();
     }
@@ -727,7 +738,9 @@ function createEventHandler(element, events) {
     var eventFns = events[type || event.type];
     var eventFnsLength = eventFns ? eventFns.length : 0;
 
-    if (!eventFnsLength) return;
+    if (!eventFnsLength) {
+      return;
+    }
 
     if (isUndefined(event.immediatePropagationStopped)) {
       var originalStopImmediatePropagation = event.stopImmediatePropagation;
@@ -775,7 +788,9 @@ forEach({
   removeData: jqLiteRemoveData,
 
   on: function jqLiteOn(element, type, fn, unsupported) {
-    if (isDefined(unsupported)) throw jqLiteMinErr('onargs', 'jqLite#on() does not support the `selector` or `eventData` parameters');
+    if (isDefined(unsupported)) {
+      throw jqLiteMinErr('onargs', 'jqLite#on() does not support the `selector` or `eventData` parameters');
+    }
 
     // Do not add event handlers to non-elements because they will not be cleaned up.
     if (!jqLiteAcceptsData(element)) {
@@ -870,7 +885,9 @@ forEach({
 
   append: function(element, node) {
     var nodeType = element.nodeType;
-    if (nodeType !== NODE_TYPE_ELEMENT && nodeType !== NODE_TYPE_DOCUMENT_FRAGMENT) return;
+    if (nodeType !== NODE_TYPE_ELEMENT && nodeType !== NODE_TYPE_DOCUMENT_FRAGMENT) {
+      return;
+    }
 
     node = new JQLite(node);
 

--- a/src/loader.js
+++ b/src/loader.js
@@ -305,7 +305,9 @@ function setupModuleLoader(window) {
          * @returns {angular.Module}
          */
         function invokeLater(provider, method, insertMethod, queue) {
-          if (!queue) queue = invokeQueue;
+          if (!queue) {
+            queue = invokeQueue;
+          }
           return function() {
             queue[insertMethod || 'push']([provider, method, arguments]);
             return moduleInstance;

--- a/src/ng/anchorScroll.js
+++ b/src/ng/anchorScroll.js
@@ -236,16 +236,24 @@ function $AnchorScrollProvider() {
       var hash = $location.hash(), elm;
 
       // empty hash, scroll to the top of the page
-      if (!hash) scrollTo(null);
+      if (!hash) {
+        scrollTo(null);
+      }
 
       // element with given id
-      else if ((elm = document.getElementById(hash))) scrollTo(elm);
+      else if ((elm = document.getElementById(hash))) {
+        scrollTo(elm);
+      }
 
       // first anchor with given name :-D
-      else if ((elm = getFirstAnchor(document.getElementsByName(hash)))) scrollTo(elm);
+      else if ((elm = getFirstAnchor(document.getElementsByName(hash)))) {
+        scrollTo(elm);
+      }
 
       // no element and hash == 'top', scroll to the top of the page
-      else if (hash === 'top') scrollTo(null);
+      else if (hash === 'top') {
+        scrollTo(null);
+      }
     }
 
     // does not scroll when user clicks on anchor link that is currently on

--- a/src/ng/anchorScroll.js
+++ b/src/ng/anchorScroll.js
@@ -235,23 +235,13 @@ function $AnchorScrollProvider() {
     function scroll() {
       var hash = $location.hash(), elm;
 
-      // empty hash, scroll to the top of the page
-      if (!hash) {
+      if (!hash) { // empty hash, scroll to the top of the page
         scrollTo(null);
-      }
-
-      // element with given id
-      else if ((elm = document.getElementById(hash))) {
+      } else if ((elm = document.getElementById(hash))) { // element with given id
         scrollTo(elm);
-      }
-
-      // first anchor with given name :-D
-      else if ((elm = getFirstAnchor(document.getElementsByName(hash)))) {
+      } else if ((elm = getFirstAnchor(document.getElementsByName(hash)))) { // first anchor with given name :-D
         scrollTo(elm);
-      }
-
-      // no element and hash == 'top', scroll to the top of the page
-      else if (hash === 'top') {
+      } else if (hash === 'top') { // no element and hash == 'top', scroll to the top of the page
         scrollTo(null);
       }
     }

--- a/src/ng/anchorScroll.js
+++ b/src/ng/anchorScroll.js
@@ -262,7 +262,9 @@ function $AnchorScrollProvider() {
       $rootScope.$watch(function autoScrollWatch() {return $location.hash();},
         function autoScrollWatchAction(newVal, oldVal) {
           // skip the initial scroll if $location.hash is empty
-          if (newVal === oldVal && newVal === '') return;
+          if (newVal === oldVal && newVal === '') {
+            return;
+          }
 
           jqLiteDocumentLoaded(function() {
             $rootScope.$evalAsync(scroll);

--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -54,8 +54,10 @@ var $AnimateProvider = ['$provide', function($provide) {
    */
   this.register = function(name, factory) {
     var key = name + '-animation';
-    if (name && name.charAt(0) != '.') throw $animateMinErr('notcsel',
+    if (name && name.charAt(0) != '.') {
+      throw $animateMinErr('notcsel',
         "Expecting class selector starting with '.' got '{0}'.", name);
+    }
     this.$$selectors[name.substr(1)] = key;
     $provide.factory(key, factory);
   };

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -103,7 +103,9 @@ function Browser(window, document, $log, $sniffer) {
    * @returns {function()} the added function
    */
   self.addPollFn = function(fn) {
-    if (isUndefined(pollTimeout)) startPoller(100, setTimeout);
+    if (isUndefined(pollTimeout)) {
+      startPoller(100, setTimeout);
+    }
     pollFns.push(fn);
     return fn;
   };
@@ -164,8 +166,12 @@ function Browser(window, document, $log, $sniffer) {
     }
 
     // Android Browser BFCache causes location, history reference to become stale.
-    if (location !== window.location) location = window.location;
-    if (history !== window.history) history = window.history;
+    if (location !== window.location) {
+      location = window.location;
+    }
+    if (history !== window.history) {
+      history = window.history;
+    }
 
     // setter
     if (url) {
@@ -288,7 +294,9 @@ function Browser(window, document, $log, $sniffer) {
       // changed by push/replaceState
 
       // html5 history api - popstate event
-      if ($sniffer.history) jqLite(window).on('popstate', cacheStateAndFireUrlChange);
+      if ($sniffer.history) {
+        jqLite(window).on('popstate', cacheStateAndFireUrlChange);
+      }
       // hashchange event
       jqLite(window).on('hashchange', cacheStateAndFireUrlChange);
 

--- a/src/ng/cacheFactory.js
+++ b/src/ng/cacheFactory.js
@@ -166,7 +166,9 @@ function $CacheFactoryProvider() {
             refresh(lruEntry);
           }
 
-          if (!(key in data)) size++;
+          if (!(key in data)) {
+            size++;
+          }
           data[key] = value;
 
           if (size > capacity) {
@@ -216,8 +218,12 @@ function $CacheFactoryProvider() {
 
             if (!lruEntry) return;
 
-            if (lruEntry == freshEnd) freshEnd = lruEntry.p;
-            if (lruEntry == staleEnd) staleEnd = lruEntry.n;
+            if (lruEntry == freshEnd) {
+              freshEnd = lruEntry.p;
+            }
+            if (lruEntry == staleEnd) {
+              staleEnd = lruEntry.n;
+            }
             link(lruEntry.n,lruEntry.p);
 
             delete lruHash[key];
@@ -307,8 +313,12 @@ function $CacheFactoryProvider() {
        */
       function link(nextEntry, prevEntry) {
         if (nextEntry != prevEntry) {
-          if (nextEntry) nextEntry.p = prevEntry; //p stands for previous, 'prev' didn't minify
-          if (prevEntry) prevEntry.n = nextEntry; //n stands for next, 'next' didn't minify
+          if (nextEntry) {
+            nextEntry.p = prevEntry; //p stands for previous, 'prev' didn't minify
+          }
+          if (prevEntry) {
+            prevEntry.n = nextEntry; //n stands for next, 'next' didn't minify
+          }
         }
       }
     }

--- a/src/ng/cacheFactory.js
+++ b/src/ng/cacheFactory.js
@@ -159,7 +159,9 @@ function $CacheFactoryProvider() {
          * @returns {*} the value stored.
          */
         put: function(key, value) {
-          if (isUndefined(value)) return;
+          if (isUndefined(value)) {
+            return;
+          }
           if (capacity < Number.MAX_VALUE) {
             var lruEntry = lruHash[key] || (lruHash[key] = {key: key});
 
@@ -193,7 +195,9 @@ function $CacheFactoryProvider() {
           if (capacity < Number.MAX_VALUE) {
             var lruEntry = lruHash[key];
 
-            if (!lruEntry) return;
+            if (!lruEntry) {
+              return;
+            }
 
             refresh(lruEntry);
           }
@@ -216,7 +220,9 @@ function $CacheFactoryProvider() {
           if (capacity < Number.MAX_VALUE) {
             var lruEntry = lruHash[key];
 
-            if (!lruEntry) return;
+            if (!lruEntry) {
+              return;
+            }
 
             if (lruEntry == freshEnd) {
               freshEnd = lruEntry.p;

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1235,8 +1235,12 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
         compile.$$addScopeInfo($linkNode, scope);
 
-        if (cloneConnectFn) cloneConnectFn($linkNode, scope);
-        if (compositeLinkFn) compositeLinkFn(scope, $linkNode, $linkNode, parentBoundTranscludeFn);
+        if (cloneConnectFn) {
+          cloneConnectFn($linkNode, scope);
+        }
+        if (compositeLinkFn) {
+          compositeLinkFn(scope, $linkNode, $linkNode, parentBoundTranscludeFn);
+        }
         return $linkNode;
       };
     }
@@ -1507,8 +1511,12 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                       attrStart, attrEnd);
           }
           if (node.nodeType == NODE_TYPE_ELEMENT) {
-            if (node.hasAttribute(attrStart)) depth++;
-            if (node.hasAttribute(attrEnd)) depth--;
+            if (node.hasAttribute(attrStart)) {
+              depth++;
+            }
+            if (node.hasAttribute(attrEnd)) {
+              depth--;
+            }
           }
           nodes.push(node);
           node = node.nextSibling;
@@ -1771,7 +1779,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
       function addLinkFns(pre, post, attrStart, attrEnd) {
         if (pre) {
-          if (attrStart) pre = groupElementsLinkFnWrapper(pre, attrStart, attrEnd);
+          if (attrStart) {
+            pre = groupElementsLinkFnWrapper(pre, attrStart, attrEnd);
+          }
           pre.require = directive.require;
           pre.directiveName = directiveName;
           if (newIsolateScopeDirective === directive || directive.$$isolateScope) {
@@ -1780,7 +1790,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           preLinkFns.push(pre);
         }
         if (post) {
-          if (attrStart) post = groupElementsLinkFnWrapper(post, attrStart, attrEnd);
+          if (attrStart) {
+            post = groupElementsLinkFnWrapper(post, attrStart, attrEnd);
+          }
           post.require = directive.require;
           post.directiveName = directiveName;
           if (newIsolateScopeDirective === directive || directive.$$isolateScope) {
@@ -1800,8 +1812,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           require = require.substring(match[0].length);
 
           if (match[3]) {
-            if (match[1]) match[3] = null;
-            else match[1] = match[3];
+            if (match[1]) {
+              match[3] = null;
+            } else {
+              match[1] = match[3];
+            }
           }
           if (match[1] === '^') {
             retrievalMethod = 'inheritedData';
@@ -2293,11 +2308,15 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
             // When transcluding a template that has bindings in the root
             // we don't have a parent and thus need to add the class during linking fn.
-            if (hasCompileParent) compile.$$addBindingClass(templateNodeParent);
+            if (hasCompileParent) {
+              compile.$$addBindingClass(templateNodeParent);
+            }
 
             return function textInterpolateLinkFn(scope, node) {
               var parent = node.parent();
-              if (!hasCompileParent) compile.$$addBindingClass(parent);
+              if (!hasCompileParent) {
+                compile.$$addBindingClass(parent);
+              }
               compile.$$addBindingInfo(parent, interpolateFn.expressions);
               scope.$watch(interpolateFn, function interpolateFnWatchAction(value) {
                 node[0].nodeValue = value;

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2078,7 +2078,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
      */
     function addDirective(tDirectives, name, location, maxPriority, ignoreDirective, startAttrName,
                           endAttrName) {
-      if (name === ignoreDirective) return null;
+      if (name === ignoreDirective) {
+        return null;
+      }
       var match = null;
       if (hasDirectives.hasOwnProperty(name)) {
         for (var directive, directives = $injector.get(name + Suffix),
@@ -2234,7 +2236,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 boundTranscludeFn = linkQueue.shift(),
                 linkNode = $compileNode[0];
 
-            if (scope.$$destroyed) continue;
+            if (scope.$$destroyed) {
+              continue;
+            }
 
             if (beforeTemplateLinkNode !== beforeTemplateCompileNode) {
               var oldClasses = beforeTemplateLinkNode.className;
@@ -2262,7 +2266,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
       return function delayedNodeLinkFn(ignoreChildLinkFn, scope, node, rootElement, boundTranscludeFn) {
         var childBoundTranscludeFn = boundTranscludeFn;
-        if (scope.$$destroyed) return;
+        if (scope.$$destroyed) {
+          return;
+        }
         if (linkQueue) {
           linkQueue.push(scope,
                          node,
@@ -2283,8 +2289,12 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
      */
     function byPriority(a, b) {
       var diff = b.priority - a.priority;
-      if (diff !== 0) return diff;
-      if (a.name !== b.name) return (a.name < b.name) ? -1 : 1;
+      if (diff !== 0) {
+        return diff;
+      }
+      if (a.name !== b.name) {
+        return (a.name < b.name) ? -1 : 1;
+      }
       return a.index - b.index;
     }
 
@@ -2364,7 +2374,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       var interpolateFn = $interpolate(value, true, trustedContext, allOrNothing);
 
       // no interpolation found -> ignore
-      if (!interpolateFn) return;
+      if (!interpolateFn) {
+        return;
+      }
 
 
       if (name === "multiple" && nodeName_(node) === "select") {
@@ -2398,7 +2410,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
                 // if attribute was updated so that there is no interpolation going on we don't want to
                 // register any observers
-                if (!interpolateFn) return;
+                if (!interpolateFn) {
+                  return;
+                }
 
                 // initialize attr object so that it's ready in case we need the value for isolate
                 // scope initialization, otherwise the value would not be available from isolate
@@ -2604,7 +2618,9 @@ function tokenDifference(str1, str2) {
   for (var i = 0; i < tokens1.length; i++) {
     var token = tokens1[i];
     for (var j = 0; j < tokens2.length; j++) {
-      if (token == tokens2[j]) continue outer;
+      if (token == tokens2[j]) {
+        continue outer;
+      }
     }
     values += (values.length > 0 ? ' ' : '') + token;
   }

--- a/src/ng/directive/a.js
+++ b/src/ng/directive/a.js
@@ -19,14 +19,18 @@ var htmlAnchorDirective = valueFn({
     if (!attr.href && !attr.xlinkHref && !attr.name) {
       return function(scope, element) {
         // If the linked element is not an anchor tag anymore, do nothing
-        if (element[0].nodeName.toLowerCase() !== 'a') return;
+        if (element[0].nodeName.toLowerCase() !== 'a') {
+          return;
+        }
 
         // SVGAElement does not use the href attribute, but rather the 'xlinkHref' attribute.
         var href = toString.call(element.prop('href')) === '[object SVGAnimatedString]' ?
                    'xlink:href' : 'href';
         element.on('click', function(event) {
           // If a different element was clicked, ignore it.
-          if (element[0] !== event.target) return;
+          if (element[0] !== event.target) {
+            return;
+          }
 
           // if we have no href url, then don't navigate anywhere.
           if (!element.attr(href)) {

--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -344,7 +344,9 @@ var ngAttributeAliasDirectives = {};
 // boolean attrs are evaluated
 forEach(BOOLEAN_ATTR, function(propName, attrName) {
   // binding to multiple is not supported
-  if (propName == "multiple") return;
+  if (propName == "multiple") {
+    return;
+  }
 
   function defaultLinkFn(scope, element, attr) {
     scope.$watch(attr[normalized], function ngBooleanAttrWatchAction(value) {

--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -428,7 +428,9 @@ forEach(['src', 'srcset', 'href'], function(attrName) {
           // then calling element.setAttribute('src', 'foo') doesn't do anything, so we need
           // to set the property as well to achieve the desired effect.
           // we use attr[attrName] value since $set can sanitize the url.
-          if (msie && propName) element.prop(propName, attr[name]);
+          if (msie && propName) {
+            element.prop(propName, attr[name]);
+          }
         });
       }
     };

--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -494,7 +494,9 @@ var formDirectiveFactory = function(isNgForm) {
             if (alias) {
               setter(scope, alias, controller, alias);
               attr.$observe(attr.name ? 'name' : 'ngForm', function(newValue) {
-                if (alias === newValue) return;
+                if (alias === newValue) {
+                  return;
+                }
                 setter(scope, alias, undefined, alias);
                 alias = newValue;
                 setter(scope, alias, controller, alias);

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -997,7 +997,9 @@ function baseInputType(scope, element, attr, ctrl, $sniffer, $browser) {
       $browser.defer.cancel(timeout);
       timeout = null;
     }
-    if (composing) return;
+    if (composing) {
+      return;
+    }
     var value = element.val(),
         event = ev && ev.type;
 
@@ -1039,7 +1041,9 @@ function baseInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 
       // ignore
       //    command            modifiers                   arrows
-      if (key === 91 || (15 < key && key < 19) || (37 <= key && key <= 40)) return;
+      if (key === 91 || (15 < key && key < 19) || (37 <= key && key <= 40)) {
+        return;
+      }
 
       deferListener(event, this, this.value);
     });
@@ -1150,7 +1154,9 @@ function createDateInputType(type, regexp, parseDate, format) {
 
     ctrl.$$parserName = type;
     ctrl.$parsers.push(function(value) {
-      if (ctrl.$isEmpty(value)) return null;
+      if (ctrl.$isEmpty(value)) {
+        return null;
+      }
       if (regexp.test(value)) {
         // Note: We cannot read ctrl.$modelValue, as there might be a different
         // parser/formatter in the processing chain so that the model
@@ -1235,8 +1241,12 @@ function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 
   ctrl.$$parserName = 'number';
   ctrl.$parsers.push(function(value) {
-    if (ctrl.$isEmpty(value))      return null;
-    if (NUMBER_REGEXP.test(value)) return parseFloat(value);
+    if (ctrl.$isEmpty(value)) {
+      return null;
+    }
+    if (NUMBER_REGEXP.test(value)) {
+      return parseFloat(value);
+    }
     return undefined;
   });
 

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -88,7 +88,9 @@ function classDirective(name, selector) {
       for (var i = 0; i < tokens1.length; i++) {
         var token = tokens1[i];
         for (var j = 0; j < tokens2.length; j++) {
-          if (token == tokens2[j]) continue outer;
+          if (token == tokens2[j]) {
+            continue outer;
+          }
         }
         values.push(token);
       }

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -227,7 +227,9 @@ var ngIncludeDirective = ['$templateRequest', '$anchorScroll', '$animate', '$sce
             //set the 2nd param to true to ignore the template request error so that the inner
             //contents and scope can be cleaned up.
             $templateRequest(src, true).then(function(response) {
-              if (thisChangeId !== changeCounter) return;
+              if (thisChangeId !== changeCounter) {
+                return;
+              }
               var newScope = scope.$new();
               ctrl.template = response;
 

--- a/src/ng/directive/ngList.js
+++ b/src/ng/directive/ngList.js
@@ -97,7 +97,9 @@ var ngListDirective = function() {
 
       var parse = function(viewValue) {
         // If the viewValue is invalid (say required but empty) it will be `undefined`
-        if (isUndefined(viewValue)) return;
+        if (isUndefined(viewValue)) {
+          return;
+        }
 
         var list = [];
 

--- a/src/ng/directive/ngList.js
+++ b/src/ng/directive/ngList.js
@@ -103,7 +103,9 @@ var ngListDirective = function() {
 
         if (viewValue) {
           forEach(viewValue.split(separator), function(value) {
-            if (value) list.push(trimValues ? trim(value) : value);
+            if (value) {
+              list.push(trimValues ? trim(value) : value);
+            }
           });
         }
 

--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -1040,7 +1040,9 @@ var ngModelDirective = ['$rootScope', function($rootScope) {
           }
 
           element.on('blur', function(ev) {
-            if (modelCtrl.$touched) return;
+            if (modelCtrl.$touched) {
+              return;
+            }
 
             if ($rootScope.$$phase) {
               scope.$evalAsync(modelCtrl.$setTouched);

--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -288,7 +288,9 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
         keys.forEach(function getOption(key) {
 
           // Ignore "angular" properties that start with $ or $$
-          if (key.charAt(0) === '$') return;
+          if (key.charAt(0) === '$') {
+            return;
+          }
 
           var value = optionValues[key];
           var locals = getLocals(value, key);
@@ -327,7 +329,9 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
 
       // if ngModel is not defined, we don't need to do anything
       var ngModelCtrl = ctrls[1];
-      if (!ngModelCtrl) return;
+      if (!ngModelCtrl) {
+        return;
+      }
 
       var selectCtrl = ctrls[0];
       var multiple = attr.multiple;

--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -422,7 +422,9 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
           if (value) {
             value.forEach(function(item) {
               var option = options.getOptionFromViewValue(item);
-              if (option) option.element.selected = true;
+              if (option) {
+                option.element.selected = true;
+              }
             });
           }
         };
@@ -466,7 +468,9 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
 
       function updateOptionElement(option, element) {
         option.element = element;
-        if (option.value !== element.value) element.value = option.selectValue;
+        if (option.value !== element.value) {
+          element.value = option.selectValue;
+        }
         if (option.label !== element.label) {
           element.label = option.label;
           element.textContent = option.label;

--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -240,7 +240,9 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
   var updateScope = function(scope, index, valueIdentifier, value, keyIdentifier, key, arrayLength) {
     // TODO(perf): generate setters to shave off ~40ms or 1-1.5%
     scope[valueIdentifier] = value;
-    if (keyIdentifier) scope[keyIdentifier] = key;
+    if (keyIdentifier) {
+      scope[keyIdentifier] = key;
+    }
     scope.$index = index;
     scope.$first = (index === 0);
     scope.$last = (index === (arrayLength - 1));
@@ -316,7 +318,9 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
         if (trackByExpGetter) {
           trackByIdExpFn = function(key, value, index) {
             // assign key, value, and $index to the locals so that they can be used in hash functions
-            if (keyIdentifier) hashFnLocals[keyIdentifier] = key;
+            if (keyIdentifier) {
+              hashFnLocals[keyIdentifier] = key;
+            }
             hashFnLocals[valueIdentifier] = value;
             hashFnLocals.$index = index;
             return trackByExpGetter($scope, hashFnLocals);
@@ -386,7 +390,9 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
             } else if (nextBlockMap[trackById]) {
               // if collision detected. restore lastBlockMap and throw an error
               forEach(nextBlockOrder, function(block) {
-                if (block && block.scope) lastBlockMap[block.id] = block;
+                if (block && block.scope) {
+                  lastBlockMap[block.id] = block;
+                }
               });
               throw ngRepeatMinErr('dupes',
                   "Duplicates in a repeater are not allowed. Use 'track by' expression to specify unique keys. Repeater: {0}, Duplicate key: {1}, Duplicate value: {2}",

--- a/src/ng/directive/ngStyle.js
+++ b/src/ng/directive/ngStyle.js
@@ -51,6 +51,8 @@ var ngStyleDirective = ngDirective(function(scope, element, attr) {
     if (oldStyles && (newStyles !== oldStyles)) {
       forEach(oldStyles, function(val, style) { element.css(style, '');});
     }
-    if (newStyles) element.css(newStyles);
+    if (newStyles) {
+      element.css(newStyles);
+    }
   });
 });

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -39,7 +39,9 @@ var SelectController =
   });
 
   self.removeUnknownOption = function() {
-    if (self.unknownOption.parent()) self.unknownOption.remove();
+    if (self.unknownOption.parent()) {
+      self.unknownOption.remove();
+    }
   };
 
   // Here we find the option that represents the "empty" value, i.e. the option with a value
@@ -70,7 +72,9 @@ var SelectController =
     if (self.hasOption(value)) {
       self.removeUnknownOption();
       $element.val(value);
-      if (value === '') self.emptyOption.prop('selected', true); // to make IE9 happy
+      if (value === '') {
+        self.emptyOption.prop('selected', true);  // to make IE9 happy
+      }
     } else {
       if (isUndefined(value) && self.emptyOption) {
         $element.val('');

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -154,7 +154,9 @@ var selectDirective = function() {
 
       // if ngModel is not defined, we don't need to do anything
       var ngModelCtrl = ctrls[1];
-      if (!ngModelCtrl) return;
+      if (!ngModelCtrl) {
+        return;
+      }
 
       var selectCtrl = ctrls[0];
 

--- a/src/ng/directive/validators.js
+++ b/src/ng/directive/validators.js
@@ -5,7 +5,9 @@ var requiredDirective = function() {
     restrict: 'A',
     require: '?ngModel',
     link: function(scope, elm, attr, ctrl) {
-      if (!ctrl) return;
+      if (!ctrl) {
+        return;
+      }
       attr.required = true; // force truthy in case we are on non input element
 
       ctrl.$validators.required = function(modelValue, viewValue) {
@@ -25,7 +27,9 @@ var patternDirective = function() {
     restrict: 'A',
     require: '?ngModel',
     link: function(scope, elm, attr, ctrl) {
-      if (!ctrl) return;
+      if (!ctrl) {
+        return;
+      }
 
       var regexp, patternExp = attr.ngPattern || attr.pattern;
       attr.$observe('pattern', function(regex) {
@@ -56,7 +60,9 @@ var maxlengthDirective = function() {
     restrict: 'A',
     require: '?ngModel',
     link: function(scope, elm, attr, ctrl) {
-      if (!ctrl) return;
+      if (!ctrl) {
+        return;
+      }
 
       var maxlength = -1;
       attr.$observe('maxlength', function(value) {
@@ -76,7 +82,9 @@ var minlengthDirective = function() {
     restrict: 'A',
     require: '?ngModel',
     link: function(scope, elm, attr, ctrl) {
-      if (!ctrl) return;
+      if (!ctrl) {
+        return;
+      }
 
       var minlength = 0;
       attr.$observe('minlength', function(value) {

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -234,8 +234,9 @@ function padNumber(num, digits, trim) {
   }
   num = '' + num;
   while (num.length < digits) num = '0' + num;
-  if (trim)
+  if (trim) {
     num = num.substr(num.length - digits);
+  }
   return neg + num;
 }
 
@@ -244,8 +245,9 @@ function dateGetter(name, size, offset, trim) {
   offset = offset || 0;
   return function(date) {
     var value = date['get' + name]();
-    if (offset > 0 || value > -offset)
+    if (offset > 0 || value > -offset) {
       value += offset;
+    }
     if (value === 0 && offset == -12) value = 12;
     return padNumber(value, size, trim);
   };

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -153,7 +153,9 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
       hasExponent = false,
       parts = [];
 
-  if (isInfinity) formatedText = '\u221e';
+  if (isInfinity) {
+    formatedText = '\u221e';
+  }
 
   if (!isInfinity && numStr.indexOf('e') !== -1) {
     var match = numStr.match(/([\d\.]+)e(-?)(\d+)/);
@@ -208,7 +210,9 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
       fraction += '0';
     }
 
-    if (fractionSize && fractionSize !== "0") formatedText += decimalSep + fraction.substr(0, fractionSize);
+    if (fractionSize && fractionSize !== "0") {
+      formatedText += decimalSep + fraction.substr(0, fractionSize);
+    }
   } else {
     if (fractionSize > 0 && number < 1) {
       formatedText = number.toFixed(fractionSize);
@@ -233,7 +237,9 @@ function padNumber(num, digits, trim) {
     num = -num;
   }
   num = '' + num;
-  while (num.length < digits) num = '0' + num;
+  while (num.length < digits) {
+    num = '0' + num;
+  }
   if (trim) {
     num = num.substr(num.length - digits);
   }
@@ -248,7 +254,9 @@ function dateGetter(name, size, offset, trim) {
     if (offset > 0 || value > -offset) {
       value += offset;
     }
-    if (value === 0 && offset == -12) value = 12;
+    if (value === 0 && offset == -12) {
+      value = 12;
+    }
     return padNumber(value, size, trim);
   };
 }

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -140,13 +140,17 @@ function numberFilter($locale) {
 
 var DECIMAL_SEP = '.';
 function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
-  if (isObject(number)) return '';
+  if (isObject(number)) {
+    return '';
+  }
 
   var isNegative = number < 0;
   number = Math.abs(number);
 
   var isInfinity = number === Infinity;
-  if (!isInfinity && !isFinite(number)) return '';
+  if (!isInfinity && !isFinite(number)) {
+    return '';
+  }
 
   var numStr = number + '',
       formatedText = '',

--- a/src/ng/filter/limitTo.js
+++ b/src/ng/filter/limitTo.js
@@ -96,7 +96,9 @@ function limitToFilter() {
     }
     if (isNaN(limit)) return input;
 
-    if (isNumber(input)) input = input.toString();
+    if (isNumber(input)) {
+      input = input.toString();
+    }
     if (!isArray(input) && !isString(input)) return input;
 
     return limit >= 0 ? input.slice(0, limit) : input.slice(limit);

--- a/src/ng/filter/limitTo.js
+++ b/src/ng/filter/limitTo.js
@@ -94,12 +94,16 @@ function limitToFilter() {
     } else {
       limit = toInt(limit);
     }
-    if (isNaN(limit)) return input;
+    if (isNaN(limit)) {
+      return input;
+    }
 
     if (isNumber(input)) {
       input = input.toString();
     }
-    if (!isArray(input) && !isString(input)) return input;
+    if (!isArray(input) && !isString(input)) {
+      return input;
+    }
 
     return limit >= 0 ? input.slice(0, limit) : input.slice(limit);
   };

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -118,7 +118,9 @@
 orderByFilter.$inject = ['$parse'];
 function orderByFilter($parse) {
   return function(array, sortPredicate, reverseOrder) {
-    if (!(isArrayLike(array))) return array;
+    if (!(isArrayLike(array))) {
+      return array;
+    }
     sortPredicate = isArray(sortPredicate) ? sortPredicate : [sortPredicate];
     if (sortPredicate.length === 0) { sortPredicate = ['+']; }
     sortPredicate = sortPredicate.map(function(predicate) {
@@ -149,7 +151,9 @@ function orderByFilter($parse) {
     function comparator(o1, o2) {
       for (var i = 0; i < sortPredicate.length; i++) {
         var comp = sortPredicate[i](o1, o2);
-        if (comp !== 0) return comp;
+        if (comp !== 0) {
+          return comp;
+        }
       }
       return 0;
     }
@@ -171,14 +175,20 @@ function orderByFilter($parse) {
     }
 
     function objectToString(value) {
-      if (value === null) return 'null';
+      if (value === null) {
+        return 'null';
+      }
       if (typeof value.valueOf === 'function') {
         value = value.valueOf();
-        if (isPrimitive(value)) return value;
+        if (isPrimitive(value)) {
+          return value;
+        }
       }
       if (typeof value.toString === 'function') {
         value = value.toString();
-        if (isPrimitive(value)) return value;
+        if (isPrimitive(value)) {
+          return value;
+        }
       }
       return '';
     }
@@ -195,7 +205,9 @@ function orderByFilter($parse) {
            v1 = v1.toLowerCase();
            v2 = v2.toLowerCase();
         }
-        if (v1 === v2) return 0;
+        if (v1 === v2) {
+          return 0;
+        }
         return v1 < v2 ? -1 : 1;
       } else {
         return t1 < t2 ? -1 : 1;

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -98,8 +98,9 @@ function headersGetter(headers) {
  * @returns {*} Transformed data.
  */
 function transformData(data, headers, status, fns) {
-  if (isFunction(fns))
+  if (isFunction(fns)) {
     return fns(data, headers, status);
+  }
 
   forEach(fns, function(fn) {
     data = fn(data, headers, status);

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -71,7 +71,9 @@ function headersGetter(headers) {
   var headersObj = isObject(headers) ? headers : undefined;
 
   return function(name) {
-    if (!headersObj) headersObj =  parseHeaders(headers);
+    if (!headersObj) {
+      headersObj =  parseHeaders(headers);
+    }
 
     if (name) {
       var value = headersObj[lowercase(name)];
@@ -1098,7 +1100,9 @@ function $HttpProvider() {
           $rootScope.$applyAsync(resolveHttpPromise);
         } else {
           resolveHttpPromise();
-          if (!$rootScope.$$phase) $rootScope.$apply();
+          if (!$rootScope.$$phase) {
+            $rootScope.$apply();
+          }
         }
       }
 
@@ -1125,7 +1129,9 @@ function $HttpProvider() {
 
       function removePendingReq() {
         var idx = $http.pendingRequests.indexOf(config);
-        if (idx !== -1) $http.pendingRequests.splice(idx, 1);
+        if (idx !== -1) {
+          $http.pendingRequests.splice(idx, 1);
+        }
       }
     }
 
@@ -1135,7 +1141,9 @@ function $HttpProvider() {
       var parts = [];
       forEachSorted(params, function(value, key) {
         if (value === null || isUndefined(value)) return;
-        if (!isArray(value)) value = [value];
+        if (!isArray(value)) {
+          value = [value];
+        }
 
         forEach(value, function(v) {
           if (isObject(v)) {

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -39,7 +39,9 @@ function isJsonLike(str) {
 function parseHeaders(headers) {
   var parsed = createMap(), key, val, i;
 
-  if (!headers) return parsed;
+  if (!headers) {
+    return parsed;
+  }
 
   forEach(headers.split('\n'), function(line) {
     i = line.indexOf(':');
@@ -1137,10 +1139,14 @@ function $HttpProvider() {
 
 
     function buildUrl(url, params) {
-      if (!params) return url;
+      if (!params) {
+        return url;
+      }
       var parts = [];
       forEachSorted(params, function(value, key) {
-        if (value === null || isUndefined(value)) return;
+        if (value === null || isUndefined(value)) {
+          return;
+        }
         if (!isArray(value)) {
           value = [value];
         }

--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -231,7 +231,9 @@ function $InterpolateProvider() {
       if (!mustHaveExpression || expressions.length) {
         var compute = function(values) {
           for (var i = 0, ii = expressions.length; i < ii; i++) {
-            if (allOrNothing && isUndefined(values[i])) return;
+            if (allOrNothing && isUndefined(values[i])) {
+              return;
+            }
             concat[expressionPositions[i]] = values[i];
           }
           return concat.join('');

--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -152,7 +152,9 @@ function $IntervalProvider() {
           delete intervals[promise.$$intervalId];
         }
 
-        if (!skipApply) $rootScope.$apply();
+        if (!skipApply) {
+          $rootScope.$apply();
+        }
 
       }, delay);
 

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -373,8 +373,9 @@ var locationPrototype = {
    * @return {string} url
    */
   url: function(url) {
-    if (isUndefined(url))
+    if (isUndefined(url)) {
       return this.$$url;
+    }
 
     var match = PATH_MATCH.exec(url);
     if (match[1] || url === '') this.path(decodeURIComponent(match[1]));
@@ -613,8 +614,9 @@ forEach([LocationHashbangInHtml5Url, LocationHashbangUrl, LocationHtml5Url], fun
    * @return {object} state
    */
   Location.prototype.state = function(state) {
-    if (!arguments.length)
+    if (!arguments.length) {
       return this.$$state;
+    }
 
     if (Location !== LocationHtml5Url || !this.$$html5) {
       throw $locationMinErr('nostate', 'History API state support is available only ' +
@@ -639,8 +641,9 @@ function locationGetter(property) {
 
 function locationGetterSetter(property, preprocess) {
   return function(value) {
-    if (isUndefined(value))
+    if (isUndefined(value)) {
       return this[property];
+    }
 
     this[property] = preprocess(value);
     this.$$compose();

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -378,8 +378,12 @@ var locationPrototype = {
     }
 
     var match = PATH_MATCH.exec(url);
-    if (match[1] || url === '') this.path(decodeURIComponent(match[1]));
-    if (match[2] || match[1] || url === '') this.search(match[3] || '');
+    if (match[1] || url === '') {
+      this.path(decodeURIComponent(match[1]));
+    }
+    if (match[2] || match[1] || url === '') {
+      this.search(match[3] || '');
+    }
     this.hash(match[5] || '');
 
     return this;
@@ -531,7 +535,9 @@ var locationPrototype = {
           search = copy(search, {});
           // remove object undefined or null properties
           forEach(search, function(value, key) {
-            if (value == null) delete search[key];
+            if (value == null) {
+              delete search[key];
+            }
           });
 
           this.$$search = search;
@@ -914,7 +920,9 @@ function $LocationProvider() {
           afterLocationChange(oldUrl, oldState);
         }
       });
-      if (!$rootScope.$$phase) $rootScope.$digest();
+      if (!$rootScope.$$phase) {
+        $rootScope.$digest();
+      }
     });
 
     // update browser

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -846,14 +846,18 @@ function $LocationProvider() {
       // TODO(vojta): rewrite link when opening in new tab/window (in legacy browser)
       // currently we open nice url link and redirect then
 
-      if (!html5Mode.rewriteLinks || event.ctrlKey || event.metaKey || event.shiftKey || event.which == 2 || event.button == 2) return;
+      if (!html5Mode.rewriteLinks || event.ctrlKey || event.metaKey || event.shiftKey || event.which == 2 || event.button == 2) {
+        return;
+      }
 
       var elm = jqLite(event.target);
 
       // traverse the DOM up to find first A tag
       while (nodeName_(elm[0]) !== 'a') {
         // ignore rewriting if no A tag (reached root element, or no parent - removed from document)
-        if (elm[0] === $rootElement[0] || !(elm = elm.parent())[0]) return;
+        if (elm[0] === $rootElement[0] || !(elm = elm.parent())[0]) {
+          return;
+        }
       }
 
       var absHref = elm.prop('href');
@@ -868,7 +872,9 @@ function $LocationProvider() {
       }
 
       // Ignore when url is started with javascript: or mailto:
-      if (IGNORE_URI_REGEXP.test(absHref)) return;
+      if (IGNORE_URI_REGEXP.test(absHref)) {
+        return;
+      }
 
       if (absHref && !elm.attr('target') && !event.isDefaultPrevented()) {
         if ($location.$$parseLinkUrl(absHref, relHref)) {
@@ -909,7 +915,9 @@ function $LocationProvider() {
 
         // if the location was changed by a `$locationChangeStart` handler then stop
         // processing this location change
-        if ($location.absUrl() !== newUrl) return;
+        if ($location.absUrl() !== newUrl) {
+          return;
+        }
 
         if (defaultPrevented) {
           $location.$$parse(oldUrl);
@@ -944,7 +952,9 @@ function $LocationProvider() {
 
           // if the location was changed by a `$locationChangeStart` handler then stop
           // processing this location change
-          if ($location.absUrl() !== newUrl) return;
+          if ($location.absUrl() !== newUrl) {
+            return;
+          }
 
           if (defaultPrevented) {
             $location.$$parse(oldUrl);

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -284,8 +284,9 @@ Lexer.prototype = {
       if (escape) {
         if (ch === 'u') {
           var hex = this.text.substring(this.index + 1, this.index + 5);
-          if (!hex.match(/[\da-f]{4}/i))
+          if (!hex.match(/[\da-f]{4}/i)) {
             this.throwError('Invalid unicode escape [\\u' + hex + ']');
+          }
           this.index += 4;
           string += String.fromCharCode(parseInt(hex, 16));
         } else {
@@ -397,8 +398,9 @@ Parser.prototype = {
   },
 
   peekToken: function() {
-    if (this.tokens.length === 0)
+    if (this.tokens.length === 0) {
       throw $parseMinErr('ueoe', 'Unexpected end of expression: {0}', this.text);
+    }
     return this.tokens[0];
   },
 
@@ -483,8 +485,9 @@ Parser.prototype = {
   statements: function() {
     var statements = [];
     while (true) {
-      if (this.tokens.length > 0 && !this.peek('}', ')', ';', ']'))
+      if (this.tokens.length > 0 && !this.peek('}', ')', ';', ']')) {
         statements.push(this.filterChain());
+      }
       if (!this.expect(';')) {
         // optimize for the common case where there is only one statement.
         // TODO(size): maybe we should not support multiple statements?

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -667,7 +667,9 @@ Parser.prototype = {
     }, {
       assign: function(scope, value, locals) {
         var o = object(scope, locals);
-        if (!o) object.assign(scope, o = {});
+        if (!o) {
+          object.assign(scope, o = {});
+        }
         return getter.assign(o, value);
       }
     });
@@ -693,7 +695,9 @@ Parser.prototype = {
         var key = ensureSafeMemberName(indexFn(self, locals), expression);
         // prevent overwriting of Function.constructor which would break ensureSafeObject check
         var o = ensureSafeObject(obj(self, locals), expression);
-        if (!o) obj.assign(self, o = {});
+        if (!o) {
+          obj.assign(self, o = {});
+        }
         return o[key] = value;
       }
     });
@@ -1193,7 +1197,9 @@ function $ParseProvider() {
         }
         if (isAllDefined(value)) {
           scope.$$postDigest(function() {
-            if (isAllDefined(lastValue)) unwatch();
+            if (isAllDefined(lastValue)) {
+              unwatch();
+            }
           });
         }
       }, objectEquality);
@@ -1201,7 +1207,9 @@ function $ParseProvider() {
       function isAllDefined(value) {
         var allDefined = true;
         forEach(value, function(val) {
-          if (!isDefined(val)) allDefined = false;
+          if (!isDefined(val)) {
+            allDefined = false;
+          }
         });
         return allDefined;
       }

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -687,7 +687,9 @@ Parser.prototype = {
           v;
 
       ensureSafeMemberName(i, expression);
-      if (!o) return undefined;
+      if (!o) {
+        return undefined;
+      }
       v = ensureSafeObject(o[i], expression);
       return v;
     }, {
@@ -856,23 +858,41 @@ function cspSafeGetterFn(key0, key1, key2, key3, key4, fullExp, expensiveChecks)
   return function cspSafeGetter(scope, locals) {
     var pathVal = (locals && locals.hasOwnProperty(key0)) ? locals : scope;
 
-    if (pathVal == null) return pathVal;
+    if (pathVal == null) {
+      return pathVal;
+    }
     pathVal = eso0(pathVal[key0]);
 
-    if (!key1) return pathVal;
-    if (pathVal == null) return undefined;
+    if (!key1) {
+      return pathVal;
+    }
+    if (pathVal == null) {
+      return undefined;
+    }
     pathVal = eso1(pathVal[key1]);
 
-    if (!key2) return pathVal;
-    if (pathVal == null) return undefined;
+    if (!key2) {
+      return pathVal;
+    }
+    if (pathVal == null) {
+      return undefined;
+    }
     pathVal = eso2(pathVal[key2]);
 
-    if (!key3) return pathVal;
-    if (pathVal == null) return undefined;
+    if (!key3) {
+      return pathVal;
+    }
+    if (pathVal == null) {
+      return undefined;
+    }
     pathVal = eso3(pathVal[key3]);
 
-    if (!key4) return pathVal;
-    if (pathVal == null) return undefined;
+    if (!key4) {
+      return pathVal;
+    }
+    if (pathVal == null) {
+      return undefined;
+    }
     pathVal = eso4(pathVal[key4]);
 
     return pathVal;
@@ -889,7 +909,9 @@ function getterFn(path, options, fullExp) {
   var expensiveChecks = options.expensiveChecks;
   var getterFnCache = (expensiveChecks ? getterFnCacheExpensive : getterFnCacheDefault);
   var fn = getterFnCache[path];
-  if (fn) return fn;
+  if (fn) {
+    return fn;
+  }
 
 
   var pathKeys = path.split('.'),
@@ -1228,7 +1250,9 @@ function $ParseProvider() {
     }
 
     function addInterceptor(parsedExpression, interceptorFn) {
-      if (!interceptorFn) return parsedExpression;
+      if (!interceptorFn) {
+        return parsedExpression;
+      }
       var watchDelegate = parsedExpression.$$watchDelegate;
 
       var regularWatch =

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -276,7 +276,9 @@ function qFactory(nextTick, exceptionHandler) {
 
       this.$$state.pending = this.$$state.pending || [];
       this.$$state.pending.push([result, onFulfilled, onRejected, progressBack]);
-      if (this.$$state.status > 0) scheduleProcessQueue(this.$$state);
+      if (this.$$state.status > 0) {
+        scheduleProcessQueue(this.$$state);
+      }
 
       return result.promise;
     },
@@ -359,7 +361,9 @@ function qFactory(nextTick, exceptionHandler) {
 
       fns = callOnce(this, this.$$resolve, this.$$reject);
       try {
-        if ((isObject(val) || isFunction(val))) then = val && val.then;
+        if ((isObject(val) || isFunction(val))) {
+          then = val && val.then;
+        }
         if (isFunction(then)) {
           this.promise.$$state.status = -1;
           then.call(val, fns[0], fns[1], this.notify);
@@ -460,7 +464,9 @@ function qFactory(nextTick, exceptionHandler) {
   var handleCallback = function handleCallback(value, isResolved, callback) {
     var callbackOutput = null;
     try {
-      if (isFunction(callback)) callbackOutput = callback();
+      if (isFunction(callback)) {
+        callbackOutput = callback();
+      }
     } catch (e) {
       return makePromise(e, false);
     }
@@ -522,7 +528,9 @@ function qFactory(nextTick, exceptionHandler) {
       when(promise).then(function(value) {
         if (results.hasOwnProperty(key)) return;
         results[key] = value;
-        if (!(--counter)) deferred.resolve(results);
+        if (!(--counter)) {
+          deferred.resolve(results);
+        }
       }, function(reason) {
         if (results.hasOwnProperty(key)) return;
         deferred.reject(reason);

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -243,7 +243,9 @@ function qFactory(nextTick, exceptionHandler) {
     var called = false;
     function wrap(fn) {
       return function(value) {
-        if (called) return;
+        if (called) {
+          return;
+        }
         called = true;
         fn.call(self, value);
       };
@@ -328,7 +330,9 @@ function qFactory(nextTick, exceptionHandler) {
   }
 
   function scheduleProcessQueue(state) {
-    if (state.processScheduled || !state.pending) return;
+    if (state.processScheduled || !state.pending) {
+      return;
+    }
     state.processScheduled = true;
     nextTick(function() { processQueue(state); });
   }
@@ -343,7 +347,9 @@ function qFactory(nextTick, exceptionHandler) {
 
   Deferred.prototype = {
     resolve: function(val) {
-      if (this.promise.$$state.status) return;
+      if (this.promise.$$state.status) {
+        return;
+      }
       if (val === this.promise) {
         this.$$reject($qMinErr(
           'qcycle',
@@ -379,7 +385,9 @@ function qFactory(nextTick, exceptionHandler) {
     },
 
     reject: function(reason) {
-      if (this.promise.$$state.status) return;
+      if (this.promise.$$state.status) {
+        return;
+      }
       this.$$reject(reason);
     },
 
@@ -526,13 +534,17 @@ function qFactory(nextTick, exceptionHandler) {
     forEach(promises, function(promise, key) {
       counter++;
       when(promise).then(function(value) {
-        if (results.hasOwnProperty(key)) return;
+        if (results.hasOwnProperty(key)) {
+          return;
+        }
         results[key] = value;
         if (!(--counter)) {
           deferred.resolve(results);
         }
       }, function(reason) {
-        if (results.hasOwnProperty(key)) return;
+        if (results.hasOwnProperty(key)) {
+          return;
+        }
         deferred.reject(reason);
       });
     });

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -355,8 +355,7 @@ function qFactory(nextTick, exceptionHandler) {
           'qcycle',
           "Expected promise to be resolved with value other than itself '{0}'",
           val));
-      }
-      else {
+      } else {
         this.$$resolve(val);
       }
 

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -559,7 +559,9 @@ function $RootScopeProvider() {
           var newLength, key, bothNaN, newItem, oldItem;
 
           // If the new value is undefined, then return undefined as the watch may be a one-time watch
-          if (isUndefined(newValue)) return;
+          if (isUndefined(newValue)) {
+            return;
+          }
 
           if (!isObject(newValue)) { // if primitive
             if (oldValue !== newValue) {
@@ -868,12 +870,16 @@ function $RootScopeProvider() {
        */
       $destroy: function() {
         // we can't destroy the root scope or a scope that has been already destroyed
-        if (this.$$destroyed) return;
+        if (this.$$destroyed) {
+          return;
+        }
         var parent = this.$parent;
 
         this.$broadcast('$destroy');
         this.$$destroyed = true;
-        if (this === $rootScope) return;
+        if (this === $rootScope) {
+          return;
+        }
 
         for (var eventName in this.$$listenerCount) {
           decrementListenerCount(this, this.$$listenerCount[eventName], eventName);
@@ -1240,7 +1246,9 @@ function $RootScopeProvider() {
               defaultPrevented: false
             };
 
-        if (!target.$$listenerCount[name]) return event;
+        if (!target.$$listenerCount[name]) {
+          return event;
+        }
 
         var listenerArgs = concat([event], arguments, 1),
             listeners, i, length;

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -231,7 +231,9 @@ function $RootScopeProvider() {
         // prototypically. In all other cases, this property needs to be set
         // when the parent scope is destroyed.
         // The listener needs to be added after the parent is set
-        if (isolate || parent != this) child.$on('$destroy', destroyChild);
+        if (isolate || parent != this) {
+          child.$on('$destroy', destroyChild);
+        }
 
         return child;
 
@@ -428,7 +430,9 @@ function $RootScopeProvider() {
           // No expressions means we call the listener ASAP
           var shouldCall = true;
           self.$evalAsync(function() {
-            if (shouldCall) listener(newValues, newValues, self);
+            if (shouldCall) {
+              listener(newValues, newValues, self);
+            }
           });
           return function deregisterWatchGroup() {
             shouldCall = false;
@@ -771,7 +775,9 @@ function $RootScopeProvider() {
                       watch.fn(value, ((last === initWatchVal) ? value : last), current);
                       if (ttl < 5) {
                         logIdx = 4 - ttl;
-                        if (!watchLog[logIdx]) watchLog[logIdx] = [];
+                        if (!watchLog[logIdx]) {
+                          watchLog[logIdx] = [];
+                        }
                         watchLog[logIdx].push({
                           msg: isFunction(watch.exp) ? 'fn: ' + (watch.exp.name || watch.exp.toString()) : watch.exp,
                           newVal: value,
@@ -875,10 +881,18 @@ function $RootScopeProvider() {
 
         // sever all the references to parent scopes (after this cleanup, the current scope should
         // not be retained by any of our references and should be eligible for garbage collection)
-        if (parent.$$childHead == this) parent.$$childHead = this.$$nextSibling;
-        if (parent.$$childTail == this) parent.$$childTail = this.$$prevSibling;
-        if (this.$$prevSibling) this.$$prevSibling.$$nextSibling = this.$$nextSibling;
-        if (this.$$nextSibling) this.$$nextSibling.$$prevSibling = this.$$prevSibling;
+        if (parent.$$childHead == this) {
+          parent.$$childHead = this.$$nextSibling;
+        }
+        if (parent.$$childTail == this) {
+          parent.$$childTail = this.$$prevSibling;
+        }
+        if (this.$$prevSibling) {
+          this.$$prevSibling.$$nextSibling = this.$$nextSibling;
+        }
+        if (this.$$nextSibling) {
+          this.$$nextSibling.$$prevSibling = this.$$prevSibling;
+        }
 
         // Disable listeners, watchers and apply/digest methods
         this.$destroy = this.$digest = this.$apply = this.$evalAsync = this.$applyAsync = noop;

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -69,7 +69,9 @@ function $SnifferProvider() {
         // when cut operation is performed.
         // IE10+ implements 'input' event but it erroneously fires under various situations,
         // e.g. when placeholder changes, or a form is focused.
-        if (event === 'input' && msie <= 11) return false;
+        if (event === 'input' && msie <= 11) {
+          return false;
+        }
 
         if (isUndefined(eventSupport[event])) {
           var divElm = document.createElement('div');

--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -59,7 +59,9 @@ function $TimeoutProvider() {
           delete deferreds[promise.$$timeoutId];
         }
 
-        if (!skipApply) $rootScope.$apply();
+        if (!skipApply) {
+          $rootScope.$apply();
+        }
       }, delay);
 
       promise.$$timeoutId = timeoutId;

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -1335,8 +1335,7 @@ angular.module('ngAnimate', ['ng'])
           } else if (lastAnimation.event == 'setClass') {
             animationsToCancel.push(lastAnimation);
             cleanup(element, className);
-          }
-          else if (runningAnimations[className]) {
+          } else if (runningAnimations[className]) {
             var current = runningAnimations[className];
             if (current.event == animationEvent) {
               skipAnimation = true;

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -1209,8 +1209,12 @@ angular.module('ngAnimate', ['ng'])
             return !classes
               ? done()
               : performAnimation('setClass', classes, element, parentElement, null, function() {
-                  if (classes[0]) $delegate.$$addClassImmediately(element, classes[0]);
-                  if (classes[1]) $delegate.$$removeClassImmediately(element, classes[1]);
+                  if (classes[0]) {
+                    $delegate.$$addClassImmediately(element, classes[0]);
+                  }
+                  if (classes[1]) {
+                    $delegate.$$removeClassImmediately(element, classes[1]);
+                  }
                 }, cache.options, done);
           });
         },

--- a/src/ngAnimate/animate.js
+++ b/src/ngAnimate/animate.js
@@ -488,7 +488,9 @@ angular.module('ngAnimate', ['ng'])
       var deregisterWatch = $rootScope.$watch(
         function() { return $templateRequest.totalPendingRequests; },
         function(val, oldVal) {
-          if (val !== 0) return;
+          if (val !== 0) {
+            return;
+          }
           deregisterWatch();
 
           // Now that all templates have been downloaded, $animate will wait until
@@ -709,7 +711,9 @@ angular.module('ngAnimate', ['ng'])
           function afterAnimationComplete(index) {
             if (cancellations) {
               (cancellations[index] || noop)();
-              if (++count < animations.length) return;
+              if (++count < animations.length) {
+                return;
+              }
               cancellations = null;
             }
             allCompleteFn();
@@ -1549,7 +1553,9 @@ angular.module('ngAnimate', ['ng'])
           //the element did not reach the root element which means that it
           //is not apart of the DOM. Therefore there is no reason to do
           //any animations on it
-          if (parentElement.length === 0) break;
+          if (parentElement.length === 0) {
+            break;
+          }
 
           var isRoot = isMatchingElement(parentElement, $rootElement);
           var state = isRoot ? rootAnimateState : (parentElement.data(NG_ANIMATE_STATE) || {});

--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -58,7 +58,9 @@ angular.module('ngCookies', ['ng']).
           lastBrowserCookies = currentCookies;
           copy(currentCookies, lastCookies);
           copy(currentCookies, cookies);
-          if (runEval) $rootScope.$apply();
+          if (runEval) {
+            $rootScope.$apply();
+          }
         }
       })();
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -599,8 +599,9 @@ function padNumber(num, digits, trim) {
   }
   num = '' + num;
   while (num.length < digits) num = '0' + num;
-  if (trim)
+  if (trim) {
     num = num.substr(num.length - digits);
+  }
   return neg + num;
 }
 
@@ -650,11 +651,12 @@ angular.mock.TzDate = function(offset, timestamp) {
     self.origDate = jsonStringToDate(timestamp);
 
     timestamp = self.origDate.getTime();
-    if (isNaN(timestamp))
+    if (isNaN(timestamp)) {
       throw {
         name: "Illegal Argument",
         message: "Arg '" + tsStr + "' passed into TzDate constructor is not a valid date string"
       };
+    }
   } else {
     self.origDate = new Date(timestamp);
   }
@@ -1184,14 +1186,16 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
     }
 
     if (expectation && expectation.match(method, url)) {
-      if (!expectation.matchData(data))
+      if (!expectation.matchData(data)) {
         throw new Error('Expected ' + expectation + ' with different data\n' +
             'EXPECTED: ' + prettyPrint(expectation.data) + '\nGOT:      ' + data);
+      }
 
-      if (!expectation.matchHeaders(headers))
+      if (!expectation.matchHeaders(headers)) {
         throw new Error('Expected ' + expectation + ' with different headers\n' +
                         'EXPECTED: ' + prettyPrint(expectation.headers) + '\nGOT:      ' +
                         prettyPrint(headers));
+      }
 
       expectations.shift();
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -85,7 +85,9 @@ angular.mock.$Browser = function() {
     var fnIndex;
 
     angular.forEach(self.deferredFns, function(fn, index) {
-      if (fn.id === deferId) fnIndex = index;
+      if (fn.id === deferId) {
+        fnIndex = index;
+      }
     });
 
     if (fnIndex !== undefined) {
@@ -479,7 +481,9 @@ angular.mock.$IntervalProvider = function() {
           deferred.resolve(iteration);
 
           angular.forEach(repeatFns, function(fn, index) {
-            if (fn.id === promise.$$intervalId) fnIndex = index;
+            if (fn.id === promise.$$intervalId) {
+              fnIndex = index;
+            }
           });
 
           if (fnIndex !== undefined) {
@@ -521,7 +525,9 @@ angular.mock.$IntervalProvider = function() {
       var fnIndex;
 
       angular.forEach(repeatFns, function(fn, index) {
-        if (fn.id === promise.$$intervalId) fnIndex = index;
+        if (fn.id === promise.$$intervalId) {
+          fnIndex = index;
+        }
       });
 
       if (fnIndex !== undefined) {
@@ -598,7 +604,9 @@ function padNumber(num, digits, trim) {
     num = -num;
   }
   num = '' + num;
-  while (num.length < digits) num = '0' + num;
+  while (num.length < digits) {
+    num = '0' + num;
+  }
   if (trim) {
     num = num.substr(num.length - digits);
   }
@@ -1519,7 +1527,9 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
    *   is called an exception is thrown (as this typically a sign of programming error).
    */
   $httpBackend.flush = function(count, digest) {
-    if (digest !== false) $rootScope.$digest();
+    if (digest !== false) {
+      $rootScope.$digest();
+    }
     if (!responses.length) throw new Error('No pending request to flush !');
 
     if (angular.isDefined(count) && count !== null) {
@@ -1551,7 +1561,9 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
    * ```
    */
   $httpBackend.verifyNoOutstandingExpectation = function(digest) {
-    if (digest !== false) $rootScope.$digest();
+    if (digest !== false) {
+      $rootScope.$digest();
+    }
     if (expectations.length) {
       throw new Error('Unsatisfied requests: ' + expectations.join(', '));
     }
@@ -1687,7 +1699,9 @@ function MockXhr() {
 
     header = undefined;
     angular.forEach(this.$$respHeaders, function(headerVal, headerName) {
-      if (!header && angular.lowercase(headerName) == name) header = headerVal;
+      if (!header && angular.lowercase(headerName) == name) {
+        header = headerVal;
+      }
     });
     return header;
   };
@@ -2305,11 +2319,18 @@ if (window.jasmine || window.mocha) {
   var ErrorAddingDeclarationLocationStack = function(e, errorForStack) {
     this.message = e.message;
     this.name = e.name;
-    if (e.line) this.line = e.line;
-    if (e.sourceId) this.sourceId = e.sourceId;
-    if (e.stack && errorForStack)
+    if (e.line) {
+      this.line = e.line;
+    }
+    if (e.sourceId) {
+      this.sourceId = e.sourceId;
+    }
+    if (e.stack && errorForStack) {
       this.stack = e.stack + '\n' + errorForStack.stack;
-    if (e.stackArray) this.stackArray = e.stackArray;
+    }
+    if (e.stackArray) {
+      this.stackArray = e.stackArray;
+    }
   };
   ErrorAddingDeclarationLocationStack.prototype.toString = Error.prototype.toString;
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -521,7 +521,9 @@ angular.mock.$IntervalProvider = function() {
      * @returns {boolean} Returns `true` if the task was successfully cancelled.
      */
     $interval.cancel = function(promise) {
-      if (!promise) return false;
+      if (!promise) {
+        return false;
+      }
       var fnIndex;
 
       angular.forEach(repeatFns, function(fn, index) {
@@ -1147,7 +1149,9 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
       copy = angular.copy;
 
   function createResponse(status, data, headers, statusText) {
-    if (angular.isFunction(status)) return status;
+    if (angular.isFunction(status)) {
+      return status;
+    }
 
     return function() {
       return angular.isNumber(status)
@@ -1222,7 +1226,9 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
           ($browser ? $browser.defer : responsesPush)(wrapResponse(definition));
         } else if (definition.passThrough) {
           $delegate(method, url, data, callback, headers, timeout, withCredentials);
-        } else throw new Error('No response defined !');
+        } else {
+          throw new Error('No response defined !');
+        }
         return;
       }
     }
@@ -1530,11 +1536,15 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
     if (digest !== false) {
       $rootScope.$digest();
     }
-    if (!responses.length) throw new Error('No pending request to flush !');
+    if (!responses.length) {
+      throw new Error('No pending request to flush !');
+    }
 
     if (angular.isDefined(count) && count !== null) {
       while (count--) {
-        if (!responses.length) throw new Error('No more pending request to flush !');
+        if (!responses.length) {
+          throw new Error('No more pending request to flush !');
+        }
         responses.shift()();
       }
     } else {
@@ -1627,30 +1637,54 @@ function MockHttpExpectation(method, url, data, headers) {
   this.headers = headers;
 
   this.match = function(m, u, d, h) {
-    if (method != m) return false;
-    if (!this.matchUrl(u)) return false;
-    if (angular.isDefined(d) && !this.matchData(d)) return false;
-    if (angular.isDefined(h) && !this.matchHeaders(h)) return false;
+    if (method != m) {
+      return false;
+    }
+    if (!this.matchUrl(u)) {
+      return false;
+    }
+    if (angular.isDefined(d) && !this.matchData(d)) {
+      return false;
+    }
+    if (angular.isDefined(h) && !this.matchHeaders(h)) {
+      return false;
+    }
     return true;
   };
 
   this.matchUrl = function(u) {
-    if (!url) return true;
-    if (angular.isFunction(url.test)) return url.test(u);
-    if (angular.isFunction(url)) return url(u);
+    if (!url) {
+      return true;
+    }
+    if (angular.isFunction(url.test)) {
+      return url.test(u);
+    }
+    if (angular.isFunction(url)) {
+      return url(u);
+    }
     return url == u;
   };
 
   this.matchHeaders = function(h) {
-    if (angular.isUndefined(headers)) return true;
-    if (angular.isFunction(headers)) return headers(h);
+    if (angular.isUndefined(headers)) {
+      return true;
+    }
+    if (angular.isFunction(headers)) {
+      return headers(h);
+    }
     return angular.equals(headers, h);
   };
 
   this.matchData = function(d) {
-    if (angular.isUndefined(data)) return true;
-    if (data && angular.isFunction(data.test)) return data.test(d);
-    if (data && angular.isFunction(data)) return data(d);
+    if (angular.isUndefined(data)) {
+      return true;
+    }
+    if (data && angular.isFunction(data.test)) {
+      return data.test(d);
+    }
+    if (data && angular.isFunction(data)) {
+      return data(d);
+    }
     if (data && !angular.isString(data)) {
       return angular.equals(angular.fromJson(angular.toJson(data)), angular.fromJson(d));
     }
@@ -1691,11 +1725,15 @@ function MockXhr() {
     // the lookup must be case insensitive,
     // that's why we try two quick lookups first and full scan last
     var header = this.$$respHeaders[name];
-    if (header) return header;
+    if (header) {
+      return header;
+    }
 
     name = angular.lowercase(name);
     header = this.$$respHeaders[name];
-    if (header) return header;
+    if (header) {
+      return header;
+    }
 
     header = undefined;
     angular.forEach(this.$$respHeaders, function(headerVal, headerName) {

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -539,9 +539,15 @@ angular.module('ngResource', ['ng']).
                   break;
                 }
               case 1:
-                if (isFunction(a1)) success = a1;
-                else if (hasBody) data = a1;
-                else params = a1;
+                if (isFunction(a1)) {
+                  success = a1;
+                }
+                else if (hasBody) {
+                  data = a1;
+                }
+                else {
+                  params = a1;
+                }
                 break;
               case 0: break;
               default:
@@ -565,7 +571,9 @@ angular.module('ngResource', ['ng']).
               }
             });
 
-            if (hasBody) httpConfig.data = data;
+            if (hasBody) {
+              httpConfig.data = data;
+            }
             route.setUrlParams(httpConfig,
               extend({}, extractParams(data, action.params || {}), params),
               action.url);

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -541,11 +541,9 @@ angular.module('ngResource', ['ng']).
               case 1:
                 if (isFunction(a1)) {
                   success = a1;
-                }
-                else if (hasBody) {
+                } else if (hasBody) {
                   data = a1;
-                }
-                else {
+                } else {
                   params = a1;
                 }
                 break;

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -484,7 +484,9 @@ function $RouteProvider() {
               var searchParams = {}, self=this;
 
               angular.forEach(Object.keys(newParams), function(key) {
-                if (!self.current.pathParams[key]) searchParams[key] = newParams[key];
+                if (!self.current.pathParams[key]) {
+                  searchParams[key] = newParams[key];
+                }
               });
 
               newParams = angular.extend({}, this.current.params, newParams);

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -492,8 +492,7 @@ function $RouteProvider() {
               newParams = angular.extend({}, this.current.params, newParams);
               $location.path(interpolate(this.current.$$route.originalPath, newParams));
               $location.search(angular.extend({}, $location.search(), searchParams));
-            }
-            else {
+            } else {
               throw $routeMinErr('norout', 'Tried updating route when with no current route');
             }
           }

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -521,10 +521,14 @@ function $RouteProvider() {
       var keys = route.keys,
           params = {};
 
-      if (!route.regexp) return null;
+      if (!route.regexp) {
+        return null;
+      }
 
       var m = route.regexp.exec(on);
-      if (!m) return null;
+      if (!m) {
+        return null;
+      }
 
       for (var i = 1, len = m.length; i < len; ++i) {
         var key = keys[i - 1];

--- a/src/ngSanitize/filter/linky.js
+++ b/src/ngSanitize/filter/linky.js
@@ -108,7 +108,9 @@ angular.module('ngSanitize').filter('linky', ['$sanitize', function($sanitize) {
       MAILTO_REGEXP = /^mailto:/;
 
   return function(text, target) {
-    if (!text) return text;
+    if (!text) {
+      return text;
+    }
     var match;
     var raw = text;
     var html = [];

--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -245,7 +245,9 @@ var validAttrs = angular.extend({},
 
 function makeMap(str) {
   var obj = {}, items = str.split(','), i;
-  for (i = 0; i < items.length; i++) obj[items[i]] = true;
+  for (i = 0; i < items.length; i++) {
+    obj[items[i]] = true;
+  }
   return obj;
 }
 
@@ -286,7 +288,9 @@ function htmlParser(html, handler) {
         index = html.indexOf("--", 4);
 
         if (index >= 0 && html.lastIndexOf("-->", index) === index) {
-          if (handler.comment) handler.comment(html.substring(4, index));
+          if (handler.comment) {
+            handler.comment(html.substring(4, index));
+          }
           html = html.substring(index + 3);
           chars = false;
         }
@@ -332,7 +336,9 @@ function htmlParser(html, handler) {
         text += index < 0 ? html : html.substring(0, index);
         html = index < 0 ? "" : html.substring(index);
 
-        if (handler.chars) handler.chars(decodeEntities(text));
+        if (handler.chars) {
+          handler.chars(decodeEntities(text));
+        }
       }
 
     } else {
@@ -340,7 +346,9 @@ function htmlParser(html, handler) {
         function(all, text) {
           text = text.replace(COMMENT_REGEXP, "$1").replace(CDATA_REGEXP, "$1");
 
-          if (handler.chars) handler.chars(decodeEntities(text));
+          if (handler.chars) {
+            handler.chars(decodeEntities(text));
+          }
 
           return "";
       });
@@ -387,7 +395,9 @@ function htmlParser(html, handler) {
 
         attrs[name] = decodeEntities(value);
     });
-    if (handler.start) handler.start(tagName, attrs, unary);
+    if (handler.start) {
+      handler.start(tagName, attrs, unary);
+    }
   }
 
   function parseEndTag(tag, tagName) {

--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -372,8 +372,9 @@ function htmlParser(html, handler) {
 
     unary = voidElements[ tagName ] || !!unary;
 
-    if (!unary)
+    if (!unary) {
       stack.push(tagName);
+    }
 
     var attrs = {};
 
@@ -392,16 +393,22 @@ function htmlParser(html, handler) {
   function parseEndTag(tag, tagName) {
     var pos = 0, i;
     tagName = angular.lowercase(tagName);
-    if (tagName)
+    if (tagName) {
       // Find the closest opened tag of the same type
-      for (pos = stack.length - 1; pos >= 0; pos--)
-        if (stack[ pos ] == tagName)
+      for (pos = stack.length - 1; pos >= 0; pos--) {
+        if (stack[ pos ] == tagName) {
           break;
+        }
+      }
+    }
 
     if (pos >= 0) {
       // Close all the open elements, up the stack
-      for (i = stack.length - 1; i >= pos; i--)
-        if (handler.end) handler.end(stack[ i ]);
+      for (i = stack.length - 1; i >= pos; i--) {
+        if (handler.end) {
+          handler.end(stack[ i ]);
+        }
+      }
 
       // Remove the open elements from the stack
       stack.length = pos;

--- a/src/ngScenario/Application.js
+++ b/src/ngScenario/Application.js
@@ -34,8 +34,9 @@ angular.scenario.Application.prototype.getFrame_ = function() {
  */
 angular.scenario.Application.prototype.getWindow_ = function() {
   var contentWindow = this.getFrame_().prop('contentWindow');
-  if (!contentWindow)
+  if (!contentWindow) {
     throw 'Frame window is not accessible.';
+  }
   return contentWindow;
 };
 

--- a/src/ngScenario/Describe.js
+++ b/src/ngScenario/Describe.js
@@ -22,7 +22,9 @@ angular.scenario.Describe = function(descName, parent) {
    */
   var beforeEachFns = this.beforeEachFns;
   this.setupBefore = function() {
-    if (parent) parent.setupBefore.call(this);
+    if (parent) {
+      parent.setupBefore.call(this);
+    }
     angular.forEach(beforeEachFns, function(fn) { fn.call(this); }, this);
   };
 
@@ -32,7 +34,9 @@ angular.scenario.Describe = function(descName, parent) {
   var afterEachFns = this.afterEachFns;
   this.setupAfter  = function() {
     angular.forEach(afterEachFns, function(fn) { fn.call(this); }, this);
-    if (parent) parent.setupAfter.call(this);
+    if (parent) {
+      parent.setupAfter.call(this);
+    }
   };
 };
 

--- a/src/ngScenario/ObjectModel.js
+++ b/src/ngScenario/ObjectModel.js
@@ -76,8 +76,9 @@ angular.scenario.ObjectModel = function(runner) {
   runner.on('StepEnd', function(spec) {
     var it = self.getSpec(spec.id);
     var step = it.getLastStep();
-    if (step.name !== step.name)
+    if (step.name !== step.name) {
       throw 'Events fired in the wrong order. Step names don\'t match.';
+    }
     complete(step);
 
     // forward the event

--- a/src/ngScenario/Runner.js
+++ b/src/ngScenario/Runner.js
@@ -36,8 +36,9 @@ angular.scenario.Runner.prototype.emit = function(eventName) {
   var self = this;
   var args = Array.prototype.slice.call(arguments, 1);
   eventName = eventName.toLowerCase();
-  if (!this.listeners[eventName])
+  if (!this.listeners[eventName]) {
     return;
+  }
   angular.forEach(this.listeners[eventName], function(listener) {
     listener.apply(self, args);
   });
@@ -157,8 +158,9 @@ angular.scenario.Runner.prototype.createSpecRunner_ = function(scope) {
 
   // Export all the methods to child scope manually as now we don't mess controllers with scopes
   // TODO(vojta): refactor scenario runner so that these objects are not tightly coupled as current
-  for (var name in Cls.prototype)
+  for (var name in Cls.prototype) {
     child[name] = angular.bind(child, Cls.prototype[name]);
+  }
 
   Cls.call(child);
   return child;

--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -42,8 +42,9 @@ angular.scenario.dsl = angular.scenario.dsl || function(name, fn) {
     /* jshint -W040 *//* The dsl binds `this` for us when calling chained functions */
     function executeStatement(statement, args) {
       var result = statement.apply(this, args);
-      if (angular.isFunction(result) || result instanceof angular.scenario.Future)
+      if (angular.isFunction(result) || result instanceof angular.scenario.Future) {
         return result;
+      }
       var self = this;
       var chain = angular.extend({}, result);
       angular.forEach(chain, function(value, name) {

--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -272,7 +272,9 @@ _jQuery.fn.bindings = function(windowJquery, bindExp) {
     match = function(actualExp) {
       if (actualExp) {
         actualExp = actualExp.replace(/\s/g, '');
-        if (actualExp == bindExp) return true;
+        if (actualExp == bindExp) {
+          return true;
+        }
         if (actualExp.indexOf(bindExp) === 0) {
           return actualExp.charAt(bindExp.length) == '|';
         }

--- a/src/ngScenario/angular-bootstrap.js
+++ b/src/ngScenario/angular-bootstrap.js
@@ -25,7 +25,9 @@
 
   window.onload = function() {
     try {
-      if (previousOnLoad) previousOnLoad();
+      if (previousOnLoad) {
+        previousOnLoad();
+      }
     } catch (e) {}
     angular.scenario.setUpAndRun({});
   };

--- a/src/ngScenario/browserTrigger.js
+++ b/src/ngScenario/browserTrigger.js
@@ -11,7 +11,9 @@
    * coordinates, keys, etc...) that are passed into the event when triggered
    */
   window.browserTrigger = function browserTrigger(element, eventType, eventData) {
-    if (element && !element.nodeName) element = element[0];
+    if (element && !element.nodeName) {
+      element = element[0];
+    }
     if (!element) return;
 
     eventData = eventData || {};

--- a/src/ngScenario/browserTrigger.js
+++ b/src/ngScenario/browserTrigger.js
@@ -59,8 +59,7 @@
       if (window.WebKitTransitionEvent) {
         evnt = new WebKitTransitionEvent(eventType, eventData);
         evnt.initEvent(eventType, false, true);
-      }
-      else {
+      } else {
         try {
           evnt = new TransitionEvent(eventType, eventData);
         }
@@ -69,13 +68,11 @@
           evnt.initTransitionEvent(eventType, null, null, null, eventData.elapsedTime || 0);
         }
       }
-    }
-    else if (/animationend/.test(eventType)) {
+    } else if (/animationend/.test(eventType)) {
       if (window.WebKitAnimationEvent) {
         evnt = new WebKitAnimationEvent(eventType, eventData);
         evnt.initEvent(eventType, false, true);
-      }
-      else {
+      } else {
         try {
           evnt = new AnimationEvent(eventType, eventData);
         }
@@ -84,8 +81,7 @@
           evnt.initAnimationEvent(eventType, null, null, null, eventData.elapsedTime || 0);
         }
       }
-    }
-    else {
+    } else {
       evnt = document.createEvent('MouseEvents');
       x = x || 0;
       y = y || 0;

--- a/src/ngScenario/browserTrigger.js
+++ b/src/ngScenario/browserTrigger.js
@@ -14,7 +14,9 @@
     if (element && !element.nodeName) {
       element = element[0];
     }
-    if (!element) return;
+    if (!element) {
+      return;
+    }
 
     eventData = eventData || {};
     var keys = eventData.keys;
@@ -96,7 +98,9 @@
      * read */
     evnt.$manualTimeStamp = eventData.timeStamp;
 
-    if (!evnt) return;
+    if (!evnt) {
+      return;
+    }
 
     var originalPreventDefault = evnt.preventDefault,
         appWindow = element.ownerDocument.defaultView,

--- a/src/ngScenario/dsl.js
+++ b/src/ngScenario/dsl.js
@@ -276,8 +276,9 @@ angular.scenario.dsl('repeater', function() {
     return this.addFutureAction("repeater '" + this.label + "' row '" + index + "'",
       function($window, $document, done) {
         var matches = $document.elements().slice(index, index + 1);
-        if (!matches.length)
+        if (!matches.length) {
           return done('row ' + index + ' out of bounds');
+        }
         done(null, matches.bindings($window.angular.element));
     });
   };

--- a/src/ngTouch/directive/ngSwipe.js
+++ b/src/ngTouch/directive/ngSwipe.js
@@ -94,7 +94,9 @@ function makeSwipeDirective(directiveName, direction, eventName) {
         // (ie. same direction as the directive wants) will have a positive delta and
         // illegal ones a negative delta.
         // Therefore this delta must be positive, and larger than the minimum.
-        if (!startCoords) return false;
+        if (!startCoords) {
+          return false;
+        }
         var deltaY = Math.abs(coords.y - startCoords.y);
         var deltaX = (coords.x - startCoords.x) * direction;
         return valid && // Short circuit for already-invalidated swipes.

--- a/src/ngTouch/swipe.js
+++ b/src/ngTouch/swipe.js
@@ -124,7 +124,9 @@ ngTouch.factory('$swipe', [function() {
       }
 
       element.on(getEvents(pointerTypes, 'move'), function(event) {
-        if (!active) return;
+        if (!active) {
+          return;
+        }
 
         // Android will send a touchcancel if it thinks we're starting to scroll.
         // So when the total distance (+ or - or both) exceeds 10px in either direction,
@@ -132,7 +134,9 @@ ngTouch.factory('$swipe', [function() {
         // - On totalX > totalY, we send preventDefault() and treat this as a swipe.
         // - On totalY > totalX, we let the browser handle it as a scroll.
 
-        if (!startCoords) return;
+        if (!startCoords) {
+          return;
+        }
         var coords = getCoordinates(event);
 
         totalX += Math.abs(coords.x - lastPos.x);
@@ -158,7 +162,9 @@ ngTouch.factory('$swipe', [function() {
       });
 
       element.on(getEvents(pointerTypes, 'end'), function(event) {
-        if (!active) return;
+        if (!active) {
+          return;
+        }
         active = false;
         eventHandlers['end'] && eventHandlers['end'](getCoordinates(event), event);
       });

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -9,7 +9,9 @@ function serializeObject(obj) {
     val = toJsonReplacer(key, val);
     if (isObject(val)) {
 
-      if (seen.indexOf(val) >= 0) return '<<already seen>>';
+      if (seen.indexOf(val) >= 0) {
+        return '<<already seen>>';
+      }
 
       seen.push(val);
     }

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -419,7 +419,9 @@ describe('angular', function() {
 
     it('should return the true when CSP is enabled manually via [ng-csp]', function() {
       spyOn(document, 'querySelector').andCallFake(function(selector) {
-        if (selector == '[ng-csp]') return {};
+        if (selector == '[ng-csp]') {
+          return {};
+        }
       });
       expect(csp()).toBe(true);
     });
@@ -427,7 +429,9 @@ describe('angular', function() {
 
     it('should return the true when CSP is enabled manually via [data-ng-csp]', function() {
       spyOn(document, 'querySelector').andCallFake(function(selector) {
-        if (selector == '[data-ng-csp]') return {};
+        if (selector == '[data-ng-csp]') {
+          return {};
+        }
       });
       expect(csp()).toBe(true);
       expect(document.querySelector).toHaveBeenCalledWith('[data-ng-csp]');

--- a/test/e2e/tests/helpers/main.js
+++ b/test/e2e/tests/helpers/main.js
@@ -4,7 +4,9 @@ var helper = {
   },
   loadFixture: function(fixture) {
     var i = 0;
-    while (fixture[i] === '/') ++i;
+    while (fixture[i] === '/') {
+      ++i;
+    }
     fixture = fixture.slice(i);
     if (!/\/(index\.html)?$/.test(fixture)) {
       fixture += '/';

--- a/test/e2e/tools/fixture.js
+++ b/test/e2e/tools/fixture.js
@@ -35,8 +35,7 @@ function generateFixture(test, query) {
     var src = $(script).attr('src');
     if (src === 'jquery.js' && jquery === null) {
       jquery = script;
-    }
-    else if (src === 'angular.js' && angular === null) {
+    } else if (src === 'angular.js' && angular === null) {
       angular = script;
     }
     if (firstScript === null) {

--- a/test/e2e/tools/fixture.js
+++ b/test/e2e/tools/fixture.js
@@ -33,9 +33,15 @@ function generateFixture(test, query) {
   var angular = null;
   $$('script').each(function(i, script) {
     var src = $(script).attr('src');
-    if (src === 'jquery.js' && jquery === null) jquery = script;
-    else if (src === 'angular.js' && angular === null) angular = script;
-    if (firstScript === null) firstScript = script;
+    if (src === 'jquery.js' && jquery === null) {
+      jquery = script;
+    }
+    else if (src === 'angular.js' && angular === null) {
+      angular = script;
+    }
+    if (firstScript === null) {
+      firstScript = script;
+    }
     if (src) {
       var s = util.stat(path.resolve(build, src));
       if (s && s.isFile()) {

--- a/test/e2e/tools/middleware.js
+++ b/test/e2e/tools/middleware.js
@@ -8,7 +8,9 @@ module.exports = middlewareFactory;
 
 function middlewareFactory(base) {
   base = base || '/e2e';
-  while (base.length && base[base.length - 1] === '/') base = base.slice(0, base.length - 1);
+  while (base.length && base[base.length - 1] === '/') {
+    base = base.slice(0, base.length - 1);
+  }
   var fixture_regexp = new RegExp('^' + base + '/fixtures/([a-zA-Z0-9_-]+)(/(index.html)?)?$');
   var static_regexp = new RegExp('^' + base + '/fixtures/([a-zA-Z0-9_-]+)(/.*)$');
 

--- a/test/e2e/tools/util.js
+++ b/test/e2e/tools/util.js
@@ -25,7 +25,9 @@ function testExists(testname) {
 
 function rewriteTestFile(testname, testfile) {
   var i = 0;
-  while (testfile[i] === '/') ++i;
+  while (testfile[i] === '/') {
+    ++i;
+  }
   testfile = testfile.slice(i);
   var s = stat(path.resolve(tests, testname, testfile));
   if (s && (s.isFile() || s.isDirectory())) {

--- a/test/helpers/matchers.js
+++ b/test/helpers/matchers.js
@@ -272,7 +272,9 @@ jasmine.Matchers.prototype.toThrow = function(expected) {
 function spyOnlyCallsWithArgs(obj, method) {
   var spy = spyOn(obj, method);
   obj[method] = function() {
-    if (arguments.length) return spy.apply(this, arguments);
+    if (arguments.length) {
+      return spy.apply(this, arguments);
+    }
     return spy.originalValue.apply(this);
   };
   return spy;

--- a/test/helpers/testabilityPatch.js
+++ b/test/helpers/testabilityPatch.js
@@ -160,8 +160,9 @@ function sortedHtml(element, showNgClass) {
         attrs.push(' class="' + className + '"');
       }
       for (var i = 0; i < attributes.length; i++) {
-        if (i > 0 && attributes[i] == attributes[i - 1])
+        if (i > 0 && attributes[i] == attributes[i - 1]) {
           continue; //IE9 creates dupes. Ignore them!
+        }
 
         var attr = attributes[i];
         if (attr.name.match(/^ng[\:\-]/) ||
@@ -221,8 +222,9 @@ function sortedHtml(element, showNgClass) {
         var tmp = style;
         style = [];
         forEach(tmp, function(value) {
-          if (!value.match(/^max[^\-]/))
+          if (!value.match(/^max[^\-]/)) {
             style.push(value);
+          }
         });
         if (style.length) {
           html += ' style="' + style.join('; ') + ';"';

--- a/test/helpers/testabilityPatch.js
+++ b/test/helpers/testabilityPatch.js
@@ -7,9 +7,13 @@
  * special event and changes it form 'change' to 'click/keydown' and
  * few others. This horrible hack removes the special treatment
  */
-if (window._jQuery) _jQuery.event.special.change = undefined;
+if (window._jQuery) {
+  _jQuery.event.special.change = undefined;
+}
 
-if (window.bindJQuery) bindJQuery();
+if (window.bindJQuery) {
+  bindJQuery();
+}
 
 beforeEach(function() {
   // all this stuff is not needed for module tests, where jqlite and publishExternalAPI and jqLite are not global vars

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1609,7 +1609,9 @@ describe('jqLite', function() {
         tested = true;
       }
       iframe_.onload = iframe_.onreadystatechange = function() {
-        if (iframe_.contentDocument) test();
+        if (iframe_.contentDocument) {
+          test()
+        };
       };
       /* jshint scripturl:true */
       iframe_.src = 'javascript:false';

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -651,7 +651,9 @@ describe('jqLite', function() {
 
     it('should properly do  with SVG elements', function() {
       // this is a jqLite & SVG only test (jquery doesn't behave this way right now, which is a bug)
-      if (!window.SVGElement || !_jqLiteMode) return;
+      if (!window.SVGElement || !_jqLiteMode) {
+        return;
+      }
       var svg = jqLite('<svg><rect></rect></svg>');
       var rect = svg.children();
 
@@ -991,7 +993,9 @@ describe('jqLite', function() {
 
   describe('on', function() {
     it('should bind to window on hashchange', function() {
-      if (jqLite.fn) return; // don't run in jQuery
+      if (jqLite.fn) {
+        return; // don't run in jQuery
+      }
       var eventFn;
       var window = {
         document: {},
@@ -1157,7 +1161,9 @@ describe('jqLite', function() {
       });
 
       it('should fire mouseenter when coming from outside the browser window', function() {
-        if (window.jQuery) return;
+        if (window.jQuery) {
+          return;
+        }
         var browserMoveTrigger = function(from, to) {
           var fireEvent = function(type, element, relatedTarget) {
             var evnt;

--- a/test/minErrSpec.js
+++ b/test/minErrSpec.js
@@ -27,7 +27,9 @@ describe('minErr', function() {
     someFn();
 
     // only Chrome, Firefox have stack
-    if (!supportStackTraces()) return;
+    if (!supportStackTraces()) {
+      return;
+    }
 
     expect(myError.stack).toMatch(/^[.\s\S]+nestedFn[.\s\S]+someFn.+/);
   });

--- a/test/ng/animateSpec.js
+++ b/test/ng/animateSpec.js
@@ -91,7 +91,9 @@ describe("$animate", function() {
     }));
 
     it("should add and remove classes on SVG elements", inject(function($animate, $rootScope) {
-      if (!window.SVGElement) return;
+      if (!window.SVGElement) {
+        return;
+      }
       var svg = jqLite('<svg><rect></rect></svg>');
       var rect = svg.children();
       $animate.enabled(false);
@@ -310,7 +312,9 @@ describe("$animate", function() {
 
 
     it('should defer class manipulation until end of digest for SVG', inject(function($rootScope, $animate) {
-      if (!window.SVGElement) return;
+      if (!window.SVGElement) {
+        return;
+      }
       setupClassManipulationSpies();
       element = jqLite('<svg><g></g></svg>');
       var target = element.children().eq(0);
@@ -337,7 +341,9 @@ describe("$animate", function() {
 
 
     it('should defer class manipulation until postDigest when outside of digest for SVG', inject(function($rootScope, $animate, log) {
-      if (!window.SVGElement) return;
+      if (!window.SVGElement) {
+        return;
+      }
       setupClassManipulationLogger(log);
       element = jqLite('<svg><g class="test-class4"></g></svg>');
       var target = element.children().eq(0);
@@ -360,7 +366,9 @@ describe("$animate", function() {
 
 
     it('should perform class manipulation in expected order at end of digest for SVG', inject(function($rootScope, $animate, log) {
-      if (!window.SVGElement) return;
+      if (!window.SVGElement) {
+        return;
+      }
       element = jqLite('<svg><g class="test-class3"></g></svg>');
       var target = element.children().eq(0);
 

--- a/test/ng/animateSpec.js
+++ b/test/ng/animateSpec.js
@@ -200,13 +200,17 @@ describe("$animate", function() {
         var removeClassImmediately = $animate.$$removeClassImmediately;
         addClass = spyOn($animate, '$$addClassImmediately').andCallFake(function(element, classes) {
           var names = classes;
-          if (Object.prototype.toString.call(classes) === '[object Array]') names = classes.join(' ');
+          if (Object.prototype.toString.call(classes) === '[object Array]') {
+            names = classes.join(' ');
+          }
           log('addClass(' + names + ')');
           return addClassImmediately.call($animate, element, classes);
         });
         removeClass = spyOn($animate, '$$removeClassImmediately').andCallFake(function(element, classes) {
           var names = classes;
-          if (Object.prototype.toString.call(classes) === '[object Array]') names = classes.join(' ');
+          if (Object.prototype.toString.call(classes) === '[object Array]') {
+            names = classes.join(' ');
+          }
           log('removeClass(' + names + ')');
           return removeClassImmediately.call($animate, element, classes);
         });

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -28,11 +28,15 @@ function MockWindow(options) {
 
   this.setTimeout.flush = function() {
     var length = timeouts.length;
-    while (length-- > 0) timeouts.shift()();
+    while (length-- > 0) {
+      timeouts.shift()();
+    }
   };
 
   this.addEventListener = function(name, listener) {
-    if (angular.isUndefined(events[name])) events[name] = [];
+    if (angular.isUndefined(events[name])) {
+      events[name] = [];
+    }
     events[name].push(listener);
   };
 
@@ -809,7 +813,9 @@ describe('browser', function() {
     });
 
     afterEach(function() {
-      if (!jQuery) jqLiteDealoc(fakeWindow);
+      if (!jQuery) {
+        jqLiteDealoc(fakeWindow);
+      }
     });
 
     it('should return registered callback', function() {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -407,7 +407,9 @@ describe('$compile', function() {
         element[0].childNodes[1] = {nodeType: 3, nodeName: 'OBJECT', textContent: 'fake node'};
       } catch (e) {
       } finally {
-        if (!element[0].childNodes[1]) return; //browser doesn't support this kind of mocking
+        if (!element[0].childNodes[1]) {
+          return; //browser doesn't support this kind of mocking
+        }
       }
 
       expect(element[0].childNodes[1].textContent).toBe('fake node');
@@ -444,7 +446,9 @@ describe('$compile', function() {
 
 
       it('should allow directives in SVG element classes', inject(function($compile, $rootScope, log) {
-        if (!window.SVGElement) return;
+        if (!window.SVGElement) {
+          return;
+        }
         element = $compile('<svg><text class="greet: angular; log:123;"></text></svg>')($rootScope);
         var text = element.children().eq(0);
         // In old Safari, SVG elements don't have innerHTML, so element.html() won't work
@@ -455,7 +459,9 @@ describe('$compile', function() {
 
 
       it('should ignore not set CSS classes on SVG elements', inject(function($compile, $rootScope, log) {
-        if (!window.SVGElement) return;
+        if (!window.SVGElement) {
+          return;
+        }
         // According to spec SVG element className property is readonly, but only FF
         // implements it this way which causes compile exceptions.
         element = $compile('<svg><text>{{1}}</text></svg>')($rootScope);

--- a/test/ng/directive/aSpec.js
+++ b/test/ng/directive/aSpec.js
@@ -48,7 +48,9 @@ describe('a', function() {
     event.preventDefaultOrg = event.preventDefault;
     event.preventDefault = function() {
       preventDefaultCalled = true;
-      if (this.preventDefaultOrg) this.preventDefaultOrg();
+      if (this.preventDefaultOrg) {
+        this.preventDefaultOrg();
+      }
     };
 
     element[0].dispatchEvent(event);
@@ -147,7 +149,9 @@ describe('a', function() {
         event.preventDefaultOrg = event.preventDefault;
         event.preventDefault = function() {
           preventDefaultCalled = true;
-          if (this.preventDefaultOrg) this.preventDefaultOrg();
+          if (this.preventDefaultOrg) {
+            this.preventDefaultOrg();
+          }
         };
 
         child[0].dispatchEvent(event);

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -257,7 +257,9 @@ describe('ngInclude', function() {
     var called = 0;
     // we want to assert only during first watch
     $rootScope.$watch(function() {
-      if (!called) expect(element.text()).toBe('');
+      if (!called) {
+        expect(element.text()).toBe('');
+      }
       called++;
     });
 

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -365,7 +365,9 @@ describe('ngInclude', function() {
 
 
   it('should construct SVG template elements with correct namespace', function() {
-    if (!window.SVGRectElement) return;
+    if (!window.SVGRectElement) {
+      return;
+    }
     module(function($compileProvider) {
       $compileProvider.directive('test', valueFn({
         templateNamespace: 'svg',
@@ -386,7 +388,9 @@ describe('ngInclude', function() {
 
 
   it('should compile only the template content of an SVG template', function() {
-    if (!window.SVGRectElement) return;
+    if (!window.SVGRectElement) {
+      return;
+    }
     module(function($compileProvider) {
       $compileProvider.directive('test', valueFn({
         templateNamespace: 'svg',

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -1155,12 +1155,16 @@ describe('ngModel', function() {
         var removeClassCallCount = 0;
         var input;
         $animate.$$addClassImmediately = function(element, className) {
-          if (input && element[0] === input[0]) ++addClassCallCount;
+          if (input && element[0] === input[0]) {
+            ++addClassCallCount;
+          }
           return addClass.call($animate, element, className);
         };
 
         $animate.$$removeClassImmediately = function(element, className) {
-          if (input && element[0] === input[0]) ++removeClassCallCount;
+          if (input && element[0] === input[0]) {
+            ++removeClassCallCount;
+          }
           return removeClass.call($animate, element, className);
         };
 
@@ -1552,7 +1556,9 @@ describe('ngModel', function() {
     function assertValidAnimation(animation, event, classNameA, classNameB) {
       expect(animation.event).toBe(event);
       expect(animation.args[1]).toBe(classNameA);
-      if (classNameB) expect(animation.args[2]).toBe(classNameB);
+      if (classNameB) {
+        expect(animation.args[2]).toBe(classNameB);
+      }
     }
 
     var doc, input, scope, model;

--- a/test/ng/directive/ngOptionsSpec.js
+++ b/test/ng/directive/ngOptionsSpec.js
@@ -120,7 +120,9 @@ describe('ngOptions', function() {
     var html = '<select';
     forEach(attrs, function(value, key) {
       if (isBoolean(value)) {
-        if (value) html += ' ' + key;
+        if (value) {
+          html += ' ' + key;
+        }
       } else {
         html += ' ' + key + '="' + value + '"';
       }

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -1463,7 +1463,9 @@ describe('ngRepeat animations', function() {
 
   it('should not change the position of the block that is being animated away via a leave animation',
     inject(function($compile, $rootScope, $animate, $document, $window, $sniffer, $timeout) {
-      if (!$sniffer.transitions) return;
+      if (!$sniffer.transitions) {
+        return;
+      }
 
       var item;
       var ss = createMockStyleSheet($document, $window);

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1007,7 +1007,9 @@ describe('$http', function() {
 
 
         it('should ignore Blob objects', function() {
-          if (!window.Blob) return;
+          if (!window.Blob) {
+            return;
+          }
 
           var blob = new Blob(['blob!'], { type: 'text/plain' });
 
@@ -1016,7 +1018,9 @@ describe('$http', function() {
         });
 
         it('should ignore FormData objects', function() {
-          if (!window.FormData) return;
+          if (!window.FormData) {
+            return;
+          }
 
           var formData = new FormData();
           formData.append('angular', 'is great');

--- a/test/ng/intervalSpec.js
+++ b/test/ng/intervalSpec.js
@@ -26,7 +26,9 @@ describe('$interval', function() {
         var fnIndex;
 
         angular.forEach(repeatFns, function(fn, index) {
-          if (fn.id === id) fnIndex = index;
+          if (fn.id === id) {
+            fnIndex = index;
+          }
         });
 
         if (fnIndex !== undefined) {

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -18,7 +18,9 @@ describe('$location', function() {
     var urlParsingNodePlaceholder;
 
     beforeEach(inject(function($sniffer) {
-      if (msie) return;
+      if (msie) {
+        return;
+      }
 
       urlParsingNodePlaceholder = urlParsingNode;
 
@@ -38,7 +40,9 @@ describe('$location', function() {
     }));
 
     afterEach(inject(function($sniffer) {
-      if (msie) return;
+      if (msie) {
+        return;
+      }
       //reset urlParsingNode
       urlParsingNode = urlParsingNodePlaceholder;
     }));

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1296,7 +1296,11 @@ describe('parser', function() {
 
         it('should stay stable once the value defined', inject(function($parse, $rootScope, log) {
           var fn = $parse('::foo');
-          $rootScope.$watch(fn, function(value, old) { if (value !== old) log(value); });
+          $rootScope.$watch(fn, function(value, old) {
+            if (value !== old) {
+              log(value);
+            }
+          });
 
           $rootScope.$digest();
           expect($rootScope.$$watchers.length).toBe(1);
@@ -1315,7 +1319,11 @@ describe('parser', function() {
 
         it('should have a stable value if at the end of a $digest it has a defined value', inject(function($parse, $rootScope, log) {
           var fn = $parse('::foo');
-          $rootScope.$watch(fn, function(value, old) { if (value !== old) log(value); });
+          $rootScope.$watch(fn, function(value, old) {
+            if (value !== old) {
+              log(value);
+            }
+          });
           $rootScope.$watch('foo', function() { if ($rootScope.foo === 'bar') {$rootScope.foo = undefined; } });
 
           $rootScope.foo = 'bar';

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -163,7 +163,9 @@ describe('q', function() {
     queue: [],
     logExceptions: true,
     flush: function() {
-      if (!mockNextTick.queue.length) throw new Error('Nothing to be flushed!');
+      if (!mockNextTick.queue.length) {
+        throw new Error('Nothing to be flushed!');
+      }
       while (mockNextTick.queue.length) {
         var queue = mockNextTick.queue;
         mockNextTick.queue = [];

--- a/test/ng/rafSpec.js
+++ b/test/ng/rafSpec.js
@@ -2,7 +2,9 @@
 
 describe('$$rAF', function() {
   it('should queue and block animation frames', inject(function($$rAF) {
-    if (!$$rAF.supported) return;
+    if (!$$rAF.supported) {
+      return;
+    }
 
     var message;
     $$rAF(function() {
@@ -15,7 +17,9 @@ describe('$$rAF', function() {
   }));
 
   it('should provide a cancellation method', inject(function($$rAF) {
-    if (!$$rAF.supported) return;
+    if (!$$rAF.supported) {
+      return;
+    }
 
     var present = true;
     var cancel = $$rAF(function() {

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -14,7 +14,9 @@ describe('Scope', function() {
 
     it('should expose the constructor', inject(function($rootScope) {
       /* jshint -W103 */
-      if (msie < 11) return;
+      if (msie < 11) {
+        return;
+      }
       expect($rootScope.__proto__).toBe($rootScope.constructor.prototype);
     }));
 

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -89,11 +89,9 @@ describe('$sniffer', function() {
         var ua = $window.navigator.userAgent.toLowerCase();
         if (/chrome/i.test(ua) || /safari/i.test(ua) || /webkit/i.test(ua)) {
           expectedPrefix = 'Webkit';
-        }
-        else if (/firefox/i.test(ua)) {
+        } else if (/firefox/i.test(ua)) {
           expectedPrefix = 'Moz';
-        }
-        else if (/ie/i.test(ua) || /trident/i.test(ua)) {
+        } else if (/ie/i.test(ua) || /trident/i.test(ua)) {
           expectedPrefix = 'Ms';
         }
         expect($sniffer.vendorPrefix).toBe(expectedPrefix);

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -30,7 +30,9 @@ describe('$sniffer', function() {
     beforeEach(function() {
       mockDocument = {createElement: jasmine.createSpy('createElement')};
       mockDocument.createElement.andCallFake(function(elm) {
-        if (elm === 'div') return mockDivElement;
+        if (elm === 'div') {
+          return mockDivElement;
+        }
       });
 
       $sniffer = sniffer({}, mockDocument);

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -625,7 +625,9 @@ describe("ngAnimate", function() {
         it("should assign the ng-event className to all animation events when transitions/keyframes are used",
           inject(function($animate, $sniffer, $rootScope) {
 
-          if (!$sniffer.transitions) return;
+          if (!$sniffer.transitions) {
+            return;
+          }
 
           $rootScope.$digest();
           element[0].removeChild(child[0]);
@@ -1212,7 +1214,9 @@ describe("ngAnimate", function() {
             });
           });
           inject(function($animate, $rootScope, $compile, $sniffer) {
-            if (!$sniffer.transitions) return;
+            if (!$sniffer.transitions) {
+              return;
+            }
 
             element = $compile(html('<div class="js-animation"></div>'))($rootScope);
             $animate.leave(element);
@@ -1384,7 +1388,9 @@ describe("ngAnimate", function() {
           it("should not apply a piggy-back-transition if the styles object contains no styles",
             inject(function($compile, $animate, $rootScope, $sniffer) {
 
-            if (!$sniffer.animations) return;
+            if (!$sniffer.animations) {
+              return;
+            }
 
             $animate.enabled(true);
             ss.addRule('.on', '-webkit-animation: 1s super-animation; animation: 1s super-animation;');
@@ -1403,7 +1409,9 @@ describe("ngAnimate", function() {
           it("should pause the playstate when performing a stagger animation",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout) {
 
-            if (!$sniffer.animations) return;
+            if (!$sniffer.animations) {
+              return;
+            }
 
             $animate.enabled(true);
 
@@ -1467,7 +1475,9 @@ describe("ngAnimate", function() {
           it("should block and unblock keyframe animations when a stagger animation kicks in while skipping the first element",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout) {
 
-            if (!$sniffer.animations) return;
+            if (!$sniffer.animations) {
+              return;
+            }
 
             $animate.enabled(true);
 
@@ -1513,7 +1523,9 @@ describe("ngAnimate", function() {
           it("should stagger items when multiple animation durations/delays are defined",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout, $document, $rootElement, $window) {
 
-            if (!$sniffer.transitions) return;
+            if (!$sniffer.transitions) {
+              return;
+            }
 
             $animate.enabled(true);
 
@@ -1556,7 +1568,9 @@ describe("ngAnimate", function() {
           it("should stagger items and apply the transition + directive styles the right time when piggy-back styles are used",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout, $document, $rootElement, $window) {
 
-            if (!$sniffer.transitions) return;
+            if (!$sniffer.transitions) {
+              return;
+            }
 
             $animate.enabled(true);
 
@@ -1742,7 +1756,9 @@ describe("ngAnimate", function() {
           it("should NOT overwrite styles with outdated values when animation completes",
             inject(function($animate, $rootScope, $compile, $sniffer) {
 
-              if (!$sniffer.transitions) return;
+              if (!$sniffer.transitions) {
+                return;
+              }
 
               var style = '-webkit-transition-duration: 1s, 2000ms, 1s;' +
                           '-webkit-transition-property: height, left, opacity;' +
@@ -1772,7 +1788,9 @@ describe("ngAnimate", function() {
           it("should NOT overwrite styles when a transition with a specific property is used",
             inject(function($animate, $rootScope, $compile, $sniffer) {
 
-            if (!$sniffer.transitions) return;
+            if (!$sniffer.transitions) {
+              return;
+            }
 
             var style = '-webkit-transition: border linear .2s;' +
                                 'transition: border linear .2s;';
@@ -1858,7 +1876,9 @@ describe("ngAnimate", function() {
           it("should place a hard block when a structural CSS transition is run",
             inject(function($animate, $rootScope, $compile, $sniffer) {
 
-            if (!$sniffer.transitions) return;
+            if (!$sniffer.transitions) {
+              return;
+            }
 
             ss.addRule('.leave-animation.ng-leave',
               '-webkit-transition:5s linear all;' +
@@ -1882,7 +1902,9 @@ describe("ngAnimate", function() {
           it("should not place a hard block when a class-based CSS transition is run",
             inject(function($animate, $rootScope, $compile, $sniffer) {
 
-            if (!$sniffer.transitions) return;
+            if (!$sniffer.transitions) {
+              return;
+            }
 
             ss.addRule('.my-class', '-webkit-transition:5s linear all;' +
                                     'transition:5s linear all;');
@@ -1908,7 +1930,9 @@ describe("ngAnimate", function() {
           it("should stagger the items when the correct CSS class is provided",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout, $document, $rootElement, $browser) {
 
-            if (!$sniffer.transitions) return;
+            if (!$sniffer.transitions) {
+              return;
+            }
 
             $animate.enabled(true);
 
@@ -1962,7 +1986,9 @@ describe("ngAnimate", function() {
           it("should stagger items when multiple transition durations/delays are defined",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout, $document, $rootElement, $window) {
 
-            if (!$sniffer.transitions) return;
+            if (!$sniffer.transitions) {
+              return;
+            }
 
             $animate.enabled(true);
 
@@ -2005,7 +2031,9 @@ describe("ngAnimate", function() {
           it("should stagger items, apply directive styles but not apply a transition style when the stagger step kicks in",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout, $document, $rootElement, $window) {
 
-            if (!$sniffer.transitions) return;
+            if (!$sniffer.transitions) {
+              return;
+            }
 
             $animate.enabled(true);
 
@@ -2082,7 +2110,9 @@ describe("ngAnimate", function() {
           it("should apply a closing timeout to close all pending transitions",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout) {
 
-            if (!$sniffer.transitions) return;
+            if (!$sniffer.transitions) {
+              return;
+            }
 
             ss.addRule('.animated-element', '-webkit-transition:5s linear all;' +
                                                     'transition:5s linear all;');
@@ -2123,7 +2153,9 @@ describe("ngAnimate", function() {
               };
             });
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout) {
-              if (!$sniffer.transitions) return;
+              if (!$sniffer.transitions) {
+                return;
+              }
 
               ss.addRule('.animate-me div', '-webkit-transition:1s linear all;' +
                                                       'transition:1s linear all;');
@@ -2169,7 +2201,9 @@ describe("ngAnimate", function() {
           it('should apply a closing timeout to close all parallel class-based animations on the same element',
             inject(function($sniffer, $compile, $rootScope, $rootElement, $animate, $timeout) {
 
-            if (!$sniffer.transitions) return;
+            if (!$sniffer.transitions) {
+              return;
+            }
 
             ss.addRule('.base-class', '-webkit-transition:2s linear all;' +
                                               'transition:2s linear all;');
@@ -2195,7 +2229,9 @@ describe("ngAnimate", function() {
           it("apply a closing timeout with respect to a staggering animation",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout) {
 
-            if (!$sniffer.transitions) return;
+            if (!$sniffer.transitions) {
+              return;
+            }
 
             ss.addRule('.entering-element.ng-enter',
               '-webkit-transition:5s linear all;' +
@@ -2247,7 +2283,9 @@ describe("ngAnimate", function() {
           it("should cancel all the existing stagger timers when the animation is cancelled",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout, $browser) {
 
-            if (!$sniffer.transitions) return;
+            if (!$sniffer.transitions) {
+              return;
+            }
 
             ss.addRule('.entering-element.ng-enter',
               '-webkit-transition:5s linear all;' +
@@ -2294,7 +2332,9 @@ describe("ngAnimate", function() {
           it("should not allow the closing animation to close off a successive animation midway",
             inject(function($animate, $rootScope, $compile, $sniffer, $timeout) {
 
-            if (!$sniffer.transitions) return;
+            if (!$sniffer.transitions) {
+              return;
+            }
 
             ss.addRule('.some-class-add', '-webkit-transition:5s linear all;' +
                                                   'transition:5s linear all;');
@@ -2328,7 +2368,9 @@ describe("ngAnimate", function() {
         it("should apply staggering to both transitions and keyframe animations when used within the same animation",
           inject(function($animate, $rootScope, $compile, $sniffer, $timeout, $document, $rootElement, $browser) {
 
-          if (!$sniffer.transitions) return;
+          if (!$sniffer.transitions) {
+            return;
+          }
 
           $animate.enabled(true);
 
@@ -2623,7 +2665,9 @@ describe("ngAnimate", function() {
         it('should fire DOM callbacks on the element being animated',
           inject(function($animate, $rootScope, $compile, $sniffer, $rootElement) {
 
-          if (!$sniffer.transitions) return;
+          if (!$sniffer.transitions) {
+            return;
+          }
 
           $animate.enabled(true);
 
@@ -3487,7 +3531,9 @@ describe("ngAnimate", function() {
 
     it("should not perform the active class animation if the animation has been cancelled before the reflow occurs", function() {
       inject(function($compile, $rootScope, $animate, $sniffer) {
-        if (!$sniffer.transitions) return;
+        if (!$sniffer.transitions) {
+          return;
+        }
 
         ss.addRule('.animated.ng-enter', '-webkit-transition: 2s linear all;' +
                                                  'transition: 2s linear all;');
@@ -3687,7 +3733,9 @@ describe("ngAnimate", function() {
 
     it("should not skip ngAnimate animations when any pre-existing CSS transitions are present on the element", function() {
       inject(function($compile, $rootScope, $animate, $timeout, $sniffer) {
-        if (!$sniffer.transitions) return;
+        if (!$sniffer.transitions) {
+          return;
+        }
 
         var element = html($compile('<div class="animated parent"></div>')($rootScope));
         var child   = html($compile('<div class="animated child"></div>')($rootScope));
@@ -3717,7 +3765,9 @@ describe("ngAnimate", function() {
     it("should wait until both the duration and delay are complete to close off the animation",
       inject(function($compile, $rootScope, $animate, $timeout, $sniffer) {
 
-      if (!$sniffer.transitions) return;
+      if (!$sniffer.transitions) {
+        return;
+      }
 
       var element = html($compile('<div class="animated parent"></div>')($rootScope));
       var child   = html($compile('<div class="animated child"></div>')($rootScope));
@@ -4096,7 +4146,9 @@ describe("ngAnimate", function() {
     it("should wait until a queue of animations are complete before performing a reflow",
       inject(function($rootScope, $compile, $timeout, $sniffer, $animate) {
 
-      if (!$sniffer.transitions) return;
+      if (!$sniffer.transitions) {
+        return;
+      }
 
       $rootScope.items = [1,2,3,4,5];
       var element = html($compile('<div><div class="animated" ng-repeat="item in items"></div></div>')($rootScope));
@@ -4299,7 +4351,9 @@ describe("ngAnimate", function() {
       });
 
       inject(function($animate, $rootScope, $compile, $rootElement, $timeout, $document, $sniffer) {
-        if (!$sniffer.transitions) return;
+        if (!$sniffer.transitions) {
+          return;
+        }
 
         $animate.enabled(true);
 
@@ -4333,7 +4387,9 @@ describe("ngAnimate", function() {
     it("should cache getComputedStyle with similar className values but with respect to the parent node",
       inject(function($compile, $rootScope, $animate, $sniffer) {
 
-      if (!$sniffer.transitions) return;
+      if (!$sniffer.transitions) {
+        return;
+      }
 
       $animate.enabled();
 
@@ -4370,7 +4426,9 @@ describe("ngAnimate", function() {
     it("should reset the getComputedStyle lookup cache even when no animation is found",
       inject(function($compile, $rootScope, $animate, $sniffer, $document) {
 
-      if (!$sniffer.transitions) return;
+      if (!$sniffer.transitions) {
+        return;
+      }
 
       $animate.enabled();
 
@@ -4429,7 +4487,9 @@ describe("ngAnimate", function() {
     it("should cancel and perform the dom operation only after the reflow has run",
       inject(function($compile, $rootScope, $animate, $sniffer) {
 
-      if (!$sniffer.transitions) return;
+      if (!$sniffer.transitions) {
+        return;
+      }
 
       ss.addRule('.green-add', '-webkit-transition:1s linear all;' +
                                        'transition:1s linear all;');
@@ -4645,7 +4705,9 @@ describe("ngAnimate", function() {
     it('should only perform the DOM operation once',
       inject(function($sniffer, $compile, $rootScope, $rootElement, $animate) {
 
-      if (!$sniffer.transitions) return;
+      if (!$sniffer.transitions) {
+        return;
+      }
 
       ss.addRule('.base-class', '-webkit-transition:1s linear all;' +
                                         'transition:1s linear all;');
@@ -4680,7 +4742,9 @@ describe("ngAnimate", function() {
     it('should block and unblock transitions before the dom operation occurs',
       inject(function($rootScope, $compile, $rootElement, $document, $animate, $sniffer) {
 
-      if (!$sniffer.transitions) return;
+      if (!$sniffer.transitions) {
+        return;
+      }
 
       $animate.enabled(true);
 
@@ -4716,7 +4780,9 @@ describe("ngAnimate", function() {
     it('should not block keyframe animations around the reflow operation',
       inject(function($rootScope, $compile, $rootElement, $document, $animate, $sniffer) {
 
-      if (!$sniffer.animations) return;
+      if (!$sniffer.animations) {
+        return;
+      }
 
       $animate.enabled(true);
 
@@ -4764,7 +4830,9 @@ describe("ngAnimate", function() {
         });
       });
       inject(function($rootScope, $compile, $rootElement, $document, $animate, $sniffer, $timeout, $window) {
-        if (!$sniffer.animations) return;
+        if (!$sniffer.animations) {
+          return;
+        }
 
         $animate.enabled(true);
 
@@ -4790,7 +4858,9 @@ describe("ngAnimate", function() {
 
     it('should round up long elapsedTime values to close off a CSS3 animation',
       inject(function($rootScope, $compile, $rootElement, $document, $animate, $sniffer) {
-        if (!$sniffer.animations) return;
+        if (!$sniffer.animations) {
+          return;
+        }
 
         ss.addRule('.millisecond-transition.ng-leave', '-webkit-transition:510ms linear all;' +
                                                        'transition:510ms linear all;');
@@ -4828,7 +4898,9 @@ describe("ngAnimate", function() {
         });
       });
       inject(function($rootScope, $compile, $rootElement, $document, $timeout, $templateCache, $sniffer, $animate) {
-        if (!$sniffer.transitions) return;
+        if (!$sniffer.transitions) {
+          return;
+        }
 
         $templateCache.put('item-template', 'item: #{{ item }} ');
         var element = $compile('<div>' +
@@ -4883,7 +4955,9 @@ describe("ngAnimate", function() {
         });
       });
       inject(function($rootScope, $compile, $rootElement, $document, $timeout, $templateCache, $sniffer, $animate) {
-        if (!$sniffer.transitions) return;
+        if (!$sniffer.transitions) {
+          return;
+        }
 
         var element = $compile('<div class="capture"></div>')($rootScope);
         $rootElement.append(element);
@@ -4934,7 +5008,9 @@ describe("ngAnimate", function() {
         });
       });
       inject(function($rootScope, $compile, $rootElement, $document, $sniffer, $animate) {
-        if (!$sniffer.transitions) return;
+        if (!$sniffer.transitions) {
+          return;
+        }
 
         var upperElement = $compile('<div><div ng-if=1><span class="capture prefixed-animation"></span></div></div>')($rootScope);
         $rootElement.append(upperElement);
@@ -4961,7 +5037,9 @@ describe("ngAnimate", function() {
     it('should respect the most relevant CSS transition property if defined in multiple classes',
       inject(function($sniffer, $compile, $rootScope, $rootElement, $animate) {
 
-      if (!$sniffer.transitions) return;
+      if (!$sniffer.transitions) {
+        return;
+      }
 
       ss.addRule('.base-class', '-webkit-transition:1s linear all;' +
                                         'transition:1s linear all;');
@@ -5005,7 +5083,9 @@ describe("ngAnimate", function() {
     it('should not apply a transition upon removal of a class that has a transition',
       inject(function($sniffer, $compile, $rootScope, $rootElement, $animate) {
 
-      if (!$sniffer.transitions) return;
+      if (!$sniffer.transitions) {
+        return;
+      }
 
       ss.addRule('.base-class.on', '-webkit-transition:5s linear all;' +
                                            'transition:5s linear all;');
@@ -5030,7 +5110,9 @@ describe("ngAnimate", function() {
     it('should immediately close the former animation if the same CSS class is added/removed',
       inject(function($sniffer, $compile, $rootScope, $rootElement, $animate) {
 
-      if (!$sniffer.transitions) return;
+      if (!$sniffer.transitions) {
+        return;
+      }
 
       ss.addRule('.water-class', '-webkit-transition:2s linear all;' +
                                          'transition:2s linear all;');
@@ -5070,7 +5152,9 @@ describe("ngAnimate", function() {
         });
       });
       inject(function($animate, $sniffer, $rootScope, $compile) {
-        if (!$sniffer.transitions) return;
+        if (!$sniffer.transitions) {
+          return;
+        }
 
         ss.addRule('.fly', '-webkit-transition:2s linear all;' +
                                    'transition:2s linear all;');
@@ -5335,7 +5419,9 @@ describe("ngAnimate", function() {
         //jQuery doesn't handle SVG elements natively. Instead, an add-on library
         //is required which is called jquery.svg.js. Therefore, when jQuery is
         //active here there is no point to test this since it won't work by default.
-        if (!$sniffer.transitions) return;
+        if (!$sniffer.transitions) {
+          return;
+        }
 
         ss.addRule('circle.ng-enter', '-webkit-transition:1s linear all;' +
                                               'transition:1s linear all;');
@@ -5513,7 +5599,9 @@ describe("ngAnimate", function() {
 
 
     it('should defer class manipulation until end of digest for SVG', inject(function($rootScope, $animate) {
-      if (!window.SVGElement) return;
+      if (!window.SVGElement) {
+        return;
+      }
       setupClassManipulationSpies();
       element = jqLite('<svg><g></g></svg>');
       var target = element.children().eq(0);
@@ -5540,7 +5628,9 @@ describe("ngAnimate", function() {
 
 
     it('should defer class manipulation until postDigest when outside of digest for SVG', inject(function($rootScope, $animate, log) {
-      if (!window.SVGElement) return;
+      if (!window.SVGElement) {
+        return;
+      }
       setupClassManipulationLogger(log);
       element = jqLite('<svg><g class="test-class4"></g></svg>');
       var target = element.children().eq(0);
@@ -5563,7 +5653,9 @@ describe("ngAnimate", function() {
 
 
     it('should perform class manipulation in expected order at end of digest for SVG', inject(function($rootScope, $animate, log) {
-      if (!window.SVGElement) return;
+      if (!window.SVGElement) {
+        return;
+      }
       element = jqLite('<svg><g class="test-class3"></g></svg>');
       var target = element.children().eq(0);
 

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -5403,13 +5403,17 @@ describe("ngAnimate", function() {
         var removeClassImmediately = $originalAnimate.$$removeClassImmediately;
         addClass = spyOn($originalAnimate, '$$addClassImmediately').andCallFake(function(element, classes) {
           var names = classes;
-          if (Object.prototype.toString.call(classes) === '[object Array]') names = classes.join(' ');
+          if (Object.prototype.toString.call(classes) === '[object Array]') {
+            names = classes.join(' ');
+          }
           log('addClass(' + names + ')');
           return addClassImmediately.call($originalAnimate, element, classes);
         });
         removeClass = spyOn($originalAnimate, '$$removeClassImmediately').andCallFake(function(element, classes) {
           var names = classes;
-          if (Object.prototype.toString.call(classes) === '[object Array]') names = classes.join(' ');
+          if (Object.prototype.toString.call(classes) === '[object Array]') {
+            names = classes.join(' ');
+          }
           log('removeClass(' + names + ')');
           return removeClassImmediately.call($originalAnimate, element, classes);
         });

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -313,7 +313,9 @@ describe('ngView', function() {
       var called = 0;
       // we want to assert only during first watch
       $rootScope.$watch(function() {
-        if (!called) expect(element.text()).toBe('');
+        if (!called) {
+          expect(element.text()).toBe('');
+        }
         called++;
       });
 

--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -17,7 +17,9 @@ describe('HTML', function() {
 
   describe('htmlParser', function() {
     /* global htmlParser */
-    if (angular.isUndefined(window.htmlParser)) return;
+    if (angular.isUndefined(window.htmlParser)) {
+      return;
+    }
 
     var handler, start, text, comment;
     beforeEach(function() {
@@ -261,7 +263,9 @@ describe('HTML', function() {
 
   describe('htmlSanitizerWriter', function() {
     /* global htmlSanitizeWriter: false */
-    if (angular.isUndefined(window.htmlSanitizeWriter)) return;
+    if (angular.isUndefined(window.htmlSanitizeWriter)) {
+      return;
+    }
 
     var writer, html, uriValidator;
     beforeEach(function() {

--- a/test/ngScenario/SpecRunnerSpec.js
+++ b/test/ngScenario/SpecRunnerSpec.js
@@ -43,8 +43,9 @@ describe('angular.scenario.SpecRunner', function() {
     runner = $root.$new();
 
     var Cls = angular.scenario.SpecRunner;
-    for (var name in Cls.prototype)
+    for (var name in Cls.prototype) {
       runner[name] = angular.bind(runner, Cls.prototype[name]);
+    }
 
     Cls.call(runner);
   }));


### PR DESCRIPTION
I split the `requireCurlyBraces` changes into three commits to make it easer to review the code. They are also ordered from the least contentious (adding curly braces to statements that are already multiline) to most contentious (single line statements that return, break or throw) which makes the code more verbose.

The `disallowKeywordsOnNewLine` changes are unfortunately dependent on the `requireCurlyBraces` so can't be done as an independent pull request.
