### PR TITLE
fix(ngAnimate): use negative delay values to drive animation blocking

### DIFF
--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1855,7 +1855,7 @@ describe("ngAnimate", function() {
             })
           );
 
-          it("should place a hard block when a structural CSS transition is run",
+          it("should block transition animations by setting a negative delay value matching the duration of the animation",
             inject(function($animate, $rootScope, $compile, $sniffer) {
 
             if (!$sniffer.transitions) return;
@@ -1872,11 +1872,12 @@ describe("ngAnimate", function() {
             $animate.leave(element);
             $rootScope.$digest();
 
-            expect(element.attr('style')).toMatch(/transition.*?:\s*none/);
+            // Safari likes to strip -delay when the style is inspected
+            expect(element.attr('style')).toMatch(/transition(?:-delay)?:.+?-5s/);
 
             $animate.triggerReflow();
 
-            expect(element.attr('style')).not.toMatch(/transition.*?:\s*none/);
+            expect(element.attr('style')).not.toMatch(/transition(?:-delay)?:.+?-5s/);
           }));
 
           it("should not place a hard block when a class-based CSS transition is run",


### PR DESCRIPTION
DO NOT MERGE YET. IT STILL NEEDS MORE LIVE TESTING USING ANYTHING < 1.4.

Applies to 1.2 and 1.3.

when CSS transitions are used via ngAnimate a pre-emptive "block" is
applied to the element (via `transition: 0s none`) in order to gaurantee
that the `.ng-enter`, `.ng-leave` and/or `.ng-move` CSS classes are
applied instantly. By setting `0s none` we gaurantee that the styles
present within these classes actually appear on the element. While this
works it causes a major issue with CSS classes since they disupt an ongoing
transition since the `0s none` value is destructive.

This fix makes use of negative delay values in transitions to handle
this "blocking" mechanism yet it doesn't trigger the problems that setting

Closes #11481
