### PR TITLE
feat($animate): provide support for animations on elements outside of $rootElement

### DIFF
--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -72,6 +72,7 @@ var $$CoreAnimateQueueProvider = function() {
       enabled: noop,
       on: noop,
       off: noop,
+      pin: noop,
 
       push: function(element, event, options, domOperation) {
         domOperation        && domOperation();
@@ -272,6 +273,25 @@ var $AnimateProvider = ['$provide', function($provide) {
       // be interpreted as null within the sub enabled function
       on: $$animateQueue.on,
       off: $$animateQueue.off,
+
+      /**
+       * @ngdoc method
+       * @name $animate#pin
+       * @kind function
+       * @description Associates the provided element with a host parent element to allow the element to be animated even if it exists
+       *    outside of the DOM structure of the Angular application. By doing so, any animation triggered via `$animate` can be issued on the
+       *    element despite being outside the realm of the application or within another application. Say for example if the application
+       *    was bootstrapped on an element that is somewhere inside of the `<body>` tag, but we wanted to allow for an element to be situated
+       *    as a direct child of `document.body`, then this can be achieved by pinning the element via `$animate.pin(element)`. Keep in mind
+       *    that calling `$animate.pin(element, parentElement)` will not actually insert into the DOM anywhere; it will just create the association.
+       *
+       *    Note that this feature is only active when the `ngAnimate` module is used.
+       *
+       * @param {DOMElement} element the external element that will be pinned
+       * @param {DOMElement} parentElement the host parent element that will be associated with the external element
+       */
+      pin: $$animateQueue.pin,
+
       enabled: $$animateQueue.enabled,
 
       cancel: function(runner) {

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1114,6 +1114,74 @@ describe("animations", function() {
     }));
   });
 
+  describe('.pin()', function() {
+    var capturedAnimation;
+
+    beforeEach(module(function($provide) {
+      capturedAnimation = null;
+      $provide.factory('$$animation', function($$AnimateRunner) {
+        return function() {
+          capturedAnimation = arguments;
+          return new $$AnimateRunner();
+        };
+      });
+    }));
+
+    it('should allow an element to pinned elsewhere and still be available in animations',
+      inject(function($animate, $compile, $document, $rootElement, $rootScope) {
+
+      var body = jqLite($document[0].body);
+      var innerParent = jqLite('<div></div>');
+      body.append(innerParent);
+      innerParent.append($rootElement);
+
+      var element = jqLite('<div></div>');
+      body.append(element);
+
+      $animate.addClass(element, 'red');
+      $rootScope.$digest();
+      expect(capturedAnimation).toBeFalsy();
+
+      $animate.pin(element, $rootElement);
+
+      $animate.addClass(element, 'blue');
+      $rootScope.$digest();
+      expect(capturedAnimation).toBeTruthy();
+
+      dealoc(element);
+    }));
+
+    it('should adhere to the disabled state of the hosted parent when an element is pinned',
+      inject(function($animate, $compile, $document, $rootElement, $rootScope) {
+
+      var body = jqLite($document[0].body);
+      var innerParent = jqLite('<div></div>');
+      body.append(innerParent);
+      innerParent.append($rootElement);
+      var innerChild = jqLite('<div></div>');
+      $rootElement.append(innerChild);
+
+      var element = jqLite('<div></div>');
+      body.append(element);
+
+      $animate.pin(element, innerChild);
+
+      $animate.enabled(innerChild, false);
+
+      $animate.addClass(element, 'blue');
+      $rootScope.$digest();
+      expect(capturedAnimation).toBeFalsy();
+
+      $animate.enabled(innerChild, true);
+
+      $animate.addClass(element, 'red');
+      $rootScope.$digest();
+      expect(capturedAnimation).toBeTruthy();
+
+      dealoc(element);
+    }));
+  });
+
   describe('callbacks', function() {
     var captureLog = [];
     var capturedAnimation = [];


### PR DESCRIPTION
By default, ngAnimate only considers animations for elements that live within `$rootElement`. This is to prevent the accidental animation of elements that fall outside of an application. This feature, however, is limited since it prevents animations from running on elements that are situated by the `body` tag while being outside of `ng-app`. Drop down menus for example use absolute positioning and are therefore situated directly inside of `document.body`. This fix allows for this to work by using `$animate.pin()` to flag elements that live outside of `$rootElement`.

--- commit ---

Beforehand it was impossible to issue an animation via $animate on an
element that is outside the realm of an Angular app. Take for example a
dropdown menu where the menu is positioned with absolute positioning...
The element will most likely need to be placed by the `<body>` tag, but
if the angular application is bootstrapped elsewhere then it cannot be
animated.

This fix provides support for `$animate.pin()` which allows for an
external element to be virtually placed in the DOM structure of a host
parent element within the DOM of an angular app.
