### PR TITLE
feat(ngAria, ngMessages): backport ngAria and ngMessages for 1.2.x

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -195,6 +195,10 @@ module.exports = function(grunt) {
         dest: 'build/angular-resource.js',
         src: util.wrap(files['angularModules']['ngResource'], 'module')
       },
+      messages: {
+        dest: 'build/angular-messages.js',
+        src: util.wrap(files['angularModules']['ngMessages'], 'module')
+      },
       animate: {
         dest: 'build/angular-animate.js',
         src: util.wrap(files['angularModules']['ngAnimate'], 'module')
@@ -206,6 +210,10 @@ module.exports = function(grunt) {
       cookies: {
         dest: 'build/angular-cookies.js',
         src: util.wrap(files['angularModules']['ngCookies'], 'module')
+      },
+      aria: {
+        dest: 'build/angular-aria.js',
+        src: util.wrap(files['angularModules']['ngAria'], 'module')
       },
       "promises-aplus-adapter": {
         dest:'tmp/promises-aplus-adapter++.js',

--- a/angularFiles.js
+++ b/angularFiles.js
@@ -82,6 +82,9 @@ var angularFiles = {
     'ngCookies': [
       'src/ngCookies/cookies.js'
     ],
+    'ngMessages': [
+      'src/ngMessages/messages.js'
+    ],
     'ngResource': [
       'src/ngResource/resource.js'
     ],
@@ -102,6 +105,9 @@ var angularFiles = {
       'src/ngTouch/swipe.js',
       'src/ngTouch/directive/ngClick.js',
       'src/ngTouch/directive/ngSwipe.js'
+    ],
+    'ngAria': [
+      'src/ngAria/aria.js'
     ],
   },
 
@@ -130,12 +136,14 @@ var angularFiles = {
     'test/auto/*.js',
     'test/ng/**/*.js',
     'test/ngAnimate/*.js',
+    'test/ngMessages/*.js',
     'test/ngCookies/*.js',
     'test/ngResource/*.js',
     'test/ngRoute/**/*.js',
     'test/ngSanitize/**/*.js',
     'test/ngMock/*.js',
-    'test/ngTouch/**/*.js'
+    'test/ngTouch/**/*.js',
+    'test/ngAria/**/*.js'
   ],
 
   'karma': [
@@ -192,11 +200,13 @@ var angularFiles = {
 angularFiles['angularSrcModules'] = [].concat(
   angularFiles['angularModules']['ngAnimate'],
   angularFiles['angularModules']['ngCookies'],
+  angularFiles['angularModules']['ngMessages'],
   angularFiles['angularModules']['ngResource'],
   angularFiles['angularModules']['ngRoute'],
   angularFiles['angularModules']['ngSanitize'],
   angularFiles['angularModules']['ngMock'],
-  angularFiles['angularModules']['ngTouch']
+  angularFiles['angularModules']['ngTouch'],
+  angularFiles['angularModules']['ngAria']
 );
 
 if (exports) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3705,7 +3705,7 @@
                   "version": "0.2.1"
                 },
                 "i": {
-                  "version": "0.3.2"
+                  "version": "0.3.3"
                 },
                 "mkdirp": {
                   "version": "0.4.0"

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -122,6 +122,7 @@ function publishExternalAPI(angular){
     'isNumber': isNumber,
     'isElement': isElement,
     'isArray': isArray,
+    'indexOf': indexOf,
     'version': version,
     'isDate': isDate,
     'lowercase': lowercase,

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -1,0 +1,389 @@
+'use strict';
+
+/**
+ * @ngdoc module
+ * @name ngAria
+ * @description
+ *
+ * The `ngAria` module provides support for common
+ * [<abbr title="Accessible Rich Internet Applications">ARIA</abbr>](http://www.w3.org/TR/wai-aria/)
+ * attributes that convey state or semantic information about the application for users
+ * of assistive technologies, such as screen readers.
+ *
+ * <div doc-module-components="ngAria"></div>
+ *
+ * ## Usage
+ *
+ * For ngAria to do its magic, simply include the module `ngAria` as a dependency. The following
+ * directives are supported:
+ * `ngModel`, `ngDisabled`, `ngShow`, `ngHide`, `ngClick`, `ngDblClick`, and `ngMessages`.
+ *
+ * Below is a more detailed breakdown of the attributes handled by ngAria:
+ *
+ * | Directive                                   | Supported Attributes                                                                   |
+ * |---------------------------------------------|----------------------------------------------------------------------------------------|
+ * | {@link ng.directive:ngDisabled ngDisabled}  | aria-disabled                                                                          |
+ * | {@link ng.directive:ngShow ngShow}          | aria-hidden                                                                            |
+ * | {@link ng.directive:ngHide ngHide}          | aria-hidden                                                                            |
+ * | {@link ng.directive:ngDblclick ngDblclick}  | tabindex                                                                               |
+ * | {@link module:ngMessages ngMessages}        | aria-live                                                                              |
+ * | {@link ng.directive:ngModel ngModel}        | aria-checked, aria-valuemin, aria-valuemax, aria-valuenow, aria-invalid, aria-required, input roles |
+ * | {@link ng.directive:ngClick ngClick}        | tabindex, keypress event, button role                                                               |
+ *
+ * Find out more information about each directive by reading the
+ * {@link guide/accessibility ngAria Developer Guide}.
+ *
+ * ##Example
+ * Using ngDisabled with ngAria:
+ * ```html
+ * <md-checkbox ng-disabled="disabled">
+ * ```
+ * Becomes:
+ * ```html
+ * <md-checkbox ng-disabled="disabled" aria-disabled="true">
+ * ```
+ *
+ * ##Disabling Attributes
+ * It's possible to disable individual attributes added by ngAria with the
+ * {@link ngAria.$ariaProvider#config config} method. For more details, see the
+ * {@link guide/accessibility Developer Guide}.
+ */
+ /* global -ngAriaModule */
+var ngAriaModule = angular.module('ngAria', ['ng']).
+                        provider('$aria', $AriaProvider);
+
+/**
+ * @ngdoc provider
+ * @name $ariaProvider
+ *
+ * @description
+ *
+ * Used for configuring the ARIA attributes injected and managed by ngAria.
+ *
+ * ```js
+ * angular.module('myApp', ['ngAria'], function config($ariaProvider) {
+ *   $ariaProvider.config({
+ *     ariaValue: true,
+ *     tabindex: false
+ *   });
+ * });
+ *```
+ *
+ * ## Dependencies
+ * Requires the {@link ngAria} module to be installed.
+ *
+ */
+function $AriaProvider() {
+  var config = {
+    ariaHidden: true,
+    ariaChecked: true,
+    ariaDisabled: true,
+    ariaRequired: true,
+    ariaInvalid: true,
+    ariaMultiline: true,
+    ariaValue: true,
+    tabindex: true,
+    bindKeypress: true,
+    bindRoleForClick: true
+  };
+
+  /**
+   * @ngdoc method
+   * @name $ariaProvider#config
+   *
+   * @param {object} config object to enable/disable specific ARIA attributes
+   *
+   *  - **ariaHidden** – `{boolean}` – Enables/disables aria-hidden tags
+   *  - **ariaChecked** – `{boolean}` – Enables/disables aria-checked tags
+   *  - **ariaDisabled** – `{boolean}` – Enables/disables aria-disabled tags
+   *  - **ariaRequired** – `{boolean}` – Enables/disables aria-required tags
+   *  - **ariaInvalid** – `{boolean}` – Enables/disables aria-invalid tags
+   *  - **ariaMultiline** – `{boolean}` – Enables/disables aria-multiline tags
+   *  - **ariaValue** – `{boolean}` – Enables/disables aria-valuemin, aria-valuemax and aria-valuenow tags
+   *  - **tabindex** – `{boolean}` – Enables/disables tabindex tags
+   *  - **bindKeypress** – `{boolean}` – Enables/disables keypress event binding on `&lt;div&gt;` and
+   *    `&lt;li&gt;` elements with ng-click
+   *  - **bindRoleForClick** – `{boolean}` – Adds role=button to non-interactive elements like `div`
+   *    using ng-click, making them more accessible to users of assistive technologies
+   *
+   * @description
+   * Enables/disables various ARIA attributes
+   */
+  this.config = function(newConfig) {
+    config = angular.extend(config, newConfig);
+  };
+
+  function watchExpr(attrName, ariaAttr, negate) {
+    return function(scope, elem, attr) {
+      var ariaCamelName = attr.$normalize(ariaAttr);
+      if (config[ariaCamelName] && !attr[ariaCamelName]) {
+        scope.$watch(attr[attrName], function(boolVal) {
+          // ensure boolean value
+          boolVal = negate ? !boolVal : !!boolVal;
+          elem.attr(ariaAttr, boolVal);
+        });
+      }
+    };
+  }
+
+  /**
+   * @ngdoc service
+   * @name $aria
+   *
+   * @description
+   * @priority 200
+   *
+   * The $aria service contains helper methods for applying common
+   * [ARIA](http://www.w3.org/TR/wai-aria/) attributes to HTML directives.
+   *
+   * ngAria injects common accessibility attributes that tell assistive technologies when HTML
+   * elements are enabled, selected, hidden, and more. To see how this is performed with ngAria,
+   * let's review a code snippet from ngAria itself:
+   *
+   *```js
+   * ngAriaModule.directive('ngDisabled', ['$aria', function($aria) {
+   *   return $aria.$$watchExpr('ngDisabled', 'aria-disabled');
+   * }])
+   *```
+   * Shown above, the ngAria module creates a directive with the same signature as the
+   * traditional `ng-disabled` directive. But this ngAria version is dedicated to
+   * solely managing accessibility attributes. The internal `$aria` service is used to watch the
+   * boolean attribute `ngDisabled`. If it has not been explicitly set by the developer,
+   * `aria-disabled` is injected as an attribute with its value synchronized to the value in
+   * `ngDisabled`.
+   *
+   * Because ngAria hooks into the `ng-disabled` directive, developers do not have to do
+   * anything to enable this feature. The `aria-disabled` attribute is automatically managed
+   * simply as a silent side-effect of using `ng-disabled` with the ngAria module.
+   *
+   * The full list of directives that interface with ngAria:
+   * * **ngModel**
+   * * **ngShow**
+   * * **ngHide**
+   * * **ngClick**
+   * * **ngDblclick**
+   * * **ngMessages**
+   * * **ngDisabled**
+   *
+   * Read the {@link guide/accessibility ngAria Developer Guide} for a thorough explanation of each
+   * directive.
+   *
+   *
+   * ## Dependencies
+   * Requires the {@link ngAria} module to be installed.
+   */
+  this.$get = function() {
+    return {
+      config: function(key) {
+        return config[key];
+      },
+      $$watchExpr: watchExpr
+    };
+  };
+}
+
+
+ngAriaModule.directive('ngShow', ['$aria', function($aria) {
+  return $aria.$$watchExpr('ngShow', 'aria-hidden', true);
+}])
+.directive('ngHide', ['$aria', function($aria) {
+  return $aria.$$watchExpr('ngHide', 'aria-hidden', false);
+}])
+.directive('ngModel', ['$aria', '$timeout', function($aria, $timeout) {
+
+  function shouldAttachAttr(attr, normalizedAttr, elem) {
+    return $aria.config(normalizedAttr) && !elem.attr(attr);
+  }
+
+  function shouldAttachRole(role, elem) {
+    return !elem.attr('role') && (elem.attr('type') === role) && (elem[0].nodeName !== 'INPUT');
+  }
+
+  function getShape(attr, elem) {
+    var type = attr.type,
+        role = attr.role;
+
+    return ((type || role) === 'checkbox' || role === 'menuitemcheckbox') ? 'checkbox' :
+           ((type || role) === 'radio'    || role === 'menuitemradio') ? 'radio' :
+           (type === 'range'              || role === 'progressbar' || role === 'slider') ? 'range' :
+           (type || role) === 'textbox'   || elem[0].nodeName === 'TEXTAREA' ? 'multiline' : '';
+  }
+
+  return {
+    restrict: 'A',
+    require: '?ngModel',
+    priority: 200, //Make sure watches are fired after any other directives that affect the ngModel value
+    compile: function(elem, attr) {
+      var shape = getShape(attr, elem);
+
+      return {
+        pre: function(scope, elem, attr, ngModel) {
+          if (shape === 'checkbox' && attr.type !== 'checkbox') {
+            //Use the input[checkbox] $isEmpty implementation for elements with checkbox roles
+            ngModel.$isEmpty = function(value) {
+              return value === false;
+            };
+          }
+        },
+        post: function(scope, elem, attr, ngModel) {
+          var needsTabIndex = shouldAttachAttr('tabindex', 'tabindex', elem);
+
+          function ngAriaWatchModelValue() {
+            return ngModel.$modelValue;
+          }
+
+          function getRadioReaction() {
+            if (needsTabIndex) {
+              needsTabIndex = false;
+              return function ngAriaRadioReaction(newVal) {
+                var boolVal = (attr.value == ngModel.$viewValue);
+                elem.attr('aria-checked', boolVal);
+                elem.attr('tabindex', 0 - !boolVal);
+              };
+            } else {
+              return function ngAriaRadioReaction(newVal) {
+                elem.attr('aria-checked', (attr.value == ngModel.$viewValue));
+              };
+            }
+          }
+
+          function ngAriaCheckboxReaction() {
+            elem.attr('aria-checked', ngModel.$viewValue);
+          }
+
+          switch (shape) {
+            case 'radio':
+            case 'checkbox':
+              if (shouldAttachRole(shape, elem)) {
+                elem.attr('role', shape);
+              }
+              if (shouldAttachAttr('aria-checked', 'ariaChecked', elem)) {
+                scope.$watch(ngAriaWatchModelValue, shape === 'radio' ?
+                    getRadioReaction() : ngAriaCheckboxReaction);
+              }
+              break;
+            case 'range':
+              if (shouldAttachRole(shape, elem)) {
+                elem.attr('role', 'slider');
+              }
+              if ($aria.config('ariaValue')) {
+                var needsAriaValuemin = !elem.attr('aria-valuemin') &&
+                    attr.hasOwnProperty('min');
+                var needsAriaValuemax = !elem.attr('aria-valuemax') &&
+                    attr.hasOwnProperty('max');
+                var needsAriaValuenow = !elem.attr('aria-valuenow');
+
+                if (needsAriaValuemin) {
+                  attr.$observe('min', function ngAriaValueMinReaction(newVal) {
+                    elem.attr('aria-valuemin', newVal);
+                  });
+                }
+                if (needsAriaValuemax) {
+                  attr.$observe('max', function ngAriaValueMinReaction(newVal) {
+                    elem.attr('aria-valuemax', newVal);
+                  });
+                }
+                if (needsAriaValuenow) {
+                  scope.$watch(ngAriaWatchModelValue, function ngAriaValueNowReaction(newVal) {
+                    elem.attr('aria-valuenow', newVal);
+                  });
+                }
+              }
+              break;
+            case 'multiline':
+              if (shouldAttachAttr('aria-multiline', 'ariaMultiline', elem)) {
+                elem.attr('aria-multiline', true);
+              }
+              break;
+          }
+
+          if (needsTabIndex) {
+            elem.attr('tabindex', 0);
+          }
+
+          if (shouldAttachAttr('aria-required', 'ariaRequired', elem)) {
+            $timeout(function () {
+              if (ngModel.$error.hasOwnProperty('required')) {
+                scope.$watch(function ngAriaRequiredWatch() {
+                  return ngModel.$error.required;
+                }, function ngAriaRequiredReaction(newVal) {
+                  elem.attr('aria-required', !!newVal);
+                });
+              }
+            });
+          }
+
+          if (shouldAttachAttr('aria-invalid', 'ariaInvalid', elem)) {
+            scope.$watch(function ngAriaInvalidWatch() {
+              return ngModel.$invalid;
+            }, function ngAriaInvalidReaction(newVal) {
+              elem.attr('aria-invalid', !!newVal);
+            });
+          }
+        }
+      };
+    }
+  };
+}])
+.directive('ngDisabled', ['$aria', function($aria) {
+  return $aria.$$watchExpr('ngDisabled', 'aria-disabled');
+}])
+.directive('ngMessages', function() {
+  return {
+    restrict: 'A',
+    require: '?ngMessages',
+    link: function(scope, elem, attr, ngMessages) {
+      if (!elem.attr('aria-live')) {
+        elem.attr('aria-live', 'assertive');
+      }
+    }
+  };
+})
+.directive('ngClick',['$aria', '$parse', function($aria, $parse) {
+  return {
+    restrict: 'A',
+    compile: function(elem, attr) {
+      var fn = $parse(attr.ngClick, /* interceptorFn */ null, /* expensiveChecks */ true);
+      return function(scope, elem, attr) {
+
+        var nodeBlackList = ['BUTTON', 'A', 'INPUT', 'TEXTAREA'];
+
+        function isNodeOneOf(elem, nodeTypeArray) {
+          if (nodeTypeArray.indexOf(elem[0].nodeName) !== -1) {
+            return true;
+          }
+        }
+
+        if ($aria.config('bindRoleForClick')
+            && !elem.attr('role')
+              && !isNodeOneOf(elem, nodeBlackList)) {
+          elem.attr('role', 'button');
+        }
+
+        if ($aria.config('tabindex') && !elem.attr('tabindex')) {
+          elem.attr('tabindex', 0);
+        }
+
+        if ($aria.config('bindKeypress') && !attr.ngKeypress && !isNodeOneOf(elem, nodeBlackList)) {
+          elem.on('keypress', function(event) {
+            var keyCode = event.which || event.keyCode;
+            if (keyCode === 32 || keyCode === 13) {
+              scope.$apply(callback);
+            }
+
+            function callback() {
+              fn(scope, { $event: event });
+            }
+          });
+        }
+      };
+    }
+  };
+}])
+.directive('ngDblclick', ['$aria', function($aria) {
+  return function(scope, elem, attr) {
+    if ($aria.config('tabindex') && !elem.attr('tabindex')) {
+      elem.attr('tabindex', 0);
+    }
+  };
+}]);

--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -1,0 +1,616 @@
+'use strict';
+
+/* jshint ignore:start */
+// this code is in the core, but not in angular-messages.js
+var isArray = angular.isArray;
+var forEach = angular.forEach;
+var isString = angular.isString;
+var jqLite = angular.element;
+/* jshint ignore:end */
+
+/**
+ * @ngdoc module
+ * @name ngMessages
+ * @description
+ *
+ * The `ngMessages` module provides enhanced support for displaying messages within templates
+ * (typically within forms or when rendering message objects that return key/value data).
+ * Instead of relying on JavaScript code and/or complex ng-if statements within your form template to
+ * show and hide error messages specific to the state of an input field, the `ngMessages` and
+ * `ngMessage` directives are designed to handle the complexity, inheritance and priority
+ * sequencing based on the order of how the messages are defined in the template.
+ *
+ * Currently, the ngMessages module only contains the code for the `ngMessages`, `ngMessagesInclude`
+ * `ngMessage` and `ngMessageExp` directives.
+ *
+ * # Usage
+ * The `ngMessages` directive listens on a key/value collection which is set on the ngMessages attribute.
+ * Since the {@link ngModel ngModel} directive exposes an `$error` object, this error object can be
+ * used with `ngMessages` to display control error messages in an easier way than with just regular angular
+ * template directives.
+ *
+ * ```html
+ * <form name="myForm">
+ *   <label>
+ *     Enter text:
+ *     <input type="text" ng-model="field" name="myField" required minlength="5" />
+ *   </label>
+ *   <div ng-messages="myForm.myField.$error" role="alert">
+ *     <div ng-message="required">You did not enter a field</div>
+ *     <div ng-message="minlength, maxlength">
+ *       Your email must be between 5 and 100 characters long
+ *     </div>
+ *   </div>
+ * </form>
+ * ```
+ *
+ * Now whatever key/value entries are present within the provided object (in this case `$error`) then
+ * the ngMessages directive will render the inner first ngMessage directive (depending if the key values
+ * match the attribute value present on each ngMessage directive). In other words, if your errors
+ * object contains the following data:
+ *
+ * ```javascript
+ * <!-- keep in mind that ngModel automatically sets these error flags -->
+ * myField.$error = { minlength : true, required : true };
+ * ```
+ *
+ * Then the `required` message will be displayed first. When required is false then the `minlength` message
+ * will be displayed right after (since these messages are ordered this way in the template HTML code).
+ * The prioritization of each message is determined by what order they're present in the DOM.
+ * Therefore, instead of having custom JavaScript code determine the priority of what errors are
+ * present before others, the presentation of the errors are handled within the template.
+ *
+ * By default, ngMessages will only display one error at a time. However, if you wish to display all
+ * messages then the `ng-messages-multiple` attribute flag can be used on the element containing the
+ * ngMessages directive to make this happen.
+ *
+ * ```html
+ * <!-- attribute-style usage -->
+ * <div ng-messages="myForm.myField.$error" ng-messages-multiple>...</div>
+ *
+ * <!-- element-style usage -->
+ * <ng-messages for="myForm.myField.$error" multiple>...</ng-messages>
+ * ```
+ *
+ * ## Reusing and Overriding Messages
+ * In addition to prioritization, ngMessages also allows for including messages from a remote or an inline
+ * template. This allows for generic collection of messages to be reused across multiple parts of an
+ * application.
+ *
+ * ```html
+ * <script type="text/ng-template" id="error-messages">
+ *   <div ng-message="required">This field is required</div>
+ *   <div ng-message="minlength">This field is too short</div>
+ * </script>
+ *
+ * <div ng-messages="myForm.myField.$error" role="alert">
+ *   <div ng-messages-include="error-messages"></div>
+ * </div>
+ * ```
+ *
+ * However, including generic messages may not be useful enough to match all input fields, therefore,
+ * `ngMessages` provides the ability to override messages defined in the remote template by redefining
+ * them within the directive container.
+ *
+ * ```html
+ * <!-- a generic template of error messages known as "my-custom-messages" -->
+ * <script type="text/ng-template" id="my-custom-messages">
+ *   <div ng-message="required">This field is required</div>
+ *   <div ng-message="minlength">This field is too short</div>
+ * </script>
+ *
+ * <form name="myForm">
+ *   <label>
+ *     Email address
+ *     <input type="email"
+ *            id="email"
+ *            name="myEmail"
+ *            ng-model="email"
+ *            minlength="5"
+ *            required />
+ *   </label>
+ *   <!-- any ng-message elements that appear BEFORE the ng-messages-include will
+ *        override the messages present in the ng-messages-include template -->
+ *   <div ng-messages="myForm.myEmail.$error" role="alert">
+ *     <!-- this required message has overridden the template message -->
+ *     <div ng-message="required">You did not enter your email address</div>
+ *
+ *     <!-- this is a brand new message and will appear last in the prioritization -->
+ *     <div ng-message="email">Your email address is invalid</div>
+ *
+ *     <!-- and here are the generic error messages -->
+ *     <div ng-messages-include="my-custom-messages"></div>
+ *   </div>
+ * </form>
+ * ```
+ *
+ * In the example HTML code above the message that is set on required will override the corresponding
+ * required message defined within the remote template. Therefore, with particular input fields (such
+ * email addresses, date fields, autocomplete inputs, etc...), specialized error messages can be applied
+ * while more generic messages can be used to handle other, more general input errors.
+ *
+ * ## Dynamic Messaging
+ * ngMessages also supports using expressions to dynamically change key values. Using arrays and
+ * repeaters to list messages is also supported. This means that the code below will be able to
+ * fully adapt itself and display the appropriate message when any of the expression data changes:
+ *
+ * ```html
+ * <form name="myForm">
+ *   <label>
+ *     Email address
+ *     <input type="email"
+ *            name="myEmail"
+ *            ng-model="email"
+ *            minlength="5"
+ *            required />
+ *   </label>
+ *   <div ng-messages="myForm.myEmail.$error" role="alert">
+ *     <div ng-message="required">You did not enter your email address</div>
+ *     <div ng-repeat="errorMessage in errorMessages">
+ *       <!-- use ng-message-exp for a message whose key is given by an expression -->
+ *       <div ng-message-exp="errorMessage.type">{{ errorMessage.text }}</div>
+ *     </div>
+ *   </div>
+ * </form>
+ * ```
+ *
+ * The `errorMessage.type` expression can be a string value or it can be an array so
+ * that multiple errors can be associated with a single error message:
+ *
+ * ```html
+ *   <label>
+ *     Email address
+ *     <input type="email"
+ *            ng-model="data.email"
+ *            name="myEmail"
+ *            ng-minlength="5"
+ *            ng-maxlength="100"
+ *            required />
+ *   </label>
+ *   <div ng-messages="myForm.myEmail.$error" role="alert">
+ *     <div ng-message-exp="'required'">You did not enter your email address</div>
+ *     <div ng-message-exp="['minlength', 'maxlength']">
+ *       Your email must be between 5 and 100 characters long
+ *     </div>
+ *   </div>
+ * ```
+ *
+ * Feel free to use other structural directives such as ng-if and ng-switch to further control
+ * what messages are active and when. Be careful, if you place ng-message on the same element
+ * as these structural directives, Angular may not be able to determine if a message is active
+ * or not. Therefore it is best to place the ng-message on a child element of the structural
+ * directive.
+ *
+ * ```html
+ * <div ng-messages="myForm.myEmail.$error" role="alert">
+ *   <div ng-if="showRequiredError">
+ *     <div ng-message="required">Please enter something</div>
+ *   </div>
+ * </div>
+ * ```
+ *
+ * ## Animations
+ * If the `ngAnimate` module is active within the application then the `ngMessages`, `ngMessage` and
+ * `ngMessageExp` directives will trigger animations whenever any messages are added and removed from
+ * the DOM by the `ngMessages` directive.
+ *
+ * Whenever the `ngMessages` directive contains one or more visible messages then the `.ng-active` CSS
+ * class will be added to the element. The `.ng-inactive` CSS class will be applied when there are no
+ * messages present. Therefore, CSS transitions and keyframes as well as JavaScript animations can
+ * hook into the animations whenever these classes are added/removed.
+ *
+ * Let's say that our HTML code for our messages container looks like so:
+ *
+ * ```html
+ * <div ng-messages="myMessages" class="my-messages" role="alert">
+ *   <div ng-message="alert" class="some-message">...</div>
+ *   <div ng-message="fail" class="some-message">...</div>
+ * </div>
+ * ```
+ *
+ * Then the CSS animation code for the message container looks like so:
+ *
+ * ```css
+ * .my-messages {
+ *   transition:1s linear all;
+ * }
+ * .my-messages.ng-active {
+ *   // messages are visible
+ * }
+ * .my-messages.ng-inactive {
+ *   // messages are hidden
+ * }
+ * ```
+ *
+ * Whenever an inner message is attached (becomes visible) or removed (becomes hidden) then the enter
+ * and leave animation is triggered for each particular element bound to the `ngMessage` directive.
+ *
+ * Therefore, the CSS code for the inner messages looks like so:
+ *
+ * ```css
+ * .some-message {
+ *   transition:1s linear all;
+ * }
+ *
+ * .some-message.ng-enter {}
+ * .some-message.ng-enter.ng-enter-active {}
+ *
+ * .some-message.ng-leave {}
+ * .some-message.ng-leave.ng-leave-active {}
+ * ```
+ *
+ * {@link ngAnimate Click here} to learn how to use JavaScript animations or to learn more about ngAnimate.
+ */
+angular.module('ngMessages', [])
+
+   /**
+    * @ngdoc directive
+    * @module ngMessages
+    * @name ngMessages
+    * @restrict AE
+    *
+    * @description
+    * `ngMessages` is a directive that is designed to show and hide messages based on the state
+    * of a key/value object that it listens on. The directive itself complements error message
+    * reporting with the `ngModel` $error object (which stores a key/value state of validation errors).
+    *
+    * `ngMessages` manages the state of internal messages within its container element. The internal
+    * messages use the `ngMessage` directive and will be inserted/removed from the page depending
+    * on if they're present within the key/value object. By default, only one message will be displayed
+    * at a time and this depends on the prioritization of the messages within the template. (This can
+    * be changed by using the `ng-messages-multiple` or `multiple` attribute on the directive container.)
+    *
+    * A remote template can also be used to promote message reusability and messages can also be
+    * overridden.
+    *
+    * {@link module:ngMessages Click here} to learn more about `ngMessages` and `ngMessage`.
+    *
+    * @usage
+    * ```html
+    * <!-- using attribute directives -->
+    * <ANY ng-messages="expression" role="alert">
+    *   <ANY ng-message="stringValue">...</ANY>
+    *   <ANY ng-message="stringValue1, stringValue2, ...">...</ANY>
+    *   <ANY ng-message-exp="expressionValue">...</ANY>
+    * </ANY>
+    *
+    * <!-- or by using element directives -->
+    * <ng-messages for="expression" role="alert">
+    *   <ng-message when="stringValue">...</ng-message>
+    *   <ng-message when="stringValue1, stringValue2, ...">...</ng-message>
+    *   <ng-message when-exp="expressionValue">...</ng-message>
+    * </ng-messages>
+    * ```
+    *
+    * @param {string} ngMessages an angular expression evaluating to a key/value object
+    *                 (this is typically the $error object on an ngModel instance).
+    * @param {string=} ngMessagesMultiple|multiple when set, all messages will be displayed with true
+    *
+    * @example
+    * <example name="ngMessages-directive" module="ngMessagesExample"
+    *          deps="angular-messages.js"
+    *          animations="true" fixBase="true">
+    *   <file name="index.html">
+    *     <form name="myForm">
+    *       <label>
+    *         Enter your name:
+    *         <input type="text"
+    *                name="myName"
+    *                ng-model="name"
+    *                ng-minlength="5"
+    *                ng-maxlength="20"
+    *                required />
+    *       </label>
+    *       <pre>myForm.myName.$error = {{ myForm.myName.$error | json }}</pre>
+    *
+    *       <div ng-messages="myForm.myName.$error" style="color:maroon" role="alert">
+    *         <div ng-message="required">You did not enter a field</div>
+    *         <div ng-message="minlength">Your field is too short</div>
+    *         <div ng-message="maxlength">Your field is too long</div>
+    *       </div>
+    *     </form>
+    *   </file>
+    *   <file name="script.js">
+    *     angular.module('ngMessagesExample', ['ngMessages']);
+    *   </file>
+    * </example>
+    */
+   .directive('ngMessages', ['$animate', function($animate) {
+     var ACTIVE_CLASS = 'ng-active';
+     var INACTIVE_CLASS = 'ng-inactive';
+
+     return {
+       require: 'ngMessages',
+       restrict: 'AE',
+       controller: ['$element', '$scope', '$attrs', function($element, $scope, $attrs) {
+         var ctrl = this;
+         var latestKey = 0;
+
+         var messages = this.messages = {};
+         var renderLater, cachedCollection;
+
+         this.render = function(collection) {
+           collection = collection || {};
+
+           renderLater = false;
+           cachedCollection = collection;
+
+           // this is true if the attribute is empty or if the attribute value is truthy
+           var multiple = isAttrTruthy($scope, $attrs.ngMessagesMultiple) ||
+                          isAttrTruthy($scope, $attrs.multiple);
+
+           var unmatchedMessages = [];
+           var matchedKeys = {};
+           var messageItem = ctrl.head;
+           var messageFound = false;
+           var totalMessages = 0;
+
+           // we use != instead of !== to allow for both undefined and null values
+           while (messageItem != null) {
+             totalMessages++;
+             var messageCtrl = messageItem.message;
+
+             var messageUsed = false;
+             if (!messageFound) {
+               forEach(collection, function(value, key) {
+                 if (!messageUsed && truthy(value) && messageCtrl.test(key)) {
+                   // this is to prevent the same error name from showing up twice
+                   if (matchedKeys[key]) return;
+                   matchedKeys[key] = true;
+
+                   messageUsed = true;
+                   messageCtrl.attach();
+                 }
+               });
+             }
+
+             if (messageUsed) {
+               // unless we want to display multiple messages then we should
+               // set a flag here to avoid displaying the next message in the list
+               messageFound = !multiple;
+             } else {
+               unmatchedMessages.push(messageCtrl);
+             }
+
+             messageItem = messageItem.next;
+           }
+
+           forEach(unmatchedMessages, function(messageCtrl) {
+             messageCtrl.detach();
+           });
+
+           unmatchedMessages.length !== totalMessages
+              ? $animate.setClass($element, ACTIVE_CLASS, INACTIVE_CLASS)
+              : $animate.setClass($element, INACTIVE_CLASS, ACTIVE_CLASS);
+         };
+
+         $scope.$watchCollection($attrs.ngMessages || $attrs['for'], ctrl.render);
+
+         this.reRender = function() {
+           if (!renderLater) {
+             renderLater = true;
+             $scope.$evalAsync(function() {
+               if (renderLater) {
+                 cachedCollection && ctrl.render(cachedCollection);
+               }
+             });
+           }
+         };
+
+         this.register = function(comment, messageCtrl) {
+           var nextKey = latestKey.toString();
+           messages[nextKey] = {
+             message: messageCtrl
+           };
+           insertMessageNode($element[0], comment, nextKey);
+           comment.$$ngMessageNode = nextKey;
+           latestKey++;
+
+           ctrl.reRender();
+         };
+
+         this.deregister = function(comment) {
+           var key = comment.$$ngMessageNode;
+           delete comment.$$ngMessageNode;
+           removeMessageNode($element[0], comment, key);
+           delete messages[key];
+           ctrl.reRender();
+         };
+
+         function findPreviousMessage(parent, comment) {
+           var prevNode = comment;
+           var parentLookup = [];
+           while (prevNode && prevNode !== parent) {
+             var prevKey = prevNode.$$ngMessageNode;
+             if (prevKey && prevKey.length) {
+               return messages[prevKey];
+             }
+
+             // dive deeper into the DOM and examine its children for any ngMessage
+             // comments that may be in an element that appears deeper in the list
+             if (prevNode.childNodes.length && angular.indexOf(parentLookup, prevNode) == -1) {
+               parentLookup.push(prevNode);
+               prevNode = prevNode.childNodes[prevNode.childNodes.length - 1];
+             } else {
+               prevNode = prevNode.previousSibling || prevNode.parentNode;
+             }
+           }
+         }
+
+         function insertMessageNode(parent, comment, key) {
+           var messageNode = messages[key];
+           if (!ctrl.head) {
+             ctrl.head = messageNode;
+           } else {
+             var match = findPreviousMessage(parent, comment);
+             if (match) {
+               messageNode.next = match.next;
+               match.next = messageNode;
+             } else {
+               messageNode.next = ctrl.head;
+               ctrl.head = messageNode;
+             }
+           }
+         }
+
+         function removeMessageNode(parent, comment, key) {
+           var messageNode = messages[key];
+
+           var match = findPreviousMessage(parent, comment);
+           if (match) {
+             match.next = messageNode.next;
+           } else {
+             ctrl.head = messageNode.next;
+           }
+         }
+       }]
+     };
+
+     function isAttrTruthy(scope, attr) {
+      return (isString(attr) && attr.length === 0) || //empty attribute
+             truthy(scope.$eval(attr));
+     }
+
+     function truthy(val) {
+       return isString(val) ? val.length : !!val;
+     }
+   }])
+
+   /**
+    * @ngdoc directive
+    * @name ngMessage
+    * @restrict AE
+    * @scope
+    *
+    * @description
+    * `ngMessage` is a directive with the purpose to show and hide a particular message.
+    * For `ngMessage` to operate, a parent `ngMessages` directive on a parent DOM element
+    * must be situated since it determines which messages are visible based on the state
+    * of the provided key/value map that `ngMessages` listens on.
+    *
+    * More information about using `ngMessage` can be found in the
+    * {@link module:ngMessages `ngMessages` module documentation}.
+    *
+    * @usage
+    * ```html
+    * <!-- using attribute directives -->
+    * <ANY ng-messages="expression" role="alert">
+    *   <ANY ng-message="stringValue">...</ANY>
+    *   <ANY ng-message="stringValue1, stringValue2, ...">...</ANY>
+    * </ANY>
+    *
+    * <!-- or by using element directives -->
+    * <ng-messages for="expression" role="alert">
+    *   <ng-message when="stringValue">...</ng-message>
+    *   <ng-message when="stringValue1, stringValue2, ...">...</ng-message>
+    * </ng-messages>
+    * ```
+    *
+    * @param {expression} ngMessage|when a string value corresponding to the message key.
+    */
+  .directive('ngMessage', ngMessageDirectiveFactory('AE'))
+
+
+   /**
+    * @ngdoc directive
+    * @name ngMessageExp
+    * @restrict AE
+    * @scope
+    *
+    * @description
+    * `ngMessageExp` is a directive with the purpose to show and hide a particular message.
+    * For `ngMessageExp` to operate, a parent `ngMessages` directive on a parent DOM element
+    * must be situated since it determines which messages are visible based on the state
+    * of the provided key/value map that `ngMessages` listens on.
+    *
+    * @usage
+    * ```html
+    * <!-- using attribute directives -->
+    * <ANY ng-messages="expression">
+    *   <ANY ng-message-exp="expressionValue">...</ANY>
+    * </ANY>
+    *
+    * <!-- or by using element directives -->
+    * <ng-messages for="expression">
+    *   <ng-message when-exp="expressionValue">...</ng-message>
+    * </ng-messages>
+    * ```
+    *
+    * {@link module:ngMessages Click here} to learn more about `ngMessages` and `ngMessage`.
+    *
+    * @param {expression} ngMessageExp|whenExp an expression value corresponding to the message key.
+    */
+  .directive('ngMessageExp', ngMessageDirectiveFactory('A'));
+
+function ngMessageDirectiveFactory(restrict) {
+  return ['$animate', function($animate) {
+    return {
+      restrict: 'AE',
+      transclude: 'element',
+      terminal: true,
+      require: '^^ngMessages',
+      link: function(scope, element, attrs, ngMessagesCtrl, $transclude) {
+        var commentNode = element[0];
+
+        var records;
+        var staticExp = attrs.ngMessage || attrs.when;
+        var dynamicExp = attrs.ngMessageExp || attrs.whenExp;
+        var assignRecords = function(items) {
+          records = items
+              ? (isArray(items)
+                    ? items
+                    : items.split(/[\s,]+/))
+              : null;
+          ngMessagesCtrl.reRender();
+        };
+
+        if (dynamicExp) {
+          assignRecords(scope.$eval(dynamicExp));
+          scope.$watchCollection(dynamicExp, assignRecords);
+        } else {
+          assignRecords(staticExp);
+        }
+
+        var currentElement, messageCtrl;
+        ngMessagesCtrl.register(commentNode, messageCtrl = {
+          test: function(name) {
+            return contains(records, name);
+          },
+          attach: function() {
+            if (!currentElement) {
+              $transclude(scope, function(elm) {
+                $animate.enter(elm, null, element);
+                currentElement = elm;
+
+                // in the event that the parent element is destroyed
+                // by any other structural directive then it's time
+                // to deregister the message from the controller
+                currentElement.on('$destroy', function() {
+                  if (currentElement) {
+                    ngMessagesCtrl.deregister(commentNode);
+                    messageCtrl.detach();
+                  }
+                });
+              });
+            }
+          },
+          detach: function() {
+            if (currentElement) {
+              var elm = currentElement;
+              currentElement = null;
+              $animate.leave(elm);
+            }
+          }
+        });
+      }
+    };
+  }];
+
+  function contains(collection, key) {
+    if (collection) {
+      return isArray(collection)
+          ? angular.indexOf(collection, key) >= 0
+          : collection.hasOwnProperty(key);
+    }
+  }
+}

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -142,6 +142,7 @@
     "waitsFor": false,
     "runs": false,
     "dump": false,
+    "they": false,
 
     /* e2e */
     "browser": false,

--- a/test/helpers/privateMocks.js
+++ b/test/helpers/privateMocks.js
@@ -1,5 +1,22 @@
 'use strict';
 
+/* globals xit */
+function baseThey(msg, vals, spec, itFn) {
+  var valsIsArray = angular.isArray(vals);
+
+  angular.forEach(vals, function(val, key) {
+    var m = msg.replace(/\$prop/g, angular.toJson(valsIsArray ? val : key));
+    itFn(m, function() {
+      /* jshint -W040 : ignore possible strict violation due to use of this */
+      spec.call(this, val);
+    });
+  });
+}
+
+function they(msg, vals, spec) {
+  baseThey(msg, vals, spec, it);
+}
+
 function createMockStyleSheet(doc, wind) {
   doc = doc ? doc[0] : document;
   wind = wind || window;
@@ -11,19 +28,19 @@ function createMockStyleSheet(doc, wind) {
   var ss = doc.styleSheets[doc.styleSheets.length - 1];
 
   return {
-    addRule : function(selector, styles) {
+    addRule: function(selector, styles) {
       try {
         ss.insertRule(selector + '{ ' + styles + '}', 0);
       }
-      catch(e) {
+      catch (e) {
         try {
           ss.addRule(selector, styles);
         }
-        catch(e2) {}
+        catch (e2) {}
       }
     },
 
-    destroy : function() {
+    destroy: function() {
       head.removeChild(node);
     }
   };

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -1,0 +1,809 @@
+'use strict';
+
+describe('$aria', function() {
+  var scope, $compile, $timeout, element;
+
+  beforeEach(module('ngAria'));
+
+  afterEach(function() {
+    dealoc(element);
+  });
+
+  function injectScopeAndCompiler() {
+    return inject(function(_$compile_, _$rootScope_, _$timeout_) {
+      $compile = _$compile_;
+      scope = _$rootScope_;
+      $timeout = _$timeout_;
+    });
+  }
+
+  function compileElement(inputHtml, flushTimeout) {
+    element = $compile(inputHtml)(scope);
+    scope.$digest();
+    if (flushTimeout) {
+        $timeout.flush();
+    }
+  }
+
+  describe('aria-hidden', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach aria-hidden to ng-show', function() {
+      compileElement('<div ng-show="val"></div>');
+      scope.$apply('val = false');
+      expect(element.attr('aria-hidden')).toBe('true');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-hidden')).toBe('false');
+    });
+
+    it('should attach aria-hidden to ng-hide', function() {
+      compileElement('<div ng-hide="val"></div>');
+      scope.$apply('val = false');
+      expect(element.attr('aria-hidden')).toBe('false');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-hidden')).toBe('true');
+    });
+
+    it('should not change aria-hidden if it is already present on ng-show', function() {
+      compileElement('<div ng-show="val" aria-hidden="userSetValue"></div>');
+      expect(element.attr('aria-hidden')).toBe('userSetValue');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-hidden')).toBe('userSetValue');
+    });
+
+    it('should not change aria-hidden if it is already present on ng-hide', function() {
+      compileElement('<div ng-hide="val" aria-hidden="userSetValue"></div>');
+      expect(element.attr('aria-hidden')).toBe('userSetValue');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-hidden')).toBe('userSetValue');
+    });
+
+    it('should always set aria-hidden to a boolean value', function() {
+      compileElement('<div ng-hide="val"></div>');
+
+      scope.$apply('val = "test angular"');
+      expect(element.attr('aria-hidden')).toBe('true');
+
+      scope.$apply('val = null');
+      expect(element.attr('aria-hidden')).toBe('false');
+
+      scope.$apply('val = {}');
+      expect(element.attr('aria-hidden')).toBe('true');
+
+
+      compileElement('<div ng-show="val"></div>');
+
+      scope.$apply('val = "test angular"');
+      expect(element.attr('aria-hidden')).toBe('false');
+
+      scope.$apply('val = null');
+      expect(element.attr('aria-hidden')).toBe('true');
+
+      scope.$apply('val = {}');
+      expect(element.attr('aria-hidden')).toBe('false');
+    });
+  });
+
+
+  describe('aria-hidden when disabled', function() {
+    beforeEach(configAriaProvider({
+      ariaHidden: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not attach aria-hidden', function() {
+      scope.$apply('val = false');
+      compileElement('<div ng-show="val"></div>');
+      expect(element.attr('aria-hidden')).toBeUndefined();
+
+      compileElement('<div ng-hide="val"></div>');
+      expect(element.attr('aria-hidden')).toBeUndefined();
+    });
+  });
+
+  describe('aria-checked', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach itself to input type="checkbox"', function() {
+      compileElement('<input type="checkbox" ng-model="val">');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-checked')).toBe('true');
+
+      scope.$apply('val = false');
+      expect(element.attr('aria-checked')).toBe('false');
+    });
+
+    it('should handle checkbox with string model values using ng(True|False)Value', function() {
+      var element = $compile('<input type="checkbox" ng-model="val" ng-true-value="yes" ' +
+          'ng-false-value="no">'
+      )(scope);
+
+      scope.$apply('val="yes"');
+      expect(element.eq(0).attr('aria-checked')).toBe('true');
+
+      scope.$apply('val="no"');
+      expect(element.eq(0).attr('aria-checked')).toBe('false');
+    });
+
+    // angular 1.2.x only takes strings for ng(True|False)Value
+    it('should handle checkbox with integer model values using ngTrueValue', function() {
+      var element = $compile('<input type="checkbox" ng-model="val" ng-true-value="0">')(scope);
+
+      scope.$apply('val="0"');
+      expect(element.eq(0).attr('aria-checked')).toBe('true');
+
+      scope.$apply('val="1"');
+      expect(element.eq(0).attr('aria-checked')).toBe('false');
+    });
+
+    it('should attach itself to input type="radio"', function() {
+      var element = $compile('<input type="radio" ng-model="val" value="one">' +
+          '<input type="radio" ng-model="val" value="two">')(scope);
+
+      scope.$apply("val='one'");
+      expect(element.eq(0).attr('aria-checked')).toBe('true');
+      expect(element.eq(1).attr('aria-checked')).toBe('false');
+
+      scope.$apply("val='two'");
+      expect(element.eq(0).attr('aria-checked')).toBe('false');
+      expect(element.eq(1).attr('aria-checked')).toBe('true');
+    });
+
+    it('should handle radios with integer model values', function() {
+      var element = $compile('<input type="radio" ng-model="val" value="0">' +
+          '<input type="radio" ng-model="val" value="1">')(scope);
+
+      scope.$apply('val=0');
+      expect(element.eq(0).attr('aria-checked')).toBe('true');
+      expect(element.eq(1).attr('aria-checked')).toBe('false');
+
+      scope.$apply('val=1');
+      expect(element.eq(0).attr('aria-checked')).toBe('false');
+      expect(element.eq(1).attr('aria-checked')).toBe('true');
+    });
+
+    it('should handle radios with boolean model values using ngValue', function() {
+      var element = $compile('<input type="radio" ng-model="val" ng-value="valExp">' +
+          '<input type="radio" ng-model="val" ng-value="valExp2">')(scope);
+
+      scope.$apply(function() {
+        scope.valExp = true;
+        scope.valExp2 = false;
+        scope.val = true;
+      });
+      expect(element.eq(0).attr('aria-checked')).toBe('true');
+      expect(element.eq(1).attr('aria-checked')).toBe('false');
+
+      scope.$apply('val = false');
+      expect(element.eq(0).attr('aria-checked')).toBe('false');
+      expect(element.eq(1).attr('aria-checked')).toBe('true');
+    });
+
+    it('should attach itself to role="radio"', function() {
+      scope.val = 'one';
+      compileElement('<div role="radio" ng-model="val" value="one"></div>');
+      expect(element.attr('aria-checked')).toBe('true');
+
+      scope.$apply("val = 'two'");
+      expect(element.attr('aria-checked')).toBe('false');
+    });
+
+    it('should attach itself to role="checkbox"', function() {
+      scope.val = true;
+      compileElement('<div role="checkbox" ng-model="val"></div>');
+      expect(element.attr('aria-checked')).toBe('true');
+
+      scope.$apply('val = false');
+      expect(element.attr('aria-checked')).toBe('false');
+    });
+
+    it('should attach itself to role="menuitemradio"', function() {
+      scope.val = 'one';
+      compileElement('<div role="menuitemradio" ng-model="val" value="one"></div>');
+      expect(element.attr('aria-checked')).toBe('true');
+
+      scope.$apply("val = 'two'");
+      expect(element.attr('aria-checked')).toBe('false');
+    });
+
+    it('should attach itself to role="menuitemcheckbox"', function() {
+      scope.val = true;
+      compileElement('<div role="menuitemcheckbox" ng-model="val"></div>');
+      expect(element.attr('aria-checked')).toBe('true');
+
+      scope.$apply('val = false');
+      expect(element.attr('aria-checked')).toBe('false');
+    });
+
+    it('should not attach itself if an aria-checked value is already present', function() {
+      var element = [
+        $compile("<input type='checkbox' ng-model='val1' aria-checked='userSetValue'>")(scope),
+        $compile("<input type='radio' ng-model='val2' value='one' aria-checked='userSetValue'><input type='radio' ng-model='val2' value='two'>")(scope),
+        $compile("<div role='radio' ng-model='val' value='{{val3}}' aria-checked='userSetValue'></div>")(scope),
+        $compile("<div role='menuitemradio' ng-model='val' value='{{val3}}' aria-checked='userSetValue'></div>")(scope),
+        $compile("<div role='checkbox' checked='checked' aria-checked='userSetValue'></div>")(scope),
+        $compile("<div role='menuitemcheckbox' checked='checked' aria-checked='userSetValue'></div>")(scope)
+      ];
+      scope.$apply("val1=true;val2='one';val3='1'");
+      expectAriaAttrOnEachElement(element, 'aria-checked', 'userSetValue');
+    });
+  });
+
+  describe('roles for custom inputs', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should add missing role="button" to custom input', function() {
+      compileElement('<div ng-click="someFunction()"></div>');
+      expect(element.attr('role')).toBe('button');
+    });
+
+    it('should not add role="button" to anchor', function() {
+      compileElement('<a ng-click="someFunction()"></a>');
+      expect(element.attr('role')).not.toBe('button');
+    });
+
+    it('should add missing role="checkbox" to custom input', function() {
+      compileElement('<div type="checkbox" ng-model="val"></div>');
+      expect(element.attr('role')).toBe('checkbox');
+    });
+
+    it('should not add a role to a native checkbox', function() {
+      compileElement('<input type="checkbox" ng-model="val"></div>');
+      expect(element.attr('role')).toBe(undefined);
+    });
+
+    it('should add missing role="radio" to custom input', function() {
+      compileElement('<div type="radio" ng-model="val"></div>');
+      expect(element.attr('role')).toBe('radio');
+    });
+
+    it('should not add a role to a native radio button', function() {
+      compileElement('<input type="radio" ng-model="val"></div>');
+      expect(element.attr('role')).toBe(undefined);
+    });
+
+    it('should add missing role="slider" to custom input', function() {
+      compileElement('<div type="range" ng-model="val"></div>');
+      expect(element.attr('role')).toBe('slider');
+    });
+
+    it('should not add a role to a native range input', function() {
+      compileElement('<input type="range" ng-model="val"></div>');
+      expect(element.attr('role')).toBe(undefined);
+    });
+  });
+
+  describe('aria-checked when disabled', function() {
+    beforeEach(configAriaProvider({
+      ariaChecked: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not attach aria-checked', function() {
+      compileElement("<div role='radio' ng-model='val' value='{{val}}'></div>");
+      expect(element.attr('aria-checked')).toBeUndefined();
+
+      compileElement("<div role='menuitemradio' ng-model='val' value='{{val}}'></div>");
+      expect(element.attr('aria-checked')).toBeUndefined();
+
+      compileElement("<div role='checkbox' checked='checked'></div>");
+      expect(element.attr('aria-checked')).toBeUndefined();
+
+      compileElement("<div role='menuitemcheckbox' checked='checked'></div>");
+      expect(element.attr('aria-checked')).toBeUndefined();
+    });
+  });
+
+  describe('aria-disabled', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach itself to input elements', function() {
+      scope.$apply('val = false');
+      compileElement("<input ng-disabled='val'>");
+      expect(element.attr('aria-disabled')).toBe('false');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-disabled')).toBe('true');
+    });
+
+    it('should attach itself to textarea elements', function() {
+      scope.$apply('val = false');
+      compileElement('<textarea ng-disabled="val"></textarea>');
+      expect(element.attr('aria-disabled')).toBe('false');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-disabled')).toBe('true');
+    });
+
+    it('should attach itself to button elements', function() {
+      scope.$apply('val = false');
+      compileElement('<button ng-disabled="val"></button>');
+      expect(element.attr('aria-disabled')).toBe('false');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-disabled')).toBe('true');
+    });
+
+    it('should attach itself to select elements', function() {
+      scope.$apply('val = false');
+      compileElement('<select ng-disabled="val"></select>');
+      expect(element.attr('aria-disabled')).toBe('false');
+
+      scope.$apply('val = true');
+      expect(element.attr('aria-disabled')).toBe('true');
+    });
+
+    it('should not attach itself if an aria-disabled attribute is already present', function() {
+      var element = [
+        $compile("<input aria-disabled='userSetValue' ng-disabled='val'>")(scope),
+        $compile("<textarea aria-disabled='userSetValue' ng-disabled='val'></textarea>")(scope),
+        $compile("<button aria-disabled='userSetValue' ng-disabled='val'></button>")(scope),
+        $compile("<select aria-disabled='userSetValue' ng-disabled='val'></select>")(scope)
+      ];
+
+      scope.$apply('val = true');
+      expectAriaAttrOnEachElement(element, 'aria-disabled', 'userSetValue');
+    });
+
+
+    it('should always set aria-disabled to a boolean value', function() {
+      compileElement('<div ng-disabled="val"></div>');
+
+      scope.$apply('val = "test angular"');
+      expect(element.attr('aria-disabled')).toBe('true');
+
+      scope.$apply('val = null');
+      expect(element.attr('aria-disabled')).toBe('false');
+
+      scope.$apply('val = {}');
+      expect(element.attr('aria-disabled')).toBe('true');
+    });
+  });
+
+  describe('aria-disabled when disabled', function() {
+    beforeEach(configAriaProvider({
+      ariaDisabled: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not attach aria-disabled', function() {
+      var element = [
+        $compile("<input ng-disabled='val'>")(scope),
+        $compile("<textarea ng-disabled='val'></textarea>")(scope),
+        $compile("<button ng-disabled='val'></button>")(scope),
+        $compile("<select ng-disabled='val'></select>")(scope)
+      ];
+
+      scope.$apply('val = false');
+      expectAriaAttrOnEachElement(element, 'aria-disabled', undefined);
+    });
+  });
+
+  describe('aria-invalid', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach aria-invalid to input', function() {
+      compileElement('<input ng-model="txtInput" ng-minlength="10">');
+      scope.$apply("txtInput='LTten'");
+      expect(element.attr('aria-invalid')).toBe('true');
+
+      scope.$apply("txtInput='morethantencharacters'");
+      expect(element.attr('aria-invalid')).toBe('false');
+    });
+
+    it('should not attach itself if aria-invalid is already present', function() {
+      compileElement('<input ng-model="txtInput" ng-minlength="10" aria-invalid="userSetValue">');
+      scope.$apply("txtInput='LTten'");
+      expect(element.attr('aria-invalid')).toBe('userSetValue');
+    });
+  });
+
+  describe('aria-invalid when disabled', function() {
+    beforeEach(configAriaProvider({
+      ariaInvalid: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not attach aria-invalid if the option is disabled', function() {
+      scope.$apply("txtInput='LTten'");
+      compileElement('<input ng-model="txtInput" ng-minlength="10">');
+      expect(element.attr('aria-invalid')).toBeUndefined();
+    });
+  });
+
+  describe('aria-required', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach aria-required to input', function() {
+      compileElement('<input ng-model="val" name="dam" required>', true);
+      expect(element.attr('aria-required')).toBe('true');
+
+      scope.$apply("val='input is valid now'");
+      expect(element.attr('aria-required')).toBe('false');
+    });
+
+    it('should attach aria-required to textarea', function() {
+      compileElement('<textarea ng-model="val" required></textarea>', true);
+      expect(element.attr('aria-required')).toBe('true');
+
+      scope.$apply("val='input is valid now'");
+      expect(element.attr('aria-required')).toBe('false');
+    });
+
+    it('should attach aria-required to select', function() {
+      compileElement('<select ng-model="val" required></select>', true);
+      expect(element.attr('aria-required')).toBe('true');
+
+      scope.$apply("val='input is valid now'");
+      expect(element.attr('aria-required')).toBe('false');
+    });
+
+    it('should attach aria-required to ngRequired', function() {
+      compileElement('<input ng-model="val" ng-required="true">', true);
+      expect(element.attr('aria-required')).toBe('true');
+
+      scope.$apply("val='input is valid now'");
+      expect(element.attr('aria-required')).toBe('false');
+    });
+
+    it('should not attach itself if aria-required is already present', function() {
+      compileElement("<input ng-model='val' required aria-required='userSetValue'>", true);
+      expect(element.attr('aria-required')).toBe('userSetValue');
+
+      compileElement("<textarea ng-model='val' required aria-required='userSetValue'></textarea>", true);
+      expect(element.attr('aria-required')).toBe('userSetValue');
+
+      compileElement("<select ng-model='val' required aria-required='userSetValue'></select>", true);
+      expect(element.attr('aria-required')).toBe('userSetValue');
+
+      compileElement("<input ng-model='val' ng-required='true' aria-required='userSetValue'>", true);
+      expect(element.attr('aria-required')).toBe('userSetValue');
+    });
+  });
+
+  describe('aria-required when disabled', function() {
+    beforeEach(configAriaProvider({
+      ariaRequired: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not add the aria-required attribute', function() {
+      compileElement("<input ng-model='val' required>", true);
+      expect(element.attr('aria-required')).toBeUndefined();
+
+      compileElement("<textarea ng-model='val' required></textarea>", true);
+      expect(element.attr('aria-required')).toBeUndefined();
+
+      compileElement("<select ng-model='val' required></select>", true);
+      expect(element.attr('aria-required')).toBeUndefined();
+    });
+  });
+
+  describe('aria-multiline', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach itself to textarea', function() {
+      compileElement('<textarea ng-model="val"></textarea>');
+      expect(element.attr('aria-multiline')).toBe('true');
+    });
+
+    it('should attach itself role="textbox"', function() {
+      compileElement('<div role="textbox" ng-model="val"></div>');
+      expect(element.attr('aria-multiline')).toBe('true');
+    });
+
+    it('should not attach itself if aria-multiline is already present', function() {
+      compileElement('<textarea aria-multiline="userSetValue"></textarea>');
+      expect(element.attr('aria-multiline')).toBe('userSetValue');
+
+      compileElement('<div role="textbox" aria-multiline="userSetValue"></div>');
+      expect(element.attr('aria-multiline')).toBe('userSetValue');
+    });
+  });
+
+  describe('aria-multiline when disabled', function() {
+    beforeEach(configAriaProvider({
+      ariaMultiline: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not attach itself to textarea', function() {
+      compileElement('<textarea></textarea>');
+      expect(element.attr('aria-multiline')).toBeUndefined();
+    });
+
+    it('should not attach itself role="textbox"', function() {
+      compileElement('<div role="textbox"></div>');
+      expect(element.attr('aria-multiline')).toBeUndefined();
+    });
+  });
+
+  describe('aria-value', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach to input type="range"', function() {
+      var element = [
+        $compile('<input type="range" ng-model="val" min="0" max="100">')(scope),
+        $compile('<div role="progressbar" min="0" max="100" ng-model="val">')(scope),
+        $compile('<div role="slider" min="0" max="100" ng-model="val">')(scope)
+      ];
+
+      scope.$apply('val = 50');
+      expectAriaAttrOnEachElement(element, 'aria-valuenow', "50");
+      expectAriaAttrOnEachElement(element, 'aria-valuemin', "0");
+      expectAriaAttrOnEachElement(element, 'aria-valuemax', "100");
+
+      scope.$apply('val = 90');
+      expectAriaAttrOnEachElement(element, 'aria-valuenow', "90");
+    });
+
+    it('should not attach if aria-value* is already present', function() {
+      var element = [
+        $compile('<input type="range" ng-model="val" min="0" max="100" aria-valuenow="userSetValue1" aria-valuemin="userSetValue2" aria-valuemax="userSetValue3">')(scope),
+        $compile('<div role="progressbar" min="0" max="100" ng-model="val" aria-valuenow="userSetValue1" aria-valuemin="userSetValue2" aria-valuemax="userSetValue3">')(scope),
+        $compile('<div role="slider" min="0" max="100" ng-model="val" aria-valuenow="userSetValue1" aria-valuemin="userSetValue2" aria-valuemax="userSetValue3">')(scope)
+      ];
+
+      scope.$apply('val = 50');
+      expectAriaAttrOnEachElement(element, 'aria-valuenow', 'userSetValue1');
+      expectAriaAttrOnEachElement(element, 'aria-valuemin', 'userSetValue2');
+      expectAriaAttrOnEachElement(element, 'aria-valuemax', 'userSetValue3');
+    });
+
+
+    it('should update `aria-valuemin/max` when `min/max` changes dynamically', function() {
+      scope.$apply('min = 25; max = 75');
+      compileElement('<input type="range" ng-model="val" min="{{min}}" max="{{max}}" />');
+
+      expect(element.attr('aria-valuemin')).toBe('25');
+      expect(element.attr('aria-valuemax')).toBe('75');
+
+      scope.$apply('min = 0');
+      expect(element.attr('aria-valuemin')).toBe('0');
+
+      scope.$apply('max = 100');
+      expect(element.attr('aria-valuemax')).toBe('100');
+    });
+
+  });
+
+  describe('announcing ngMessages', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach aria-live', function() {
+      var element = [
+        $compile('<div ng-messages="myForm.myName.$error">')(scope)
+      ];
+      expectAriaAttrOnEachElement(element, 'aria-live', "assertive");
+    });
+  });
+
+  describe('aria-value when disabled', function() {
+    beforeEach(configAriaProvider({
+      ariaValue: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not attach itself', function() {
+      scope.$apply('val = 50');
+
+      compileElement('<input type="range" ng-model="val" min="0" max="100">');
+      expect(element.attr('aria-valuenow')).toBeUndefined();
+      expect(element.attr('aria-valuemin')).toBeUndefined();
+      expect(element.attr('aria-valuemax')).toBeUndefined();
+
+      compileElement('<div role="progressbar" min="0" max="100" ng-model="val">');
+      expect(element.attr('aria-valuenow')).toBeUndefined();
+      expect(element.attr('aria-valuemin')).toBeUndefined();
+      expect(element.attr('aria-valuemax')).toBeUndefined();
+    });
+  });
+
+  describe('tabindex', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    it('should attach tabindex to role="checkbox", ng-click, and ng-dblclick', function() {
+      compileElement('<div role="checkbox" ng-model="val"></div>');
+      expect(element.attr('tabindex')).toBe('0');
+
+      compileElement('<div ng-click="someAction()"></div>');
+      expect(element.attr('tabindex')).toBe('0');
+
+      compileElement('<div ng-dblclick="someAction()"></div>');
+      expect(element.attr('tabindex')).toBe('0');
+    });
+
+    it('should not attach tabindex if it is already on an element', function() {
+      compileElement('<div role="button" tabindex="userSetValue"></div>');
+      expect(element.attr('tabindex')).toBe('userSetValue');
+
+      compileElement('<div role="checkbox" tabindex="userSetValue"></div>');
+      expect(element.attr('tabindex')).toBe('userSetValue');
+
+      compileElement('<div ng-click="someAction()" tabindex="userSetValue"></div>');
+      expect(element.attr('tabindex')).toBe('userSetValue');
+
+      compileElement('<div ng-dblclick="someAction()" tabindex="userSetValue"></div>');
+      expect(element.attr('tabindex')).toBe('userSetValue');
+    });
+
+    it('should set proper tabindex values for radiogroup', function() {
+      compileElement('<div role="radiogroup">' +
+                     '<div role="radio" ng-model="val" value="one">1</div>' +
+                     '<div role="radio" ng-model="val" value="two">2</div>' +
+                   '</div>');
+
+      var one = element.contents().eq(0);
+      var two = element.contents().eq(1);
+
+      scope.$apply("val = 'one'");
+      expect(one.attr('tabindex')).toBe('0');
+      expect(two.attr('tabindex')).toBe('-1');
+
+      scope.$apply("val = 'two'");
+      expect(one.attr('tabindex')).toBe('-1');
+      expect(two.attr('tabindex')).toBe('0');
+
+      dealoc(element);
+    });
+  });
+
+  describe('accessible actions', function() {
+    beforeEach(injectScopeAndCompiler);
+
+    var clickFn;
+
+    it('should trigger a click from the keyboard', function() {
+      scope.someAction = function() {};
+
+      var elements = $compile('<section>' +
+                  '<div class="div-click" ng-click="someAction(\'div\')" tabindex="0"></div>' +
+                  '<ul><li ng-click="someAction( \'li\')" tabindex="0"></li></ul>' +
+                  '</section>')(scope);
+
+      scope.$digest();
+
+      clickFn = spyOn(scope, 'someAction');
+
+      var divElement = elements.find('div');
+      var liElement = elements.find('li');
+
+      divElement.triggerHandler({type: 'keypress', keyCode: 32});
+      liElement.triggerHandler({type: 'keypress', keyCode: 32});
+
+      expect(clickFn).toHaveBeenCalledWith('div');
+      expect(clickFn).toHaveBeenCalledWith('li');
+    });
+
+    it('should trigger a click in browsers that provide event.which instead of event.keyCode', function() {
+      scope.someAction = function() {};
+
+      var elements = $compile('<section>' +
+      '<div class="div-click" ng-click="someAction(\'div\')" tabindex="0"></div>' +
+      '<ul><li ng-click="someAction( \'li\')" tabindex="0"></li></ul>' +
+      '</section>')(scope);
+
+      scope.$digest();
+
+      clickFn = spyOn(scope, 'someAction');
+
+      var divElement = elements.find('div');
+      var liElement = elements.find('li');
+
+      divElement.triggerHandler({type: 'keypress', which: 32});
+      liElement.triggerHandler({type: 'keypress', which: 32});
+
+      expect(clickFn).toHaveBeenCalledWith('div');
+      expect(clickFn).toHaveBeenCalledWith('li');
+    });
+
+    it('should not override existing ng-keypress', function() {
+      scope.someOtherAction = function() {};
+      var keypressFn = spyOn(scope, 'someOtherAction');
+
+      scope.someAction = function() {};
+      clickFn = spyOn(scope, 'someAction');
+      compileElement('<div ng-click="someAction()" ng-keypress="someOtherAction()" tabindex="0"></div>');
+
+      element.triggerHandler({type: 'keypress', keyCode: 32});
+
+      expect(clickFn).not.toHaveBeenCalled();
+      expect(keypressFn).toHaveBeenCalled();
+    });
+
+    it('should update bindings when keypress handled', function() {
+      compileElement('<div ng-click="text = \'clicked!\'">{{text}}</div>');
+      expect(element.text()).toBe('');
+      spyOn(scope.$root, '$digest').andCallThrough();
+      element.triggerHandler({ type: 'keypress', keyCode: 13 });
+      expect(element.text()).toBe('clicked!');
+      expect(scope.$root.$digest).toHaveBeenCalledOnce();
+    });
+
+    it('should pass $event to ng-click handler as local', function() {
+      compileElement('<div ng-click="event = $event">{{event.type}}' +
+                      '{{event.keyCode}}</div>');
+      expect(element.text()).toBe('');
+      element.triggerHandler({ type: 'keypress', keyCode: 13 });
+      expect(element.text()).toBe('keypress13');
+    });
+
+    it('should not bind keypress to elements not in the default config', function() {
+      compileElement('<button ng-click="event = $event">{{event.type}}{{event.keyCode}}</button>');
+      expect(element.text()).toBe('');
+      element.triggerHandler({ type: 'keypress', keyCode: 13 });
+      expect(element.text()).toBe('');
+    });
+  });
+
+  describe('actions when bindRoleForClick is set to false', function() {
+    beforeEach(configAriaProvider({
+      bindRoleForClick: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not add a button role', function() {
+      compileElement('<radio-group ng-click="something"></radio-group>');
+      expect(element.attr('role')).toBeUndefined();
+    });
+  });
+
+  describe('actions when bindKeypress is set to false', function() {
+    beforeEach(configAriaProvider({
+      bindKeypress: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not a trigger click', function() {
+      scope.someAction = function() {};
+      var clickFn = spyOn(scope, 'someAction');
+
+      element = $compile('<div ng-click="someAction()" tabindex="0"></div>')(scope);
+
+      element.triggerHandler({type: 'keypress', keyCode: 32});
+
+      expect(clickFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tabindex when disabled', function() {
+    beforeEach(configAriaProvider({
+      tabindex: false
+    }));
+    beforeEach(injectScopeAndCompiler);
+
+    it('should not add a tabindex attribute', function() {
+      compileElement('<div role="button"></div>');
+      expect(element.attr('tabindex')).toBeUndefined();
+
+      compileElement('<div role="checkbox"></div>');
+      expect(element.attr('tabindex')).toBeUndefined();
+
+      compileElement('<div ng-click="someAction()"></div>');
+      expect(element.attr('tabindex')).toBeUndefined();
+
+      compileElement('<div ng-dblclick="someAction()"></div>');
+      expect(element.attr('tabindex')).toBeUndefined();
+    });
+  });
+});
+
+function expectAriaAttrOnEachElement(elem, ariaAttr, expected) {
+  angular.forEach(elem, function(val) {
+    expect(angular.element(val).attr(ariaAttr)).toBe(expected);
+  });
+}
+
+function configAriaProvider(config) {
+  return function() {
+    angular.module('ariaTest', ['ngAria']).config(function($ariaProvider) {
+      $ariaProvider.config(config);
+    });
+    module('ariaTest');
+  };
+}

--- a/test/ngMessages/messagesSpec.js
+++ b/test/ngMessages/messagesSpec.js
@@ -1,0 +1,428 @@
+'use strict';
+
+describe('ngMessages', function() {
+  beforeEach(module('ngMessages'));
+
+  function messageChildren(element) {
+    return (element.length ? element[0] : element).querySelectorAll('[ng-message], [ng-message-exp]');
+  }
+
+  function s(str) {
+    return str.replace(/\s+/g,'');
+  }
+
+  var element;
+  afterEach(function() {
+    dealoc(element);
+  });
+
+  it('should render based off of a hashmap collection', inject(function($rootScope, $compile) {
+    element = $compile('<div ng-messages="col">' +
+                       '  <div ng-message="val">Message is set</div>' +
+                       '</div>')($rootScope);
+    $rootScope.$digest();
+
+    expect(element.text()).not.toContain('Message is set');
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { val: true };
+    });
+
+    expect(element.text()).toContain('Message is set');
+  }));
+
+  it('should render the same message if multiple message keys match', inject(function($rootScope, $compile) {
+    element = $compile('<div ng-messages="col">' +
+                       '  <div ng-message="one, two, three">Message is set</div>' +
+                       '</div>')($rootScope);
+    $rootScope.$digest();
+
+    expect(element.text()).not.toContain('Message is set');
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { one: true };
+    });
+
+    expect(element.text()).toContain('Message is set');
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { two: true, one: false };
+    });
+
+    expect(element.text()).toContain('Message is set');
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { three: true, two: false };
+    });
+
+    expect(element.text()).toContain('Message is set');
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { three: false };
+    });
+
+    expect(element.text()).not.toContain('Message is set');
+  }));
+
+  it('should use the when attribute when an element directive is used',
+    inject(function($rootScope, $compile) {
+
+    element = $compile('<ng-messages for="col">' +
+                       '  <ng-message when="val">Message is set</div>' +
+                       '</ng-messages>')($rootScope);
+    $rootScope.$digest();
+
+    expect(element.text()).not.toContain('Message is set');
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { val: true };
+    });
+
+    expect(element.text()).toContain('Message is set');
+  }));
+
+  it('should render the same message if multiple message keys match based on the when attribute', inject(function($rootScope, $compile) {
+    element = $compile('<ng-messages for="col">' +
+                       '  <ng-message when=" one two three ">Message is set</div>' +
+                       '</ng-messages>')($rootScope);
+    $rootScope.$digest();
+
+    expect(element.text()).not.toContain('Message is set');
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { one: true };
+    });
+
+    expect(element.text()).toContain('Message is set');
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { two: true, one: false };
+    });
+
+    expect(element.text()).toContain('Message is set');
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { three: true, two: false };
+    });
+
+    expect(element.text()).toContain('Message is set');
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { three: false };
+    });
+
+    expect(element.text()).not.toContain('Message is set');
+  }));
+
+  it('should allow a dynamic expression to be set when ng-message-exp is used',
+    inject(function($rootScope, $compile) {
+
+    element = $compile('<div ng-messages="col">' +
+                       '  <div ng-message-exp="variable">Message is crazy</div>' +
+                       '</div>')($rootScope);
+    $rootScope.$digest();
+
+    expect(element.text()).not.toContain('Message is crazy');
+
+    $rootScope.$apply(function() {
+      $rootScope.variable = 'error';
+      $rootScope.col = { error: true };
+    });
+
+    expect(element.text()).toContain('Message is crazy');
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { error: false, failure: true };
+    });
+
+    expect(element.text()).not.toContain('Message is crazy');
+
+    $rootScope.$apply(function() {
+      $rootScope.variable = ['failure'];
+    });
+
+    expect(element.text()).toContain('Message is crazy');
+
+    $rootScope.$apply(function() {
+      $rootScope.variable = null;
+    });
+
+    expect(element.text()).not.toContain('Message is crazy');
+  }));
+
+  it('should allow a dynamic expression to be set when the when-exp attribute is used',
+    inject(function($rootScope, $compile) {
+
+    element = $compile('<ng-messages for="col">' +
+                       '  <ng-message when-exp="variable">Message is crazy</ng-message>' +
+                       '</ng-messages>')($rootScope);
+    $rootScope.$digest();
+
+    expect(element.text()).not.toContain('Message is crazy');
+
+    $rootScope.$apply(function() {
+      $rootScope.variable = 'error, failure';
+      $rootScope.col = { error: true };
+    });
+
+    expect(element.text()).toContain('Message is crazy');
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { error: false, failure: true };
+    });
+
+    expect(element.text()).toContain('Message is crazy');
+
+    $rootScope.$apply(function() {
+      $rootScope.variable = [];
+    });
+
+    expect(element.text()).not.toContain('Message is crazy');
+
+    $rootScope.$apply(function() {
+      $rootScope.variable = null;
+    });
+
+    expect(element.text()).not.toContain('Message is crazy');
+  }));
+
+  they('should render empty when $prop is used as a collection value',
+    { 'null': null,
+      'false': false,
+      '0': 0,
+      '[]': [],
+      '[{}]': [{}],
+      '': '',
+      '{ val2 : true }': { val2: true } },
+  function(prop) {
+    inject(function($rootScope, $compile) {
+      element = $compile('<div ng-messages="col">' +
+                         '  <div ng-message="val">Message is set</div>' +
+                         '</div>')($rootScope);
+      $rootScope.$digest();
+
+      $rootScope.$apply(function() {
+        $rootScope.col = prop;
+      });
+      expect(element.text()).not.toContain('Message is set');
+    });
+  });
+
+  they('should insert and remove matching inner elements when $prop is used as a value',
+    { 'true': true,
+      '1': 1,
+      '{}': {},
+      '[]': [],
+      '[null]': [null] },
+  function(prop) {
+    inject(function($rootScope, $compile) {
+
+      element = $compile('<div ng-messages="col">' +
+                         '  <div ng-message="blue">This message is blue</div>' +
+                         '  <div ng-message="red">This message is red</div>' +
+                         '</div>')($rootScope);
+
+      $rootScope.$apply(function() {
+        $rootScope.col = {};
+      });
+
+      expect(messageChildren(element).length).toBe(0);
+      expect(trim(element.text())).toEqual('');
+
+      $rootScope.$apply(function() {
+        $rootScope.col = {
+          blue: true,
+          red: false
+        };
+      });
+
+      expect(messageChildren(element).length).toBe(1);
+      expect(trim(element.text())).toEqual('This message is blue');
+
+      $rootScope.$apply(function() {
+        $rootScope.col = {
+          red: prop
+        };
+      });
+
+      expect(messageChildren(element).length).toBe(1);
+      expect(trim(element.text())).toEqual('This message is red');
+
+      $rootScope.$apply(function() {
+        $rootScope.col = null;
+      });
+      expect(messageChildren(element).length).toBe(0);
+      expect(trim(element.text())).toEqual('');
+
+
+      $rootScope.$apply(function() {
+        $rootScope.col = {
+          blue: 0,
+          red: null
+        };
+      });
+
+      expect(messageChildren(element).length).toBe(0);
+      expect(trim(element.text())).toEqual('');
+    });
+  });
+
+  it('should display the elements in the order defined in the DOM',
+    inject(function($rootScope, $compile) {
+
+    element = $compile('<div ng-messages="col">' +
+                       '  <div ng-message="one">Message#one</div>' +
+                       '  <div ng-message="two">Message#two</div>' +
+                       '  <div ng-message="three">Message#three</div>' +
+                       '</div>')($rootScope);
+
+    $rootScope.$apply(function() {
+      $rootScope.col = {
+        three: true,
+        one: true,
+        two: true
+      };
+    });
+
+    angular.forEach(['one','two','three'], function(key) {
+      expect(s(element.text())).toEqual('Message#' + key);
+
+      $rootScope.$apply(function() {
+        $rootScope.col[key] = false;
+      });
+    });
+
+    expect(s(element.text())).toEqual('');
+  }));
+
+  it('should add ng-active/ng-inactive CSS classes to the element when errors are/aren\'t displayed',
+    inject(function($rootScope, $compile) {
+
+    element = $compile('<div ng-messages="col">' +
+                       '  <div ng-message="ready">This message is ready</div>' +
+                       '</div>')($rootScope);
+
+    $rootScope.$apply(function() {
+      $rootScope.col = {};
+    });
+
+    expect(element.hasClass('ng-active')).toBe(false);
+    expect(element.hasClass('ng-inactive')).toBe(true);
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { ready: true };
+    });
+
+    expect(element.hasClass('ng-active')).toBe(true);
+    expect(element.hasClass('ng-inactive')).toBe(false);
+  }));
+
+  it('should automatically re-render the messages when other directives dynmically change them',
+    inject(function($rootScope, $compile) {
+
+    element = $compile('<div ng-messages="col">' +
+                       '  <div ng-message="primary">Enter something</div>' +
+                       '  <div ng-repeat="item in items">' +
+                       '    <div ng-message-exp="item.name">{{ item.text }}</div>' +
+                       '  </div>' +
+                       '</div>')($rootScope);
+
+    $rootScope.$apply(function() {
+      $rootScope.col = {};
+      $rootScope.items = [
+        { text: 'Your age is incorrect', name: 'age' },
+        { text: 'You\'re too tall man!', name: 'height' },
+        { text: 'Your hair is too long', name: 'hair' }
+      ];
+    });
+
+    expect(messageChildren(element).length).toBe(0);
+    expect(trim(element.text())).toEqual("");
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { hair: true };
+    });
+
+    expect(messageChildren(element).length).toBe(1);
+    expect(trim(element.text())).toEqual("Your hair is too long");
+
+    $rootScope.$apply(function() {
+      $rootScope.col = { age: true, hair: true};
+    });
+
+    expect(messageChildren(element).length).toBe(1);
+    expect(trim(element.text())).toEqual("Your age is incorrect");
+
+    $rootScope.$apply(function() {
+      // remove the age!
+      $rootScope.items.shift();
+    });
+
+    expect(messageChildren(element).length).toBe(1);
+    expect(trim(element.text())).toEqual("Your hair is too long");
+
+    $rootScope.$apply(function() {
+      // remove the hair!
+      $rootScope.items.length = 0;
+      $rootScope.col.primary = true;
+    });
+
+    expect(messageChildren(element).length).toBe(1);
+    expect(trim(element.text())).toEqual("Enter something");
+  }));
+
+
+  it('should render animations when the active/inactive classes are added/removed', function() {
+    module('ngAnimate');
+    module('ngAnimateMock');
+    inject(function($rootScope, $compile, $animate) {
+      element = $compile('<div ng-messages="col">' +
+                         '  <div ng-message="ready">This message is ready</div>' +
+                         '</div>')($rootScope);
+
+      $rootScope.$apply(function() {
+        $rootScope.col = {};
+      });
+
+      var event = $animate.queue.pop();
+      expect(event.event).toBe('setClass');
+      expect(event.args[1]).toBe('ng-inactive');
+      expect(event.args[2]).toBe('ng-active');
+
+      $rootScope.$apply(function() {
+        $rootScope.col = { ready: true };
+      });
+
+      event = $animate.queue.pop();
+      expect(event.event).toBe('setClass');
+      expect(event.args[1]).toBe('ng-active');
+      expect(event.args[2]).toBe('ng-inactive');
+    });
+  });
+
+  describe('when multiple', function() {
+    they('should show all truthy messages when the $prop attr is present',
+      { 'multiple': 'multiple',
+        'ng-messages-multiple': 'ng-messages-multiple' },
+    function(prop) {
+      inject(function($rootScope, $compile) {
+        element = $compile('<div ng-messages="data" ' + prop + '>' +
+                           '  <div ng-message="one">1</div>' +
+                           '  <div ng-message="two">2</div>' +
+                           '  <div ng-message="three">3</div>' +
+                           '</div>')($rootScope);
+
+        $rootScope.$apply(function() {
+          $rootScope.data = {
+            'one': true,
+            'two': false,
+            'three': true
+          };
+        });
+
+        expect(messageChildren(element).length).toBe(2);
+        expect(s(element.text())).toContain("13");
+      });
+    });
+  });
+});


### PR DESCRIPTION
Support ngAria and ngMessages in 1.2.x. Some features from ^1.3.0 could
not be backported due to absence of a feature in 1.2.x (i.e. ng-min,
ng-messages-include).

Pretty much replaces PR #12626 by creating a 1.2.x specific implementation. 
@gkalpak @Narretz please review.

Noticed IE8 auto tests fail weirdly on aria, looks like something is throwing errors but cannot reproduce this myself. Any help is appreciated.
Also noticed IE8 ngMessages test for usage by element (i.e. `<ng-messages for="x">`) which I know does not fly well in general for IE8. Should this even be tested? I tried patching to `<ng:messages>` as this sometimes fixed things for me, but could not get it to work in this case (probably because `ng-message` uses `require`).

Please advise. 
