### PR TITLE
fix($rootScope): Internal state consistency

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -1040,14 +1040,17 @@ function $RootScopeProvider() {
       $apply: function(expr) {
         try {
           beginPhase('$apply');
-          return this.$eval(expr);
-        } catch (e) {
+          try {
+            return this.$eval(expr);
+          } finally {
+            clearPhase();
+          }
+        } catch(e) {
           $exceptionHandler(e);
         } finally {
-          clearPhase();
           try {
             $rootScope.$digest();
-          } catch (e) {
+          } catch(e) {
             $exceptionHandler(e);
             throw e;
           }

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1505,6 +1505,19 @@ describe('Scope', function() {
       }));
 
 
+      it('should not clear the state when calling $apply during an $apply', inject(
+          function($rootScope) {
+        $rootScope.$apply(function() {
+          expect(function() {
+            $rootScope.$apply();
+          }).toThrowMinErr('$rootScope', 'inprog', '$apply already in progress');
+          expect(function() {
+            $rootScope.$apply();
+          }).toThrowMinErr('$rootScope', 'inprog', '$apply already in progress');
+        });
+      }));
+
+
       it('should throw an exception if $apply is called while flushing evalAsync queue', inject(
           function($rootScope) {
         expect(function() {


### PR DESCRIPTION
During a recursive $apply, clear the state only if the state was set in that call.
