### PR TITLE
docs(versioning): modify versioning for < v1.0.1

### DIFF
--- a/docs/app/src/versions.js
+++ b/docs/app/src/versions.js
@@ -21,11 +21,13 @@ angular.module('versions', [])
   };
 
   $scope.jumpToDocsVersion = function(version) {
-    var currentPagePath = $location.path().replace(/\/$/, '');
-
-    // TODO: We need to do some munging of the path for different versions of the API...
-
-
-    $window.location = version.docsUrl + currentPagePath;
+    var currentPagePath = $location.path().replace(/\/$/, ''),
+        url = '';
+    if (version.isOldDocsUrl) {
+      url = version.docsUrl;
+    }else{
+      url = version.docsUrl + currentPagePath;
+    }
+    $window.location = url;
   };
 }]);

--- a/lib/versions/version-info.js
+++ b/lib/versions/version-info.js
@@ -110,10 +110,16 @@ var getPreviousVersions =  function() {
       })
       .filter()
       .map(function(version) {
+        // angular.js didn't follow semantic version until 1.20rc1
+        if ((version.major === 1 && version.minor === 0 && version.prerelease.length > 0) || (version.major === 1 && version.minor === 2 && version.prerelease[0] === 'rc1')) {
+          version.version = [version.major, version.minor, version.patch].join('.') + version.prerelease.join('');
+          version.raw = 'v' + version.version;
+        }
         version.docsUrl = 'http://code.angularjs.org/' + version.version + '/docs';
         // Versions before 1.0.2 had a different docs folder name
-        if (version.major < 1 || (version.major === 1 && version.minor === 0 && version.dot < 2)) {
+        if (version.major < 1 || (version.major === 1 && version.minor === 0 && version.patch < 2)) {
           version.docsUrl += '-' + version.version;
+          version.isOldDocsUrl = true;
         }
         return version;
       })


### PR DESCRIPTION
less than angular v1.0.2 dose not support Semantic Versioning. so You can not access api docs because of difference of file path. fix it.

If merge this PR You can access less than v1.0.2 api docs from versioning select menu on api doc.
