### PR TITLE
WIP: transclude element and template elements

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -881,7 +881,10 @@ forEach({
   },
 
   contents: function(element) {
-    return element.contentDocument || element.childNodes || [];
+    return element.contentDocument ||
+           element.childNodes.length > 0 && element.childNodes ||
+           element.content && element.content.childNodes.length > 0 && element.content.childNodes ||
+           [];
   },
 
   append: function(element, node) {

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1750,8 +1750,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             assertNoDuplicate('transclusion', nonTlbTranscludeDirective, directive, $compileNode);
             nonTlbTranscludeDirective = directive;
           }
-
-          if (directiveValue == 'element') {
+          if (directiveValue == 'element' && nodeName_(compileNode) !== 'template') {
             hasElementTranscludeDirective = true;
             terminalPriority = directive.priority;
             $template = $compileNode;
@@ -1775,6 +1774,14 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           } else {
             $template = jqLite(jqLiteClone(compileNode)).contents();
             $compileNode.empty(); // clear contents
+            // This implies that the current element is a <template>
+            if (directiveValue === 'element' && nodeName_(compileNode) === 'template') {
+              var replacementNode = jqLite(document.createComment(' ' + directiveName + ': ' +
+                                                templateAttrs[directiveName] + ' '));
+              compileNode = replacementNode[0];
+              replaceWith(jqCollection, $compileNode, compileNode);
+              $compileNode = replacementNode;
+            }
             childTranscludeFn = compile($template, transcludeFn);
           }
         }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -6975,6 +6975,21 @@ describe('$compile', function() {
           expect(lowercase(nodeName_(child.contents().eq(1)))).toBe('div');
         });
       });
+
+      describe('transclude element and <template>', function() {
+        it('should transform a transclude element on a template to transclude content', function() {
+          inject(function($compile, $rootScope) {
+            $rootScope.foo = [1, 2, 3];
+            element = $compile('<div><template ng-repeat="bar in foo"><div>{{bar}}</div>:{{bar}}#</template></div>')($rootScope);
+            $rootScope.$digest();
+            expect(element.text()).toEqual('1:1#2:2#3:3#');
+            expect(element.children().length).toEqual(6);
+            expect(element.children()[0].outerHTML).toEqual('<div class="ng-binding ng-scope">1</div>');
+            expect(element.children()[1].outerHTML).toEqual('<span class="ng-binding ng-scope">:1#</span>');
+            expect(element.children()[4].outerHTML).toEqual('<div class="ng-binding ng-scope">3</div>');
+          });
+        });
+      });
     });
 
     it('should safely create transclude comment node and not break with "-->"',


### PR DESCRIPTION
DO NOT MERGE
This PR is just to open the discussion to get some feedback if this would be an interesting feature.

When a directive of type transclude element is on a <template> element, then the transclude function contains the content of the <template> element and the <template> element is replaced with a comment node.
