### PR TITLE
fix(form): allow dynamic form names which initially evaluate to blank

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -454,9 +454,11 @@ var formDirectiveFactory = function(isNgForm) {
       name: 'form',
       restrict: isNgForm ? 'EAC' : 'E',
       controller: FormController,
-      compile: function ngFormCompile(formElement) {
+      compile: function ngFormCompile(formElement, attr) {
         // Setup initial state of the control
         formElement.addClass(PRISTINE_CLASS).addClass(VALID_CLASS);
+
+        var nameAttr = attr.name ? 'name' : (isNgForm && attr.ngForm ? 'ngForm' : false);
 
         return {
           pre: function ngFormPreLink(scope, formElement, attr, controller) {
@@ -488,23 +490,21 @@ var formDirectiveFactory = function(isNgForm) {
               });
             }
 
-            var parentFormCtrl = controller.$$parentForm,
-                alias = controller.$name;
+            var parentFormCtrl = controller.$$parentForm;
 
-            if (alias) {
-              setter(scope, alias, controller, alias);
-              attr.$observe(attr.name ? 'name' : 'ngForm', function(newValue) {
-                if (alias === newValue) return;
-                setter(scope, alias, undefined, alias);
-                alias = newValue;
-                setter(scope, alias, controller, alias);
-                parentFormCtrl.$$renameControl(controller, alias);
+            if (nameAttr) {
+              setter(scope, controller.$name, controller, controller.$name);
+              attr.$observe(nameAttr, function(newValue) {
+                if (controller.$name === newValue) return;
+                setter(scope, controller.$name, undefined, controller.$name);
+                parentFormCtrl.$$renameControl(controller, newValue);
+                setter(scope, controller.$name, controller, controller.$name);
               });
             }
             formElement.on('$destroy', function() {
               parentFormCtrl.$removeControl(controller);
-              if (alias) {
-                setter(scope, alias, undefined, alias);
+              if (nameAttr) {
+                setter(scope, attr[nameAttr], undefined, controller.$name);
               }
               extend(controller, nullFormCtrl); //stop propagating child destruction handlers upwards
             });

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -881,20 +881,38 @@ describe('form', function() {
 
   it('should rename forms with no parent when interpolated name changes', function() {
     var element = $compile('<form name="name{{nameID}}"></form>')(scope);
-    var element2 = $compile('<div ng-form="name{{nameID}}"></div>')(scope);
+    var element2 = $compile('<div ng-form="ngform{{nameID}}"></div>')(scope);
     scope.nameID = "A";
     scope.$digest();
     var form = element.controller('form');
     var form2 = element2.controller('form');
+    expect(scope.nameA).toBe(form);
+    expect(scope.ngformA).toBe(form2);
     expect(form.$name).toBe('nameA');
-    expect(form2.$name).toBe('nameA');
+    expect(form2.$name).toBe('ngformA');
 
     scope.nameID = "B";
     scope.$digest();
+    expect(scope.nameA).toBeUndefined();
+    expect(scope.ngformA).toBeUndefined();
+    expect(scope.nameB).toBe(form);
+    expect(scope.ngformB).toBe(form2);
     expect(form.$name).toBe('nameB');
-    expect(form2.$name).toBe('nameB');
+    expect(form2.$name).toBe('ngformB');
   });
 
+  it('should rename forms with an initially blank name', function() {
+    var element = $compile('<form name="{{name}}"></form>')(scope);
+    scope.$digest();
+    var form = element.controller('form');
+    expect(scope['']).toBe(form);
+    expect(form.$name).toBe('');
+    scope.name = 'foo';
+    scope.$digest();
+    expect(scope.foo).toBe(form);
+    expect(form.$name).toBe('foo');
+    expect(scope.foo).toBe(form);
+  });
 
   describe('$setSubmitted', function() {
     beforeEach(function() {


### PR DESCRIPTION
Previously the form name watching was initialized based on the initial name _value_ instead of the attribute being set.
