### PR TITLE
fix(ngAnimate): class-based animations must set the addClass/removeClass class on the element

### DIFF
--- a/src/ngAnimate/animateCssDriver.js
+++ b/src/ngAnimate/animateCssDriver.js
@@ -226,20 +226,20 @@ var $$AnimateCssDriverProvider = ['$$animationProvider', function($$animationPro
       var element = animationDetails.element;
       var options = animationDetails.options || {};
 
-      options.structural = animationDetails.structural;
+      if (animationDetails.structural) {
+        // structural animations ensure that the CSS classes are always applied
+        // before the detection starts.
+        options.structural = options.applyClassesEarly = true;
 
-      // structural animations ensure that the CSS classes are always applied
-      // before the detection starts.
-      options.applyClassesEarly = options.structural;
-
-      // we special case the leave animation since we want to ensure that
-      // the element is removed as soon as the animation is over. Otherwise
-      // a flicker might appear or the element may not be removed until all
-      // the other animations have completed themselves (which would then
-      // leave a pending element in the background).
-      options.event = animationDetails.event;
-      if (options.event === 'leave') {
-        options.onDone = options.domOperation;
+        // we special case the leave animation since we want to ensure that
+        // the element is removed as soon as the animation is over. Otherwise
+        // a flicker might appear or the element may not be removed at all
+        options.event = animationDetails.event;
+        if (options.event === 'leave') {
+          options.onDone = options.domOperation;
+        }
+      } else {
+        options.event = null;
       }
 
       var animator = $animateCss(element, options);

--- a/test/ngAnimate/animateCssDriverSpec.js
+++ b/test/ngAnimate/animateCssDriverSpec.js
@@ -104,6 +104,14 @@ describe("ngAnimate $$animateCssDriver", function() {
         driver({ element: element });
         expect(capturedAnimation[1].applyClassesEarly).toBeFalsy();
       }));
+
+      it("should not provide a `method` as an option value if the animation is not structural", inject(function() {
+        driver({ element: element, structural: true, event: 'superman' });
+        expect(capturedAnimation[1].event).toBe('superman');
+
+        driver({ element: element, event: 'batman' });
+        expect(capturedAnimation[1].event).toBeFalsy();
+      }));
     });
 
     describe("anchored animations", function() {
@@ -214,7 +222,9 @@ describe("ngAnimate $$animateCssDriver", function() {
             'out': jqLite('<div></div>')
           };
 
+          fromAnimation.structural = true;
           fromAnimation.element.append(anchorAnimation['out']);
+          toAnimation.structural = true;
           toAnimation.element.append(anchorAnimation['in']);
 
           var animator = driver({
@@ -240,6 +250,9 @@ describe("ngAnimate $$animateCssDriver", function() {
         captureFn = function(element, details) {
           element.addClass(details.event);
         };
+
+        fromAnimation.structural = true;
+        toAnimation.structural = true;
 
         var runner = driver({
           from: fromAnimation,
@@ -267,6 +280,9 @@ describe("ngAnimate $$animateCssDriver", function() {
           });
         });
         inject(function() {
+          fromAnimation.structural = true;
+          toAnimation.structural = true;
+
           var runner = driver({
             from: fromAnimation,
             to: toAnimation
@@ -907,8 +923,11 @@ describe("ngAnimate $$animateCssDriver", function() {
       it("should pass the provided domOperation into $animateCss to be run right after the element is animated if a leave animation is present",
         inject(function($rootElement, $$rAF) {
 
+        toAnimation.structural = true;
         toAnimation.event = 'enter';
         toAnimation.options = {};
+
+        fromAnimation.structural = true;
         fromAnimation.event = 'leave';
         fromAnimation.options = {};
 


### PR DESCRIPTION
With the abstraction system that ngAnimate uses, $animateCss internally
sets the provided `event` as a CSS class on the element. In this
situation the `addClass` and `removeClass` events on the element as a
CSS class. This should not happen with class-based animations and this
feature is unnecessary and has now been removed.

Closes #11810
