### PR TITLE
A new directive for the focusout event.

### DIFF
--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -43,10 +43,11 @@ var ngEventDirectives = {};
 // so that they are not executed in an inconsistent state.
 var forceAsyncEvents = {
   'blur': true,
-  'focus': true
+  'focus': true,
+  'focusout': true,
 };
 forEach(
-  'click dblclick mousedown mouseup mouseover mouseout mousemove mouseenter mouseleave keydown keyup keypress submit focus blur copy cut paste'.split(' '),
+  'click dblclick mousedown mouseup mouseover mouseout mousemove mouseenter mouseleave keydown keyup keypress submit focus focusout blur copy cut paste'.split(' '),
   function(eventName) {
     var directiveName = directiveNormalize('ng-' + eventName);
     ngEventDirectives[directiveName] = ['$parse', '$rootScope', function($parse, $rootScope) {
@@ -392,6 +393,26 @@ forEach(
  * @priority 0
  * @param {expression} ngFocus {@link guide/expression Expression} to evaluate upon
  * focus. ({@link guide/expression#-event- Event object is available as `$event`})
+ *
+ * @example
+ * See {@link ng.directive:ngClick ngClick}
+ */
+
+/**
+ * @ngdoc directive
+ * @name ngFocusout
+ *
+ * @description
+ * Specify custom behavior on focusout event.
+ *
+ * Note: As the `focusout` event is executed synchronously when calling `input.focusout()`
+ * AngularJS executes the expression using `scope.$evalAsync` if the event is fired
+ * during an `$apply` to ensure a consistent state.
+ *
+ * @element window, input, select, textarea, a
+ * @priority 0
+ * @param {expression} ngFocusout {@link guide/expression Expression} to evaluate upon
+ * focusout. ({@link guide/expression#-event- Event object is available as `$event`})
  *
  * @example
  * See {@link ng.directive:ngClick ngClick}

--- a/test/ng/directive/ngEventDirsSpec.js
+++ b/test/ng/directive/ngEventDirsSpec.js
@@ -90,6 +90,48 @@ describe('event directives', function() {
 
   });
 
+  describe('focusout', function() {
+
+    describe('call the listener asynchronously during $apply', function() {
+      function run(scope) {
+        inject(function($compile) {
+          element = $compile('<input type="text" ng-focusout="focusout()">')(scope);
+          scope.focusout = jasmine.createSpy('focusout');
+
+          scope.$apply(function() {
+            element.triggerHandler('focusout');
+            expect(scope.focusout).not.toHaveBeenCalled();
+          });
+
+          expect(scope.focusout).toHaveBeenCalledOnce();
+        });
+      }
+
+      it('should call the listener with non isolate scopes', inject(function($rootScope) {
+        run($rootScope.$new());
+      }));
+
+      it('should call the listener with isolate scopes', inject(function($rootScope) {
+        run($rootScope.$new(true));
+      }));
+
+    });
+
+    it('should call the listener synchronously inside of $apply if outside of $apply',
+        inject(function($rootScope, $compile) {
+      element = $compile('<input type="text" ng-focusout="focusout()" ng-model="value">')($rootScope);
+      $rootScope.focusout = jasmine.createSpy('focusout').andCallFake(function() {
+        $rootScope.value = 'newValue';
+      });
+
+      element.triggerHandler('focusout');
+
+      expect($rootScope.focusout).toHaveBeenCalledOnce();
+      expect(element.val()).toBe('newValue');
+    }));
+
+  });
+
   describe('security', function() {
     it('should allow access to the $event object', inject(function($rootScope, $compile) {
       var scope = $rootScope.$new();


### PR DESCRIPTION
I could not find a built in directive for the focusout event, so here it is.

The problem I was facing was to close a "layer" (typically a small popup) when clicking outside of the directive's markup. The idea I had and initially solved it with, was to use ngBlur and check the $event.relatedTarget to see if it was known to the scope of the directive's html elements or not.
However when using Internet Explorer the relatedTarget does not seem to be set. So the closest thing to the blur event is a focusout event, which solved this particular problem for me.

Please let me know if you have any other solution to this problem, otherwise I believe a focusout directive in AngularJs wouldn't hurt :-)
