### PR TITLE
remove scare quotes and so-called

### DIFF
--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -55,11 +55,11 @@ Try out the Live Preview above, and then let's walk through the example and desc
 <img class="pull-right" style="padding-left: 3em; padding-bottom: 1em;" src="img/guide/concepts-databinding1.png">
 
 This looks like normal HTML, with some new markup. In Angular, a file like this is called a
-<a name="template">"{@link templates template}"</a>. When Angular starts your application, it parses and
-processes this new markup from the template using the so-called <a name="compiler">"{@link compiler compiler}"</a>.
-The loaded, transformed and rendered DOM is then called the <a name="view">"view"</a>.
+<a name="template">{@link templates template}</a>. When Angular starts your application, it parses and
+processes this new markup from the template using the <a name="compiler">{@link compiler compiler}</a>.
+The loaded, transformed and rendered DOM is then called the <a name="view">view</a>.
 
-The first kind of new markup are the so-called <a name="directive">"{@link directive directives}"</a>.
+The first kind of new markup are the <a name="directive">{@link directive directives}</a>.
 They apply special behavior to attributes or elements in the HTML. In the example above we use the
 {@link ng.directive:ngApp `ng-app`} attribute, which is linked to a directive that automatically
 initializes our application. Angular also defines a directive for the {@link ng.directive:input `input`}
@@ -75,16 +75,16 @@ stores/updates the value of the input field into/from a variable.
 
 The second kind of new markup are the double curly braces `{{ expression | filter }}`:
 When the compiler encounters this markup, it will replace it with the evaluated value of the markup.
-An <a name="expression">"{@link expression expression}"</a> in a template is a JavaScript-like code snippet that allows
+An <a name="expression">{@link expression expression}</a> in a template is a JavaScript-like code snippet that allows
 to read and write variables. Note that those variables are not global variables.
 Just like variables in a JavaScript function live in a scope,
-Angular provides a <a name="scope">"{@link scope scope}"</a> for the variables accessible to expressions.
-The values that are stored in variables on the scope are referred to as the <a name="model">"model"</a>
+Angular provides a <a name="scope">{@link scope scope}</a> for the variables accessible to expressions.
+The values that are stored in variables on the scope are referred to as the <a name="model">model</a>
 in the rest of the documentation.
 Applied to the example above, the markup directs Angular to "take the data we got from the input widgets
 and multiply them together".
 
-The example above also contains a <a name="filter">"{@link guide/filter filter}"</a>.
+The example above also contains a <a name="filter">{@link guide/filter filter}</a>.
 A filter formats the value of an expression for display to the user.
 In the example above, the filter {@link ng.filter:currency `currency`} formats a number
 into an output that looks like money.
@@ -92,7 +92,7 @@ into an output that looks like money.
 The important thing in the example is that Angular provides _live_ bindings:
 Whenever the input values change, the value of the expressions are automatically
 recalculated and the DOM is updated with their values.
-The concept behind this is <a name="databinding">"{@link databinding two-way data binding}"</a>.
+The concept behind this is <a name="databinding">{@link databinding two-way data binding}</a>.
 
 
 ## Adding UI logic: Controllers
@@ -150,7 +150,7 @@ different currencies and also pay the invoice.
 
 What changed?
 
-First, there is a new JavaScript file that contains a so-called <a name="controller">"{@link controller controller}"</a>.
+First, there is a new JavaScript file that contains a <a name="controller">{@link controller controller}</a>.
 More exactly, the file contains a constructor function that creates the actual controller instance.
 The purpose of controllers is to expose variables and functionality to expressions and directives.
 
@@ -182,8 +182,8 @@ The following graphic shows how everything works together after we introduced th
 ## View independent business logic: Services
 
 Right now, the `InvoiceController` contains all logic of our example. When the application grows it
-is a good practice to move view independent logic from the controller into a so called
-<a name="service">"{@link services service}"</a>, so it can be reused by other parts
+is a good practice to move view independent logic from the controller into a 
+<a name="service">{@link services service}</a>, so it can be reused by other parts
 of the application as well. Later on, we could also change that service to load the exchange rates
 from the web, e.g. by calling the Yahoo Finance API, without changing the controller.
 
@@ -255,15 +255,15 @@ We moved the `convertCurrency` function and the definition of the existing curre
 into the new file `finance2.js`. But how does the controller
 get a hold of the now separated function?
 
-This is where <a name="di">"{@link di Dependency Injection}"</a> comes into play.
+This is where <a name="di">{@link di Dependency Injection}</a> comes into play.
 Dependency Injection (DI) is a software design pattern that
 deals with how objects and functions get created and how they get a hold of their dependencies.
 Everything within Angular (directives, filters, controllers,
 services, ...) is created and wired using dependency injection. Within Angular,
-the DI container is called the <a name="injector">"{@link di injector}"</a>.
+the DI container is called the <a name="injector">{@link di injector}</a>.
 
 To use DI, there needs to be a place where all the things that should work together are registered.
-In Angular, this is the purpose of the so-called <a name="module">"{@link module modules}"</a>.
+In Angular, this is the purpose of the <a name="module">{@link module modules}</a>.
 When Angular starts, it will use the configuration of the module with the name defined by the `ng-app` directive,
 including the configuration of all modules that this module depends on.
 


### PR DESCRIPTION
So-called is defined as "commonly named" or "falsely or improperly so named". The scare quotes are definitely unnecessary. It makes it sound like things aren't actually called that, or it hints at sarcasm: "He's the so-called 'mayor', but he never does anything!" 

http://en.wikipedia.org/wiki/Scare_quotes
