### PR TITLE
fix ($compile): keeps prototype properties for template URL directives

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2155,7 +2155,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           afterTemplateChildLinkFn,
           beforeTemplateCompileNode = $compileNode[0],
           origAsyncDirective = directives.shift(),
-          // The fact that we have to copy and patch the directive seems wrong!
           derivedSyncDirective = inherit(origAsyncDirective, {
             templateUrl: null, transclude: null, replace: null, $$originalDirective: origAsyncDirective
           }),

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2156,7 +2156,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           beforeTemplateCompileNode = $compileNode[0],
           origAsyncDirective = directives.shift(),
           // The fact that we have to copy and patch the directive seems wrong!
-          derivedSyncDirective = extend({}, origAsyncDirective, {
+          derivedSyncDirective = inherit(origAsyncDirective, {
             templateUrl: null, transclude: null, replace: null, $$originalDirective: origAsyncDirective
           }),
           templateUrl = (isFunction(origAsyncDirective.templateUrl))

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1120,7 +1120,7 @@ describe('$compile', function() {
           module(function() {
             function DirectiveClass() {
               this.restrict = 'E';
-              this.template = "<p>{{value}}<p>";
+              this.template = "<p>{{value}}</p>";
             }
 
             DirectiveClass.prototype.compile = function() {
@@ -1135,7 +1135,7 @@ describe('$compile', function() {
           inject(function($compile, $rootScope) {
             element = $compile('<template-url-with-prototype><template-url-with-prototype>')($rootScope);
             $rootScope.$digest();
-            expect(element.find("p")[0].innerText).toEqual("Test Value");
+            expect(element.find("p")[0].innerHTML).toEqual("Test Value");
           });
         });
       });
@@ -2079,7 +2079,7 @@ describe('$compile', function() {
             element = $compile('<template-url-with-prototype><template-url-with-prototype>')($rootScope);
             $httpBackend.flush();
             $rootScope.$digest();
-            expect(element.find("p")[0].innerText).toEqual("Test Value");
+            expect(element.find("p")[0].innerHTML).toEqual("Test Value");
           });
         });
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1115,6 +1115,29 @@ describe('$compile', function() {
             expect(element.find('p').text()).toBe('Hello, world!');
           });
         });
+
+        it('should keep prototype properties on directive', function() {
+          module(function() {
+            function DirectiveClass() {
+              this.restrict = 'E';
+              this.template = "<p>{{value}}<p>";
+            }
+
+            DirectiveClass.prototype.compile = function() {
+              return function(scope, element, attrs) {
+                scope.value = "Test Value";
+              };
+            };
+
+            directive('templateUrlWithPrototype', valueFn(new DirectiveClass()));
+          });
+
+          inject(function($compile, $rootScope) {
+            element = $compile('<template-url-with-prototype><template-url-with-prototype>')($rootScope);
+            $rootScope.$digest();
+            expect(element.find("p")[0].innerText).toEqual("Test Value");
+          });
+        });
       });
 
 
@@ -2044,8 +2067,8 @@ describe('$compile', function() {
             DirectiveClass.prototype.compile = function() {
               return function(scope, element, attrs) {
                 scope.value = "Test Value";
-              }
-            }
+              };
+            };
 
             directive('templateUrlWithPrototype', valueFn(new DirectiveClass()));
           });
@@ -2056,7 +2079,6 @@ describe('$compile', function() {
             element = $compile('<template-url-with-prototype><template-url-with-prototype>')($rootScope);
             $httpBackend.flush();
             $rootScope.$digest();
-            console.log(element.find("p")[0]);
             expect(element.find("p")[0].innerText).toEqual("Test Value");
           });
         });

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2034,6 +2034,33 @@ describe('$compile', function() {
           });
         });
 
+        it('should keep prototype properties on sync version of async directive', function() {
+          module(function() {
+            function DirectiveClass() {
+              this.restrict = 'E';
+              this.templateUrl = "test.html";
+            }
+
+            DirectiveClass.prototype.compile = function() {
+              return function(scope, element, attrs) {
+                scope.value = "Test Value";
+              }
+            }
+
+            directive('templateUrlWithPrototype', valueFn(new DirectiveClass()));
+          });
+
+          inject(function($compile, $rootScope, $httpBackend) {
+            $httpBackend.whenGET('test.html').
+              respond('<p>{{value}}</p>');
+            element = $compile('<template-url-with-prototype><template-url-with-prototype>')($rootScope);
+            $httpBackend.flush();
+            $rootScope.$digest();
+            console.log(element.find("p")[0]);
+            expect(element.find("p")[0].innerText).toEqual("Test Value");
+          });
+        });
+
       });
 
 


### PR DESCRIPTION
currently, if a directive definition objects has prototype properties, such as a compile function, those are lost when compiled if the directive has a templateUrl function. Steps to reproduce:

``` js
directive("templateUrlDoesntWork", function() {
   var base = {
      compile: function() { 
         return function(scope, element, attrs) {
            scope.value = "Test"
         }
     }
  }
  inherited = Object.create(base)
  inherited.templateUrl = "test.html"
  return inherited;
}
```

The DDO's compile function will never be called. On the other hand the same version with a plain template works:

``` js
directive("templateWorks", function() {
   var base = {
      compile: function() { 
         return function(scope, element, attrs) {
            scope.value = "Test"
         }
     }
  }
  inherited = Object.create(base)
  inherited.template = "<p>{{value}}<p>"
  return inherited;
}
```

The DDO's compile function will be called.

This makes a difference for an increasing number of people particularly who are experimenting with ES6 classes in Angular 1.x.
