### PR TITLE
chore(apis): add HashMap to the DI

### DIFF
--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -65,6 +65,7 @@
   $FilterProvider,
   $InterpolateProvider,
   $IntervalProvider,
+  $$HashMapProvider,
   $HttpProvider,
   $HttpBackendProvider,
   $LocationProvider,
@@ -241,6 +242,7 @@ function publishExternalAPI(angular) {
         $$rAF: $$RAFProvider,
         $$asyncCallback: $$AsyncCallbackProvider,
         $$jqLite: $$jqLiteProvider,
+        $$HashMap: $$HashMapProvider,
         $$cookieReader: $$CookieReaderProvider
       });
     }

--- a/src/apis.js
+++ b/src/apis.js
@@ -73,3 +73,9 @@ HashMap.prototype = {
     return value;
   }
 };
+
+var $$HashMapProvider = [function() {
+  this.$get = [function() {
+    return HashMap;
+  }];
+}];


### PR DESCRIPTION
HashMap will be used inside of `angular-animate.js` to store details of ongoing animations on a per-element basis. Right now HashMap is only available in core, but this patch will make it available to other areas.
