### PR TITLE
docs(ngDisabled): Clarify "incorrect" example

### DIFF
--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -170,6 +170,7 @@
  * <div ng-init="isDisabled = false">
  *  <button disabled="{{isDisabled}}">Disabled</button>
  * </div>
+ * <!-- See below for an example of ng-disabled being used correctly -->
  * ```
  *
  * This is because the HTML specification does not require browsers to preserve the values of


### PR DESCRIPTION
Add obvious label to example of incorrect usage. To a user scanning the docs (ie. me) it's easy to miss the fact that this top example doesn't actually work.
