### PR TITLE
fix(select): select doesn't work when label and ngModel value match.

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -715,13 +715,15 @@ var selectDirective = ['$compile', '$parse', function($compile,   $parse) {
             }
             optionGroup[0].element.remove();
           }
-          forEach(labelMap, function(count, label) {
-            if (count > 0) {
-              selectCtrl.addOption(label);
-            } else if (count < 0) {
-              selectCtrl.removeOption(label);
-            }
-          });
+          if (!anySelected) {
+            forEach(labelMap, function(count, label) {
+              if (count > 0) {
+                selectCtrl.addOption(label);
+              } else if (count < 0) {
+                selectCtrl.removeOption(label);
+              }
+            });
+          }
         }
       }
     }

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -888,6 +888,26 @@ describe('select', function() {
         expect(scope.selected).toBe(20);
       });
 
+      it('should support single select with array source with matching label and id', function() {
+        createSelect({
+          'ng-model': 'selected.id',
+          'ng-options': 'item.id as item.label for item in arrTmp'
+        }, true);
+
+        scope.arrTmp = [];
+        var arr = [{id: 10, label: 'ten'}, {id:20, label: 'twenty'}, {id: 30, label: '10'}, {id:40, label: '20'}];
+
+        scope.$apply(function() {
+          scope.selected = {id: 20};
+        });
+        expect(element.val()).toBe('');
+
+        scope.$apply(function() {
+          scope.arrTmp = arr;
+        });
+        expect(element.val()).toBe('1');
+      });
+
 
       it('should support multi select with array source', function() {
         createSelect({


### PR DESCRIPTION
The selectCtrl `addOption` compares the label value with the
ngModel value when determining when to set the value of the select
element.  This causes a problem if the label matches model value but
not the selectAs value of the option.

fixes #11835
