### PR TITLE
fix(ngAnimate): only buffer rAF requests within the animation runners

### DIFF
--- a/src/ng/raf.js
+++ b/src/ng/raf.js
@@ -10,7 +10,7 @@ function $$RAFProvider() { //rAF
                                $window.webkitCancelRequestAnimationFrame;
 
     var rafSupported = !!requestAnimationFrame;
-    var rafFn = rafSupported
+    var raf = rafSupported
       ? function(fn) {
           var id = requestAnimationFrame(fn);
           return function() {
@@ -24,46 +24,8 @@ function $$RAFProvider() { //rAF
           };
         };
 
-    queueFn.supported = rafSupported;
+    raf.supported = rafSupported;
 
-    var cancelLastRAF;
-    var taskCount = 0;
-    var taskQueue = [];
-    return queueFn;
-
-    function flush() {
-      for (var i = 0; i < taskQueue.length; i++) {
-        var task = taskQueue[i];
-        if (task) {
-          taskQueue[i] = null;
-          task();
-        }
-      }
-      taskCount = taskQueue.length = 0;
-    }
-
-    function queueFn(asyncFn) {
-      var index = taskQueue.length;
-
-      taskCount++;
-      taskQueue.push(asyncFn);
-
-      if (index === 0) {
-        cancelLastRAF = rafFn(flush);
-      }
-
-      return function cancelQueueFn() {
-        if (index >= 0) {
-          taskQueue[index] = null;
-          index = null;
-
-          if (--taskCount === 0 && cancelLastRAF) {
-            cancelLastRAF();
-            cancelLastRAF = null;
-            taskQueue.length = 0;
-          }
-        }
-      };
-    }
+    return raf;
   }];
 }

