### PR TITLE
docs(form): Add comma to line 319 for readability

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -316,7 +316,7 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
  *
  * # Alias: {@link ng.directive:ngForm `ngForm`}
  *
- * In Angular forms can be nested. This means that the outer form is valid when all of the child
+ * In Angular, forms can be nested. This means that the outer form is valid when all of the child
  * forms are valid as well. However, browsers do not allow nesting of `<form>` elements, so
  * Angular provides the {@link ng.directive:ngForm `ngForm`} directive which behaves identically to
  * `<form>` but can be nested.  This allows you to have nested forms, which is very useful when


### PR DESCRIPTION
Line 319 is hard to read on the first glimpse. 

Currently the sentence reads: 
"In Angular forms can be nested"

The sentence should read either 
"In Angular, forms can be nested"
or 
"Forms can be nested in angular"

I changed it to the former in this pull request.
