### PR TITLE
fix($http): promise chain for helper methods

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -807,17 +807,15 @@ function $HttpProvider() {
       }
 
       promise.success = function(fn) {
-        promise.then(function(response) {
-          fn(response.data, response.status, response.headers, config);
+        return promise.then(function(response) {
+          return fn(response.data, response.status, response.headers, config);
         });
-        return promise;
       };
 
       promise.error = function(fn) {
-        promise.then(null, function(response) {
-          fn(response.data, response.status, response.headers, config);
+        return promise.then(null, function(response) {
+          return fn(response.data, response.status, response.headers, config);
         });
-        return promise;
       };
 
       return promise;


### PR DESCRIPTION
can has less promise chain breaking

``` javascript
angular.module('app', [])
.factory('Auth', function($http) {
  return {
    login: function(data) {
      return $http.post('/signup', data)
        .success(function(data) {
          return data;
        })
        .error(function(err) {
          return $q.reject(err);
        });
    } // end login
  }; // end module
}) // end factory
.controller('MainCtrl', function($scope, $state, Auth) {

  $scope.login = function(user) {
    Auth.login(user).then(function(data) {
      $state.go('dashboard');
    })
    .catch(function(err) {
      alert(err);
    });
  }; // end login
}); // end ctrl
```

since the promise chain is broken when using `Auth.login().then(otherStuff).catch(errorStuff)` you get the result from the http and not the error from `.error`.
