### PR TITLE
perf($compile): use createMap() for directive bindings to allow fast forEach

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -738,7 +738,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
   function parseIsolateBindings(scope, directiveName, isController) {
     var LOCAL_REGEXP = /^\s*([@&]|=(\*?))(\??)\s*(\w*)\s*$/;
 
-    var bindings = {};
+    var bindings = createMap();
 
     forEach(scope, function(definition, scopeName) {
       var match = definition.match(LOCAL_REGEXP);


### PR DESCRIPTION
Very minor and I haven't actually measured it. But since `forEach` now has a [fast path for blank objects](https://github.com/angular/angular.js/blob/ed3a33a063f09d7ca356d15c278d95ad82e680a0/src/Angular.js#L273) I thought it would be worth it.
