### PR TITLE
Fix #1678 by allowing headers.Authorization to be a 2 item username/password array

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -48,7 +48,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
 
       var xhr = createXhr();
       
-      if (('Authorization' in headers) && headers.Authorization.length == 2) {
+      if (('Authorization' in headers || {}) && headers.Authorization.length == 2) {
         xhr.open(method, url, true, headers.Authorization[0], headers.Authorization[1]);
         delete headers.Authorization;
       } else {

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -47,7 +47,6 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
     } else {
 
       var xhr = createXhr();
-      
       if (isDefined(headers) && isDefined(headers.Authorization) && headers.Authorization.length == 2) {
         xhr.open(method, url, true, headers.Authorization[0], headers.Authorization[1]);
         delete headers.Authorization;

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -47,8 +47,14 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
     } else {
 
       var xhr = createXhr();
+      
+      if (('Authorization' in headers) && headers.Authorization.length == 2) {
+        xhr.open(method, url, true, headers.Authorization[0], headers.Authorization[1]);
+        delete headers.Authorization;
+      } else {
+        xhr.open(method, url, true);
+      }
 
-      xhr.open(method, url, true);
       forEach(headers, function(value, key) {
         if (isDefined(value)) {
             xhr.setRequestHeader(key, value);

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -48,7 +48,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
 
       var xhr = createXhr();
       
-      if (('Authorization' in headers || {}) && headers.Authorization.length == 2) {
+      if (isDefined(headers) && isDefined(headers.Authorization) && headers.Authorization.length == 2) {
         xhr.open(method, url, true, headers.Authorization[0], headers.Authorization[1]);
         delete headers.Authorization;
       } else {


### PR DESCRIPTION
Just to kick things off after my $provide.decorator fix in #1678 

todo:
- [ ] docs
- [ ] tests (how?)
