### PR TITLE
fix(input): patched input cjk binding bug on ie11 browser. (angularjs v1.2.28)

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -498,7 +498,7 @@ function textInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   }
 
   var listener = function(ev) {
-    if (composing) return;
+    if (msie !== 11 && composing) return;
     var value = element.val();
 
     // IE (11 and under) seem to emit an 'input' event if the placeholder value changes.


### PR DESCRIPTION
Related #12659 

I append "if condition" code about ie11.
