### PR TITLE
fix(filterFilter): allow array like objects to be filtered

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -127,7 +127,7 @@
  */
 function filterFilter() {
   return function(array, expression, comparator) {
-    if (!isArray(array)) {
+    if (!isArrayLike(array)) {
       if (array == null) {
         return array;
       } else {
@@ -157,7 +157,7 @@ function filterFilter() {
         return array;
     }
 
-    return array.filter(predicateFn);
+    return Array.prototype.filter.call(array, predicateFn);
   };
 }
 

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -425,6 +425,23 @@ describe('Filter: filter', function() {
       toThrowMinErr('filter', 'notarray', 'Expected array but received: {"toString":null,"valueOf":null}');
   });
 
+  it('should not throw an error if used with an array like object', function() {
+    function getArguments() {
+      return arguments;
+    }
+    var argsObj = getArguments({name: 'Misko'}, {name: 'Igor'}, {name: 'Brad'});
+
+    var nodeList = jqLite("<p><span>Misko</span><span>Igor</span><span>Brad</span></p>")[0].childNodes;
+    function nodeFilterPredicate(node) {
+      return node.innerHTML.indexOf("I") !== -1;
+    }
+
+    expect(filter(argsObj, 'i').length).toBe(2);
+    expect(filter('abc','b').length).toBe(1);
+    expect(filter(nodeList, nodeFilterPredicate).length).toBe(1);
+
+  });
+
 
   it('should return undefined when the array is undefined', function() {
     expect(filter(undefined, {})).toBeUndefined();


### PR DESCRIPTION
Throw error if filter is not used with an array like object.

Previous PR #10352 restricted filterFilter to use only arrays, but it can perfectly work with array like objects.

Closes #11782
