### PR TITLE
Update angular-locale_hr-hr.js

### DIFF
--- a/src/ngLocale/angular-locale_hr-hr.js
+++ b/src/ngLocale/angular-locale_hr-hr.js
@@ -42,20 +42,20 @@ $provide.value("$locale", {
       "pr. Kr.",
       "p. Kr."
     ],
-    "FIRSTDAYOFWEEK": 0,
+    "FIRSTDAYOFWEEK": 1,
     "MONTH": [
-      "sije\u010dnja",
-      "velja\u010de",
-      "o\u017eujka",
-      "travnja",
-      "svibnja",
-      "lipnja",
-      "srpnja",
-      "kolovoza",
-      "rujna",
-      "listopada",
-      "studenoga",
-      "prosinca"
+      "sije\u010danj",
+      "velja\u010da",
+      "o\u017eujak",
+      "travanj",
+      "svibanj",
+      "lipanj",
+      "srpanj",
+      "kolovoz",
+      "rujan",
+      "listopad",
+      "studeni",
+      "prosinac"
     ],
     "SHORTDAY": [
       "ned",


### PR DESCRIPTION
Changed "MONTH" values to be more consistent with Croatian language. The genitiv forms are rarely used, only in very formal occasions, it is much more useful to have nominativ forms
.
Changed "FIRSTDAYOFWEEK" from 0 to 1 because in Croatia, as in most European countries, Monday is the first day of the week.
