### PR TITLE
fix(ngMessages): use function paramater to assign to `restrict` property

### DIFF
--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -568,7 +568,7 @@ angular.module('ngMessages', [])
    /**
     * @ngdoc directive
     * @name ngMessageExp
-    * @restrict AE
+    * @restrict A
     * @scope
     *
     * @description
@@ -599,7 +599,7 @@ angular.module('ngMessages', [])
 function ngMessageDirectiveFactory(restrict) {
   return ['$animate', function($animate) {
     return {
-      restrict: 'AE',
+      restrict: restrict,
       transclude: 'element',
       terminal: true,
       require: '^^ngMessages',


### PR DESCRIPTION
Summary:
    - map unused ngMessageDirectiveFactory paramater `restrict`
      to hard coded `restrict` property
    - update `ngMessageExp` document to reflect actual
      `restrict` type
