### PR TITLE
docs(angular.extend): final param documentation does not match functionality

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -362,8 +362,6 @@ function baseExtend(dst, objs, deep) {
  *
  * @param {Object} dst Destination object.
  * @param {...Object} src Source object(s).
- * @param {boolean=} deep if the last parameter is set to `true`, objects are recursively merged
- *    (deep copy). Defaults to `false`.
  * @returns {Object} Reference to `dst`.
  */
 function extend(dst) {


### PR DESCRIPTION
The `deep` property is hard-coded to `false` and is not configurable as the docs suggest. I'm not sure if the documentation is incorrect or the implementation is incorrect.
