### PR TITLE
docs(guide/Directives): correct the sentence describing compiling a HTML

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -31,7 +31,7 @@ When Angular {@link guide/bootstrap bootstraps} your application, the
 **What does it mean to "compile" an HTML template?**
 
 For AngularJS, "compilation" means attaching event listeners to the HTML to make it interactive.
-The reason we use the term "compile" is that the recursive process of attaching directives
+The reason we use the term "compile" is that the recursive process of attaching event listeners
 mirrors the process of compiling source code in
 [compiled programming languages](http://en.wikipedia.org/wiki/Compiled_languages).
 </div>


### PR DESCRIPTION
> The reason we use the term "compile" is that the recursive process of attaching <directives>
> mirrors the process of compiling source code in [compiled programming languages]

substitute "directives" with "event listeners" in the above sentence.
