### PR TITLE
fix(ngModel): allow setting model to NaN when asyncValidator is present

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -810,7 +810,10 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
 
     // if scope model value and ngModel value are out of sync
     // TODO(perf): why not move this to the action fn?
-    if (modelValue !== ctrl.$modelValue) {
+    // Second check is needed to allow setting the model to NaN when there's an asyncValidator
+    if (modelValue !== ctrl.$modelValue &&
+       (ctrl.$modelValue === ctrl.$modelValue || modelValue === modelValue)
+    ) {
       ctrl.$modelValue = ctrl.$$rawModelValue = modelValue;
       parserValid = undefined;
 

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -578,6 +578,30 @@ describe('ngModel', function() {
 
         dealoc(form);
       }));
+
+
+      it('should set NaN as the $modelValue when an asyncValidator is present',
+        inject(function($q) {
+
+        ctrl.$asyncValidators.test = function() {
+          return $q(function(resolve, reject) {
+            resolve();
+          });
+        };
+
+        scope.$apply('value = 10');
+        expect(ctrl.$modelValue).toBe(10);
+
+        expect(function() {
+          scope.$apply(function() {
+            scope.value = NaN;
+          });
+        }).not.toThrowMinErr('$rootScope', 'infdig', '10 $digest() iterations reached. Aborting!\n' +
+          'Watchers fired in the last 5 iterations: []');
+
+        expect(ctrl.$modelValue).toBeNaN();
+
+      }));
     });
 
 


### PR DESCRIPTION
Fixes #11315 
