### PR TITLE
Fixed Chilean locales

### DIFF
--- a/src/ngLocale/angular-locale_es-cl.js
+++ b/src/ngLocale/angular-locale_es-cl.js
@@ -24,7 +24,7 @@ $provide.value("$locale", {
       "a. C.",
       "d. C."
     ],
-    "FIRSTDAYOFWEEK": 0,
+    "FIRSTDAYOFWEEK": 1,
     "MONTH": [
       "enero",
       "febrero",
@@ -34,37 +34,37 @@ $provide.value("$locale", {
       "junio",
       "julio",
       "agosto",
-      "setiembre",
+      "septiembre",
       "octubre",
       "noviembre",
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
-      "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "set.",
-      "oct.",
-      "nov.",
-      "dic."
+      "ene",
+      "feb",
+      "mar",
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "WEEKENDRANGE": [
-      5,
-      6
+      6,
+      0
     ],
     "fullDate": "EEEE, d 'de' MMMM 'de' y",
     "longDate": "d 'de' MMMM 'de' y",


### PR DESCRIPTION
- Chilean translation to September is "Septiembre", "Setiembre" is a slang translation.
- Short days and months should not have an ending dot, it's dependent on the usage.
- Weekends are Sunday and Saturday.
- First day of week is Monday.
