### PR TITLE
docs($animate): Consistent naming

### DIFF
--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -338,8 +338,8 @@ var $AnimateProvider = ['$provide', function($provide) {
        * // remove all the animation event listeners listening for `enter` on the given element and its children
        * $animate.off('enter', container);
        *
-       * // remove the event listener function provided by `listenerFn` that is set
-       * // to listen for `enter` on the given `element` as well as its children
+       * // remove the event listener function provided by `callback` that is set
+       * // to listen for `enter` on the given `container` as well as its children
        * $animate.off('enter', container, callback);
        * ```
        *


### PR DESCRIPTION
In the description of the example, you use `element` to refer to the container parameter and `listenerFn` to refer to the callback parameter.
