### PR TITLE
fix(ngMock): support `before` test framework hook.

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2197,11 +2197,26 @@ if (window.jasmine || window.mocha) {
     return angular.mock.$$annotate.apply(this, arguments);
   };
 
-
-  (window.beforeEach || window.setup)(function() {
+  var doSetUp = function doSetUp() {
     annotatedFunctions = [];
     currentSpec = this;
-  });
+  };
+
+  // Hook `before` to provide the same module and injector configuration as
+  // `beforeEach`, knowing that `afterEach` will undo all of this (so it is not
+  // necessary to hook `after`).
+  if (window.before) {
+    // Mocha BDD, Exports, and QUnit interfaces.
+    window.before(doSetUp);
+  } else if (window.beforeAll) {
+    // Jasmine 2.1+ interface.
+    window.beforeAll(doSetUp);
+  } else if (window.suiteSetup) {
+    // Mocha TDD interface.
+    window.suiteSetup(doSetUp);
+  }
+
+  (window.beforeEach || window.setup)(doSetUp);
 
   (window.afterEach || window.teardown)(function() {
     var injector = currentSpec.$injector;


### PR DESCRIPTION
Both Jasmine 2.1+ and Mocha support `before` hooks that run setup
code once before all `beforeEach` hooks and test cases are run.
Initialize `annotatedFunctions` and `currentSpec` for `before`,
`beforeAll`, and `suiteSetup` test framework synonyms just as we do
for `beforeEach` and `setup` so that `before` hooks can be used with
ngMock.

Closes #12154
