### PR TITLE
docs(filter.js): documents second parameter to .register

### DIFF
--- a/src/ng/filter.js
+++ b/src/ng/filter.js
@@ -115,6 +115,7 @@ function $FilterProvider($provide) {
    *    your filters, then you can use capitalization (`myappSubsectionFilterx`) or underscores
    *    (`myapp_subsection_filterx`).
    *    </div>
+    * @param {Function} factory If the first argument was a string, a factory function for the filter to be registered.
    * @returns {Object} Registered filter instance, or if a map of filters was provided then a map
    *    of the registered filter instances.
    */


### PR DESCRIPTION
Is there any reason the second parameter of $FilterProvider#register wasn't documented? If not, here.
