### PR TITLE
PR refactor for #12271

### DIFF
--- a/src/ngAnimate/shared.js
+++ b/src/ngAnimate/shared.js
@@ -172,7 +172,15 @@ function mergeAnimationOptions(element, target, newOptions) {
   var toRemove = (target.removeClass || '') + ' ' + (newOptions.removeClass || '');
   var classes = resolveElementClasses(element.attr('class'), toAdd, toRemove);
 
+  // noop is basically when there is no callback; otherwise something has been set
+  var realDomOperation = target.domOperation !== noop ? target.domOperation : null;
+
   extend(target, newOptions);
+
+  // TODO(matsko or sreeramu): proper fix is to maintain all animation callback in array and call at last,but now only leave has the callback so no issue with this.
+  if (realDomOperation) {
+    target.domOperation = realDomOperation;
+  }
 
   if (classes.addClass) {
     target.addClass = classes.addClass;

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1646,5 +1646,23 @@ describe("animations", function() {
       expect(count).toBe(1);
     }));
 
+    it('leave: should remove the element even if another animation is called after',
+      inject(function($animate, $rootScope, $$rAF, $rootElement) {
+
+      var outerContainer = jqLite('<div></div>');
+      element = jqLite('<div></div>');
+      outerContainer.append(element);
+      $rootElement.append(outerContainer);
+
+      var runner = $animate.leave(element, $rootElement);
+      $animate.removeClass(element,'rclass');
+      $rootScope.$digest();
+      runner.end();
+      $$rAF.flush();
+
+      var isElementRemoved = !outerContainer[0].contains(element[0]);
+      expect(isElementRemoved).toBe(true);
+    }));
+
   });
 });


### PR DESCRIPTION
fix($animate): leave animation callback should not overridden by follow-up animation

Closes #12271
Closes #12249
Closes #12161
