### PR TITLE
fix($parse): remove references to last arguments to a fn call

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -728,6 +728,11 @@ Parser.prototype = {
             ? fn.apply(context, args)
             : fn(args[0], args[1], args[2], args[3], args[4]);
 
+      if (args) {
+        // Free-up the memory (arguments of the last function call).
+        args.length = 0;
+      }
+
       return ensureSafeObject(v, expressionText);
       };
   },


### PR DESCRIPTION
This can be an issue if running (and killing) multiple apps/injectors on the same page. The `args` array holds references to all previous arguments to a function call and thus they cannot be garbage-collected.

In a regular (one app/injector on a page) app, this is not an issue.

cc @aaronfrost
