### PR TITLE
fix(merge): clone elements instead of threating them like objects

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -354,6 +354,8 @@ function baseExtend(dst, objs, deep) {
       if (deep && isObject(src)) {
         if (isDate(src)) {
           dst[key] = new Date(src.valueOf());
+        } else if (isElement(src)) {
+          dst[key] = src[0] ? jqLite(src).clone()[0] : jqLite(src).clone();
         } else {
           if (!isObject(dst[key])) dst[key] = isArray(src) ? [] : {};
           baseExtend(dst[key], [src], true);

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -491,6 +491,17 @@ describe('angular', function() {
 
       expect(dst.date).toBe(src.date);
     });
+
+    it('should copy elements by reference', function() {
+      var src = { element: document.createElement('div'),
+        jqObject: jqLite("<p><span>s1</span><span>s2</span></p>").find("span") };
+      var dst = {};
+
+      extend(dst, src);
+
+      expect(dst.element).toBe(src.element);
+      expect(dst.jqObject).toBe(src.jqObject);
+    });
   });
 
 
@@ -569,6 +580,21 @@ describe('angular', function() {
       expect(dst.date).not.toBe(src.date);
       expect(isDate(dst.date)).toBeTruthy();
       expect(dst.date.valueOf()).toEqual(src.date.valueOf());
+    });
+
+
+    it('should copy(clone) elements', function() {
+      var src = { element: document.createElement('div'),
+        jqObject: jqLite("<p><span>s1</span><span>s2</span></p>").find("span") };
+      var dst = {};
+
+      merge(dst, src);
+
+      expect(dst.element).not.toBe(src.element);
+      expect(dst.jqObject).not.toBe(src.jqObject);
+
+      expect(isElement(dst.element)).toBeTruthy();
+      expect(isElement(dst.jqObject)).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
Similar fix to #11720. Without this fix there is only empty object created in destination object.
