### PR TITLE
docs(ngMessages): missing quote in sample

### DIFF
--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -159,7 +159,7 @@ var jqLite = angular.element;
  *         required />
  *   <div ng-messages="myForm.myEmail.$error">
  *     <div ng-message-exp="'required'">You did not enter your email address</div>
- *     <div ng-message-exp="['minlength', 'maxlength]">
+ *     <div ng-message-exp="['minlength', 'maxlength']">
  *       Your email must be between 5 and 100 characters long
  *     </div>
  *   </div>


### PR DESCRIPTION
A tiny quote is missing in documentation of `ngMessages` for the brand new `ngMessageExp`
