### PR TITLE
feat(ngList): add support for preserving blank tokens

### DIFF
--- a/src/ng/directive/ngList.js
+++ b/src/ng/directive/ngList.js
@@ -10,16 +10,20 @@
  * delimiter is a comma followed by a space - equivalent to `ng-list=", "`. You can specify a custom
  * delimiter as the value of the `ngList` attribute - for example, `ng-list=" | "`.
  *
- * The behaviour of the directive is affected by the use of the `ngTrim` attribute.
- * * If `ngTrim` is set to `"false"` then whitespace around both the separator and each
+ * @param {string=} ngList optional delimiter that should be used to split the value.
+ * @param {boolean=} ngTrim If set to `"false"`, then whitespace around both the separator and each
  *   list item is respected. This implies that the user of the directive is responsible for
  *   dealing with whitespace but also allows you to use whitespace as a delimiter, such as a
  *   tab or newline character.
- * * Otherwise whitespace around the delimiter is ignored when splitting (although it is respected
- *   when joining the list items back together) and whitespace around each list item is stripped
- *   before it is added to the model.
  *
- * ### Example with Validation
+ *   Otherwise whitespace around the delimiter is ignored when splitting
+ *   (although it is respected when joining the list items back together) and whitespace around
+ *   each list item is stripped before it is added to the model.
+ * @param {boolean=} preserveBlanks If set to true, then empty tokens will be included in resulting
+ *   array
+ *
+ * @example
+ * ### With Validation
  *
  * <example name="ngList-directive" module="listExample">
  *   <file name="app.js">
@@ -66,7 +70,7 @@
  *   </file>
  * </example>
  *
- * ### Example - splitting on whitespace
+ * ### Splitting on whitespace
  * <example name="ngList-directive-newlines">
  *   <file name="index.html">
  *    <textarea ng-model="list" ng-list="&#10;" ng-trim="false"></textarea>
@@ -83,7 +87,6 @@
  * </example>
  *
  * @element input
- * @param {string=} ngList optional delimiter that should be used to split the value.
  */
 var ngListDirective = function() {
   return {
@@ -96,6 +99,7 @@ var ngListDirective = function() {
       var ngList = element.attr(attr.$attr.ngList) || ', ';
       var trimValues = attr.ngTrim !== 'false';
       var separator = trimValues ? trim(ngList) : ngList;
+      var preserveBlanks = attr.preserveBlanks === 'true';
 
       var parse = function(viewValue) {
         // If the viewValue is invalid (say required but empty) it will be `undefined`
@@ -105,7 +109,7 @@ var ngListDirective = function() {
 
         if (viewValue) {
           forEach(viewValue.split(separator), function(value) {
-            if (value) list.push(trimValues ? trim(value) : value);
+            if (preserveBlanks || value) list.push(trimValues ? trim(value) : value);
           });
         }
 

--- a/test/ng/directive/ngListSpec.js
+++ b/test/ng/directive/ngListSpec.js
@@ -138,5 +138,26 @@ describe('ngList', function() {
       expect($rootScope.list).toEqual(['a','b']);
     });
   });
+
+  describe('preserveBlanks', function() {
+    it('should not preserve blanks when undefined', function() {
+      helper.compileInput('<input type="text" ng-model="list" ng-list="|" />');
+      helper.changeInputValueTo('a||b');
+      expect($rootScope.list).toEqual(['a','b']);
+    });
+
+    it('should not preserve blanks when false', function() {
+      helper.compileInput('<input type="text" ng-model="list" ng-list="|" preserve-blanks="false" />');
+      helper.changeInputValueTo('a||b');
+      expect($rootScope.list).toEqual(['a','b']);
+    });
+
+    it('should preserve blanks when true', function() {
+      helper.compileInput('<input type="text" ng-model="list" ng-list="|" preserve-blanks="true" />');
+      helper.changeInputValueTo('a||b');
+      expect($rootScope.list).toEqual(['a', '', 'b']);
+    });
+  });
+
 });
 


### PR DESCRIPTION
Added feature to allow preserving blank tokens when 2 delimiters are back to back.  Previously, the blank tokens would be dropped. 
