### PR TITLE
refactor(ngCsp): Make use of document.head

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -116,7 +116,7 @@ module.exports = {
         .replace(/\\/g, '\\\\')
         .replace(/'/g, "\\'")
         .replace(/\r?\n/g, '\\n');
-      js = "!window.angular.$$csp() && window.angular.element(document).find('head').prepend('<style type=\"text/css\">" + css + "</style>');";
+      js = "!window.angular.$$csp() && window.angular.element(document.head).prepend('<style type=\"text/css\">" + css + "</style>');";
       state.js.push(js);
 
       return state;


### PR DESCRIPTION
document.head is available since IE9 (https://developer.mozilla.org/en-US/docs/Web/API/Document/head)

Saves us a bit of DOM querying during startup and a couple of bytes.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.js/11905)

<!-- Reviewable:end -->
