### PR TITLE
feat(ng, decorator): Add decorator Method (provider.$decorator) to angular.Module

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -193,6 +193,18 @@ function setupModuleLoader(window) {
            */
           constant: invokeLater('$provide', 'constant', 'unshift'),
 
+           /**
+           * @ngdoc method
+           * @name angular.Module#decorator
+           * @module ng
+           * @param {string} name service name
+           * @param {Function} providerType Construction function for creating new instance of the
+           *                                service.
+           * @description
+           * See {@link auto.$provide#decorator $provide.decorator()}.
+           */
+          decorator: invokeLater('$provide', 'decorator'),
+
           /**
            * @ngdoc method
            * @name angular.Module#animation

--- a/src/loader.js
+++ b/src/loader.js
@@ -197,9 +197,9 @@ function setupModuleLoader(window) {
            * @ngdoc method
            * @name angular.Module#decorator
            * @module ng
-           * @param {string} name service name
-           * @param {Function} providerType Construction function for creating new instance of the
-           *                                service.
+           * @param {string} The name of the service to decorate.
+           * @param {Function} This function will be invoked when the service needs to be
+           *                                    instantiated and should return the decorated service instance.
            * @description
            * See {@link auto.$provide#decorator $provide.decorator()}.
            */

--- a/test/loaderSpec.js
+++ b/test/loaderSpec.js
@@ -32,6 +32,7 @@ describe('module loader', function() {
     var myModule = window.angular.module('my', ['other'], 'config');
 
     expect(myModule.
+      decorator('dk', 'dv').
       provider('sk', 'sv').
       factory('fk', 'fv').
       service('a', 'aa').
@@ -46,6 +47,7 @@ describe('module loader', function() {
     expect(myModule.requires).toEqual(['other']);
     expect(myModule._invokeQueue).toEqual([
       ['$provide', 'constant', ['abc', 123]],
+      ['$provide', 'decorator', ['dk', 'dv']],
       ['$provide', 'provider', ['sk', 'sv']],
       ['$provide', 'factory', ['fk', 'fv']],
       ['$provide', 'service', ['a', 'aa']],


### PR DESCRIPTION
Allow for decorators to be added prior to the angular.config process.

Use case: I am working on a project using ui.router and would like to modify the $stateProvide.state service and would like to ensure that my modification will always be applied prior to any angular.config blocks which could contain $stateProvide.state requests.

This would also allow any decorators to be clearly delineated in your code and not lost in a config block.

Replaces Pull Request #11300
