### PR TITLE
fix($parse): Initialize elements in an array from left to right

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -996,7 +996,7 @@ ASTCompiler.prototype = {
           self.if(self.notNull(right), function() {
             self.addEnsureSafeFunction(right);
             forEach(ast.arguments, function(expr) {
-              self.recurse(expr, undefined, undefined, function(argument) {
+              self.recurse(expr, self.nextId(), undefined, function(argument) {
                 args.push(self.ensureSafeObject(argument));
               });
             });
@@ -1027,14 +1027,14 @@ ASTCompiler.prototype = {
           self.addEnsureSafeObject(self.member(left.context, left.name, left.computed));
           expression = self.member(left.context, left.name, left.computed) + ast.operator + right;
           self.assign(intoId, expression);
-          recursionFn(expression);
+          recursionFn(intoId || expression);
         });
       }, 1);
       break;
     case AST.ArrayExpression:
       args = [];
       forEach(ast.elements, function(expr) {
-        self.recurse(expr, undefined, undefined, function(argument) {
+        self.recurse(expr, self.nextId(), undefined, function(argument) {
           args.push(argument);
         });
       });
@@ -1045,7 +1045,7 @@ ASTCompiler.prototype = {
     case AST.ObjectExpression:
       args = [];
       forEach(ast.properties, function(property) {
-        self.recurse(property.value, undefined, undefined, function(expr) {
+        self.recurse(property.value, self.nextId(), undefined, function(expr) {
           args.push(self.escape(
               property.key.type === AST.Identifier ? property.key.name :
                 ('' + property.key.value)) +

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -2204,6 +2204,24 @@ describe('parser', function() {
         expect(scope.$eval('a + \n b.c + \r "\td" + \t \r\n\r "\r\n\n"')).toEqual("abc\td\r\n\n");
       });
 
+
+      // https://github.com/angular/angular.js/issues/10968
+      it('should evaluate arrays literals initializers left-to-right', inject(function($parse) {
+        var s = {c:function() {return {b: 1}; }};
+        expect($parse("e=1;[a=c(),d=a.b+1]")(s)).toEqual([{b: 1}, 2]);
+      }));
+
+      it('should evaluate function arguments left-to-right', inject(function($parse) {
+        var s = {c:function() {return {b: 1}; }, i: function(x, y) { return [x, y];}};
+        expect($parse("e=1;i(a=c(),d=a.b+1)")(s)).toEqual([{b: 1}, 2]);
+      }));
+
+      it('should evaluate object properties expressions left-to-right', inject(function($parse) {
+        var s = {c:function() {return {b: 1}; }};
+        expect($parse("e=1;{x: a=c(), y: d=a.b+1}")(s)).toEqual({x: {b: 1}, y: 2});
+      }));
+
+
       describe('sandboxing', function() {
         describe('Function constructor', function() {
           it('should not tranverse the Function constructor in the getter', function() {


### PR DESCRIPTION
When constructing an array, never lazy initialize the elements and build the array strictly from left to right.

Closes: #10968
