### PR TITLE
$animate callbacks using DOM queries

### DIFF
--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -278,20 +278,29 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @name $animate#on
        * @kind function
        * @description Sets up an event listener to fire whenever the animation event (enter, leave, move, etc...)
-       *    has fired on the given element or among any of its children. Once the listener is fired, the provided callback
-       *    is fired with the following params:
+       *    has fired on the given element or among any of its children or within a matched query selector.
+       *    Once the listener is fired, the provided callback is fired. The example code below shows that in action:
        *
        * ```js
-       * $animate.on('enter', container,
+       * // using a DOM container
+       * $animate.on('enter', containerNode,
        *    function callback(element, phase) {
        *      // cool we detected an enter animation within the container
+       *    }
+       * );
+       *
+       * // using a query-selector
+       * $animate.on('enter', '[ng-view]',
+       *    function callback(element, phase) {
+       *      // cool, looks like the view element is entering
        *    }
        * );
        * ```
        *
        * @param {string} event the animation event that will be captured (e.g. enter, leave, move, addClass, removeClass, etc...)
-       * @param {DOMElement} container the container element that will capture each of the animation events that are fired on itself
-       *     as well as among its children
+       * @param {DOMElement|string} target the target element that will capture each of the animation events that are
+       *     fired on itself as well as among its children. If a string is provided then it will act as a querySelector
+       *     that will be used for the detection of animated elements with a matching event
        * @param {Function} callback the callback function that will be fired when the listener is triggered
        *
        * The arguments present in the callback function are:
@@ -321,7 +330,8 @@ var $AnimateProvider = ['$provide', function($provide) {
        * ```
        *
        * @param {string} event the animation event (e.g. enter, leave, move, addClass, removeClass, etc...)
-       * @param {DOMElement=} container the container element the event listener was placed on
+       * @param {(string|DOMElement)=} target the target element (element node or query selector) the event
+       *        listener was placed on
        * @param {Function=} callback the callback function that was registered as the listener
        */
       off: $$animateQueue.off,

--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -97,7 +97,8 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
       }
     );
 
-    var bodyElement = jqLite($document[0].body);
+    var documentNode = $document[0];
+    var bodyElement = jqLite(documentNode.body);
 
     var callbackRegistry = {};
 
@@ -123,7 +124,15 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
       var entries = callbackRegistry[event];
       if (entries) {
         forEach(entries, function(entry) {
-          if (entry.node.contains(targetNode)) {
+          if (entry.query) {
+            var results = documentNode.querySelectorAll(entry.query);
+            for (var i = 0; i < results.length; i++) {
+              if (results[i] === targetNode) {
+                matches.push(entry.callback);
+                break;
+              }
+            }
+          } else if (entry.node.contains(targetNode)) {
             matches.push(entry.callback);
           }
         });
@@ -142,12 +151,16 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
 
     return {
       on: function(event, container, callback) {
-        var node = extractElementNode(container);
         callbackRegistry[event] = callbackRegistry[event] || [];
-        callbackRegistry[event].push({
-          node: node,
+        var data = {
           callback: callback
-        });
+        };
+        if (isString(container)) {
+          data.query = container;
+        } else {
+          data.node = extractElementNode(container);
+        }
+        callbackRegistry[event].push(data);
       },
 
       off: function(event, container, callback) {
@@ -159,10 +172,13 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
             : filterFromRegistry(entries, container, callback);
 
         function filterFromRegistry(list, matchContainer, matchCallback) {
-          var containerNode = extractElementNode(matchContainer);
+          if (isElement(matchContainer)) {
+            matchContainer = extractElementNode(matchContainer);
+          }
+
           return list.filter(function(entry) {
-            var isMatch = entry.node === containerNode &&
-                            (!matchCallback || entry.callback === matchCallback);
+            var target = entry.query || entry.node;
+            var isMatch = target === matchContainer && (!matchCallback || entry.callback === matchCallback);
             return !isMatch;
           });
         }

--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -263,6 +263,7 @@ function ngViewFillContentFactory($compile, $controller, $route) {
       var current = $route.current,
           locals = current.locals;
 
+      locals.$element = $element;
       $element.html(locals.$template);
 
       var link = $compile($element.contents());

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1318,6 +1318,25 @@ describe("animations", function() {
       expect(callbackTriggered).toBe(true);
     }));
 
+    it('should fire a callback if the element is matched against a container selector',
+      inject(function($animate, $rootScope, $$rAF, $rootElement) {
+
+      element = jqLite('<div class="the-chosen-one"></div>');
+
+      var callbackTriggered = false;
+      $animate.on('enter', '.the-chosen-one',
+        function(element, phase, data) {
+
+        callbackTriggered = true;
+      });
+
+      $animate.enter(element, $rootElement);
+      $rootScope.$digest();
+      $$rAF.flush();
+
+      expect(callbackTriggered).toBe(true);
+    }));
+
     it('should remove all the event-based event listeners when $animate.off(event) is called',
       inject(function($animate, $rootScope, $$rAF, $rootElement) {
 
@@ -1374,6 +1393,35 @@ describe("animations", function() {
       $$rAF.flush();
 
       expect(count).toBe(3);
+    }));
+
+    it('should remove the query-based event listeners when $animate.off(event, query) is called',
+      inject(function($animate, $rootScope, $$rAF, $rootElement) {
+
+      element = jqLite('<div class="special-node"></div>');
+
+      var count = 0;
+      $animate.on('enter', '.special-node', counter);
+
+      function counter(element, phase) {
+        if (phase === 'start') {
+          count++;
+        }
+      }
+
+      $animate.enter(element, $rootElement);
+      $rootScope.$digest();
+      $$rAF.flush();
+
+      expect(count).toBe(1);
+
+      $animate.off('enter', '.special-node');
+
+      $animate.enter(element, $rootElement);
+      $rootScope.$digest();
+      $$rAF.flush();
+
+      expect(count).toBe(1);
     }));
 
     it('should remove the callback-based event listener when $animate.off(event, container, callback) is called',

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -79,6 +79,29 @@ describe('ngView', function() {
     });
   });
 
+  it('should instantiate the associated controller and inject $element into the locals', function() {
+    var capturedElement,
+        Ctrl = function($element) {
+          capturedElement = $element;
+        };
+
+    module(function($routeProvider) {
+      $routeProvider.when('/element-page', {templateUrl: '/page.html', controller: Ctrl});
+    });
+
+    inject(function($route, $rootScope, $templateCache, $location) {
+      $templateCache.put('/page.html', [200, '', {}]);
+      $location.path('/element-page');
+
+      expect(function() {
+        $rootScope.$digest();
+      }).not.toThrow();
+
+      expect(capturedElement).toBeDefined();
+      expect(capturedElement[0].nodeName).toBe('NG:VIEW');
+    });
+  });
+
 
   it('should instantiate controller with an alias', function() {
     var log = [], controllerScope,


### PR DESCRIPTION
This patch fixes ngView to inject `$element` and also patches `$animate.on` and `$animate.off` to provide support for triggering callbacks based on a DOM-query.

All of this is to make using animation callbacks within controllers easier.
