### PR TITLE
fix(ngTouch): make tests pass on Chrome with touch enabled

### DIFF
--- a/src/ngScenario/browserTrigger.js
+++ b/src/ngScenario/browserTrigger.js
@@ -134,17 +134,15 @@
   }
 
   function createTouchEvent(element, eventType, x, y) {
-    var evnt = document.createEvent('TouchEvent');
+    var evnt = new Event(eventType);
     x = x || 0;
     y = y || 0;
 
     var touch = document.createTouch(window, element, Date.now(), x, y, x, y);
     var touches = document.createTouchList(touch);
-    var targetTouches = document.createTouchList(touch);
-    var changedTouches = document.createTouchList(touch);
 
-    evnt.initTouchEvent(eventType, true, true, window, null, 0, 0, 0, 0, false, false, false, false,
-      touches, targetTouches, changedTouches, 1, 0);
+    evnt.touches = touches;
+
     return evnt;
   }
 }());


### PR DESCRIPTION
Using the `initTouchEvent()` method (introduces in 06a9f0a) did not correctly initialize the event, nor did the event get dispatched on the target element (e.g. on desktop Chrome with touch-events enabled).

Using the `Event` constructor and manually attaching a `TouchList`, works around the issue (although not a proper fix).

/ping @mzgol, @petebacondarwin
