### PR TITLE
docs($compile): pluralize DOM element

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -433,7 +433,7 @@
  *
  * ### Transclusion
  *
- * Transclusion is the process of extracting a collection of DOM element from one part of the DOM and
+ * Transclusion is the process of extracting a collection of DOM elements from one part of the DOM and
  * copying them to another part of the DOM, while maintaining their connection to the original AngularJS
  * scope from where they were taken.
  *


### PR DESCRIPTION
Previous description includes singular `collection of DOM element`. Current change revises `element` to be plural.
