### PR TITLE
test(IE8): Remove workarounds for IE8

### DIFF
--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1326,16 +1326,10 @@ describe('$compile', function() {
               $rootScope.$digest();
 
 
-              expect(sortedHtml(element)).toBeOneOf(
-                  '<div><b class="i-hello"></b><span class="i-cau">Cau!</span></div>',
-                  '<div><b class="i-hello"></b><span class="i-cau" i-cau="">Cau!</span></div>' //ie8
-              );
+              expect(sortedHtml(element)).toBe('<div><b class="i-hello"></b><span class="i-cau">Cau!</span></div>');
 
               $httpBackend.flush();
-              expect(sortedHtml(element)).toBeOneOf(
-                  '<div><span class="i-hello">Hello!</span><span class="i-cau">Cau!</span></div>',
-                  '<div><span class="i-hello" i-hello="">Hello!</span><span class="i-cau" i-cau="">Cau!</span></div>' //ie8
-              );
+              expect(sortedHtml(element)).toBe('<div><span class="i-hello">Hello!</span><span class="i-cau">Cau!</span></div>');
             }
         ));
 
@@ -1362,10 +1356,7 @@ describe('$compile', function() {
 
               $rootScope.$digest();
 
-              expect(sortedHtml(element)).toBeOneOf(
-                  '<div><span class="i-hello">Hello, Elvis!</span></div>',
-                  '<div><span class="i-hello" i-hello="">Hello, Elvis!</span></div>' //ie8
-              );
+              expect(sortedHtml(element)).toBe('<div><span class="i-hello">Hello, Elvis!</span></div>');
             }
         ));
 
