### PR TITLE
fix @param tag for $provide.decorator

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -179,7 +179,7 @@ function annotate(fn, strictDi, name) {
  * Return an instance of the service.
  *
  * @param {string} name The name of the instance to retrieve.
- * @param {string} caller An optional string to provide the origin of the function call for error messages.
+ * @param {string=} caller An optional string to provide the origin of the function call for error messages.
  * @return {*} The instance.
  */
 

--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -593,7 +593,7 @@ function annotate(fn, strictDi, name) {
  * object which replaces or wraps and delegates to the original service.
  *
  * @param {string} name The name of the service to decorate.
- * @param {Function|Array decorator This function will be invoked when the service needs to be
+ * @param {Function|Array} decorator This function will be invoked when the service needs to be
  *    instantiated and should return the decorated service instance. The function is called using
  *    the {@link auto.$injector#invoke injector.invoke} method and is therefore fully injectable.
  *    Local injection arguments:

--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -593,7 +593,7 @@ function annotate(fn, strictDi, name) {
  * object which replaces or wraps and delegates to the original service.
  *
  * @param {string} name The name of the service to decorate.
- * @param {function()} decorator This function will be invoked when the service needs to be
+ * @param {Function|Array decorator This function will be invoked when the service needs to be
  *    instantiated and should return the decorated service instance. The function is called using
  *    the {@link auto.$injector#invoke injector.invoke} method and is therefore fully injectable.
  *    Local injection arguments:


### PR DESCRIPTION
The $provide.decorator function, as per the documentation, "is called using the auto.injector.invoke method and is therefore fully injectable."

The current @param contradicts this by stating that only Functions may be used as an argument.
