### PR TITLE
fix(jqLite): properly deregister the listeners for `mouseenter/mouseleave`

### DIFF
--- a/src/ngScenario/browserTrigger.js
+++ b/src/ngScenario/browserTrigger.js
@@ -15,6 +15,7 @@
     if (!element) return;
 
     eventData = eventData || {};
+    var relatedTarget = eventData.relatedTarget || element;
     var keys = eventData.keys;
     var x = eventData.x;
     var y = eventData.y;
@@ -84,7 +85,7 @@
       x = x || 0;
       y = y || 0;
       evnt.initMouseEvent(eventType, true, true, window, 0, x, y, x, y, pressed('ctrl'),
-          pressed('alt'), pressed('shift'), pressed('meta'), 0, element);
+          pressed('alt'), pressed('shift'), pressed('meta'), 0, relatedTarget);
     }
 
     /* we're unable to change the timeStamp value directly so this

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1426,6 +1426,26 @@ describe('jqLite', function() {
     });
 
 
+    it('should correctly deregister the mouseenter/mouseleave listeners', function() {
+      var aElem = jqLite(a);
+      var onMouseenter = jasmine.createSpy('onMouseenter');
+      var onMouseleave = jasmine.createSpy('onMouseleave');
+
+      aElem.on('mouseenter', onMouseenter);
+      aElem.on('mouseleave', onMouseleave);
+      aElem.off('mouseenter', onMouseenter);
+      aElem.off('mouseleave', onMouseleave);
+      aElem.on('mouseenter', onMouseenter);
+      aElem.on('mouseleave', onMouseleave);
+
+      browserTrigger(a, 'mouseover', {relatedTarget: b});
+      expect(onMouseenter).toHaveBeenCalledOnce();
+
+      browserTrigger(a, 'mouseout', {relatedTarget: b});
+      expect(onMouseleave).toHaveBeenCalledOnce();
+    });
+
+
     describe('native listener deregistration', function() {
 
       it('should deregister the native listener when all jqLite listeners for given type are gone ' +


### PR DESCRIPTION
Fixes #12795
