### PR TITLE
fix(ngJq): properly detect when `ng-jq` is empty

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1671,10 +1671,9 @@ function bindJQuery() {
 
   // bind to jQuery if present;
   var jqName = jq();
-  jQuery = window.jQuery; // use default jQuery.
-  if (isDefined(jqName)) { // `ngJq` present
-    jQuery = jqName === null ? undefined : window[jqName]; // if empty; use jqLite. if not empty, use jQuery specified by `ngJq`.
-  }
+  jQuery = isUndefined(jqName) ? window.jQuery :   // use jQuery (if present)
+           !jqName             ? undefined     :   // use jqLite
+                                 window[jqName];   // use jQuery specified by `ngJq`
 
   // Use jQuery if it exists with proper functionality, otherwise default to us.
   // Angular 1.2+ requires jQuery 1.7+ for on()/off() support.

--- a/test/e2e/fixtures/ngJq/index.html
+++ b/test/e2e/fixtures/ngJq/index.html
@@ -4,6 +4,10 @@
     {{jqueryVersion}}
 
     <script src="../../../../bower_components/jquery/dist/jquery.js"></script>
+    <script type="text/javascript">
+      // Trying to trick `bindJQuery()`
+      window[''] = window.jQuery;
+    </script>
     <script src="angular.js"></script>
     <script type="text/javascript" src="script.js"></script>
   </body>

--- a/test/e2e/fixtures/ngJq/index.html
+++ b/test/e2e/fixtures/ngJq/index.html
@@ -5,7 +5,8 @@
 
     <script src="../../../../bower_components/jquery/dist/jquery.js"></script>
     <script type="text/javascript">
-      // Trying to trick `bindJQuery()`
+      // Verifying that we are not accessing `window['']`.
+      // (See https://github.com/angular/angular.js/issues/12741 for more details)
       window[''] = window.jQuery;
     </script>
     <script src="angular.js"></script>


### PR DESCRIPTION
Previously, even when `ng-jq` was empty (which should force the use of jqLite), Angular tried to find jQuery on `window['']`. If it didn't find anything there, it would fall back to jqLite (as expected).

Nonetheless, trying to access `window['']` calls `getElementById('')`, which issues a warning in Firefox (maybe others).

This fix properly detects when `ng-jq` is empty and avoids trying to access `window['']`.

Fixes #12741
