### PR TITLE
fix(ngAria): simplify aria-required attribute detection to support angular v1.2.x

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -301,7 +301,7 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
             elem.attr('tabindex', 0);
           }
 
-          if (ngModel.$validators.required && shouldAttachAttr('aria-required', 'ariaRequired', elem)) {
+          if (shouldAttachAttr('aria-required', 'ariaRequired', elem)) {
             scope.$watch(function ngAriaRequiredWatch() {
               return ngModel.$error.required;
             }, function ngAriaRequiredReaction(newVal) {


### PR DESCRIPTION
Remove the ngModel.$validators check to support angular 1.2.x. The check
serves no purpose but breaks aria on older angular versions.
