### PR TITLE
docs($httpParamSerializerJQLike): fix link to `jquery.param`

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -61,7 +61,7 @@ function $HttpParamSerializerJQLikeProvider() {
    * @name $httpParamSerializerJQLike
    * @description
    *
-   * Alternative $http params serializer that follows jQuerys `param()` method {http://api.jquery.com/jquery.param/} logic.
+   * Alternative $http params serializer that follows jQuery's [`param()`](http://api.jquery.com/jquery.param/) method logic.
    * */
   this.$get = function() {
     return paramSerializerFactory(true);


### PR DESCRIPTION
Currently, the trailing `}` is interpreted as part of the URL, leading to a 404 on `jquery.com`.
