### PR TITLE
fix(select): Select option with ngOptions when label equals $viewValue

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -205,7 +205,8 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
           optionsMap = {},
           ngModelCtrl = nullModelCtrl,
           nullOption,
-          unknownOption;
+          unknownOption,
+          optionsExp = $attrs.ngOptions;
 
 
       self.databound = $attrs.ngModel;
@@ -221,8 +222,8 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
       self.addOption = function(value, element) {
         assertNotHasOwnProperty(value, '"option value"');
         optionsMap[value] = true;
-
-        if (ngModelCtrl.$viewValue == value) {
+        
+        if (isUndefined(optionsExp) && ngModelCtrl.$viewValue == value) {
           $element.val(value);
           if (unknownOption.parent()) unknownOption.remove();
         }
@@ -238,7 +239,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
       self.removeOption = function(value) {
         if (this.hasOption(value)) {
           delete optionsMap[value];
-          if (ngModelCtrl.$viewValue === value) {
+          if (isUndefined(optionsExp) && ngModelCtrl.$viewValue === value) {
             this.renderUnknownOption(value);
           }
         }

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -222,7 +222,7 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
       self.addOption = function(value, element) {
         assertNotHasOwnProperty(value, '"option value"');
         optionsMap[value] = true;
-        
+
         if (isUndefined(optionsExp) && ngModelCtrl.$viewValue == value) {
           $element.val(value);
           if (unknownOption.parent()) unknownOption.remove();

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1887,8 +1887,8 @@ describe('select', function() {
         expect(option.val()).toBe('?');
         expect(option.text()).toBe('');
       });
-      
-      it('should select the correct option when label equals $viewValue', function(){
+
+      it('should select the correct option when label equals $viewValue', function() {
         scope.numbersArray = ["Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"];
         scope.values= {};
         scope.selected='Four';
@@ -1896,9 +1896,9 @@ describe('select', function() {
           'ng-model': 'selected',
           'ng-options': 'option.value as option.value for option in values'
         });
-        
-        scope.$apply(function(){
-          scope.values=scope.numbersArray.map(function (value, index) {
+
+        scope.$apply(function() {
+          scope.values=scope.numbersArray.map(function(value, index) {
             return {
               id: index,
               value: value
@@ -1909,7 +1909,7 @@ describe('select', function() {
       });
     });
 
-    
+
 
     describe('blank option', function() {
 

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1888,7 +1888,7 @@ describe('select', function() {
         expect(option.text()).toBe('');
       });
       
-      iit('should select the correct option when label equals $viewValue', function(){
+      it('should select the correct option when label equals $viewValue', function(){
         scope.numbersArray = ["Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"];
         scope.values= {};
         scope.selected='Four'

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1891,7 +1891,7 @@ describe('select', function() {
       it('should select the correct option when label equals $viewValue', function(){
         scope.numbersArray = ["Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"];
         scope.values= {};
-        scope.selected='Four'
+        scope.selected='Four';
         createSelect({
           'ng-model': 'selected',
           'ng-options': 'option.value as option.value for option in values'

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1887,8 +1887,29 @@ describe('select', function() {
         expect(option.val()).toBe('?');
         expect(option.text()).toBe('');
       });
+      
+      iit('should select the correct option when label equals $viewValue', function(){
+        scope.numbersArray = ["Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"];
+        scope.values= {};
+        scope.selected='Four'
+        createSelect({
+          'ng-model': 'selected',
+          'ng-options': 'option.value as option.value for option in values'
+        });
+        
+        scope.$apply(function(){
+          scope.values=scope.numbersArray.map(function (value, index) {
+            return {
+              id: index,
+              value: value
+            };
+          });
+        });
+        expect(element[0].selectedIndex).toBe(4);
+      });
     });
 
+    
 
     describe('blank option', function() {
 


### PR DESCRIPTION
Fix selectController when using ngOptions and the label equals the $viewValue of the ngModel.
Otherwise, when the options are loaded, selectController set the value of the select to a 
non existing value

Fixes #11170
