### PR TITLE
fix(ngAnimate): ensure that a filtered-out leave animation always runs its DOM operation

### DIFF
--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -250,7 +250,7 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
 
       var className = [node.className, options.addClass, options.removeClass].join(' ');
       if (!isAnimatableClassName(className)) {
-        runner.end();
+        close();
         return runner;
       }
 

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -106,7 +106,7 @@ describe("animations", function() {
       module(function($animateProvider) {
         $animateProvider.classNameFilter(/only-allow-this-animation/);
       });
-      inject(function($animate, $rootScope, $document, $rootElement) {
+      inject(function($animate, $rootScope) {
         expect(element).not.toHaveClass('only-allow-this-animation');
 
         $animate.enter(element, parent);
@@ -118,6 +118,22 @@ describe("animations", function() {
         $animate.leave(element, parent);
         $rootScope.$digest();
         expect(capturedAnimation).toBeTruthy();
+      });
+    });
+
+    it('should complete the leave DOM operation in case the classNameFilter fails', function() {
+      module(function($animateProvider) {
+        $animateProvider.classNameFilter(/memorable-animation/);
+      });
+      inject(function($animate, $rootScope) {
+        expect(element).not.toHaveClass('memorable-animation');
+
+        parent.append(element);
+        $animate.leave(element);
+        $rootScope.$digest();
+
+        expect(capturedAnimation).toBeFalsy();
+        expect(element[0].parentNode).toBeFalsy();
       });
     });
 


### PR DESCRIPTION
This patch fixes the issue where filtered-out leave animations were not
properly run the DOM operation when closed.

Closes #11555
