### PR TITLE
test($compile): fix test

### DIFF
--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2998,7 +2998,7 @@ describe('$compile', function() {
 
       // Create and register the MutationObserver
       var observer = new window.MutationObserver(noop);
-      observer.observe(document.body, {childList: true, sublist: true});
+      observer.observe(document.body, {childList: true, subtree: true});
 
       // Run the actual test
       var base = jqLite('<div>&mdash; {{ "This doesn\'t." }}</div>');


### PR DESCRIPTION
The fixed test is supposed to test a fix for an IE11 bug/peculiarity that arises when using a specifically configured MutationObserver on the page (see #11781 for more info).

The configuration contained a typo (`sublist` instead of `subtree`), which effectively failed to set up the MutationObserver in a way that would make the IE11 bug appear.
