### PR TITLE
fix(ngAnimate): close parent animations only when there are classes to resolve

### DIFF
--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -388,6 +388,7 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
           // it, otherwise if it's the same then the end result will be the same too
           if (animationCancelled || (isStructural && animationDetails.event !== event)) {
             options.domOperation();
+            runner.end();
           }
 
           return;
@@ -482,7 +483,7 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
       // animations to properly function (otherwise any CSS selectors may not work)
       function examineParentAnimation(node, animationDetails) {
         // enter/leave/move always have priority
-        if (animationDetails.structural) return;
+        if (animationDetails.structural || !hasAnimationClasses(animationDetails.options)) return;
 
         if (animationDetails.state === RUNNING_STATE) {
           animationDetails.runner.end();


### PR DESCRIPTION
Previously if a parent animation was cancelled then it would not resolve
the runner when that happens. This is now fixed in this patch. Another
fix in this patch ensures that a parent animation is only cancelled if
the animation contains any classes to resolve. This prevents inline
animations from being cancelled.
