### PR TITLE
chore(grunt): add filename to comment header

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -124,8 +124,9 @@ module.exports = {
   },
 
 
-  process: function(src, NG_VERSION, strict){
+  process: function(src, NG_VERSION, fileName, strict){
     var processed = src
+	  .replace(/"NG_FILENAME"/g, fileName)
       .replace(/"NG_VERSION_FULL"/g, NG_VERSION.full)
       .replace(/"NG_VERSION_MAJOR"/, NG_VERSION.major)
       .replace(/"NG_VERSION_MINOR"/, NG_VERSION.minor)
@@ -146,7 +147,7 @@ module.exports = {
       return grunt.file.read(filepath);
     }).join(grunt.util.normalizelf('\n'));
     //process
-    var processed = this.process(src, grunt.config('NG_VERSION'), config.strict);
+    var processed = this.process(src, grunt.config('NG_VERSION'), this.extractFileName(config.dest), config.strict);
     if (styles) {
       processedStyles = this.addStyle(processed, styles.css, styles.minify);
       processed = processedStyles.js;
@@ -164,23 +165,30 @@ module.exports = {
     }
   },
 
-
   singleStrict: function(src, insert){
     return src
       .replace(/\s*("|')use strict("|');\s*/g, insert) // remove all file-specific strict mode flags
       .replace(/(\(function\([^)]*\)\s*\{)/, "$1'use strict';"); // add single strict mode flag
   },
 
+  extractFileName: function(path) {
+    return path.match(/[^\/]+$/)[0];
+  },
 
   sourceMap: function(mapFile, fileContents) {
     var sourceMapLine = '//# sourceMappingURL=' + mapFile + '\n';
     return fileContents + sourceMapLine;
   },
 
+  fileToMinFile: function(fileName, minFileName, fileContents) {
+    return fileContents.replace(fileName, minFileName);
+  },
 
   min: function(file, done) {
     var classPathSep = (process.platform === "win32") ? ';' : ':';
+    var fileName = this.extractFileName(file);
     var minFile = file.replace(/\.js$/, '.min.js');
+    var minFileName = this.extractFileName(minFile);
     var mapFile = minFile + '.map';
     var mapFileName = mapFile.match(/[^\/]+$/)[0];
     var errorFileName = file.replace(/\.js$/, '-errors.json');
@@ -212,6 +220,10 @@ module.exports = {
 
         // move add use strict into the closure + add source map pragma
         grunt.file.write(minFile, this.sourceMap(mapFileName, this.singleStrict(grunt.file.read(minFile), '\n')));
+
+        // change comment header filename to minified filename
+        grunt.file.write(minFile, this.fileToMinFile(fileName, minFileName, grunt.file.read(minFile)));
+		
         grunt.log.ok(file + ' minified into ' + minFile);
         done();
     }.bind(this));

--- a/src/angular.prefix
+++ b/src/angular.prefix
@@ -1,5 +1,6 @@
-/**
- * @license AngularJS v"NG_VERSION_FULL"
+/** 
+ * @license "NG_FILENAME"
+ * AngularJS v"NG_VERSION_FULL"
  * (c) 2010-2015 Google, Inc. http://angularjs.org
  * License: MIT
  */

--- a/src/loader.prefix
+++ b/src/loader.prefix
@@ -1,5 +1,6 @@
 /**
- * @license AngularJS v"NG_VERSION_FULL"
+ * @license "NG_FILENAME"
+ * AngularJS v"NG_VERSION_FULL"
  * (c) 2010-2015 Google, Inc. http://angularjs.org
  * License: MIT
  */

--- a/src/module.prefix
+++ b/src/module.prefix
@@ -1,5 +1,6 @@
 /**
- * @license AngularJS v"NG_VERSION_FULL"
+ * @license "NG_FILENAME"
+ * AngularJS v"NG_VERSION_FULL"
  * (c) 2010-2015 Google, Inc. http://angularjs.org
  * License: MIT
  */


### PR DESCRIPTION
Add the filename of each .js and .min.js file to it's own comment header.
