### PR TITLE
fix(merge): regExp should not be treated as a objects when merging.

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -354,6 +354,8 @@ function baseExtend(dst, objs, deep) {
       if (deep && isObject(src)) {
         if (isDate(src)) {
           dst[key] = new Date(src.valueOf());
+        } else if (isRegExp(src)) {
+          dst[key] = new RegExp(src);
         } else {
           if (!isObject(dst[key])) dst[key] = isArray(src) ? [] : {};
           baseExtend(dst[key], [src], true);

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -570,6 +570,17 @@ describe('angular', function() {
       expect(isDate(dst.date)).toBeTruthy();
       expect(dst.date.valueOf()).toEqual(src.date.valueOf());
     });
+
+    it('should copy regexp by value', function() {
+      var src = { regexp: /blah/ };
+      var dst = {};
+
+      merge(dst, src);
+
+      expect(dst.regexp).not.toBe(src.regexp);
+      expect(isRegExp(dst.regexp)).toBeTruthy();
+      expect(dst.regexp.toString()).toBe(src.regexp.toString());
+    });
   });
 
 


### PR DESCRIPTION
While merging two objects RegExp should not be treated same as the object.

Closes : #12409
