### PR TITLE
Bug: Address issue where headers modified in transformers are ignored

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -190,7 +190,7 @@ function parseHeaders(headers) {
  *   - if called with no arguments returns an object containing all headers.
  */
 function headersGetter(headers) {
-  var headersObj;
+  var headersObj = isObject(headers) ? headers : undefined;
 
   return function(name) {
     if (!headersObj) headersObj =  parseHeaders(headers);


### PR DESCRIPTION
This bug looks like it was introduced in Angular 1.4.0 as I found it when upgrading from angular 1.2.26.

The issue is reproduced when you define a request transformer that modifies the headers. In angular 1.3.x and lower you are able to change the request headers in the transformer and inject additional / modify request parameters.

In Angular 1.4.0 and newer this no longer works any more.
