### PR TITLE
Leave Animation callback overridden by next animation

### DIFF
--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -185,6 +185,7 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
       push: function(element, event, options, domOperation) {
         options = options || {};
         options.domOperation = domOperation;
+        options.hasDomOpreation = !isUndefined(domOperation);
         return queueAnimation(element, event, options);
       },
 

--- a/src/ngAnimate/shared.js
+++ b/src/ngAnimate/shared.js
@@ -171,8 +171,15 @@ function mergeAnimationOptions(element, target, newOptions) {
   var toAdd = (target.addClass || '') + ' ' + (newOptions.addClass || '');
   var toRemove = (target.removeClass || '') + ' ' + (newOptions.removeClass || '');
   var classes = resolveElementClasses(element.attr('class'), toAdd, toRemove);
+  var targetDomOperation = target.hasDomOpreation ? target.domOperation : null;
 
   extend(target, newOptions);
+
+  // TODO : proper fix is to maintain all animation callback in array and call at last,but now only leave has the callback so no issue with this.
+  if (targetDomOperation) {
+    target.hasDomOpreation = true;
+    target.domOperation = targetDomOperation;
+  }
 
   if (classes.addClass) {
     target.addClass = classes.addClass;

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1646,5 +1646,24 @@ describe("animations", function() {
       expect(count).toBe(1);
     }));
 
+    it('Leave : should remove the element even other animation are called after leave, should not override leave callback',
+      inject(function($animate, $rootScope, $$rAF, $rootElement) {
+
+      var isElementRemoved = false;
+      var outerContainer = jqLite('<div></div>');
+      element = jqLite('<div></div>');
+      outerContainer.append(element);
+      $rootElement.append(outerContainer);
+      var runner = $animate.leave(element, $rootElement);
+      $animate.removeClass(element,'rclass');
+      $rootScope.$digest();
+      runner.end();
+      $$rAF.flush();
+
+      isElementRemoved = !outerContainer[0].contains(element[0]);
+
+      expect(isElementRemoved).toBe(true);
+    }));
+
   });
 });


### PR DESCRIPTION
This patch will fix the overriding or loosing the leave callback object of the animation.

Example:

```
var app = angular.module("app", ['ngMessages', 'ngAnimate']);

app.directive('iholder', ['$animate','$timeout', function($animate,$timeout) {
    return {
        restrict: 'EA',
        scope: {},
        template: '<div class="level1 level2" ng-click="clickHandler()" style="width:100%;height:10em;background-color:red;"></div>',
        replace: true,
        link: function($scope, element, attrs) {
            $scope.clickHandler = function() {
                $animate.leave(element);
                $animate.removeClass(element,'level2');
            }
        }
    }
}]);
```

In above example removeClass is called as soon as the leave is called so in queueAnimation the the leave animation option (callback) is overridden with the removeClass option so the element is not removed.

This patch will fix the #12249 issue , in this issue leave is called by ngRepeatDirective for removing the element and on destroy ngForm called removeClass so the leave callback is overridden in mergeAnimationOptions so the element is not removed.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.js/12271)

<!-- Reviewable:end -->