@@ -1394,10 +1385,7 @@ describe('$compile', function() {
               element = template($rootScope);
               $rootScope.$digest();
 
-              expect(sortedHtml(element)).toBeOneOf(
-                  '<div><span class="i-hello">Hello, Elvis!</span></div>',
-                  '<div><span class="i-hello" i-hello="">Hello, Elvis!</span></div>' //ie8
-              );
+              expect(sortedHtml(element)).toBe('<div><span class="i-hello">Hello, Elvis!</span></div>');
             }
         ));
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -551,12 +551,8 @@ describe('input', function() {
 
       expect(inputElm.val()).toBe('2013-01');
 
-      try {
-        //set to text for browsers with datetime-local validation.
-        inputElm[0].setAttribute('type', 'text');
-      } catch (e) {
-        //for IE8
-      }
+      //set to text for browsers with datetime-local validation.
+      inputElm[0].setAttribute('type', 'text');
 
       helper.changeInputValueTo('stuff');
       expect(inputElm.val()).toBe('stuff');
@@ -776,12 +772,8 @@ describe('input', function() {
 
       expect(inputElm.val()).toBe('2013-W02');
 
-      try {
-        //set to text for browsers with datetime-local validation.
-        inputElm[0].setAttribute('type', 'text');
-      } catch (e) {
-        //for IE8
-      }
+      //set to text for browsers with datetime-local validation.
+      inputElm[0].setAttribute('type', 'text');
 
       helper.changeInputValueTo('stuff');
       expect(inputElm.val()).toBe('stuff');
@@ -965,12 +957,8 @@ describe('input', function() {
 
       expect(inputElm.val()).toBe('2009-01-06T16:25:00.000');
 
-      try {
-        //set to text for browsers with datetime-local validation.
-        inputElm[0].setAttribute('type', 'text');
-      } catch (e) {
-        //for IE8
-      }
+      //set to text for browsers with datetime-local validation.
+      inputElm[0].setAttribute('type', 'text');
 
       helper.changeInputValueTo('stuff');
       expect(inputElm.val()).toBe('stuff');
@@ -1277,12 +1265,8 @@ describe('input', function() {
 
       expect(inputElm.val()).toBe('16:25:00.000');
 
-      try {
-        //set to text for browsers with time validation.
-        inputElm[0].setAttribute('type', 'text');
-      } catch (e) {
-        //for IE8
-      }
+      //set to text for browsers with time validation.
+      inputElm[0].setAttribute('type', 'text');
 
       helper.changeInputValueTo('stuff');
       expect(inputElm.val()).toBe('stuff');
@@ -1571,12 +1555,8 @@ describe('input', function() {
 
       expect(inputElm.val()).toBe('2014-09-14');
 
-      try {
-        //set to text for browsers with date validation.
-        inputElm[0].setAttribute('type', 'text');
-      } catch (e) {
-        //for IE8
-      }
+      //set to text for browsers with date validation.
+      inputElm[0].setAttribute('type', 'text');
 
       helper.changeInputValueTo('1-2-3');
       expect(inputElm.val()).toBe('1-2-3');
@@ -1843,12 +1823,10 @@ describe('input', function() {
       $rootScope.$apply('age = 123');
       expect(inputElm.val()).toBe('123');
 
-      try {
-        // to allow non-number values, we have to change type so that
-        // the browser which have number validation will not interfere with
-        // this test. IE8 won't allow it hence the catch.
-        inputElm[0].setAttribute('type', 'text');
-      } catch (e) {}
+      // to allow non-number values, we have to change type so that
+      // the browser which have number validation will not interfere with
+      // this test.
+      inputElm[0].setAttribute('type', 'text');
 
       helper.changeInputValueTo('123X');
       expect(inputElm.val()).toBe('123X');

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -354,11 +354,7 @@ describe('ngInclude', function() {
 
     expect(window._ngIncludeCausesScriptToRun).toBe(true);
 
-    // IE8 doesn't like deleting properties of window
-    window._ngIncludeCausesScriptToRun = undefined;
-    try {
-      delete window._ngIncludeCausesScriptToRun;
-    } catch (e) {}
+    delete window._ngIncludeCausesScriptToRun;
   }));
 
 

--- a/test/ng/directive/styleSpec.js
+++ b/test/ng/directive/styleSpec.js
@@ -14,8 +14,7 @@ describe('style', function() {
     $compile(element)($rootScope);
     $rootScope.$digest();
 
-    // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe('.header{font-size:1.5em; h3{font-size:1.5em}}');
+    expect(element[0].innerHTML).toBe('.header{font-size:1.5em; h3{font-size:1.5em}}');
   }));
 
 
@@ -24,15 +23,13 @@ describe('style', function() {
     $compile(element)($rootScope);
     $rootScope.$digest();
 
-    // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe('.some-container{ width: px; }');
+    expect(element[0].innerHTML).toBe('.some-container{ width: px; }');
 
     $rootScope.$apply(function() {
       $rootScope.elementWidth = 200;
     });
 
-    // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe('.some-container{ width: 200px; }');
+    expect(element[0].innerHTML).toBe('.some-container{ width: 200px; }');
   }));
 
 
@@ -41,15 +38,13 @@ describe('style', function() {
     $compile(element)($rootScope);
     $rootScope.$digest();
 
-    // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe('.header{ h3 { font-size: em }}');
+    expect(element[0].innerHTML).toBe('.header{ h3 { font-size: em }}');
 
     $rootScope.$apply(function() {
       $rootScope.fontSize = 1.5;
     });
 
-    // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe('.header{ h3 { font-size: 1.5em }}');
+    expect(element[0].innerHTML).toBe('.header{ h3 { font-size: 1.5em }}');
   }));
 
 
@@ -58,16 +53,14 @@ describe('style', function() {
     $compile(element)($rootScope);
     $rootScope.$digest();
 
-    // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe('.header{ h3 { font-size:  }}');
+    expect(element[0].innerHTML).toBe('.header{ h3 { font-size:  }}');
 
     $rootScope.$apply(function() {
       $rootScope.fontSize = 1.5;
       $rootScope.unit = 'em';
     });
 
-    // read innerHTML and trim to pass on IE8
-    expect(trim(element[0].innerHTML)).toBe('.header{ h3 { font-size: 1.5em }}');
+    expect(element[0].innerHTML).toBe('.header{ h3 { font-size: 1.5em }}');
   }));
 
 


### PR DESCRIPTION
For some reason shrink-wrap just blew on my system, so this is untested.
