### PR TITLE
docs(ngMessages): ng-messages-include defined on ng-messages element

### DIFF
--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -80,9 +80,7 @@ var jqLite = angular.element;
  *   <div ng-message="minlength">This field is too short</div>
  * </script>
  *
- * <div ng-messages="myForm.myField.$error">
- *   <div ng-messages-include="error-messages"></div>
- * </div>
+ * <div ng-messages="myForm.myField.$error" ng-messages-include="error-messages"></div>
  * ```
  *
  * However, including generic messages may not be useful enough to match all input fields, therefore,
@@ -104,17 +102,14 @@ var jqLite = angular.element;
  *          minlength="5"
  *          required />
  *
- *   <!-- any ng-message elements that appear BEFORE the ng-messages-include will
+ *   <!-- any ng-message elements that appear INSIDE the ng-messages-include will
  *        override the messages present in the ng-messages-include template -->
- *   <div ng-messages="myForm.myEmail.$error">
+ *   <div ng-messages="myForm.myEmail.$error" ng-messages-include="error-messages">
  *     <!-- this required message has overridden the template message -->
  *     <div ng-message="required">You did not enter your email address</div>
  *
  *     <!-- this is a brand new message and will appear last in the prioritization -->
  *     <div ng-message="email">Your email address is invalid</div>
- *
- *     <!-- and here are the generic error messages -->
- *     <div ng-messages-include="error-messages"></div>
  *   </div>
  * </form>
  * ```
@@ -481,9 +476,7 @@ angular.module('ngMessages', [])
     * @usage
     * ```html
     * <!-- using attribute directives -->
-    * <ANY ng-messages="expression">
-    *   <ANY ng-messages-include="remoteTplString">...</ANY>
-    * </ANY>
+    * <ANY ng-messages="expression" ng-messages-include="remoteTplString">...</ANY>
     *
     * <!-- or by using element directives -->
     * <ng-messages for="expression">


### PR DESCRIPTION
I was having issues implementing `ngMessages` together with `ngMessagesInclude` where the template I was trying to include simply wouldn't show up. This was until I realized that, contrary to how the docs describe it, Angular expected ng-messages-include to be defined on the same element as ng-messages (which I later discovered was how eg. [this tutorial](http://www.yearofmoo.com/2014/05/how-to-use-ngmessages-in-angularjs.html) described the implementation of ngMessages).
