### PR TITLE
docs(guide/Conceptual Overview): missing word in sentnce

### DIFF
--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -76,7 +76,7 @@ stores/updates the value of the input field into/from a variable.
 The second kind of new markup are the double curly braces `{{ expression | filter }}`:
 When the compiler encounters this markup, it will replace it with the evaluated value of the markup.
 An <a name="expression">{@link expression expression}</a> in a template is a JavaScript-like code snippet that allows
-to read and write variables. Note that those variables are not global variables.
+to read and write variables. <-- Make this sentence make sense! thx. Note that those variables are not global variables.
 Just like variables in a JavaScript function live in a scope,
 Angular provides a <a name="scope">{@link scope scope}</a> for the variables accessible to expressions.
 The values that are stored in variables on the scope are referred to as the <a name="model">model</a>


### PR DESCRIPTION
This sentence is missing something...

An expression in a template is a JavaScript-like code snippet that allows to read and write variables.
