### PR TITLE
fix($interpolate): use const to define constants

### DIFF
--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -89,9 +89,9 @@ function $InterpolateProvider() {
 
 
   this.$get = ['$parse', '$exceptionHandler', '$sce', function($parse, $exceptionHandler, $sce) {
-    var startSymbolLength = startSymbol.length,
-        endSymbolLength = endSymbol.length,
-        escapedStartRegexp = new RegExp(startSymbol.replace(/./g, escape), 'g'),
+    const startSymbolLength = startSymbol.length,
+        endSymbolLength = endSymbol.length;
+    var escapedStartRegexp = new RegExp(startSymbol.replace(/./g, escape), 'g'),
         escapedEndRegexp = new RegExp(endSymbol.replace(/./g, escape), 'g');
 
     function escape(ch) {


### PR DESCRIPTION
startSymbolLength,endSymbolLength are constants.
Therefore, this commit replaces length var statements with const statements
