### PR TITLE
fix(sanitize): handle newline characters inside special tags

### DIFF
--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -336,7 +336,7 @@ function htmlParser(html, handler) {
       }
 
     } else {
-      html = html.replace(new RegExp("(.*)<\\s*\\/\\s*" + stack.last() + "[^>]*>", 'i'),
+      html = html.replace(new RegExp("([^]*)<\\s*\\/\\s*" + stack.last() + "[^>]*>", 'i'),
         function(all, text) {
           text = text.replace(COMMENT_REGEXP, "$1").replace(CDATA_REGEXP, "$1");
 

--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -138,6 +138,7 @@ describe('HTML', function() {
 
   it('should remove script', function() {
     expectHTML('a<SCRIPT>evil< / scrIpt >c.').toEqual('ac.');
+    expectHTML('a<SCRIPT>\n\revil\n\r< / scrIpt >c.').toEqual('ac.');
   });
 
   it('should remove DOCTYPE header', function() {
@@ -158,6 +159,7 @@ describe('HTML', function() {
 
   it('should remove style', function() {
     expectHTML('a<STyle>evil</stYle>c.').toEqual('ac.');
+    expectHTML('a<STyle>\n\revil\n\r</stYle>c.').toEqual('ac.');
   });
 
   it('should remove script and style', function() {


### PR DESCRIPTION
Handle newlines characters when they are present inside `<script>` and `<style>` tags.

Closes #10943
