### PR TITLE
fix(ngForm): don't block submit when method=dialog

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -364,7 +364,8 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
  * to handle the form submission in an application-specific way.
  *
  * For this reason, Angular prevents the default action (form submission to the server) unless the
- * `<form>` element has an `action` attribute specified.
+ * `<form>` element has a `method` attribute with the value `"dialog"` or has an `action` attribute
+ * specified.
  *
  * You can use one of the following two ways to specify what javascript method should be called when
  * a form is submitted:
@@ -485,7 +486,7 @@ var formDirectiveFactory = function(isNgForm) {
             var controller = ctrls[0];
 
             // if `action` attr is not present on the form, prevent the default action (submission)
-            if (!('action' in attr)) {
+            if (!('action' in attr) && attr['method'] !== 'dialog') {
               // we can't use jq events because if a form is destroyed during submission the default
               // action is not prevented. see #1238
               //

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -483,6 +483,20 @@ describe('form', function() {
       browserTrigger(doc, 'submit');
       expect(callback).toHaveBeenCalledOnce();
     });
+
+
+    it('should NOT prevent form submission if method attribute id "dialog"', function() {
+      var callback = jasmine.createSpy('submit').andCallFake(function(event) {
+        expect(event.isDefaultPrevented()).toBe(false);
+        event.preventDefault();
+      });
+
+      doc = $compile('<form method="dialog"></form>')(scope);
+      doc.on('submit', callback);
+
+      browserTrigger(doc, 'submit');
+      expect(callback).toHaveBeenCalledOnce();
+    });
   });
 
 


### PR DESCRIPTION
When a form's method is set to "dialog" it does not post to a server but instead closes the nearest parent <dialog> element. An action is not required.

https://html.spec.whatwg.org/multipage/forms.html#submit-dialog
