### PR TITLE
docs($log): Add debug button to example

### DIFF
--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -32,6 +32,7 @@
          <button ng-click="$log.warn(message)">warn</button>
          <button ng-click="$log.info(message)">info</button>
          <button ng-click="$log.error(message)">error</button>
+         <button ng-click="$log.debug(message)">debug</button>
        </div>
      </file>
    </example>


### PR DESCRIPTION
Add debug button to example. It was in teh docs but not the example.

No breaking changes.
