### PR TITLE
docs($httpBackend): compare $httpBackend API to $http API

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -900,7 +900,7 @@ angular.mock.dump = function(object) {
  *
  * When an Angular application needs some data from a server, it calls the $http service, which
  * sends the request to a real server using $httpBackend service. With dependency injection, it is
- * easy to inject $httpBackend mock (which has the same API as $httpBackend) and use it to verify
+ * easy to inject $httpBackend mock (which has the same API as $http) and use it to verify
  * the requests and respond with some testing data without sending a request to a real server.
  *
  * There are two ways to specify what test data should be returned as http responses by the mock


### PR DESCRIPTION
Documentation states $httpBackend has the same API as $httpBackend, it compares the API to itself. This change compares the API to $http instead.
