### PR TITLE
fix: parseKeyValue function does not allow additional equals signs

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1129,9 +1129,9 @@ function parseKeyValue(/**string*/keyValue) {
   forEach((keyValue || "").split('&'), function(keyValue) {
     if ( keyValue ) {
       key_value = keyValue.replace(/\+/g,'%20').split('=');
-      key = tryDecodeURIComponent(key_value[0]);
+      key = tryDecodeURIComponent(key_value.shift());
       if ( isDefined(key) ) {
-        var val = isDefined(key_value[1]) ? tryDecodeURIComponent(key_value[1]) : true;
+        var val = key_value.length > 0 ? tryDecodeURIComponent(key_value.join('=')) : true;
         if (!hasOwnProperty.call(obj, key)) {
           obj[key] = val;
         } else if(isArray(obj[key])) {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -505,6 +505,12 @@ describe('angular', function() {
         'toString': '123'
       });
     });
+    
+    it('should ignore badly escaped = characters', function() {
+      expect(parseKeyValue('test=a=b')).toEqual({
+          'test': 'a=b'
+      });
+    });
   });
 
   describe('toKeyValue', function() {


### PR DESCRIPTION
In some cases people will not follow all URL standards and may have unescaped = characters in their GET parameter values. Currently $location will not parse them correctly (or rather too correctly) and in combination with the routing will make a pushState that removes them from the URL.
My proposed fix will just join everything after the key back together with the '=' character it is split by before.
