### PR TITLE
feat(ngAria): add option to disable role=button

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -83,7 +83,8 @@ function $AriaProvider() {
     ariaMultiline: true,
     ariaValue: true,
     tabindex: true,
-    bindKeypress: true
+    bindKeypress: true,
+    bindRoleForClick: true
   };
 
   /**
@@ -102,6 +103,8 @@ function $AriaProvider() {
    *  - **tabindex** – `{boolean}` – Enables/disables tabindex tags
    *  - **bindKeypress** – `{boolean}` – Enables/disables keypress event binding on `&lt;div&gt;` and
    *    `&lt;li&gt;` elements with ng-click
+   *  - **bindRoleForClick** – `{boolean}` – Adds role=button to non-interactive elements like `div`
+   *    using ng-click, making them more accessible to users of assistive technologies
    *
    * @description
    * Enables/disables various ARIA attributes
@@ -346,7 +349,10 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
             return true;
           }
         }
-        if (!elem.attr('role') && !isNodeOneOf(elem, nodeBlackList)) {
+
+        if ($aria.config('bindRoleForClick')
+            && !elem.attr('role')
+              && !isNodeOneOf(elem, nodeBlackList)) {
           elem.attr('role', 'button');
         }
 

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -750,6 +750,18 @@ describe('$aria', function() {
     });
   });
 
+  describe('actions when bindRoleForClick is set to false', function() {
+    beforeEach(configAriaProvider({
+      bindRoleForClick: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not add a button role', function() {
+      compileElement('<radio-group ng-click="something"></radio-group>');
+      expect(element.attr('role')).toBeUndefined();
+    });
+  });
+
   describe('actions when bindKeypress is set to false', function() {
     beforeEach(configAriaProvider({
       bindKeypress: false


### PR DESCRIPTION
I am separating a larger ngAria refactor into smaller pieces and getting them submitted! Starting with a config option for `role="button"`, which is added by ngClick onto divs or custom elements like `<radio-group>`. If `bindRoleForClick` is set to false in the config, ngAria will not add the button role to custom elements using `ng-click`. I'm totally open to renaming the config variable.

Closes https://github.com/angular/angular.js/issues/11580

Note config options are app-wide–an awesome improvement would be to scope them by controllers or directives. Related to #11174.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.js/12234)

<!-- Reviewable:end -->
