### PR TITLE
docs($rootScope.Scope): reinsert lost example

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -128,7 +128,7 @@ function $RootScopeProvider() {
          // still old value, since watches have not been called yet
          expect(scope.greeting).toEqual(undefined);
 
-         scope.$digest(); // fire all  the watches
+         scope.$digest(); // fire all the watches
          expect(scope.greeting).toEqual('Hello Misko!');
      * ```
      *

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -112,8 +112,24 @@ function $RootScopeProvider() {
      * compiled HTML template is executed.)
      *
      * Here is a simple scope snippet to show how you can interact with the scope.
-     * ```html
-     * <file src="./test/ng/rootScopeSpec.js" tag="docs1" />
+     * ```js
+         var scope = $rootScope.$new();
+         scope.salutation = 'Hello';
+         scope.name = 'World';
+
+         expect(scope.greeting).toEqual(undefined);
+
+         scope.$watch('name', function() {
+           scope.greeting = scope.salutation + ' ' + scope.name + '!';
+         }); // initialize the watch
+
+         expect(scope.greeting).toEqual(undefined);
+         scope.name = 'Misko';
+         // still old value, since watches have not been called yet
+         expect(scope.greeting).toEqual(undefined);
+
+         scope.$digest(); // fire all  the watches
+         expect(scope.greeting).toEqual('Hello Misko!');
      * ```
      *
      * # Inheritance


### PR DESCRIPTION
This doc example was lost long ago here https://github.com/angular/angular.js/commit/2845dd159087fc59eb29845a578f32c7c462e8e6

As it is now, it says 'here is a simple scope snippet...' but has a non-linking file link to the test doc.  Doesn't make sense.  This change simply puts back the example as it originally was.
