### PR TITLE
refactor(form): remove the use of the private setter function

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -163,9 +163,6 @@
     /* ng/compile.js */
     "directiveNormalize": false,
 
-    /* ng/parse.js */
-    "setter": false,
-
     /* ng/directive/directives.js */
     "ngDirective": false,
 

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1610,29 +1610,6 @@ Parser.prototype = {
   }
 };
 
-//////////////////////////////////////////////////
-// Parser helper functions
-//////////////////////////////////////////////////
-
-function setter(obj, path, setValue, fullExp) {
-  ensureSafeObject(obj, fullExp);
-
-  var element = path.split('.'), key;
-  for (var i = 0; element.length > 1; i++) {
-    key = ensureSafeMemberName(element.shift(), fullExp);
-    var propertyObj = ensureSafeObject(obj[key], fullExp);
-    if (!propertyObj) {
-      propertyObj = {};
-      obj[key] = propertyObj;
-    }
-    obj = propertyObj;
-  }
-  key = ensureSafeMemberName(element.shift(), fullExp);
-  ensureSafeObject(obj[key], fullExp);
-  obj[key] = setValue;
-  return setValue;
-}
-
 var getterFnCacheDefault = createMap();
 var getterFnCacheExpensive = createMap();
 


### PR DESCRIPTION
Remove the private `setter` function from $parse
Replace the use of `setter` from the `form` directive to use $parse
