### PR TITLE
Fix bug in JSON vulnerability regex

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -7,7 +7,7 @@ var JSON_ENDS = {
   '[': /]$/,
   '{': /}$/
 };
-var JSON_PROTECTION_PREFIX = /^\)\]\}',?\n/;
+var JSON_PROTECTION_PREFIX = /^\)\]\}',?\r?\n/;
 
 function serializeValue(v) {
   if (isObject(v)) {


### PR DESCRIPTION
The old regex fails on Windows or Mac carriage returns/linefeeds.
