### PR TITLE
Fix for #12266 : Fixed skipping/cleaning of elements pending animations.

### DIFF
--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -330,8 +330,9 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
             // method which will call the runner methods in async.
             existingAnimation.close();
           } else {
-            // this will merge the existing animation options into this new follow-up animation
-            mergeAnimationOptions(element, newAnimation.options, existingAnimation.options);
+            // this will merge the new animation options into existing animation options
+            mergeAnimationOptions(element, existingAnimation.options, newAnimation.options);
+            return existingAnimation.runner;
           }
         } else {
           // a joined animation means that this animation will take over the existing one

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1206,6 +1206,24 @@ describe("animations", function() {
         expect(r1).toBe(r2);
         expect(r2).toBe(r3);
       }));
+
+      it('should not skip or miss the animations when animations are executed sequential',
+        inject(function($animate, $rootScope, $$rAF, $rootElement) {
+
+        element = jqLite('<div></div>');
+
+        $rootElement.append(element);
+
+        $animate.addClass(element, 'rclass');
+        $animate.removeClass(element, 'rclass');
+        $animate.addClass(element, 'rclass');
+        $animate.removeClass(element, 'rclass');
+
+        $rootScope.$digest();
+        $$rAF.flush();
+
+        expect(element).not.toHaveClass('rclass');
+      }));
     });
   });
 


### PR DESCRIPTION
Instead of merging existing animation option to new animation options we can merge in reverse and utilize old animation runner.

This PR will fix #12266,#12007 issue.

Example to test:

```
var app = angular.module("app", ['ngAnimate']);

app.directive('iholder', ['$animate','$timeout', function($animate,$timeout) {
    return {
        restrict: 'EA',
        scope: {},
        template: '<div ng-click="clickHandler()" style="width:100%;height:10em;background-color:red;"></div>',
        replace: true,
        link: function($scope, element, attrs) {
            $scope.clickHandler = function() {
                $animate.addClass(element,'test1');
                $animate.removeClass(element,'test1');
                $animate.addClass(element,'test1');
                $animate.removeClass(element,'test1');
            }
        }
    }
}]);
```
