### PR TITLE
chore(ci): force travis to print logs after driver provider timeout

### DIFF
--- a/scripts/travis/wait_for_browser_provider.sh
+++ b/scripts/travis/wait_for_browser_provider.sh
@@ -9,6 +9,7 @@ while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   let "counter++"
   if [ $counter -gt 240 ]; then
     echo "Timed out after 2 minutes waiting for browser provider ready file"
+    ./print_logs.sh
     exit 5
   fi
   sleep .5


### PR DESCRIPTION
Travis does not do the after_script step if before_script fails,
so wait_for_browser_provider.sh was not printing out logs.
Force it to print them manually.
