### PR TITLE
perf($compile): use static jquery data method to avoid creating new instances

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2505,7 +2505,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         // Copy over user data (that includes Angular's $scope etc.). Don't copy private
         // data here because there's no public interface in jQuery to do that and copying over
         // event listeners (which is the main use of private data) wouldn't work anyway.
-        jqLite(newNode).data(jqLite(firstElementToRemove).data());
+        jqLite.data(newNode, jqLite.data(firstElementToRemove));
 
         // Remove data of the replaced element. We cannot just call .remove()
         // on the element it since that would deallocate scope that is needed


### PR DESCRIPTION
Really minor, but the static `jqLite.data` does the same thing when there is only one node...
