### PR TITLE
fix($location): do not get caught in infinite digest in IE9

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -147,7 +147,7 @@ function Browser(window, document, $log, $sniffer) {
         // Do the assignment again so that those two variables are referentially identical.
         lastHistoryState = cachedState;
       } else {
-        if (!sameBase) {
+        if (!sameBase || reloadLocation) {
           reloadLocation = url;
         }
         if (replace) {

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -669,12 +669,17 @@ describe('$location', function() {
       mockUpBrowser({initialUrl:'http://server/base/home', baseHref:'/base/'});
       inject(
         function($browser, $location, $rootScope, $window) {
+          var handlerCalled = false;
           $rootScope.$on('$locationChangeSuccess', function() {
+            handlerCalled = true;
             if ($location.path() !== '/') {
                 $location.path('/').replace();
             }
           });
+          expect($browser.url()).toEqual('http://server/base/#/home');
           $rootScope.$digest();
+          expect(handlerCalled).toEqual(true);
+          expect($browser.url()).toEqual('http://server/base/#/');
         }
       );
     });
@@ -768,10 +773,10 @@ describe('$location', function() {
 
 
     describe('location watch for HTML5 browsers', function() {
-      beforeEach(initService({html5Mode: true, supportHistory: true}));
-      beforeEach(inject(initBrowser({basePath: '/app/'})));
 
       it('should not infinite $digest when going to base URL without trailing slash when $locationChangeSuccess watcher changes path to /Home', function() {
+        initService({html5Mode: true, supportHistory: true});
+        mockUpBrowser({initialUrl:'http://server/app/', baseHref:'/app/'});
         inject(function($rootScope, $injector, $browser) {
           var $browserUrl = spyOnlyCallsWithArgs($browser, 'url').andCallThrough();
 
@@ -790,6 +795,8 @@ describe('$location', function() {
       });
 
       it('should not infinite $digest when going to base URL without trailing slash when $locationChangeSuccess watcher changes path to /', function() {
+        initService({html5Mode: true, supportHistory: true});
+        mockUpBrowser({initialUrl:'http://server/app/', baseHref:'/app/'});
         inject(function($rootScope, $injector, $browser) {
           var $browserUrl = spyOnlyCallsWithArgs($browser, 'url').andCallThrough();
 
@@ -808,6 +815,8 @@ describe('$location', function() {
       });
 
       it('should not infinite $digest when going to base URL with trailing slash when $locationChangeSuccess watcher changes path to /Home', function() {
+        initService({html5Mode: true, supportHistory: true});
+        mockUpBrowser({initialUrl:'http://server/app/', baseHref:'/app/'});
         inject(function($rootScope, $injector, $browser) {
           var $browserUrl = spyOnlyCallsWithArgs($browser, 'url').andCallThrough();
 
@@ -826,6 +835,8 @@ describe('$location', function() {
       });
 
       it('should not infinite $digest when going to base URL with trailing slash when $locationChangeSuccess watcher changes path to /', function() {
+        initService({html5Mode: true, supportHistory: true});
+        mockUpBrowser({initialUrl:'http://server/app/', baseHref:'/app/'});
         inject(function($rootScope, $injector, $browser) {
           var $browserUrl = spyOnlyCallsWithArgs($browser, 'url').andCallThrough();
 
@@ -1209,49 +1220,6 @@ describe('$location', function() {
         initBrowser({url:'http://domain.com/base/index.html',basePath: '/base/index.html'}),
         function($browser, $location) {
           expect($browser.url()).toBe('http://domain.com/base/index.html#!/index.html');
-        }
-      );
-    });
-
-
-    function mockUpBrowser(options) {
-      module(function($windowProvider, $browserProvider) {
-        $windowProvider.$get = function() {
-          var win = {};
-          angular.extend(win, window);
-          win.addEventListener = angular.noop;
-          win.removeEventListener = angular.noop;
-          win.location = {
-            href: options.initialUrl,
-            replace: function(val) {
-              //win.location.href = val;
-            }
-          };
-          return win;
-        };
-        $browserProvider.$get = function($document, $window, $log, $sniffer) {
-          /* global Browser: false */
-          var b = new Browser($window, $document, $log, $sniffer);
-          b.baseHref = function() {
-            return options.baseHref;
-          };
-          return b;
-        };
-      });
-    }
-
-
-    it('should not get caught in infinite digest when replacing empty path with slash', function() {
-      initService({html5Mode:true,supportHistory:false});
-      mockUpBrowser({initialUrl:'http://server/base', baseHref:'/base/'});
-      inject(
-        function($browser, $location, $rootScope, $window) {
-          $rootScope.$on('$locationChangeSuccess', function() {
-            if ($location.path() !== '/') {
-                $location.path('/').replace();
-            }
-          });
-          $rootScope.$digest();
         }
       );
     });

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -787,7 +787,7 @@ describe('$location', function() {
 
           expect($browser.url()).toEqual('http://server/app/Home');
           expect($location.path()).toEqual('/Home');
-          expect($browserUrl.calls.length).toEqual(3);
+          expect($browserUrl.calls.length).toEqual(1);
         });
       });
 
@@ -804,7 +804,7 @@ describe('$location', function() {
 
           expect($browser.url()).toEqual('http://server/app/');
           expect($location.path()).toEqual('/');
-          expect($browserUrl.calls.length).toEqual(2);
+          expect($browserUrl.calls.length).toEqual(0);
         });
       });
 
@@ -821,7 +821,7 @@ describe('$location', function() {
 
           expect($browser.url()).toEqual('http://server/app/Home');
           expect($location.path()).toEqual('/Home');
-          expect($browserUrl.calls.length).toEqual(2);
+          expect($browserUrl.calls.length).toEqual(1);
         });
       });
 
@@ -838,7 +838,7 @@ describe('$location', function() {
 
           expect($browser.url()).toEqual('http://server/app/');
           expect($location.path()).toEqual('/');
-          expect($browserUrl.calls.length).toEqual(1);
+          expect($browserUrl.calls.length).toEqual(0);
         });
       });
     });

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -780,9 +780,6 @@ describe('$location', function() {
         inject(function($rootScope, $injector, $browser) {
           var $browserUrl = spyOnlyCallsWithArgs($browser, 'url').andCallThrough();
 
-          $browser.url('http://server/app');
-          $browser.poll();
-
           var $location = $injector.get('$location');
           updatePathOnLocationChangeSuccessTo('/Home');
 
@@ -799,9 +796,6 @@ describe('$location', function() {
         mockUpBrowser({initialUrl:'http://server/app/', baseHref:'/app/'});
         inject(function($rootScope, $injector, $browser) {
           var $browserUrl = spyOnlyCallsWithArgs($browser, 'url').andCallThrough();
-
-          $browser.url('http://server/app');
-          $browser.poll();
 
           var $location = $injector.get('$location');
           updatePathOnLocationChangeSuccessTo('/');
@@ -820,9 +814,6 @@ describe('$location', function() {
         inject(function($rootScope, $injector, $browser) {
           var $browserUrl = spyOnlyCallsWithArgs($browser, 'url').andCallThrough();
 
-          $browser.url('http://server/app/');
-          $browser.poll();
-
           var $location = $injector.get('$location');
           updatePathOnLocationChangeSuccessTo('/Home');
 
@@ -839,9 +830,6 @@ describe('$location', function() {
         mockUpBrowser({initialUrl:'http://server/app/', baseHref:'/app/'});
         inject(function($rootScope, $injector, $browser) {
           var $browserUrl = spyOnlyCallsWithArgs($browser, 'url').andCallThrough();
-
-          $browser.url('http://server/app/');
-          $browser.poll();
 
           var $location = $injector.get('$location');
           updatePathOnLocationChangeSuccessTo('/');


### PR DESCRIPTION
The problem appears to occur when we have triggered a reload (via replace()) that updates the `reloadLocation` but then before the reload happens we trigger another change to the URL that would not have triggered a reload if we had already reloaded. In this case, the `$browser` is ignoring the `reloadLocation` because it thinks that we will no longer reload.

So to be more explicit:

Navigate to http://my.server.com/Home
Because we are on IE9 this get rewritten (with replace()) to http://my.server.com/#/Home, which would cause a reload on IE9
The SuccessChangeHandler kicks in and then changes the $location.path to /, i.e. the URL gets changed to http://my.server.com/#/`.
Since http://my.server.com/#/Home -> http://my.server.com/#/ would not normally trigger a reload we don't update the reloadLocation, which gets stuck at http://my.server.com/#/Home
We get stuck in an infinite digest as the $location keeps trying to update the URL to http://my.server.com/#/ but failing because the reloadLocation is stuck at http://my.server.com/#/Home
This is why @hamfastgamgee's fix appears to work. When we see that we are in an infinite loop and there is a reloadLocation then we force it to change to the proper URL.

A better solution is simply to realize that we are updating a URL in $browser that is expected to cause a reload by changing the line at https://github.com/angular/angular.js/blob/v1.4.0/src/ng/browser.js#L150:

```
  if ($sniffer.history && (!sameBase || !sameState)) {
    history[replace ? 'replaceState' : 'pushState'](state, '', url);
    cacheState();
    // Do the assignment again so that those two variables are referentially identical.
    lastHistoryState = cachedState;
  } else {
    if (!sameBase) {
      reloadLocation = url;
    }
    if (replace) {
      location.replace(url);
    } else if (!sameBase) {
      location.href = url;
    } else {
      location.hash = getHash(url);
    }
  }
```

to

```
  if ($sniffer.history && (!sameBase || !sameState)) {
    history[replace ? 'replaceState' : 'pushState'](state, '', url);
    cacheState();
    // Do the assignment again so that those two variables are referentially identical.
    lastHistoryState = cachedState;
  } else {
    if (!sameBase || reloadLocation) {
      reloadLocation = url;
    }
    if (replace) {
      location.replace(url);
    } else if (!sameBase) {
      location.href = url;
    } else {
      location.hash = getHash(url);
    }
  }
```

In other words we check not only whether the base has changed but also whether we are in the middle of a reload any way.

Closes #11439
Closes #11935
Closes #11675
