### PR TITLE
Decreases indentation to fix markdown

### DIFF
--- a/docs/content/tutorial/step_00.ngdoc
+++ b/docs/content/tutorial/step_00.ngdoc
@@ -93,8 +93,8 @@ being the element on which the `ngApp` directive was defined.
 
   This line demonstrates two core features of Angular's templating capabilities:
 
-    * a binding, denoted by double-curlies `{{ }}`
-    * a simple expression `'yet' + '!'` used in this binding.
+  * a binding, denoted by double-curlies `{{ }}`
+  * a simple expression `'yet' + '!'` used in this binding.
 
   The binding tells Angular that it should evaluate an expression and insert the result into the
   DOM in place of the binding. Rather than a one-time insert, as we'll see in the next steps, a


### PR DESCRIPTION
Two bullet points were indented causing the entire lines to be formatted as code by markdown. Decreased indentation level by one, as it seems this was not the intention.
