### PR TITLE
docs(orderBy): correctly is not the right word

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -8,7 +8,7 @@
  * @description
  * Orders a specified `array` by the `expression` predicate. It is ordered alphabetically
  * for strings and numerically for numbers. Note: if you notice numbers are not being sorted
- * correctly, make sure they are actually being saved as numbers and not strings.
+ * as expected, make sure they are actually being saved as numbers and not strings.
  *
  * @param {Array} array The array to sort.
  * @param {function(*)|string|Array.<(function(*)|string)>=} expression A predicate to be


### PR DESCRIPTION
The use of correctly implies that Angular is doing something incorrect, however it is that we expect a number passed as a string to be sorted as a number. Angular does not do what we are expecting, although it responds correctly to what we have actually asked - sorting based on the string representation of a number.
