### PR TITLE
docs(tutorial/Tutorial): mention package.json file

### DIFF
--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -129,7 +129,7 @@ Once you have Node.js installed on your machine you can download the tool depend
 npm install
 ```
 
-This command will download the following tools, into the `node_modules` directory:
+This command reads angular-phonecat's project.json file and will download the following tools, into the `node_modules` directory:
 
 - [Bower][bower] - client-side code package manager
 - [Http-Server][http-server] - simple local static web server

--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -129,7 +129,7 @@ Once you have Node.js installed on your machine you can download the tool depend
 npm install
 ```
 
-This command reads angular-phonecat's project.json file and will download the following tools, into the `node_modules` directory:
+This command reads angular-phonecat's package.json file and will download the following tools, into the `node_modules` directory:
 
 - [Bower][bower] - client-side code package manager
 - [Http-Server][http-server] - simple local static web server


### PR DESCRIPTION
If reader does not cd into angular-phonecat subdirectory - npm install will not work.   This comment helps newbies understand npm install is dependent on a custom project.json file.
