### PR TITLE
docs(guide/Conceptual Overview): adding a hyphen for clarity

### DIFF
--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -179,10 +179,10 @@ The following graphic shows how everything works together after we introduced th
 
 <img style="padding-left: 3em; padding-bottom: 1em;" src="img/guide/concepts-databinding2.png">
 
-## View independent business logic: Services
+## View-independent business logic: Services
 
 Right now, the `InvoiceController` contains all logic of our example. When the application grows it
-is a good practice to move view independent logic from the controller into a 
+is a good practice to move view-independent logic from the controller into a 
 <a name="service">{@link services service}</a>, so it can be reused by other parts
 of the application as well. Later on, we could also change that service to load the exchange rates
 from the web, e.g. by calling the Yahoo Finance API, without changing the controller.


### PR DESCRIPTION
Minor change, but the heading for "View independent business logic..." would be more clear if it had a hyphen, "View-independent".  Perhaps it's because I'm new to javascript and its terminology, but I read "View" as a verb rather than a noun on the first pass and had to read on a bit to understand that it was, instead, referring to The View.   If you go just by grammar rules, making "view independent" into the compound adjective, "view-independent", makes it clear that it is modifying "business logic".  (http://www.grammarbook.com/punctuation/hyphens.asp - see Rule 1).
