### PR TITLE
fix($browser): prevent infinite $digest from no trailing slash in IE9

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -190,9 +190,7 @@ function Browser(window, document, $log, $sniffer) {
         // Do the assignment again so that those two variables are referentially identical.
         lastHistoryState = cachedState;
       } else {
-        if (!sameBase) {
-          reloadLocation = url;
-        }
+        reloadLocation = url;
         if (replace) {
           location.replace(url);
         } else if (!sameBase) {

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -883,7 +883,7 @@ function $LocationProvider() {
       $browser.url($location.absUrl(), true);
     }
 
-    var initializing = true;
+    var initializing = true, skipLocationWatch = false;
 
     // update $location when $browser url changes
     $browser.onUrlChange(function(newUrl, newState) {
@@ -916,6 +916,11 @@ function $LocationProvider() {
 
     // update browser
     $rootScope.$watch(function $locationWatch() {
+      if (skipLocationWatch && !$location.$$replace) {
+        //prevent infinite $digest errors in hashbang mode
+        skipLocationWatch = false;
+        return;
+      }
       var oldUrl = trimEmptyHash($browser.url());
       var newUrl = trimEmptyHash($location.absUrl());
       var oldState = $browser.state();
@@ -943,7 +948,12 @@ function $LocationProvider() {
               setBrowserUrlWithFallback(newUrl, currentReplace,
                                         oldState === $location.$$state ? null : $location.$$state);
             }
+            var oldLocationAbsUrl = $location.absUrl();
             afterLocationChange(oldUrl, oldState);
+            if (oldLocationAbsUrl !== $location.absUrl() &&
+                  trimEmptyHash($location.absUrl()) !== trimEmptyHash($browser.url())) {
+                skipLocationWatch = true;
+            }
           }
         });
       }

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -883,7 +883,7 @@ function $LocationProvider() {
       $browser.url($location.absUrl(), true);
     }
 
-    var initializing = true, skipLocationWatch = false;
+    var initializing = true;
 
     // update $location when $browser url changes
     $browser.onUrlChange(function(newUrl, newState) {
@@ -916,11 +916,6 @@ function $LocationProvider() {
 
     // update browser
     $rootScope.$watch(function $locationWatch() {
-      if (skipLocationWatch && !$location.$$replace) {
-        //prevent infinite $digest errors in hashbang mode
-        skipLocationWatch = false;
-        return;
-      }
       var oldUrl = trimEmptyHash($browser.url());
       var newUrl = trimEmptyHash($location.absUrl());
       var oldState = $browser.state();
@@ -948,12 +943,7 @@ function $LocationProvider() {
               setBrowserUrlWithFallback(newUrl, currentReplace,
                                         oldState === $location.$$state ? null : $location.$$state);
             }
-            var oldLocationAbsUrl = $location.absUrl();
             afterLocationChange(oldUrl, oldState);
-            if (oldLocationAbsUrl !== $location.absUrl() &&
-                  trimEmptyHash($location.absUrl()) !== trimEmptyHash($browser.url())) {
-                skipLocationWatch = true;
-            }
           }
         });
       }


### PR DESCRIPTION
fix($browser): prevent infinite $digest from no trailing slash in IE9

This fix prevents IE9 from throwing an infinite $digest error when the user accesses the base
URL of the site without a trailing slash. Suppose you owned http://www.mysite.com/app
and had an Angular app hosted in a subdirectory "app". If an IE9 user accessed
http://www.mysite.com/app infinite $digest errors would be thrown on the console, but the app
itself would eventually resolve properly and work fine. Now the infinite $digest errors will
not be thrown.

Closes #11439
