### PR TITLE
fix(ngOptions): allow falsy values as option group identifiers

### DIFF
--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -653,7 +653,7 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
           var groupElement;
           var optionElement;
 
-          if (option.group) {
+          if (isDefined(option.group)) {
 
             // This option is to live in a group
             // See if we have already created this group

--- a/test/ng/directive/ngOptionsSpec.js
+++ b/test/ng/directive/ngOptionsSpec.js
@@ -1497,28 +1497,37 @@ describe('ngOptions', function() {
 
       scope.$apply(function() {
         scope.values = [{name: 'A'},
-                        {name: 'B', group: 'first'},
-                        {name: 'C', group: 'second'},
-                        {name: 'D', group: 'first'},
-                        {name: 'E', group: 'second'}];
+                        {name: 'B', group: 0},
+                        {name: 'C', group: 'first'},
+                        {name: 'D', group: 'second'},
+                        {name: 'E', group: 0},
+                        {name: 'F', group: 'first'},
+                        {name: 'G', group: 'second'}];
         scope.selected = scope.values[3];
       });
 
       expect(element).toEqualSelectValue(scope.selected);
 
-      var first = jqLite(element.find('optgroup')[0]);
-      var b = jqLite(first.find('option')[0]);
-      var d = jqLite(first.find('option')[1]);
-      expect(first.attr('label')).toEqual('first');
+      var zero = jqLite(element.find('optgroup')[0]);
+      var b = jqLite(zero.find('option')[0]);
+      var e = jqLite(zero.find('option')[1]);
+      expect(zero.attr('label')).toEqual('0');
       expect(b.text()).toEqual('B');
-      expect(d.text()).toEqual('D');
-
-      var second = jqLite(element.find('optgroup')[1]);
-      var c = jqLite(second.find('option')[0]);
-      var e = jqLite(second.find('option')[1]);
-      expect(second.attr('label')).toEqual('second');
-      expect(c.text()).toEqual('C');
       expect(e.text()).toEqual('E');
+
+      var first = jqLite(element.find('optgroup')[1]);
+      var c = jqLite(first.find('option')[0]);
+      var f = jqLite(first.find('option')[1]);
+      expect(first.attr('label')).toEqual('first');
+      expect(c.text()).toEqual('C');
+      expect(f.text()).toEqual('F');
+
+      var second = jqLite(element.find('optgroup')[2]);
+      var d = jqLite(second.find('option')[0]);
+      var g = jqLite(second.find('option')[1]);
+      expect(second.attr('label')).toEqual('second');
+      expect(d.text()).toEqual('D');
+      expect(g.text()).toEqual('G');
 
       scope.$apply(function() {
         scope.selected = scope.values[0];


### PR DESCRIPTION
Now one can use `''`, `0`, `false` and `null` as option groups. Previously
all of these falsy values were treated as the option not being a member of
a group.

Closes #7015
Closes #7024

BREAKING CHANGES
If your data contains falsy values for option groups, then these options
will now be placed into option groups. Only option groups that are `undefined`
will result in the option being put in no group. If you have data that
contains falsy values that should not be used as groups then you must
filter the values before passing them to `ngOptions` converting falsy
values to `undefined`.
