### PR TITLE
docs(ngSwitch): Replace tt tag with code tag

### DIFF
--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -43,7 +43,7 @@
  *
  * @scope
  * @priority 1200
- * @param {*} ngSwitch|on expression to match against <tt>ng-switch-when</tt>.
+ * @param {*} ngSwitch|on expression to match against <code>ng-switch-when</code>.
  * On child elements add:
  *
  * * `ngSwitchWhen`: the case statement to match against. If match then this
@@ -60,7 +60,7 @@
       <div ng-controller="ExampleController">
         <select ng-model="selection" ng-options="item for item in items">
         </select>
-        <tt>selection={{selection}}</tt>
+        <code>selection={{selection}}</code>
         <hr/>
         <div class="animate-switch-container"
           ng-switch on="selection">


### PR DESCRIPTION
Use of tt is discouraged, see:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt
http://www.w3.org/wiki/HTML/Elements/tt
