### PR TITLE
fix($location): Infinite digest in $location replace in IE9

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -92,6 +92,13 @@ function Browser(window, document, $log, $sniffer) {
   cacheState();
   lastHistoryState = cachedState;
 
+  self.forceReloadLocationUpdate = function(url) {
+    if (reloadLocation) {
+      reloadLocation = url;
+    }
+  };
+
+
   /**
    * @name $browser#url
    *

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -894,7 +894,7 @@ function $LocationProvider() {
       $browser.url($location.absUrl(), true);
     }
 
-    var initializing = true;
+    var initializing = true, previousOldUrl = null, previousNewUrl = null;
 
     // update $location when $browser url changes
     $browser.onUrlChange(function(newUrl, newState) {
@@ -929,6 +929,15 @@ function $LocationProvider() {
     $rootScope.$watch(function $locationWatch() {
       var oldUrl = trimEmptyHash($browser.url());
       var newUrl = trimEmptyHash($location.absUrl());
+      if ($location.$$html5 && !$sniffer.history) {
+        if (previousOldUrl === oldUrl && previousNewUrl === newUrl) {
+          // break out of infinite $digest loops caused by default routes in hashbang mode
+          $browser.forceReloadLocationUpdate(newUrl);
+          previousOldUrl = previousNewUrl = null;
+          return;
+        }
+        previousOldUrl = oldUrl, previousNewUrl = newUrl;
+      }
       var oldState = $browser.state();
       var currentReplace = $location.$$replace;
       var urlOrStateChanged = oldUrl !== newUrl ||


### PR DESCRIPTION
@hamfastgamgee - I think this is the right unit test. Can you take a look. The nice thing is that it even fails on Chrome as well (since we are simulating no-history support) without the fix.
