### PR TITLE
fix(Angular): properly compare RegExp with other objects for equality

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -860,10 +860,11 @@ function equals(o1, o2) {
       } else if (isDate(o1)) {
         if (!isDate(o2)) return false;
         return equals(o1.getTime(), o2.getTime());
-      } else if (isRegExp(o1) && isRegExp(o2)) {
-        return o1.toString() == o2.toString();
+      } else if (isRegExp(o1)) {
+        return isRegExp(o2) ? o1.toString() == o2.toString() : false;
       } else {
-        if (isScope(o1) || isScope(o2) || isWindow(o1) || isWindow(o2) || isArray(o2)) return false;
+        if (isScope(o1) || isScope(o2) || isWindow(o1) || isWindow(o2) ||
+          isArray(o2) || isDate(o2) || isRegExp(o2)) return false;
         keySet = {};
         for (key in o1) {
           if (key.charAt(0) === '$' || isFunction(o1[key])) continue;

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -547,6 +547,7 @@ describe('angular', function() {
       expect(equals(new Date(undefined), new Date(0))).toBe(false);
       expect(equals(new Date(undefined), new Date(null))).toBe(false);
       expect(equals(new Date(undefined), new Date('wrong'))).toBe(true);
+      expect(equals(new Date(), /abc/)).toBe(false);
     });
 
     it('should correctly test for keys that are present on Object.prototype', function() {
@@ -564,11 +565,21 @@ describe('angular', function() {
       expect(equals(/abc/, /def/)).toBe(false);
       expect(equals(/^abc/, /abc/)).toBe(false);
       expect(equals(/^abc/, '/^abc/')).toBe(false);
+      expect(equals(/abc/, new Date())).toBe(false);
     });
 
     it('should return false when comparing an object and an array', function() {
       expect(equals({}, [])).toBe(false);
       expect(equals([], {})).toBe(false);
+    });
+
+    it('should return false when comparing an object and a RegExp', function() {
+      expect(equals({}, /abc/)).toBe(false);
+      expect(equals({}, new RegExp('abc', 'i'))).toBe(false);
+    });
+
+    it('should return false when comparing an object and a Date', function() {
+      expect(equals({}, new Date())).toBe(false);
     });
   });
 


### PR DESCRIPTION
Fixes #11204
