### PR TITLE
feat($httpParamSerializerJQLike): honor object.toJSON function if present

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -110,12 +110,14 @@ function $HttpParamSerializerJQLikeProvider() {
       return parts.join('&');
 
       function serialize(toSerialize, prefix, topLevel) {
-        if (toSerialize === null || isUndefined(toSerialize)) return;
+        if (toSerialize === null || isUndefined(toSerialize) || isFunction(toSerialize)) return;
         if (isArray(toSerialize)) {
           forEach(toSerialize, function(value, index) {
             serialize(value, prefix + '[' + (isObject(value) ? index : '') + ']');
           });
-        } else if (isObject(toSerialize) && !isDate(toSerialize)) {
+        } else if (isFunction(toSerialize.toJSON)) {
+          serialize(toSerialize.toJSON(), prefix, topLevel);
+        } else if (isObject(toSerialize)) {
           forEachSorted(toSerialize, function(value, key) {
             serialize(value, prefix +
                 (topLevel ? '' : '[') +

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -2274,6 +2274,37 @@ describe('$http param serializers', function() {
       expect(jqrSer({someDate: new Date('2014-07-15T17:30:00.000Z')})).toEqual('someDate=2014-07-15T17:30:00.000Z');
     });
 
+    it('should ignore functions', function() {
+      expect(jqrSer({
+        foo: {
+          a: 'b',
+          c: function() {
+            return 'd';
+          }
+        }
+      })).toEqual('foo%5Ba%5D=b');
+    });
+
+    it('should honor toJSON function', function() {
+      expect(jqrSer({
+        foo: {
+          a: 'b',
+          toJSON: function() {
+            return {
+              e: 'f',
+              g: 'h'
+            };
+          }
+        },
+        bar: {
+          c: 'd',
+          toJSON: function() {
+            return 'baz';
+          }
+        }
+      })).toEqual('bar=baz&foo%5Be%5D=f&foo%5Bg%5D=h');
+    });
+
   });
 
   describe('default array serialization', function() {


### PR DESCRIPTION
`$httpParamSerializerJQLike` gives dates special treatment (i.e. treats them as values instead of drilling down into their properties).

This change extends this behavior by honoring the [toJSON](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON%28%29_behavior) function, if present on the object being serialized.

While keeping the existing behavior for dates, it also adds support for serializing custom objects which should be treated as values, such as `Moment.js` moments.
