### PR TITLE
fix($animate) : will not skip the animation of ng-hide remove.

### DIFF
--- a/css/angular.css
+++ b/css/angular.css
@@ -2,7 +2,7 @@
 
 [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak],
 .ng-cloak, .x-ng-cloak,
-.ng-hide:not(.ng-hide-animate) {
+.ng-hide:not(.ng-hide-animate):not(.ng-hide-remove) {
   display: none !important;
 }
 

--- a/src/ng/directive/ngShowHide.js
+++ b/src/ng/directive/ngShowHide.js
@@ -41,11 +41,11 @@ var NG_HIDE_IN_PROGRESS_CLASS = 'ng-hide-animate';
  *
  * By default, the `.ng-hide` class will style the element with `display: none!important`. If you wish to change
  * the hide behavior with ngShow/ngHide then this can be achieved by restating the styles for the `.ng-hide`
- * class CSS. Note that the selector that needs to be used is actually `.ng-hide:not(.ng-hide-animate)` to cope
+ * class CSS. Note that the selector that needs to be used is actually `.ng-hide:not(.ng-hide-animate):not(.ng-hide-remove)` to cope
  * with extra animation classes that can be added.
  *
  * ```css
- * .ng-hide:not(.ng-hide-animate) {
+ * .ng-hide:not(.ng-hide-animate):not(.ng-hide-remove) {
  *   /&#42; this is just another form of hiding an element &#42;/
  *   display: block!important;
  *   position: absolute;


### PR DESCRIPTION
According to current ngAnimate code both adding/removing of animate classes and real change classes are done in single requestAnimationFrame , so when ng-hide is removed from the element it will skip the transition.

This is one way of fixing or other way can be just do only adding of classes at same frame with animate for removing the classes wait for one  requestAnimationFrame after applying of animate classes, or we want to go back to the previous behavior that ngAnimate having to wait for one
requestAnimationFrame before CSS classes were added/removed.

closes #12453
