### PR TITLE
Fix ng style lazy one-time binding regression

### DIFF
--- a/src/ng/directive/ngStyle.js
+++ b/src/ng/directive/ngStyle.js
@@ -47,10 +47,10 @@
    </example>
  */
 var ngStyleDirective = ngDirective(function(scope, element, attr) {
-  scope.$watchCollection(attr.ngStyle, function ngStyleWatchAction(newStyles, oldStyles) {
+  scope.$watch(attr.ngStyle, function ngStyleWatchAction(newStyles, oldStyles) {
     if (oldStyles && (newStyles !== oldStyles)) {
       forEach(oldStyles, function(val, style) { element.css(style, '');});
     }
     if (newStyles) element.css(newStyles);
-  });
+  }, true);
 });

--- a/test/ng/directive/ngStyleSpec.js
+++ b/test/ng/directive/ngStyleSpec.js
@@ -23,6 +23,15 @@ describe('ngStyle', function() {
   }));
 
 
+  it('should support lazy one-time binding for object literals', inject(function($rootScope, $compile) {
+    element = $compile('<div ng-style="::{height: heightStr}"></div>')($rootScope);
+    $rootScope.$digest();
+    expect(element.css('height')).toBeFalsy();
+    $rootScope.$apply('heightStr = "40px"');
+    expect(element.css('height')).toBe('40px');
+  }));
+
+
   describe('preserving styles set before and after compilation', function() {
     var scope, preCompStyle, preCompVal, postCompStyle, postCompVal, element;
 


### PR DESCRIPTION
There's no easy way to make the one-time binding work woth $watchCollection, so the easiest way is probably to revert the commit, as suggested by @lgalfaso 
