### PR TITLE
docs($sce): .trustAs() contexts list contains typo

### DIFF
--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -797,7 +797,7 @@ function $SceProvider() {
      * escaping.
      *
      * @param {string} type The kind of context in which this value is safe for use.  e.g. url,
-     *   resource_url, html, js and css.
+     *   resourceUrl, html, js and css.
      * @param {*} value The value that that should be considered trusted/safe.
      * @returns {*} A value that can be used to stand in for the provided `value` in places
      * where Angular expects a $sce.trustAs() return value.


### PR DESCRIPTION
`resource_url` --> `resourceUrl`
Documentation for docs($secDelegate) is correct.
