### PR TITLE
One way binding for objects in directive

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -757,7 +757,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
   var EVENT_HANDLER_ATTR_REGEXP = /^(on[a-z]+|formaction)$/;
 
   function parseIsolateBindings(scope, directiveName, isController) {
-    var LOCAL_REGEXP = /^\s*([@&]|=(\*?))(\??)\s*(\w*)\s*$/;
+    var LOCAL_REGEXP = /^\s*([@&#]|=(\*?))(\??)\s*(\w*)\s*$/;
 
     var bindings = {};
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2663,6 +2663,31 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               return parentGet(scope, locals);
             };
             break;
+
+        case '#':
+        	parentGet = attrs.hasOwnProperty(attrName) ? $parse(attrs[attrName]) : noop;
+
+        	if (parentGet === noop && optional) break;
+
+        	var parentValue = parentGet(scope);
+
+        	if (!isObject(parentValue))
+        		throw $compileMinErr('nonassign',
+					"Attribute value has to be an object in directive '{0}'." +
+					" Definition: {... {1}: '{2}' ...}",
+					directive.name, scopeName, definition);
+
+        	destination[scopeName] = copy(parentValue);
+
+        	var unwatch;
+        	unwatch = scope.$watch(function parentValueWatch() {
+        		return $parse(attrs[attrName])(scope);
+        	}, function onParentValueChange(newParentValue) {
+        		destination[scopeName] = copy(newParentValue);
+        	});
+        	onNewScopeDestroyed = (onNewScopeDestroyed || []);
+        	onNewScopeDestroyed.push(unwatch);
+        	break;
         }
       });
       var destroyBindings = onNewScopeDestroyed ? function destroyBindings() {


### PR DESCRIPTION
While I was trying to build a modal with angular, i ended up with the problem of changing something in the modal pop-up and the changes were sync-ed with the original object.

Instead of doing all the work in each directive for copying the objects, i decided to extend the directive's operators to support one-way object binding.

I would like to also discuss about these changes if they are between the guidelines of angular js so we don`t pollute it with unwanted code.

This was tested on version 1.2.16(code is a little bit different there) and code was adjusted for this version.

If this gets approved by the community, I`ll upgrade my project to the latest version and have it tested fully.
