### PR TITLE
docs(input[datetime-local]): change type of ngModel in docs

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -226,7 +226,7 @@ var inputType = {
     * The timezone to be used to read/write the `Date` instance in the model can be defined using
     * {@link ng.directive:ngModelOptions ngModelOptions}. By default, this is the timezone of the browser.
     *
-    * @param {string} ngModel Assignable angular expression to data-bind to.
+    * @param {Date} ngModel Assignable angular expression to data-bind to.
     * @param {string=} name Property name of the form under which the control is published.
     * @param {string=} min Sets the `min` validation error key if the value entered is less than `min`. This must be a
     * valid ISO datetime format (yyyy-MM-ddTHH:mm:ss).
@@ -1674,6 +1674,3 @@ var ngValueDirective = function() {
     }
   };
 };
-
-
-


### PR DESCRIPTION
In the docs for `input[datetime-local]` it says in the text that model should always be a `Date` object but under Usage and Arguments it says `string`. This fixes so both says `Date`.

Docs here: https://docs.angularjs.org/api/ng/input/input%5Bdatetime-local%5D
