### PR TITLE
perf(filterFilter): change loop validation

### DIFF
--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -69,6 +69,8 @@ function $ControllerProvider() {
      *    * check if evaluating the string on the current scope returns a constructor
      *    * if $controllerProvider#allowGlobals, check `window[constructor]` on the global
      *      `window` object (not recommended)
+     *    * if use controllerAs syntax, the controller instance is published into a scope property.
+     *      (scope must be injected into locals param)
      *
      *    The string can use the `controller as property` syntax, where the controller instance is published
      *    as the specified property on the `scope`; the `scope` must be injected into `locals` param for this

--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -70,7 +70,7 @@ function $ControllerProvider() {
      *    * if $controllerProvider#allowGlobals, check `window[constructor]` on the global
      *      `window` object (not recommended)
      *
-     *    If use a string with `controller as` syntax, the controller instance is published into a `scope` 
+     *    If use a string with `controller as` syntax, the controller instance is published into a `scope`
      *    property, but the `scope` must be injected into `locals` param.
      *
      *    The string can use the `controller as property` syntax, where the controller instance is published

--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -69,8 +69,9 @@ function $ControllerProvider() {
      *    * check if evaluating the string on the current scope returns a constructor
      *    * if $controllerProvider#allowGlobals, check `window[constructor]` on the global
      *      `window` object (not recommended)
-     *    * if use controllerAs syntax, the controller instance is published into a scope property.
-     *      (scope must be injected into locals param)
+     *
+     *    If use a string with `controller as` syntax, the controller instance is published into a `scope` 
+     *    property, but the `scope` must be injected into `locals` param.
      *
      *    The string can use the `controller as property` syntax, where the controller instance is published
      *    as the specified property on the `scope`; the `scope` must be injected into `locals` param for this

--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -70,9 +70,6 @@ function $ControllerProvider() {
      *    * if $controllerProvider#allowGlobals, check `window[constructor]` on the global
      *      `window` object (not recommended)
      *
-     *    If use a string with `controller as` syntax, the controller instance is published into a `scope`
-     *    property, but the `scope` must be injected into `locals` param.
-     *
      *    The string can use the `controller as property` syntax, where the controller instance is published
      *    as the specified property on the `scope`; the `scope` must be injected into `locals` param for this
      *    to work correctly.

--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -152,7 +152,15 @@ function filterFilter() {
         return array;
     }
 
-    return array.filter(predicateFn);
+    var filtered = [];
+
+    for (var i = 0, length = array.length;i < length;i++) {
+      if (predicateFn(array[i], i)) {
+        filtered.push(array[i]);
+      }
+    }
+
+    return filtered;
   };
 }
 

--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -154,7 +154,7 @@ function filterFilter() {
 
     var filtered = [];
 
-    for (var i = 0, length = array.length;i < length;i++) {
+    for (var i = 0, length = array.length; i < length; i++) {
       if (predicateFn(array[i], i)) {
         filtered.push(array[i]);
       }


### PR DESCRIPTION
The filterFilter uses the filter method from Array but it seems that the forLoop is more performatic than the native methods.

jsPerf: http://jsperf.com/aarontgrogg-array-filter-vs-for-loop
