### PR TITLE
docs(form): remove obsolete tt element

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -415,11 +415,11 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
        <form name="myForm" ng-controller="FormController" class="my-form">
          userType: <input name="input" ng-model="userType" required>
          <span class="error" ng-show="myForm.input.$error.required">Required!</span><br>
-         <tt>userType = {{userType}}</tt><br>
-         <tt>myForm.input.$valid = {{myForm.input.$valid}}</tt><br>
-         <tt>myForm.input.$error = {{myForm.input.$error}}</tt><br>
-         <tt>myForm.$valid = {{myForm.$valid}}</tt><br>
-         <tt>myForm.$error.required = {{!!myForm.$error.required}}</tt><br>
+         <code>userType = {{userType}}</code><br>
+         <code>myForm.input.$valid = {{myForm.input.$valid}}</code><br>
+         <code>myForm.input.$error = {{myForm.input.$error}}</code><br>
+         <code>myForm.$valid = {{myForm.$valid}}</code><br>
+         <code>myForm.$error.required = {{!!myForm.$error.required}}</code><br>
         </form>
       </file>
       <file name="protractor.js" type="protractor">


### PR DESCRIPTION
Remove the [**obsolete** HTML Teletype Text Element `<tt>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt) and replace it with [`<code>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code). Add more semanticity and make use of the [HTML5 specification](http://www.w3.org/TR/html5/text-level-semantics.html#the-code-element).

Similar to https://github.com/rparrapy/angular.js/commit/8b6deb6f4f924bda469a68c7256235257a8bf9b1
