### PR TITLE
Fix($animateCss): should clear cache if element has no animation.

### DIFF
--- a/src/ngAnimate/animateCss.js
+++ b/src/ngAnimate/animateCss.js
@@ -777,6 +777,8 @@ var $AnimateCssProvider = ['$animateProvider', function($animateProvider) {
           cancel: cancelFn
         });
 
+        // should flush the cache animation
+        waitUntilQuiet(noop);
         close();
 
         return {

--- a/test/ngAnimate/animateCssSpec.js
+++ b/test/ngAnimate/animateCssSpec.js
@@ -1277,6 +1277,25 @@ describe("ngAnimate $animateCss", function() {
       expect(element.attr('style')).not.toContain('transition');
     }));
 
+    it("should clear cache if no animation so follow-up animation on the same element will not be from cache",
+      inject(function($animateCss, $rootElement, $$body, $$rAF) {
+        var element = jqLite('<div class="rclass"></div>');
+        var options = {
+          event: 'enter',
+          structural: true
+        };
+        $rootElement.append(element);
+        $$body.append($rootElement);
+        var animator = $animateCss(element, options);
+        expect(animator.$$willAnimate).toBeFalsy();
+
+        $$rAF.flush();
+        ss.addRule('.ng-enter', '-webkit-animation:3.5s keyframe_animation;' +
+                                        'animation:3.5s keyframe_animation;');
+        animator = $animateCss(element, options);
+        expect(animator.$$willAnimate).toBeTruthy();
+    }));
+
     it('should apply a custom temporary class when a non-structural animation is used',
       inject(function($animateCss, $rootElement, $$body) {
 


### PR DESCRIPTION
We should remove animation cache if the element don't have animation so follow-up animation on the same element will not be from cache.

This PR will close #12214 #12518
