### PR TITLE
ngBind directive and array

### DIFF
--- a/src/ng/directive/ngBind.js
+++ b/src/ng/directive/ngBind.js
@@ -61,7 +61,7 @@ var ngBindDirective = ['$compile', function($compile) {
         element = element[0];
         scope.$watch(attr.ngBind, function ngBindWatchAction(value) {
           element.textContent = value === undefined ? '' : value;
-        });
+        }, true);
       };
     }
   };


### PR DESCRIPTION
Hello,
I have an issue with the ngBind directive.
If I try to pass an array or a function that return an array angular give me this error:

> Error: 10 $digest() iterations reached. Aborting!
> Watchers fired in the last 5 iterations: [["[\"1\",\"2\",\"3\"]; newVal: [\"1\",\"2\",\"3\"]; oldVal: [\"1\",\"2\",\"3\"]"],["[\"1\",\"2\",\"3\"]; newVal: [\"1\",\"2\",\"3\"]; oldVal: [\"1\",\"2\",\"3\"]"],["[\"1\",\"2\",\"3\"]; newVal: [\"1\",\"2\",\"3\"]; oldVal: [\"1\",\"2\",\"3\"]"],["[\"1\",\"2\",\"3\"]; newVal: [\"1\",\"2\",\"3\"]; oldVal: [\"1\",\"2\",\"3\"]"],["[\"1\",\"2\",\"3\"]; newVal: [\"1\",\"2\",\"3\"]; oldVal: [\"1\",\"2\",\"3\"]"]]
>     at Error (native)
>     at Object.$get.e.$digest (http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.0.3/angular.min.js:85:217)
>     at Object.$get.e.$apply (http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.0.3/angular.min.js:86:469)
>     at http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.0.3/angular.min.js:15:396
>     at Object.d [as invoke](http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.0.3/angular.min.js:26:401)
>     at pb (http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.0.3/angular.min.js:15:317)
>     at jc (http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.0.3/angular.min.js:15:178)
>     at http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.0.3/angular.min.js:159:424
>     at HTMLDocument.a (http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.0.3/angular.min.js:114:500)
>     at http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.0.3/angular.min.js:22:462
> 2015-02-20 14:17:54.409angular.min.js:85 Uncaught Error: 10 $digest() iterations reached. Aborting!
> Watchers fired in the last 5 iterations: [["[\"1\",\"2\",\"3\"]; newVal: [\"1\",\"2\",\"3\"]; oldVal: [\"1\",\"2\",\"3\"]"],["[\"1\",\"2\",\"3\"]; newVal: [\"1\",\"2\",\"3\"]; oldVal: [\"1\",\"2\",\"3\"]"],["[\"1\",\"2\",\"3\"]; newVal: [\"1\",\"2\",\"3\"]; oldVal: [\"1\",\"2\",\"3\"]"],["[\"1\",\"2\",\"3\"]; newVal: [\"1\",\"2\",\"3\"]; oldVal: [\"1\",\"2\",\"3\"]"],["[\"1\",\"2\",\"3\"]; newVal: [\"1\",\"2\",\"3\"]; oldVal: [\"1\",\"2\",\"3\"]"]]

I think that the problem is that the watcher un nbBind directive don't compare the result of the expression the right way because of the third argument:

> When objectEquality == true, inequality of the watchExpression is determined according to the angular.equals function. To save the value of the object for later comparison, the angular.copy function is used. This therefore means that watching complex objects will have adverse memory and performance implications.

Maybe that set it to true all the time is not a good solution for that problem (memory and so perfomance), but I think add a strict argument to the directive (or an orther ngBindStrict directive) may be usefull ?

I put the case in a jsfiddle here -> http://jsfiddle.net/rk5g8gmc/17/

thanks !
