### PR TITLE
fix(ngTouch): don't blur form elements

### DIFF
--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -158,9 +158,6 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     // If we didn't find an allowable region, bust the click.
     event.stopPropagation();
     event.preventDefault();
-
-    // Blur focused form elements
-    event.target && event.target.blur && event.target.blur();
   }
 
 

--- a/test/ngTouch/directive/ngClickSpec.js
+++ b/test/ngTouch/directive/ngClickSpec.js
@@ -314,18 +314,6 @@ describe('ngClick (touch)', function() {
 
       expect($rootScope.count1).toBe(1);
 
-      time = 90;
-      // Verify that it is blured so we don't get soft-keyboard
-      element1[0].blur = jasmine.createSpy('blur');
-      browserTrigger(element1, 'click',{
-        keys: [],
-        x: 10,
-        y: 10
-      });
-      expect(element1[0].blur).toHaveBeenCalled();
-
-      expect($rootScope.count1).toBe(1);
-
       time = 100;
       browserTrigger(element1, 'touchstart',{
         keys: [],


### PR DESCRIPTION
Form element focus should not be prevented by ng-click.
The issue was introduced by #2989, and happens on mobile browsers that support touch events.
Plunker to demonstrate the issue: http://embed.plnkr.co/CxeuWocoPE70vzrevrIi

Closes #4030, #6432

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.js/11212)

<!-- Reviewable:end -->
