### PR TITLE
refactor($compile): remove skipDestroyOnNextJQueryCleanData, fix data leak on some replaced nodes

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -94,8 +94,6 @@
     "VALIDITY_STATE_PROPERTY": false,
     "reloadWithDebugInfo": false,
 
-    "skipDestroyOnNextJQueryCleanData": true,
-
     "NODE_TYPE_ELEMENT": false,
     "NODE_TYPE_ATTRIBUTE": false,
     "NODE_TYPE_TEXT": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1678,7 +1678,6 @@ function snake_case(name, separator) {
 }
 
 var bindJQueryFired = false;
-var skipDestroyOnNextJQueryCleanData;
 function bindJQuery() {
   var originalCleanData;
 
@@ -1712,15 +1711,11 @@ function bindJQuery() {
     originalCleanData = jQuery.cleanData;
     jQuery.cleanData = function(elems) {
       var events;
-      if (!skipDestroyOnNextJQueryCleanData) {
-        for (var i = 0, elem; (elem = elems[i]) != null; i++) {
-          events = jQuery._data(elem, "events");
-          if (events && events.$destroy) {
-            jQuery(elem).triggerHandler('$destroy');
-          }
+      for (var i = 0, elem; (elem = elems[i]) != null; i++) {
+        events = jQuery._data(elem, "events");
+        if (events && events.$destroy) {
+          jQuery(elem).triggerHandler('$destroy');
         }
-      } else {
-        skipDestroyOnNextJQueryCleanData = false;
       }
       originalCleanData(elems);
     };

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -189,6 +189,12 @@ function jqLiteHasData(node) {
   return false;
 }
 
+function jqLiteCleanData(nodes) {
+  for (var i = 0, ii = nodes.length; i < ii; i++) {
+    jqLiteRemoveData(nodes[i]);
+  }
+}
+
 function jqLiteBuildFragment(html, context) {
   var tmp, tag, wrap,
       fragment = context.createDocumentFragment(),
@@ -571,7 +577,8 @@ function getAliasedAttrName(name) {
 forEach({
   data: jqLiteData,
   removeData: jqLiteRemoveData,
-  hasData: jqLiteHasData
+  hasData: jqLiteHasData,
+  cleanData: jqLiteCleanData
 }, function(fn, name) {
   JQLite[name] = fn;
 });


### PR DESCRIPTION
This removes the `skipDestroyOnNextJQueryCleanData` global while also fixing an edge case where some elements removed by `replaceWith` did not have child elements cleaned and could leak jq data/handlers. It's a bit of an edge case but would be reproduced if jq data ever got onto the child element of a `ng-if` or `ng-repeat` before the transclude `replaceWith` call (or similar situations with `replace:true`). This is captured in the added tests (3 previously failed). Also added a test ensuring the `firstElementToRemove` does not trigger the element $destroy.

`skipDestroyOnNextJQueryCleanData` is removed by doing `jqLite(firstElementToRemove).off('$destroy')` before doing `cleanData(fragment.qSA(*))`.

Doing `cleanData(fragment.qSA(*))` avoids `jqLite(elements[1...n]).remove()` for the multi element case while also fixing the bug mentioned above by also fetching child elements. This makes use of the fragment meaning #12041 that avoided creating it would no longer work.

`JQLite.cleanData` is added so this code doesn't need JQLite vs jQuery specific logic.

For the single node case this adds the `.qSA(*)` and may add `.off('$destroy')` but all the benchmarks I tried showed no effect. The `replaceWith` is just too small/infrequent when doing compile/link/digest.
