### PR TITLE
docs($compile): clarify re 'sharing' controllers

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -198,7 +198,7 @@
  *
  * #### `controller`
  * Controller constructor function. The controller is instantiated before the
- * pre-linking phase and it is shared with other directives (see
+ * pre-linking phase and can be accessed by other directives (see
  * `require` attribute). This allows the directives to communicate with each other and augment
  * each other's behavior. The controller is injectable (and supports bracket notation) with the following locals:
  *


### PR DESCRIPTION
The current wording may make the reader erroneously think that one controller can belong to multiple directives.
