### PR TITLE
fix(select): prevent unknown option being added to select when bound …

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -59,7 +59,7 @@ var SelectController =
       $element.val(value);
       if (value === '') self.emptyOption.prop('selected', true); // to make IE9 happy
     } else {
-      if (isUndefined(value) && self.emptyOption) {
+      if (value == null && self.emptyOption) {
         self.removeUnknownOption();
         $element.val('');
       } else {

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -404,7 +404,7 @@ describe('select', function() {
         scope.$apply(function() {
           scope.robot = null;
         });
-        expect(element).toEqualSelect([unknownValue(null)], '', 'c3p0', 'r2d2');
+        expect(element).toEqualSelect([''], 'c3p0', 'r2d2');
 
         scope.$apply(function() {
           scope.robot = 'r2d2';


### PR DESCRIPTION
…to null property

If a select directive was bound, using ng-model, to a property with a value of null this would
result in an unknown option being added to the select element with the value "? object:null ?".
This change prevents a null value from adding an unknown option meaning that the extra option is
not added as a child of the select element

Closes #11872
