### PR TITLE
fix(ngOptions): allow empty option selection with multiple attribute

### DIFF
--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -526,7 +526,7 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
 
           forEach(selectedValues, function(value) {
             var option = options.selectValueMap[value];
-            if (!option.disabled) selections.push(options.getViewValueFromOption(option));
+            if (option && !option.disabled) selections.push(options.getViewValueFromOption(option));
           });
 
           return selections;

--- a/test/ng/directive/ngOptionsSpec.js
+++ b/test/ng/directive/ngOptionsSpec.js
@@ -2058,6 +2058,18 @@ describe('ngOptions', function() {
       // ensure the option has not changed following the digest
       expect(element[0].selectedIndex).toEqual(0);
     });
+
+    // bug fix #12511
+    it('should be selectable if multiple attribute is applied on select element',function() {
+      createMultiSelect(true);
+
+      // select the empty option
+      setSelectValue(element,0);
+
+      // ensure selection and correct binding
+      expect(element[0].selectedIndex).toEqual(0);
+      expect(scope.selected).toEqual([]);
+    });
   });
 
 


### PR DESCRIPTION
fixes #12511
