### PR TITLE
fix($parse): `assign` returns the new value

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -774,6 +774,7 @@ ASTCompiler.prototype = {
       this.state.computing = 'assign';
       var result = this.nextId();
       this.recurse(assignable, result);
+      this.return_(result);
       extra = 'fn.assign=' + this.generateFunction('assign', 's,v,l');
     }
     var toWatch = getInputs(ast.body);

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -2797,6 +2797,14 @@ describe('parser', function() {
           expect(scope).toEqual({a:123});
         }));
 
+        it('should return the assigned value', inject(function($parse) {
+          var fn = $parse('a');
+          var scope = {};
+          expect(fn.assign(scope, 123)).toBe(123);
+          var someObject = {};
+          expect(fn.assign(scope, someObject)).toBe(someObject);
+        }));
+
         it('should expose working assignment function for expressions ending with brackets', inject(function($parse) {
           var fn = $parse('a.b["c"]');
           expect(fn.assign).toBeTruthy();


### PR DESCRIPTION
The `.assign` function returns the new value.
The version with csp enabled already has this behavior.

Closes #12675
