### PR TITLE
Fix test issue

### DIFF
--- a/docs/content/tutorial/step_06.ngdoc
+++ b/docs/content/tutorial/step_06.ngdoc
@@ -75,7 +75,7 @@ __`test/e2e/scenarios.js`__:
       query.sendKeys('nexus');
       element.all(by.css('.phones li a')).first().click();
       browser.getLocationAbsUrl().then(function(url) {
-        expect(url.split('#')[1]).toBe('/phones/nexus-s');
+        expect(url).toBe('/phones/nexus-s');
       });
     });
 ...


### PR DESCRIPTION
Unnecessary split. The url returns a string without the hash, resulting in an undefined value and making the test fails.
