### PR TITLE
fix(ngSrc) don't update the src property for iframe elements in IE:

### DIFF
--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -439,7 +439,7 @@ forEach(['src', 'srcset', 'href'], function(attrName) {
           // then calling element.setAttribute('src', 'foo') doesn't do anything, so we need
           // to set the property as well to achieve the desired effect.
           // we use attr[attrName] value since $set can sanitize the url.
-          if (msie && propName) element.prop(propName, attr[name]);
+          if (msie && propName && element[0].tagName !== 'IFRAME') element.prop(propName, attr[name]);
         });
       }
     };

--- a/test/ng/directive/booleanAttrsSpec.js
+++ b/test/ng/directive/booleanAttrsSpec.js
@@ -212,15 +212,11 @@ describe('ngSrc', function() {
 
     it('should NOT update the element property for iframe elements', inject(
         function($compile, $rootScope, $sce) {
-          var element = $compile('<iframe ng-src="{{id}}">')($rootScope);
+          var element = angular.element('<iframe ng-src="http://somewhere"></iframe>');
+          $compile(element);
+          spyOn(element, "prop");
           $rootScope.$digest();
-          expect(element.prop('src')).toBeUndefined();
-
-          $rootScope.$apply(function() {
-            $rootScope.id = $sce.trustAsResourceUrl('http://somewhere');
-          });
-          $rootScope.$digest();
-          expect(element.prop('src')).toBeUndefined();
+          expect(element.prop).not.toHaveBeenCalled();
           dealoc(element);
         }));
   }

--- a/test/ng/directive/booleanAttrsSpec.js
+++ b/test/ng/directive/booleanAttrsSpec.js
@@ -209,6 +209,20 @@ describe('ngSrc', function() {
 
           dealoc(element);
         }));
+
+    it('should NOT update the element property for iframe elements', inject(
+        function($compile, $rootScope, $sce) {
+          var element = $compile('<iframe ng-src="{{id}}">')($rootScope);
+          $rootScope.$digest();
+          expect(element.prop('src')).toBeUndefined();
+
+          $rootScope.$apply(function() {
+            $rootScope.id = $sce.trustAsResourceUrl('http://somewhere');
+          });
+          $rootScope.$digest();
+          expect(element.prop('src')).toBeUndefined();
+          dealoc(element);
+        }));
   }
 });
 


### PR DESCRIPTION
no longer set the "src" property on iframe elements in Internet Explorer to avoid sending a duplicate request for iframe content

Closes #9843
