### PR TITLE
chore(ci): make wait_for_browser_provider time out after 2 minutes

### DIFF
--- a/scripts/travis/wait_for_browser_provider.sh
+++ b/scripts/travis/wait_for_browser_provider.sh
@@ -2,6 +2,14 @@
 
 
 # Wait for Connect to be ready before exiting
+# Time out if we wait for more than 2 minutes, so that we can print logs.
+let "counter=0"
+
 while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
+  let "counter++"
+  if [ $counter -gt 240 ]; then
+    echo "Timed out after 2 minutes waiting for browser provider ready file"
+    exit 5
+  fi
   sleep .5
 done


### PR DESCRIPTION
Before, if something went wrong, wait_for_browser_provider.sh would
wait indefinitely, and logs would never get printed. Now, we'll bail
early, and get some actual logs on what the problem was.
