### PR TITLE
fix(syntax): `.finally` syntax error in Android 2.3

### DIFF
--- a/src/ng/templateRequest.js
+++ b/src/ng/templateRequest.js
@@ -40,7 +40,7 @@ function $TemplateRequestProvider() {
       };
 
       return $http.get(tpl, httpOptions)
-        .finally(function() {
+        ['finally'](function() {
           handleRequestFn.totalPendingRequests--;
         })
         .then(function(response) {


### PR DESCRIPTION
Android 2.3 throws an `Uncaught SyntaxError: Unexpected token finally`
pointing at this line. Change `.finally` to bracket notation.
