### PR TITLE
fix($location): prevent page reload if url has empty hash at the end

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -882,7 +882,7 @@ function $LocationProvider() {
 
 
     // rewrite hashbang url <> html5 url
-    if ($location.absUrl() != initialUrl) {
+    if (trimEmptyHash($location.absUrl()) != trimEmptyHash(initialUrl)) {
       $browser.url($location.absUrl(), true);
     }
 

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -673,6 +673,16 @@ describe('$location', function() {
     }));
   });
 
+  describe('rewrite hashbang url <> html5 url', function() {
+    beforeEach(initService({html5Mode: true, supportHistory: true}));
+    beforeEach(inject(initBrowser({url:'http://new.com/#', basePath: '/'})));
+
+    it('should not replace browser url if only the empty hash fragment is cleared', inject(function($browser, $location) {
+      expect($browser.url()).toBe('http://new.com/#');
+      expect($location.absUrl()).toBe('http://new.com/');
+    }));
+  });
+
   describe('wiring', function() {
 
     beforeEach(initService({html5Mode:false,hashPrefix: '!',supportHistory: true}));


### PR DESCRIPTION
If initial url has empty hash at the end, $location replaces it with url without hash causing page reload

Closes #10397
