### PR TITLE
feat(http): Add 'useLegacyMethods' to $httpProvider

### DIFF
--- a/docs/content/error/$http/noerror.ngdoc
+++ b/docs/content/error/$http/noerror.ngdoc
@@ -1,0 +1,10 @@
+@ngdoc error
+@name $http:noerror
+@fullName The method `error` on the $http result has been disabled.
+@description
+
+This error occurs when the legacy promise extensions {@link ng.$http `$http`} have been disabled.
+
+To resolve this error, either change to code to use `then` or add `$httpProvider.useLegacyPromiseExtensions(true);` to your application.
+
+For more information, see the {@link ng.$http `$http`} service API documentation.

--- a/docs/content/error/$http/nosuccess.ngdoc
+++ b/docs/content/error/$http/nosuccess.ngdoc
@@ -1,0 +1,10 @@
+@ngdoc error
+@name $http:nosuccess
+@fullName The method `success` on the $http result has been disabled.
+@description
+
+This error occurs when the legacy promise extensions {@link ng.$http `$http`} have been disabled.
+
+To resolve this error, either change to code to use `then` or add `$httpProvider.useLegacyPromiseExtensions(true);` to your application.
+
+For more information, see the {@link ng.$http `$http`} service API documentation.

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1975,6 +1975,36 @@ describe('$http with $applyAsync', function() {
   });
 });
 
+describe('$http without useLegacyPromiseExtensions', function() {
+  var $httpBackend, $http;
+  beforeEach(module(function($httpProvider) {
+    $httpProvider.useLegacyPromiseExtensions(false);
+  }, provideLog));
+
+  beforeEach(inject(['$httpBackend', '$http', '$rootScope', function($hb, $h, $rs) {
+    $httpBackend = $hb;
+    $http = $h;
+  }]));
+
+  it('should throw when the success or error methods are called if useLegacyPromiseExtensions is false', function() {
+    $httpBackend.expect('GET', '/url').respond('');
+    var promise = $http({url: '/url'});
+
+    function callSucess() {
+      promise.success();
+    }
+
+    function callError() {
+      promise.error();
+    }
+
+    expect(callSucess).toThrowMinErr(
+            '$http', 'nosuccess', 'The method `success` on the $http result has been disabled.');
+    expect(callError).toThrowMinErr(
+            '$http', 'noerror', 'The method `error` on the $http result has been disabled.');
+  });
+});
+
 describe('$http param serializers', function() {
 
   var defSer, jqrSer;


### PR DESCRIPTION
For now it defaults to true. This will open up a path to remove the short hand methods in the long run.
