### PR TITLE
fix($http): stop $httpBackend coersion of falsy values to null before xh...

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -109,7 +109,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
         }
       }
 
-      xhr.send(post || null);
+      xhr.send(post);
     }
 
     if (timeout > 0) {

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -50,6 +50,13 @@ describe('$httpBackend', function() {
     expect(xhr.$$data).toBe(null);
   });
 
+  it('should pass false to send if false body is set', function() {
+    $backend('GET', '/some-url', false, noop);
+    xhr = MockXhr.$$lastInstance;
+
+    expect(xhr.$$data).toBe(false);
+  });
+
   it('should call completion function with xhr.statusText if present', function() {
     callback.andCallFake(function(status, response, headers, statusText) {
       expect(statusText).toBe('OK');


### PR DESCRIPTION
...r.send()

stop $httpBackend from potentially overriding false values to null when sending a falsy value to a web service via POST or PUT et al
