### PR TITLE
respect explicit return values from controller functions (fixes #11147)

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1967,7 +1967,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           for (i in elementControllers) {
             controller = elementControllers[i];
             var controllerResult = controller();
-            if (controllerResult !== controller.instance && (isObject(controllerResult) || isFunction(controllerResult))) {
+            if (controllerResult !== controller.instance) {
               controller.instance = controllerResult;
               $element.data('$' + directive.name + 'Controller', controllerResult);
               if (controller === controllerForBindings) {

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1967,13 +1967,16 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           for (i in elementControllers) {
             controller = elementControllers[i];
             var controllerResult = controller();
-            if (controllerResult !== controller.instance &&
-                controller === controllerForBindings) {
-              // Remove and re-install bindToController bindings
-              thisLinkFn.$$destroyBindings();
-              thisLinkFn.$$destroyBindings =
+            if (controllerResult !== controller.instance && (isObject(controllerResult) || isFunction(controllerResult))) {
+              controller.instance = controllerResult;
+              $element.data('$' + directive.name + 'Controller', controllerResult);
+              if (controller === controllerForBindings) {
+                // Remove and re-install bindToController bindings
+                thisLinkFn.$$destroyBindings();
+                thisLinkFn.$$destroyBindings =
                   initializeDirectiveBindings(scope, attrs, controllerResult,
-                                              bindings, scopeDirective);
+                    bindings, scopeDirective);
+              }
             }
           }
         }

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1974,8 +1974,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 // Remove and re-install bindToController bindings
                 thisLinkFn.$$destroyBindings();
                 thisLinkFn.$$destroyBindings =
-                  initializeDirectiveBindings(scope, attrs, controllerResult,
-                    bindings, scopeDirective);
+                  initializeDirectiveBindings(scope, attrs, controllerResult, bindings, scopeDirective);
               }
             }
           }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4197,6 +4197,27 @@ describe('$compile', function() {
     });
 
 
+    it('should respect controller return value', function() {
+      module(function() {
+        directive('logControllerProp', function(log) {
+          return {
+            controller: function($scope) {
+              this.foo = 'baz'; // value should not be used.
+              return {foo: 'bar'};
+            },
+            link: function(scope, element, attrs, controller) {
+              log(controller.foo);
+            }
+          };
+        });
+      });
+      inject(function(log, $compile, $rootScope) {
+        element = $compile('<log-controller-prop></log-controller-prop>')($rootScope);
+        expect(log).toEqual('bar');
+      });
+    });
+
+
     it('should get required parent controller', function() {
       module(function() {
         directive('nested', function(log) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4214,6 +4214,7 @@ describe('$compile', function() {
       inject(function(log, $compile, $rootScope) {
         element = $compile('<log-controller-prop></log-controller-prop>')($rootScope);
         expect(log).toEqual('bar');
+        expect(element.data('$logControllerPropController').foo).toEqual('bar');
       });
     });
 


### PR DESCRIPTION
When controller functions return an explicit value that value should be what is passed to the linking functions, and to any child/sibling controllers that `require` it. It should also be bound to the data store on the DOM element.

Closes #11147 
