### PR TITLE
fix($compile): Better error message on empty template

### DIFF
--- a/docs/content/error/$compile/tplrt.ngdoc
+++ b/docs/content/error/$compile/tplrt.ngdoc
@@ -51,3 +51,8 @@ well.  Consider the following template:
 
 The `<!-- container -->` comment is interpreted as a second root element and causes the template to
 be invalid.
+
+If your template contains nothing at all (and therefore no root element), it is also invalid.  For example:
+
+```
+```

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1242,6 +1242,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
     function compile($compileNodes, transcludeFn, maxPriority, ignoreDirective,
                         previousCompileContext) {
+      if ($compileNodes === '') {
+        throw $compileMinErr('tplrt', 'An empty string is not a valid template');
+      }
       if (!($compileNodes instanceof jqLite)) {
         // jquery always rewraps, whereas we need to preserve the original selector so that we can
         // modify it.


### PR DESCRIPTION
If a user ends up trying to call $compile with an empty string, they will get an error from jqLite
This commit introduces a much more accurate error to aid in debugging.

Plunker: http://plnkr.co/edit/YNxDVQNMTsiNV3WhmjcT?p=preview
