### PR TITLE
feat(ngMock): invoke nested calls to module immediately

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2282,16 +2282,21 @@ if (window.jasmine || window.mocha) {
       if (currentSpec.$injector) {
         throw new Error('Injector already created, can not register a module!');
       } else {
-        var modules = currentSpec.$modules || (currentSpec.$modules = []);
+        var fn, modules = currentSpec.$modules || (currentSpec.$modules = []);
         angular.forEach(moduleFns, function(module) {
           if (angular.isObject(module) && !angular.isArray(module)) {
-            modules.push(function($provide) {
+            fn = function($provide) {
               angular.forEach(module, function(value, key) {
                 $provide.value(key, value);
               });
-            });
+            };
           } else {
-            modules.push(module);
+            fn = module;
+          }
+          if (currentSpec.$providerInjector) {
+            currentSpec.$providerInjector.invoke(fn);
+          } else {
+            modules.push(fn);
           }
         });
       }
@@ -2405,6 +2410,9 @@ if (window.jasmine || window.mocha) {
     function workFn() {
       var modules = currentSpec.$modules || [];
       var strictDi = !!currentSpec.$injectorStrict;
+      modules.unshift(function($injector) {
+        currentSpec.$providerInjector = $injector;
+      });
       modules.unshift('ngMock');
       modules.unshift('ng');
       var injector = currentSpec.$injector;

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -831,6 +831,19 @@ describe('ngMock', function() {
         });
       });
 
+      describe('nested calls', function() {
+        it('should invoke nested module calls immediately', function() {
+          module(function($provide) {
+            $provide.constant('someConst', 'blah');
+            module(function(someConst) {
+              log = someConst;
+            });
+          });
+          inject(function() {
+            expect(log).toBe('blah');
+          });
+        });
+      });
 
       describe('inline in test', function() {
         it('should load module', function() {


### PR DESCRIPTION
before this change calling a nested module was just ignored, but it makes sense that ppl might use module() inside some helper function in order to get providers from DI and those helper methods should work no matter if they are called before or during the injector creation.
