### PR TITLE
fix(orderBy): ensure correct ordering with arrays of objects and no predicate

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -55,6 +55,7 @@
     "isBlob": false,
     "isBoolean": false,
     "isPromiseLike": false,
+    "hasCustomToString": false,
     "trim": false,
     "escapeForRegexp": false,
     "isElement": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -464,6 +464,11 @@ identity.$inject = [];
 
 function valueFn(value) {return function() {return value;};}
 
+function hasCustomToString(obj) {
+  return isFunction(obj.toString) && obj.toString !== Object.prototype.toString;
+}
+
+
 /**
  * @ngdoc function
  * @name angular.isUndefined

--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -163,10 +163,6 @@ function filterFilter() {
   };
 }
 
-function hasCustomToString(obj) {
-  return isFunction(obj.toString) && obj.toString !== Object.prototype.toString;
-}
-
 // Helper functions for `filterFilter`
 function createPredicateFn(expression, comparator, matchAgainstAnyProp) {
   var shouldMatchPrimitives = isObject(expression) && ('$' in expression);

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -23,7 +23,7 @@ describe('Filter: orderBy', function() {
     });
 
 
-    it('shouldSortArrayInReverse', function() {
+    it('should reverse collection if `reverseOrder` param is truthy', function() {
       expect(orderBy([{a:15}, {a:2}], 'a', true)).toEqualData([{a:15}, {a:2}]);
       expect(orderBy([{a:15}, {a:2}], 'a', "T")).toEqualData([{a:15}, {a:2}]);
       expect(orderBy([{a:15}, {a:2}], 'a', "reverse")).toEqualData([{a:15}, {a:2}]);
@@ -116,7 +116,7 @@ describe('Filter: orderBy', function() {
     });
 
 
-    it('should not reverse array of objects with no predicate', function() {
+    it('should not reverse array of objects with no predicate and reverse is not `true`', function() {
       var array = [
         { id: 2 },
         { id: 1 },
@@ -124,6 +124,39 @@ describe('Filter: orderBy', function() {
         { id: 3 }
       ];
       expect(orderBy(array)).toEqualData(array);
+    });
+
+    it('should reverse array of objects with no predicate and reverse is `true`', function() {
+      var array = [
+        { id: 2 },
+        { id: 1 },
+        { id: 4 },
+        { id: 3 }
+      ];
+      var reversedArray = [
+        { id: 3 },
+        { id: 4 },
+        { id: 1 },
+        { id: 2 }
+      ];
+      expect(orderBy(array, '', true)).toEqualData(reversedArray);
+    });
+
+
+    it('should reverse array of objects with predicate of "-"', function() {
+      var array = [
+        { id: 2 },
+        { id: 1 },
+        { id: 4 },
+        { id: 3 }
+      ];
+      var reversedArray = [
+        { id: 3 },
+        { id: 4 },
+        { id: 1 },
+        { id: 2 }
+      ];
+      expect(orderBy(array, '-')).toEqualData(reversedArray);
     });
 
 
@@ -151,6 +184,16 @@ describe('Filter: orderBy', function() {
         null
       ]);
     });
+
+
+    it('should sort array of arrays as Array.prototype.sort', function() {
+      expect(orderBy([['one'], ['two'], ['three']])).toEqualData([['one'], ['three'], ['two']]);
+    });
+
+
+    it('should sort mixed array of objects and values in a stable way', function() {
+      expect(orderBy([{foo: 2}, {foo: {}}, {foo: 3}, {foo: 4}], 'foo')).toEqualData([{foo: 2}, {foo: 3}, {foo: 4}, {foo: {}}]);
+    })
   });
 
 


### PR DESCRIPTION
This fix also considerably refactors how the `orderBy` filter works in internally.

The new algorithm precomputes the predicate values for the array being ordered. This makes the algorith easier to follow but also ensures that this computation is done a maximum of n times, whereas in the previous algorithm it could be greater. The downside is that we must temporarily store this intermediate array.

There could be performance implications, but they are as likely to be beneficial as detrimental. It could probably do with benchmarking.

Closes #11866
