### PR TITLE
docs($cookiesProvider): Escaping of HTML

### DIFF
--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -43,7 +43,7 @@ angular.module('ngCookies', ['ng']).
      *   or a Date object indicating the exact date/time this cookie will expire.
      * - **secure** - `{boolean}` - The cookie will be available only in secured connection.
      *
-     * Note: by default the address that appears in your <base> tag will be used as path.
+     * Note: by default the address that appears in your `<base>` tag will be used as path.
      * This is import so that cookies will be visible for all routes in case html5mode is enabled
      *
      **/


### PR DESCRIPTION
Escape the "base" HTML element so it will be displayed in the online documentation.
