### PR TITLE
(docs)remove dead link

### DIFF
--- a/docs/app/assets/css/doc_widgets.css
+++ b/docs/app/assets/css/doc_widgets.css
@@ -56,7 +56,7 @@ li.doc-example-live {
 }
 
 div.syntaxhighlighter {
-  padding-bottom: 1px !important; /* fix to remove unnecessary scrollbars http://is.gd/gSMgC */
+  padding-bottom: 1px !important; /* fix to remove unnecessary scrollbars */
 }
 
 /* TABS - tutorial environment navigation */


### PR DESCRIPTION
This removes a dead link (https://bitbucket.org/alexg/syntaxhighlighter/issues/177/superfluous-vertical-scrollbars-in-chrome) which linked to an issue on Bitbucket that no longer exists due to the project moving to GitHub.
