### PR TITLE
feat(annotate): support injection of `@` function parameters in CoffeeScript 1.9

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -64,7 +64,7 @@
 
 var FN_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
 var FN_ARG_SPLIT = /,/;
-var FN_ARG = /^\s*(_?)(\S+?)\1\s*$/;
+var FN_ARG = /^\s*(?:_at_)?(_?)(\S+?)\1\s*$/;
 var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 var $injectorMinErr = minErr('$injector');
 

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -204,6 +204,11 @@ describe('injector', function() {
       expect(annotate(beforeEachFn)).toEqual(['foo']);
     });
 
+    it('should strip leading "_at_" from arg name during inference (CoffeeScript 1.9)', function() {
+      function beforeEachFn(_at_foo) { /* foo = _foo_ */ }
+      expect(annotate(beforeEachFn)).toEqual(['foo']);
+    });
+
     it('should not strip service names with a single underscore', function() {
       function beforeEachFn(_) { /* _ = _ */ }
       expect(annotate(beforeEachFn)).toEqual(['_']);


### PR DESCRIPTION
With the release of CoffeeScript 1.9, they changed the strategy for the
generation of internal compiler variable names. This means using
function parameters prefixed with an `@` no longer are injected
properly due to CoffeeScript converting them to an `_at_`. (ie. `@myVal`
becomes `_at_myVal`). This commit adds support to the Angular
annotator for this.
