### PR TITLE
test(expression): add timeout to alert protractor spec to prevent failure

### DIFF
--- a/docs/content/guide/expression.ngdoc
+++ b/docs/content/guide/expression.ngdoc
@@ -141,6 +141,9 @@ provide mockable access to globals.
       }
       element(by.css('[ng-click="greet()"]')).click();
 
+      // We need to give the browser time to display the alert
+      browser.sleep(100);
+
       var alertDialog = browser.switchTo().alert();
 
       expect(alertDialog.getText()).toEqual('Hello World');


### PR DESCRIPTION
In Chrome, if two alert boxes pop up, without enough time between them,
Protractor (or possibly ChromeDriver) sometimes fails to recognize the
second alert.
