### PR TITLE
docs(orderBy): Replace operator = with ===

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -17,7 +17,7 @@
  *    Can be one of:
  *
  *    - `function`: Getter function. The result of this function will be sorted using the
- *      `<`, `=`, `>` operator.
+ *      `<`, `===`, `>` operator.
  *    - `string`: An Angular expression. The result of this expression is used to compare elements
  *      (for example `name` to sort by a property called `name` or `name.substr(0, 3)` to sort by
  *      3 first characters of a property called `name`). The result of a constant expression


### PR DESCRIPTION
Fix documentation error on line 20 incorrectly mentioning an assignment operator in a comparison operation. Code on line 235 uses strict comparison operator.

Closes #11392
