### PR TITLE
docs($http): specifies that url is the cache key

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -582,8 +582,10 @@ function $HttpProvider() {
      * cache) or to a custom cache object (built with {@link ng.$cacheFactory `$cacheFactory`}).
      * When the cache is enabled, `$http` stores the response from the server in the specified
      * cache. The next time the same request is made, the response is served from the cache without
-     * sending a request to the server.
-     *
+     * sending a request to the server. `$http` store the response using the required url as key in the cache.
+     * When using a custom cache object, you can then clear cached data with something like
+     * `myCache.remove(requestedUrl)`
+     * 
      * Note that even if the response is served from cache, delivery of the data is asynchronous in
      * the same way that real requests are.
      *


### PR DESCRIPTION
When using a custom cache, it may be handy to clear some cached data. For instance, when you have a sequence of GET, POST and then GET on the same URL, the second GET must not use a cached data. Using a custom cache object from `$cacheFactory`, cached data can be cleared with `myCache.remove(url)`.

This works but uses an undocumented feature: the fact that `$http` use the required url as cache key. This change specifies that point.

Hope this helps
