### PR TITLE
fix(ngAnimate): ensure anchored animations remove the leave element at the correct time

### DIFF
--- a/src/ngAnimate/animateCssDriver.js
+++ b/src/ngAnimate/animateCssDriver.js
@@ -234,10 +234,12 @@ var $$AnimateCssDriverProvider = ['$$animationProvider', function($$animationPro
 
       // we special case the leave animation since we want to ensure that
       // the element is removed as soon as the animation is over. Otherwise
-      // a flicker might appear or the element may not be removed at all
+      // a flicker might appear or the element may not be removed until all
+      // the other animations have completed themselves (which would then
+      // leave a pending element in the background).
       options.event = animationDetails.event;
-      if (options.event === 'leave' && animationDetails.domOperation) {
-        options.onDone = animationDetails.domOperation;
+      if (options.event === 'leave') {
+        options.onDone = options.domOperation;
       }
 
       var animator = $animateCss(element, options);

--- a/test/ngAnimate/animateCssDriverSpec.js
+++ b/test/ngAnimate/animateCssDriverSpec.js
@@ -908,10 +908,12 @@ describe("ngAnimate $$animateCssDriver", function() {
         inject(function($rootElement, $$rAF) {
 
         toAnimation.event = 'enter';
+        toAnimation.options = {};
         fromAnimation.event = 'leave';
+        fromAnimation.options = {};
 
         var leaveOp = function() { };
-        fromAnimation.domOperation = leaveOp;
+        fromAnimation.options.domOperation = leaveOp;
 
         driver({
           from: fromAnimation,


### PR DESCRIPTION
Due to a mismatch of where the `options.domOperation` value was stored,
the element involved in the `leave` animation for an anchored animation
session was not removed as soon as the leave animation ended. This
resulted in a pending element persisting within the DOM until all
animations involved in the associated anchor animation were complete.
This patch fixes this issue.

Closes #11850
