### PR TITLE
docs(guide/Forms): replace `form` with `user`

### DIFF
--- a/docs/content/guide/forms.ngdoc
+++ b/docs/content/guide/forms.ngdoc
@@ -33,7 +33,7 @@ for other directives to augment its behavior.
         <input type="button" ng-click="reset()" value="Reset" />
         <input type="submit" ng-click="update(user)" value="Save" />
       </form>
-      <pre>form = {{user | json}}</pre>
+      <pre>user = {{user | json}}</pre>
       <pre>master = {{master | json}}</pre>
     </div>
 
@@ -95,7 +95,7 @@ and failing to satisfy its validity.
         <input type="button" ng-click="reset()" value="Reset" />
         <input type="submit" ng-click="update(user)" value="Save" />
       </form>
-      <pre>form = {{user | json}}</pre>
+      <pre>user = {{user | json}}</pre>
       <pre>master = {{master | json}}</pre>
     </div>
 
@@ -185,7 +185,7 @@ didn't interact with a control
         <input type="button" ng-click="reset(form)" value="Reset" />
         <input type="submit" ng-click="update(user)" value="Save" />
       </form>
-      <pre>form = {{user | json}}</pre>
+      <pre>user = {{user | json}}</pre>
       <pre>master = {{master | json}}</pre>
     </div>
   </file>


### PR DESCRIPTION
Referring to the `user` as `form` in the previews is confusing, since it makes it seem as though the data being displayed is attached to the `form` object, when the `form` object is separate, albeit controlling whether data is synced to the `user` object.
