### PR TITLE
fix($parse): set null reference properties to `undefined`

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -982,10 +982,10 @@ ASTCompiler.prototype = {
               nameId.name = ast.property.name;
             }
           }
-          recursionFn(intoId);
         }, function() {
           self.assign(intoId, 'undefined');
         });
+        recursionFn(intoId);
       }, !!create);
       break;
     case AST.CallExpression:
@@ -1023,8 +1023,10 @@ ASTCompiler.prototype = {
             }
             expression = self.ensureSafeObject(expression);
             self.assign(intoId, expression);
-            recursionFn(intoId);
+          }, function() {
+            self.assign(intoId, 'undefined');
           });
+          recursionFn(intoId);
         });
       }
       break;

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1746,9 +1746,15 @@ describe('parser', function() {
         expect(scope.$eval("0||2")).toEqual(0 || 2);
         expect(scope.$eval("0||1&&2")).toEqual(0 || 1 && 2);
         expect(scope.$eval("true&&a")).toEqual(true && undefined);
+        expect(scope.$eval("true&&a()")).toEqual(true && undefined);
+        expect(scope.$eval("true&&a()()")).toEqual(true && undefined);
         expect(scope.$eval("true&&a.b")).toEqual(true && undefined);
+        expect(scope.$eval("true&&a.b.c")).toEqual(true && undefined);
         expect(scope.$eval("false||a")).toEqual(false || undefined);
+        expect(scope.$eval("false||a()")).toEqual(false || undefined);
+        expect(scope.$eval("false||a()()")).toEqual(false || undefined);
         expect(scope.$eval("false||a.b")).toEqual(false || undefined);
+        expect(scope.$eval("false||a.b.c")).toEqual(false || undefined);
       });
 
       it('should parse ternary', function() {


### PR DESCRIPTION
When there is an expression of the form
- true && a.b.c
- true && a()
- true && a()()
- false || a.b.c
- false || a()
- false || a()()

where `a == null`

Closes #12099
