### PR TITLE
feat(jqLite): change camelCase to convert first letter to lowercase

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -133,7 +133,7 @@ JQLite._data = function(node) {
 function jqNextId() { return ++jqId; }
 
 
-var SPECIAL_CHARS_REGEXP = /([\:\-\_]+(.))/g;
+var SPECIAL_CHARS_REGEXP = /((?:^|[\:\-\_])[\:\-\_]*(.))/g;
 var MOZ_HACK_REGEXP = /^moz([A-Z])/;
 var MOUSE_EVENT_MAP= { mouseleave: "mouseout", mouseenter: "mouseover"};
 var jqLiteMinErr = minErr('jqLite');
@@ -146,7 +146,7 @@ var jqLiteMinErr = minErr('jqLite');
 function camelCase(name) {
   return name.
     replace(SPECIAL_CHARS_REGEXP, function(_, separator, letter, offset) {
-      return offset ? letter.toUpperCase() : letter;
+      return offset ? letter.toUpperCase() : letter.toLowerCase();
     }).
     replace(MOZ_HACK_REGEXP, 'Moz$1');
 }

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -2013,8 +2013,15 @@ describe('jqLite', function() {
 
     it('should covert browser specific css properties', function() {
       expect(camelCase('-moz-foo-bar')).toBe('MozFooBar');
+      expect(camelCase('MozFooBar')).toBe('MozFooBar');
       expect(camelCase('-webkit-foo-bar')).toBe('webkitFooBar');
       expect(camelCase('-webkit-foo-bar')).toBe('webkitFooBar');
+    });
+
+    it('should convert strings that start with an upper-case letter', function() {
+      expect(camelCase('Foo_Bar')).toBe('fooBar');
+      expect(camelCase('Foo-Bar')).toBe('fooBar');
+      expect(camelCase('FooBar')).toBe('fooBar');
     });
   });
 


### PR DESCRIPTION
There currently is no way to match class directives of the form
`"MyDirective"` or `"My_Directive"`, because directives must start
with a lowercase letter and the `camelCase` function does not change
the case of the first letter. This change allows matching directives
that start with an uppercase letter.

Before, `camelCase('FooBar') === 'FooBar'` and
`camelCase('Foo_Bar') === 'FooBar'`. Now, the first letter will be
lowercase: `camelCase('FooBar') === 'fooBar'`.
