### PR TITLE
refactor(ngSwitch):delete default directive restriction

### DIFF
--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -130,7 +130,6 @@
  */
 var ngSwitchDirective = ['$animate', function($animate) {
   return {
-    restrict: 'EA',
     require: 'ngSwitch',
 
     // asks for $scope to fool the BC controller module


### PR DESCRIPTION
Delete the directive restriction to avoid code duplication since the default is already applied

This line is uneccesary because the default value is set inside the registerDirective function:

```
directive.index = index;
directive.name = directive.name || name;
directive.require = directive.require || (directive.controller && directive.name);
directive.restrict = directive.restrict || 'EA';
```

PR baked during http://www.meetup.com/AngularJS-BH/events/220033641/
