### PR TITLE
fix(ngAria): change accessibility keypress event to use event.which if it is provided

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -334,7 +334,8 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
 
         if ($aria.config('bindKeypress') && !attr.ngKeypress && !isNodeOneOf(elem, nodeBlackList)) {
           elem.on('keypress', function(event) {
-            if (event.keyCode === 32 || event.keyCode === 13) {
+            var keyCode = event.which || event.keyCode;
+            if (keyCode === 32 || keyCode === 13) {
               scope.$apply(callback);
             }
 

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -586,7 +586,7 @@ describe('$aria', function() {
 
     var clickFn;
 
-    it('should a trigger click from the keyboard', function() {
+    it('should trigger click from the keyboard', function() {
       scope.someAction = function() {};
 
       var elements = $compile('<section>' +
@@ -603,6 +603,28 @@ describe('$aria', function() {
 
       divElement.triggerHandler({type: 'keypress', keyCode: 32});
       liElement.triggerHandler({type: 'keypress', keyCode: 32});
+
+      expect(clickFn).toHaveBeenCalledWith('div');
+      expect(clickFn).toHaveBeenCalledWith('li');
+    });
+
+    it('should trigger click in some browsers that provide event.which instead event.keyCode', function() {
+      scope.someAction = function() {};
+
+      var elements = $compile('<section>' +
+      '<div class="div-click" ng-click="someAction(\'div\')" tabindex="0"></div>' +
+      '<ul><li ng-click="someAction( \'li\')" tabindex="0"></li></ul>' +
+      '</section>')(scope);
+
+      scope.$digest();
+
+      clickFn = spyOn(scope, 'someAction');
+
+      var divElement = elements.find('div');
+      var liElement = elements.find('li');
+
+      divElement.triggerHandler({type: 'keypress', which: 32});
+      liElement.triggerHandler({type: 'keypress', which: 32});
 
       expect(clickFn).toHaveBeenCalledWith('div');
       expect(clickFn).toHaveBeenCalledWith('li');


### PR DESCRIPTION
fix(ngAria): change accessibility keypress event to use event.which if it is provided

In Firefox, keyboard events for printable characters (e.g. space) do not use event.keyCode. Use event.which if it is provided before falling back to event.keyCode.
