### PR TITLE
docs(orderBy): improve reverse order example

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -83,9 +83,23 @@
                   {name:'Mike', phone:'555-4321', age:21},
                   {name:'Adam', phone:'555-5678', age:35},
                   {name:'Julie', phone:'555-8765', age:29}];
-             $scope.predicate = '-age';
+             $scope.predicate = 'age';
+             $scope.reverse = true;
+             $scope.order = function(predicate) {
+               $scope.reverse = ($scope.predicate === predicate) ? !$scope.reverse : false;
+               $scope.predicate = predicate;
+             };
            }]);
        </script>
+       <style type="text/css">
+         SPAN.sortorder:after {
+           content: '\25b2';
+         }
+      
+         SPAN.sortorder.reverse:after {
+           content: '\25bc';
+         }
+       </style>
        <div ng-controller="ExampleController">
          <pre>Sorting predicate = {{predicate}}; reverse = {{reverse}}</pre>
          <hr/>
@@ -93,16 +107,16 @@
          <table class="friend">
            <tr>
              <th>
-               <a href="" ng-click="predicate == 'name' ? reverse = !reverse : reverse = false; predicate='name';">Name</a>
-               <span ng-show="predicate == 'name'"><span ng-show="reverse">&#9660;</span><span ng-show="!reverse">&#9650;</span></span>
+               <a href="" ng-click="order('name')">Name</a>
+               <span class="sortorder" ng-show="predicate === 'name'" ng-class="{reverse:reverse}"></span>
              </th>
              <th>
-               <a href="" ng-click="predicate == 'phone' ? reverse = !reverse : reverse = false; predicate='phone';">Phone Number</a>
-               <span ng-show="predicate == 'phone'"><span ng-show="reverse">&#9660;</span><span ng-show="!reverse">&#9650;</span></span>
+               <a href="" ng-click="order('phone')">Phone Number</a>
+               <span class="sortorder" ng-show="predicate === 'phone'" ng-class="{reverse:reverse}"></span>
              </th>
              <th>
-               <a href="" ng-click="predicate == 'age' ? reverse = !reverse : reverse = false; predicate='age';">Age</a>
-               <span ng-show="predicate == 'age'"><span ng-show="reverse">&#9660;</span><span ng-show="!reverse">&#9650;</span></span>
+               <a href="" ng-click="order('age')">Age</a>
+               <span class="sortorder" ng-show="predicate === 'age'" ng-class="{reverse:reverse}"></span>
              </th>
            </tr>
            <tr ng-repeat="friend in friends | orderBy:predicate:reverse">

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -92,10 +92,18 @@
          [ <a href="" ng-click="predicate=''">unsorted</a> ]
          <table class="friend">
            <tr>
-             <th><a href="" ng-click="predicate = 'name'; reverse=false">Name</a>
-                 (<a href="" ng-click="predicate = '-name'; reverse=false">^</a>)</th>
-             <th><a href="" ng-click="predicate = 'phone'; reverse=!reverse">Phone Number</a></th>
-             <th><a href="" ng-click="predicate = 'age'; reverse=!reverse">Age</a></th>
+             <th>
+               <a href="" ng-click="predicate == 'name' ? reverse = !reverse : reverse = false; predicate='name';">Name</a>
+               <span ng-show="predicate == 'name'"><span ng-show="reverse">&#9660;</span><span ng-show="!reverse">&#9650;</span></span>
+             </th>
+             <th>
+               <a href="" ng-click="predicate == 'phone' ? reverse = !reverse : reverse = false; predicate='phone';">Phone Number</a>
+               <span ng-show="predicate == 'phone'"><span ng-show="reverse">&#9660;</span><span ng-show="!reverse">&#9650;</span></span>
+             </th>
+             <th>
+               <a href="" ng-click="predicate == 'age' ? reverse = !reverse : reverse = false; predicate='age';">Age</a>
+               <span ng-show="predicate == 'age'"><span ng-show="reverse">&#9660;</span><span ng-show="!reverse">&#9650;</span></span>
+             </th>
            </tr>
            <tr ng-repeat="friend in friends | orderBy:predicate:reverse">
              <td>{{friend.name}}</td>


### PR DESCRIPTION
Changed the second example to demonstrate typical sorting behavior (like Finder and Win Explorer) where the first click on a column sorts alpha and the second click on an already sorted column sorts in reverse alpha.  Also shows a simple sort indicator automated using ngShow.
