### PR TITLE
Added invokeApply parameter to $http to skip apply

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -920,7 +920,7 @@ function $HttpProvider() {
 </file>
 </example>
      */
-    function $http(requestConfig) {
+    function $http(requestConfig, invokeApply) {
 
       if (!angular.isObject(requestConfig)) {
         throw minErr('$http')('badreq', 'Http request configuration must be an object.  Received: {0}', requestConfig);
@@ -956,7 +956,7 @@ function $HttpProvider() {
         }
 
         // send request
-        return sendReq(config, reqData).then(transformResponse, transformResponse);
+        return sendReq(config, reqData, invokeApply).then(transformResponse, transformResponse);
       };
 
       var chain = [serverRequest, undefined];
@@ -1170,11 +1170,11 @@ function $HttpProvider() {
 
     function createShortMethods(names) {
       forEach(arguments, function(name) {
-        $http[name] = function(url, config) {
+        $http[name] = function(url, config, invokeApply) {
           return $http(extend({}, config || {}, {
             method: name,
             url: url
-          }));
+          }), invokeApply);
         };
       });
     }
@@ -1182,12 +1182,12 @@ function $HttpProvider() {
 
     function createShortMethodsWithData(name) {
       forEach(arguments, function(name) {
-        $http[name] = function(url, data, config) {
+        $http[name] = function(url, data, config, invokeApply) {
           return $http(extend({}, config || {}, {
             method: name,
             url: url,
             data: data
-          }));
+          }), invokeApply);
         };
       });
     }
@@ -1199,7 +1199,7 @@ function $HttpProvider() {
      * !!! ACCESSES CLOSURE VARS:
      * $httpBackend, defaults, $log, $rootScope, defaultCache, $http.pendingRequests
      */
-    function sendReq(config, reqData) {
+    function sendReq(config, reqData, invokeApply) {
       var deferred = $q.defer(),
           promise = deferred.promise,
           cache,
@@ -1276,11 +1276,17 @@ function $HttpProvider() {
           resolvePromise(response, status, headersString, statusText);
         }
 
-        if (useApplyAsync) {
-          $rootScope.$applyAsync(resolveHttpPromise);
+        var skipApply = (isDefined(invokeApply) && !invokeApply);
+
+        if (!skipApply) {
+          if (useApplyAsync) {
+            $rootScope.$applyAsync(resolveHttpPromise);
+          } else {
+            resolveHttpPromise();
+            if (!$rootScope.$$phase) $rootScope.$apply();
+          }
         } else {
           resolveHttpPromise();
-          if (!$rootScope.$$phase) $rootScope.$apply();
         }
       }
 

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -825,6 +825,8 @@ function $HttpProvider() {
      *    - **responseType** - `{string}` - see
      *      [XMLHttpRequest.responseType](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#xmlhttprequest-responsetype).
      *
+     * @param {boolean=} invokeApply: if false, skips model dirty checking after request succeeds
+     *
      * @returns {HttpPromise} Returns a {@link ng.$q `Promise}` that will be resolved to a response object
      *                        when the request succeeds or fails.
      *
@@ -1083,6 +1085,7 @@ function $HttpProvider() {
      *
      * @param {string} url Relative or absolute URL specifying the destination of the request
      * @param {Object=} config Optional configuration object
+     * @param {boolean=} invokeApply: if false, skips model dirty checking after request succeeds
      * @returns {HttpPromise} Future object
      */
 
@@ -1095,6 +1098,7 @@ function $HttpProvider() {
      *
      * @param {string} url Relative or absolute URL specifying the destination of the request
      * @param {Object=} config Optional configuration object
+     * @param {boolean=} invokeApply: if false, skips model dirty checking after request succeeds
      * @returns {HttpPromise} Future object
      */
 
@@ -1108,6 +1112,7 @@ function $HttpProvider() {
      * @param {string} url Relative or absolute URL specifying the destination of the request.
      *                     The name of the callback should be the string `JSON_CALLBACK`.
      * @param {Object=} config Optional configuration object
+     * @param {boolean=} invokeApply: if false, skips model dirty checking after request succeeds
      * @returns {HttpPromise} Future object
      */
     createShortMethods('get', 'delete', 'head', 'jsonp');
@@ -1122,6 +1127,7 @@ function $HttpProvider() {
      * @param {string} url Relative or absolute URL specifying the destination of the request
      * @param {*} data Request content
      * @param {Object=} config Optional configuration object
+     * @param {boolean=} invokeApply: if false, skips model dirty checking after request succeeds
      * @returns {HttpPromise} Future object
      */
 
@@ -1135,6 +1141,7 @@ function $HttpProvider() {
      * @param {string} url Relative or absolute URL specifying the destination of the request
      * @param {*} data Request content
      * @param {Object=} config Optional configuration object
+     * @param {boolean=} invokeApply: if false, skips model dirty checking after request succeeds
      * @returns {HttpPromise} Future object
      */
 
@@ -1148,6 +1155,7 @@ function $HttpProvider() {
       * @param {string} url Relative or absolute URL specifying the destination of the request
       * @param {*} data Request content
       * @param {Object=} config Optional configuration object
+      * @param {boolean=} invokeApply: if false, skips model dirty checking after request succeeds
       * @returns {HttpPromise} Future object
       */
     createShortMethodsWithData('post', 'put', 'patch');

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1013,32 +1013,76 @@ describe('$http', function() {
 
     describe('scope.$apply', function() {
 
-      it('should $apply after success callback', function() {
-        $httpBackend.when('GET').respond(200);
-        $http({method: 'GET', url: '/some'});
-        $httpBackend.flush();
-        expect($rootScope.$apply).toHaveBeenCalledOnce();
+      describe('when invokeApply is undefined', function() {
+
+        it('should $apply after success callback', function() {
+          $httpBackend.when('GET').respond(200);
+          $http({method: 'GET', url: '/some'});
+          $httpBackend.flush();
+          expect($rootScope.$apply).toHaveBeenCalledOnce();
+        });
+
+
+        it('should $apply after error callback', function() {
+          $httpBackend.when('GET').respond(404);
+          $http({method: 'GET', url: '/some'});
+          $httpBackend.flush();
+          expect($rootScope.$apply).toHaveBeenCalledOnce();
+        });
+
+
+        it('should $apply even if exception thrown during callback', inject(function($exceptionHandler) {
+          $httpBackend.when('GET').respond(200);
+          callback.andThrow('error in callback');
+
+          $http({method: 'GET', url: '/some'}).then(callback);
+          $httpBackend.flush();
+          expect($rootScope.$apply).toHaveBeenCalledOnce();
+
+          $exceptionHandler.errors = [];
+        }));
       });
 
+      describe('when invokeApply is defined and falsy', function() {
 
-      it('should $apply after error callback', function() {
-        $httpBackend.when('GET').respond(404);
-        $http({method: 'GET', url: '/some'});
-        $httpBackend.flush();
-        expect($rootScope.$apply).toHaveBeenCalledOnce();
+        it('should resolve promises anyway', function() {
+          $httpBackend.when('GET').respond(200);
+          var promiseCompleted = false;
+          $http({method: 'GET', url: '/some'}, false).then(function() {
+            promiseCompleted = true;
+          });
+          $httpBackend.flush();
+          expect(promiseCompleted).toBe(true);
+        });
+
+
+        it('should not $apply after success callback', function() {
+          $httpBackend.when('GET').respond(200);
+          $http({method: 'GET', url: '/some'}, false);
+          $httpBackend.flush();
+          expect($rootScope.$apply).not.toHaveBeenCalledOnce();
+        });
+
+
+        it('should not $apply after error callback', function() {
+          $httpBackend.when('GET').respond(404);
+          $http({method: 'GET', url: '/some'}, false);
+          $httpBackend.flush();
+          expect($rootScope.$apply).not.toHaveBeenCalledOnce();
+        });
+
+
+        it('should not $apply if exception thrown during callback', inject(function($exceptionHandler) {
+          $httpBackend.when('GET').respond(200);
+          callback.andThrow('error in callback');
+
+          $http({method: 'GET', url: '/some'}, false).then(callback);
+          $httpBackend.flush();
+          expect($rootScope.$apply).not.toHaveBeenCalledOnce();
+
+          $exceptionHandler.errors = [];
+        }));
       });
-
-
-      it('should $apply even if exception thrown during callback', inject(function($exceptionHandler) {
-        $httpBackend.when('GET').respond(200);
-        callback.andThrow('error in callback');
-
-        $http({method: 'GET', url: '/some'}).then(callback);
-        $httpBackend.flush();
-        expect($rootScope.$apply).toHaveBeenCalledOnce();
-
-        $exceptionHandler.errors = [];
-      }));
     });
 
 


### PR DESCRIPTION
There are a bunch of times when we don't want a $rootScope.$apply after an http request succeeds. [This](http://stackoverflow.com/questions/21935215/make-angularjs-skip-running-a-digest-loop-if-http-get-resulted-in-no-new-data) stackoverflow question gives a good use case: polling.
We can also use this to do scope specific digests, which really helps performance and snappiness on mobile devices.

It also gives us a little more control over the API, and also makes it similar to $timeout. 
