### PR TITLE
fix(validators): check if viewValue is empty for maxlength

### DIFF
--- a/src/ng/directive/validators.js
+++ b/src/ng/directive/validators.js
@@ -65,7 +65,7 @@ var maxlengthDirective = function() {
         ctrl.$validate();
       });
       ctrl.$validators.maxlength = function(modelValue, viewValue) {
-        return (maxlength < 0) || ctrl.$isEmpty(modelValue) || (viewValue.length <= maxlength);
+        return (maxlength < 0) || ctrl.$isEmpty(viewValue) || (viewValue.length <= maxlength);
       };
     }
   };

--- a/test/ng/directive/validatorsSpec.js
+++ b/test/ng/directive/validatorsSpec.js
@@ -410,6 +410,20 @@ describe('validators', function() {
       expect($rootScope.value).toBe(12345);
       expect($rootScope.form.input.$error.maxlength).toBeUndefined();
     });
+
+    it('should validate emptiness against the viewValue', function() {
+      var inputElm = helper.compileInput('<input type="text" name="input" ng-model="value" maxlength="10" />');
+
+      var ctrl = inputElm.controller('ngModel');
+      spyOn(ctrl, '$isEmpty').andCallThrough();
+
+      ctrl.$parsers.push(function(value) {
+        return value + '678';
+      });
+
+      helper.changeInputValueTo('12345');
+      expect(ctrl.$isEmpty).toHaveBeenCalledWith('12345');
+    });
   });
 
 


### PR DESCRIPTION
@petebacondarwin This is the bug you found where $isEmpty is called with the modelValue. To make this consistent, we should also add this test to all other validators. Does this make sense to you?
