### PR TITLE
fix(ngSanitize): use the smallest match on searching end tags

### DIFF
--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -350,7 +350,7 @@ function htmlParser(html, handler) {
 
     } else {
       // IE versions 9 and 10 do not understand the regex '[^]', so using a workaround with [\W\w].
-      html = html.replace(new RegExp("([\\W\\w]*)<\\s*\\/\\s*" + stack.last() + "[^>]*>", 'i'),
+      html = html.replace(new RegExp("([\\W\\w]*?)<\\s*\\/\\s*" + stack.last() + "[^>]*>", 'i'),
         function(all, text) {
           text = text.replace(COMMENT_REGEXP, "$1").replace(CDATA_REGEXP, "$1");
 

--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -176,6 +176,10 @@ describe('HTML', function() {
     expectHTML('a<SCRIPT>ev<script>evil</sCript>il</scrIpt>c.').toEqual('ac.');
   });
 
+  it('should not remove elements between script elements', function() {
+    expectHTML('a<script>ev</script>b<script>il</script>c.').toEqual('abc.');
+  });
+
   it('should remove unknown  names', function() {
     expectHTML('a<xxx><B>b</B></xxx>c').toEqual('a<b>b</b>c');
   });


### PR DESCRIPTION
ngSanitize searches the string of the end tag with the longest match.
So it removes all of the HTML strings between script elements.
We should use the smallest possible match.

Closes #11442
