### PR TITLE
fix($cookies): update $cookies to prevent duplicate cookie writes

### DIFF
--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -86,6 +86,7 @@ angular.module('ngCookies', ['ng']).
         for (name in lastCookies) {
           if (isUndefined(cookies[name])) {
             $browser.cookies(name, undefined);
+            delete lastCookies[name];
           }
         }
 
@@ -98,13 +99,13 @@ angular.module('ngCookies', ['ng']).
           }
           if (value !== lastCookies[name]) {
             $browser.cookies(name, value);
+            lastCookies[name] = value;
             updated = true;
           }
         }
 
         //verify what was actually stored
         if (updated) {
-          updated = false;
           browserCookies = $browser.cookies();
 
           for (name in cookies) {
@@ -112,10 +113,10 @@ angular.module('ngCookies', ['ng']).
               //delete or reset all cookies that the browser dropped from $cookies
               if (isUndefined(browserCookies[name])) {
                 delete cookies[name];
+                delete lastCookies[name];
               } else {
-                cookies[name] = browserCookies[name];
+                cookies[name] = lastCookies[name] = browserCookies[name];
               }
-              updated = true;
             }
           }
         }

--- a/test/ngCookies/cookiesSpec.js
+++ b/test/ngCookies/cookiesSpec.js
@@ -45,6 +45,51 @@ describe('$cookies', function() {
   }));
 
 
+  it('should only set the browser cookie once per cookie change',
+      inject(function($cookies, $browser, $rootScope) {
+    function hasArgs(call) {
+      return call.args.length > 0;
+    }
+
+    spyOn($browser, 'cookies').andCallThrough();
+
+    $cookies.oatmealCookie = 'nom nom';
+    $rootScope.$digest();
+
+    expect($browser.cookies.calls.filter(hasArgs).length).toEqual(1);
+  }));
+
+
+  it('should only delete the browser cookie once per cookie delete',
+      inject(function($cookies, $browser, $rootScope) {
+    function hasArgs(call) {
+      return call.args.length > 0;
+    }
+
+    spyOn($browser, 'cookies').andCallThrough();
+
+    delete $cookies.preexisting;
+    $rootScope.$digest();
+
+    expect($browser.cookies.calls.filter(hasArgs).length).toEqual(1);
+  }));
+
+
+  it('should allow cookies to be set outside the service without overwriting/duplicating',
+      inject(function($cookies, $browser, $rootScope) {
+    var browserCookieSpy = spyOn($browser, 'cookies').andCallThrough();
+
+    function hasArgs(call) {
+      return call.args.length > 0;
+    }
+
+    $browser.cookieHash['preexisting'] = 'vanilla';
+    $cookies.oatmealCookie = 'nom nom';
+    $rootScope.$digest();
+    expect(browserCookieSpy.calls.filter(hasArgs).length).toEqual(1);
+  }));
+
+
   it('should convert non-string values to string',
       inject(function($cookies, $browser, $rootScope) {
     $cookies.nonString = [1, 2, 3];


### PR DESCRIPTION
update $cookies to prevent duplicate cookie writes and play nice with external code

Update the ngCookies service to prevent repetitive writes via $browser.cookies()
Also it is possible for $cookies to get confused about cookies modified outside of $cookies and
see those changes as user changes via the $cookies service which would then be set again. This
unnecessary setting of cookies can duplicate or overwrite depending on the original cookie's
domain. This update prevents that scenario.

Closes #11490
