### PR TITLE
revert: "fix($compile): do not write @-bound properties if attribute …

### DIFF
--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2543,17 +2543,10 @@ describe('$compile', function() {
                 };
 
                 expect(func).not.toThrow();
-                var scope = element.isolateScope();
-                expect(element.find('span').scope()).toBe(scope);
-                expect(scope).not.toBe($rootScope);
-
-                // Not shadowed because optional
-                expect(scope.constructor).toBe($rootScope.constructor);
-                expect(scope.hasOwnProperty('constructor')).toBe(false);
-
-                // Shadowed with undefined because not optional
-                expect(scope.valueOf).toBeUndefined();
-                expect(scope.hasOwnProperty('valueOf')).toBe(true);
+                expect(element.find('span').scope()).toBe(element.isolateScope());
+                expect(element.isolateScope()).not.toBe($rootScope);
+                expect(element.isolateScope()['constructor']).toBe($rootScope.constructor);
+                expect(element.isolateScope()['valueOf']).toBeUndefined();
               })
             );
 
@@ -2568,13 +2561,10 @@ describe('$compile', function() {
                   };
 
                   expect(func).not.toThrow();
-                  var scope = element.isolateScope();
-                  expect(element.find('span').scope()).toBe(scope);
-                  expect(scope).not.toBe($rootScope);
-                  expect(scope.constructor).toBe('constructor');
-                  expect(scope.hasOwnProperty('constructor')).toBe(true);
-                  expect(scope.valueOf).toBe('valueOf');
-                  expect(scope.hasOwnProperty('valueOf')).toBe(true);
+                  expect(element.find('span').scope()).toBe(element.isolateScope());
+                  expect(element.isolateScope()).not.toBe($rootScope);
+                  expect(element.isolateScope()['constructor']).toBe('constructor');
+                  expect(element.isolateScope()['valueOf']).toBe('valueOf');
                 })
             );
 
@@ -2585,17 +2575,10 @@ describe('$compile', function() {
                   };
 
                   expect(func).not.toThrow();
-                  var scope = element.isolateScope();
-                  expect(element.find('span').scope()).toBe(scope);
-                  expect(scope).not.toBe($rootScope);
-
-                  // Does not shadow value because optional
-                  expect(scope.constructor).toBe($rootScope.constructor);
-                  expect(scope.hasOwnProperty('constructor')).toBe(false);
-
-                  // Shadows value because not optional
-                  expect(scope.valueOf).toBeUndefined();
-                  expect(scope.hasOwnProperty('valueOf')).toBe(true);
+                  expect(element.find('span').scope()).toBe(element.isolateScope());
+                  expect(element.isolateScope()).not.toBe($rootScope);
+                  expect(element.isolateScope()['constructor']).toBe($rootScope.constructor);
+                  expect(element.isolateScope()['valueOf']).toBeUndefined();
                 })
             );
 
@@ -3593,31 +3576,6 @@ describe('$compile', function() {
     }));
 
 
-    it('should not overwrite @-bound property each digest when not present', function() {
-      module(function($compileProvider) {
-        $compileProvider.directive('testDir', valueFn({
-          scope: {prop: '@'},
-          controller: function($scope) {
-            $scope.prop = $scope.prop || 'default';
-            this.getProp = function() {
-              return $scope.prop;
-            };
-          },
-          controllerAs: 'ctrl',
-          template: '<p></p>'
-        }));
-      });
-      inject(function($compile, $rootScope) {
-        element = $compile('<div test-dir></div>')($rootScope);
-        var scope = element.isolateScope();
-        expect(scope.ctrl.getProp()).toBe('default');
-
-        $rootScope.$digest();
-        expect(scope.ctrl.getProp()).toBe('default');
-      });
-    });
-
-
     describe('bind-once', function() {
 
       function countWatches(scope) {
@@ -4477,64 +4435,6 @@ describe('$compile', function() {
         expect(childScope.theCtrl).not.toBe(myCtrl);
         expect(childScope.theCtrl.constructor).toBe(MyCtrl);
         childScope.theCtrl.test();
-      });
-    });
-
-    describe('should not overwrite @-bound property each digest when not present', function() {
-      it('when creating new scope', function() {
-        module(function($compileProvider) {
-          $compileProvider.directive('testDir', valueFn({
-            scope: true,
-            bindToController: {
-              prop: '@'
-            },
-            controller: function() {
-              var self = this;
-              this.prop = this.prop || 'default';
-              this.getProp = function() {
-                return self.prop;
-              };
-            },
-            controllerAs: 'ctrl',
-            template: '<p></p>'
-          }));
-        });
-        inject(function($compile, $rootScope) {
-          element = $compile('<div test-dir></div>')($rootScope);
-          var scope = element.scope();
-          expect(scope.ctrl.getProp()).toBe('default');
-
-          $rootScope.$digest();
-          expect(scope.ctrl.getProp()).toBe('default');
-        });
-      });
-
-      it('when creating isolate scope', function() {
-        module(function($compileProvider) {
-          $compileProvider.directive('testDir', valueFn({
-            scope: {},
-            bindToController: {
-              prop: '@'
-            },
-            controller: function() {
-              var self = this;
-              this.prop = this.prop || 'default';
-              this.getProp = function() {
-                return self.prop;
-              };
-            },
-            controllerAs: 'ctrl',
-            template: '<p></p>'
-          }));
-        });
-        inject(function($compile, $rootScope) {
-          element = $compile('<div test-dir></div>')($rootScope);
-          var scope = element.isolateScope();
-          expect(scope.ctrl.getProp()).toBe('default');
-
-          $rootScope.$digest();
-          expect(scope.ctrl.getProp()).toBe('default');
-        });
       });
     });
   });


### PR DESCRIPTION
…is not present"

This reverts commit 8a1eb1625c080445ce1e519762e1f2d4fd842b72.

This commit broke the tabs component on the material project,
which caused internal breakages. Will open a separate issue to
look into the issue.
