### PR TITLE
feat(ngSrcAlt): add ng-src-alt directive for image error handling

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -69,6 +69,7 @@ var angularFiles = {
     'src/ng/directive/ngPluralize.js',
     'src/ng/directive/ngRepeat.js',
     'src/ng/directive/ngShowHide.js',
+    'src/ng/directive/ngSrcAlt.js',
     'src/ng/directive/ngStyle.js',
     'src/ng/directive/ngSwitch.js',
     'src/ng/directive/ngTransclude.js',

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -185,6 +185,7 @@ function publishExternalAPI(angular) {
             ngRepeat: ngRepeatDirective,
             ngShow: ngShowDirective,
             ngStyle: ngStyleDirective,
+            ngSrcAlt: ngSrcAltDirective,
             ngSwitch: ngSwitchDirective,
             ngSwitchWhen: ngSwitchWhenDirective,
             ngSwitchDefault: ngSwitchDefaultDirective,

--- a/src/ng/directive/ngSrcAlt.js
+++ b/src/ng/directive/ngSrcAlt.js
@@ -16,13 +16,13 @@ var ngSrcAltDirective = ngDirective({
     restrict: 'A',
     priority: 99, // it needs to run after the attributes are interpolated
     link: function ($scope, $element, $attr) {
-        var regex_isString = /(^['"]|['"]$)/g,
-            isValue = regex_isString.test($attr.ngSrcAlt);
         $element.bind('error', function () {
-            var value = isValue ? $attr.ngSrcAlt.replace(regex_isString, '') : $scope[$attr.ngSrcAlt];
-            if ($attr.src !== value) {
-                $attr.$set('src', value);
+            $attr.$set('src', $attr['ngSrcAlt']);
+
+            if (msie) {
+                $element.prop('src-alt', $attr['src']);
             }
         });
+
     }
 });

--- a/src/ng/directive/ngSrcAlt.js
+++ b/src/ng/directive/ngSrcAlt.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name ngSrcAlt
+ * @restrict A
+ *
+ * @description
+ * Executes if the URL in the src attribute throws an 404 error and replaces the value of the src attribute with the value in the expression.
+ * @param {expression} ngSrcAlt
+ *
+ * {@link guide/expression Expression} which evals to an
+ * string which contains an URL.
+ */
+var ngSrcAltDirective = ngDirective({
+    restrict: 'A',
+    priority: 99, // it needs to run after the attributes are interpolated
+    link: function ($scope, $element, $attr) {
+        var regex_isString = /(^['"]|['"]$)/g,
+            isValue = regex_isString.test($attr.ngSrcAlt);
+        $element.bind('error', function () {
+            var value = isValue ? $attr.ngSrcAlt.replace(regex_isString, '') : $scope[$attr.ngSrcAlt];
+            if ($attr.src !== value) {
+                $attr.$set('src', value);
+            }
+        });
+    }
+});


### PR DESCRIPTION
I've added a simple directive, that replaces the `src` attribute of an `<img>` Tag with the content of the `ngSrcAlt` Attribute if the file linking to doesn't exist.

That means this:

``` html
<img src="someNonExisting.png" ng-src-alt="{{'someExisting.png'}}" >
```

Would then resolve to this:

``` html
<img src="someExisting.png" ng-src-alt="{{'someExisting.png'}}">
```

if the image `someNonExisting.png` does not exist.
