### PR TITLE
Ensure boolean values for aria-* attributes

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -115,9 +115,8 @@ function $AriaProvider() {
       var ariaCamelName = attr.$normalize(ariaAttr);
       if (config[ariaCamelName] && !attr[ariaCamelName]) {
         scope.$watch(attr[attrName], function(boolVal) {
-          if (negate) {
-            boolVal = !boolVal;
-          }
+          // ensure boolean value
+          boolVal = negate ? !boolVal : !!boolVal;
           elem.attr(ariaAttr, boolVal);
         });
       }


### PR DESCRIPTION
aria-\* (e.g. aria-hidden) values should mirror the truthiness of their ng-*
counterparts (e.g. ng-show, ng-hide) instead of their actual value
