### PR TITLE
feat(compile): add support for Angular 2 event bindings

### DIFF
--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -7184,14 +7184,6 @@ describe('$compile', function() {
           "Please use the ng- versions (such as ng-click instead of onclick) instead.");
     }));
 
-    it('should pass through arbitrary values on onXYZ event attributes that contain a hyphen', inject(function($compile, $rootScope) {
-      /* jshint scripturl:true */
-      element = $compile('<button on-click="{{onClickJs}}"></script>')($rootScope);
-      $rootScope.onClickJs = 'javascript:doSomething()';
-      $rootScope.$apply();
-      expect(element.attr('on-click')).toEqual('javascript:doSomething()');
-    }));
-
     it('should pass through arbitrary values on "on" and "data-on" attributes', inject(function($compile, $rootScope) {
       element = $compile('<button data-on="{{dataOnVar}}"></script>')($rootScope);
       $rootScope.dataOnVar = 'data-on text';
@@ -7521,6 +7513,28 @@ describe('$compile', function() {
       });
     });
 
+  });
+
+
+  describe('event attribute binding', function() {
+
+    it('should work with different syntaxes', inject(function($compile, $rootScope) {
+      var testEventBinding = function(template) {
+        $rootScope.clicked = false;
+        element = $compile(template)($rootScope);
+        browserTrigger(element, 'click');
+        expect($rootScope.clicked).toBe(true);
+      };
+
+      $rootScope.onClick = function() {
+        $rootScope.clicked = true;
+      };
+
+      testEventBinding('<div (click)="onClick()"></div>');
+      testEventBinding('<div (^click)="onClick()"></div>');
+      testEventBinding('<div on-click="onClick()"></div>');
+      testEventBinding('<div onbubble-click="onClick()"></div>');
+    }));
   });
 
 


### PR DESCRIPTION
- Adds support for event bindings to match Angular 2, i.e. `(event)`, `(^event)`, `on-event`, and `onbubble-event`

This implements #12197.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.js/12236)

<!-- Reviewable:end -->
