### PR TITLE
Fix ngjq

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -943,16 +943,13 @@ var csp = function() {
 var jq = function() {
   if (isDefined(jq.name_)) return jq.name_;
   var el;
-  var i, ii = ngAttrPrefixes.length;
+  var i, ii = ngAttrPrefixes.length, prefix, name;
   for (i = 0; i < ii; ++i) {
-    if (el = document.querySelector('[' + ngAttrPrefixes[i].replace(':', '\\:') + 'jq]')) {
+    prefix = ngAttrPrefixes[i];
+    if (el = document.querySelector('[' + prefix.replace(':', '\\:') + 'jq]')) {
+      name = el.getAttribute(prefix + 'jq');
       break;
     }
-  }
-
-  var name;
-  if (el) {
-    name = getNgAttribute(el, "jq");
   }
 
   return (jq.name_ = name);
@@ -1195,10 +1192,9 @@ var ngAttrPrefixes = ['ng-', 'data-ng-', 'ng:', 'x-ng-'];
 
 function getNgAttribute(element, ngAttr) {
   var attr, i, ii = ngAttrPrefixes.length;
-  element = jqLite(element);
   for (i = 0; i < ii; ++i) {
     attr = ngAttrPrefixes[i] + ngAttr;
-    if (isString(attr = element.attr(attr))) {
+    if (isString(attr = element.getAttribute(attr))) {
       return attr;
     }
   }

--- a/test/e2e/fixtures/ngJq/index.html
+++ b/test/e2e/fixtures/ngJq/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html ng-app="test" ng-jq>
+  <body>
+    {{jqueryVersion}}
+
+    <script src="../../../../bower_components/jquery/dist/jquery.js"></script>
+    <script src="angular.js"></script>
+    <script type="text/javascript" src="script.js"></script>
+  </body>
+</html>

--- a/test/e2e/fixtures/ngJq/script.js
+++ b/test/e2e/fixtures/ngJq/script.js
@@ -1,0 +1,6 @@
+'use strict';
+
+angular.module('test', [])
+  .run(function($rootScope) {
+    $rootScope.jqueryVersion = window.angular.element().jquery || 'jqLite';
+  });

--- a/test/e2e/fixtures/ngJqJquery/index.html
+++ b/test/e2e/fixtures/ngJqJquery/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html ng-app="test" ng-jq="jQuery_2_1_0">
+  <body>
+      {{jqueryVersion}}
+
+      <script src="../../../../bower_components/jquery/dist/jquery.js"></script>
+      <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
+      <script>
+        var jQuery_2_1_0 = jQuery.noConflict();
+      </script>
+      <script src="angular.js"></script>
+      <script type="text/javascript" src="script.js"></script>
+    </body>
+</html>

--- a/test/e2e/fixtures/ngJqJquery/script.js
+++ b/test/e2e/fixtures/ngJqJquery/script.js
@@ -1,0 +1,6 @@
+'use strict';
+
+angular.module('test', [])
+  .run(function($rootScope) {
+    $rootScope.jqueryVersion = window.angular.element().jquery || 'jqLite';
+  });

--- a/test/e2e/tests/ngJqSpec.js
+++ b/test/e2e/tests/ngJqSpec.js
@@ -1,0 +1,12 @@
+describe('Customizing the jqlite / jquery version', function() {
+
+  it('should be able to force jqlite', function() {
+    loadFixture("ngJq").andWaitForAngular();
+    expect(element(by.binding('jqueryVersion')).getText()).toBe('jqLite');
+  });
+
+  it('should be able to use a specific version jQuery', function() {
+    loadFixture("ngJqJquery").andWaitForAngular();
+    expect(element(by.binding('jqueryVersion')).getText()).toBe('2.1.0');
+  });
+});

--- a/test/e2e/tools/util.js
+++ b/test/e2e/tools/util.js
@@ -24,6 +24,10 @@ function testExists(testname) {
 }
 
 function rewriteTestFile(testname, testfile) {
+  if (testfile.indexOf('http') === 0) {
+    return testfile;
+  }
+
   var i = 0;
   while (testfile[i] === '/') ++i;
   testfile = testfile.slice(i);


### PR DESCRIPTION
@mboudreau This is a wip for the e2e tests. You can play around with it. (use `grunt test:protractor`) You can als comment out the other test paths in `protractor.conf.js`, so only the e2e folders get run:

```
// 'build/docs/ptore2e/**/*.js',
// 'docs/app/e2e/**/*.scenario.js'
```

The problem is currently that we don't have a reliable method of detecting what is loaded, because `jq` is private. We might have to expose it. Currently we can only test that it doesn't break.
