### PR TITLE
feat(ngLocale): Add FIRSTDAYOFWEEK and WEEKENDRANGE from google data

### DIFF
--- a/i18n/spec/closureI18nExtractorSpec.js
+++ b/i18n/spec/closureI18nExtractorSpec.js
@@ -184,6 +184,8 @@ describe("extractDateTimeSymbols", function() {
                       'nov.', 'déc.'],
                   DAY: ['dimanche', 'lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi'],
                   SHORTDAY: ['dim.', 'lun.', 'mar.', 'mer.', 'jeu.', 'ven.', 'sam.'],
+                  FIRSTDAYOFWEEK: 6,
+                  WEEKENDRANGE: [5, 6],
                   AMPMS: ['AM', 'PM'],
                   medium: 'yyyy-MM-dd HH:mm:ss',
                   short: 'yy-MM-dd HH:mm',

--- a/i18n/src/converter.js
+++ b/i18n/src/converter.js
@@ -42,6 +42,8 @@ function convertDatetimeData(dataObj) {
   datetimeFormats.DAY = dataObj.WEEKDAYS;
   datetimeFormats.SHORTDAY = dataObj.SHORTWEEKDAYS;
   datetimeFormats.AMPMS = dataObj.AMPMS;
+  datetimeFormats.FIRSTDAYOFWEEK = dataObj.FIRSTDAYOFWEEK;
+  datetimeFormats.WEEKENDRANGE = dataObj.WEEKENDRANGE;
 
 
   datetimeFormats.medium      = dataObj.DATEFORMATS[2] + ' ' + dataObj.TIMEFORMATS[2];


### PR DESCRIPTION
This data is available on the Google closure localization data used. This pull request adds `FIRSTDAYOFWEEK` and `WEEKENDRANGE` into the `DATETIME_FORMATS` property of $locale.
