### PR TITLE
docs(Dependency Injection): fix angular.injector arguments list

### DIFF
--- a/docs/content/guide/di.ngdoc
+++ b/docs/content/guide/di.ngdoc
@@ -293,7 +293,7 @@ Create a new injector that can provide components defined in our `myModule` modu
 `greeter` service from the injector. (This is usually done automatically by angular bootstrap).
 
 ```js
-var injector = angular.injector(['myModule', 'ng']);
+var injector = angular.injector(['ng', 'myModule']);
 var greeter = injector.get('greeter');
 ```
 


### PR DESCRIPTION
The original file includes a code sample using `angular.injector(['myModule', 'ng'])` which throws an error when trying to retrieve anything attached to `myModule`.  Reversing the args fixes this.
