### PR TITLE
fix(ngModel): remove reference to parentForm from removed control

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -167,6 +167,7 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
     });
 
     arrayRemove(controls, control);
+    control.$$parentForm = nullFormCtrl;
   };
 
 

--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -113,11 +113,23 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
   /**
    * @ngdoc method
    * @name form.FormController#$addControl
+   * @param {object} control control object, either a {@link form.FormController} or an
+   * {@link ngModel.NgModelController}
    *
    * @description
-   * Register a control with the form.
+   * Register a control with the form. Input elements using ngModelController do this automatically
+   * when they are linked.
    *
-   * Input elements using ngModelController do this automatically when they are linked.
+   * Note that the current state of the control will not be reflected on the new parent form. This
+   * is not an issue with normal use, as freshly compiled and linked controls are in a `$pristine`
+   * state.
+   *
+   * However, if the method is used programmatically, for example by adding dynamically created controls,
+   * or controls that have been previously removed without destroying their corresponding DOM element,
+   * it's the developers responsiblity to make sure the current state propagates to the parent form.
+   *
+   * For example, if an input control is added that is already `$dirty` and has `$error` properties,
+   * calling `$setDirty()` and `$validate()` afterwards will propagate the state to the parent form.
    */
   form.$addControl = function(control) {
     // Breaking change - before, inputs whose name was "hasOwnProperty" were quietly ignored
@@ -146,11 +158,18 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
   /**
    * @ngdoc method
    * @name form.FormController#$removeControl
+   * @param {object} control control object, either a {@link form.FormController} or an
+   * {@link ngModel.NgModelController}
    *
    * @description
    * Deregister a control from the form.
    *
    * Input elements using ngModelController do this automatically when they are destroyed.
+   *
+   * Note that only the removed control's validation state (`$errors`etc.) will be removed from the
+   * form. `$dirty`, `$submitted` states will not be changed, because the expected behavior can be
+   * different from case to case. For example, removing the only `$dirty` control from a form may or
+   * may not mean that the form is still `$dirty`.
    */
   form.$removeControl = function(control) {
     if (control.$name && form[control.$name] === control) {
@@ -502,13 +521,13 @@ var formDirectiveFactory = function(isNgForm) {
               attr.$observe(nameAttr, function(newValue) {
                 if (controller.$name === newValue) return;
                 setter(scope, undefined);
-                parentFormCtrl.$$renameControl(controller, newValue);
+                controller.$$parentForm.$$renameControl(controller, newValue);
                 setter = getSetter(controller.$name);
                 setter(scope, controller);
               });
             }
             formElement.on('$destroy', function() {
-              parentFormCtrl.$removeControl(controller);
+              controller.$$parentForm.$removeControl(controller);
               setter(scope, undefined);
               extend(controller, nullFormCtrl); //stop propagating child destruction handlers upwards
             });

--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -1029,12 +1029,12 @@ var ngModelDirective = ['$rootScope', function($rootScope) {
 
           attr.$observe('name', function(newValue) {
             if (modelCtrl.$name !== newValue) {
-              formCtrl.$$renameControl(modelCtrl, newValue);
+              modelCtrl.$$parentForm.$$renameControl(modelCtrl, newValue);
             }
           });
 
           scope.$on('$destroy', function() {
-            formCtrl.$removeControl(modelCtrl);
+            modelCtrl.$$parentForm.$removeControl(modelCtrl);
           });
         },
         post: function ngModelPostLink(scope, element, attr, ctrls) {

--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -236,7 +236,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
   this.$$success = {}; // keep valid keys here
   this.$pending = undefined; // keep pending keys here
   this.$name = $interpolate($attr.name || '', false)($scope);
-
+  this.$$parentForm = nullFormCtrl;
 
   var parsedNgModel = $parse($attr.ngModel),
       parsedNgModelAssign = parsedNgModel.assign,
@@ -316,8 +316,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
     return isUndefined(value) || value === '' || value === null || value !== value;
   };
 
-  var parentForm = $element.inheritedData('$formController') || nullFormCtrl,
-      currentValidationRunId = 0;
+  var currentValidationRunId = 0;
 
   /**
    * @ngdoc method
@@ -350,7 +349,6 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
     unset: function(object, property) {
       delete object[property];
     },
-    parentForm: parentForm,
     $animate: $animate
   });
 
@@ -388,7 +386,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
     ctrl.$pristine = false;
     $animate.removeClass($element, PRISTINE_CLASS);
     $animate.addClass($element, DIRTY_CLASS);
-    parentForm.$setDirty();
+    ctrl.$$parentForm.$setDirty();
   };
 
   /**
@@ -1022,7 +1020,7 @@ var ngModelDirective = ['$rootScope', function($rootScope) {
       return {
         pre: function ngModelPreLink(scope, element, attr, ctrls) {
           var modelCtrl = ctrls[0],
-              formCtrl = ctrls[1] || nullFormCtrl;
+              formCtrl = ctrls[1] || modelCtrl.$$parentForm;
 
           modelCtrl.$$setOptions(ctrls[2] && ctrls[2].$options);
 
@@ -1258,7 +1256,6 @@ function addSetValidityMethod(context) {
       classCache = {},
       set = context.set,
       unset = context.unset,
-      parentForm = context.parentForm,
       $animate = context.$animate;
 
   classCache[INVALID_CLASS] = !(classCache[VALID_CLASS] = $element.hasClass(VALID_CLASS));
@@ -1310,7 +1307,7 @@ function addSetValidityMethod(context) {
     }
 
     toggleValidationCss(validationErrorKey, combinedState);
-    parentForm.$setValidity(validationErrorKey, combinedState, ctrl);
+    ctrl.$$parentForm.$setValidity(validationErrorKey, combinedState, ctrl);
   }
 
   function createAndSet(name, value, controller) {

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -660,35 +660,36 @@ describe('form', function() {
       expect(doc.find('div').hasClass('ng-pending')).toBe(false);
     });
 
-  it('should leave the parent form invalid when deregister a removed input', function() {
-    doc = jqLite(
-      '<form name="parent">' +
-        '<div class="ng-form" name="child">' +
-          '<input ng-if="inputPresent" ng-model="modelA" name="inputA" required>' +
-          '<input ng-model="modelB" name="inputB" required>' +
-        '</div>' +
-      '</form>');
-    $compile(doc)(scope);
-    scope.inputPresent = true;
-    scope.$apply();
 
-    var parent = scope.parent,
-        child = scope.child,
-        inputA = child.inputA,
-        inputB = child.inputB;
+    it('should leave the parent form invalid when deregister a removed input', function() {
+      doc = jqLite(
+        '<form name="parent">' +
+          '<div class="ng-form" name="child">' +
+            '<input ng-if="inputPresent" ng-model="modelA" name="inputA" required>' +
+            '<input ng-model="modelB" name="inputB" required>' +
+          '</div>' +
+        '</form>');
+      $compile(doc)(scope);
+      scope.inputPresent = true;
+      scope.$apply();
 
-    expect(parent).toBeDefined();
-    expect(child).toBeDefined();
-    expect(parent.$error.required).toEqual([child]);
-    expect(child.$error.required).toEqual([inputB, inputA]);
+      var parent = scope.parent,
+          child = scope.child,
+          inputA = child.inputA,
+          inputB = child.inputB;
 
-    //remove child input
-    scope.inputPresent = false;
-    scope.$apply();
+      expect(parent).toBeDefined();
+      expect(child).toBeDefined();
+      expect(parent.$error.required).toEqual([child]);
+      expect(child.$error.required).toEqual([inputB, inputA]);
 
-    expect(parent.$error.required).toEqual([child]);
-    expect(child.$error.required).toEqual([inputB]);
-  });
+      //remove child input
+      scope.inputPresent = false;
+      scope.$apply();
+
+      expect(parent.$error.required).toEqual([child]);
+      expect(child.$error.required).toEqual([inputB]);
+    });
 
 
     it('should ignore changes in manually removed child forms', function() {

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -58,6 +58,43 @@ describe('form', function() {
     expect(form.alias).toBeUndefined();
   });
 
+
+  it('should ignore changes in manually removed controls', function() {
+    doc = $compile(
+      '<form name="myForm">' +
+        '<input name="control" ng-maxlength="1" ng-model="value" store-model-ctrl/>' +
+      '</form>')(scope);
+
+    var form = scope.myForm;
+
+    var input = doc.find('input').eq(0);
+    var inputController = input.controller('ngModel');
+
+    changeInputValue(input, 'ab');
+    scope.$apply();
+
+    expect(form.$error.maxlength).toBeTruthy();
+    expect(form.$dirty).toBe(true);
+    expect(form.$error.maxlength[0].$name).toBe('control');
+
+    // remove control
+    form.$removeControl(form.control);
+    expect(form.control).toBeUndefined();
+    expect(form.$error.maxlength).toBeFalsy();
+
+    inputController.$setPristine();
+    expect(form.$dirty).toBe(true);
+
+    form.$setPristine();
+
+    changeInputValue(input, 'abc');
+    scope.$apply();
+
+    expect(form.$error.maxlength).toBeFalsy();
+    expect(form.$dirty).toBe(false);
+  });
+
+
   it('should remove scope reference when form with no parent form is removed from the DOM', function() {
     var formController;
     scope.ctrl = {};

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -19,7 +19,6 @@ describe('ngModel', function() {
       };
 
       element = jqLite('<form><input></form>');
-      element.data('$formController', parentFormCtrl);
 
       scope = $rootScope;
       ngModelAccessor = jasmine.createSpy('ngModel accessor');
@@ -28,6 +27,9 @@ describe('ngModel', function() {
         $element: element.find('input'),
         $attrs: attrs
       });
+
+      //Assign the mocked parentFormCtrl to the model controller
+      ctrl.$$parentForm = parentFormCtrl;
     }));
 
 


### PR DESCRIPTION
Otherwise, once the removed control's validity changes,
it will continue to be reflected on its former parent form.

Fixes #12263

@gkalpak can you take a look?
