### PR TITLE
fix(ngAnimate): ensure that cancelled class-based animations are properly cleaned up

### DIFF
--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -394,6 +394,13 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
             runner.end();
           }
 
+          // in the event that the element animation was not cancelled or a follow-up animation
+          // isn't allowed to animate from here then we need to clear the state of the element
+          // so that any future animations won't read the expired animation data.
+          if (!isValidAnimation) {
+            clearElementAnimationState(element);
+          }
+
           return;
         }
 

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1029,6 +1029,22 @@ describe("animations", function() {
 
         expect(runner1).not.toBe(runner2);
       }));
+
+      it('should properly cancel out animations when the same class is added/removed within the same digest',
+        inject(function($animate, $rootScope) {
+
+        parent.append(element);
+        $animate.addClass(element, 'red');
+        $animate.removeClass(element, 'red');
+        $rootScope.$digest();
+
+        expect(capturedAnimation).toBeFalsy();
+
+        $animate.addClass(element, 'blue');
+        $rootScope.$digest();
+
+        expect(capturedAnimation[2].addClass).toBe('blue');
+      }));
     });
 
     describe('should merge', function() {


### PR DESCRIPTION
Prior to this fix if the same CSS class was added and removed quickly
then the element being animated would be left with a stale cache of the
cancelled out animation. This would then result in follow-up animations
being added to the previous animation which would then never run. A
stale cache was to blame for that. This patch takes care of this issue.

Closes #11652
