### PR TITLE
fix(ngMessages): ensure that multi-level transclusion works with ngMessagesInclude

### DIFF
--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -500,27 +500,21 @@ angular.module('ngMessages', [])
 
      return {
        restrict: 'AE',
-       require: '^^ngMessages',
-       compile: function(element, attrs) {
-         var comment = jqLite($document[0].createComment(' ngMessagesInclude: '));
-         element.after(comment);
+       require: '^^ngMessages', // we only require this for validation sake
+       link: function($scope, element, attrs) {
+         var src = attrs.ngMessagesInclude || attrs.src;
+         $templateRequest(src).then(function(html) {
+           $compile(html)($scope, function(contents) {
+             element.after(contents);
 
-         return function($scope, $element, attrs, ngMessagesCtrl) {
-           // we're removing this since we only need access to the newly
-           // created comment node as an anchor.
-           element.remove();
+             // the anchor is placed for debugging purposes
+             var anchor = jqLite($document[0].createComment(' ngMessagesInclude: ' + src + ' '));
+             element.after(anchor);
 
-           $templateRequest(attrs.ngMessagesInclude || attrs.src).then(function(html) {
-             var elements = jqLite('<div></div>').html(html).contents();
-             var cursor = comment;
-             forEach(elements, function(elm) {
-               elm = jqLite(elm);
-               cursor.after(elm);
-               cursor = elm;
-             });
-             $compile(elements)($scope);
+             // we don't want to pollute the DOM anymore by keeping an empty directive element
+             element.remove();
            });
-         };
+         });
        }
      };
    }])


### PR DESCRIPTION
ngRepeat and any other directives that alter the DOM structure using
transclusion may cause ngMessagesInclude to behave in an unpredictable
manner. This fix ensures that the element containing the ngMessagesInclude
directive will stay in the DOM to avoid these issues.

Closes #11196
