### PR TITLE
docs(angular.element): css() api incompatibility.

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -55,7 +55,7 @@
  * - [`children()`](http://api.jquery.com/children/) - Does not support selectors
  * - [`clone()`](http://api.jquery.com/clone/)
  * - [`contents()`](http://api.jquery.com/contents/)
- * - [`css()`](http://api.jquery.com/css/) - Only retrieves inline-styles, does not call `getComputedStyle()`
+ * - [`css()`](http://api.jquery.com/css/) - Only retrieves inline-styles, does not call `getComputedStyle()`. On write, does not convert numbers to strings and append 'px'.
  * - [`data()`](http://api.jquery.com/data/)
  * - [`detach()`](http://api.jquery.com/detach/)
  * - [`empty()`](http://api.jquery.com/empty/)


### PR DESCRIPTION
"When a number is passed as the value, jQuery will convert it to a string and add px to the end of that string."
http://api.jquery.com/css/#css2

jqLite does not appear to do this. 

Partial fix for #11626 .
(can submit full fix if desired)
