### PR TITLE
Refine csp checks for `unsafeEval`.

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -65,6 +65,7 @@
     "shallowCopy": false,
     "equals": false,
     "csp": false,
+    "unsafeEval": false,
     "concat": false,
     "sliceArgs": false,
     "bind": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -978,22 +978,27 @@ function equals(o1, o2) {
   return false;
 }
 
+var unsafeEval = function() { /* jshint ignore:line */
+  if (isDefined(unsafeEval.isActive_)) return unsafeEval.isActive_;
+
+  var active = true;
+  try {
+    /* jshint -W031, -W054 */
+    new Function('');
+    /* jshint +W031, +W054 */
+  } catch (e) {
+    active = false;
+  }
+  return (unsafeEval.isActive_ = active);
+};
+
 var csp = function() {
   if (isDefined(csp.isActive_)) return csp.isActive_;
 
   var active = !!(document.querySelector('[ng-csp]') ||
                   document.querySelector('[data-ng-csp]'));
 
-  if (!active) {
-    try {
-      /* jshint -W031, -W054 */
-      new Function('');
-      /* jshint +W031, +W054 */
-    } catch (e) {
-      active = true;
-    }
-  }
-
+  active = active || !unsafeEval();
   return (csp.isActive_ = active);
 };
 

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1698,12 +1698,14 @@ function $ParseProvider() {
   var cacheExpensive = createMap();
 
   this.$get = ['$filter', '$sniffer', function($filter, $sniffer) {
+    var csp = $sniffer.csp && !$sniffer.unsafeEval;
+
     var $parseOptions = {
-          csp: $sniffer.csp,
+          csp: csp,
           expensiveChecks: false
         },
         $parseOptionsExpensive = {
-          csp: $sniffer.csp,
+          csp: csp,
           expensiveChecks: true
         };
 

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -79,6 +79,7 @@ function $SnifferProvider() {
         return eventSupport[event];
       },
       csp: csp(),
+      unsafeEval: unsafeEval(),
       vendorPrefix: vendorPrefix,
       transitions: transitions,
       animations: animations,

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -61,6 +61,7 @@
     "shallowCopy": false,
     "equals": false,
     "csp": false,
+    "unsafeEval": false,
     "jq": false,
     "concat": false,
     "sliceArgs": false,

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -711,6 +711,7 @@ describe('angular', function() {
     afterEach(function() {
       window.Function = originalFunction;
       delete csp.isActive_;
+      delete unsafeEval.isActive_;
     });
 
 


### PR DESCRIPTION
This PR refines the csp checks for function compilation because the default policy in WWA (Windows Web Apps) allows `unsafe-eval`. This would give a [~30% boost](https://docs.angularjs.org/api/ng/directive/ngCsp) when evaluating expressions.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.js/11933)

<!-- Reviewable:end -->
