### PR TITLE
docs(tutorial/0 - Bootstrapping): Add a "the" before "imperative / manua...

### DIFF
--- a/docs/content/tutorial/step_00.ngdoc
+++ b/docs/content/tutorial/step_00.ngdoc
@@ -111,7 +111,7 @@ being the element on which the `ngApp` directive was defined.
 ## Bootstrapping AngularJS apps
 
 Bootstrapping AngularJS apps automatically using the `ngApp` directive is very easy and suitable
-for most cases. In advanced cases, such as when using script loaders, you can use
+for most cases. In advanced cases, such as when using script loaders, you can use the
 {@link guide/bootstrap imperative / manual way} to bootstrap the app.
 
 There are 3 important things that happen during the app bootstrap:


### PR DESCRIPTION
...l way"

I'm assuming "imperative / manual" is modifying "way" in which case I think "the" is needed.

I don't really know grammar, but as a native speaker it sounds odd without "the".
