### PR TITLE
Make NgModelController $setValidity a noop if the scope is destroyed

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -182,6 +182,7 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
    */
   addSetValidityMethod({
     ctrl: this,
+    $scope: $scope,
     $element: element,
     set: function(object, property, controller) {
       var list = object[property];

--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -344,6 +344,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
    */
   addSetValidityMethod({
     ctrl: this,
+    $scope: $scope,
     $element: $element,
     set: function(object, property) {
       object[property] = true;
@@ -1255,6 +1256,7 @@ var ngModelOptionsDirective = function() {
 // helper methods
 function addSetValidityMethod(context) {
   var ctrl = context.ctrl,
+      $scope = context.$scope,
       $element = context.$element,
       classCache = {},
       set = context.set,
@@ -1267,6 +1269,9 @@ function addSetValidityMethod(context) {
   ctrl.$setValidity = setValidity;
 
   function setValidity(validationErrorKey, state, controller) {
+    if ($scope.$$destroyed) {
+      return;  // Do nothing to the destroyed scope.
+    }
     if (state === undefined) {
       createAndSet('$pending', validationErrorKey, controller);
     } else {


### PR DESCRIPTION
Prevent setValidity from doing anything if the scope it is associated to has been destroyed.  This can happen if an asynchronous event in the directive used the controller after the scope had been destroyed.
