### PR TITLE
docs(ngClass): add class 'has-error' to demonstrate hyphen use

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -162,7 +162,7 @@ function classDirective(name, selector) {
  * @example Example that demonstrates basic bindings via ngClass directive.
    <example>
      <file name="index.html">
-       <p ng-class="{strike: deleted, bold: important, red: error}">Map Syntax Example</p>
+       <p ng-class="{strike: deleted, bold: important, 'red-error': error}">Map Syntax Example</p>
        <label>
           <input type="checkbox" ng-model="deleted">
           deleted (apply "strike" class)
@@ -201,6 +201,10 @@ function classDirective(name, selector) {
        }
        .red {
            color: red;
+       }
+       .red-error {
+           color: red;
+           background-color: yellow;
        }
        .orange {
            color: orange;

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -162,7 +162,7 @@ function classDirective(name, selector) {
  * @example Example that demonstrates basic bindings via ngClass directive.
    <example>
      <file name="index.html">
-       <p ng-class="{strike: deleted, bold: important, 'red-error': error}">Map Syntax Example</p>
+       <p ng-class="{strike: deleted, bold: important, 'has-error': error}">Map Syntax Example</p>
        <label>
           <input type="checkbox" ng-model="deleted">
           deleted (apply "strike" class)
@@ -173,7 +173,7 @@ function classDirective(name, selector) {
        </label><br>
        <label>
           <input type="checkbox" ng-model="error">
-          error (apply "red" class)
+          error (apply "has-error" class)
        </label>
        <hr>
        <p ng-class="style">Using String Syntax</p>
@@ -202,7 +202,7 @@ function classDirective(name, selector) {
        .red {
            color: red;
        }
-       .red-error {
+       .has-error {
            color: red;
            background-color: yellow;
        }

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -216,13 +216,13 @@ function classDirective(name, selector) {
        it('should let you toggle the class', function() {
 
          expect(ps.first().getAttribute('class')).not.toMatch(/bold/);
-         expect(ps.first().getAttribute('class')).not.toMatch(/red/);
+         expect(ps.first().getAttribute('class')).not.toMatch(/has-error/);
 
          element(by.model('important')).click();
          expect(ps.first().getAttribute('class')).toMatch(/bold/);
 
          element(by.model('error')).click();
-         expect(ps.first().getAttribute('class')).toMatch(/red/);
+         expect(ps.first().getAttribute('class')).toMatch(/has-error/);
        });
 
        it('should let you toggle string example', function() {


### PR DESCRIPTION
Sorry, I don't know how to put it in the original pull request. I'm new to GitHub. But here it is, with just one additional class, red-error, which is the only one with quotes.

   Thanks, 
        Ori
