### PR TITLE
feat($location): add post parse app url hook

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -30,6 +30,13 @@ function parseAbsoluteUrl(absoluteUrl, locationObj) {
   locationObj.$$port = toInt(parsedUrl.port) || DEFAULT_PORTS[parsedUrl.protocol] || null;
 }
 
+/**
+ * Default post parse app url hook, performs no changes to location object
+ * @param locationObj
+ */
+var postParseAppUrlHook = function(locationObj, url) {
+  return;
+};
 
 function parseAppUrl(relativeUrl, locationObj) {
   var prefixed = (relativeUrl.charAt(0) !== '/');
@@ -41,6 +48,9 @@ function parseAppUrl(relativeUrl, locationObj) {
       match.pathname.substring(1) : match.pathname);
   locationObj.$$search = parseKeyValue(match.search);
   locationObj.$$hash = decodeURIComponent(match.hash);
+
+  // send locationObj and match off to hook processing
+  postParseAppUrlHook && postParseAppUrlHook(locationObj, match);
 
   // make sure path starts with '/';
   if (locationObj.$$path && locationObj.$$path.charAt(0) != '/') {
@@ -707,6 +717,24 @@ function $LocationProvider() {
         requireBase: true,
         rewriteLinks: true
       };
+
+  /**
+   * @ngdoc method
+   * @name $locationProvider#setPostParseAppUrlHook
+   * @description
+   * Use the setPostParseAppUrlHook method to configure a method to modify the location object
+   * after Angular's default location parsing methods. This is required in cases where the
+   * location object is getting damaged by external rewriting procedures (for example, SSL VPN
+   * solutions).
+   * @param {Object} func Function that will modify the locationObj, it must accept
+   * locationObj and url as parameters. The url parameter will contain useful information
+   * that can be used to help repair the locationObj.
+   */
+  this.setPostParseAppUrlHook = function(func) {
+    if (isFunction(func)) {
+      postParseAppUrlHook = func;
+    }
+  };
 
   /**
    * @ngdoc method

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -845,6 +845,25 @@ describe('$location', function() {
 
   });
 
+  describe('post parse url hook', function() {
+    function repairLocationObj(locationObj, url) {
+      locationObj.$$path = '/repaired';
+      return;
+    }
+
+    it('should allow repair of locationObj via hook', function() {
+      initService({html5Mode: false, hashPrefix: '!', supportHistory: true, postParseAppUrlHook: repairLocationObj});
+      mockUpBrowser({initialUrl: 'http://new.com/a/b#!', baseHref: '/a/b'});
+      inject(function($window, $browser, $location, $rootScope) {
+        spyOn($location, '$$parse').andCallThrough();
+        $window.location.href = 'http://new.com/a/b#!/aaa';
+        $browser.$$checkUrlChange();
+        expect($location.path()).toBe('/repaired');
+        expect($location.$$parse).toHaveBeenCalledOnce();
+      });
+    });
+  });
+
   describe('wiring', function() {
 
     it('should update $location when browser url changes', function() {
@@ -2519,6 +2538,7 @@ describe('$location', function() {
     return module(function($provide, $locationProvider) {
       $locationProvider.html5Mode(options.html5Mode);
       $locationProvider.hashPrefix(options.hashPrefix);
+      $locationProvider.setPostParseAppUrlHook(options.postParseAppUrlHook || function() {return;});
       $provide.value('$sniffer', {history: options.supportHistory});
     });
   }


### PR DESCRIPTION
Add a hook into the $location service's parse app url method. The hook allows the locationObj to be
repaired in the event it gets damaged by some external source (such as an SSL VPN appliance).

Closes #8905
