### PR TITLE
docs(ngModel): getterSetter and `arguments.length` vs. `angular.isDefined`

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -1205,7 +1205,11 @@ var DEFAULT_REGEXP = /(\s+|^)default(\s+|$)/;
           var _name = 'Brian';
           $scope.user = {
             name: function(newName) {
-              return angular.isDefined(newName) ? (_name = newName) : _name;
+              // Note that newName can be undefined for two reasons:
+              // 1. Because it is called as a getter and thus called with no arguments
+              // 2. Because the property should actually be set to undefined. This happens e.g. if the
+              //    input is invalid
+              return arguments.length ? (_name = newName) : _name;
             }
           };
         }]);


### PR DESCRIPTION
When using `ng-model-options="{ getterSetter: true }"` one should be aware that the getter/setter method could be called with an argument set to undefined even if the method is used as setter. This e.g. happens when the model is invalid:
https://github.com/angular/angular.js/blob/dd8b157299520e8167b918439c2d3534e8cba550/src/ng/directive/ngModel.js#L535

Using `arguments.length` reliably detects whether the getter/setter should act as getter or setter.
Credits for the concept:
https://github.com/angular/angular.js/issues/11361#issuecomment-84022489

I believe that this should be documented as failing to realise this can cause weird behaviour and large time spendings on hunting bugs (at least that happened to me).
