### PR TITLE
fix(ngAnimate): ensure that "element" caintains html node

### DIFF
--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -223,7 +223,7 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
     function queueAnimation(element, event, options) {
       var node, parent;
       element = stripCommentsFromElement(element);
-      if (element) {
+      if (element && element.length) {
         node = getDomNode(element);
         parent = element.parent();
       }


### PR DESCRIPTION
Ensure that "element" jqlite wrapper contains html node. It results in an error if it is defined but empty.
