### PR TITLE
docs(guide/Directives): Use data-ng-model

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -51,7 +51,7 @@ In the following example, we say that the `<input>` element **matches** the `ngM
 The following also **matches** `ngModel`:
 
 ```html
-<input data-ng:model="foo">
+<input data-ng-model="foo">
 ```
 
 ### Normalization


### PR DESCRIPTION
Use data-ng-model instead of data-ng:model which is accepted for legacy reason.
The next "Normalization" section is saying:

> Best Practice: Prefer using the dash-delimited format (e.g. ng-bind for
> ngBind). If you want to use an HTML validating tool, you can instead use the
> data-prefixed version (e.g. data-ng-bind for ngBind). The other forms
> shown above are accepted for legacy reasons but we advise you to avoid
> them.
