### PR TITLE
fix($animateCss): ensure animations execute if only a keyframeStyle is provided

### DIFF
--- a/src/ngAnimate/animateCss.js
+++ b/src/ngAnimate/animateCss.js
@@ -556,10 +556,11 @@ var $AnimateCssProvider = ['$animateProvider', function($animateProvider) {
       var fullClassName = classes + ' ' + setupClasses;
       var activeClasses = pendClasses(setupClasses, '-active');
       var hasToStyles = styles.to && Object.keys(styles.to).length > 0;
+      var containsKeyframeAnimation = (options.keyframeStyle || '').length > 0;
 
       // there is no way we can trigger an animation since no styles and
       // no classes are being applied which would then trigger a transition
-      if (!hasToStyles && !setupClasses) {
+      if (!containsKeyframeAnimation && !hasToStyles && !setupClasses) {
         return closeAndReturnNoopAnimator();
       }
 

--- a/src/ngAnimate/animateCss.js
+++ b/src/ngAnimate/animateCss.js
@@ -560,7 +560,10 @@ var $AnimateCssProvider = ['$animateProvider', function($animateProvider) {
 
       // there is no way we can trigger an animation since no styles and
       // no classes are being applied which would then trigger a transition
-      if (!containsKeyframeAnimation && !hasToStyles && !setupClasses) {
+      // is there a raw keyframe value that is applied to the element
+      if (!containsKeyframeAnimation
+           && !hasToStyles
+           && !setupClasses) {
         return closeAndReturnNoopAnimator();
       }
 

--- a/test/ngAnimate/animateCssSpec.js
+++ b/test/ngAnimate/animateCssSpec.js
@@ -2167,6 +2167,23 @@ describe("ngAnimate $animateCss", function() {
           expect(element.css(prefix + 'animation-duration')).toEqual('5.5s');
           expect(element.css(prefix + 'animation-name')).toEqual('my_animation');
         }));
+
+        it("should be able to execute the animation if it is the only provided value",
+          inject(function($animateCss, $rootElement) {
+
+          var options = {
+            keyframeStyle: 'my_animation 5.5s 10s'
+          };
+
+          var animator = $animateCss(element, options);
+
+          animator.start();
+          triggerAnimationStartFrame();
+
+          expect(element.css(prefix + 'animation-delay')).toEqual('10s');
+          expect(element.css(prefix + 'animation-duration')).toEqual('5.5s');
+          expect(element.css(prefix + 'animation-name')).toEqual('my_animation');
+        }));
       });
 
       describe("[from] and [to]", function() {

--- a/test/ngAnimate/animateCssSpec.js
+++ b/test/ngAnimate/animateCssSpec.js
@@ -2017,7 +2017,7 @@ describe("ngAnimate $animateCss", function() {
         });
       });
 
-      describe("[transtionStyle]", function() {
+      describe("[transitionStyle]", function() {
         it("should apply the transition directly onto the element and animate accordingly",
           inject(function($animateCss, $rootElement) {
 
@@ -2091,6 +2091,29 @@ describe("ngAnimate $animateCss", function() {
           expect(element.css('transition-duration')).toMatch('5.5s');
           expect(element.css('transition-property')).toMatch('color');
           expect(style).toContain('ease-in');
+        }));
+
+        it("should only execute the animation if any CSS to styles are mixed into together",
+          inject(function($animateCss, $rootElement) {
+
+          var options = {
+            transitionStyle: '6s 4s ease-out all'
+          };
+
+          $animateCss(element, options).start();
+          triggerAnimationStartFrame();
+
+          expect(element.css(prefix + 'transition-delay')).not.toEqual('4s');
+          expect(element.css(prefix + 'transition-duration')).not.toEqual('6s');
+          expect(element.css(prefix + 'transition-timing-function')).not.toEqual('ease-out');
+
+          options.to = { color: 'brown' };
+          $animateCss(element, options).start();
+          triggerAnimationStartFrame();
+
+          expect(element.css(prefix + 'transition-delay')).toEqual('4s');
+          expect(element.css(prefix + 'transition-duration')).toEqual('6s');
+          expect(element.css(prefix + 'transition-timing-function')).toEqual('ease-out');
         }));
       });
 


### PR DESCRIPTION
`$animateCss` is a fan of transition animations, but it turns out that
if only a keyframeStyle is provided into the animation upon constrution
then it will quit because it assumes that nothing will be animated
(since no classes or styles are being applied). This patch ensures that
a keyframe style can solely be applied to an animation triggered with
`$animateCss`.

``` js
// this will now work as expected
$animateCss(element, { keyframeStyle: '1s rotate' }).start();
```

Closes #12124
