### PR TITLE
fix(ngOptions): correctly watch displayed value for changes

### DIFF
--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -303,7 +303,7 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
           watchedArray.push(selectValue);
 
           // Only need to watch the displayFn if there is a specific label expression
-          if (match[2]) {
+          if (match[2] || match[1]) {
             var label = displayFn(scope, locals);
             watchedArray.push(label);
           }


### PR DESCRIPTION
ngOptions does not update the displayed value properly if the property being used as the label changes when not using the "select as" or "track by" syntax, i.e `<select ng-options="value.label for value in array"></select>` will not update if `array[0].label` is changed but `<select ng-options="value.label as value.label for value in array></select>` will correctly update.

The bug is demonstrated here: [https://jsfiddle.net/76qrsctv/17/](https://jsfiddle.net/76qrsctv/18/)

The proposed change fixes this issue.
