### PR TITLE
docs(guide/Filters): describe your change...

### DIFF
--- a/docs/content/guide/filter.ngdoc
+++ b/docs/content/guide/filter.ngdoc
@@ -64,7 +64,18 @@ or the filter expression is changed).
 
   <file name="script.js">
     angular.module('FilterInControllerModule', []).
-      controller('FilterController', ['filterFilter', function(filterFilter) {
+      filter('name', function () {
+        return function (names, value) {
+          var matches = [];
+          for(var i=0; i<names.length; i++) {
+            if (names[i].match(value)) {
+              matches.push(names[i]);
+            }
+          }
+          return matches;
+        };
+      }).
+      controller('FilterController', ['nameFilter', function(nameFilter) {
         this.array = [
           {name: 'Tobias'},
           {name: 'Jeff'},
@@ -73,7 +84,7 @@ or the filter expression is changed).
           {name: 'James'},
           {name: 'Brad'}
         ];
-        this.filteredArray = filterFilter(this.array, 'a');
+        this.filteredArray = nameFilter(this.array, 'a');
       }]);
   </file>
 </example>


### PR DESCRIPTION
I had a really hard time understanding that if I use a custom filter from a controller or service, I needed to add the string "Filter" to the name of the filter when listing it as a dependency of my controller or service.  I hope, by adding this example of the custom filter, "name", it becomes apparent.  

It's weird that a developer could refer to the custom filter by it's name in a view, like `<div ng-repeat="user in array | name:'a'">{{user.name}}</div>` but they have to refer to it by "nameFilter" from a controller or service instead of just "name".

In this example, the error message from angular is really unhelpful when the controller fails to refer to the "name" filter by the string "nameFilter".  The error is, "Error: [$injector:unpr] Unknown provider: nameProvider <- name <- FilterController".