--- a/src/ngAnimate/animateJs.js
+++ b/src/ngAnimate/animateJs.js
@@ -5,8 +5,8 @@
 //  by the time...
 
 var $$AnimateJsProvider = ['$animateProvider', function($animateProvider) {
-  this.$get = ['$injector', '$$AnimateRunner', '$$rAFMutex', '$$jqLite',
-       function($injector,   $$AnimateRunner,   $$rAFMutex,   $$jqLite) {
+  this.$get = ['$injector', '$$AnimateRunner', '$$jqLite',
+       function($injector,   $$AnimateRunner,   $$jqLite) {
 
     var applyAnimationClasses = applyAnimationClassesFactory($$jqLite);
          // $animateJs(element, 'enter');

--- a/src/ngAnimate/module.js
+++ b/src/ngAnimate/module.js
@@ -3,7 +3,7 @@
 /* global angularAnimateModule: true,
 
    $$BodyProvider,
-   $$rAFMutexFactory,
+   $$AnimateAsyncRunFactory,
    $$AnimateChildrenDirective,
    $$AnimateRunnerFactory,
    $$AnimateQueueProvider,
@@ -745,9 +745,8 @@ angular.module('ngAnimate', [])
 
   .directive('ngAnimateChildren', $$AnimateChildrenDirective)
 
-  .factory('$$rAFMutex', $$rAFMutexFactory)
-
   .factory('$$AnimateRunner', $$AnimateRunnerFactory)
+  .factory('$$animateAsyncRun', $$AnimateAsyncRunFactory)
 
   .provider('$$animateQueue', $$AnimateQueueProvider)
   .provider('$$animation', $$AnimationProvider)

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -763,25 +763,50 @@ angular.mock.animate = angular.module('ngAnimateMock', ['ng'])
       return reflowFn;
     });
 
-    $provide.decorator('$animate', ['$delegate', '$timeout', '$browser', '$$rAF', '$$forceReflow',
-                            function($delegate,   $timeout,   $browser,   $$rAF,   $$forceReflow) {
+    $provide.factory('$$animateAsyncRun', function() {
+      var queue = [];
+      var queueFn = function() {
+        return function(fn) {
+          queue.push(fn);
+        };
+      };
+      queueFn.flush = function() {
+        if (queue.length === 0) return false;
+
+        for (var i = 0; i < queue.length; i++) {
+          queue[i]();
+        }
+        queue = [];
+
+        return true;
+      };
+      return queueFn;
+    });
+
+    $provide.decorator('$animate', ['$delegate', '$timeout', '$browser', '$$rAF', '$$forceReflow', '$$animateAsyncRun',
+                            function($delegate,   $timeout,   $browser,   $$rAF,   $$forceReflow,   $$animateAsyncRun) {
 
       var animate = {
         queue: [],
         cancel: $delegate.cancel,
+        on: $delegate.on,
+        off: $delegate.off,
+        pin: $delegate.pin,
         get reflows() {
           return $$forceReflow.totalReflows;
         },
         enabled: $delegate.enabled,
-        triggerCallbackEvents: function() {
-          $$rAF.flush();
-        },
-        triggerCallbackPromise: function() {
-          $timeout.flush(0);
-        },
-        triggerCallbacks: function() {
-          this.triggerCallbackEvents();
-          this.triggerCallbackPromise();
+        flush: function() {
+          var rafsFlushed = false;
+          if ($$rAF.queue.length) {
+            $$rAF.flush();
+            rafsFlushed = true;
+          }
+
+          var animatorsFlushed = $$animateAsyncRun.flush();
+          if (!rafsFlushed && !animatorsFlushed) {
+            throw new Error('No pending animations ready to be closed or flushed');
+          }
         }
       };
 
@@ -1733,28 +1758,28 @@ angular.mock.$TimeoutDecorator = ['$delegate', '$browser', function($delegate, $
 }];
 
 angular.mock.$RAFDecorator = ['$delegate', function($delegate) {
-  var queue = [];
   var rafFn = function(fn) {
-    var index = queue.length;
-    queue.push(fn);
+    var index = rafFn.queue.length;
+    rafFn.queue.push(fn);
     return function() {
-      queue.splice(index, 1);
+      rafFn.queue.splice(index, 1);
     };
   };
 
+  rafFn.queue = [];
   rafFn.supported = $delegate.supported;
 
   rafFn.flush = function() {
-    if (queue.length === 0) {
+    if (rafFn.queue.length === 0) {
       throw new Error('No rAF callbacks present');
     }
 
-    var length = queue.length;
+    var length = rafFn.queue.length;
     for (var i = 0; i < length; i++) {
-      queue[i]();
+      rafFn.queue[i]();
     }
 
-    queue = queue.slice(i);
+    rafFn.queue = rafFn.queue.slice(i);
   };
 
   return rafFn;

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -468,7 +468,7 @@ describe('ngClass animations', function() {
         };
       });
     });
-    inject(function($compile, $rootScope, $browser, $rootElement, $animate, $timeout, $$body, $$rAF) {
+    inject(function($compile, $rootScope, $browser, $rootElement, $animate, $timeout, $$body) {
       $animate.enabled(true);
 
       $rootScope.val = 'crazy';
@@ -488,7 +488,7 @@ describe('ngClass animations', function() {
       expect(enterComplete).toBe(false);
 
       $rootScope.$digest();
-      $$rAF.flush();
+      $animate.flush();
       $rootScope.$digest();
 
       expect(element.hasClass('crazy')).toBe(true);

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -428,9 +428,11 @@ describe('ngInclude', function() {
       });
 
       expect(autoScrollSpy).not.toHaveBeenCalled();
-      expect($animate.queue.shift().event).toBe('enter');
-      $animate.triggerCallbacks();
 
+      $animate.flush();
+      $rootScope.$digest();
+
+      expect($animate.queue.shift().event).toBe('enter');
       expect(autoScrollSpy).toHaveBeenCalledOnce();
     }));
 
@@ -446,7 +448,6 @@ describe('ngInclude', function() {
       });
 
       expect($animate.queue.shift().event).toBe('enter');
-      $animate.triggerCallbacks();
 
       $rootScope.$apply(function() {
         $rootScope.tpl = 'another.html';
@@ -455,7 +456,6 @@ describe('ngInclude', function() {
 
       expect($animate.queue.shift().event).toBe('leave');
       expect($animate.queue.shift().event).toBe('enter');
-      $animate.triggerCallbacks();
 
       $rootScope.$apply(function() {
         $rootScope.tpl = 'template.html';
@@ -464,7 +464,9 @@ describe('ngInclude', function() {
 
       expect($animate.queue.shift().event).toBe('leave');
       expect($animate.queue.shift().event).toBe('enter');
-      $animate.triggerCallbacks();
+
+      $animate.flush();
+      $rootScope.$digest();
 
       expect(autoScrollSpy).toHaveBeenCalled();
       expect(autoScrollSpy.callCount).toBe(3);
@@ -480,7 +482,6 @@ describe('ngInclude', function() {
       });
 
       expect($animate.queue.shift().event).toBe('enter');
-      $animate.triggerCallbacks();
       expect(autoScrollSpy).not.toHaveBeenCalled();
     }));
 
@@ -496,7 +497,6 @@ describe('ngInclude', function() {
       });
 
       expect($animate.queue.shift().event).toBe('enter');
-      $animate.triggerCallbacks();
 
       $rootScope.$apply(function() {
         $rootScope.tpl = 'template.html';
@@ -518,7 +518,9 @@ describe('ngInclude', function() {
 
           $rootScope.$apply("tpl = 'template.html'");
           expect($animate.queue.shift().event).toBe('enter');
-          $animate.triggerCallbacks();
+
+          $animate.flush();
+          $rootScope.$digest();
 
           expect(autoScrollSpy).toHaveBeenCalledOnce();
         }

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -1462,7 +1462,7 @@ describe('ngRepeat animations', function() {
   }));
 
   it('should not change the position of the block that is being animated away via a leave animation',
-    inject(function($compile, $rootScope, $animate, $document, $window, $sniffer, $timeout, $$rAF) {
+    inject(function($compile, $rootScope, $animate, $document, $window, $sniffer, $timeout) {
       if (!$sniffer.transitions) return;
 
       var item;
@@ -1487,7 +1487,7 @@ describe('ngRepeat animations', function() {
         $rootScope.$digest();
 
         expect(element.text()).toBe('123'); // the original order should be preserved
-        $$rAF.flush();
+        $animate.flush();
         $timeout.flush(1500); // 1s * 1.5 closing buffer
         expect(element.text()).toBe('13');
       } finally {

--- a/test/ng/rafSpec.js
+++ b/test/ng/rafSpec.js
@@ -31,46 +31,6 @@ describe('$$rAF', function() {
     expect(present).toBe(true);
   }));
 
-  it('should only consume only one RAF if multiple async functions are registered before the first frame kicks in', inject(function($$rAF) {
-    if (!$$rAF.supported) return;
-
-    //we need to create our own injector to work around the ngMock overrides
-    var rafLog = [];
-    var injector = createInjector(['ng', function($provide) {
-      $provide.value('$window', {
-        location: window.location,
-        history: window.history,
-        webkitRequestAnimationFrame: function(fn) {
-          rafLog.push(fn);
-        }
-      });
-    }]);
-
-    $$rAF = injector.get('$$rAF');
-
-    var log = [];
-    function logFn() {
-      log.push(log.length);
-    }
-
-    $$rAF(logFn);
-    $$rAF(logFn);
-    $$rAF(logFn);
-
-    expect(log).toEqual([]);
-    expect(rafLog.length).toBe(1);
-
-    rafLog[0]();
-
-    expect(log).toEqual([0,1,2]);
-    expect(rafLog.length).toBe(1);
-
-    $$rAF(logFn);
-
-    expect(log).toEqual([0,1,2]);
-    expect(rafLog.length).toBe(2);
-  }));
-
   describe('$timeout fallback', function() {
     it("it should use a $timeout incase native rAF isn't suppored", function() {
       var timeoutSpy = jasmine.createSpy('callback');

--- a/test/ngAnimate/animateCssDriverSpec.js
+++ b/test/ngAnimate/animateCssDriverSpec.js
@@ -3,6 +3,7 @@
 describe("ngAnimate $$animateCssDriver", function() {
 
   beforeEach(module('ngAnimate'));
+  beforeEach(module('ngAnimateMock'));
 
   function int(x) {
     return parseInt(x, 10);
@@ -414,7 +415,7 @@ describe("ngAnimate $$animateCssDriver", function() {
       }));
 
       it("should then do an addClass('ng-anchor-in') animation on the cloned anchor and remove the old class",
-        inject(function($rootElement, $$rAF) {
+        inject(function($rootElement) {
 
         var fromAnchor = jqLite('<div></div>');
         from.append(fromAnchor);
@@ -434,7 +435,6 @@ describe("ngAnimate $$animateCssDriver", function() {
         }).start();
 
         captureLog.pop().runner.end();
-        $$rAF.flush();
 
         var anchorDetails = captureLog.pop().args[1];
         expect(anchorDetails.removeClass.trim()).toBe('ng-anchor-out');
@@ -464,7 +464,7 @@ describe("ngAnimate $$animateCssDriver", function() {
           });
         });
 
-        inject(function($rootElement, $$rAF) {
+        inject(function($rootElement, $animate) {
           var fromAnchor = jqLite('<div></div>');
           from.append(fromAnchor);
           var toAnchor = jqLite('<div></div>');
@@ -488,7 +488,7 @@ describe("ngAnimate $$animateCssDriver", function() {
 
           expect(animationStarted).toBe(expectedClass);
           runner.end();
-          $$rAF.flush();
+          $animate.flush();
           expect(complete).toBe(true);
         });
       });
@@ -552,7 +552,7 @@ describe("ngAnimate $$animateCssDriver", function() {
         expect(int(fromStyles.left)).toBeGreaterThan(149);
       }));
 
-      it("should append a `px` value for all seeded animation styles", inject(function($rootElement, $$rAF) {
+      it("should append a `px` value for all seeded animation styles", inject(function($rootElement) {
         ss.addRule('.starting-element', 'width:10px; height:20px; display:inline-block;');
 
         var fromAnchor = jqLite('<div class="starting-element"' +
@@ -582,7 +582,6 @@ describe("ngAnimate $$animateCssDriver", function() {
 
         // the out animation goes first
         anchorAnimation.runner.end();
-        $$rAF.flush();
 
         anchorAnimation = captureLog.pop();
         anchorDetails = anchorAnimation.args[1];
@@ -593,7 +592,7 @@ describe("ngAnimate $$animateCssDriver", function() {
       }));
 
       it("should then do an removeClass('out') + addClass('in') animation on the cloned anchor",
-        inject(function($rootElement, $$rAF) {
+        inject(function($rootElement) {
 
         var fromAnchor = jqLite('<div></div>');
         from.append(fromAnchor);
@@ -614,7 +613,6 @@ describe("ngAnimate $$animateCssDriver", function() {
 
         // the out animation goes first
         captureLog.pop().runner.end();
-        $$rAF.flush();
 
         var anchorDetails = captureLog.pop().args[1];
         expect(anchorDetails.removeClass).toMatch(/\bout\b/);
@@ -623,7 +621,7 @@ describe("ngAnimate $$animateCssDriver", function() {
       }));
 
       it("should add the `ng-anchor` class to the cloned anchor element",
-        inject(function($rootElement, $$rAF) {
+        inject(function($rootElement) {
 
         var fromAnchor = jqLite('<div></div>');
         from.append(fromAnchor);
@@ -647,7 +645,7 @@ describe("ngAnimate $$animateCssDriver", function() {
       }));
 
       it("should add and remove the `ng-animate-shim` class on the in anchor element during the animation",
-        inject(function($rootElement, $$rAF) {
+        inject(function($rootElement) {
 
         var fromAnchor = jqLite('<div></div>');
         from.append(fromAnchor);
@@ -670,14 +668,13 @@ describe("ngAnimate $$animateCssDriver", function() {
 
         // the out animation goes first
         captureLog.pop().runner.end();
-        $$rAF.flush();
         captureLog.pop().runner.end();
 
         expect(fromAnchor).not.toHaveClass('ng-animate-shim');
       }));
 
       it("should add and remove the `ng-animate-shim` class on the out anchor element during the animation",
-        inject(function($rootElement, $$rAF) {
+        inject(function($rootElement) {
 
         var fromAnchor = jqLite('<div></div>');
         from.append(fromAnchor);
@@ -700,7 +697,6 @@ describe("ngAnimate $$animateCssDriver", function() {
 
         // the out animation goes first
         captureLog.pop().runner.end();
-        $$rAF.flush();
 
         expect(toAnchor).toHaveClass('ng-animate-shim');
         captureLog.pop().runner.end();
@@ -709,7 +705,7 @@ describe("ngAnimate $$animateCssDriver", function() {
       }));
 
       it("should create the cloned anchor with all of the classes from the from anchor element",
-        inject(function($rootElement, $$rAF) {
+        inject(function($rootElement) {
 
         var fromAnchor = jqLite('<div class="yes no maybe"></div>');
         from.append(fromAnchor);
@@ -733,7 +729,7 @@ describe("ngAnimate $$animateCssDriver", function() {
       }));
 
       it("should remove the classes of the starting anchor from the cloned anchor node during the in animation and also add the classes of the destination anchor within the same animation",
-        inject(function($rootElement, $$rAF) {
+        inject(function($rootElement) {
 
         var fromAnchor = jqLite('<div class="yes no maybe"></div>');
         from.append(fromAnchor);
@@ -754,7 +750,6 @@ describe("ngAnimate $$animateCssDriver", function() {
 
         // the out animation goes first
         captureLog.pop().runner.end();
-        $$rAF.flush();
 
         var anchorDetails = captureLog.pop().args[1];
         var removedClasses = anchorDetails.removeClass.split(' ');
@@ -765,7 +760,7 @@ describe("ngAnimate $$animateCssDriver", function() {
       }));
 
       it("should not attempt to add/remove any classes that contain a `ng-` prefix",
-        inject(function($rootElement, $$rAF) {
+        inject(function($rootElement) {
 
         var fromAnchor = jqLite('<div class="ng-yes ng-no sure"></div>');
         from.append(fromAnchor);
@@ -786,7 +781,6 @@ describe("ngAnimate $$animateCssDriver", function() {
 
         // the out animation goes first
         captureLog.pop().runner.end();
-        $$rAF.flush();
 
         var inAnimation = captureLog.pop();
         var details = inAnimation.args[1];
@@ -802,7 +796,7 @@ describe("ngAnimate $$animateCssDriver", function() {
       }));
 
       it("should not remove any shared CSS classes between the starting and destination anchor element during the in animation",
-        inject(function($rootElement, $$rAF) {
+        inject(function($rootElement) {
 
         var fromAnchor = jqLite('<div class="blue green red"></div>');
         from.append(fromAnchor);
@@ -823,7 +817,6 @@ describe("ngAnimate $$animateCssDriver", function() {
 
         // the out animation goes first
         captureLog.pop().runner.end();
-        $$rAF.flush();
 
         var inAnimation = captureLog.pop();
         var clonedAnchor = inAnimation.element;
@@ -851,7 +844,7 @@ describe("ngAnimate $$animateCssDriver", function() {
       }));
 
       it("should continue the anchor animation by seeding the to styles based on where the final anchor element will be positioned",
-      inject(function($rootElement, $$rAF) {
+      inject(function($rootElement) {
         ss.addRule('.ending-element', 'width:9999px; height:6666px; display:inline-block;');
 
         var fromAnchor = jqLite('<div></div>');
@@ -874,7 +867,6 @@ describe("ngAnimate $$animateCssDriver", function() {
         }).start();
 
         captureLog.pop().runner.end();
-        $$rAF.flush();
 
         var anchorAnimation = captureLog.pop();
         var anchorElement = anchorAnimation.element;
@@ -889,7 +881,7 @@ describe("ngAnimate $$animateCssDriver", function() {
       }));
 
       it("should remove the cloned anchor node from the DOM once the 'in' animation is complete",
-        inject(function($rootElement, $$rAF) {
+        inject(function($rootElement) {
 
         var fromAnchor = jqLite('<div class="blue green red"></div>');
         from.append(fromAnchor);
@@ -913,7 +905,6 @@ describe("ngAnimate $$animateCssDriver", function() {
         var clonedAnchor = inAnimation.element;
         expect(clonedAnchor.parent().length).toBe(1);
         inAnimation.runner.end();
-        $$rAF.flush();
 
         // now the in animation completes
         expect(clonedAnchor.parent().length).toBe(1);
@@ -923,7 +914,7 @@ describe("ngAnimate $$animateCssDriver", function() {
       }));
 
       it("should pass the provided domOperation into $animateCss to be run right after the element is animated if a leave animation is present",
-        inject(function($rootElement, $$rAF) {
+        inject(function($rootElement) {
 
         toAnimation.structural = true;
         toAnimation.event = 'enter';
@@ -949,7 +940,7 @@ describe("ngAnimate $$animateCssDriver", function() {
       }));
 
       it("should fire the returned runner promise when the from, to and anchor animations are all complete",
-        inject(function($rootElement, $rootScope, $$rAF) {
+        inject(function($rootElement, $rootScope, $animate) {
 
         ss.addRule('.ending-element', 'width:9999px; height:6666px; display:inline-block;');
 
@@ -978,7 +969,8 @@ describe("ngAnimate $$animateCssDriver", function() {
         captureLog.pop().runner.end(); //to
         captureLog.pop().runner.end(); //anchor(out)
         captureLog.pop().runner.end(); //anchor(in)
-        $$rAF.flush();
+
+        $animate.flush();
         $rootScope.$digest();
 
         expect(completed).toBe(true);

--- a/test/ngAnimate/animateCssSpec.js
+++ b/test/ngAnimate/animateCssSpec.js
@@ -3,6 +3,7 @@
 describe("ngAnimate $animateCss", function() {
 
   beforeEach(module('ngAnimate'));
+  beforeEach(module('ngAnimateMock'));
 
   function assertAnimationRunning(element, not) {
     var className = element.attr('class');
@@ -52,7 +53,7 @@ describe("ngAnimate $animateCss", function() {
     if (!browserSupportsCssAnimations()) return;
 
     it("should silently quit the animation and not throw when an element has no parent during preparation",
-      inject(function($animateCss, $$rAF, $rootScope, $document, $rootElement) {
+      inject(function($animateCss, $rootScope, $document, $rootElement) {
 
       var element = jqLite('<div></div>');
       expect(function() {
@@ -385,7 +386,7 @@ describe("ngAnimate $animateCss", function() {
         they("should close the animation, but still accept $prop callbacks if no animation is detected",
           ['done', 'then'], function(method) {
 
-          inject(function($animateCss, $$rAF, $rootScope) {
+          inject(function($animateCss, $animate, $rootScope) {
             ss.addRule('.the-third-fake-animation', 'background:green;');
 
             element.addClass('another-fake-animation');
@@ -400,7 +401,8 @@ describe("ngAnimate $animateCss", function() {
             });
 
             expect(done).toBe(false);
-            $$rAF.flush();
+            $animate.flush();
+
             if (method === 'then') {
               $rootScope.$digest();
             }
@@ -411,7 +413,7 @@ describe("ngAnimate $animateCss", function() {
         they("should close the animation, but still accept recognize runner.$prop if no animation is detected",
           ['done(cancel)', 'catch'], function(method) {
 
-          inject(function($animateCss, $$rAF, $rootScope) {
+          inject(function($animateCss, $rootScope) {
             ss.addRule('.the-third-fake-animation', 'background:green;');
 
             element.addClass('another-fake-animation');
@@ -1078,7 +1080,7 @@ describe("ngAnimate $animateCss", function() {
         }));
 
         it("should still resolve the animation once expired",
-          inject(function($animateCss, $$body, $rootElement, $timeout) {
+          inject(function($animateCss, $$body, $rootElement, $timeout, $animate, $rootScope) {
 
           ss.addRule('.ng-enter', 'transition:10s linear all;');
 
@@ -1097,11 +1099,13 @@ describe("ngAnimate $animateCss", function() {
 
           triggerAnimationStartFrame();
           $timeout.flush(15000);
+          $animate.flush();
+          $rootScope.$digest();
           expect(passed).toBe(true);
         }));
 
         it("should not resolve/reject after passing if the animation completed successfully",
-          inject(function($animateCss, $$body, $rootElement, $timeout, $rootScope) {
+          inject(function($animateCss, $$body, $rootElement, $timeout, $rootScope, $animate) {
 
           ss.addRule('.ng-enter', 'transition:10s linear all;');
 
@@ -1125,6 +1129,7 @@ describe("ngAnimate $animateCss", function() {
           browserTrigger(element, 'transitionend',
             { timeStamp: Date.now() + 1000, elapsedTime: 10 });
 
+          $animate.flush();
           $rootScope.$digest();
 
           expect(passed).toBe(true);
@@ -1137,7 +1142,7 @@ describe("ngAnimate $animateCss", function() {
         }));
 
         it("should close all stacked animations after the last timeout runs on the same element",
-          inject(function($animateCss, $$body, $rootElement, $timeout) {
+          inject(function($animateCss, $$body, $rootElement, $timeout, $animate) {
 
           var now = 0;
           spyOn(Date, 'now').andCallFake(function() {
@@ -1176,6 +1181,8 @@ describe("ngAnimate $animateCss", function() {
 
           // this will close the animations fully
           fastForwardClock(3500);
+          $animate.flush();
+
           expect(doneSpy).toHaveBeenCalled();
           expect(doneSpy.callCount).toBe(3);
 
@@ -1218,7 +1225,7 @@ describe("ngAnimate $animateCss", function() {
         }));
 
         it("should cache frequent calls to getComputedStyle before the next animation frame kicks in",
-          inject(function($animateCss, $document, $rootElement, $$rAF) {
+          inject(function($animateCss, $document, $rootElement) {
 
           var i, elm, animator;
           for (i = 0; i < 5; i++) {

--- a/test/ngAnimate/animateJsDriverSpec.js
+++ b/test/ngAnimate/animateJsDriverSpec.js
@@ -3,6 +3,7 @@
 describe("ngAnimate $$animateJsDriver", function() {
 
   beforeEach(module('ngAnimate'));
+  beforeEach(module('ngAnimateMock'));
 
   it('should register the $$animateJsDriver into the list of drivers found in $animateProvider',
     module(function($animateProvider) {
@@ -96,7 +97,7 @@ describe("ngAnimate $$animateJsDriver", function() {
     }));
 
     they('should $prop both animations when $prop() is called on the runner', ['end', 'cancel'], function(method) {
-      inject(function($rootScope, $$rAF) {
+      inject(function($rootScope, $animate) {
         var child1 = jqLite('<div></div>');
         element.append(child1);
         var child2 = jqLite('<div></div>');
@@ -127,7 +128,7 @@ describe("ngAnimate $$animateJsDriver", function() {
         $rootScope.$digest();
 
         runner[method]();
-        $$rAF.flush();
+        $animate.flush();
 
         expect(animationsClosed).toBe(true);
         expect(status).toBe(method === 'end' ? true : false);
@@ -135,7 +136,7 @@ describe("ngAnimate $$animateJsDriver", function() {
     });
 
     they('should fully $prop when all inner animations are complete', ['end', 'cancel'], function(method) {
-      inject(function($rootScope, $$rAF) {
+      inject(function($rootScope, $animate) {
         var child1 = jqLite('<div></div>');
         element.append(child1);
         var child2 = jqLite('<div></div>');
@@ -163,12 +164,12 @@ describe("ngAnimate $$animateJsDriver", function() {
           status = s;
         });
 
-        $$rAF.flush();
-
         captureLog[0].runner[method]();
         expect(animationsClosed).toBe(false);
 
         captureLog[1].runner[method]();
+        $animate.flush();
+
         expect(animationsClosed).toBe(true);
 
         expect(status).toBe(method === 'end' ? true : false);

--- a/test/ngAnimate/animateJsSpec.js
+++ b/test/ngAnimate/animateJsSpec.js
@@ -3,6 +3,7 @@
 describe("ngAnimate $$animateJs", function() {
 
   beforeEach(module('ngAnimate'));
+  beforeEach(module('ngAnimateMock'));
 
   function getDoneFunction(args) {
     for (var i = 1; i < args.length; i++) {
@@ -86,7 +87,7 @@ describe("ngAnimate $$animateJs", function() {
       $animateProvider.register('.two', makeAnimation('enter'));
       $animateProvider.register('.three', makeAnimation('enter'));
     });
-    inject(function($$animateJs, $$rAF) {
+    inject(function($$animateJs, $animate) {
       var element = jqLite('<div class="one two three"></div>');
       var animator = $$animateJs(element, 'enter');
       var complete = false;
@@ -97,7 +98,7 @@ describe("ngAnimate $$animateJs", function() {
       forEach(doneCallbacks, function(cb) {
         cb();
       });
-      $$rAF.flush();
+      $animate.flush();
       expect(complete).toBe(true);
     });
   });
@@ -206,7 +207,7 @@ describe("ngAnimate $$animateJs", function() {
         };
       });
     });
-    inject(function($$animateJs, $$rAF) {
+    inject(function($$animateJs, $animate) {
       var element = jqLite('<div class="the-end"></div>');
       var animator = $$animateJs(element, 'addClass', {
         addClass: 'red'
@@ -221,12 +222,12 @@ describe("ngAnimate $$animateJs", function() {
       before();
 
       expect(after).toBeUndefined();
-      $$rAF.flush();
+      $animate.flush();
       expect(after).toBeDefined();
       after();
 
       expect(endCalled).toBeUndefined();
-      $$rAF.flush();
+      $animate.flush();
       expect(endCalled).toBe(true);
     });
   });
@@ -251,7 +252,7 @@ describe("ngAnimate $$animateJs", function() {
         };
       });
     });
-    inject(function($$animateJs, $$rAF) {
+    inject(function($$animateJs, $animate) {
       var element = jqLite('<div class="the-end"></div>');
       var animator = $$animateJs(element, 'addClass', {
         domOperation: function() {
@@ -264,7 +265,7 @@ describe("ngAnimate $$animateJs", function() {
       });
       runner[method]();
 
-      $$rAF.flush();
+      $animate.flush();
       expect(log).toEqual(
         ['before addClass ' + method,
          'dom addClass',
@@ -278,7 +279,7 @@ describe("ngAnimate $$animateJs", function() {
         return { beforeAddClass: noop };
       });
     });
-    inject(function($$animateJs, $$rAF, $rootScope) {
+    inject(function($$animateJs, $animate, $rootScope) {
       var element = jqLite('<div class="the-end"></div>');
       var animator = $$animateJs(element, 'addClass');
       var runner = animator.start();
@@ -291,7 +292,7 @@ describe("ngAnimate $$animateJs", function() {
         });
 
       runner.end();
-      $$rAF.flush();
+      $animate.flush();
       $rootScope.$digest();
       expect(done).toBe(true);
       expect(cancelled).toBe(false);
@@ -304,7 +305,7 @@ describe("ngAnimate $$animateJs", function() {
         return { beforeAddClass: noop };
       });
     });
-    inject(function($$animateJs, $$rAF, $rootScope) {
+    inject(function($$animateJs, $animate, $rootScope) {
       var element = jqLite('<div class="the-end"></div>');
       var animator = $$animateJs(element, 'addClass');
       var runner = animator.start();
@@ -317,7 +318,7 @@ describe("ngAnimate $$animateJs", function() {
       });
 
       runner.cancel();
-      $$rAF.flush();
+      $animate.flush();
       $rootScope.$digest();
       expect(done).toBe(false);
       expect(cancelled).toBe(true);
@@ -504,7 +505,7 @@ describe("ngAnimate $$animateJs", function() {
     var allEvents = ['leave'].concat(otherEvents).concat(enterMoveEvents);
 
     they("$prop should asynchronously render the before$prop animation", otherEvents, function(event) {
-      inject(function($$rAF) {
+      inject(function($animate) {
         var beforeMethod = 'before' + event.charAt(0).toUpperCase() + event.substr(1);
         animations[beforeMethod] = function(element, a, b, c) {
           log.push('before ' + event);
@@ -514,14 +515,14 @@ describe("ngAnimate $$animateJs", function() {
 
         runAnimation(event);
         expect(log).toEqual(['before ' + event]);
-        $$rAF.flush();
+        $animate.flush();
 
         expect(log).toEqual(['before ' + event, 'dom ' + event]);
       });
     });
 
     they("$prop should asynchronously render the $prop animation", allEvents, function(event) {
-      inject(function($$rAF) {
+      inject(function($animate) {
         animations[event] = function(element, a, b, c) {
           log.push('after ' + event);
           var done = getDoneFunction(arguments);
@@ -534,11 +535,11 @@ describe("ngAnimate $$animateJs", function() {
 
         if (event === 'leave') {
           expect(log).toEqual(['after leave']);
-          $$rAF.flush();
+          $animate.flush();
           expect(log).toEqual(['after leave', 'dom leave', 'complete']);
         } else {
           expect(log).toEqual(['dom ' + event, 'after ' + event]);
-          $$rAF.flush();
+          $animate.flush();
           expect(log).toEqual(['dom ' + event, 'after ' + event, 'complete']);
         }
       });
@@ -547,7 +548,7 @@ describe("ngAnimate $$animateJs", function() {
     they("$prop should asynchronously render the $prop animation when a start/end animator object is returned",
       allEvents, function(event) {
 
-      inject(function($$rAF, $$AnimateRunner) {
+      inject(function($animate, $$AnimateRunner) {
         var runner;
         animations[event] = function(element, a, b, c) {
           return {
@@ -565,12 +566,12 @@ describe("ngAnimate $$animateJs", function() {
         if (event === 'leave') {
           expect(log).toEqual(['start leave']);
           runner.end();
-          $$rAF.flush();
+          $animate.flush();
           expect(log).toEqual(['start leave', 'dom leave', 'complete']);
         } else {
           expect(log).toEqual(['dom ' + event, 'start ' + event]);
           runner.end();
-          $$rAF.flush();
+          $animate.flush();
           expect(log).toEqual(['dom ' + event, 'start ' + event, 'complete']);
         }
       });
@@ -579,7 +580,7 @@ describe("ngAnimate $$animateJs", function() {
     they("$prop should asynchronously render the $prop animation when an instance of $$AnimateRunner is returned",
       allEvents, function(event) {
 
-      inject(function($$rAF, $$AnimateRunner) {
+      inject(function($animate, $$AnimateRunner) {
         var runner;
         animations[event] = function(element, a, b, c) {
           log.push('start ' + event);
@@ -593,19 +594,19 @@ describe("ngAnimate $$animateJs", function() {
         if (event === 'leave') {
           expect(log).toEqual(['start leave']);
           runner.end();
-          $$rAF.flush();
+          $animate.flush();
           expect(log).toEqual(['start leave', 'dom leave', 'complete']);
         } else {
           expect(log).toEqual(['dom ' + event, 'start ' + event]);
           runner.end();
-          $$rAF.flush();
+          $animate.flush();
           expect(log).toEqual(['dom ' + event, 'start ' + event, 'complete']);
         }
       });
     });
 
     they("$prop should asynchronously reject the before animation if the callback function is called with false", otherEvents, function(event) {
-      inject(function($$rAF, $rootScope) {
+      inject(function($animate, $rootScope) {
         var beforeMethod = 'before' + event.charAt(0).toUpperCase() + event.substr(1);
         animations[beforeMethod] = function(element, a, b, c) {
           log.push('before ' + event);
@@ -624,13 +625,13 @@ describe("ngAnimate $$animateJs", function() {
           function() { log.push('fail'); });
 
         expect(log).toEqual(['before ' + event]);
-        $$rAF.flush();
+        $animate.flush();
         expect(log).toEqual(['before ' + event, 'dom ' + event, 'fail']);
       });
     });
 
     they("$prop should asynchronously reject the after animation if the callback function is called with false", allEvents, function(event) {
-      inject(function($$rAF, $rootScope) {
+      inject(function($animate, $rootScope) {
         animations[event] = function(element, a, b, c) {
           log.push('after ' + event);
           var done = getDoneFunction(arguments);
@@ -644,17 +645,17 @@ describe("ngAnimate $$animateJs", function() {
         var expectations = [];
         if (event === 'leave') {
           expect(log).toEqual(['after leave']);
-          $$rAF.flush();
+          $animate.flush();
           expect(log).toEqual(['after leave', 'dom leave', 'fail']);
         } else {
           expect(log).toEqual(['dom ' + event, 'after ' + event]);
-          $$rAF.flush();
+          $animate.flush();
           expect(log).toEqual(['dom ' + event, 'after ' + event, 'fail']);
         }
       });
     });
 
-    it('setClass should delegate down to addClass/removeClass if not defined', inject(function($$rAF) {
+    it('setClass should delegate down to addClass/removeClass if not defined', inject(function($animate) {
       animations.addClass = function(element, done) {
         log.push('addClass');
       };
@@ -671,7 +672,7 @@ describe("ngAnimate $$animateJs", function() {
     }));
 
     it('beforeSetClass should delegate down to beforeAddClass/beforeRemoveClass if not defined',
-      inject(function($$rAF) {
+      inject(function($animate) {
 
       animations.beforeAddClass = function(element, className, done) {
         log.push('beforeAddClass');
@@ -686,13 +687,13 @@ describe("ngAnimate $$animateJs", function() {
       expect(animations.setClass).toBeFalsy();
 
       runAnimation('setClass');
-      $$rAF.flush();
+      $animate.flush();
 
       expect(log).toEqual(['beforeRemoveClass', 'beforeAddClass', 'dom setClass']);
     }));
 
     it('leave should always ignore the `beforeLeave` animation',
-      inject(function($$rAF) {
+      inject(function($animate) {
 
       animations.beforeLeave = function(element, done) {
         log.push('beforeLeave');
@@ -705,13 +706,13 @@ describe("ngAnimate $$animateJs", function() {
       };
 
       runAnimation('leave');
-      $$rAF.flush();
+      $animate.flush();
 
       expect(log).toEqual(['leave', 'dom leave']);
     }));
 
     it('should allow custom events to be triggered',
-      inject(function($$rAF) {
+      inject(function($animate) {
 
       animations.beforeFlex = function(element, done) {
         log.push('beforeFlex');
@@ -724,7 +725,7 @@ describe("ngAnimate $$animateJs", function() {
       };
 
       runAnimation('flex');
-      $$rAF.flush();
+      $animate.flush();
 
       expect(log).toEqual(['beforeFlex', 'dom flex', 'flex']);
     }));

--- a/test/ngAnimate/animateRunnerSpec.js
+++ b/test/ngAnimate/animateRunnerSpec.js
@@ -1,12 +1,12 @@
 'use strict';
 
-describe('$$rAFMutex', function() {
+describe('$$animateAsyncRun', function() {
   beforeEach(module('ngAnimate'));
 
   it('should fire the callback only when one or more RAFs have passed',
-    inject(function($$rAF, $$rAFMutex) {
+    inject(function($$animateAsyncRun, $$rAF) {
 
-    var trigger = $$rAFMutex();
+    var trigger = $$animateAsyncRun();
     var called = false;
     trigger(function() {
       called = true;
@@ -18,9 +18,9 @@ describe('$$rAFMutex', function() {
   }));
 
   it('should immediately fire the callback if a RAF has passed since construction',
-    inject(function($$rAF, $$rAFMutex) {
+    inject(function($$animateAsyncRun, $$rAF) {
 
-    var trigger = $$rAFMutex();
+    var trigger = $$animateAsyncRun();
     $$rAF.flush();
 
     var called = false;
@@ -89,7 +89,7 @@ describe("$$AnimateRunner", function() {
   they("should immediately resolve each combined runner in a bottom-up order when $prop is called",
     ['end', 'cancel'], function(method) {
 
-    inject(function($$AnimateRunner, $$rAF) {
+    inject(function($$AnimateRunner) {
       var runner1 = new $$AnimateRunner();
       var runner2 = new $$AnimateRunner();
       runner1.setHost(runner2);
@@ -206,7 +206,7 @@ describe("$$AnimateRunner", function() {
     they("should immediately resolve if and when all runners have been $prop",
       { ended: 'end', cancelled: 'cancel' }, function(method) {
 
-      inject(function($$rAF, $$AnimateRunner) {
+      inject(function($$AnimateRunner) {
         var runner1 = new $$AnimateRunner();
         var runner2 = new $$AnimateRunner();
         var runner3 = new $$AnimateRunner();
@@ -227,7 +227,7 @@ describe("$$AnimateRunner", function() {
     });
 
     it("should return a status of `false` if one or more runners was cancelled",
-      inject(function($$rAF, $$AnimateRunner) {
+      inject(function($$AnimateRunner) {
 
       var runner1 = new $$AnimateRunner();
       var runner2 = new $$AnimateRunner();

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -3,6 +3,7 @@
 describe("animations", function() {
 
   beforeEach(module('ngAnimate'));
+  beforeEach(module('ngAnimateMock'));
 
   var element, applyAnimationClasses;
   afterEach(inject(function($$jqLite) {
@@ -410,7 +411,7 @@ describe("animations", function() {
     }));
 
     it('should remove all element and comment nodes during leave animation',
-      inject(function($compile, $rootScope, $$rAF, $$AnimateRunner) {
+      inject(function($compile, $rootScope, $animate, $$AnimateRunner) {
 
       element = $compile(
         '<div>' +
@@ -433,7 +434,7 @@ describe("animations", function() {
       $rootScope.items.length = 0;
       $rootScope.$digest();
       runner.end();
-      $$rAF.flush();
+      $animate.flush();
 
       // we're left with a text node and a comment node
       expect(element[0].childNodes.length).toBeLessThan(3);
@@ -671,7 +672,7 @@ describe("animations", function() {
       they('should not cancel a pre-digest parent class-based animation if a child $prop animation is set to run',
         ['structural', 'class-based'], function(animationType) {
 
-        inject(function($rootScope, $animate, $$rAF) {
+        inject(function($rootScope, $animate) {
           parent.append(element);
           var child = jqLite('<div></div>');
 
@@ -692,7 +693,7 @@ describe("animations", function() {
       they('should not cancel a post-digest parent class-based animation if a child $prop animation is set to run',
         ['structural', 'class-based'], function(animationType) {
 
-        inject(function($rootScope, $animate, $$rAF) {
+        inject(function($rootScope, $animate) {
           parent.append(element);
           var child = jqLite('<div></div>');
 
@@ -717,7 +718,7 @@ describe("animations", function() {
       they('should not cancel a post-digest $prop child animation if a class-based parent animation is set to run',
         ['structural', 'class-based'], function(animationType) {
 
-        inject(function($rootScope, $animate, $$rAF) {
+        inject(function($rootScope, $animate) {
           parent.append(element);
 
           var child = jqLite('<div></div>');
@@ -815,8 +816,8 @@ describe("animations", function() {
         expect(capturedAnimation).toBeFalsy();
       }));
 
-      it("should disable all child animations for atleast one RAF when a structural animation is issued",
-        inject(function($animate, $rootScope, $compile, $$body, $rootElement, $$rAF, $$AnimateRunner) {
+      it("should disable all child animations for atleast one turn when a structural animation is issued",
+        inject(function($animate, $rootScope, $compile, $$body, $rootElement, $$AnimateRunner) {
 
         element = $compile(
           '<div><div class="if-animation" ng-if="items.length">' +
@@ -847,7 +848,7 @@ describe("animations", function() {
         expect(element[0].querySelectorAll('.repeat-animation').length).toBe(2);
 
         runner.end();
-        $$rAF.flush();
+        $animate.flush();
 
         $rootScope.items = [1, 2, 3];
         $rootScope.$digest();
@@ -946,7 +947,7 @@ describe("animations", function() {
       }));
 
       it('should allow follow-up class-based animations to run in parallel on the same element',
-        inject(function($rootScope, $animate, $$rAF) {
+        inject(function($rootScope, $animate) {
 
         parent.append(element);
 
@@ -957,7 +958,7 @@ describe("animations", function() {
         });
 
         $rootScope.$digest();
-        $$rAF.flush();
+        $animate.flush();
         expect(capturedAnimation).toBeTruthy();
         expect(runner1done).toBeFalsy();
 
@@ -977,7 +978,7 @@ describe("animations", function() {
         });
 
         $rootScope.$digest();
-        $$rAF.flush();
+        $animate.flush();
         expect(capturedAnimation).toBeTruthy();
         expect(runner2done).toBeFalsy();
 
@@ -990,7 +991,7 @@ describe("animations", function() {
       }));
 
       it('should remove the animation block on child animations once the parent animation is complete',
-        inject(function($rootScope, $rootElement, $animate, $$AnimateRunner, $$rAF) {
+        inject(function($rootScope, $rootElement, $animate, $$AnimateRunner) {
 
         var runner = new $$AnimateRunner();
         overriddenAnimationRunner = runner;
@@ -1005,7 +1006,7 @@ describe("animations", function() {
         expect(capturedAnimationHistory.length).toBe(1);
 
         runner.end();
-        $$rAF.flush();
+        $animate.flush();
 
         $animate.addClass(element, 'stark');
         $rootScope.$digest();
@@ -1036,19 +1037,19 @@ describe("animations", function() {
       }));
 
       it('should cancel the previous structural animation if a follow-up structural animation takes over before the postDigest',
-        inject(function($animate, $$rAF) {
+        inject(function($animate) {
 
         var enterDone = jasmine.createSpy('enter animation done');
         $animate.enter(element, parent).done(enterDone);
         expect(enterDone).not.toHaveBeenCalled();
 
         $animate.leave(element);
-        $$rAF.flush();
+        $animate.flush();
         expect(enterDone).toHaveBeenCalled();
       }));
 
       it('should cancel the previously running addClass animation if a follow-up removeClass animation is using the same class value',
-        inject(function($animate, $rootScope, $$rAF) {
+        inject(function($animate, $rootScope) {
 
         parent.append(element);
         var runner = $animate.addClass(element, 'active-class');
@@ -1057,7 +1058,7 @@ describe("animations", function() {
         var doneHandler = jasmine.createSpy('addClass done');
         runner.done(doneHandler);
 
-        $$rAF.flush();
+        $animate.flush();
 
         expect(doneHandler).not.toHaveBeenCalled();
 
@@ -1068,7 +1069,7 @@ describe("animations", function() {
       }));
 
       it('should cancel the previously running removeClass animation if a follow-up addClass animation is using the same class value',
-        inject(function($animate, $rootScope, $$rAF) {
+        inject(function($animate, $rootScope) {
 
         element.addClass('active-class');
         parent.append(element);
@@ -1078,7 +1079,7 @@ describe("animations", function() {
         var doneHandler = jasmine.createSpy('addClass done');
         runner.done(doneHandler);
 
-        $$rAF.flush();
+        $animate.flush();
 
         expect(doneHandler).not.toHaveBeenCalled();
 
@@ -1294,7 +1295,7 @@ describe("animations", function() {
       }));
 
       it('should not skip or miss the animations when animations are executed sequential',
-        inject(function($animate, $rootScope, $$rAF, $rootElement) {
+        inject(function($animate, $rootScope, $rootElement) {
 
         element = jqLite('<div></div>');
 
@@ -1306,8 +1307,6 @@ describe("animations", function() {
         $animate.removeClass(element, 'rclass');
 
         $rootScope.$digest();
-        $$rAF.flush();
-
         expect(element).not.toHaveClass('rclass');
       }));
     });
@@ -1532,7 +1531,7 @@ describe("animations", function() {
     }));
 
     it('should trigger a callback for an enter animation',
-      inject(function($animate, $rootScope, $$rAF, $rootElement, $$body) {
+      inject(function($animate, $rootScope, $rootElement, $$body) {
 
       var callbackTriggered = false;
       $animate.on('enter', $$body, function() {
@@ -1543,13 +1542,13 @@ describe("animations", function() {
       $animate.enter(element, $rootElement);
       $rootScope.$digest();
 
-      $$rAF.flush();
+      $animate.flush();
 
       expect(callbackTriggered).toBe(true);
     }));
 
     it('should fire the callback with the signature of (element, phase, data)',
-      inject(function($animate, $rootScope, $$rAF, $rootElement, $$body) {
+      inject(function($animate, $rootScope, $rootElement, $$body) {
 
       var capturedElement;
       var capturedPhase;
@@ -1565,7 +1564,7 @@ describe("animations", function() {
       element = jqLite('<div></div>');
       $animate.enter(element, $rootElement);
       $rootScope.$digest();
-      $$rAF.flush();
+      $animate.flush();
 
       expect(capturedElement).toBe(element);
       expect(isString(capturedPhase)).toBe(true);
@@ -1573,7 +1572,7 @@ describe("animations", function() {
     }));
 
     it('should not fire a callback if the element is outside of the given container',
-      inject(function($animate, $rootScope, $$rAF, $rootElement) {
+      inject(function($animate, $rootScope, $rootElement) {
 
       var callbackTriggered = false;
       var innerContainer = jqLite('<div></div>');
@@ -1588,13 +1587,13 @@ describe("animations", function() {
       element = jqLite('<div></div>');
       $animate.enter(element, $rootElement);
       $rootScope.$digest();
-      $$rAF.flush();
+      $animate.flush();
 
       expect(callbackTriggered).toBe(false);
     }));
 
     it('should fire a callback if the element is the given container',
-      inject(function($animate, $rootScope, $$rAF, $rootElement) {
+      inject(function($animate, $rootScope, $rootElement) {
 
       element = jqLite('<div></div>');
 
@@ -1607,13 +1606,13 @@ describe("animations", function() {
 
       $animate.enter(element, $rootElement);
       $rootScope.$digest();
-      $$rAF.flush();
+      $animate.flush();
 
       expect(callbackTriggered).toBe(true);
     }));
 
     it('should remove all the event-based event listeners when $animate.off(event) is called',
-      inject(function($animate, $rootScope, $$rAF, $rootElement, $$body) {
+      inject(function($animate, $rootScope, $rootElement, $$body) {
 
       element = jqLite('<div></div>');
 
@@ -1627,7 +1626,7 @@ describe("animations", function() {
 
       $animate.enter(element, $rootElement);
       $rootScope.$digest();
-      $$rAF.flush();
+      $animate.flush();
 
       expect(count).toBe(2);
 
@@ -1635,13 +1634,13 @@ describe("animations", function() {
 
       $animate.enter(element, $rootElement);
       $rootScope.$digest();
-      $$rAF.flush();
+      $animate.flush();
 
       expect(count).toBe(2);
     }));
 
     it('should remove the container-based event listeners when $animate.off(event, container) is called',
-      inject(function($animate, $rootScope, $$rAF, $rootElement, $$body) {
+      inject(function($animate, $rootScope, $rootElement, $$body) {
 
       element = jqLite('<div></div>');
 
@@ -1657,7 +1656,7 @@ describe("animations", function() {
 
       $animate.enter(element, $rootElement);
       $rootScope.$digest();
-      $$rAF.flush();
+      $animate.flush();
 
       expect(count).toBe(2);
 
@@ -1665,13 +1664,13 @@ describe("animations", function() {
 
       $animate.enter(element, $rootElement);
       $rootScope.$digest();
-      $$rAF.flush();
+      $animate.flush();
 
       expect(count).toBe(3);
     }));
 
     it('should remove the callback-based event listener when $animate.off(event, container, callback) is called',
-      inject(function($animate, $rootScope, $$rAF, $rootElement) {
+      inject(function($animate, $rootScope, $rootElement) {
 
       element = jqLite('<div></div>');
 
@@ -1693,7 +1692,7 @@ describe("animations", function() {
 
       $animate.enter(element, $rootElement);
       $rootScope.$digest();
-      $$rAF.flush();
+      $animate.flush();
 
       expect(count).toBe(2);
 
@@ -1701,13 +1700,13 @@ describe("animations", function() {
 
       $animate.enter(element, $rootElement);
       $rootScope.$digest();
-      $$rAF.flush();
+      $animate.flush();
 
       expect(count).toBe(3);
     }));
 
     it('should fire a `start` callback when the animation starts with the matching element',
-      inject(function($animate, $rootScope, $$rAF, $rootElement, $$body) {
+      inject(function($animate, $rootScope, $rootElement, $$body) {
 
       element = jqLite('<div></div>');
 
@@ -1720,14 +1719,14 @@ describe("animations", function() {
 
       $animate.enter(element, $rootElement);
       $rootScope.$digest();
-      $$rAF.flush();
+      $animate.flush();
 
       expect(capturedState).toBe('start');
       expect(capturedElement).toBe(element);
     }));
 
     it('should fire a `close` callback when the animation ends with the matching element',
-      inject(function($animate, $rootScope, $$rAF, $rootElement, $$body) {
+      inject(function($animate, $rootScope, $rootElement, $$body) {
 
       element = jqLite('<div></div>');
 
@@ -1741,14 +1740,14 @@ describe("animations", function() {
       var runner = $animate.enter(element, $rootElement);
       $rootScope.$digest();
       runner.end();
-      $$rAF.flush();
+      $animate.flush();
 
       expect(capturedState).toBe('close');
       expect(capturedElement).toBe(element);
     }));
 
     it('should remove the event listener if the element is removed',
-      inject(function($animate, $rootScope, $$rAF, $rootElement) {
+      inject(function($animate, $rootScope, $rootElement) {
 
       element = jqLite('<div></div>');
 
@@ -1764,19 +1763,20 @@ describe("animations", function() {
 
       $animate.enter(element, $rootElement);
       $rootScope.$digest();
-      $$rAF.flush();
+      $animate.flush();
 
       expect(count).toBe(1);
       element.remove();
 
       $animate.addClass(element, 'viljami');
       $rootScope.$digest();
-      $$rAF.flush();
+
+      $animate.flush();
       expect(count).toBe(1);
     }));
 
     it('leave: should remove the element even if another animation is called after',
-      inject(function($animate, $rootScope, $$rAF, $rootElement) {
+      inject(function($animate, $rootScope, $rootElement) {
 
       var outerContainer = jqLite('<div></div>');
       element = jqLite('<div></div>');
@@ -1787,7 +1787,7 @@ describe("animations", function() {
       $animate.removeClass(element,'rclass');
       $rootScope.$digest();
       runner.end();
-      $$rAF.flush();
+      $animate.flush();
 
       var isElementRemoved = !outerContainer[0].contains(element[0]);
       expect(isElementRemoved).toBe(true);

--- a/test/ngAnimate/animationSpec.js
+++ b/test/ngAnimate/animationSpec.js
@@ -3,6 +3,7 @@
 describe('$$animation', function() {
 
   beforeEach(module('ngAnimate'));
+  beforeEach(module('ngAnimateMock'));
 
   var element;
   afterEach(function() {
@@ -14,14 +15,14 @@ describe('$$animation', function() {
   }));
 
   it("should not run an animation if there are no drivers",
-    inject(function($$animation, $$rAF, $rootScope) {
+    inject(function($$animation, $animate, $rootScope) {
 
     element = jqLite('<div></div>');
     var done = false;
     $$animation(element, 'someEvent').then(function() {
       done = true;
     });
-    $$rAF.flush();
+    $animate.flush();
     $rootScope.$digest();
     expect(done).toBe(true);
   }));
@@ -33,14 +34,14 @@ describe('$$animation', function() {
         return false;
       });
     });
-    inject(function($$animation, $$rAF, $rootScope) {
+    inject(function($$animation, $animate, $rootScope) {
       element = jqLite('<div></div>');
       var done = false;
       $$animation(element, 'someEvent').then(function() {
         done = true;
       });
       $rootScope.$digest();
-      $$rAF.flush();
+      $animate.flush();
       $rootScope.$digest();
       expect(done).toBe(true);
     });
@@ -195,7 +196,7 @@ describe('$$animation', function() {
         });
       });
 
-      inject(function($$animation, $rootScope, $$rAF) {
+      inject(function($$animation, $rootScope, $animate) {
         var status, element = jqLite('<div></div>');
         var runner = $$animation(element, 'enter');
         runner.then(function() {
@@ -210,7 +211,7 @@ describe('$$animation', function() {
         event === 'resolve' ? runner.end() : runner.cancel();
 
         // the resolve/rejection digest
-        $$rAF.flush();
+        $animate.flush();
         $rootScope.$digest();
 
         expect(status).toBe(event);
@@ -306,7 +307,7 @@ describe('$$animation', function() {
 
       they('should close the animation if runner.$prop() is called before the $postDigest phase kicks in',
         ['end', 'cancel'], function(method) {
-        inject(function($$animation, $rootScope, $$rAF) {
+        inject(function($$animation, $rootScope, $animate) {
           var status;
           var runner = $$animation(element, 'someEvent');
           runner.then(function() { status = 'end'; },
@@ -316,7 +317,7 @@ describe('$$animation', function() {
           $rootScope.$digest();
           expect(runnerLog).toEqual([]);
 
-          $$rAF.flush();
+          $animate.flush();
           expect(status).toBe(method);
         });
       });
@@ -363,11 +364,10 @@ describe('$$animation', function() {
       }));
 
       it('should immediately end the animation if the element is removed from the DOM during the animation',
-        inject(function($$animation, $$rAF, $rootScope) {
+        inject(function($$animation, $animate, $rootScope) {
 
         var runner = $$animation(element, 'someEvent');
         $rootScope.$digest();
-        $$rAF.flush(); //the animation is "animating"
 
         expect(capturedAnimation).toBeTruthy();
         expect(runnerLog).toEqual([]);
@@ -376,14 +376,13 @@ describe('$$animation', function() {
       }));
 
       it('should not end the animation when the leave animation removes the element from the DOM',
-        inject(function($$animation, $$rAF, $rootScope) {
+        inject(function($$animation, $animate, $rootScope) {
 
         var runner = $$animation(element, 'leave', {}, function() {
           element.remove();
         });
 
         $rootScope.$digest();
-        $$rAF.flush(); //the animation is "animating"
 
         expect(runnerLog).toEqual([]);
         capturedAnimation.options.domOperation(); //this removes the element
@@ -392,7 +391,7 @@ describe('$$animation', function() {
       }));
 
       it('should remove the $destroy event listener when the animation is closed',
-        inject(function($$animation, $$rAF, $rootScope) {
+        inject(function($$animation, $rootScope) {
 
         var addListen = spyOn(element, 'on').andCallThrough();
         var removeListen = spyOn(element, 'off').andCallThrough();
@@ -408,7 +407,7 @@ describe('$$animation', function() {
       }));
 
       it('should always sort parent-element animations to run in order of parent-to-child DOM structure',
-        inject(function($$animation, $$rAF, $rootScope) {
+        inject(function($$animation, $rootScope) {
 
         var child = jqLite('<div></div>');
         var grandchild = jqLite('<div></div>');
@@ -649,7 +648,7 @@ describe('$$animation', function() {
       });
 
       it("should not end the animation when the `from` animation calls its own leave dom operation",
-        inject(function($$animation, $rootScope, $$rAF) {
+        inject(function($$animation, $rootScope) {
 
         fromElement.addClass('group-1');
         var elementRemoved = false;
@@ -679,7 +678,7 @@ describe('$$animation', function() {
       }));
 
       it("should not end the animation if any of the anchor elements are removed from the DOM during the animation",
-        inject(function($$animation, $rootScope, $$rAF) {
+        inject(function($$animation, $rootScope) {
 
         fromElement.addClass('group-1');
         var elementRemoved = false;
@@ -702,7 +701,7 @@ describe('$$animation', function() {
       }));
 
       it('should prepare a parent-element animation to run first before the anchored animation',
-        inject(function($$animation, $$rAF, $rootScope, $rootElement) {
+        inject(function($$animation, $rootScope, $rootElement) {
 
         fromAnchors[0].attr('ng-animate-ref', 'shared');
         toAnchors[0].attr('ng-animate-ref', 'shared');
@@ -869,7 +868,7 @@ describe('$$animation', function() {
           };
         });
       });
-      inject(function($$animation, $rootScope, $$rAF) {
+      inject(function($$animation, $rootScope, $animate) {
         element.addClass('four');
 
         var completed = false;
@@ -882,7 +881,7 @@ describe('$$animation', function() {
 
         $rootScope.$digest(); //runs the animation
         $rootScope.$digest(); //flushes the step code
-        $$rAF.flush(); //runs the $$animation promise
+        $animate.flush();
         $rootScope.$digest(); //the runner promise
 
         expect(completed).toBe(true);
@@ -921,7 +920,7 @@ describe('$$animation', function() {
           };
         });
       });
-      inject(function($$animation, $rootScope, $$rAF) {
+      inject(function($$animation, $rootScope, $animate) {
         element.addClass('four');
 
         var completed = false;
@@ -937,7 +936,7 @@ describe('$$animation', function() {
         $rootScope.$digest(); //flushes the step code
 
         runner.end();
-        $$rAF.flush(); //runs the $$animation promise
+        $animate.flush();
         $rootScope.$digest(); //the runner promise
 
         expect(completed).toBe(true);

--- a/test/ngAnimate/integrationSpec.js
+++ b/test/ngAnimate/integrationSpec.js
@@ -3,6 +3,7 @@
 describe('ngAnimate integration tests', function() {
 
   beforeEach(module('ngAnimate'));
+  beforeEach(module('ngAnimateMock'));
 
   var element, html, ss;
   beforeEach(module(function() {
@@ -30,7 +31,7 @@ describe('ngAnimate integration tests', function() {
     they('should render an $prop animation',
       ['enter', 'leave', 'move', 'addClass', 'removeClass', 'setClass'], function(event) {
 
-      inject(function($animate, $compile, $rootScope, $rootElement, $$rAF) {
+      inject(function($animate, $compile, $rootScope, $rootElement) {
         element = jqLite('<div class="animate-me"></div>');
         $compile(element)($rootScope);
 
@@ -97,10 +98,11 @@ describe('ngAnimate integration tests', function() {
         });
 
         expect(element).toHaveClass(setupClass);
-        $$rAF.flush();
+        $animate.flush();
         expect(element).toHaveClass(activeClass);
 
         browserTrigger(element, 'transitionend', { timeStamp: Date.now(), elapsedTime: 2 });
+        $animate.flush();
 
         expect(element).not.toHaveClass(setupClass);
         expect(element).not.toHaveClass(activeClass);
@@ -112,7 +114,7 @@ describe('ngAnimate integration tests', function() {
     });
 
     it('should not throw an error if the element is orphaned before the CSS animation starts',
-      inject(function($rootScope, $rootElement, $animate, $$rAF) {
+      inject(function($rootScope, $rootElement, $animate) {
 
       ss.addRule('.animate-me', 'transition:2s linear all;');
 
@@ -127,19 +129,19 @@ describe('ngAnimate integration tests', function() {
       $rootScope.$digest();
 
       // this will run the first class-based animation
-      $$rAF.flush();
+      $animate.flush();
 
       element.remove();
 
       expect(function() {
-        $$rAF.flush();
+        $animate.flush();
       }).not.toThrow();
 
       dealoc(element);
     }));
 
     it('should always synchronously add css classes in order for child animations to animate properly',
-      inject(function($animate, $compile, $rootScope, $rootElement, $$rAF, $document) {
+      inject(function($animate, $compile, $rootScope, $rootElement, $document) {
 
       ss.addRule('.animations-enabled .animate-me.ng-enter', 'transition:2s linear all;');
 
@@ -160,18 +162,19 @@ describe('ngAnimate integration tests', function() {
       expect(element).toHaveClass('animations-enabled');
       expect(child).toHaveClass('ng-enter');
 
-      $$rAF.flush();
+      $animate.flush();
 
       expect(child).toHaveClass('ng-enter-active');
 
       browserTrigger(child, 'transitionend', { timeStamp: Date.now(), elapsedTime: 2 });
+      $animate.flush();
 
       expect(child).not.toHaveClass('ng-enter-active');
       expect(child).not.toHaveClass('ng-enter');
     }));
 
     it('should synchronously add/remove ng-class expressions in time for other animations to run on the same element',
-      inject(function($animate, $compile, $rootScope, $rootElement, $$rAF, $document) {
+      inject(function($animate, $compile, $rootScope, $rootElement, $document) {
 
       ss.addRule('.animate-me.ng-enter.on', 'transition:2s linear all;');
 
@@ -184,7 +187,7 @@ describe('ngAnimate integration tests', function() {
 
       $rootScope.exp = true;
       $rootScope.$digest();
-      $$rAF.flush();
+      $animate.flush();
 
       var child = element.find('div');
 
@@ -203,18 +206,19 @@ describe('ngAnimate integration tests', function() {
       expect(child).toHaveClass('on');
       expect(child).toHaveClass('ng-enter');
 
-      $$rAF.flush();
+      $animate.flush();
 
       expect(child).toHaveClass('ng-enter-active');
 
       browserTrigger(child, 'transitionend', { timeStamp: Date.now(), elapsedTime: 2 });
+      $animate.flush();
 
       expect(child).not.toHaveClass('ng-enter-active');
       expect(child).not.toHaveClass('ng-enter');
     }));
 
     it('should animate ng-class and a structural animation in parallel on the same element',
-      inject(function($animate, $compile, $rootScope, $rootElement, $$rAF, $document) {
+      inject(function($animate, $compile, $rootScope, $rootElement, $document) {
 
       ss.addRule('.animate-me.ng-enter', 'transition:2s linear all;');
       ss.addRule('.animate-me.expand', 'transition:5s linear all; font-size:200px;');
@@ -236,12 +240,13 @@ describe('ngAnimate integration tests', function() {
       expect(child).toHaveClass('expand-add');
       expect(child).toHaveClass('expand');
 
-      $$rAF.flush();
+      $animate.flush();
 
       expect(child).toHaveClass('ng-enter-active');
       expect(child).toHaveClass('expand-add-active');
 
       browserTrigger(child, 'transitionend', { timeStamp: Date.now(), elapsedTime: 2 });
+      $animate.flush();
 
       expect(child).not.toHaveClass('ng-enter-active');
       expect(child).not.toHaveClass('ng-enter');
@@ -251,7 +256,7 @@ describe('ngAnimate integration tests', function() {
 
     it('should issue a reflow for each element animation on all DOM levels', function() {
       module('ngAnimateMock');
-      inject(function($animate, $compile, $rootScope, $rootElement, $$rAF, $document) {
+      inject(function($animate, $compile, $rootScope, $rootElement, $document) {
         element = jqLite(
           '<div ng-class="{parent:exp}">' +
             '<div ng-class="{parent2:exp}">' +
@@ -281,7 +286,7 @@ describe('ngAnimate integration tests', function() {
 
     it('should issue a reflow for each element and also its children', function() {
       module('ngAnimateMock');
-      inject(function($animate, $compile, $rootScope, $rootElement, $$rAF, $document) {
+      inject(function($animate, $compile, $rootScope, $rootElement, $document) {
         element = jqLite(
           '<div ng-class="{one:exp}">' +
              '<div ng-if="exp"></div>' +
@@ -312,7 +317,7 @@ describe('ngAnimate integration tests', function() {
 
     it('should always issue atleast one reflow incase there are no parent class-based animations', function() {
       module('ngAnimateMock');
-      inject(function($animate, $compile, $rootScope, $rootElement, $$rAF, $document) {
+      inject(function($animate, $compile, $rootScope, $rootElement, $document) {
         element = jqLite(
           '<div ng-repeat="item in items" ng-class="{someAnimation:exp}">' +
             '{{ item }}' +
@@ -355,7 +360,7 @@ describe('ngAnimate integration tests', function() {
         });
       });
 
-      inject(function($animate, $compile, $rootScope, $rootElement, $$rAF) {
+      inject(function($animate, $compile, $rootScope, $rootElement) {
         element = jqLite('<div class="animate-me"></div>');
         $compile(element)($rootScope);
 
@@ -407,7 +412,7 @@ describe('ngAnimate integration tests', function() {
         expect(isFunction(endAnimation)).toBe(true);
 
         endAnimation();
-        $$rAF.flush();
+        $animate.flush();
         expect(animateCompleteCallbackFired).toBe(true);
 
         $rootScope.$digest();

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -712,7 +712,6 @@ describe('ngView animations', function() {
       $location.path('/foo');
       $rootScope.$digest();
 
-      $animate.triggerCallbacks();
 
       $location.path('/');
       $rootScope.$digest();
@@ -810,7 +809,7 @@ describe('ngView animations', function() {
         });
       });
 
-      inject(function($rootScope, $compile, $location, $route, $timeout, $rootElement, $sniffer, $animate, $$rAF) {
+      inject(function($rootScope, $compile, $location, $route, $timeout, $rootElement, $sniffer, $animate) {
         element = $compile(html('<div><ng:view onload="load()" class="my-animation"></ng:view></div>'))($rootScope);
         $animate.enabled(true);
 
@@ -834,7 +833,7 @@ describe('ngView animations', function() {
         expect($animate.queue.shift().event).toBe('enter'); //ngRepeat 3
         expect($animate.queue.shift().event).toBe('enter'); //ngRepeat 4
 
-        $$rAF.flush();
+        $animate.flush();
 
         expect(element.text()).toEqual('34');
 
@@ -913,9 +912,11 @@ describe('ngView animations', function() {
 
       $location.path('/foo');
       $rootScope.$digest();
-      expect($animate.queue.shift().event).toBe('enter');
-      $animate.triggerCallbacks();
 
+      $animate.flush();
+      $rootScope.$digest();
+
+      expect($animate.queue.shift().event).toBe('enter');
       expect(autoScrollSpy).toHaveBeenCalledOnce();
     }));
 
@@ -927,9 +928,11 @@ describe('ngView animations', function() {
       $rootScope.value = true;
       $location.path('/foo');
       $rootScope.$digest();
-      expect($animate.queue.shift().event).toBe('enter');
-      $animate.triggerCallbacks();
 
+      $animate.flush();
+      $rootScope.$digest();
+
+      expect($animate.queue.shift().event).toBe('enter');
       expect(autoScrollSpy).toHaveBeenCalledOnce();
     }));
 
@@ -941,7 +944,6 @@ describe('ngView animations', function() {
       $location.path('/foo');
       $rootScope.$digest();
       expect($animate.queue.shift().event).toBe('enter');
-      $animate.triggerCallbacks();
 
       expect(autoScrollSpy).not.toHaveBeenCalled();
     }));
@@ -955,7 +957,6 @@ describe('ngView animations', function() {
       $location.path('/foo');
       $rootScope.$digest();
       expect($animate.queue.shift().event).toBe('enter');
-      $animate.triggerCallbacks();
 
       expect(autoScrollSpy).not.toHaveBeenCalled();
     }));
@@ -972,7 +973,9 @@ describe('ngView animations', function() {
         expect(autoScrollSpy).not.toHaveBeenCalled();
 
         expect($animate.queue.shift().event).toBe('enter');
-        $animate.triggerCallbacks();
+
+        $animate.flush();
+        $rootScope.$digest();
 
         expect($animate.enter).toHaveBeenCalledOnce();
         expect(autoScrollSpy).toHaveBeenCalledOnce();


### PR DESCRIPTION
Closes #12280

Here are demos to show that this works (test in IE):

Multiple RAF Requests in Angular 1.4 ([#11791](https://github.com/angular/angular.js/issues/11791))
- Pre 1.4.0 functionality (really slow on **IE 11** ... this was the reason why we decided to bundle the calls into a single function): https://jsfiddle.net/oga2z7bb/3/
- Current functionality (fixed for **IE 11**): https://angular-development.appspot.com/raf-perf/fast/index.html
- Patched functionality (fixed for **IE 11**): https://angular-development.appspot.com/raf-perf/slow/index.html

Material Design $$rAF perf issue ([#12280](https://github.com/angular/angular.js/issues/12280))
- Current functionality (**slow**): https://angular-development.appspot.com/slow-raf/slow/index.html
- Patched functionality (**fast**): https://angular-development.appspot.com/slow-raf/fast/index.html
