### PR TITLE
fix($animateCss): fix parse errors on older Android WebViews which choke with reserved keywords

### DIFF
--- a/src/ng/animateCss.js
+++ b/src/ng/animateCss.js
@@ -35,10 +35,10 @@ var $CoreAnimateCssProvider = function() {
         return this.getPromise().then(f1,f2);
       },
       'catch': function(f1) {
-        return this.getPromise().catch(f1);
+        return this.getPromise()['catch'](f1);
       },
       'finally': function(f1) {
-        return this.getPromise().finally(f1);
+        return this.getPromise()['finally'](f1);
       }
     };
 


### PR DESCRIPTION
Without this change it is impossible to run an app on an Android 2.3 device directly using Angular source code.

Similar to #11455 and #11051
