### PR TITLE
docs(ngDisabled): correct directive.

### DIFF
--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -169,7 +169,7 @@
  * ```html
  * <!-- See below for an example of ng-disabled being used correctly -->
  * <div ng-init="isDisabled = false">
- *  <button disabled="{{isDisabled}}">Disabled</button>
+ *  <button ng-disabled="{{isDisabled}}">Disabled</button>
  * </div>
  * ```
  *


### PR DESCRIPTION
In example of "ng-disabled" previously disabled was used in place of "ng-disabled" directive.
![untitled](https://cloud.githubusercontent.com/assets/11410696/7789256/07a82b14-0278-11e5-8ded-317ee4ba7b82.png)
