### PR TITLE
fix(ngAria): handle custom elements with role="checkbox"

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -211,88 +211,101 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
     restrict: 'A',
     require: '?ngModel',
     priority: 200, //Make sure watches are fired after any other directives that affect the ngModel value
-    link: function(scope, elem, attr, ngModel) {
+    compile: function(elem, attr) {
       var shape = getShape(attr, elem);
-      var needsTabIndex = shouldAttachAttr('tabindex', 'tabindex', elem);
 
-      function ngAriaWatchModelValue() {
-        return ngModel.$modelValue;
-      }
+      return {
+        pre: function(scope, elem, attr, ngModel) {
+          if (shape === 'checkbox' && attr.type !== 'checkbox') {
+            //Use the input[checkbox] $isEmpty implementation for elements with checkbox roles
+            ngModel.$isEmpty = function(value) {
+              return value === false;
+            };
+          }
+        },
+        post: function(scope, elem, attr, ngModel) {
+          var needsTabIndex = shouldAttachAttr('tabindex', 'tabindex', elem);
 
-      function getRadioReaction() {
-        if (needsTabIndex) {
-          needsTabIndex = false;
-          return function ngAriaRadioReaction(newVal) {
-            var boolVal = (attr.value == ngModel.$viewValue);
-            elem.attr('aria-checked', boolVal);
-            elem.attr('tabindex', 0 - !boolVal);
-          };
-        } else {
-          return function ngAriaRadioReaction(newVal) {
-            elem.attr('aria-checked', (attr.value == ngModel.$viewValue));
-          };
+          function ngAriaWatchModelValue() {
+            return ngModel.$modelValue;
+          }
+
+          function getRadioReaction() {
+            if (needsTabIndex) {
+              needsTabIndex = false;
+              return function ngAriaRadioReaction(newVal) {
+                var boolVal = (attr.value == ngModel.$viewValue);
+                elem.attr('aria-checked', boolVal);
+                elem.attr('tabindex', 0 - !boolVal);
+              };
+            } else {
+              return function ngAriaRadioReaction(newVal) {
+                elem.attr('aria-checked', (attr.value == ngModel.$viewValue));
+              };
+            }
+          }
+
+          function ngAriaCheckboxReaction() {
+            elem.attr('aria-checked', !ngModel.$isEmpty(ngModel.$viewValue));
+          }
+
+          switch (shape) {
+            case 'radio':
+            case 'checkbox':
+              if (shouldAttachRole(shape, elem)) {
+                elem.attr('role', shape);
+              }
+              if (shouldAttachAttr('aria-checked', 'ariaChecked', elem)) {
+                scope.$watch(ngAriaWatchModelValue, shape === 'radio' ?
+                    getRadioReaction() : ngAriaCheckboxReaction);
+              }
+              break;
+            case 'range':
+              if (shouldAttachRole(shape, elem)) {
+                elem.attr('role', 'slider');
+              }
+              if ($aria.config('ariaValue')) {
+                if (attr.min && !elem.attr('aria-valuemin')) {
+                  elem.attr('aria-valuemin', attr.min);
+                }
+                if (attr.max && !elem.attr('aria-valuemax')) {
+                  elem.attr('aria-valuemax', attr.max);
+                }
+                if (!elem.attr('aria-valuenow')) {
+                  scope.$watch(ngAriaWatchModelValue, function ngAriaValueNowReaction(newVal) {
+                    elem.attr('aria-valuenow', newVal);
+                  });
+                }
+              }
+              break;
+            case 'multiline':
+              if (shouldAttachAttr('aria-multiline', 'ariaMultiline', elem)) {
+                elem.attr('aria-multiline', true);
+              }
+              break;
+          }
+
+          if (needsTabIndex) {
+            elem.attr('tabindex', 0);
+          }
+
+          if (ngModel.$validators.required && shouldAttachAttr('aria-required', 'ariaRequired', elem)) {
+            scope.$watch(function ngAriaRequiredWatch() {
+              return ngModel.$error.required;
+            }, function ngAriaRequiredReaction(newVal) {
+              elem.attr('aria-required', !!newVal);
+            });
+          }
+
+          if (shouldAttachAttr('aria-invalid', 'ariaInvalid', elem)) {
+            scope.$watch(function ngAriaInvalidWatch() {
+              return ngModel.$invalid;
+            }, function ngAriaInvalidReaction(newVal) {
+              elem.attr('aria-invalid', !!newVal);
+            });
+          }
         }
-      }
-
-      function ngAriaCheckboxReaction(newVal) {
-        elem.attr('aria-checked', !ngModel.$isEmpty(ngModel.$viewValue));
-      }
-
-      switch (shape) {
-        case 'radio':
-        case 'checkbox':
-          if (shouldAttachRole(shape, elem)) {
-            elem.attr('role', shape);
-          }
-          if (shouldAttachAttr('aria-checked', 'ariaChecked', elem)) {
-            scope.$watch(ngAriaWatchModelValue, shape === 'radio' ?
-                getRadioReaction() : ngAriaCheckboxReaction);
-          }
-          break;
-        case 'range':
-          if (shouldAttachRole(shape, elem)) {
-            elem.attr('role', 'slider');
-          }
-          if ($aria.config('ariaValue')) {
-            if (attr.min && !elem.attr('aria-valuemin')) {
-              elem.attr('aria-valuemin', attr.min);
-            }
-            if (attr.max && !elem.attr('aria-valuemax')) {
-              elem.attr('aria-valuemax', attr.max);
-            }
-            if (!elem.attr('aria-valuenow')) {
-              scope.$watch(ngAriaWatchModelValue, function ngAriaValueNowReaction(newVal) {
-                elem.attr('aria-valuenow', newVal);
-              });
-            }
-          }
-          break;
-        case 'multiline':
-          if (shouldAttachAttr('aria-multiline', 'ariaMultiline', elem)) {
-            elem.attr('aria-multiline', true);
-          }
-          break;
-      }
-
-      if (needsTabIndex) {
-        elem.attr('tabindex', 0);
-      }
-
-      if (ngModel.$validators.required && shouldAttachAttr('aria-required', 'ariaRequired', elem)) {
-        scope.$watch(function ngAriaRequiredWatch() {
-          return ngModel.$error.required;
-        }, function ngAriaRequiredReaction(newVal) {
-          elem.attr('aria-required', !!newVal);
-        });
-      }
-
-      if (shouldAttachAttr('aria-invalid', 'ariaInvalid', elem)) {
-        scope.$watch(function ngAriaInvalidWatch() {
-          return ngModel.$invalid;
-        }, function ngAriaInvalidReaction(newVal) {
-          elem.attr('aria-invalid', !!newVal);
-        });
-      }
+      };
     }
   };
 }])

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -155,27 +155,39 @@ describe('$aria', function() {
     });
 
     it('should attach itself to role="radio"', function() {
-      scope.$apply("val = 'one'");
-      compileElement('<div role="radio" ng-model="val" value="{{val}}"></div>');
+      scope.val = 'one';
+      compileElement('<div role="radio" ng-model="val" value="one"></div>');
       expect(element.attr('aria-checked')).toBe('true');
+
+      scope.$apply("val = 'two'");
+      expect(element.attr('aria-checked')).toBe('false');
     });
 
     it('should attach itself to role="checkbox"', function() {
       scope.val = true;
       compileElement('<div role="checkbox" ng-model="val"></div>');
       expect(element.attr('aria-checked')).toBe('true');
+
+      scope.$apply('val = false');
+      expect(element.attr('aria-checked')).toBe('false');
     });
 
     it('should attach itself to role="menuitemradio"', function() {
       scope.val = 'one';
-      compileElement('<div role="menuitemradio" ng-model="val" value="{{val}}"></div>');
+      compileElement('<div role="menuitemradio" ng-model="val" value="one"></div>');
       expect(element.attr('aria-checked')).toBe('true');
+
+      scope.$apply("val = 'two'");
+      expect(element.attr('aria-checked')).toBe('false');
     });
 
     it('should attach itself to role="menuitemcheckbox"', function() {
       scope.val = true;
       compileElement('<div role="menuitemcheckbox" ng-model="val"></div>');
       expect(element.attr('aria-checked')).toBe('true');
+
+      scope.$apply('val = false');
+      expect(element.attr('aria-checked')).toBe('false');
     });
 
     it('should not attach itself if an aria-checked value is already present', function() {


### PR DESCRIPTION
In https://github.com/angular/angular.js/commit/d6eba21733c6e67e90e3a4763d8d41ad89a73a0c#diff-91e9129201746ba107348c9a0a7735edR218, we fixed some issues with checkboxes with string and integer models using ngTrueValue / ngFalseValue, but I did not take into consideration custom `role="checkbox"` elements (as in the ngAria docs). They are currently broken, because the new way of checking "checkedness" is by using ngModel.$isEmpty, which has a special implementation for checkboxes. Custom elements obviously lack this.
My idea is to provide the checkbox $isEmpety implementation as a default to all elements that come with role="checkbox" in the preLink fn. It can then be overwritten by the custom implementation. (since ngAria is simply assuming that a custom checkbox will have a boolean checkstate, which might not be the case).

@marcysutton can you have a look at this?
