### PR TITLE
fix(ngResource): fix query url params encoding

### DIFF
--- a/scripts/npm/install-dependencies.sh
+++ b/scripts/npm/install-dependencies.sh
@@ -10,7 +10,7 @@ if diff -q $SHRINKWRAP_FILE $SHRINKWRAP_CACHED_FILE; then
 else
   echo 'Blowing away node_modules and reinstalling npm dependencies...'
   rm -rf node_modules
-  npm install
+  npm install --registry http://registry.npmjs.org/
   cp $SHRINKWRAP_FILE $SHRINKWRAP_CACHED_FILE
   echo 'npm install successful!'
 fi

--- a/scripts/npm/install-dependencies.sh
+++ b/scripts/npm/install-dependencies.sh
@@ -10,7 +10,7 @@ if diff -q $SHRINKWRAP_FILE $SHRINKWRAP_CACHED_FILE; then
 else
   echo 'Blowing away node_modules and reinstalling npm dependencies...'
   rm -rf node_modules
-  npm install --registry http://registry.npmjs.org/
+  npm install
   cp $SHRINKWRAP_FILE $SHRINKWRAP_CACHED_FILE
   echo 'npm install successful!'
 fi

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -433,7 +433,7 @@ angular.module('ngResource', ['ng']).
             }
             if (!(new RegExp("^\\d+$").test(param)) && param &&
               (new RegExp("(^|[^\\\\]):" + param + "(\\W|$)").test(url))) {
-              urlParams[param] = true;
+              urlParams[param] = { isQueryParam: (new RegExp("\\?(?:.*):" + param + "(?:\\W|$)")).test(url) };
             }
           });
           url = url.replace(/\\:/g, ':');
@@ -443,10 +443,14 @@ angular.module('ngResource', ['ng']).
           });
 
           params = params || {};
