### PR TITLE
fix(ngAnimate): allow animations on body and root elements

### DIFF
--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -524,8 +524,8 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
     }
 
     function areAnimationsAllowed(element, parentElement, event) {
-      var bodyElementDetected = false;
-      var rootElementDetected = false;
+      var bodyElementDetected = isMatchingElement(element, bodyElement);
+      var rootElementDetected = isMatchingElement(element, $rootElement);
       var parentAnimationDetected = false;
       var animateChildren;
 


### PR DESCRIPTION
##### Overview of the Issue:

Animations on `<body>` and the root element don't work.
##### Motivation for or Use Case:

I have a class-based animation on the `<body>` element (though I noticed this would also be an issue for animations on the root element).
##### Angular Version(s):

v1.4.0-rc.2
##### Browsers and Operating System:

Chrome Version 45.0.2414.0 canary (64-bit), Mac OS X Yosemite Version 10.10.3 (14D136)
##### Reproduce the Error:

See [this Plunker](http://plnkr.co/AZEHn1).
##### Related Issues:

The only open issue related to animate and body or root I found was #10527.
##### Suggest a Fix:

All that needed to be fixed was initializing `(body|root)ElementDetected` to whether the current element matches the body or root element rather than false; otherwise, the animated element is never checked as being within the body and root element and can therefore never be animated.

I believe all that needs to be added to this fix is testing if you agree this is a valid and relevant issue as fixed.
