### PR TITLE
refactor($compile): remove unused `return` statement

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -802,7 +802,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     if (!letter || letter !== lowercase(letter)) {
       throw $compileMinErr('baddir', "Directive name '{0}' is invalid. The first character must be a lowercase letter", name);
     }
-    return name;
   }
 
   /**


### PR DESCRIPTION
As discussed in https://github.com/angular/angular.js/commit/89447b3f2b4c6db62c24473a81fedc3b04242b85#commitcomment-10280666.
