### PR TITLE
fix($angular): use strict equality comparison

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -198,7 +198,7 @@ msie = document.documentMode;
  *                   String ...)
  */
 function isArrayLike(obj) {
-  if (obj == null || isWindow(obj)) {
+  if (obj === null || isWindow(obj)) {
     return false;
   }
 


### PR DESCRIPTION
There is no type-conversion to be done because both parameters are already the same type. 
Therefore, the === operator should be used for better performance.
