### PR TITLE
chore(grunt): use rimraf to remove node_modules on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "semver": "~4.0.3",
     "shelljs": "~0.3.0",
     "sorted-object": "^1.0.0",
-    "stringmap": "^0.2.2"
+    "stringmap": "^0.2.2",
+    "rimraf": "~2.2.8"
   },
   "licenses": [
     {

--- a/scripts/npm/call-rimraf.js
+++ b/scripts/npm/call-rimraf.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+var rimraf = require('rimraf');
+
+if (process.platform === "win32") {
+  rimraf('node_modules', function() {
+    console.log('cleaned node_modules using rimraf');
+    process.exit(0);
+  });
+} else {
+  process.exit(1);
+}

--- a/scripts/npm/install-dependencies.sh
+++ b/scripts/npm/install-dependencies.sh
@@ -9,7 +9,10 @@ if diff -q $SHRINKWRAP_FILE $SHRINKWRAP_CACHED_FILE; then
   echo 'No shrinkwrap changes detected. npm install will be skipped...';
 else
   echo 'Blowing away node_modules and reinstalling npm dependencies...'
-  rm -rf node_modules
+  if !(node 'scripts/npm/call-rimraf.js'); then
+    rm -rf node_modules;
+    echo 'cleaned node_modules using rm -rf';
+  fi
   npm install
   cp $SHRINKWRAP_FILE $SHRINKWRAP_CACHED_FILE
   echo 'npm install successful!'


### PR DESCRIPTION
This works very well.
The way it's called however is quite obtuse at the moment, so I'm happy with any suggestions.
