### PR TITLE
docs(guide/expression): replace tt by code

### DIFF
--- a/docs/content/guide/expression.ngdoc
+++ b/docs/content/guide/expression.ngdoc
@@ -70,7 +70,7 @@ You can try evaluating different expressions here:
       <ul>
        <li ng-repeat="expr in exprs track by $index">
          [ <a href="" ng-click="removeExp($index)">X</a> ]
-         <tt>{{expr}}</tt> => <span ng-bind="$parent.$eval(expr)"></span>
+         <code>{{expr}}</code> => <span ng-bind="$parent.$eval(expr)"></span>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Replace tag `<tt>` by `<code>`.

> This element is obsolete. Use a more appropriate element, such as `<code>` or `<span>` with CSS, instead.
