### PR TITLE
fix(ngAnimate): callback detection should only use RAF when necessary

### DIFF
--- a/test/ngAnimate/integrationSpec.js
+++ b/test/ngAnimate/integrationSpec.js
@@ -319,6 +319,38 @@ describe('ngAnimate integration tests', function() {
         }
       });
     });
+
+    it('should trigger callbacks at the start and end of an animation',
+      inject(function($rootScope, $rootElement, $animate, $compile) {
+
+      ss.addRule('.animate-me', 'transition:2s linear all;');
+
+      var parent = jqLite('<div><div ng-if="exp" class="animate-me"></div></div>');
+      element = parent.find('div');
+      html(parent);
+
+      $compile(parent)($rootScope);
+      $rootScope.$digest();
+
+      var spy = jasmine.createSpy();
+      $animate.on('enter', parent, spy);
+
+      $rootScope.exp = true;
+      $rootScope.$digest();
+
+      element = parent.find('div');
+
+      $animate.flush();
+
+      expect(spy.callCount).toBe(1);
+
+      browserTrigger(element, 'transitionend', { timeStamp: Date.now(), elapsedTime: 2 });
+      $animate.flush();
+
+      expect(spy.callCount).toBe(2);
+
+      dealoc(element);
+    }));
   });
 
   describe('JS animations', function() {


### PR DESCRIPTION
Callbacks are detected within the internals of ngAnimate whenever an
animation starts and ends. In order to allow the user to set callbacks
the callback detection needs to happen during the next tick. Prior to
this fix we used `$$rAF` to do the tick detection, however, with this
patch we intelligently use `$$postDigest` to do that for us and then
only issue a call to `$$rAF` if necessary.
