### PR TITLE
feat(ngModel): public method to force run model -> view binding pipeline

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -296,6 +296,21 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
 
   /**
    * @ngdoc method
+   * @name ngModel.NgModelController#$forceModelToViewBound
+   *
+   * @description
+   * This might be called to force update model -> view binding without changing actual model
+   *
+   * It will trigger $formatters pipeline, and in case of changed $viewValue, will run validators and
+   * update the UI.
+   *
+   * For instance you might use this to change the input's value, but keep the original scope.value the same.
+   */
+  this.$forceModelToViewBound = ngModelWatch.bind(this, true);
+
+
+  /**
+   * @ngdoc method
    * @name ngModel.NgModelController#$isEmpty
    *
    * @description
@@ -814,14 +829,15 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
   //    -> scope value did not change since the last digest as
   //       ng-change executes in apply phase
   // 4. view should be changed back to 'a'
-  $scope.$watch(function ngModelWatch() {
+  $scope.$watch(ngModelWatch);
+  function ngModelWatch() {
     var modelValue = ngModelGet($scope);
 
-    // if scope model value and ngModel value are out of sync
+    // if forced to run formatters and validators, or scope model value and ngModel value are out of sync
     // TODO(perf): why not move this to the action fn?
-    if (modelValue !== ctrl.$modelValue &&
+    if (arguments[0] === true || (modelValue !== ctrl.$modelValue &&
        // checks for NaN is needed to allow setting the model to NaN when there's an asyncValidator
-       (ctrl.$modelValue === ctrl.$modelValue || modelValue === modelValue)
+       (ctrl.$modelValue === ctrl.$modelValue || modelValue === modelValue))
     ) {
       ctrl.$modelValue = ctrl.$$rawModelValue = modelValue;
       parserValid = undefined;
@@ -842,7 +858,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
     }
 
     return modelValue;
-  });
+  }
 }];
 
 

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -482,6 +482,19 @@ describe('ngModel', function() {
       });
 
 
+      it('should be possible to force model -> view binding from ngModelController', function() {
+        var spyFormatter = jasmine.createSpy('spyValidator');
+        ctrl.$formatters = ctrl.$formatters.concat(spyFormatter);
+        spyOn(ctrl, '$render');
+        spyOn(ctrl, '$$runValidators');
+
+        ctrl.$forceModelToViewBound();
+        expect(spyFormatter).toHaveBeenCalledOnce();
+        expect(ctrl.$render).toHaveBeenCalledOnce();
+        expect(ctrl.$$runValidators).toHaveBeenCalledOnce();
+      });
+
+
       it('should clear the view even if invalid', function() {
         spyOn(ctrl, '$render');
 


### PR DESCRIPTION
Added ngModel.NgModelController#$forceModelToViewBound.
It triggers $formatters pipeline, and in case of changed $viewValue,
runs validators and update the UI without changing actual model.
Basically it simulates fake model value change.

Closes #12815
