### PR TITLE
docs(misc/Downloading): upgrade CDN path 1.3.15

### DIFF
--- a/docs/content/misc/downloading.ngdoc
+++ b/docs/content/misc/downloading.ngdoc
@@ -15,14 +15,14 @@ development.
 production.
 
 To point your code to an angular script on the Google CDN server, use the following template.  This
-example points to the minified version 1.3.14:
+example points to the minified version 1.3.15:
 
 ```
   <!doctype html>
   <html ng-app>
     <head>
       <title>My Angular App</title>
-      <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular.min.js"></script>
+      <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
     </head>
     <body>
     </body>


### PR DESCRIPTION
In order to reference to the latest stable angular version.
Background: a lot of people, including me, copy this snipped and use them in their project without checking for the latest stable version.
