### PR TITLE
WIP: Feat: watch ngModel with object equality via ngModelOptions

### DIFF
--- a/test/ng/directive/ngChangeSpec.js
+++ b/test/ng/directive/ngChangeSpec.js
@@ -58,4 +58,19 @@ describe('ngChange', function() {
     helper.changeInputValueTo('a');
     expect(inputElm.val()).toBe('b');
   });
+
+
+  it('should set the view if the model is changed by ngChange', function() {
+    $rootScope.reset = function() {
+      $rootScope.value = 'a';
+    };
+    $rootScope.value = 'a';
+    var input = helper.compileInput('<input type="text" ng-change="reset()" ng-model="value">');
+    var inputController = input.controller('ngModel');
+
+    $rootScope.$digest();
+
+    helper.changeInputValueTo('b');
+    expect(input.val()).toBe('a');
+  });
 });


### PR DESCRIPTION
This is a first draft for watching models with object equality. 
Use cases:
- models are collections (ngList / multiple) (also the next step after this)
- models are objects, and only part of objects change

Notes:
- we cannot use watch with third param set to true / watchCollection due to the way the model watch currently works. Basically, all actions happen inside the watch fn, not the action fn. The added test shows why.
- the current implementation copies the model if the deepWatch is true, so scope model is never === $modelValue; and so changes can be detected with equals(). I'm not sure if this is the most performant way, or actually the same as having a watch with objectEquality = true. (Note: There are some PRs for making copy faster)

For ngList / (select, url, email) multiple to use deepWatch, I can think of two ways: 
- Let it set $$options.deepWatch inside the modelController to true, before the options are evaluated inside ngModelOptions. However, (even with https://github.com/angular/angular.js/pull/10922,) we would need to extend the options (once more), so that what is preset on the ctrl gets merged with the actual ngModelOptions
- Set a special property on the controller, such as `$isCollection`, that tells the controller to use deepWatch. This could still be overruled if deepWatch is explicitly set to `false`. This is however not very obvious for people who have their own controls. ngModelOptions would centralize everything.
