### PR TITLE
refactor(animate): add the new operator to injected $q

### DIFF
--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -54,7 +54,7 @@ function prepareAnimateOptions(options) {
 }
 
 var $$CoreAnimateRunnerProvider = function() {
-  this.$get = ['$q', '$$rAF', function($q, $$rAF) {
+  this.$get = ['$q', '$$rAF', function(Q, $$rAF) {
     function AnimateRunner() {}
     AnimateRunner.all = noop;
     AnimateRunner.chain = noop;
@@ -65,7 +65,7 @@ var $$CoreAnimateRunnerProvider = function() {
       pause: noop,
       complete: noop,
       then: function(pass, fail) {
-        return new $q(function(resolve) {
+        return new Q(function(resolve) {
           $$rAF(function() {
             resolve();
           });

--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -65,7 +65,7 @@ var $$CoreAnimateRunnerProvider = function() {
       pause: noop,
       complete: noop,
       then: function(pass, fail) {
-        return $q(function(resolve) {
+        return new $q(function(resolve) {
           $$rAF(function() {
             resolve();
           });


### PR DESCRIPTION
When replacing $q with Bluebird, it complains `this is undefined`. Missing the new keyword
