### PR TITLE
fix:$http:Silently fail when isJsonLike wrongly detects JSON

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -93,8 +93,12 @@ function defaultHttpResponseTransform(data, headers) {
 
     if (tempData) {
       var contentType = headers('Content-Type');
-      if ((contentType && (contentType.indexOf(APPLICATION_JSON) === 0)) || isJsonLike(tempData)) {
+      if (contentType && (contentType.indexOf(APPLICATION_JSON) === 0)) {
         data = fromJson(tempData);
+      } else if (isJsonLike(tempData)) {
+        try {
+          data = fromJson(tempData);
+        } catch(e) {}
       }
     }
   }


### PR DESCRIPTION
isJsonLike can have false positives.  Instead of crashing, the defaultHttpHandler should return the string.

It may be a problem for developers trying to load a broken JSON document without using the correct Content-Type. A log message could be added to the try-catch.
