### PR TITLE
docs(ngRepeat): improve the explanation of keys

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -33,8 +33,8 @@
  * <div ng-repeat="(key, value) in myObj"> ... </div>
  * ```
  *
- * You need to be aware that the JavaScript specification does not define what order
- * it will return the keys for an object. (To mitigate this in Angular 1.3 the `ngRepeat` directive
+ * You need to be aware that the JavaScript specification does not define the order of keys
+ * returned for an object. (To mitigate this in Angular 1.3 the `ngRepeat` directive
  * used to sort the keys alphabetically.)
  *
  * Version 1.4 removed the alphabetic sorting. We now rely on the order returned by the browser


### PR DESCRIPTION
Improve grammar and phrasing on lines 36/37. The existing language uses poor grammar. Another possible replacement is "the order in which keys are returned," but the keys are not actually returned in any order--they are all returned at once, and they have an order. The best phrasing seems to be "the order of keys returned." An even better explanation might actually say what function is returning the keys eg Object.keys. This might read something like "You need to be aware that the JavaScript specification does not define the order of keys returned by Object.keys()," however it is not clear if the original author was referring to Object.keys().
