### PR TITLE
fix(merge): treat dates as atomic values instead of objects.

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -352,8 +352,12 @@ function baseExtend(dst, objs, deep) {
       var src = obj[key];
 
       if (deep && isObject(src)) {
-        if (!isObject(dst[key])) dst[key] = isArray(src) ? [] : {};
-        baseExtend(dst[key], [src], true);
+        if (isDate(src)) {
+          dst[key] = new Date(src.valueOf());
+        } else {
+          if (!isObject(dst[key])) dst[key] = isArray(src) ? [] : {};
+          baseExtend(dst[key], [src], true);
+        }
       } else {
         dst[key] = src;
       }

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -481,6 +481,16 @@ describe('angular', function() {
       // make sure we retain the old key
       expect(hashKey(dst)).toEqual(h);
     });
+
+
+    it('should copy dates by reference', function() {
+      var src = { date: new Date() };
+      var dst = {};
+
+      extend(dst, src);
+
+      expect(dst.date).toBe(src.date);
+    });
   });
 
 
@@ -547,6 +557,18 @@ describe('angular', function() {
         foo: [1,2,3]
       });
       expect(dst.foo).not.toBe(src.foo);
+    });
+
+
+    it('should copy dates by value', function() {
+      var src = { date: new Date() };
+      var dst = {};
+
+      merge(dst, src);
+
+      expect(dst.date).not.toBe(src.date);
+      expect(isDate(dst.date)).toBeTruthy();
+      expect(dst.date.valueOf()).toEqual(src.date.valueOf());
     });
   });
 


### PR DESCRIPTION
Makes `angular.merge` copy dates correctly.

Before and after this change:

![image](https://cloud.githubusercontent.com/assets/6508058/7330176/fb9a8f08-eabf-11e4-8e4d-a1517e02198a.png)
