### PR TITLE
chore(scripts/publish): get dist-tag from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "license": "MIT",
   "branchVersion": "^1.4.0-beta.0",
   "branchPattern": "1.4.*",
+  "distTag": "latest",
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.js.git"

--- a/scripts/bower/publish.sh
+++ b/scripts/bower/publish.sh
@@ -95,19 +95,10 @@ function publish {
 
     # don't publish every build to npm
     if [ "${NEW_VERSION/+sha}" = "$NEW_VERSION" ] ; then
-      if [ "${NEW_VERSION/-}" = "$NEW_VERSION" ] ; then
-        if [[ $NEW_VERSION =~ ^1\.2\.[0-9]+$ ]] ; then
-          # publish 1.2.x releases with the appropriate tag
-          # this ensures that `npm install` by default will not grab `1.2.x` releases
-          npm publish --tag=old
-        else
-          # publish releases as "latest"
-          npm publish
-        fi
-      else
-        # publish prerelease builds with the beta tag
-        npm publish --tag=beta
-      fi
+      # get the npm dist-tag from a custom property (distTag) in package.json
+      DIST_TAG=$(readJsonProp "package.json" "distTag")
+      echo "-- Publishing to npm as $DIST_TAG"
+      npm publish --tag=$DIST_TAG
     fi
 
     cd $SCRIPT_DIR


### PR DESCRIPTION
This change would need to be cherry-picked to the previous version branches (with suitable change to package.json) to prevent releases from them breaking npm dist-tags.

Where does this need to be documented? New big version release tasks? Contributor documentation?
