### PR TITLE
feat($animateCss): automatically append "px" for positional numeric values

### DIFF
--- a/src/ngAnimate/shared.js
+++ b/src/ngAnimate/shared.js
@@ -12,6 +12,7 @@ var isUndefined = angular.isUndefined;
 var isDefined   = angular.isDefined;
 var isFunction  = angular.isFunction;
 var isElement   = angular.isElement;
+var isNumber    = angular.isNumber;
 
 var ELEMENT_NODE = 1;
 var COMMENT_NODE = 8;
@@ -144,8 +145,38 @@ function prepareAnimationOptions(options) {
       domOperation = noop;
     };
     options.$$prepared = true;
+
+    if (options.from) {
+      options.from = pixelifyNumericStyles(options.from);
+    }
+
+    if (options.to) {
+      options.to = pixelifyNumericStyles(options.to);
+    }
   }
   return options;
+}
+
+function pixelifyNumericStyles(styles) {
+  for (var prop in styles) {
+    // this should satisfy `z-index` and `zIndex` since
+    // both values are always numeric, but don't require a
+    // `px` prefix.
+    if (prop.charAt(0) === 'z') continue;
+
+    var value = styles[prop];
+
+    // some styles may use a `0` value as a default to clear
+    // the style property entirely. Since transitions are able
+    // to animate directly from zero (without a px value) then
+    // it fine to leave this style as is without the px suffix.
+    if (value === 0) continue;
+
+    if (isNumber(value)) {
+      styles[prop] = value + 'px';
+    }
+  }
+  return styles;
 }
 
 function applyAnimationStyles(element, options) {

--- a/test/ngAnimate/animationHelperFunctionsSpec.js
+++ b/test/ngAnimate/animationHelperFunctionsSpec.js
@@ -30,6 +30,57 @@ describe("animation option helper functions", function() {
       var options2 = {};
       expect(prepareAnimationOptions(options2)).not.toBe(options);
     }));
+
+    they('should append a "px" value to the $prop styles if they are provided as number values',
+      ['from', 'to'], function(phase) {
+
+      inject(function() {
+        var options = {};
+        options[phase] = {};
+        options[phase].height = 200;
+        options[phase].width = '200';
+        options[phase].border = '1px solid red';
+
+        options = prepareAnimationOptions(options);
+        expect(options[phase].height).toBe('200px');
+        expect(options[phase].width).toBe('200');
+        expect(options[phase].border).toBe('1px solid red');
+      });
+    });
+
+    it('should ignore appending a "px" to the from/to styles when a style with a value of `0` is provided',
+      inject(function() {
+
+      var options = {
+        from: {},
+        to: {}
+      };
+
+      options.from.width = 0;
+      options.to.height = 0;
+
+      options = prepareAnimationOptions(options);
+      expect(options.from.width).toBe(0);
+      expect(options.to.height).toBe(0);
+    }));
+
+    they('should ignore appending a "px" to the styles value when a $prop style is provided with a numerical value',
+      ['z-index', 'zIndex'], function(prop) {
+
+      inject(function() {
+        var options = {
+          from: {},
+          to: {}
+        };
+
+        options.from[prop] = 2;
+        options.to[prop] = 10;
+
+        options = prepareAnimationOptions(options);
+        expect(options.from[prop]).toBe(2);
+        expect(options.to[prop]).toBe(10);
+      });
+    });
   });
 
   describe('applyAnimationStyles', function() {


### PR DESCRIPTION
Plugins/frameworks like jQuery and GreenSock automatically append a px
value when a number value is provided a style value for an animation.
This patch ensures that the same thing happens on `$animateCss` for
the `from` and `to` styles. This patch also ensures that common
properties such as `z-index` and string-based values are not appended
with a `px` suffix.
