### PR TITLE
Add hasBody to ngResource action configuration

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -194,7 +194,7 @@ function shallowClearAndCopy(src, dst) {
  *     `response` and `responseError`. Both `response` and `responseError` interceptors get called
  *     with `http response` object. See {@link ng.$http $http interceptors}.
  *   - **`hasBody`** - `{boolean}` - allows to specify if a request body should be included or not.
- *     If not specified only POST, PUT and PATCH will have a request.
+ *     If not specified only POST, PUT and PATCH requests will have a body.
  *
  * @param {Object} options Hash with custom settings that should extend the
  *   default `$resourceProvider` behavior.  The supported options are:

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -193,6 +193,8 @@ function shallowClearAndCopy(src, dst) {
  *   - **`interceptor`** - `{Object=}` - The interceptor object has two optional methods -
  *     `response` and `responseError`. Both `response` and `responseError` interceptors get called
  *     with `http response` object. See {@link ng.$http $http interceptors}.
+ *   - **`hasBody`** - `{boolean}` - allows to specify if a request body is to be used (not
+ *     required for POST,PUT,PATCH and can't disable body inclusion on this methods).
  *
  * @param {Object} options Hash with custom settings that should extend the
  *   default `$resourceProvider` behavior.  The supported options are:
@@ -640,7 +642,7 @@ angular.module('ngResource', ['ng']).
         };
 
         forEach(actions, function(action, name) {
-          var hasBody = /^(POST|PUT|PATCH)$/i.test(action.method);
+          var hasBody = /^(POST|PUT|PATCH)$/i.test(action.method) || action.hasBody === true;
           var numericTimeout = action.timeout;
           var cancellable = isDefined(action.cancellable) ?
               action.cancellable : route.defaults.cancellable;

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -194,7 +194,7 @@ function shallowClearAndCopy(src, dst) {
  *     `response` and `responseError`. Both `response` and `responseError` interceptors get called
  *     with `http response` object. See {@link ng.$http $http interceptors}.
  *   - **`hasBody`** - `{boolean}` - allows to specify if a request body should be included or not.
- *     If not specified POST,PUT and PATCH will have a request body.
+ *     If not specified only POST, PUT and PATCH will have a request.
  *
  * @param {Object} options Hash with custom settings that should extend the
  *   default `$resourceProvider` behavior.  The supported options are:

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -193,8 +193,8 @@ function shallowClearAndCopy(src, dst) {
  *   - **`interceptor`** - `{Object=}` - The interceptor object has two optional methods -
  *     `response` and `responseError`. Both `response` and `responseError` interceptors get called
  *     with `http response` object. See {@link ng.$http $http interceptors}.
- *   - **`hasBody`** - `{boolean}` - allows to specify if a request body is to be used (not
- *     required for POST,PUT,PATCH and can't disable body inclusion on this methods).
+ *   - **`hasBody`** - `{boolean}` - allows to specify if a request body should be included or not.
+ *     If not specified POST,PUT and PATCH will have a request body.
  *
  * @param {Object} options Hash with custom settings that should extend the
  *   default `$resourceProvider` behavior.  The supported options are:

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -642,7 +642,7 @@ angular.module('ngResource', ['ng']).
         };
 
         forEach(actions, function(action, name) {
-          var hasBody = /^(POST|PUT|PATCH)$/i.test(action.method) || action.hasBody === true;
+          var hasBody = action.hasBody === true || (action.hasBody !== false && /^(POST|PUT|PATCH)$/i.test(action.method));
           var numericTimeout = action.timeout;
           var cancellable = isDefined(action.cancellable) ?
               action.cancellable : route.defaults.cancellable;

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -102,6 +102,10 @@ describe('basic usage', function() {
     var condition = {at: '2038-01-19 03:14:08'};
 
     $httpBackend.expect('CREATE', '/fooresource', instant).respond({fid: 42});
+    $httpBackend.expectPOST('/fooresource').respond(function(method, url, data) {
+      expect(data).not.toBeUndefined();
+      return [200, {id: 42}];
+    });
     $httpBackend.expect('DELETE', '/fooresource', condition).respond({});
 
     var r = $resource('/fooresource', {}, {
@@ -110,16 +114,21 @@ describe('basic usage', function() {
     });
 
     var creationResponse = r.create(instant);
+    var saveResponse = r.save(null, {id: -1});
     var deleteResponse = r.delete(condition);
 
     $httpBackend.flush();
 
     expect(creationResponse.fid).toBe(42);
+    expect(saveResponse.id).toBe(42);
     expect(deleteResponse.$resolved).toBe(true);
   });
 
   it('should not include a request body if hasBody is false on POST, PUT and PATCH', function() {
-    $httpBackend.expect('POST', '/foo').respond({});
+    $httpBackend.expectPOST('/foo').respond(function(method, url, data) {
+      expect(data).toBeUndefined();
+      return [200, {id: 42}];
+    });
     $httpBackend.expect('PUT', '/foo').respond({});
     $httpBackend.expect('PATCH', '/foo').respond({});
 
@@ -135,7 +144,7 @@ describe('basic usage', function() {
 
     $httpBackend.flush();
 
-    expect(postResponse.$resolved).toBe(true);
+    expect(postResponse.id).toBe(42);
     expect(putResponse.$resolved).toBe(true);
     expect(patchResponse.$resolved).toBe(true);
   });

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -98,11 +98,10 @@ describe('basic usage', function() {
   });
 
   it('should include a request body when calling custom method with hasBody is true', function() {
-    var instant = {name: 'info.txt', value: 'V2hlbiB0aGUgdGltZSBlbmRzLg=='};
-    var fid = 42;
-    var created = {fid: fid, filname: 'fooresource', value: 'V2hlbiB0aGUgdGltZSBlbmRzLg=='};
+    var instant = {name: 'info.txt'};
     var condition = {at: '2038-01-19 03:14:08'};
-    $httpBackend.expect('CREATE', '/fooresource', instant).respond(created);
+
+    $httpBackend.expect('CREATE', '/fooresource', instant).respond({fid: 42});
     $httpBackend.expect('DELETE', '/fooresource', condition).respond({});
 
     var r = $resource('/fooresource', {}, {
@@ -115,7 +114,7 @@ describe('basic usage', function() {
 
     $httpBackend.flush();
 
-    expect(creationResponse.fid).toBe(fid);
+    expect(creationResponse.fid).toBe(42);
     expect(deleteResponse.$resolved).toBe(true);
   });
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -102,10 +102,6 @@ describe('basic usage', function() {
     var condition = {at: '2038-01-19 03:14:08'};
 
     $httpBackend.expect('CREATE', '/fooresource', instant).respond({fid: 42});
-    $httpBackend.expectPOST('/fooresource').respond(function(method, url, data) {
-      expect(data).not.toBeUndefined();
-      return [200, {id: 42}];
-    });
     $httpBackend.expect('DELETE', '/fooresource', condition).respond({});
 
     var r = $resource('/fooresource', {}, {
@@ -114,23 +110,23 @@ describe('basic usage', function() {
     });
 
     var creationResponse = r.create(instant);
-    var saveResponse = r.save(null, {id: -1});
     var deleteResponse = r.delete(condition);
 
     $httpBackend.flush();
 
     expect(creationResponse.fid).toBe(42);
-    expect(saveResponse.id).toBe(42);
     expect(deleteResponse.$resolved).toBe(true);
   });
 
   it('should not include a request body if hasBody is false on POST, PUT and PATCH', function() {
-    $httpBackend.expectPOST('/foo').respond(function(method, url, data) {
+    function verifyRequest(method, url, data) {
       expect(data).toBeUndefined();
       return [200, {id: 42}];
-    });
-    $httpBackend.expect('PUT', '/foo').respond({});
-    $httpBackend.expect('PATCH', '/foo').respond({});
+    }
+
+    $httpBackend.expect('POST', '/foo').respond(verifyRequest);
+    $httpBackend.expect('PUT', '/foo').respond(verifyRequest);
+    $httpBackend.expect('PATCH', '/foo').respond(verifyRequest);
 
     var R = $resource('/foo', {}, {
       post: {method: 'POST', hasBody: false},

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -97,6 +97,43 @@ describe('basic usage', function() {
     $httpBackend.flush();
   });
 
+  it('should include a request body when calling custom delete with hasBody is true', function() {
+    var condition = {at: '2038-01-19 03:14:08'};
+    $httpBackend.expect('DELETE', '/fooresource', condition).respond({});
+
+    var r = $resource('/fooresource', {}, {
+      delete: {method: 'DELETE', hasBody: true}
+    });
+
+    var deleteResponse = r.delete(condition);
+
+    $httpBackend.flush();
+
+    expect(deleteResponse.$resolved).toBe(true);
+  });
+
+  it('should expect a body if hasBody is true', function() {
+    var username = 'yathos';
+    var loginRequest = {name: username, password: 'Smile'};
+    var user = {id: 1, name: username};
+
+    $httpBackend.expect('LOGIN', '/user/me', loginRequest).respond(user);
+
+    $httpBackend.expect('LOGOUT', '/user/me', null).respond(null);
+
+    var UserService = $resource('/user/me', {}, {
+      login: {method: 'LOGIN', hasBody: true},
+      logout: {method: 'LOGOUT', hasBody: false}
+    });
+
+    var loginResponse = UserService.login(loginRequest);
+    var logoutResponse = UserService.logout();
+
+    $httpBackend.flush();
+
+    expect(loginResponse.id).toBe(user.id);
+    expect(logoutResponse.$resolved).toBe(true);
+  });
 
   it('should build resource', function() {
     expect(typeof CreditCard).toBe('function');

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -97,19 +97,48 @@ describe('basic usage', function() {
     $httpBackend.flush();
   });
 
-  it('should include a request body when calling custom delete with hasBody is true', function() {
+  it('should include a request body when calling custom method with hasBody is true', function() {
+    var instant = {name: 'info.txt', value: 'V2hlbiB0aGUgdGltZSBlbmRzLg=='};
+    var fid = 42;
+    var created = {fid: fid, filname: 'fooresource', value: 'V2hlbiB0aGUgdGltZSBlbmRzLg=='};
     var condition = {at: '2038-01-19 03:14:08'};
+    $httpBackend.expect('CREATE', '/fooresource', instant).respond(created);
     $httpBackend.expect('DELETE', '/fooresource', condition).respond({});
 
     var r = $resource('/fooresource', {}, {
+      create: {method: 'CREATE', hasBody: true},
       delete: {method: 'DELETE', hasBody: true}
     });
 
+    var creationResponse = r.create(instant);
     var deleteResponse = r.delete(condition);
 
     $httpBackend.flush();
 
+    expect(creationResponse.fid).toBe(fid);
     expect(deleteResponse.$resolved).toBe(true);
+  });
+
+  it('should not include a request body if hasBody is false on POST, PUT and PATCH', function() {
+    $httpBackend.expect('POST', '/foo').respond({});
+    $httpBackend.expect('PUT', '/foo').respond({});
+    $httpBackend.expect('PATCH', '/foo').respond({});
+
+    var R = $resource('/foo', {}, {
+      post: {method: 'POST', hasBody: false},
+      put: {method: 'PUT', hasBody: false},
+      patch: {method: 'PATCH', hasBody: false}
+    });
+
+    var postResponse = R.post();
+    var putResponse = R.put();
+    var patchResponse = R.patch();
+
+    $httpBackend.flush();
+
+    expect(postResponse.$resolved).toBe(true);
+    expect(putResponse.$resolved).toBe(true);
+    expect(patchResponse.$resolved).toBe(true);
   });
 
   it('should expect a body if hasBody is true', function() {

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -141,8 +141,8 @@ describe('basic usage', function() {
     $httpBackend.flush();
 
     expect(postResponse.id).toBe(42);
-    expect(putResponse.$resolved).toBe(true);
-    expect(patchResponse.$resolved).toBe(true);
+    expect(putResponse.id).toBe(42);
+    expect(patchResponse.id).toBe(42);
   });
 
   it('should expect a body if hasBody is true', function() {


### PR DESCRIPTION
The use of hasBody would allow developers of REST interfaces to decide if a request body is necessary or not on a per method basis.

The way ngResource currently handles request bodies in custom requests make the definition of custom requests pretty useless. It’s not possible to transfere a request body through a  other requests than POST, PUT, PATCH. Or am I wrong?

It may be true that some browser implementations are also brocken when it comes to methods like DELETE but this broken behavior should not be enforced by angular.

Even as i read the https://github.com/angular/angular.js/issues/3207 after creating the patch its somehow picking up pmariduenas comment on creating a enableDeleteRequestBody. Its just the generic version for all custom requests.
