### PR TITLE
fix(ngTouch): check undefined tagName for SVG event target

### DIFF
--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -1,6 +1,8 @@
 'use strict';
 
-/* global ngTouch: false */
+/* global ngTouch: false,
+  nodeName_: false
+*/
 
 /**
  * @ngdoc directive
@@ -142,7 +144,7 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
       lastLabelClickCoordinates = null;
     }
     // remember label click coordinates to prevent click busting of trigger click event on input
-    if (event.target.tagName.toLowerCase() === 'label') {
+    if (nodeName_(event.target) === 'label') {
       lastLabelClickCoordinates = [x, y];
     }
 
@@ -158,7 +160,7 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     event.preventDefault();
 
     // Blur focused form elements
-    event.target && event.target.blur();
+    event.target && event.target.blur && event.target.blur();
   }
 
 

--- a/src/ngTouch/touch.js
+++ b/src/ngTouch/touch.js
@@ -22,3 +22,6 @@
 /* global -ngTouch */
 var ngTouch = angular.module('ngTouch', []);
 
+function nodeName_(element) {
+  return angular.lowercase(element.nodeName || (element[0] && element[0].nodeName));
+}

--- a/test/ngTouch/directive/ngClickSpec.js
+++ b/test/ngTouch/directive/ngClickSpec.js
@@ -171,6 +171,18 @@ describe('ngClick (touch)', function() {
     expect($rootScope.tapped).toBe(true);
   }));
 
+  it('should click when target element is an SVG', inject(
+    function($rootScope, $compile, $rootElement) {
+      element = $compile('<svg ng-click="tapped = true"></svg>')($rootScope);
+      $rootElement.append(element);
+      $rootScope.$digest();
+
+      browserTrigger(element, 'touchstart');
+      browserTrigger(element, 'touchend');
+      browserTrigger(element, 'click', {x:1, y:1});
+
+      expect($rootScope.tapped).toEqual(true);
+  }));
 
   describe('the clickbuster', function() {
     var element1, element2;


### PR DESCRIPTION
When target click element is an SVG tag, event.target.tagName and event.target.blur are undefined on Chrome v40 and iOS 8.1.3
