### PR TITLE
feat(ngModel, form): add 'reset all errors' functionality

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -7,6 +7,7 @@ var nullFormCtrl = {
   $$renameControl: nullFormRenameControl,
   $removeControl: noop,
   $setValidity: noop,
+  $resetErrors: noop,
   $setDirty: noop,
   $setPristine: noop,
   $setSubmitted: noop
@@ -183,6 +184,7 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
   addSetValidityMethod({
     ctrl: this,
     $element: element,
+    classCache: {},
     set: function(object, property, controller) {
       var list = object[property];
       if (!list) {
@@ -280,6 +282,28 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
     $animate.addClass(element, SUBMITTED_CLASS);
     form.$submitted = true;
     parentForm.$setSubmitted();
+  };
+
+  /**
+   * @ngdoc method
+   * @name form.FormController#$resetErrors
+   *
+   * @description
+   * Deletes all validities of a form control.
+   */
+  form.$resetErrors = function() {
+    var errors = copy(form.$error);
+    forEach(errors, function(fields, validityName) {
+      forEach(fields, function(field) {
+        field.$resetErrors();
+        cleanUp(form.$error, validityName);
+        $animate.removeClass(element, INVALID_CLASS + '-' + snake_case(validityName, '-'));
+      });
+    });
+
+    function cleanUp(object, name) {
+      delete object[name];
+    }
   };
 }
 

--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -1367,9 +1367,9 @@ function addResetErrorsMethod(context) {
   function resetErrors(controller) {
     var errors = copy(ctrl.$error);
     forEach(errors, function(value, validationName) {
-       unset(ctrl.$error, validationName, controller);
-       unset(ctrl.$$success, validationName, controller);
-       toggleValidationCss(validationName);
+      unset(ctrl.$error, validationName, controller);
+      unset(ctrl.$$success, validationName, controller);
+      toggleValidationCss(validationName);
     });
   }
 

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -1000,3 +1000,56 @@ describe('form animations', function() {
     assertValidAnimation($animate.queue[3], 'removeClass', 'ng-invalid-custom-error');
   }));
 });
+
+describe('reset errors', function() {
+
+  var doc, scope, form;
+  beforeEach(inject(function($rootScope, $compile, $rootElement, $animate) {
+    scope = $rootScope.$new();
+    doc = jqLite('<form name="myForm"><input name="alias" ng-model="name" type="text"/></form>');
+    $rootElement.append(doc);
+    $compile(doc)(scope);
+    $animate.queue = [];
+    form = scope.myForm;
+  }));
+
+  afterEach(function() {
+    dealoc(doc);
+  });
+
+  function expectClear() {
+    expect(form.$$success).toEqual({});
+    expect(form.$error).toEqual({});
+    expect(form.alias.$error).toEqual({});
+  }
+
+  function expectError() {
+    expect(form.$error.someError.length).toBe(1);
+    expect(form.alias.$error).toEqual({someError: true});
+    expect(form.$$success).toEqual({});
+  }
+
+  function expectTwoErrors() {
+    expect(form.$error.someError1.length).toBe(1);
+    expect(form.$error.someError2.length).toBe(1);
+    expect(form.alias.$error).toEqual({someError1: true, someError2: true});
+    expect(form.$$success).toEqual({});
+  }
+
+  it('should trigger an animation when invalid', function() {
+    expectClear();
+
+    form.alias.$setValidity('someError', false);
+    expectError();
+
+    form.$resetErrors();
+    expectClear();
+
+    form.alias.$setValidity('someError1', false);
+    form.alias.$setValidity('someError2', false);
+    expectTwoErrors();
+
+    form.$resetErrors();
+    expectClear();
+  });
+});

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -2263,3 +2263,51 @@ describe('ngModelOptions attributes', function() {
     expect($rootScope.changed).toHaveBeenCalledOnce();
   });
 });
+
+describe('reset errors', function() {
+
+    function assertValidAnimation(animation, event, classNameA, classNameB) {
+      expect(animation.event).toBe(event);
+      expect(animation.args[1]).toBe(classNameA);
+      if (classNameB) expect(animation.args[2]).toBe(classNameB);
+    }
+
+    var doc, input, scope, model;
+
+    beforeEach(inject(function($rootScope, $compile, $rootElement, $animate) {
+      scope = $rootScope.$new();
+      doc = jqLite('<form name="myForm">' +
+                   '  <input type="text" ng-model="input" name="myInput" />' +
+                   '</form>');
+      $rootElement.append(doc);
+      $compile(doc)(scope);
+      $animate.queue = [];
+
+      input = doc.find('input');
+      model = scope.myForm.myInput;
+    }));
+
+    afterEach(function() {
+      dealoc(input);
+    });
+
+    function expectErrors(errors) {
+      for (var index = 0; index < errors.length; index++) {
+        var currentError = errors[index];
+        expect(model.$error[currentError]).toBe(true);
+      }
+    }
+
+    function expectClear() {
+        expect(model.$error).toEqual({});
+    }
+
+    it('should clear all errors', inject(function($animate) {
+      model.$setValidity('required', false);
+      model.$setValidity('onlyNumbers', false);
+      expectErrors(['required', 'onlyNumbers']);
+      model.$resetErrors();
+      expectClear();
+
+    }));
+});


### PR DESCRIPTION
This PR contains new method for form and inputs (controllers) that allows to reset all errors added with $setValidity method.
Use case:
1. User fills form and click submit button. Application sends request to the server. Server validates this form somehow. Server decided that field 'A' is invalid.
2. Application calls $setValidity method for the input 'A' to mark it as ng-invalid-*
3. User changes field 'A' and click submit button.
4. At this time server decided that in this condition user specified wrong value in the field 'B'.
At this time, application can't reset fields marked with $setValidity all together.

That's the functionality I tried to cover with this PR.

plunker: http://plnkr.co/edit/aev16Y3cAxTljhctUDMI
