### PR TITLE
fix($location): $locationchangesuccess not fires with browser back when path ends with '/#'. #12175

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -922,12 +922,12 @@ function $LocationProvider() {
         $location.$$parse(newUrl);
         $location.$$state = newState;
 
-        defaultPrevented = $rootScope.$broadcast('$locationChangeStart', newUrl, oldUrl,
+        defaultPrevented = $rootScope.$broadcast('$locationChangeStart', trimEmptyHash(newUrl), oldUrl,
             newState, oldState).defaultPrevented;
 
         // if the location was changed by a `$locationChangeStart` handler then stop
         // processing this location change
-        if ($location.absUrl() !== newUrl) return;
+        if ($location.absUrl() !== trimEmptyHash(newUrl)) return;
 
         if (defaultPrevented) {
           $location.$$parse(oldUrl);


### PR DESCRIPTION
In line #930, $location.absUrl() returns "path/", and newUrl returns "path/#". with browser back, so if condition is positive and returns. For fix I used trimEmptyHash function to trim # from newUrl, the same function is used in browser forward scenario @line#947. 
