### PR TITLE
fix(jqLite): return if element is undefined

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -315,6 +315,9 @@ function jqLiteOff(element, type, fn, unsupported) {
 }
 
 function jqLiteRemoveData(element, name) {
+  if(element == undefined) {
+    return;
+  }
   var expandoId = element.ng339;
   var expandoStore = expandoId && jqCache[expandoId];
 

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -315,7 +315,7 @@ function jqLiteOff(element, type, fn, unsupported) {
 }
 
 function jqLiteRemoveData(element, name) {
-  if(element == undefined) {
+  if (element === null) {
     return;
   }
   var expandoId = element.ng339;


### PR DESCRIPTION
ngAnimate has problems removing elements, causing errors. A detailed explanation of this can be found at #8796.

See #9485

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.js/12226)

<!-- Reviewable:end -->
