### PR TITLE
fix($animate): invalid CSS class names should not break subsequent elements

### DIFF
--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -151,18 +151,20 @@ var $$CoreAnimateQueueProvider = function() {
 
 
     function addRemoveClassesPostDigest(element, add, remove) {
-      var classVal, data = postDigestQueue.get(element);
-
-      if (!data) {
-        postDigestQueue.put(element, data = {});
-        postDigestElements.push(element);
-      }
+      var data = postDigestQueue.get(element) || {};
 
       var classesAdded = updateData(data, add, true);
       var classesRemoved = updateData(data, remove, false);
-      if ((!classesAdded && !classesRemoved) || postDigestElements.length > 1) return;
 
-      $rootScope.$$postDigest(handleCSSClassChanges);
+      if (classesAdded || classesRemoved) {
+
+        postDigestQueue.put(element, data);
+        postDigestElements.push(element);
+
+        if (postDigestElements.length === 1) {
+          $rootScope.$$postDigest(handleCSSClassChanges);
+        }
+      }
     }
   }];
 };

--- a/test/ng/animateSpec.js
+++ b/test/ng/animateSpec.js
@@ -341,6 +341,21 @@ describe("$animate", function() {
     });
   });
 
+
+  it('should not break postDigest for subsequent elements if addClass contains non-valid CSS class names', function() {
+    inject(function($animate, $rootScope, $rootElement) {
+      var element1 = jqLite('<div></div>');
+      var element2 = jqLite('<div></div>');
+
+      $animate.enter(element1, $rootElement, null, { addClass: ' ' });
+      $animate.enter(element2, $rootElement, null, { addClass: 'valid-name' });
+      $rootScope.$digest();
+
+      expect(element2.hasClass('valid-name')).toBeTruthy();
+    });
+  });
+
+
   it('should not issue a call to removeClass if the provided class value is not a string or array', function() {
     inject(function($animate, $rootScope, $rootElement) {
       var spy = spyOn(window, 'jqLiteRemoveClass').andCallThrough();


### PR DESCRIPTION
The postDigest handler was not being added if the first element in
to modify the CSS classes contained invalid CSS class names. This meant
that subsequent valid CSS class changes were not being handled since we
were not then adding the handler for those correct cases.

Closes #12674
