### PR TITLE
fix(ngAnimate): buffer repeated calls to RAF to improve performance for animations

### DIFF
--- a/src/ng/raf.js
+++ b/src/ng/raf.js
@@ -1,6 +1,10 @@
 'use strict';
 
 function $$RAFProvider() { //rAF
+
+  var provider = this;
+  provider.$$bufferLimit = 10;
+
   this.$get = ['$window', '$timeout', function($window, $timeout) {
     var requestAnimationFrame = $window.requestAnimationFrame ||
                                 $window.webkitRequestAnimationFrame;
@@ -26,42 +30,73 @@ function $$RAFProvider() { //rAF
 
     queueFn.supported = rafSupported;
 
-    var cancelLastRAF;
-    var taskCount = 0;
-    var taskQueue = [];
-    return queueFn;
-
-    function flush() {
-      for (var i = 0; i < taskQueue.length; i++) {
-        var task = taskQueue[i];
-        if (task) {
-          taskQueue[i] = null;
-          task();
-        }
-      }
-      taskCount = taskQueue.length = 0;
+    function RAFTaskQueue(fn) {
+      this.queue = [];
+      this.count = 0;
+      this.afterFlushFn = fn;
     }
 
-    function queueFn(asyncFn) {
-      var index = taskQueue.length;
+    RAFTaskQueue.prototype = {
+      push: function(fn) {
+        var self = this;
 
-      taskCount++;
-      taskQueue.push(asyncFn);
+        self.queue.push(fn);
+        self.count++;
 
-      if (index === 0) {
-        cancelLastRAF = rafFn(flush);
+        self.rafWait(function() {
+          self.flush();
+        });
+      },
+      remove: function(index) {
+        if (this.queue[index] !== noop) {
+          this.queue[index] = noop;
+          if (--this.count === 0) {
+            this.reset();
+            this.flush();
+          }
+        }
+      },
+      reset:function() {
+        (this.cancelRaf || noop)();
+        this.count = this.queue.length = 0;
+      },
+      rafWait: function(fn) {
+        var self = this;
+        if (!self.cancelRaf) {
+          self.cancelRaf = rafFn(function() {
+            self.cancelRaf = null;
+            fn();
+          });
+        }
+      },
+      flush: function() {
+        for (var i = 0; i < this.queue.length; i++) {
+          this.queue[i]();
+        }
+        this.count = this.queue.length = 0;
+        this.afterFlushFn(this);
       }
+    };
 
+    var tasks = [];
+    return queueFn;
+
+    function queueFn(fn) {
+      var lastTask = tasks.length && tasks[tasks.length - 1];
+      if (!lastTask || lastTask.count === provider.$$bufferLimit) {
+        lastTask = tasks[tasks.length] = new RAFTaskQueue(function(self) {
+          var taskIndex = tasks.indexOf(self);
+          if (taskIndex >= 0) {
+            tasks.splice(taskIndex, 1);
+          }
+        });
+      }
+      lastTask.push(fn);
+      var index = lastTask.count - 1;
       return function cancelQueueFn() {
         if (index >= 0) {
-          taskQueue[index] = null;
+          lastTask.remove(index);
           index = null;
-
-          if (--taskCount === 0 && cancelLastRAF) {
-            cancelLastRAF();
-            cancelLastRAF = null;
-            taskQueue.length = 0;
-          }
         }
       };
     }


### PR DESCRIPTION
Prior to this patch ngAnimate buffered all repeated calls to
requestAnimationFrame into a task queue that is flushed once the next
animation frame has passed. While this works it causes a random lag to
jump out when any CPU intensive rAF requests are processed. This patch
sets a configurable task range which then offsets followup rAF requests
into the next available frame.

Closes #12280
