### PR TITLE
fix($http): continue promise chain with HttpPromise

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -911,7 +911,7 @@ function $HttpProvider() {
         assertArgFn(fn, 'fn');
 
         promise.then(function(response) {
-          fn(response.data, response.status, response.headers, config);
+          return fn(response.data, response.status, response.headers, config);
         });
         return promise;
       };
@@ -920,7 +920,7 @@ function $HttpProvider() {
         assertArgFn(fn, 'fn');
 
         promise.then(null, function(response) {
-          fn(response.data, response.status, response.headers, config);
+          return fn(response.data, response.status, response.headers, config);
         });
         return promise;
       };

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -458,6 +458,15 @@ describe('$http', function() {
           expect(httpPromise.success(callback)).toBe(httpPromise);
         });
 
+        it('should continue promise chain with promise returned in HttpPromise callback', function() {
+          $httpBackend.expect('GET', '/url/a').respond(200);
+          $http({url: '/url/a', method: 'GET'}).success(function() {
+            $httpBackend.expect('GET', '/url/b').respond(400);
+            return $http({url: '/url/b', method:  'GET'});
+          }).error(function(data, status) {
+            expect(status).toEqual(400);
+          });
+        });
 
         it('should error if the callback is not a function', function() {
           expect(function() {


### PR DESCRIPTION
`.success` and `.error` methods will now continue the promise chain.
Returning a promise in either of these callbacks will be appropriately
handled by the chain.

Closes #11972
