### PR TITLE
fix($compile): workaround for IE11 MutationObserver

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1540,6 +1540,13 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           }
           break;
         case NODE_TYPE_TEXT: /* Text Node */
+          if (msie === 11) {
+            // Workaround for #11781
+            while (node.parentNode && node.nextSibling && node.nextSibling.nodeType === NODE_TYPE_TEXT) {
+              node.nodeValue = node.nodeValue + node.nextSibling.nodeValue;
+              node.parentNode.removeChild(node.nextSibling);
+            }
+          }
           addTextInterpolateDirective(directives, node.nodeValue);
           break;
         case NODE_TYPE_COMMENT: /* Comment */

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2762,6 +2762,23 @@ describe('$compile', function() {
     }));
 
 
+    it('should handle consecutive text elements as a single text element', inject(function($rootScope, $compile) {
+      window.addMutationObserver = function() {
+        if (!window.MutationObserver) {
+          return;
+        }
+        new window.MutationObserver(function() {}).observe(document.body, {
+          childList: true,
+          subtree: true
+        });
+      };
+      var base = jqLite('<div>&mdash; {{ "This doesn\'t." }}</div>');
+      element = $compile(base)($rootScope);
+      $rootScope.$digest();
+      expect(element.text()).toBe("— This doesn't.");
+    }));
+
+
     it('should support custom start/end interpolation symbols in template and directive template',
         function() {
       module(function($interpolateProvider, $compileProvider) {


### PR DESCRIPTION
IE11 MutationObserver breaks consecutive text nodes into several text nodes.
This patch merges consecutive text nodes into a single node before
looking for interpolations.

Closes #11781
