### PR TITLE
fix($animate): accept unwrapped DOM elements as inputs for enter + move

### DIFF
--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -424,6 +424,8 @@ var $AnimateProvider = ['$provide', function($provide) {
        */
       enter: function(element, parent, after, options) {
         assertNoCallback(options);
+        parent = parent && jqLite(parent);
+        after = after && jqLite(after);
         parent = parent || after.parent();
         domInsert(element, parent, after);
         return $$animateQueue.push(element, 'enter', options);
@@ -449,6 +451,8 @@ var $AnimateProvider = ['$provide', function($provide) {
        */
       move: function(element, parent, after, options) {
         assertNoCallback(options);
+        parent = parent && jqLite(parent);
+        after = after && jqLite(after);
         parent = parent || after.parent();
         domInsert(element, parent, after);
         return $$animateQueue.push(element, 'move', options);

--- a/test/ng/animateSpec.js
+++ b/test/ng/animateSpec.js
@@ -216,6 +216,32 @@ describe("$animate", function() {
 
       expect(element).toHaveClass('ng-hide');
     }));
+
+    they("should accept an unwrapped \"parent\" element for the $prop event",
+      ['enter', 'move'], function(method) {
+
+      inject(function($document, $animate, $rootElement) {
+        var element = jqLite('<div></div>');
+        var parent = $document[0].createElement('div');
+        $rootElement.append(parent);
+
+        $animate[method](element, parent);
+        expect(element[0].parentNode).toBe(parent);
+      });
+    });
+
+    they("should accept an unwrapped \"after\" element for the $prop event",
+      ['enter', 'move'], function(method) {
+
+      inject(function($document, $animate, $rootElement) {
+        var element = jqLite('<div></div>');
+        var after = $document[0].createElement('div');
+        $rootElement.append(after);
+
+        $animate[method](element, null, after);
+        expect(element[0].previousSibling).toBe(after);
+      });
+    });
   });
 
   describe('CSS class DOM manipulation', function() {


### PR DESCRIPTION
Prior to this fix the $animate.enter() and $animate.move() events caused
an error when a parent or after element was provided that was not
already wrapped as a jqLite element. This patch ensures that both
wrapped and unwrapped DOM nodes are allowed.

Closes #11848
