### PR TITLE
docs(filter/number): Change description of returned value

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -80,7 +80,7 @@ function currencyFilter($locale) {
  * @description
  * Formats a number as text.
  *
- * If the input is not a number an empty string is returned.
+ * If the input is not a number an empty string is returned but null or undefined, these values will be passed through.
  *
  * If the input is an infinite (Infinity/-Infinity) the Infinity symbol '∞' is returned.
  *


### PR DESCRIPTION
I think this is not correct because since 1.3.0-RC.0 sonic-boltification this change: https://github.com/angular/angular.js/commit/2ae10f67fcde3e172f695956301ef796b68a50c2 and null and undefined are passing through
