### PR TITLE
docs(ngAnimate): Change event to ng-enter

### DIFF
--- a/src/ngAnimate/module.js
+++ b/src/ngAnimate/module.js
@@ -364,7 +364,7 @@
  *   return {
  *     enter: function(element, doneFn) {
  *       var animation = $animateCss(element, {
- *         event: 'enter'
+ *         event: 'ng-enter'
  *       });
  *
  *       if (animation) {
@@ -390,7 +390,7 @@
  *   return {
  *     enter: function(element, doneFn) {
  *       var animation = $animateCss(element, {
- *         event: 'enter',
+ *         event: 'ng-enter',
  *         addClass: 'maroon-setting',
  *         from: { height:0 },
  *         to: { height: 200 }


### PR DESCRIPTION
The event needs to map to the css class, or else the css class won't fire

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.js/11833)

<!-- Reviewable:end -->
