### PR TITLE
fix(ngAria): Ensure aria-hidden attribute is always "true" or "false"

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -115,9 +115,7 @@ function $AriaProvider() {
       var ariaCamelName = attr.$normalize(ariaAttr);
       if (config[ariaCamelName] && !attr[ariaCamelName]) {
         scope.$watch(attr[attrName], function(boolVal) {
-          if (negate) {
-            boolVal = !boolVal;
-          }
+          boolVal = negate ? !boolVal : !!boolVal;
           elem.attr(ariaAttr, boolVal);
         });
       }

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -57,6 +57,31 @@ describe('$aria', function() {
       scope.$apply('val = true');
       expect(element.attr('aria-hidden')).toBe('userSetValue');
     });
+
+    it('should always set aria-hidden to a boolean value', function() {
+      compileElement('<div ng-hide="val"></div>');
+
+      scope.$apply('val = "test angular"');
+      expect(element.attr('aria-hidden')).toBe('true');
+
+      scope.$apply('val = null');
+      expect(element.attr('aria-hidden')).toBe('false');
+
+      scope.$apply('val = {}');
+      expect(element.attr('aria-hidden')).toBe('true');
+
+
+      compileElement('<div ng-show="val"></div>');
+
+      scope.$apply('val = "test angular"');
+      expect(element.attr('aria-hidden')).toBe('false');
+
+      scope.$apply('val = null');
+      expect(element.attr('aria-hidden')).toBe('true');
+
+      scope.$apply('val = {}');
+      expect(element.attr('aria-hidden')).toBe('false');
+    });
   });
 
 


### PR DESCRIPTION
Currently when using ngAria with ng-hide directive when value passed
to ng-hide is not boolean aria-hidden attribute is set to an invalid value.
This fix ensures aria-hidden attribute is always either "true" or "false".

Fixes #11365 as well.
