### PR TITLE
fix(ngOptions): fix frozen ui in ie with more than one select[multiple]

### DIFF
--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -576,11 +576,16 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
       function updateOptionElement(option, element) {
         option.element = element;
         element.disabled = option.disabled;
-        if (option.value !== element.value) element.value = option.selectValue;
+        // NOTE: The label must be set before the value, otherwise IE10/11/EDGE create unresponsive
+        // selects in certain circumstances when multiple selects are next to each other and display
+        // the option list in listbox style, i.e. the select is [multiple], or specifies a [size].
+        // See https://github.com/angular/angular.js/issues/11314 for more info.
+        // This is unfortunately untestable with unit / e2e tests
         if (option.label !== element.label) {
           element.label = option.label;
           element.textContent = option.label;
         }
+        if (option.value !== element.value) element.value = option.selectValue;
       }
 
       function addOrReuseElement(parent, current, type, templateElement) {


### PR DESCRIPTION
If there are more than one select, and the first select is wrappend
in an element with display: inline or display: inline-block, all but
the last select are completely unresponsive to any user input.

This cannot be tested in a unit-test, as the events must come directly
from the ui.

Close #11314 

This is pretty tricky, as we probably need an e2e test for this, but they currently don't run on IE. I'm also not sure if we can simply leave the label setting out.

@petebacondarwin should we wait with this until we have IE e2e tests?
