### PR TITLE
routeParams are {!Object<string, string>}

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -477,7 +477,7 @@ function $RouteProvider() {
            * definitions will be interpolated into the location's path, while
            * remaining properties will be treated as query params.
            *
-           * @param {Object} newParams mapping of URL parameter names to values
+           * @param {!Object<string, string>} newParams mapping of URL parameter names to values
            */
           updateParams: function(newParams) {
             if (this.current && this.current.$$route) {


### PR DESCRIPTION
Calling Object.keys on null is a TypeError. And the mapping should be string -> string.
