### PR TITLE
feat($compile): Throw error on incorrect casing

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -779,6 +779,14 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     return bindings;
   }
 
+  function assertValidDirectiveName(name) {
+    var letter = name.charAt(0);
+    if (!letter || letter !== lowercase(letter)) {
+      throw ngMinErr('badname', "Directive name '{0}' is invalid. The first letter of a directive must be a lowercase letter");
+    }
+    return name;
+  }
+
   /**
    * @ngdoc method
    * @name $compileProvider#directive
@@ -797,6 +805,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    this.directive = function registerDirective(name, directiveFactory) {
     assertNotHasOwnProperty(name, 'directive');
     if (isString(name)) {
+      assertValidDirectiveName(name);
       assertArg(directiveFactory, 'directiveFactory');
       if (!hasDirectives.hasOwnProperty(name)) {
         hasDirectives[name] = [];

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -147,6 +147,15 @@ describe('$compile', function() {
 
 
   describe('configuration', function() {
+
+    it('should fail to register a directive that does not start with a lowercase letter', function() {
+      module(function($compileProvider) {
+        expect($compileProvider.directive('BadDirectiveName', function() {
+          return {};
+        })).toThrowMinErr('badname', "Directive name 'BadDirectiveName' is invalid. The first letter of a directive must be a lowercase letter");
+      });
+    });
+
     it('should register a directive', function() {
       module(function() {
         directive('div', function(log) {


### PR DESCRIPTION
- Adds error message for when the first letter of the directive name is
  not capitalized in the definition

This addresses #11109 .
