### PR TITLE
Fixing problems with large numbers and formatNumber

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -174,10 +174,13 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
       fractionSize = Math.min(Math.max(pattern.minFrac, fractionLen), pattern.maxFrac);
     }
 
-    // safely round numbers in JS without hitting imprecisions of floating-point arithmetics
-    // inspired by:
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
-    number = +(Math.round(+(number.toString() + 'e' + fractionSize)).toString() + 'e' + -fractionSize);
+    // round the number only if it's decimal
+    if(number.toString().indexOf('.') >= 0) {
+      // safely round numbers in JS without hitting imprecisions of floating-point arithmetics
+      // inspired by:
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
+      number = +(Math.round(+(number.toString() + 'e' + fractionSize)).toString() + 'e' + -fractionSize);
+    }
 
     var fraction = ('' + number).split(DECIMAL_SEP);
     var whole = fraction[0];

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -175,7 +175,7 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
     }
 
     // round the number only if it's decimal
-    if(number.toString().indexOf('.') >= 0) {
+    if (number.toString().indexOf('.') >= 0) {
       // safely round numbers in JS without hitting imprecisions of floating-point arithmetics
       // inspired by:
       // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -96,7 +96,8 @@ describe('filters', function() {
       // were ending up with a second exponent in them, then coercing to
       // NaN when formatNumber rounded them with the safe rounding
       // function.
-      var localLimitMax = 999999999999999934463,
+
+      var localLimitMax = 999999999999999900000,
           localLimitMin = 10000000000000000000,
           exampleNumber = 444444444400000000000;
 

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -90,6 +90,24 @@ describe('filters', function() {
       expect(formatNumber(-0.0001, pattern, ',', '.', 3)).toBe('0.000');
       expect(formatNumber(-0.0000001, pattern, ',', '.', 6)).toBe('0.000000');
     });
+
+    it('should work with numbers that are close to the limit for exponent notation', function() {
+      // previously, numbers that n * (10 ^ fractionSize) > localLimitMax
+      // were ending up with a second exponent in them, then coercing to
+      // NaN when formatNumber rounded them with the safe rounding
+      // function.
+      var localLimitMax = 999999999999999934463,
+          localLimitMin = 10000000000000000000,
+          exampleNumber = 444444444400000000000;
+
+      expect(formatNumber(localLimitMax, pattern, ',', '.', 2))
+        .toBe('999,999,999,999,999,900,000.00');
+      expect(formatNumber(localLimitMin, pattern, ',', '.', 2))
+        .toBe('10,000,000,000,000,000,000.00');
+      expect(formatNumber(exampleNumber, pattern, ',', '.', 2))
+        .toBe('444,444,444,400,000,000,000.00');
+
+    });
   });
 
   describe('currency', function() {


### PR DESCRIPTION
Use a simple check to prevent the decimal rounding code doesn't try to round integers. This prevents formatNumber from returning NaN for numbers that fit the criteria described in #12707.

Tests show it working with numbers lower and upper limit numbers as well as the example from the above issue.

Fixes #12707
Fixes #8674
