### PR TITLE
Updated Custom Form Directive Example

### DIFF
--- a/docs/content/guide/forms.ngdoc
+++ b/docs/content/guide/forms.ngdoc
@@ -491,9 +491,7 @@ The following example shows how to add two-way data-binding to contentEditable e
         link: function(scope, elm, attrs, ctrl) {
           // view -> model
           elm.on('blur', function() {
-            scope.$apply(function() {
               ctrl.$setViewValue(elm.html());
-            });
           });
 
           // model -> view


### PR DESCRIPTION
As of angular 1.3 $setViewValue already calls $apply and triggers a digest cycle so now there is no need wrapping the $setViewValue function call with $apply which will just trigger an additional digest cycle.
