### PR TITLE
let ngOptions ignore array values starting with `$$`

### DIFF
--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -303,6 +303,13 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
         values = values || [];
 
         Object.keys(values).forEach(function getWatchable(key) {
+          if (isString(values[key]) &&
+              values[key].charAt(0) == '$' &&
+              values[key].charAt(1) == '$'
+          ) {
+            return;
+          }
+
           var locals = getLocals(values[key], key);
           var selectValue = getTrackByValueFn(values[key], locals);
           watchedArray.push(selectValue);
@@ -348,6 +355,12 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
         var optionValuesLength = optionValuesKeys.length;
 
         for (var index = 0; index < optionValuesLength; index++) {
+          if (isString(optionValuesKeys[index]) &&
+              optionValuesKeys[index].charAt(0) === '$' &&
+              optionValuesKeys[index].charAt(1) === '$'
+          ) {
+            continue;
+          }
           var key = (optionValues === optionValuesKeys) ? index : optionValuesKeys[index];
           var value = optionValues[key];
           var locals = getLocals(value, key);

--- a/test/ng/directive/ngOptionsSpec.js
+++ b/test/ng/directive/ngOptionsSpec.js
@@ -922,6 +922,25 @@ describe('ngOptions', function() {
       expect(scope.selected).toEqual([20]);
       expect(element).toEqualSelectValue([20], true);
     });
+
+
+    it('should ignore array values beginning with $$', function() {
+      scope.arr = ['one', 'two', '$$hashKey'];
+
+      scope.modify = function(item) {
+        return item;
+      };
+
+      spyOn(scope, 'modify');
+
+      createSelect({
+        'ng-model': 'selected',
+        'multiple': false,
+        'ng-options': 'item as modify(item) for item in arr'
+      });
+
+      expect(scope.modify).not.toHaveBeenCalledWith('$$hashKey');
+    });
   });
 
 


### PR DESCRIPTION
@gkalpak @petebacondarwin 
I wanted to get the ball rolling on this, but the solution looks pretty ugly tbh. Also, should we equally ignore elements starting with `$`?

edit: actually, it's not array elements, but specifically ngRepeat that sets the `$$hashKey` property on array which are used for ngOptions. So the fix doesn't actually apply.
