### PR TITLE
docs(guide/Directives): mentioned shorthand for "return function()"

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -867,6 +867,7 @@ element?
   </file>
 </example>
 
+Note: Returning a `function(scope, element, attr){...}` is just a shorthand for `{link: function(scope, element, attr){...}}`.
 
 
 ### Creating Directives that Communicate


### PR DESCRIPTION
The shorthand is little confusing, added clarification.
