### PR TITLE
docs(misc-core): Add `undefined` as in/outputs of to/fromJson

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -979,7 +979,7 @@ function toJsonReplacer(key, value) {
  * Serializes input into a JSON-formatted string. Properties with leading $$ characters will be
  * stripped since angular uses this notation internally.
  *
- * @param {Object|Array|Date|string|number} obj Input to be serialized into JSON.
+ * @param {Object|Array|Date|string|number|undefined} obj Input to be serialized into JSON.
  * @param {boolean|number=} pretty If set to true, the JSON output will contain newlines and whitespace.
  *    If set to an integer, the JSON output will contain that many spaces per indentation (the default is 2).
  * @returns {string|undefined} JSON-ified string representing `obj`.
@@ -1002,8 +1002,8 @@ function toJson(obj, pretty) {
  * @description
  * Deserializes a JSON string.
  *
- * @param {string} json JSON string to deserialize.
- * @returns {Object|Array|string|number} Deserialized JSON string.
+ * @param {string|undefined} json JSON string to deserialize.
+ * @returns {Object|Array|string|number|undefined} Deserialized JSON string.
  */
 function fromJson(json) {
   return isString(json)

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1369,6 +1369,10 @@ describe('angular', function() {
       expect(fromJson('{}')).toEqual({});
       expect(spy).toHaveBeenCalled();
     });
+
+    it('should deserialize undefined as undefined', function() {
+      expect(fromJson(undefined)).toEqual(undefined);
+    });
   });
 
 


### PR DESCRIPTION
Request Type: docs

Component(s): misc-core

Impact: small

Complexity: small

Detailed Description:
It is acceptable to pass and possible to receive `undefined` when using the `angular.toJson` and `angular.fromJson` methods.
