### PR TITLE
Add provider.$decorator to angular.Module

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -192,7 +192,7 @@ function setupModuleLoader(window) {
            * See {@link auto.$provide#constant $provide.constant()}.
            */
           constant: invokeLater('$provide', 'constant', 'unshift'),
-          
+
           /**
            * @ngdoc method
            * @name angular.Module#decorator

--- a/src/loader.js
+++ b/src/loader.js
@@ -192,6 +192,18 @@ function setupModuleLoader(window) {
            * See {@link auto.$provide#constant $provide.constant()}.
            */
           constant: invokeLater('$provide', 'constant', 'unshift'),
+          
+          /**
+           * @ngdoc method
+           * @name angular.Module#decorator
+           * @module ng
+           * @param {string} name service name
+           * @param {Function} providerType Construction function for creating new instance of the
+           *                                service.
+           * @description
+           * See {@link auto.$provide#decorator $provide.decorator()}.
+           */
+          decorator: invokeLater('$provide', 'decorator'),
 
           /**
            * @ngdoc method

--- a/test/loaderSpec.js
+++ b/test/loaderSpec.js
@@ -41,10 +41,12 @@ describe('module loader', function() {
       controller('ctrl', 'ccc').
       config('init2').
       constant('abc', 123).
+      decorator('dk', 'dv').
       run('runBlock')).toBe(myModule);
 
     expect(myModule.requires).toEqual(['other']);
     expect(myModule._invokeQueue).toEqual([
+      ['$provide', 'decorator', ['dk', 'dv']],
       ['$provide', 'constant', ['abc', 123]],
       ['$provide', 'provider', ['sk', 'sv']],
       ['$provide', 'factory', ['fk', 'fv']],

--- a/test/loaderSpec.js
+++ b/test/loaderSpec.js
@@ -32,6 +32,7 @@ describe('module loader', function() {
     var myModule = window.angular.module('my', ['other'], 'config');
 
     expect(myModule.
+      decorator('dk', 'dv').
       provider('sk', 'sv').
       factory('fk', 'fv').
       service('a', 'aa').
@@ -41,7 +42,6 @@ describe('module loader', function() {
       controller('ctrl', 'ccc').
       config('init2').
       constant('abc', 123).
-      decorator('dk', 'dv').
       run('runBlock')).toBe(myModule);
 
     expect(myModule.requires).toEqual(['other']);

--- a/test/loaderSpec.js
+++ b/test/loaderSpec.js
@@ -46,8 +46,8 @@ describe('module loader', function() {
 
     expect(myModule.requires).toEqual(['other']);
     expect(myModule._invokeQueue).toEqual([
-      ['$provide', 'decorator', ['dk', 'dv']],
       ['$provide', 'constant', ['abc', 123]],
+      ['$provide', 'decorator', ['dk', 'dv']],
       ['$provide', 'provider', ['sk', 'sv']],
       ['$provide', 'factory', ['fk', 'fv']],
       ['$provide', 'service', ['a', 'aa']],


### PR DESCRIPTION
Allow for decorators to be added prior to the angular.config process.

Use case: I am working on a project using ui.router and would like to modify the $stateProvide.state service and would like to ensure that my modification will always be applied prior to any angular.config blocks which could contain $stateProvide.state requests.

This would also allow any decorators to be clearly delineated in your code and not lost in a config block.
