### PR TITLE
ng-animate-ref leave clone element fix - Call $animate.leave on the cloned element rather than just remove to provide some more animation hooks.

### DIFF
--- a/src/ngAnimate/animateCssDriver.js
+++ b/src/ngAnimate/animateCssDriver.js
@@ -9,8 +9,8 @@ var $$AnimateCssDriverProvider = ['$$animationProvider', function($$animationPro
   var NG_OUT_ANCHOR_CLASS_NAME = 'ng-anchor-out';
   var NG_IN_ANCHOR_CLASS_NAME = 'ng-anchor-in';
 
-  this.$get = ['$animateCss', '$rootScope', '$$AnimateRunner', '$rootElement', '$$body', '$sniffer', '$$jqLite',
-       function($animateCss,   $rootScope,   $$AnimateRunner,   $rootElement,   $$body,   $sniffer,   $$jqLite) {
+  this.$get = ['$animate', '$animateCss', '$rootScope', '$$AnimateRunner', '$rootElement', '$$body', '$sniffer', '$$jqLite',
+       function($animate, $animateCss,   $rootScope,   $$AnimateRunner,   $rootElement,   $$body,   $sniffer,   $$jqLite) {
 
     // only browsers that support these properties can render animations
     if (!$sniffer.animations && !$sniffer.transitions) return noop;
@@ -165,7 +165,7 @@ var $$AnimateCssDriverProvider = ['$$animationProvider', function($$animationPro
       }
 
       function end() {
-        clone.remove();
+        $animate.leave(clone);
         outAnchor.removeClass(NG_ANIMATE_SHIM_CLASS_NAME);
         inAnchor.removeClass(NG_ANIMATE_SHIM_CLASS_NAME);
       }

--- a/test/ngAnimate/animateCssDriverSpec.js
+++ b/test/ngAnimate/animateCssDriverSpec.js
@@ -888,8 +888,8 @@ describe("ngAnimate $$animateCssDriver", function() {
         expect(int(toStyles.left)).toBeGreaterThan(20);
       }));
 
-      it("should remove the cloned anchor node from the DOM once the 'in' animation is complete",
-        inject(function($rootElement, $$rAF) {
+      it("should remove the cloned anchor node from the DOM once the 'in' animation is complete using $animate leave to provide animation hooks",
+        inject(function($rootElement, $$rAF, $animate, $rootScope) {
 
         var fromAnchor = jqLite('<div class="blue green red"></div>');
         from.append(fromAnchor);
@@ -917,8 +917,11 @@ describe("ngAnimate $$animateCssDriver", function() {
 
         // now the in animation completes
         expect(clonedAnchor.parent().length).toBe(1);
+
+        spyOn($animate, 'leave').andCallThrough();
         captureLog.pop().runner.end();
 
+        expect($animate.leave).toHaveBeenCalledWith(clonedAnchor);
         expect(clonedAnchor.parent().length).toBe(0);
       }));
 


### PR DESCRIPTION
ng-animate-ref leave clone element fix - Call $animate.leave on the cloned element rather than just remove to provide some more animation hooks.
https://github.com/angular/angular.js/issues/12539
