### PR TITLE
Update controller.ngdoc fixes grammar

### DIFF
--- a/docs/content/guide/controller.ngdoc
+++ b/docs/content/guide/controller.ngdoc
@@ -75,7 +75,7 @@ In order to react to events or execute computation in the view we must provide b
 scope. We add behavior to the scope by attaching methods to the `$scope` object.  These methods are
 then available to be called from the template/view.
 
-The following example uses a Controller to add a method to the scope, which doubles a number:
+The following example uses a Controller to add a method, which doubles a number, to the scope:
 
 ```js
 var myApp = angular.module('myApp',[]);


### PR DESCRIPTION
Improper use of the word 'which'.  

BEFORE: The following example uses a Controller to add a method to the scope, which doubles a number:
AFTER: The following example uses a Controller to add a method, which doubles a number, to the scope:
