### PR TITLE
fix($compile): validate directive name for whitespaces

### DIFF
--- a/docs/content/error/$compile/baddir.ngdoc
+++ b/docs/content/error/$compile/baddir.ngdoc
@@ -5,4 +5,4 @@
 
 This error occurs when the name of a directive is not valid.
 
-Directives must start with a lowercase character.
+Directives must start with a lowercase character and must not contain leading or trailing whitespaces.

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -802,6 +802,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     if (!letter || letter !== lowercase(letter)) {
       throw $compileMinErr('baddir', "Directive name '{0}' is invalid. The first character must be a lowercase letter", name);
     }
+    if (name !== name.trim()) {
+      throw $compileMinErr('baddir',
+            "Directive name '{0}' is invalid. The name should not contain leading or trailing whitespaces",
+            name);
+    }
   }
 
   /**

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -211,6 +211,21 @@ describe('$compile', function() {
       });
       inject(function($compile) {});
     });
+    it('should throw an exception if a directive name has leading or trailing whitespace', function() {
+      module(function() {
+        function assertLeadingOrTrailingWhitespaceInDirectiveName(name) {
+          expect(function() {
+            directive(name, function() { });
+          }).toThrowMinErr(
+            '$compile','baddir', 'Directive name \'' + name + '\' is invalid. ' +
+            "The name should not contain leading or trailing whitespaces");
+        }
+        assertLeadingOrTrailingWhitespaceInDirectiveName(' leadingWhitespaceDirectiveName');
+        assertLeadingOrTrailingWhitespaceInDirectiveName('trailingWhitespaceDirectiveName ');
+        assertLeadingOrTrailingWhitespaceInDirectiveName(' leadingAndTrailingWhitespaceDirectiveName ');
+      });
+      inject(function($compile) {});
+    });
   });
 
 


### PR DESCRIPTION
Throw an exception if directive name contains leading or trailing whitespaces

Closes #11397
