### PR TITLE
Fix for #12096 : Fixed leave start & close callback

### DIFF
--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -124,14 +124,17 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
       return mergeAnimationOptions(element, options, {});
     }
 
-    function findCallbacks(element, event) {
+    function findCallbacks(parent, element, event) {
       var targetNode = getDomNode(element);
+      var targetParentNode = getDomNode(parent);
 
       var matches = [];
       var entries = callbackRegistry[event];
       if (entries) {
         forEach(entries, function(entry) {
           if (entry.node.contains(targetNode)) {
+            matches.push(entry.callback);
+          } else if (event === 'leave' && entry.node.contains(targetParentNode)) {
             matches.push(entry.callback);
           }
         });
@@ -140,9 +143,9 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
       return matches;
     }
 
-    function triggerCallback(event, element, phase, data) {
+    function triggerCallback(event, parent, element, phase, data) {
       $$rAF(function() {
-        forEach(findCallbacks(element, event), function(callback) {
+        forEach(findCallbacks(parent, element, event), function(callback) {
           callback(element, phase, data);
         });
       });
@@ -455,7 +458,7 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
       return runner;
 
       function notifyProgress(runner, event, phase, data) {
-        triggerCallback(event, element, phase, data);
+        triggerCallback(event, parent, element, phase, data);
         runner.progress(event, phase, data);
       }
 

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1646,5 +1646,87 @@ describe("animations", function() {
       expect(count).toBe(1);
     }));
 
+    it('Leave : should trigger a callback for an leave animation',
+      inject(function($animate, $rootScope, $$rAF, $rootElement) {
+
+      var callbackTriggered = false;
+      $animate.on('leave', body, function() {
+        callbackTriggered = true;
+      });
+
+      element = jqLite('<div></div>');
+      $rootElement.append(element);
+      $animate.leave(element, $rootElement);
+      $rootScope.$digest();
+
+      $$rAF.flush();
+
+      expect(callbackTriggered).toBe(true);
+    }));
+
+    it('Leave : should not fire a callback if the element is outside of the given container',
+      inject(function($animate, $rootScope, $$rAF, $rootElement) {
+
+      var callbackTriggered = false;
+      var innerContainer = jqLite('<div></div>');
+      $rootElement.append(innerContainer);
+
+      $animate.on('leave', innerContainer,
+        function(element, phase, data) {
+        callbackTriggered = true;
+      });
+
+      element = jqLite('<div></div>');
+      $rootElement.append(element);
+      $animate.leave(element, $rootElement);
+      $rootScope.$digest();
+      $$rAF.flush();
+
+      expect(callbackTriggered).toBe(false);
+    }));
+
+    it('Leave : should fire a `start` callback when the animation starts with the matching element',
+      inject(function($animate, $rootScope, $$rAF, $rootElement) {
+
+      element = jqLite('<div></div>');
+
+      var capturedState;
+      var capturedElement;
+      $animate.on('leave', body, function(element, phase) {
+        capturedState = phase;
+        capturedElement = element;
+      });
+
+      $rootElement.append(element);
+      $animate.leave(element, $rootElement);
+      $rootScope.$digest();
+      $$rAF.flush();
+
+      expect(capturedState).toBe('start');
+      expect(capturedElement).toBe(element);
+    }));
+
+    it('Leave : should fire a `close` callback when the animation ends with the matching element',
+      inject(function($animate, $rootScope, $$rAF, $rootElement) {
+
+      element = jqLite('<div></div>');
+
+      var capturedState;
+      var capturedElement;
+      $animate.on('leave', body, function(element, phase) {
+        capturedState = phase;
+        capturedElement = element;
+      });
+
+      $rootElement.append(element);
+      var runner = $animate.leave(element, $rootElement);
+      $rootScope.$digest();
+      runner.end();
+      $$rAF.flush();
+
+      expect(capturedState).toBe('close');
+      expect(capturedElement).toBe(element);
+    }));
+
   });
 });


### PR DESCRIPTION
This PR fixes #12096 issue.

As leave event removes the node from the document `entry.node.contains(targetNode)` will not match for leave animation so no callbacks are called for leave.
