### PR TITLE
Fix documentation formatting for angular.version

### DIFF
--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -98,8 +98,9 @@
  * @name angular.version
  * @module ng
  * @description
- * An object that contains information about the current AngularJS version. This object has the
- * following properties:
+ * An object that contains information about the current AngularJS version.
+ * 
+ * This object has the following properties:
  *
  * - `full` – `{string}` – Full version string, such as "0.9.18".
  * - `major` – `{number}` – Major version number, such as "0".


### PR DESCRIPTION
Fixes summary description of angular.version on https://docs.angularjs.org/api/ng#object
The property description is best kept for the detailed page.
![screen shot 2015-09-09 at 12 50 01 am](https://cloud.githubusercontent.com/assets/1273012/9745017/f3adc2ae-568c-11e5-8836-abbf17c1044b.png)
