### PR TITLE
Watch the ngInit so that if it changes it can be re-evaluated.

### DIFF
--- a/src/ng/directive/ngInit.js
+++ b/src/ng/directive/ngInit.js
@@ -62,6 +62,11 @@ var ngInitDirective = ngDirective({
     return {
       pre: function(scope, element, attrs) {
         scope.$eval(attrs.ngInit);
+      },
+      post: function(scope, element, attrs) {
+        scope.$watch(attrs.ngInit, function() {
+          scope.$eval(attrs.ngInit);
+        });
       }
     };
   }


### PR DESCRIPTION
If `ng-init` is used for creating a variable alias it currently only evaluates that alias when it is created.  For example:

``` html
<div ng-init="model=some.long.variable.name.object">
    <input ng-model="model.foo">
    <input ng-model="model.bar">
</div>
```

If `some.long.variable.name.object` changes then model won't be updated.  This change will ensure that if it changes it will be re-evaluated.
