### PR TITLE
fix($templateRequest): Set `Accept` header on template requests

### DIFF
--- a/src/ng/templateRequest.js
+++ b/src/ng/templateRequest.js
@@ -36,7 +36,8 @@ function $TemplateRequestProvider() {
 
       var httpOptions = {
         cache: $templateCache,
-        transformResponse: transformResponse
+        transformResponse: transformResponse,
+        headers: { 'Accept': 'text/html, text/ng-template' }
       };
 
       return $http.get(tpl, httpOptions)


### PR DESCRIPTION
Set the `Accept` header on HTTP requests for templates to `text/html, text/ng-template`.
Previously the default request headers sent by `$http` were used.

Closes #6860

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.js/11868)

<!-- Reviewable:end -->
