### PR TITLE
fix(ngTouch): prevent touchmove from canceling a click

### DIFF
--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -227,10 +227,6 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
       touchStartY = e.clientY;
     });
 
-    element.on('touchmove', function(event) {
-      resetState();
-    });
-
     element.on('touchcancel', function(event) {
       resetState();
     });

--- a/test/ngTouch/directive/ngClickSpec.js
+++ b/test/ngTouch/directive/ngClickSpec.js
@@ -97,7 +97,7 @@ describe('ngClick (touch)', function() {
   }));
 
 
-  it('should not click if a touchmove comes before touchend', inject(function($rootScope, $compile, $rootElement) {
+  it('should still click if a touchmove comes before touchend', inject(function($rootScope, $compile, $rootElement) {
     element = $compile('<div ng-click="tapped = true"></div>')($rootScope);
     $rootElement.append(element);
     $rootScope.$digest();
@@ -112,11 +112,11 @@ describe('ngClick (touch)', function() {
     browserTrigger(element, 'touchmove');
     browserTrigger(element, 'touchend',{
       keys: [],
-      x: 400,
-      y: 400
+      x: 10,
+      y: 10
     });
 
-    expect($rootScope.tapped).toBeUndefined();
+    expect($rootScope.tapped).toBe(true);
   }));
 
   it('should add the CSS class while the element is held down, and then remove it', inject(function($rootScope, $compile, $rootElement) {


### PR DESCRIPTION
Usually browsers fire touchstart and touchend, and ng-click works.
But some browsers (I only experienced it on iOS) fire touchmove
between touchstart and touchend, and so before this fix ng-click
would not work in this case.
Also, the test for touchmove was incorrect: it did not test
the touchmove event itself, but rather the coordinates change,
which is handled elsewhere. If the coordinates are the same and
the interval is not too long, ng-click should fire, no matter if
there was a touchmove or not.
