### PR TITLE
fix(ngMock): Add responseType function parameter in mock httpbackend for passthrough

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1129,7 +1129,7 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
   }
 
   // TODO(vojta): change params to: method, url, data, headers, callback
-  function $httpBackend(method, url, data, callback, headers, timeout, withCredentials) {
+  function $httpBackend(method, url, data, callback, headers, timeout, withCredentials, responseType) {
     var xhr = new MockXhr(),
         expectation = expectations[0],
         wasExpected = false;
@@ -1193,7 +1193,7 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
           // if $browser specified, we do auto flush all requests
           ($browser ? $browser.defer : responsesPush)(wrapResponse(definition));
         } else if (definition.passThrough) {
-          $delegate(method, url, data, callback, headers, timeout, withCredentials);
+          $delegate(method, url, data, callback, headers, timeout, withCredentials, responseType);
         } else throw new Error('No response defined !');
         return;
       }

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1796,19 +1796,19 @@ describe('ngMockE2E', function() {
     describe('passThrough()', function() {
       it('should delegate requests to the real backend when passThrough is invoked', function() {
         hb.when('GET', /\/passThrough\/.*/).passThrough();
-        hb('GET', '/passThrough/23', null, callback, {}, null, true);
+        hb('GET', '/passThrough/23', null, callback, {}, null, true, 'arraybuffer');
 
         expect(realHttpBackend).toHaveBeenCalledOnceWith(
-            'GET', '/passThrough/23', null, callback, {}, null, true);
+            'GET', '/passThrough/23', null, callback, {}, null, true, 'arraybuffer');
       });
 
       it('should be able to override a respond definition with passThrough', function() {
         var definition = hb.when('GET', /\/passThrough\/.*/).respond('override me');
         definition.passThrough();
-        hb('GET', '/passThrough/23', null, callback, {}, null, true);
+        hb('GET', '/passThrough/23', null, callback, {}, null, true, 'arraybuffer');
 
         expect(realHttpBackend).toHaveBeenCalledOnceWith(
-            'GET', '/passThrough/23', null, callback, {}, null, true);
+            'GET', '/passThrough/23', null, callback, {}, null, true, 'arraybuffer');
       });
 
       it('should be able to override a respond definition with passThrough', inject(function($browser) {


### PR DESCRIPTION
The ngMock $httpBackend allows http request routes that have not been defined
for mocking to be passed through to the real http backend service. The
responseType parameter was missing in the ngMock httpbackend parameter
list.

closes #5415
