### PR TITLE
fix(cacheFactory): check key exists before decreasing size

### DIFF
--- a/src/ng/cacheFactory.js
+++ b/src/ng/cacheFactory.js
@@ -93,9 +93,9 @@ function $CacheFactoryProvider() {
 
       var size = 0,
           stats = extend({}, options, {id: cacheId}),
-          data = {},
+          data = createMap(),
           capacity = (options && options.capacity) || Number.MAX_VALUE,
-          lruHash = {},
+          lruHash = createMap(),
           freshEnd = null,
           staleEnd = null;
 
@@ -223,6 +223,8 @@ function $CacheFactoryProvider() {
             delete lruHash[key];
           }
 
+          if (!(key in data)) return;
+
           delete data[key];
           size--;
         },
@@ -237,9 +239,9 @@ function $CacheFactoryProvider() {
          * Clears the cache object of any entries.
          */
         removeAll: function() {
-          data = {};
+          data = createMap();
           size = 0;
-          lruHash = {};
+          lruHash = createMap();
           freshEnd = staleEnd = null;
         },
 
@@ -399,4 +401,3 @@ function $TemplateCacheProvider() {
     return $cacheFactory('templates');
   }];
 }
-

--- a/test/ng/cacheFactorySpec.js
+++ b/test/ng/cacheFactorySpec.js
@@ -133,6 +133,19 @@ describe('$cacheFactory', function() {
         expect(cache.info().size).toBe(0);
       }));
 
+      it('should only decrement size when an element is actually removed via remove', inject(function($cacheFactory) {
+        cache.put('foo', 'bar');
+        expect(cache.info().size).toBe(1);
+
+        cache.remove('undefined');
+        expect(cache.info().size).toBe(1);
+
+        cache.remove('hasOwnProperty');
+        expect(cache.info().size).toBe(1);
+
+        cache.remove('foo');
+        expect(cache.info().size).toBe(0);
+      }));
 
       it('should return cache id', inject(function($cacheFactory) {
         expect(cache.info().id).toBe('test');


### PR DESCRIPTION
When $cacheFactory.remove() is called, if the key does not exist, return
before modifying size. There is currently no check for the key's
existence.

Closes #12321
