### PR TITLE
feat(ngAnimate): generate shared anchor classes between anchor elements as well

### DIFF
--- a/src/ngAnimate/.jshintrc
+++ b/src/ngAnimate/.jshintrc
@@ -37,6 +37,9 @@
     "removeFromArray": false,
     "stripCommentsFromElement": false,
     "extractElementNode": false,
-    "getDomNode": false
+
+    "getDomNode": false,
+    "getSharedTokens": false,
+    "getUniqueTokens": false
   }
 }

--- a/src/ngAnimate/animateCssDriver.js
+++ b/src/ngAnimate/animateCssDriver.js
@@ -35,17 +35,14 @@ var $$AnimateCssDriverProvider = ['$$animationProvider', function($$animationPro
       return classes.replace(/\bng-\S+\b/g, '');
     }
 
-    function getUniqueValues(a, b) {
-      if (isString(a)) a = a.split(' ');
-      if (isString(b)) b = b.split(' ');
-      return a.filter(function(val) {
-        return b.indexOf(val) === -1;
-      }).join(' ');
+    function getClassVal(element) {
+      return element.attr('class') || '';
     }
 
-    function prepareAnchoredAnimation(classes, outAnchor, inAnchor) {
+    function prepareAnchoredAnimation(sharedAnimationClasses, outAnchor, inAnchor) {
+      var classes = [sharedAnimationClasses, getSharedTokens(getClassVal(outAnchor), getClassVal(inAnchor))].join(' ');
       var clone = jqLite(getDomNode(outAnchor).cloneNode(true));
-      var startingClasses = filterCssClasses(clone.attr('class') || '');
+      var startingClasses = filterCssClasses(getClassVal(clone));
       var anchorClasses = pendClasses(classes, NG_ANIMATE_ANCHOR_SUFFIX);
 
       outAnchor.addClass(NG_ANIMATE_SHIM_CLASS_NAME);
@@ -142,7 +139,7 @@ var $$AnimateCssDriverProvider = ['$$animationProvider', function($$animationPro
 
       function prepareInAnimation() {
         var endingClasses = filterCssClasses(inAnchor.attr('class'));
-        var classes = getUniqueValues(endingClasses, startingClasses);
+        var classes = getUniqueTokens(endingClasses, startingClasses);
         return $animateCss(clone, {
           to: calculateAnchorStyles(inAnchor),
           addClass: NG_IN_ANCHOR_CLASS_NAME + ' ' + classes,

--- a/src/ngAnimate/animation.js
+++ b/src/ngAnimate/animation.js
@@ -181,7 +181,7 @@ var $$AnimationProvider = ['$animateProvider', function($animateProvider) {
                 fromAnimation.close();
                 toAnimation.close();
               },
-              classes: cssClassesIntersection(fromAnimation.classes, toAnimation.classes),
+              classes: getSharedTokens(fromAnimation.classes, toAnimation.classes),
               from: fromAnimation,
               to: toAnimation,
               anchors: [] // TODO(matsko): change to reference nodes
@@ -204,26 +204,6 @@ var $$AnimationProvider = ['$animateProvider', function($animateProvider) {
         });
 
         return preparedAnimations;
-      }
-
-      function cssClassesIntersection(a,b) {
-        a = a.split(' ');
-        b = b.split(' ');
-        var matches = [];
-
-        for (var i = 0; i < a.length; i++) {
-          var aa = a[i];
-          if (aa.substring(0,3) === 'ng-') continue;
-
-          for (var j = 0; j < b.length; j++) {
-            if (aa === b[j]) {
-              matches.push(aa);
-              break;
-            }
-          }
-        }
-
-        return matches.join(' ');
       }
 
       function invokeFirstDriver(animationDetails) {

--- a/src/ngAnimate/shared.js
+++ b/src/ngAnimate/shared.js
@@ -249,3 +249,31 @@ function resolveElementClasses(existing, toAdd, toRemove) {
 function getDomNode(element) {
   return (element instanceof angular.element) ? element[0] : element;
 }
+
+function getSharedTokens(a,b) {
+  a = a.split(' ');
+  b = b.split(' ');
+  var matches = [];
+
+  for (var i = 0; i < a.length; i++) {
+    var aa = a[i];
+    if (aa.substring(0,3) === 'ng-') continue;
+
+    for (var j = 0; j < b.length; j++) {
+      if (aa === b[j]) {
+        matches.push(aa);
+        break;
+      }
+    }
+  }
+
+  return matches.join(' ');
+}
+
+function getUniqueTokens(a, b) {
+  if (isString(a)) a = a.split(' ');
+  if (isString(b)) b = b.split(' ');
+  return a.filter(function(val) {
+    return b.indexOf(val) === -1;
+  }).join(' ');
+}

--- a/test/ngAnimate/animateCssDriverSpec.js
+++ b/test/ngAnimate/animateCssDriverSpec.js
@@ -709,6 +709,58 @@ describe("ngAnimate $$animateCssDriver", function() {
         expect(hasAll(addedClasses, ['yes', 'no', 'maybe'])).toBe(true);
       }));
 
+      it("should create a cloned anchor with all the shared CSS classes between both anchor elements suffixed with an -anchor CSS class",
+        inject(function($rootElement, $$rAF) {
+
+        var fromAnchor = jqLite('<div class="zero one two three"></div>');
+        from.append(fromAnchor);
+        var toAnchor = jqLite('<div class="zero two four six"></div>');
+        to.append(toAnchor);
+
+        $rootElement.append(fromAnchor);
+        $rootElement.append(toAnchor);
+
+        driver({
+          from: fromAnimation,
+          to: toAnimation,
+          anchors: [{
+            'out': fromAnchor,
+            'in': toAnchor
+          }]
+        }).start();
+
+        var clone = jqLite($rootElement[0].querySelector('.ng-animate-anchor'));
+        expect(clone).toHaveClass('zero-anchor');
+        expect(clone).toHaveClass('two-anchor');
+      }));
+
+      it("should create a cloned anchor with all the provided CSS classes within the animation driver suffixed with an -anchor CSS class",
+        inject(function($rootElement, $$rAF) {
+
+        var fromAnchor = jqLite('<div></div>');
+        from.append(fromAnchor);
+        var toAnchor = jqLite('<div></div>');
+        to.append(toAnchor);
+
+        $rootElement.append(fromAnchor);
+        $rootElement.append(toAnchor);
+
+        driver({
+          from: fromAnimation,
+          to: toAnimation,
+          classes: 'red green blue',
+          anchors: [{
+            'out': fromAnchor,
+            'in': toAnchor
+          }]
+        }).start();
+
+        var clone = jqLite($rootElement[0].querySelector('.ng-animate-anchor'));
+        expect(clone).toHaveClass('red-anchor');
+        expect(clone).toHaveClass('green-anchor');
+        expect(clone).toHaveClass('blue-anchor');
+      }));
+
       it("should remove the classes of the starting anchor from the cloned anchor node during the in animation and also add the classes of the destination anchor within the same animation",
         inject(function($rootElement, $$rAF) {
 


### PR DESCRIPTION
Prior to this fix when anchored CSS animations were put to use, only the
shared CSS classes between **container** elements were suffixed and
applied to the anchor element. This patch now ensures that in addition
to the container classes, the shared classes between the starting anchor
element and the destination anchor element are prefixed and applied as
well.
