### PR TITLE
chore(ci): update to use the latest sauce connect (4.3 to 4.3.6)

### DIFF
--- a/lib/saucelabs/start_tunnel.sh
+++ b/lib/saucelabs/start_tunnel.sh
@@ -12,9 +12,9 @@ set -e
 # before_script:
 #   - curl https://gist.github.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash
 
-CONNECT_URL="https://saucelabs.com/downloads/sc-4.3-linux.tar.gz"
+CONNECT_URL="https://saucelabs.com/downloads/sc-4.3.6-linux.tar.gz"
 CONNECT_DIR="/tmp/sauce-connect-$RANDOM"
-CONNECT_DOWNLOAD="sc-4.3-linux.tar.gz"
+CONNECT_DOWNLOAD="sc-4.3.6-linux.tar.gz"
 
 CONNECT_LOG="$LOGS_DIR/sauce-connect"
 CONNECT_STDOUT="$LOGS_DIR/sauce-connect.stdout"


### PR DESCRIPTION
I'm hoping that this will address some of the 'Bad Gateway' issues that we've been seeing with sauce labs.
