### PR TITLE
chore(angularFiles): add default en-us locale to angularFiles

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -75,7 +75,8 @@ var angularFiles = {
     'src/ng/directive/script.js',
     'src/ng/directive/select.js',
     'src/ng/directive/style.js',
-    'src/ng/directive/validators.js'
+    'src/ng/directive/validators.js',
+    'src/ngLocale/angular-locale_en-us.js'
   ],
 
   'angularLoader': [


### PR DESCRIPTION
The lack of a default locale was breaking some internal builds 
that depend on some provider of an ngLocale module to be present.

Note: I'm not sure this is the best solution. I'm still talking with @petebacondarwin 
about this. Please don't merge
