### PR TITLE
wip-chore: refactor npm install

### DIFF
--- a/Gruntfile-test.js
+++ b/Gruntfile-test.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var npmInstall = require('./scripts/npm/install-dependencies');
+
+module.exports = function(grunt) {
+
+  grunt.registerTask('npm-install', function() {
+    npmInstall.installDependencies();
+  });
+}

--- a/scripts/npm/install-dependencies.js
+++ b/scripts/npm/install-dependencies.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var rimraf = require('rimraf');
+var shell = require('shelljs');
+var q = require('q');
+var child_process = require('child_process');
+
+var SHRINKWRAP_FILE = 'npm-shrinkwrap.json';
+var SHRINKWRAP_CACHED_FILE = 'node_modules/npm-shrinkwrap.cached.json';
+
+function cleanNodeModules() {
+  if (process.platform === "win32") {
+    var deferred = q.defer();
+    rimraf('node_modules', function(error) {
+      if (error) {
+        deferred.reject(new Error(error));
+      } else {
+        console.log('cleaned node_modules using rimraf');
+        deferred.resolve();
+      }
+    });
+
+    return deferred.promise;
+  }
+
+  shell.rm('-rf', 'node_modules');
+  console.log('cleaned node_modules using rm -rf');
+}
+
+function installDependencies() {
+
+  if (!shell.exec('diff ' + SHRINKWRAP_FILE + ' ' + SHRINKWRAP_CACHED_FILE, {silent: true}).output) {
+    console.log('No shrinkwrap changes detected. npm install will be skipped...');
+  } else {
+    console.log('Blowing away node_modules and reinstalling npm dependencies...');
+    q.when(cleanNodeModules()).then(function() {
+      shell.exec('npm install');
+      shell.cp(SHRINKWRAP_FILE, SHRINKWRAP_CACHED_FILE);
+      console.log('npm install successful!');
+    });
+  }
+}
+
+exports.installDependencies = installDependencies;


### PR DESCRIPTION
This is an attempt to nodejs-ify the install-dependencies.sh script. 

`Gruntfile-test.js` is almost empty, so you can test the install script without having to do a complete `npm install`. Basically, you just need to `npm install rimraf grunt shelljs q` if the removing / install does not go through completely.

The problem is now that `grunt npm-install --gruntfile=Gruntfile-test.js` does not actually call 'rimraf'. It works when I call the file directly via `node` and append `installDependencies()` at the end of the .js file.
