### PR TITLE
Corrected date format for Portuguese (both locales)

### DIFF
--- a/i18n/closure/datetimeSymbols.js
+++ b/i18n/closure/datetimeSymbols.js
@@ -3349,7 +3349,7 @@ goog.i18n.DateTimeSymbols_pt_PT = {
     '4.º trimestre'],
   AMPMS: ['da manhã', 'da tarde'],
   DATEFORMATS: ['EEEE, d \'de\' MMMM \'de\' y', 'd \'de\' MMMM \'de\' y',
-    'dd/MM/y', 'dd/MM/yy'],
+    'dd/MM/y', 'dd/MM/yyyy'],
   TIMEFORMATS: ['HH:mm:ss zzzz', 'HH:mm:ss z', 'HH:mm:ss', 'HH:mm'],
   DATETIMEFORMATS: ['{1} \'às\' {0}', '{1} \'às\' {0}', '{1}, {0}',
     '{1}, {0}'],

--- a/i18n/closure/datetimeSymbols.js
+++ b/i18n/closure/datetimeSymbols.js
@@ -3304,7 +3304,7 @@ goog.i18n.DateTimeSymbols_pt = {
     '4º trimestre'],
   AMPMS: ['AM', 'PM'],
   DATEFORMATS: ['EEEE, d \'de\' MMMM \'de\' y', 'd \'de\' MMMM \'de\' y',
-    'd \'de\' MMM \'de\' y', 'dd/MM/yy'],
+    'd \'de\' MMM \'de\' y', 'dd/MM/yyyy'],
   TIMEFORMATS: ['HH:mm:ss zzzz', 'HH:mm:ss z', 'HH:mm:ss', 'HH:mm'],
   DATETIMEFORMATS: ['{1} {0}', '{1} {0}', '{1} {0}', '{1} {0}'],
   FIRSTDAYOFWEEK: 6,


### PR DESCRIPTION
Short date formats in Portuguese (both in Portugal and Brazil) are expressed as dd/MM/yyyy (http://en.wikipedia.org/wiki/Date_format_by_country). I've updated the symbols to reflect that.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.js/11925)

<!-- Reviewable:end -->
