### PR TITLE
docs(guide/Forms): The CSS example is missing binding results

### DIFF
--- a/docs/content/guide/forms.ngdoc
+++ b/docs/content/guide/forms.ngdoc
@@ -95,6 +95,8 @@ and failing to satisfy its validity.
         <input type="button" ng-click="reset()" value="Reset" />
         <input type="submit" ng-click="update(user)" value="Save" />
       </form>
+      <pre>form = {{user | json}}</pre>
+      <pre>master = {{master | json}}</pre>
     </div>
 
     <style type="text/css">


### PR DESCRIPTION
It will be good to have the binding results of CSS example, similar to the Simple Form example.
