### PR TITLE
refactor(ngSwitch):delete default directive restriction

### DIFF
--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -130,7 +130,6 @@
  */
 var ngSwitchDirective = ['$animate', function($animate) {
   return {
-    restrict: 'EA',
     require: 'ngSwitch',
 
     // asks for $scope to fool the BC controller module


### PR DESCRIPTION
delete the directive restriction to avoid code duplication since the default is already applied

Closes #10987
