### PR TITLE
fix(ngAnimate): do not assume $document[0] exists

### DIFF
--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -66,10 +66,10 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
     return (nO.addClass && nO.addClass === cO.removeClass) || (nO.removeClass && nO.removeClass === cO.addClass);
   });
 
-  this.$get = ['$$rAF', '$rootScope', '$rootElement', '$document', '$$HashMap',
-               '$$animation', '$$AnimateRunner', '$templateRequest', '$$jqLite',
-       function($$rAF,   $rootScope,   $rootElement,   $document,   $$HashMap,
-                $$animation,   $$AnimateRunner,   $templateRequest,   $$jqLite) {
+  this.$get = ['$$rAF', '$rootScope', '$rootElement', '$$HashMap', '$$animation',
+               '$$AnimateRunner', '$templateRequest', '$$jqLite',
+       function($$rAF,   $rootScope,   $rootElement,   $$HashMap,   $$animation,
+                $$AnimateRunner,   $templateRequest,   $$jqLite) {
 
     var activeAnimationsLookup = new $$HashMap();
     var disabledElementsLookup = new $$HashMap();
@@ -105,7 +105,7 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
       }
     );
 
-    var bodyElement = jqLite($document[0].body);
+    var bodyElement = jqLite(document.body);
 
     var callbackRegistry = {};
 

--- a/test/ng/windowSpec.js
+++ b/test/ng/windowSpec.js
@@ -9,4 +9,9 @@ describe('$window', function() {
     module({$window: {}});
     inject(['$sce', angular.noop]);
   });
+
+  it('should be able to mock $window with $animate', function() {
+    module('ngAnimate', {$window: {}});
+    inject(['$animate', angular.noop]);
+  });
 });


### PR DESCRIPTION
Use document.body instead of $document[0].body. Enable mocking of $window
without having to add an empty document object into it.

Closes #11964
