### PR TITLE
Add hasBody to ngResource action configuration

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -161,6 +161,8 @@ function shallowClearAndCopy(src, dst) {
  *   - **`interceptor`** - `{Object=}` - The interceptor object has two optional methods -
  *     `response` and `responseError`. Both `response` and `responseError` interceptors get called
  *     with `http response` object. See {@link ng.$http $http interceptors}.
+ *   - **`hasBody`** - `{boolean}` - allows to specify if a request body is to be used (not
+ *     required for POST,PUT,PATCH and can't disable body inclusion on this methods).
  *
  * @param {Object} options Hash with custom settings that should extend the
  *   default `$resourceProvider` behavior.  The only supported option is
@@ -511,7 +513,7 @@ angular.module('ngResource', ['ng']).
         };
 
         forEach(actions, function(action, name) {
-          var hasBody = /^(POST|PUT|PATCH)$/i.test(action.method);
+          var hasBody = /^(POST|PUT|PATCH)$/i.test(action.method) || action.hasBody === true;
 
           Resource[name] = function(a1, a2, a3, a4) {
             var params = {}, data, success, error;


### PR DESCRIPTION
The use of hasBody would allow developers of REST interfaces to decide if a request body is necessary or not on a per method basis.

The way ngResource currently handles request bodies in custom requests make the definition of custom requests pretty useless. It’s not possible to transfere a request body through a  other requests than POST, PUT, PATCH. Or am I wrong?

It may be true that some browser implementations are also brocken when it comes to methods like DELETE but this broken behavior should not be enforced by angular.

Even as i read https://github.com/angular/angular.js/issues/3207 after creating the patch its somehow picking up pmariduenas comment on creating a enableDeleteRequestBody. Its just the generic version for all custom requests.
