### PR TITLE
fix(jqLite): Check "length" in obj in isArrayLike for iOS JIT bug

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -200,7 +200,9 @@ function isArrayLike(obj) {
     return false;
   }
 
-  var length = obj.length;
+  // Support: iOS 8.2 (not reproducible in simulator)
+  // "length" in obj used to prevent JIT error (gh-11508)
+  var length = "length" in Object(obj) && obj.length;
 
   if (obj.nodeType === NODE_TYPE_ELEMENT && length) {
     return true;


### PR DESCRIPTION
to prevent iOS8 JIT bug (https://bugs.webkit.org/show_bug.cgi?id=142792) from surfacing

This is the fix implemented in [underscore.js](https://github.com/jridgewell/underscore/commit/086a56d04c0214054219d83eff25a4cbba524fc2) and most likely the fix that will be implemented in [jQuery](https://github.com/jquery/jquery/issues/2145#issuecomment-88650887).

It's not a very easy to recreate bug, but I stumbled upon it myself in our production app and was able to narrow it down to isArrayLike after several hours of banging my head.  This plunkr was the closest I got to consistently surfacing the bug in Angular: http://plnkr.co/edit/UQ5NhZnRuafNxWiJuuyN

That ng-repeat will fail, but only on iOS8 (and i've personally only had it fail on iPad) about 50% of the time after a few digests.  If it doesn't fail quick reloading the plunkr a few times will usually get it to fail.
