### PR TITLE
WIP - DO NOT MERGE - feat($compile): multiple transclusion via slots

### DIFF
--- a/src/ng/directive/ngTransclude.js
+++ b/src/ng/directive/ngTransclude.js
@@ -65,9 +65,20 @@ var ngTranscludeDirective = ngDirective({
        startingTag($element));
     }
 
-    $transclude(function(clone) {
-      $element.empty();
-      $element.append(clone);
-    });
+    if ($attrs.ngTransclude) {
+      $transclude = $transclude.$$boundTransclude.$$slots[$attrs.ngTransclude];
+      if (!$transclude) return;
+
+      $transclude(undefined, function(clone) {
+        $element.empty();
+        $element.append(clone);
+      });
+    } else {
+
+      $transclude(function(clone) {
+        $element.empty();
+        $element.append(clone);
+      });
+    }
   }
 });


### PR DESCRIPTION
This is a really rough and ready spike of multiple transclusion via slots.

There are LOTS of issues, primarily around the way that transclude functions are created, wrapped and passed around often hidden inside closures with access to a variety of other variables.
It is also notable that the transclude function, that gets passed to the directive's controller and link functions, is incompatible with the transclude functions (even the bound ones) that are passed around internally, since the former allows the scope parameter to be missing.
For this to be implemented properly I fear we may need to completely refactor large parts of the way transclusion is passed around inside the compiler.

Also it doesn't currently work for `element` transclusion.

This is an alternative strategy to #11736
