### PR TITLE
Fixing ng-jq issue with getNgAttribute

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -943,17 +943,13 @@ var csp = function() {
 var jq = function() {
   if (isDefined(jq.name_)) return jq.name_;
   var el;
-  var i, ii = ngAttrPrefixes.length, prefix;
+  var i, ii = ngAttrPrefixes.length, prefix, name;
   for (i = 0; i < ii; ++i) {
     prefix = ngAttrPrefixes[i];
     if (el = document.querySelector('[' + prefix.replace(':', '\\:') + 'jq]')) {
+      name = el.getAttribute(prefix + 'jq');
       break;
     }
-  }
-
-  var name;
-  if (el) {
-    name = el.getAttribute(prefix + 'jq');
   }
 
   return (jq.name_ = name);
@@ -1196,10 +1192,9 @@ var ngAttrPrefixes = ['ng-', 'data-ng-', 'ng:', 'x-ng-'];
 
 function getNgAttribute(element, ngAttr) {
   var attr, i, ii = ngAttrPrefixes.length;
-  element = jqLite(element);
   for (i = 0; i < ii; ++i) {
     attr = ngAttrPrefixes[i] + ngAttr;
-    if (isString(attr = element.attr(attr))) {
+    if (isString(attr = element.getAttribute(attr))) {
       return attr;
     }
   }

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -941,22 +941,22 @@ var csp = function() {
  ```
  */
 var jq = function() {
-	if (isDefined(jq.name_)) return jq.name_;
-	var el;
-	var i, ii = ngAttrPrefixes.length, prefix;
-	for (i = 0; i < ii; ++i) {
-		prefix = ngAttrPrefixes[i];
-		if (el = document.querySelector('[' + prefix.replace(':', '\\:') + 'jq]')) {
-			break;
-		}
-	}
+  if (isDefined(jq.name_)) return jq.name_;
+  var el;
+  var i, ii = ngAttrPrefixes.length, prefix;
+  for (i = 0; i < ii; ++i) {
+    prefix = ngAttrPrefixes[i];
+    if (el = document.querySelector('[' + prefix.replace(':', '\\:') + 'jq]')) {
+      break;
+    }
+  }
 
-	var name;
-	if (el) {
-		name = el.getAttribute(prefix + 'jq');
-	}
+  var name;
+  if (el) {
+    name = el.getAttribute(prefix + 'jq');
+  }
 
-	return (jq.name_ = name);
+  return (jq.name_ = name);
 };
 
 function concat(array1, array2, index) {

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -941,21 +941,22 @@ var csp = function() {
  ```
  */
 var jq = function() {
-  if (isDefined(jq.name_)) return jq.name_;
-  var el;
-  var i, ii = ngAttrPrefixes.length;
-  for (i = 0; i < ii; ++i) {
-    if (el = document.querySelector('[' + ngAttrPrefixes[i].replace(':', '\\:') + 'jq]')) {
-      break;
-    }
-  }
+	if (isDefined(jq.name_)) return jq.name_;
+	var el;
+	var i, ii = ngAttrPrefixes.length, prefix;
+	for (i = 0; i < ii; ++i) {
+		prefix = ngAttrPrefixes[i];
+		if (el = document.querySelector('[' + prefix.replace(':', '\\:') + 'jq]')) {
+			break;
+		}
+	}
 
-  var name;
-  if (el) {
-    name = getNgAttribute(el, "jq");
-  }
+	var name;
+	if (el) {
+		name = el.getAttribute(prefix + 'jq');
+	}
 
-  return (jq.name_ = name);
+	return (jq.name_ = name);
 };
 
 function concat(array1, array2, index) {


### PR DESCRIPTION
The unit tests wasn't able to catch this unless it's on a 'fresh' angular page with ng-jq already added before angular bootstrapping. I've removed the need for jq() to rely on getNgAttribute and instead using element.getAttribute function with the found prefix.

Could use some direction on how to test ng-jq more thoroughly so this doesn't happen again in the future.

This fixes issue #11016.
