### PR TITLE
fix($rootScope, ngRepeat): accomodate objects resulting from Object.create(null)

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -363,7 +363,7 @@ var ngRepeatDirective = ['$parse', '$animate', function($parse, $animate) {
             // if object, extract keys, in enumeration order, unsorted
             collectionKeys = [];
             for (var itemKey in collection) {
-              if (collection.hasOwnProperty(itemKey) && itemKey.charAt(0) !== '$') {
+              if (hasOwnProperty.call(collection, itemKey) && itemKey.charAt(0) !== '$') {
                 collectionKeys.push(itemKey);
               }
             }

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -603,7 +603,7 @@ function $RootScopeProvider() {
             // copy the items to oldValue and look for changes.
             newLength = 0;
             for (key in newValue) {
-              if (newValue.hasOwnProperty(key)) {
+              if (hasOwnProperty.call(newValue, key)) {
                 newLength++;
                 newItem = newValue[key];
                 oldItem = oldValue[key];
@@ -625,7 +625,7 @@ function $RootScopeProvider() {
               // we used to have more keys, need to find them and destroy them.
               changeDetected++;
               for (key in oldValue) {
-                if (!newValue.hasOwnProperty(key)) {
+                if (!hasOwnProperty.call(newValue, key)) {
                   oldLength--;
                   delete oldValue[key];
                 }

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -166,6 +166,18 @@ describe('ngRepeat', function() {
     expect(element.text()).toEqual('age:20|wealth:20|prodname:Bingo|dogname:Bingo|codename:20|');
   });
 
+  it('should iterate over an object/map not inheriting from Object.prototype', function() {
+    element = $compile(
+      '<ul>' +
+        '<li ng-repeat="(  key ,  value  ) in items">{{key}}:{{value}}|</li>' +
+      '</ul>')(scope);
+    scope.items = Object.create(null);
+    scope.items.go = 'cougs';
+    scope.items.viva = 'pumas';
+    scope.$digest();
+    expect(element.text()).toEqual('go:cougs|viva:pumas|');
+  });
+
   describe('track by', function() {
     it('should track using expression function', function() {
       element = $compile(

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -829,6 +829,14 @@ describe('Scope', function() {
           }).not.toThrow();
         });
 
+        it('should not throw an error because the object does not inherit from Object.prototype', function() {
+          $rootScope.obj = Object.create(null);
+          $rootScope.obj.a = 'B';
+          expect(function() {
+            $rootScope.$digest();
+          }).not.toThrow();
+        });
+
       });
     });
 


### PR DESCRIPTION
Use Object.hasOwnProperty.call when iterating over properties of user-supplied objects.
Allow for objects not inheriting from Object.prototype.
