### PR TITLE
Updated the require section to reflect issue 11198

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -211,7 +211,8 @@
  * Require another directive and inject its controller as the fourth argument to the linking function. The
  * `require` takes a string name (or array of strings) of the directive(s) to pass in. If an array is used, the
  * injected argument will be an array in corresponding order. If no such directive can be
- * found, or if the directive does not have a controller, then an error is raised. The name can be prefixed with:
+ * found, or if the directive does not have a controller, then an error is raised (unless a link function 
+ * is not specified, in which case error checking is skipped). The name can be prefixed with:
  *
  * * (no prefix) - Locate the required controller on the current element. Throw an error if not found.
  * * `?` - Attempt to locate the required controller or pass `null` to the `link` fn if not found.


### PR DESCRIPTION
To make things less confusing, explicitly state that require WILL NOT cause a compile error if a link function is not specified.

https://github.com/angular/angular.js/issues/11198
stackoverflow.com/questions/28730346/require-ddo-option-of-angular-directive-does-not-throw-an-error-when-it-should
