### PR TITLE
chore(npm): Add the license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "angularjs",
+  "license": "MIT",
   "branchVersion": "^1.4.0-beta.0",
   "branchPattern": "1.4.*",
   "repository": {


### PR DESCRIPTION
This removes a warning when executing npm install
