### PR TITLE
fix($rootScope): stop memory leak in IE9

### DIFF
--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1211,6 +1211,34 @@ describe('Scope', function() {
       expect(child.parentModel).toBe('parent');
       expect(child.childModel).toBe('child');
     }));
+
+
+    if (msie === 9) {
+      // See issue https://github.com/angular/angular.js/issues/10706
+      it('should completely disconnect all child scopes on IE9', inject(function($rootScope) {
+        var parent = $rootScope.$new(),
+            child1 = parent.$new(),
+            child2 = parent.$new(),
+            grandChild = child1.$new();
+        parent.$destroy();
+
+        $rootScope.$digest();
+
+        expect(isDisconnected(parent)).toBe(true);
+        expect(isDisconnected(child1)).toBe(true);
+        expect(isDisconnected(child2)).toBe(true);
+        expect(isDisconnected(grandChild)).toBe(true);
+
+        function isDisconnected($scope) {
+          return $scope.$$nextSibling === null &&
+                 $scope.$$prevSibling === null &&
+                 $scope.$$childHead === null &&
+                 $scope.$$childTail === null &&
+                 $scope.$root === null &&
+                 $scope.$$watchers === null;
+        }
+      }));
+    }
   });
 
 


### PR DESCRIPTION
DO NOT MERGE
This is a work in progress for discussion - it is not ideal is lacking tests.

Closes #10706
