### PR TITLE
Clarify's test case for ng-repeat stability test.

### DIFF
--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -1084,7 +1084,7 @@ describe('ngRepeat', function() {
     beforeEach(function() {
       element = $compile(
         '<ul>' +
-          '<li ng-repeat="item in items">{{key}}:{{val}}|></li>' +
+          '<li ng-repeat="item in items">{{item}}</li>' +
         '</ul>')(scope);
       a = {};
       b = {};


### PR DESCRIPTION
Hey Angular devs,

I was going through the `ng-repeat` directive test cases, and noticed a typo (or at least, I think its a typo) in the setup for the stability test case.

Having `{{key}}:{{val}}` in the repeated element did not seem to make sense to me, especially when the expression is `ng-repeat="item in items"`. 

Anyways, hope this helps!
