### PR TITLE
fix($compile): backport to 1.2 of workaround for IE11 MutationObserver

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3705,7 +3705,7 @@
                   "version": "0.2.1"
                 },
                 "i": {
-                  "version": "0.3.2"
+                  "version": "0.3.3"
                 },
                 "mkdirp": {
                   "version": "0.4.0"

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1088,6 +1088,13 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           }
           break;
         case 3: /* Text Node */
+          if (msie === 11) {
+            // Workaround for #11781
+            while (node.parentNode && node.nextSibling && node.nextSibling.nodeType === 3 /* Text Node */) {
+              node.nodeValue = node.nodeValue + node.nextSibling.nodeValue;
+              node.parentNode.removeChild(node.nextSibling);
+            }
+          }
           addTextInterpolateDirective(directives, node.nodeValue);
           break;
         case 8: /* Comment */

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2214,6 +2214,23 @@ describe('$compile', function() {
                 '</select>');
     }));
 
+    it('should handle consecutive text elements as a single text element', inject(function($rootScope, $compile) {
+      // No point it running the test, if there is no MutationObserver
+      if (!window.MutationObserver) return;
+
+      // Create and register the MutationObserver
+      var observer = new window.MutationObserver(noop);
+      observer.observe(document.body, {childList: true, subtree: true});
+
+      // Run the actual test
+      var base = jqLite('<div>&mdash; {{ "This doesn\'t." }}</div>');
+      element = $compile(base)($rootScope);
+      $rootScope.$digest();
+      expect(element.text()).toBe("— This doesn't.");
+
+      // Unregister the MutationObserver (and hope it doesn't mess up with subsequent tests)
+      observer.disconnect();
+    }));
 
     it('should support custom start/end interpolation symbols in template and directive template',
         function() {


### PR DESCRIPTION
Backport #11796 to 1.2 branch.
IE11 MutationObserver breaks consecutive text nodes into several text nodes.
This patch merges consecutive text nodes into a single node before looking for interpolations.

Closes #11781
