### PR TITLE
aria-checked="{{checked}}" - to reflect check state 

### DIFF
--- a/docs/content/guide/accessibility.ngdoc
+++ b/docs/content/guide/accessibility.ngdoc
@@ -81,7 +81,7 @@ attributes (if they have not been explicitly specified by the developer):
   </style>
  <div>
  <form ng-controller="formsController">
-  <some-checkbox role="checkbox" ng-model="checked" ng-class="{active: checked}"
+  <some-checkbox role="checkbox" aria-checked = {{checked}} ng-model="checked" ng-class="{active: checked}"
     ng-disabled="isDisabled" ng-click="toggleCheckbox()"
     aria-label="Custom Checkbox" show-attrs>
     <span class="icon" aria-hidden="true"></span>


### PR DESCRIPTION
IMHO this needs to be changed from 
<some-checkbox role="checkbox"  ng-model="checked" ng-class="{active: checked}"
to
<some-checkbox role="checkbox" aria-checked="{{checked}}" ng-model="checked" ng-class="{active: checked}"

in order to be proper read by a screen-reader
