### PR TITLE
fix($http): do not modify the config object passed into $http short methods

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -1076,7 +1076,7 @@ function $HttpProvider() {
     function createShortMethods(names) {
       forEach(arguments, function(name) {
         $http[name] = function(url, config) {
-          return $http(extend(config || {}, {
+          return $http(extend({}, config || {}, {
             method: name,
             url: url
           }));
@@ -1088,7 +1088,7 @@ function $HttpProvider() {
     function createShortMethodsWithData(name) {
       forEach(arguments, function(name) {
         $http[name] = function(url, data, config) {
-          return $http(extend(config || {}, {
+          return $http(extend({}, config || {}, {
             method: name,
             url: url,
             data: data

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -230,13 +230,16 @@ describe('$http', function() {
           });
         });
         inject(function($http, $httpBackend, $rootScope) {
-          var config = { method: 'get', url: '/url', headers: { foo: 'bar'} };
+          var config = { headers: { foo: 'bar'} };
+          var configCopy = angular.copy(config);
           $httpBackend.expect('GET', '/intercepted').respond('');
-          $http.get('/url');
+          $http.get('/url', config);
           $rootScope.$apply();
-          expect(config.method).toEqual('get');
-          expect(config.url).toEqual('/url');
-          expect(config.headers.foo).toEqual('bar');
+          expect(config).toEqual(configCopy);
+          $httpBackend.expect('POST', '/intercepted').respond('');
+          $http.post('/url', {bar: 'baz'}, config);
+          $rootScope.$apply();
+          expect(config).toEqual(configCopy);
         });
       });
 


### PR DESCRIPTION
Update $http's `createShortMethods` and `createShortMethodsWithData` to extend an empty object instead of the passed-in config.

Previously, since $http was extending the passed-in config, the changes to the config object persisted even after the call to $http's get/post/etc. returned:

```
var config = { some_key: 1 };
$http.get('/testUrl', config);
// config now contains { some_key: 1, url: '/testUrl', method: 'GET' }
```

This causes unexpected behavior if that config object is reused in subsequent calls to $http. The existing test in httpSpec was not properly testing this situation.
