### PR TITLE
docs(error/unpr): Adding hint about ngStrictDi

### DIFF
--- a/docs/content/error/$injector/unpr.ngdoc
+++ b/docs/content/error/$injector/unpr.ngdoc
@@ -81,3 +81,6 @@ angular.module('myModule', [])
     // a scope object cannot be injected into a service.
   }]);
 ```
+
+If you encounter this error only with minified code, consider using `ngStrictDi` (see
+{@link ng.directive:ngApp ngApp}) to provoke the error with the non-minified source.


### PR DESCRIPTION
The unknown provider error often happens when code is minified and one did not use the correct syntax that supports minification. It's frustrating to have to hunt for a bug in minified code, so adding the simple hint that `ngStrictDi` will tell you what is wrong in the original code will save you quite some trouble.
