### PR TITLE
docs(guide/Unit Testing): update $filter test example

### DIFF
--- a/docs/content/guide/unit-testing.ngdoc
+++ b/docs/content/guide/unit-testing.ngdoc
@@ -261,8 +261,10 @@ myModule.filter('length', function() {
 
 describe('length filter', function() {
 
+  var $filter;
+
   beforeEach(inject(function(_$filter_){
-    $filter= _$filter_;
+    $filter = _$filter_;
   }));
 
   it('returns 0 when given null', function() {


### PR DESCRIPTION
The $filter example never declares `$filter` and therefore would add `$filter` to the global namespace. Add variable declaration.
