### PR TITLE
fix($parse): default expressions of the form `a.b` to `undefined`

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -983,6 +983,8 @@ ASTCompiler.prototype = {
             }
           }
           recursionFn(intoId);
+        }, function() {
+          self.assign(intoId, 'undefined');
         });
       }, !!create);
       break;

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1745,6 +1745,10 @@ describe('parser', function() {
         expect(scope.$eval("0&&2")).toEqual(0 && 2);
         expect(scope.$eval("0||2")).toEqual(0 || 2);
         expect(scope.$eval("0||1&&2")).toEqual(0 || 1 && 2);
+        expect(scope.$eval("true&&a")).toEqual(true && undefined);
+        expect(scope.$eval("true&&a.b")).toEqual(true && undefined);
+        expect(scope.$eval("false||a")).toEqual(false || undefined);
+        expect(scope.$eval("false||a.b")).toEqual(false || undefined);
       });
 
       it('should parse ternary', function() {


### PR DESCRIPTION
When there is an expression of the form `a.b` and there is a recursion that specifies where the value should be placed, then when `a == null` then set the value of the returned identifier to `undefined`

Closes #11959
