### PR TITLE
fix(dateFilter): follow the CLDR on pattern escape sequences

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -509,7 +509,7 @@ function dateFilter($locale) {
     forEach(parts, function(value) {
       fn = DATE_FORMATS[value];
       text += fn ? fn(date, $locale.DATETIME_FORMATS, dateTimezoneOffset)
-                 : value.replace(/(^'|'$)/g, '').replace(/''/g, "'");
+                 : value === "''" ? "'" : value.replace(/(^'|'$)/g, '').replace(/''/g, "'");
     });
 
     return text;

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -381,6 +381,8 @@ describe('filters', function() {
     it('should treat a sequence of two single quotes as a literal single quote', function() {
       expect(date(midnight, "yyyy'de' 'a''dd' 'adZ' h=H:m:saZ")).
                       toEqual("2010de a'dd adZ 12=0:5:8AM-0500");
+      expect(date(midnight, "EEE, MMM d, ''yy")).
+                      toEqual("Fri, Sep 3, '10");
     });
 
     it('should accept default formats', function() {


### PR DESCRIPTION
When there are two single quotes "''" (quotes for clarification) that are not part of an escape sequence, then this sequence should be handled as one single quote. See http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns second and forth examples
