### PR TITLE
fix($browser): prevent infinite $digest from no trailing slash in IE9

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -136,6 +136,26 @@ function Browser(window, document, $log, $sniffer) {
   lastHistoryState = cachedState;
 
   /**
+   * @name $browser#forceReloadLocationUpdate
+   *
+   * @description
+   * This method is a setter.
+   *
+   * If the reloadLocation variable is already set, it will be reset to
+   * the passed-in URL.
+   *
+   * NOTE: this api is intended for use only by the $location service in the
+   * $locationWatch function.
+   *
+   * @param {string} url New url
+   */
+  self.forceReloadLocationUpdate = function(url) {
+    if (reloadLocation) {
+      reloadLocation = url;
+    }
+  };
+
+  /**
    * @name $browser#url
    *
    * @description

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -883,7 +883,7 @@ function $LocationProvider() {
       $browser.url($location.absUrl(), true);
     }
 
-    var initializing = true;
+    var initializing = true, previousOldUrl = null, previousNewUrl = null;
 
     // update $location when $browser url changes
     $browser.onUrlChange(function(newUrl, newState) {
@@ -918,6 +918,15 @@ function $LocationProvider() {
     $rootScope.$watch(function $locationWatch() {
       var oldUrl = trimEmptyHash($browser.url());
       var newUrl = trimEmptyHash($location.absUrl());
+      if ($location.$$html5 && !$sniffer.history) {
+        if (previousOldUrl === oldUrl && previousNewUrl === newUrl) {
+          // break out of infinite $digest loops caused by default routes in hashbang mode
+          $browser.forceReloadLocationUpdate(newUrl);
+          previousOldUrl = previousNewUrl = null;
+          return;
+        }
+        previousOldUrl = oldUrl, previousNewUrl = newUrl;
+      }
       var oldState = $browser.state();
       var currentReplace = $location.$$replace;
       var urlOrStateChanged = oldUrl !== newUrl ||


### PR DESCRIPTION
fix($browser): prevent infinite $digest from no trailing slash in IE9

This fix prevents IE9 from throwing an infinite $digest error when the user accesses the base
URL of the site without a trailing slash. Suppose you owned http://www.mysite.com/app
and had an Angular app hosted in a subdirectory "app". If an IE9 user accessed
http://www.mysite.com/app infinite $digest errors would be thrown on the console, but the app
itself would eventually resolve properly and work fine. Now the infinite $digest errors will
not be thrown.

Closes #11439
