### PR TITLE
Set toggleClass to be compatible with jQuery 1.4

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -936,6 +936,9 @@ forEach({
 
   toggleClass: function(element, selector, condition) {
     if (selector) {
+      if (isFunction(selector)) {
+        selector = selector.call(element, 0, element.className, condition);
+      }
       forEach(selector.split(' '), function(className) {
         var classCondition = condition;
         if (isUndefined(classCondition)) {


### PR DESCRIPTION
Allow toggleClass to accept a function as first argument.

Resolves https://github.com/angular/angular.js/issues/12793
