### PR TITLE
fix($animate): silently ignore the options param if an object is not passed in

### DIFF
--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -12,6 +12,10 @@ function mergeClasses(a,b) {
   return a + ' ' + b;
 }
 
+function makeAnimateOptions(options) {
+  return isObject(options) ? options : {};
+}
+
 function extractElementNode(element) {
   for (var i = 0; i < element.length; i++) {
     var elm = element[i];
@@ -406,6 +410,7 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @return {Promise} the animation callback promise
        */
       enter: function(element, parent, after, options) {
+        options = makeAnimateOptions(options);
         parent = parent || after.parent();
         domInsert(element, parent, after);
         return $$animateQueue.push(element, 'enter', options);
@@ -430,6 +435,7 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @return {Promise} the animation callback promise
        */
       move: function(element, parent, after, options) {
+        options = makeAnimateOptions(options);
         parent = parent || after.parent();
         domInsert(element, parent, after);
         return $$animateQueue.push(element, 'move', options);
@@ -449,6 +455,7 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @return {Promise} the animation callback promise
        */
       leave: function(element, options) {
+        options = makeAnimateOptions(options);
         return $$animateQueue.push(element, 'leave', options, function() {
           element.remove();
         });
@@ -473,7 +480,7 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @return {Promise} the animation callback promise
        */
       addClass: function(element, className, options) {
-        options = options || {};
+        options = makeAnimateOptions(options);
         options.addClass = mergeClasses(options.addclass, className);
         return $$animateQueue.push(element, 'addClass', options);
       },
@@ -497,7 +504,7 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @return {Promise} the animation callback promise
        */
       removeClass: function(element, className, options) {
-        options = options || {};
+        options = makeAnimateOptions(options);
         options.removeClass = mergeClasses(options.removeClass, className);
         return $$animateQueue.push(element, 'removeClass', options);
       },
@@ -522,7 +529,7 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @return {Promise} the animation callback promise
        */
       setClass: function(element, add, remove, options) {
-        options = options || {};
+        options = makeAnimateOptions(options);
         options.addClass = mergeClasses(options.addClass, add);
         options.removeClass = mergeClasses(options.removeClass, remove);
         return $$animateQueue.push(element, 'setClass', options);
@@ -550,7 +557,7 @@ var $AnimateProvider = ['$provide', function($provide) {
        * @return {Promise} the animation callback promise
        */
       animate: function(element, from, to, className, options) {
-        options = options || {};
+        options = makeAnimateOptions(options);
         options.from = options.from ? extend(options.from, from) : from;
         options.to   = options.to   ? extend(options.to, to)     : to;
 

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -486,6 +486,54 @@ describe("animations", function() {
       });
     });
 
+    they('$prop() shouldn\'t blow up when a function is passed as the options param',
+      ['enter', 'move', 'leave', 'addClass', 'removeClass', 'setClass', 'animate'], function(event) {
+
+      inject(function($animate, $rootScope, $document) {
+        var element = $document[0].createElement('div');
+        element.setAttribute('id', 'crazy-man');
+        if (event !== 'enter' && event !== 'move') {
+          parent.append(element);
+        }
+
+        var fakeOption = function() { };
+
+        switch (event) {
+          case 'enter':
+          case 'move':
+            $animate[event](element, parent, parent2, fakeOption);
+            break;
+
+          case 'addClass':
+            $animate.addClass(element, 'klass', fakeOption);
+            break;
+
+          case 'removeClass':
+            element.className = 'klass';
+            $animate.removeClass(element, 'klass', fakeOption);
+            break;
+
+          case 'setClass':
+            element.className = 'two';
+            $animate.setClass(element, 'one', 'two', fakeOption);
+            break;
+
+          case 'leave':
+            $animate.leave(element, fakeOption);
+            break;
+
+          case 'animate':
+            var toStyles = { color: 'red' };
+            $animate.animate(element, {}, toStyles, 'klass', fakeOption);
+            break;
+        }
+
+        $rootScope.$digest();
+        var options = capturedAnimation[2];
+        expect(isObject(options)).toBeTruthy();
+      });
+    });
+
     describe('addClass / removeClass', function() {
       it('should not perform an animation if there are no valid CSS classes to add',
         inject(function($animate, $rootScope) {


### PR DESCRIPTION
Earlier versions of Angular expected a function to be passed into the
same param as the options value. This causes a nasty issue since the
internal animation code expects the options value to be an object
instead of a function. This patch adds the code to convert a function
value into an empty object when that occurs.

Closes #11713
