### PR TITLE
refactor(directives.js): restrict default AC -> AE

### DIFF
--- a/src/ng/directive/directives.js
+++ b/src/ng/directive/directives.js
@@ -6,6 +6,6 @@ function ngDirective(directive) {
       link: directive
     };
   }
-  directive.restrict = directive.restrict || 'AC';
+  directive.restrict = directive.restrict || 'AE';
   return valueFn(directive);
 }


### PR DESCRIPTION
let's be honest, no one uses Class directives in Angular1 and this will be more inline with Angular2. I can also change it to 'AEC' for the defaults to be backwards compatible.
