### PR TITLE
refactor($compile): use indexof/splice instead of manually manipulating jquery object

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -56,6 +56,7 @@
   isElement,
   makeMap,
   includes,
+  indexOf
   arrayRemove,
   copy,
   equals,
@@ -731,8 +732,10 @@ function nodeName_(element) {
   return lowercase(element.nodeName || (element[0] && element[0].nodeName));
 }
 
+var indexOf = Array.prototype.indexOf;
+
 function includes(array, obj) {
-  return Array.prototype.indexOf.call(array, obj) !== -1;
+  return indexOf.call(array, obj) !== -1;
 }
 
 function arrayRemove(array, value) {

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -11,6 +11,8 @@
  *     Or gives undesired access to variables likes document or window?    *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+/* global indexOf: true */
+
 /* ! VARIABLE/FUNCTION NAMING CONVENTIONS THAT APPLY TO THIS FILE!
  *
  * DOM-related variables:
@@ -3281,31 +3283,21 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       var firstElementToRemove = elementsToRemove[0],
           removeCount = elementsToRemove.length,
           parent = firstElementToRemove.parentNode,
-          i, ii;
+          i;
 
-      if ($rootElement) {
-        for (i = 0, ii = $rootElement.length; i < ii; i++) {
-          if ($rootElement[i] === firstElementToRemove) {
-            $rootElement[i++] = newNode;
-            for (var j = i, j2 = j + removeCount - 1,
-                     jj = $rootElement.length;
-                 j < jj; j++, j2++) {
-              if (j2 < jj) {
-                $rootElement[j] = $rootElement[j2];
-              } else {
-                delete $rootElement[j];
-              }
-            }
-            $rootElement.length -= removeCount - 1;
+      var index;
+      if ($rootElement && (index = indexOf.call($rootElement, firstElementToRemove)) !== -1) {
+        if (removeCount === 1) {
+          $rootElement[index] = newNode;
+        } else {
+          $rootElement.splice(index, removeCount, newNode);
+        }
 
-            // If the replaced element is also the jQuery .context then replace it
-            // .context is a deprecated jQuery api, so we should set it only when jQuery set it
-            // http://api.jquery.com/context/
-            if ($rootElement.context === firstElementToRemove) {
-              $rootElement.context = newNode;
-            }
-            break;
-          }
+        // If the replaced element is also the jQuery .context then replace it
+        // .context is a deprecated jQuery api, so we should set it only when jQuery set it
+        // http://api.jquery.com/context/
+        if ($rootElement.context === firstElementToRemove) {
+          $rootElement.context = newNode;
         }
       }
 


### PR DESCRIPTION
jQuery/jqLite objects have a `splice` method on them, and `indexof.call` works on them, so those 2 methods can be used instead of the double loop.

The standard case (replacing one element) just does an assignment while other cases use `splice`. This could be changed to always use splice if wanted, but I thought the 99% case was worth it.

(this is a subset of #9365 that can be done on it's own)
