### PR TITLE
docs(ngTouch): Document event parameter for $swipe handlers

### DIFF
--- a/src/ngTouch/swipe.js
+++ b/src/ngTouch/swipe.js
@@ -74,7 +74,8 @@ ngTouch.factory('$swipe', [function() {
      * `$swipe` will listen for `mouse` and `touch` events.
      *
      * The four events are `start`, `move`, `end`, and `cancel`. `start`, `move`, and `end`
-     * receive as a parameter a coordinates object of the form `{ x: 150, y: 310 }`.
+     * receive as a parameter a coordinates object of the form `{ x: 150, y: 310 }` and the raw
+     * event. `cancel` receives the raw event as it's single parameter.
      *
      * `start` is called on either `mousedown` or `touchstart`. After this event, `$swipe` is
      * watching for `touchmove` or `mousemove` events. These events are ignored until the total


### PR DESCRIPTION
Document that the event handlers provided by $swipe do receive the raw
event as their last parameter.

Closes #11983
