### PR TITLE
fix(injector): check that modulesToLoad isArray.

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -718,6 +718,7 @@ function createInjector(modulesToLoad, strictDi) {
   // Module Loading
   ////////////////////////////////////
   function loadModules(modulesToLoad) {
+    assertArg(isUndefined(modulesToLoad) || isArray(modulesToLoad), 'modulesToLoad', 'not an array');
     var runBlocks = [], moduleFn;
     forEach(modulesToLoad, function(module) {
       if (loadedModules.get(module)) return;

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -35,6 +35,12 @@ describe('injector', function() {
   });
 
 
+  it('should check its modulesToLoad argument', function() {
+    expect(function() { angular.injector('test'); })
+        .toThrowMinErr('ng', 'areq');
+  });
+
+
   it('should resolve dependency graph and instantiate all services just once', function() {
     var log = [];
 


### PR DESCRIPTION
When users accidentally just pass a single string, e.g.
`angular.injector('myModule')`, this change give them a better error message.

Currently Angular just reports that the module with the name 'm' is missing,
as it's iterating through all characters in the string, instead of all strings
in the module.
