### PR TITLE
fix(ngSanitize): escape the wide char quote marks in a regex in linky.js

### DIFF
--- a/src/ngSanitize/filter/linky.js
+++ b/src/ngSanitize/filter/linky.js
@@ -104,7 +104,7 @@
  */
 angular.module('ngSanitize').filter('linky', ['$sanitize', function($sanitize) {
   var LINKY_URL_REGEXP =
-        /((ftp|https?):\/\/|(www\.)|(mailto:)?[A-Za-z0-9._%+-]+@)\S*[^\s.;,(){}<>"”’]/,
+        /((ftp|https?):\/\/|(www\.)|(mailto:)?[A-Za-z0-9._%+-]+@)\S*[^\s.;,(){}<>"\u201d\u2019]/,
       MAILTO_REGEXP = /^mailto:/;
 
   return function(text, target) {


### PR DESCRIPTION
[#11598](https://github.com/angular/angular.js/issues/11598)

It is all about the wide quote mark chars introduced in 1.3.x. I have escaped these chars.

Actually the escaped chars are what is in the compressed sanitize.min.js. If not escaped, there is a chance to get messed up on some machines, causing the script not working.
