### PR TITLE
docs($http): remove trailing comma from code example

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -377,7 +377,7 @@ function $HttpProvider() {
      *  headers: {
      *    'Content-Type': undefined
      *  },
-     *  data: { test: 'test' },
+     *  data: { test: 'test' }
      * }
      *
      * $http(req).success(function(){...}).error(function(){...});


### PR DESCRIPTION
Remove trailing comma from code example to keep flow with the rest of the code examples