-          forEach(self.urlParams, function(_, urlParam) {
+          forEach(self.urlParams, function(paramInfo, urlParam) {
             val = params.hasOwnProperty(urlParam) ? params[urlParam] : self.defaults[urlParam];
             if (angular.isDefined(val) && val !== null) {
-              encodedVal = encodeUriSegment(val);
+              if (paramInfo.isQueryParam === true) {
+                encodedVal = encodeUriQuery(val, true);
+              } else {
+                encodedVal = encodeUriSegment(val);
+              }
               url = url.replace(new RegExp(":" + urlParam + "(\\W|$)", "g"), function(match, p1) {
                 return encodedVal + p1;
               });

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -433,7 +433,7 @@ angular.module('ngResource', ['ng']).
             }
             if (!(new RegExp("^\\d+$").test(param)) && param &&
               (new RegExp("(^|[^\\\\]):" + param + "(\\W|$)").test(url))) {
-              urlParams[param] = { isQueryParamValue: (new RegExp("\\?(?:.*)=:" + param + "(?:\\W|$)")).test(url) };
+              urlParams[param] = { isQueryParamValue: (new RegExp("\\?.*=:" + param + "(?:\\W|$)")).test(url) };
             }
           });
           url = url.replace(/\\:/g, ':');
@@ -446,7 +446,7 @@ angular.module('ngResource', ['ng']).
           forEach(self.urlParams, function(paramInfo, urlParam) {
             val = params.hasOwnProperty(urlParam) ? params[urlParam] : self.defaults[urlParam];
             if (angular.isDefined(val) && val !== null) {
-              if (paramInfo.isQueryParamiValue === true) {
+              if (paramInfo.isQueryParamValue === true) {
                 encodedVal = encodeUriQuery(val, true);
               } else {
                 encodedVal = encodeUriSegment(val);

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -433,7 +433,7 @@ angular.module('ngResource', ['ng']).
             }
             if (!(new RegExp("^\\d+$").test(param)) && param &&
               (new RegExp("(^|[^\\\\]):" + param + "(\\W|$)").test(url))) {
-              urlParams[param] = { isQueryParam: (new RegExp("\\?(?:.*):" + param + "(?:\\W|$)")).test(url) };
+              urlParams[param] = { isQueryParamValue: (new RegExp("\\?(?:.*)=:" + param + "(?:\\W|$)")).test(url) };
             }
           });
           url = url.replace(/\\:/g, ':');
@@ -446,7 +446,7 @@ angular.module('ngResource', ['ng']).
           forEach(self.urlParams, function(paramInfo, urlParam) {
             val = params.hasOwnProperty(urlParam) ? params[urlParam] : self.defaults[urlParam];
             if (angular.isDefined(val) && val !== null) {
-              if (paramInfo.isQueryParam === true) {
+              if (paramInfo.isQueryParamiValue === true) {
                 encodedVal = encodeUriQuery(val, true);
               } else {
                 encodedVal = encodeUriSegment(val);

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -338,7 +338,7 @@ describe("resource", function() {
   });
 
 
-  it('should handle url encoding in mapped params', function() {
+  it('should encode & in query params unless in query param value', function() {
     var R1 = $resource('/api/myapp/resource?:query');
     $httpBackend.expect('GET', '/api/myapp/resource?foo&bar').respond({});
     R1.get({query: 'foo&bar'});

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -338,6 +338,13 @@ describe("resource", function() {
   });
 
 
+  it('should handle url encoding in mapped params', function() {
+    var R = $resource('/api/myapp/resource?from=:from');
+    $httpBackend.expect('GET', '/api/myapp/resource?from=bar%20%26%20blanks').respond({});
+    R.get({from: 'bar & blanks'});
+  });
+
+
   it('should build resource with default param', function() {
     $httpBackend.expect('GET', '/Order/123/Line/456.visa?minimum=0.05').respond({id: 'abc'});
     var LineItem = $resource('/Order/:orderId/Line/:id:verb',

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -331,21 +331,18 @@ describe("resource", function() {
   });
 
 
-  it('should encode & in url params', function() {
-    var R = $resource('/Path/:a');
-    $httpBackend.expect('GET', '/Path/doh&foo?bar=baz%261').respond('{}');
-    R.get({a: 'doh&foo', bar: 'baz&1'});
-  });
-
-
   it('should encode & in query params unless in query param value', function() {
     var R1 = $resource('/api/myapp/resource?:query');
-    $httpBackend.expect('GET', '/api/myapp/resource?foo&bar').respond({});
+    $httpBackend.expect('GET', '/api/myapp/resource?foo&bar').respond('{}');
     R1.get({query: 'foo&bar'});
 
     var R2 = $resource('/api/myapp/resource?from=:from');
-    $httpBackend.expect('GET', '/api/myapp/resource?from=bar%20%26%20blanks').respond({});
+    $httpBackend.expect('GET', '/api/myapp/resource?from=bar%20%26%20blanks').respond('{}');
     R2.get({from: 'bar & blanks'});
+
+    var R3 = $resource('/Path/:a');
+    $httpBackend.expect('GET', '/Path/doh&foo?bar=baz%261').respond('{}');
+    R3.get({a: 'doh&foo', bar: 'baz&1'});
   });
 
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -339,9 +339,13 @@ describe("resource", function() {
 
 
   it('should handle url encoding in mapped params', function() {
-    var R = $resource('/api/myapp/resource?from=:from');
+    var R1 = $resource('/api/myapp/resource?:query');
+    $httpBackend.expect('GET', '/api/myapp/resource?foo&bar').respond({});
+    R1.get({query: 'foo&bar'});
+
+    var R2 = $resource('/api/myapp/resource?from=:from');
     $httpBackend.expect('GET', '/api/myapp/resource?from=bar%20%26%20blanks').respond({});
-    R.get({from: 'bar & blanks'});
+    R2.get({from: 'bar & blanks'});
   });
 
 


### PR DESCRIPTION
Encoding URL Query Parameters should be "more aggressive" than the URL Segment encoding.
You can see what I mean in the added test case.

I'm currently using AngularJS 1.3.16 but I found this bug is still there in master.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.js/12201)

<!-- Reviewable:end -->
