### PR TITLE
docs(ngClass): Put single quotes around classes

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -162,7 +162,7 @@ function classDirective(name, selector) {
  * @example Example that demonstrates basic bindings via ngClass directive.
    <example>
      <file name="index.html">
-       <p ng-class="{strike: deleted, bold: important, red: error}">Map Syntax Example</p>
+       <p ng-class="{'strike': deleted, 'bold': important, 'red': error}">Map Syntax Example</p>
        <label>
           <input type="checkbox" ng-model="deleted">
           deleted (apply "strike" class)


### PR DESCRIPTION
For the classes in the map notation ({'strike': deleted, 'bold': important, 'red': error}). I don't know why, but on Chrome sometimes it doesn't work without those quotes.
