### PR TITLE
chore(grunt): use path.normalize in grunt shell:npm-install

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -282,7 +282,7 @@ module.exports = function(grunt) {
 
     shell: {
       "npm-install": {
-        command: 'scripts/npm/install-dependencies.sh'
+        command: path.normalize('scripts/npm/install-dependencies.sh')
       },
 
       "promises-aplus-tests": {


### PR DESCRIPTION
This fixes the command on Windows clients.

cc @IgorMinar 

Also needed for 1.3.x
