### PR TITLE
perf(ngSwitch): Define this directive as terminal

### DIFF
--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -185,6 +185,7 @@ var ngSwitchDirective = ['$animate', function($animate) {
 var ngSwitchWhenDirective = ngDirective({
   transclude: 'element',
   priority: 1200,
+  terminal: true,
   require: '^ngSwitch',
   multiElement: true,
   link: function(scope, element, attrs, ctrl, $transclude) {
@@ -196,6 +197,7 @@ var ngSwitchWhenDirective = ngDirective({
 var ngSwitchDefaultDirective = ngDirective({
   transclude: 'element',
   priority: 1200,
+  terminal: true,
   require: '^ngSwitch',
   multiElement: true,
   link: function(scope, element, attr, ctrl, $transclude) {


### PR DESCRIPTION
Since a switch statement ( and therefore `ngSwitch` ) can really be
thought of as simply a combination of if statements, there's no reason
that this directive should differ from `ngIf` in how it compiles the
element.  This should also prevents needless compilation of directives
when the ngSwitch condition isn't yet matched.
