### PR TITLE
fix($resource) add @ support for properties names

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -5,7 +5,7 @@ var $resourceMinErr = angular.$$minErr('$resource');
 // Helper functions and regex to lookup a dotted path on an object
 // stopping at undefined/null.  The path must be composed of ASCII
 // identifiers (just like $parse)
-var MEMBER_NAME_REGEX = /^(\.[a-zA-Z_$][0-9a-zA-Z_$]*)+$/;
+var MEMBER_NAME_REGEX = /^(\.[a-zA-Z_$@][0-9a-zA-Z_$@]*)+$/;
 
 function isValidDottedPath(path) {
   return (path != null && path !== '' && path !== 'hasOwnProperty' &&

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -44,6 +44,7 @@ describe("resource", function() {
       expect(isValidDottedPath('1abc')).toBe(false);
       expect(isValidDottedPath('.')).toBe(false);
       expect(isValidDottedPath('$')).toBe(true);
+      expect(isValidDottedPath('@')).toBe(true);
       expect(isValidDottedPath('a')).toBe(true);
       expect(isValidDottedPath('A')).toBe(true);
       expect(isValidDottedPath('a1')).toBe(true);
@@ -53,12 +54,14 @@ describe("resource", function() {
       expect(isValidDottedPath('$.$')).toBe(true);
       expect(isValidDottedPath('.$')).toBe(false);
       expect(isValidDottedPath('$.')).toBe(false);
+      expect(isValidDottedPath('@.')).toBe(false);
+      expect(isValidDottedPath('.@')).toBe(false);
     });
   });
 
   describe('lookupDottedPath', function() {
     /* global lookupDottedPath: false */
-    var data = {a: {b: 'foo', c: null}};
+    var data = {a: {b: 'foo', c: null, '@d':'d-foo'},'@b':'b-foo'};
 
     it('should throw for invalid path', function() {
       expect(function() {
@@ -68,9 +71,11 @@ describe("resource", function() {
     });
 
     it('should get dotted paths', function() {
-      expect(lookupDottedPath(data, 'a')).toEqual({b: 'foo', c: null});
+      expect(lookupDottedPath(data, 'a')).toEqual({b: 'foo', c: null, '@d':'d-foo'});
       expect(lookupDottedPath(data, 'a.b')).toBe('foo');
       expect(lookupDottedPath(data, 'a.c')).toBeNull();
+      expect(lookupDottedPath(data, 'a.@d')).toBe('d-foo');
+      expect(lookupDottedPath(data, '@b')).toBe('b-foo');
     });
 
     it('should skip over null/undefined members', function() {


### PR DESCRIPTION
Add support for properties that starts with @. This is useful when working with BadgerFish convention.
