### PR TITLE
chore(docs): fix nav scrolling for non-mobile screens

### DIFF
--- a/docs/app/assets/css/docs.css
+++ b/docs/app/assets/css/docs.css
@@ -415,7 +415,7 @@ iframe.example {
 
 .main-body-grid .side-navigation {
   position:relative;
-  padding-bottom:50px;
+  padding-bottom:120px;
 }
 
 .main-body-grid .side-navigation.ng-hide {
@@ -631,6 +631,7 @@ ul.events > li {
   }
   .main-body-grid .side-navigation {
     display:block!important;
+    padding-bottom:50px;
   }
   .main-body-grid .side-navigation.ng-hide {
     display:none!important;


### PR DESCRIPTION
Left nav is hidden behind the footer and it's impossible to scroll up further

![screen shot 2015-02-02 at 18 53 25](https://cloud.githubusercontent.com/assets/326935/6005962/cc830588-ab0e-11e4-8ced-a643a7ac59e8.png)

Browsers: Chrome 40, FF 35
