### PR TITLE
refactor(ngScenario): merge duplicate callback functions of StepFailu…

### DIFF
--- a/src/ngScenario/ObjectModel.js
+++ b/src/ngScenario/ObjectModel.js
@@ -85,27 +85,22 @@ angular.scenario.ObjectModel = function(runner) {
     self.emit('StepEnd', it, step);
   });
 
-  runner.on('StepFailure', function(spec, step, error) {
-    var it = self.getSpec(spec.id),
-        modelStep = it.getLastStep();
+  function handleError(errorStatus, eventName) {
+    return function(spec, step, error) {
+      var it = self.getSpec(spec.id),
+          modelStep = it.getLastStep();
 
-    modelStep.setErrorStatus('failure', error, step.line());
-    it.setStatusFromStep(modelStep);
+      modelStep.setErrorStatus(errorStatus, error, step.line());
+      it.setStatusFromStep(modelStep);
 
-    // forward the event
-    self.emit('StepFailure', it, modelStep, error);
-  });
+      // forward the event
+      self.emit(eventName, it, modelStep, error);
+    };
+  }
 
-  runner.on('StepError', function(spec, step, error) {
-    var it = self.getSpec(spec.id),
-        modelStep = it.getLastStep();
+  runner.on('StepFailure', handleError('failure', 'StepFailure'));
 
-    modelStep.setErrorStatus('error', error, step.line());
-    it.setStatusFromStep(modelStep);
-
-    // forward the event
-    self.emit('StepError', it, modelStep, error);
-  });
+  runner.on('StepError', handleError('error', 'StepError'));
 
   runner.on('RunnerBegin', function() {
     self.emit('RunnerBegin');


### PR DESCRIPTION
…re and StepError

The callback functions of StepFailure and StepError share the same functionality except that they are different in string literals. They can be merged into one to reduce maintenance efforts.

Remarks:
I am a student who is studying code clones. I try to refactor the code clones in your system and propose the following changes. The proposed changes have passed all unit tests on my machine. Please let me know what you think.

In case the proposed changes do not match your coding style or contain any issues, I would appreciate it if you can let me know how I can improve them. Thank you.
