### PR TITLE
feat(compile): add 'directives' property to ddo to preload templates

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1662,6 +1662,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         var attrStart = directive.$$start;
         var attrEnd = directive.$$end;
 
+        downloadTemplateDependencies(directive);
+
         // collect multiblock sections
         if (attrStart) {
           $compileNode = groupScan(compileNode, attrStart, attrEnd);
@@ -2167,6 +2169,20 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           dstAttr[key] = srcAttr[key];
         }
       });
+    }
+
+
+    function downloadTemplateDependencies(directive) {
+      if (directive.directives) {
+        directive.directives.forEach(function(name) {
+          $injector.get(name + Suffix).forEach(function(dependency) {
+            downloadTemplateDependencies(dependency);
+            if (isString(dependency.templateUrl)) {
+              $templateRequest($sce.getTrustedResourceUrl(dependency.templateUrl));
+            }
+          });
+        });
+      }
     }
 
 


### PR DESCRIPTION
this can be useful when you have many nested directives and you want to download all of the required templates in parallel instead of downloading the next template serially only after each downloaded template is compiled.
