### PR TITLE
fix($parse): throw error when accessing a restricted property indirectly

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -38,6 +38,7 @@ var $parseMinErr = minErr('$parse');
 
 
 function ensureSafeMemberName(name, fullExpression) {
+  name =  (isObject(name) && name.toString) ? name.toString() : name;
   if (name === "__defineGetter__" || name === "__defineSetter__"
       || name === "__lookupGetter__" || name === "__lookupSetter__"
       || name === "__proto__") {

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1679,12 +1679,10 @@ describe('parser', function() {
   forEach([true, false], function(cspEnabled) {
     describe('csp: ' + cspEnabled, function() {
 
-      beforeEach(module(function($provide) {
-        $provide.decorator('$sniffer', function($delegate) {
-          expect($delegate.csp.noUnsafeEval === true ||
-                 $delegate.csp.noUnsafeEval === false).toEqual(true);
-          $delegate.csp.noUnsafeEval = cspEnabled;
-        });
+      beforeEach(module(function() {
+        expect(csp().noUnsafeEval === true ||
+               csp().noUnsafeEval === false).toEqual(true);
+        csp().noUnsafeEval = cspEnabled;
       }, provideLog));
 
       beforeEach(inject(function($rootScope) {
@@ -2667,6 +2665,20 @@ describe('parser', function() {
             }).toThrowMinErr('$parse', 'isecfld');
             expect(function() {
               scope.$eval('{}["__proto__"].foo = 1');
+            }).toThrowMinErr('$parse', 'isecfld');
+
+            expect(function() {
+              scope.$eval('{}[["__proto__"]]');
+            }).toThrowMinErr('$parse', 'isecfld');
+            expect(function() {
+              scope.$eval('{}[["__proto__"]].foo = 1');
+            }).toThrowMinErr('$parse', 'isecfld');
+
+            expect(function() {
+              scope.$eval('0[["__proto__"]]');
+            }).toThrowMinErr('$parse', 'isecfld');
+            expect(function() {
+              scope.$eval('0[["__proto__"]].foo = 1');
             }).toThrowMinErr('$parse', 'isecfld');
 
             scope.a = "__pro";


### PR DESCRIPTION
When accessing an instance thru a computed member and the property is an array, then also check the string value of the array.
