### PR TITLE
fix(jqLite) - toggleClass & removeClass reflect documentation

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -384,6 +384,7 @@ function jqLiteHasClass(element, selector) {
 function jqLiteRemoveClass(element, cssClassesOrFunc) {
   if (element.setAttribute) {
 
+    //if selector is passed
     if (cssClassesOrFunc) {
       //if cssClassesOrFunc is a function
       if (isFunction(cssClassesOrFunc)) {
@@ -392,7 +393,7 @@ function jqLiteRemoveClass(element, cssClassesOrFunc) {
         * index of element in set will always be 0
         * returns one or more space-separated class names to be removed
         */
-        cssClassesOrFunc = cssClassesOrFunc(0, element.className);
+        cssClassesOrFunc = cssClassesOrFunc.call(element, 0, element.className);
       }
       //remove classes
       forEach(cssClassesOrFunc.split(' '), function(cssClass) {
@@ -951,34 +952,30 @@ forEach({
   addClass: jqLiteAddClass,
   removeClass: jqLiteRemoveClass,
 
-  toggleClass: function(element, selector, condition) {
+  toggleClass: function(element, selectorOrFunc, condition) {
 
-    if (selector) {
+    //if selector passed toggle classes
+    if (selectorOrFunc) {
 
-      // the class name to be toggled can be determined by passing in a function.
-      if (isFunction(selector)) {
-
-        forEach(element.className.split(/\s+/), function(className, index) {
-          if (isArray(condition) && condition.length >= index) {
-            selector(index, className, condition[index]);
-          } else {
-            selector(index, className);
-          }
-        });
-
-      // if has the class, then it is removed; if does not have the class, then it is added.
-      } else {
-
-        forEach(selector.split(' '), function(className) {
-          var classCondition = condition;
-          if (isUndefined(classCondition)) {
-            classCondition = !jqLiteHasClass(element, className);
-          }
-          (classCondition ? jqLiteAddClass : jqLiteRemoveClass)(element, className);
-        });
+      //if selector is a function
+      if (isFunction(selectorOrFunc)) {
+        /*
+        * takes index of element in the set, and a list of the elements class names
+        * index of element in set will always be 0
+        * returns one or more space-separated class names to be toggled
+        */
+        selectorOrFunc = selectorOrFunc.call(element, 0, element.className, condition);
       }
+      //toggle values
+      forEach(selectorOrFunc.split(' '), function(className) {
+        var classCondition = condition;
+        if (isUndefined(classCondition)) {
+          classCondition = !jqLiteHasClass(element, className);
+        }
+        (classCondition ? jqLiteAddClass : jqLiteRemoveClass)(element, className);
+      });
 
-    // if no arguments are passed all class names on the element will be toggled.
+    // if no selector is passed all class names on the element will be toggled.
     } else {
       jqLiteRemoveClass(element);
     }

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -383,20 +383,26 @@ function jqLiteHasClass(element, selector) {
 
 function jqLiteRemoveClass(element, cssClassesOrFunc) {
   if (element.setAttribute) {
+
     if (cssClassesOrFunc) {
-      if (typeof cssClassesOrFunc === 'function') {
-        forEach(element.className.split(/\s+/), function(className, index) {
-          cssClassesOrFunc(index, className);
-        });
-      } else {
-        forEach(cssClassesOrFunc.split(' '), function(cssClass) {
-          element.setAttribute('class', trim(
-              (" " + (element.getAttribute('class') || '') + " ")
-              .replace(/[\n\t]/g, " ")
-              .replace(" " + trim(cssClass) + " ", " "))
-          );
-        });
+      //if cssClassesOrFunc is a function
+      if (isFunction(cssClassesOrFunc)) {
+        /*
+        * takes index of element in the set, and a list of the elements class names
+        * index of element in set will always be 0
+        * returns one or more space-separated class names to be removed
+        */
+        cssClassesOrFunc = cssClassesOrFunc(0, element.className);
       }
+      //remove classes
+      forEach(cssClassesOrFunc.split(' '), function(cssClass) {
+        element.setAttribute('class', trim(
+            (" " + (element.getAttribute('class') || '') + " ")
+            .replace(/[\n\t]/g, " ")
+            .replace(" " + trim(cssClass) + " ", " "))
+        );
+      });
+
     } else {
       // if no class names are specified in the parameter, all classes will be removed
       element.setAttribute('class', '');
@@ -950,10 +956,10 @@ forEach({
     if (selector) {
 
       // the class name to be toggled can be determined by passing in a function.
-      if (typeof selector === 'function') {
+      if (isFunction(selector)) {
 
         forEach(element.className.split(/\s+/), function(className, index) {
-          if (Array.isArray(condition) && condition.length >= index) {
+          if (isArray(condition) && condition.length >= index) {
             selector(index, className, condition[index]);
           } else {
             selector(index, className);

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -839,6 +839,65 @@ describe('jqLite', function() {
         expect(jqLite(b).hasClass('cde')).toBe(false);
       });
 
+      it('should allow function to be passed with conditions', function() {
+        var selector = jqLite([a, b]);
+        selector.addClass('abc');
+        selector.addClass('cde');
+        selector.addClass('fgh');
+        selector.addClass('ijk');
+
+        expect(selector.toggleClass(function(index, className, state) {
+          selector.toggleClass(className, state);
+        }, [true, true, false, false])).toBe(selector);
+
+        expect(jqLite(a).hasClass('abc')).toBe(true);
+        expect(jqLite(a).hasClass('cde')).toBe(true);
+        expect(jqLite(a).hasClass('fgh')).toBe(false);
+        expect(jqLite(a).hasClass('ijk')).toBe(false);
+
+        expect(jqLite(b).hasClass('abc')).toBe(true);
+        expect(jqLite(b).hasClass('cde')).toBe(true);
+        expect(jqLite(b).hasClass('fgh')).toBe(false);
+        expect(jqLite(b).hasClass('ijk')).toBe(false);
+      });
+
+      it('should allow function to be passed without condition', function() {
+        var selector = jqLite([a, b]);
+        selector.addClass('abc');
+        selector.addClass('cde');
+        selector.addClass('fgh');
+        selector.addClass('ijk');
+
+        expect(selector.toggleClass(function(index, className) {
+          if (className === 'abc' || className === 'cde') {
+            selector.removeClass(className);
+          }
+        })).toBe(selector);
+
+        expect(jqLite(a).hasClass('abc')).toBe(false);
+        expect(jqLite(a).hasClass('cde')).toBe(false);
+        expect(jqLite(a).hasClass('fgh')).toBe(true);
+        expect(jqLite(a).hasClass('ijk')).toBe(true);
+
+        expect(jqLite(b).hasClass('abc')).toBe(false);
+        expect(jqLite(b).hasClass('cde')).toBe(false);
+        expect(jqLite(b).hasClass('fgh')).toBe(true);
+        expect(jqLite(b).hasClass('ijk')).toBe(true);
+      });
+
+      it('should toggle all classes if no selector is passed', function() {
+        var selector = jqLite([a, b]);
+        selector.addClass('abc');
+        selector.addClass('cde');
+
+        expect(selector.toggleClass()).toBe(selector);
+
+        expect(jqLite(a).hasClass('abc')).toBe(false);
+        expect(jqLite(a).hasClass('cde')).toBe(false);
+        expect(jqLite(b).hasClass('abc')).toBe(false);
+        expect(jqLite(b).hasClass('cde')).toBe(false);
+      });
+
       it('should not break for null / undefined selectors', function() {
         var selector = jqLite([a, b]);
         expect(selector.toggleClass(null)).toBe(selector);
@@ -864,6 +923,32 @@ describe('jqLite', function() {
         element.removeClass('bar');
 
         expect(element.hasClass('foo')).toBe(true);
+        expect(element.hasClass('bar')).toBe(false);
+        expect(element.hasClass('baz')).toBe(true);
+      });
+
+
+      it('should remove all classes if no class is specified', function() {
+        var element = jqLite('<div class="foo bar baz"></div>');
+
+        expect(element.removeClass()).toEqual(element);
+
+        expect(element.hasClass('foo')).toBe(false);
+        expect(element.hasClass('bar')).toBe(false);
+        expect(element.hasClass('baz')).toBe(false);
+      });
+
+
+      it('should allow a function as a paramater', function() {
+        var element = jqLite('<div class="foo bar baz"></div>');
+
+        expect(element.removeClass(function(index, className) {
+          if (className === 'foo' || className === 'bar') {
+            element.removeClass(className);
+          }
+        })).toEqual(element);
+
+        expect(element.hasClass('foo')).toBe(false);
         expect(element.hasClass('bar')).toBe(false);
         expect(element.hasClass('baz')).toBe(true);
       });

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -839,29 +839,8 @@ describe('jqLite', function() {
         expect(jqLite(b).hasClass('cde')).toBe(false);
       });
 
-      it('should allow function to be passed with conditions', function() {
-        var selector = jqLite([a, b]);
-        selector.addClass('abc');
-        selector.addClass('cde');
-        selector.addClass('fgh');
-        selector.addClass('ijk');
 
-        expect(selector.toggleClass(function(index, className, state) {
-          selector.toggleClass(className, state);
-        }, [true, true, false, false])).toBe(selector);
-
-        expect(jqLite(a).hasClass('abc')).toBe(true);
-        expect(jqLite(a).hasClass('cde')).toBe(true);
-        expect(jqLite(a).hasClass('fgh')).toBe(false);
-        expect(jqLite(a).hasClass('ijk')).toBe(false);
-
-        expect(jqLite(b).hasClass('abc')).toBe(true);
-        expect(jqLite(b).hasClass('cde')).toBe(true);
-        expect(jqLite(b).hasClass('fgh')).toBe(false);
-        expect(jqLite(b).hasClass('ijk')).toBe(false);
-      });
-
-      it('should allow function to be passed without condition', function() {
+      it('should allow function to be passed', function() {
         var selector = jqLite([a, b]);
         selector.addClass('abc');
         selector.addClass('cde');
@@ -869,9 +848,7 @@ describe('jqLite', function() {
         selector.addClass('ijk');
 
         expect(selector.toggleClass(function(index, className) {
-          if (className === 'abc' || className === 'cde') {
-            selector.removeClass(className);
-          }
+          return 'abc cde';
         })).toBe(selector);
 
         expect(jqLite(a).hasClass('abc')).toBe(false);

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -943,9 +943,7 @@ describe('jqLite', function() {
         var element = jqLite('<div class="foo bar baz"></div>');
 
         expect(element.removeClass(function(index, className) {
-          if (className === 'foo' || className === 'bar') {
-            element.removeClass(className);
-          }
+          return 'foo bar';
         })).toEqual(element);
 
         expect(element.hasClass('foo')).toBe(false);


### PR DESCRIPTION
Updates removeClass to accept function  in spec with 1.9 (current) jQuery docs.
Updates removeClass to accept no parameters in spec with 1.9 (current) jQuery docs.
Updates toggleClass to accept function in spec with 1.9 (current) jQuery docs.
Updates toggleClass to accept no parameters in spec with 1.9 (current) jQuery docs.
Provides tests for all changes.

fixes angular/angular.js#12793
fixes angular/angular.js#12851
