### PR TITLE
fix(input): re-validate when partially editing a date-family input

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -19,6 +19,7 @@ var DATETIMELOCAL_REGEXP = /^(\d{4})-(\d\d)-(\d\d)T(\d\d):(\d\d)(?::(\d\d)(\.\d{
 var WEEK_REGEXP = /^(\d{4})-W(\d\d)$/;
 var MONTH_REGEXP = /^(\d{4})-(\d\d)$/;
 var TIME_REGEXP = /^(\d\d):(\d\d)(?::(\d\d)(\.\d{1,3})?)?$/;
+var DATE_INPUT_TYPES = ['date', 'datetime-local', 'month', 'time', 'week'];
 
 var inputType = {
 
@@ -1134,6 +1135,15 @@ function baseInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   // input event on backspace, delete or cut
   if ($sniffer.hasEvent('input')) {
     element.on('input', listener);
+
+    // On date-family inputs, we also need to listen for `keyup` in case the date is partially
+    // edited by the user using the keyboard, resulting in a change in the validity state, but
+    // without an accompanying change in the input value (thus no `input` event).
+    // (This is only necessary on browsers that support inputs of that type - other browsers set the
+    //  `type` property to "text".)
+    var isTypeSupported = (type === attr.type);
+    var listenForKeyup = isTypeSupported && (DATE_INPUT_TYPES.indexOf(type) !== -1);
+    if (listenForKeyup) element.on('keyup', function() { element.triggerHandler('input'); });
   } else {
     var timeout;
 

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1141,9 +1141,9 @@ function baseInputType(scope, element, attr, ctrl, $sniffer, $browser) {
     // without an accompanying change in the input value (thus no `input` event).
     // (This is only necessary on browsers that support inputs of that type - other browsers set the
     //  `type` property to "text".)
-    var isTypeSupported = (type === attr.type);
-    var listenForKeyup = isTypeSupported && (DATE_INPUT_TYPES.indexOf(type) !== -1);
-    if (listenForKeyup) element.on('keyup', function() { element.triggerHandler('input'); });
+    var browserSupportsType = (type === attr.type);
+    var listenForKeyup = browserSupportsType && (DATE_INPUT_TYPES.indexOf(type) !== -1);
+    if (listenForKeyup) element.on('keyup', function() { listener('input'); });
   } else {
     var timeout;
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -645,6 +645,7 @@ describe('input', function() {
       expect(inputElm.val()).toBe('2013-12');
     });
 
+
     it('should only change the month of a bound date in any timezone', function() {
       var inputElm = helper.compileInput('<input type="month" ng-model="value" ng-model-options="{timezone: \'+0500\'}" />');
 
@@ -655,6 +656,73 @@ describe('input', function() {
       expect(+$rootScope.value).toBe(Date.UTC(2013, 7, 31, 20, 0, 0));
       expect(inputElm.val()).toBe('2013-09');
     });
+
+
+    it('should re-validate when partially editing the input value', function() {
+      // This testcase tests re-validation on interactions involved in the following scenario
+      // (on a browser that supports this type of input):
+      //
+      // 1. Initially empty field.
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      // 2. The user fills part of the value (e.g. the year) using the keyboard.
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: false, badInput: true, ...}
+      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
+      // 3. The user fills the value completely (using either the keyboard or the date-picker).
+      //    - `input.value`: '<some-valid-value>'
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      //    - 'input' event: Fired
+      // 4. The user deletes part of the value (e.g. the year) using the keyboard.
+      //    - `input.value`: ''   (since a partial value is invalid)
+      //    - `input.validity`: {valid: false, badInput: true, ...}
+      //    - 'input' event: Fired
+      // 5. The user deletes all parts of the value using the keyboard (i.e. clears the field).
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
+      //
+      // The problematic cases are (2) and (5), because there is a change in the validity state,
+      // but no 'input' event is fired to inform Angular of that change and the need to re-validate.
+
+      var inputType = 'month';
+
+      if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+        var mockValidity = {valid: true, badInput: false};
+        helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+        var inputElm = helper.inputElm;
+
+        expect(inputElm).toBeValid();
+
+        mockValidity.valid = false;
+        mockValidity.badInput = true;
+        browserTrigger(inputElm, 'keyup');
+        expect(inputElm).toBeInvalid();
+
+        mockValidity.valid = true;
+        mockValidity.badInput = false;
+        browserTrigger(inputElm, 'keyup');
+        expect(inputElm).toBeValid();
+      }
+    });
+
+
+    it('should fire \'input\' event on \'keyup\' only on browsers that support this input type',
+      function() {
+        var inputType = 'month';
+
+        var inputEventExpectedToFire = browserSupportsInputTypeAndEvent(inputType, 'input');
+        var inputEventActuallyFired = false;
+
+        var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
+        inputElm.on('input', function() { inputEventActuallyFired = true; });
+
+        browserTrigger(inputElm, 'keyup');
+
+        expect(inputEventActuallyFired).toBe(inputEventExpectedToFire);
+      }
+    );
+
 
     describe('min', function() {
       var inputElm;
@@ -697,6 +765,7 @@ describe('input', function() {
         expect($rootScope.form.alias.$error.min).toBeFalsy();
       });
     });
+
 
     describe('max', function() {
       var inputElm;
@@ -870,6 +939,73 @@ describe('input', function() {
       expect($rootScope.form.alias.$error.week).toBeTruthy();
     });
 
+
+    it('should re-validate when partially editing the input value', function() {
+      // This testcase tests re-validation on interactions involved in the following scenario
+      // (on a browser that supports this type of input):
+      //
+      // 1. Initially empty field.
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      // 2. The user fills part of the value (e.g. the year) using the keyboard.
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: false, badInput: true, ...}
+      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
+      // 3. The user fills the value completely (using either the keyboard or the date-picker).
+      //    - `input.value`: '<some-valid-value>'
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      //    - 'input' event: Fired
+      // 4. The user deletes part of the value (e.g. the year) using the keyboard.
+      //    - `input.value`: ''   (since a partial value is invalid)
+      //    - `input.validity`: {valid: false, badInput: true, ...}
+      //    - 'input' event: Fired
+      // 5. The user deletes all parts of the value using the keyboard (i.e. clears the field).
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
+      //
+      // The problematic cases are (2) and (5), because there is a change in the validity state,
+      // but no 'input' event is fired to inform Angular of that change and the need to re-validate.
+
+      var inputType = 'week';
+
+      if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+        var mockValidity = {valid: true, badInput: false};
+        helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+        var inputElm = helper.inputElm;
+
+        expect(inputElm).toBeValid();
+
+        mockValidity.valid = false;
+        mockValidity.badInput = true;
+        browserTrigger(inputElm, 'keyup');
+        expect(inputElm).toBeInvalid();
+
+        mockValidity.valid = true;
+        mockValidity.badInput = false;
+        browserTrigger(inputElm, 'keyup');
+        expect(inputElm).toBeValid();
+      }
+    });
+
+
+    it('should fire \'input\' event on \'keyup\' only on browsers that support this input type',
+      function() {
+        var inputType = 'week';
+
+        var inputEventExpectedToFire = browserSupportsInputTypeAndEvent(inputType, 'input');
+        var inputEventActuallyFired = false;
+
+        var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
+        inputElm.on('input', function() { inputEventActuallyFired = true; });
+
+        browserTrigger(inputElm, 'keyup');
+
+        expect(inputEventActuallyFired).toBe(inputEventExpectedToFire);
+      }
+    );
+
+
     describe('min', function() {
       var inputElm;
       beforeEach(function() {
@@ -911,6 +1047,7 @@ describe('input', function() {
         expect($rootScope.form.alias.$error.min).toBeFalsy();
       });
     });
+
 
     describe('max', function() {
       var inputElm;
@@ -1119,6 +1256,73 @@ describe('input', function() {
       expect($rootScope.form.alias.$error.datetimelocal).toBeTruthy();
     });
 
+
+    it('should re-validate when partially editing the input value', function() {
+      // This testcase tests re-validation on interactions involved in the following scenario
+      // (on a browser that supports this type of input):
+      //
+      // 1. Initially empty field.
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      // 2. The user fills part of the value (e.g. the year) using the keyboard.
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: false, badInput: true, ...}
+      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
+      // 3. The user fills the value completely (using either the keyboard or the date-picker).
+      //    - `input.value`: '<some-valid-value>'
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      //    - 'input' event: Fired
+      // 4. The user deletes part of the value (e.g. the year) using the keyboard.
+      //    - `input.value`: ''   (since a partial value is invalid)
+      //    - `input.validity`: {valid: false, badInput: true, ...}
+      //    - 'input' event: Fired
+      // 5. The user deletes all parts of the value using the keyboard (i.e. clears the field).
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
+      //
+      // The problematic cases are (2) and (5), because there is a change in the validity state,
+      // but no 'input' event is fired to inform Angular of that change and the need to re-validate.
+
+      var inputType = 'datetime-local';
+
+      if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+        var mockValidity = {valid: true, badInput: false};
+        helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+        var inputElm = helper.inputElm;
+
+        expect(inputElm).toBeValid();
+
+        mockValidity.valid = false;
+        mockValidity.badInput = true;
+        browserTrigger(inputElm, 'keyup');
+        expect(inputElm).toBeInvalid();
+
+        mockValidity.valid = true;
+        mockValidity.badInput = false;
+        browserTrigger(inputElm, 'keyup');
+        expect(inputElm).toBeValid();
+      }
+    });
+
+
+    it('should fire \'input\' event on \'keyup\' only on browsers that support this input type',
+      function() {
+        var inputType = 'datetime-local';
+
+        var inputEventExpectedToFire = browserSupportsInputTypeAndEvent(inputType, 'input');
+        var inputEventActuallyFired = false;
+
+        var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
+        inputElm.on('input', function() { inputEventActuallyFired = true; });
+
+        browserTrigger(inputElm, 'keyup');
+
+        expect(inputEventActuallyFired).toBe(inputEventExpectedToFire);
+      }
+    );
+
+
     describe('min', function() {
       var inputElm;
       beforeEach(function() {
@@ -1160,6 +1364,7 @@ describe('input', function() {
         expect($rootScope.form.alias.$error.min).toBeFalsy();
       });
     });
+
 
     describe('max', function() {
       var inputElm;
@@ -1444,6 +1649,73 @@ describe('input', function() {
       expect(+$rootScope.value).toBe(+new Date(2013, 2, 3, 1, 2, 0));
     });
 
+
+    it('should re-validate when partially editing the input value', function() {
+      // This testcase tests re-validation on interactions involved in the following scenario
+      // (on a browser that supports this type of input):
+      //
+      // 1. Initially empty field.
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      // 2. The user fills part of the value (e.g. the hours) using the keyboard.
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: false, badInput: true, ...}
+      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
+      // 3. The user fills the value completely (using either the keyboard or the buttons).
+      //    - `input.value`: '<some-valid-value>'
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      //    - 'input' event: Fired
+      // 4. The user deletes part of the value (e.g. the hours) using the keyboard.
+      //    - `input.value`: ''   (since a partial value is invalid)
+      //    - `input.validity`: {valid: false, badInput: true, ...}
+      //    - 'input' event: Fired
+      // 5. The user deletes all parts of the value using the keyboard (i.e. clears the field).
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
+      //
+      // The problematic cases are (2) and (5), because there is a change in the validity state,
+      // but no 'input' event is fired to inform Angular of that change and the need to re-validate.
+
+      var inputType = 'time';
+
+      if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+        var mockValidity = {valid: true, badInput: false};
+        helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+        var inputElm = helper.inputElm;
+
+        expect(inputElm).toBeValid();
+
+        mockValidity.valid = false;
+        mockValidity.badInput = true;
+        browserTrigger(inputElm, 'keyup');
+        expect(inputElm).toBeInvalid();
+
+        mockValidity.valid = true;
+        mockValidity.badInput = false;
+        browserTrigger(inputElm, 'keyup');
+        expect(inputElm).toBeValid();
+      }
+    });
+
+
+    it('should fire \'input\' event on \'keyup\' only on browsers that support this input type',
+      function() {
+        var inputType = 'time';
+
+        var inputEventExpectedToFire = browserSupportsInputTypeAndEvent(inputType, 'input');
+        var inputEventActuallyFired = false;
+
+        var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
+        inputElm.on('input', function() { inputEventActuallyFired = true; });
+
+        browserTrigger(inputElm, 'keyup');
+
+        expect(inputEventActuallyFired).toBe(inputEventExpectedToFire);
+      }
+    );
+
+
     describe('min', function() {
       var inputElm;
       beforeEach(function() {
@@ -1485,6 +1757,7 @@ describe('input', function() {
         expect($rootScope.form.alias.$error.min).toBeFalsy();
       });
     });
+
 
     describe('max', function() {
       var inputElm;
@@ -1744,6 +2017,73 @@ describe('input', function() {
       dealoc(formElm);
     });
 
+
+    it('should re-validate when partially editing the input value', function() {
+      // This testcase tests re-validation on interactions involved in the following scenario
+      // (on a browser that supports this type of input):
+      //
+      // 1. Initially empty field.
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      // 2. The user fills part of the value (e.g. the year) using the keyboard.
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: false, badInput: true, ...}
+      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
+      // 3. The user fills the value completely (using either the keyboard or the date-picker).
+      //    - `input.value`: '<some-valid-value>'
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      //    - 'input' event: Fired
+      // 4. The user deletes part of the value (e.g. the year) using the keyboard.
+      //    - `input.value`: ''   (since a partial value is invalid)
+      //    - `input.validity`: {valid: false, badInput: true, ...}
+      //    - 'input' event: Fired
+      // 5. The user deletes all parts of the value using the keyboard (i.e. clears the field).
+      //    - `input.value`: ''
+      //    - `input.validity`: {valid: true, badInput: false, ...}
+      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
+      //
+      // The problematic cases are (2) and (5), because there is a change in the validity state,
+      // but no 'input' event is fired to inform Angular of that change and the need to re-validate.
+
+      var inputType = 'date';
+
+      if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+        var mockValidity = {valid: true, badInput: false};
+        helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+        var inputElm = helper.inputElm;
+
+        expect(inputElm).toBeValid();
+
+        mockValidity.valid = false;
+        mockValidity.badInput = true;
+        browserTrigger(inputElm, 'keyup');
+        expect(inputElm).toBeInvalid();
+
+        mockValidity.valid = true;
+        mockValidity.badInput = false;
+        browserTrigger(inputElm, 'keyup');
+        expect(inputElm).toBeValid();
+      }
+    });
+
+
+    it('should fire \'input\' event on \'keyup\' only on browsers that support this input type',
+      function() {
+        var inputType = 'date';
+
+        var inputEventExpectedToFire = browserSupportsInputTypeAndEvent(inputType, 'input');
+        var inputEventActuallyFired = false;
+
+        var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
+        inputElm.on('input', function() { inputEventActuallyFired = true; });
+
+        browserTrigger(inputElm, 'keyup');
+
+        expect(inputEventActuallyFired).toBe(inputEventExpectedToFire);
+      }
+    );
+
+
     describe('min', function() {
 
       it('should invalidate', function() {
@@ -1782,6 +2122,7 @@ describe('input', function() {
         expect($rootScope.form.alias.$error.min).toBeFalsy();
       });
     });
+
 
     describe('max', function() {
 
@@ -2859,4 +3200,15 @@ describe('input', function() {
       dealoc(inputElm);
     });
   });
+
+
+  // Helpers
+  function browserSupportsInputTypeAndEvent(inputType, event) {
+    var input = jqLite('<input type="' + inputType + '" />');
+
+    var supportsType = (inputType === input.prop('type'));
+    var supportsEvent = $sniffer.hasEvent(event);
+
+    return supportsType && supportsEvent;
+  }
 });

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1,6 +1,8 @@
 'use strict';
 
-/* globals getInputCompileHelper: false */
+/* globals getInputCompileHelper: false,
+  KEYS_PER_DATE_INPUT_TYPE: false
+ */
 
 describe('input', function() {
   var helper, $compile, $rootScope, $browser, $sniffer, $timeout, $q;
@@ -658,42 +660,100 @@ describe('input', function() {
     });
 
 
-    it('should re-validate when partially editing the input value', function() {
-      // This testcase simulates keyboard interactions that lead to a change in the validity state
-      // of the element, but no change in its value (thus no 'input' event).
-      // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
+    they('should re-validate when partially editing the input value (keyCode: $prop)',
+      getKeyCodesForType('month'),
+      function(keyCode) {
+        // This testcase simulates keyboard interactions that lead to a change in the validity state
+        // of the element, but no change in its value (thus no 'input' event).
+        // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
 
-      var inputType = 'month';
+        var inputType = 'month';
 
-      if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
-        var mockValidity = {valid: true, badInput: false};
-        helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
-        var inputElm = helper.inputElm;
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
 
-        expect(inputElm).toBeValid();
+          expect(inputElm).toBeValid();
 
-        mockValidity.valid = false;
-        mockValidity.badInput = true;
-        browserTrigger(inputElm, 'keyup');
-        expect(inputElm).toBeInvalid();
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeInvalid();
 
-        mockValidity.valid = true;
-        mockValidity.badInput = false;
-        browserTrigger(inputElm, 'keyup');
-        expect(inputElm).toBeValid();
+          mockValidity.valid = true;
+          mockValidity.badInput = false;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeValid();
+        }
       }
-    });
+    );
+
+
+    they('should not re-validate when a modifier key is pressed (modifier: $prop)',
+      ['alt', 'ctrl', 'meta', 'shift'],
+      function(modifier) {
+        // This testcase simulates keyboard interactions that lead to a change in the validity state
+        // of the element, but no change in its value (thus no 'input' event).
+        // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
+
+        var inputType = 'month';
+
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
+          var mockEvt = {type: 'keyup', keyCode: 8};
+
+          expect(inputElm).toBeValid();
+
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler(mockEvt);
+          expect(inputElm).toBeInvalid();
+
+          mockEvt[modifier + 'Key'] = true;
+
+          mockValidity.valid = true;
+          mockValidity.badInput = false;
+          inputElm.triggerHandler(mockEvt);
+          expect(inputElm).toBeInvalid();
+        }
+      }
+    );
+
+
+    they('should not re-validate on keys that can\'t affect the input (keyCode: $prop)',
+      getIgnoredKeyCodesForType('month'),
+      function(keyCode) {
+        var inputType = 'month';
+
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
+
+          expect(inputElm).toBeValid();
+
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeValid();
+        }
+      }
+    );
 
 
     it('should listen for \'keyup\' only on browsers that support this input type', function() {
       var inputType = 'month';
 
       var shouldListenForKeyup = browserSupportsInputTypeAndEvent(inputType, 'input');
+      var keyCode = getKeyCodesForType(inputType)[0];
       var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
       var ctrl = inputElm.controller('ngModel');
       spyOn(ctrl, '$setViewValue');
 
-      inputElm.triggerHandler('keyup');
+      inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
 
       expect(ctrl.$setViewValue.callCount).toBe(shouldListenForKeyup ? 1 : 0);
     });
@@ -915,42 +975,100 @@ describe('input', function() {
     });
 
 
-    it('should re-validate when partially editing the input value', function() {
-      // This testcase simulates keyboard interactions that lead to a change in the validity state
-      // of the element, but no change in its value (thus no 'input' event).
-      // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
+    they('should re-validate when partially editing the input value (keyCode: $prop)',
+      getKeyCodesForType('week'),
+      function(keyCode) {
+        // This testcase simulates keyboard interactions that lead to a change in the validity state
+        // of the element, but no change in its value (thus no 'input' event).
+        // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
 
-      var inputType = 'week';
+        var inputType = 'week';
 
-      if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
-        var mockValidity = {valid: true, badInput: false};
-        helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
-        var inputElm = helper.inputElm;
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
 
-        expect(inputElm).toBeValid();
+          expect(inputElm).toBeValid();
 
-        mockValidity.valid = false;
-        mockValidity.badInput = true;
-        browserTrigger(inputElm, 'keyup');
-        expect(inputElm).toBeInvalid();
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeInvalid();
 
-        mockValidity.valid = true;
-        mockValidity.badInput = false;
-        browserTrigger(inputElm, 'keyup');
-        expect(inputElm).toBeValid();
+          mockValidity.valid = true;
+          mockValidity.badInput = false;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeValid();
+        }
       }
-    });
+    );
+
+
+    they('should not re-validate when a modifier key is pressed (modifier: $prop)',
+      ['alt', 'ctrl', 'meta', 'shift'],
+      function(modifier) {
+        // This testcase simulates keyboard interactions that lead to a change in the validity state
+        // of the element, but no change in its value (thus no 'input' event).
+        // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
+
+        var inputType = 'week';
+
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
+          var mockEvt = {type: 'keyup', keyCode: 8};
+
+          expect(inputElm).toBeValid();
+
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler(mockEvt);
+          expect(inputElm).toBeInvalid();
+
+          mockEvt[modifier + 'Key'] = true;
+
+          mockValidity.valid = true;
+          mockValidity.badInput = false;
+          inputElm.triggerHandler(mockEvt);
+          expect(inputElm).toBeInvalid();
+        }
+      }
+    );
+
+
+    they('should not re-validate on keys that can\'t affect the input (keyCode: $prop)',
+      getIgnoredKeyCodesForType('week'),
+      function(keyCode) {
+        var inputType = 'week';
+
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
+
+          expect(inputElm).toBeValid();
+
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeValid();
+        }
+      }
+    );
 
 
     it('should listen for \'keyup\' only on browsers that support this input type', function() {
       var inputType = 'week';
 
       var shouldListenForKeyup = browserSupportsInputTypeAndEvent(inputType, 'input');
+      var keyCode = getKeyCodesForType(inputType)[0];
       var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
       var ctrl = inputElm.controller('ngModel');
       spyOn(ctrl, '$setViewValue');
 
-      inputElm.triggerHandler('keyup');
+      inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
 
       expect(ctrl.$setViewValue.callCount).toBe(shouldListenForKeyup ? 1 : 0);
     });
@@ -1207,42 +1325,100 @@ describe('input', function() {
     });
 
 
-    it('should re-validate when partially editing the input value', function() {
-      // This testcase simulates keyboard interactions that lead to a change in the validity state
-      // of the element, but no change in its value (thus no 'input' event).
-      // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
+    they('should re-validate when partially editing the input value (keyCode: $prop)',
+      getKeyCodesForType('datetime-local'),
+      function(keyCode) {
+        // This testcase simulates keyboard interactions that lead to a change in the validity state
+        // of the element, but no change in its value (thus no 'input' event).
+        // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
 
-      var inputType = 'datetime-local';
+        var inputType = 'datetime-local';
 
-      if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
-        var mockValidity = {valid: true, badInput: false};
-        helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
-        var inputElm = helper.inputElm;
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
 
-        expect(inputElm).toBeValid();
+          expect(inputElm).toBeValid();
 
-        mockValidity.valid = false;
-        mockValidity.badInput = true;
-        browserTrigger(inputElm, 'keyup');
-        expect(inputElm).toBeInvalid();
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeInvalid();
 
-        mockValidity.valid = true;
-        mockValidity.badInput = false;
-        browserTrigger(inputElm, 'keyup');
-        expect(inputElm).toBeValid();
+          mockValidity.valid = true;
+          mockValidity.badInput = false;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeValid();
+        }
       }
-    });
+    );
+
+
+    they('should not re-validate when a modifier key is pressed (modifier: $prop)',
+      ['alt', 'ctrl', 'meta', 'shift'],
+      function(modifier) {
+        // This testcase simulates keyboard interactions that lead to a change in the validity state
+        // of the element, but no change in its value (thus no 'input' event).
+        // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
+
+        var inputType = 'datetime-local';
+
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
+          var mockEvt = {type: 'keyup', keyCode: 8};
+
+          expect(inputElm).toBeValid();
+
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler(mockEvt);
+          expect(inputElm).toBeInvalid();
+
+          mockEvt[modifier + 'Key'] = true;
+
+          mockValidity.valid = true;
+          mockValidity.badInput = false;
+          inputElm.triggerHandler(mockEvt);
+          expect(inputElm).toBeInvalid();
+        }
+      }
+    );
+
+
+    they('should not re-validate on keys that can\'t affect the input (keyCode: $prop)',
+      getIgnoredKeyCodesForType('datetime-local'),
+      function(keyCode) {
+        var inputType = 'datetime-local';
+
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
+
+          expect(inputElm).toBeValid();
+
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeValid();
+        }
+      }
+    );
 
 
     it('should listen for \'keyup\' only on browsers that support this input type', function() {
       var inputType = 'datetime-local';
 
       var shouldListenForKeyup = browserSupportsInputTypeAndEvent(inputType, 'input');
+      var keyCode = getKeyCodesForType(inputType)[0];
       var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
       var ctrl = inputElm.controller('ngModel');
       spyOn(ctrl, '$setViewValue');
 
-      inputElm.triggerHandler('keyup');
+      inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
 
       expect(ctrl.$setViewValue.callCount).toBe(shouldListenForKeyup ? 1 : 0);
     });
@@ -1575,42 +1751,100 @@ describe('input', function() {
     });
 
 
-    it('should re-validate when partially editing the input value', function() {
-      // This testcase simulates keyboard interactions that lead to a change in the validity state
-      // of the element, but no change in its value (thus no 'input' event).
-      // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
+    they('should re-validate when partially editing the input value (keyCode: $prop)',
+      getKeyCodesForType('time'),
+      function(keyCode) {
+        // This testcase simulates keyboard interactions that lead to a change in the validity state
+        // of the element, but no change in its value (thus no 'input' event).
+        // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
 
-      var inputType = 'time';
+        var inputType = 'time';
 
-      if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
-        var mockValidity = {valid: true, badInput: false};
-        helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
-        var inputElm = helper.inputElm;
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
 
-        expect(inputElm).toBeValid();
+          expect(inputElm).toBeValid();
 
-        mockValidity.valid = false;
-        mockValidity.badInput = true;
-        browserTrigger(inputElm, 'keyup');
-        expect(inputElm).toBeInvalid();
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeInvalid();
 
-        mockValidity.valid = true;
-        mockValidity.badInput = false;
-        browserTrigger(inputElm, 'keyup');
-        expect(inputElm).toBeValid();
+          mockValidity.valid = true;
+          mockValidity.badInput = false;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeValid();
+        }
       }
-    });
+    );
+
+
+    they('should not re-validate when a modifier key is pressed (modifier: $prop)',
+      ['alt', 'ctrl', 'meta', 'shift'],
+      function(modifier) {
+        // This testcase simulates keyboard interactions that lead to a change in the validity state
+        // of the element, but no change in its value (thus no 'input' event).
+        // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
+
+        var inputType = 'time';
+
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
+          var mockEvt = {type: 'keyup', keyCode: 8};
+
+          expect(inputElm).toBeValid();
+
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler(mockEvt);
+          expect(inputElm).toBeInvalid();
+
+          mockEvt[modifier + 'Key'] = true;
+
+          mockValidity.valid = true;
+          mockValidity.badInput = false;
+          inputElm.triggerHandler(mockEvt);
+          expect(inputElm).toBeInvalid();
+        }
+      }
+    );
+
+
+    they('should not re-validate on keys that can\'t affect the input (keyCode: $prop)',
+      getIgnoredKeyCodesForType('time'),
+      function(keyCode) {
+        var inputType = 'time';
+
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
+
+          expect(inputElm).toBeValid();
+
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeValid();
+        }
+      }
+    );
 
 
     it('should listen for \'keyup\' only on browsers that support this input type', function() {
       var inputType = 'time';
 
       var shouldListenForKeyup = browserSupportsInputTypeAndEvent(inputType, 'input');
+      var keyCode = getKeyCodesForType(inputType)[0];
       var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
       var ctrl = inputElm.controller('ngModel');
       spyOn(ctrl, '$setViewValue');
 
-      inputElm.triggerHandler('keyup');
+      inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
 
       expect(ctrl.$setViewValue.callCount).toBe(shouldListenForKeyup ? 1 : 0);
     });
@@ -1918,42 +2152,100 @@ describe('input', function() {
     });
 
 
-    it('should re-validate when partially editing the input value', function() {
-      // This testcase simulates keyboard interactions that lead to a change in the validity state
-      // of the element, but no change in its value (thus no 'input' event).
-      // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
+    they('should re-validate when partially editing the input value (keyCode: $prop)',
+      getKeyCodesForType('date'),
+      function(keyCode) {
+        // This testcase simulates keyboard interactions that lead to a change in the validity state
+        // of the element, but no change in its value (thus no 'input' event).
+        // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
 
-      var inputType = 'date';
+        var inputType = 'date';
 
-      if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
-        var mockValidity = {valid: true, badInput: false};
-        helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
-        var inputElm = helper.inputElm;
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
 
-        expect(inputElm).toBeValid();
+          expect(inputElm).toBeValid();
 
-        mockValidity.valid = false;
-        mockValidity.badInput = true;
-        browserTrigger(inputElm, 'keyup');
-        expect(inputElm).toBeInvalid();
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeInvalid();
 
-        mockValidity.valid = true;
-        mockValidity.badInput = false;
-        browserTrigger(inputElm, 'keyup');
-        expect(inputElm).toBeValid();
+          mockValidity.valid = true;
+          mockValidity.badInput = false;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeValid();
+        }
       }
-    });
+    );
+
+
+    they('should not re-validate when a modifier key is pressed (modifier: $prop)',
+      ['alt', 'ctrl', 'meta', 'shift'],
+      function(modifier) {
+        // This testcase simulates keyboard interactions that lead to a change in the validity state
+        // of the element, but no change in its value (thus no 'input' event).
+        // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
+
+        var inputType = 'date';
+
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
+          var mockEvt = {type: 'keyup', keyCode: 8};
+
+          expect(inputElm).toBeValid();
+
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler(mockEvt);
+          expect(inputElm).toBeInvalid();
+
+          mockEvt[modifier + 'Key'] = true;
+
+          mockValidity.valid = true;
+          mockValidity.badInput = false;
+          inputElm.triggerHandler(mockEvt);
+          expect(inputElm).toBeInvalid();
+        }
+      }
+    );
+
+
+    they('should not re-validate on keys that can\'t affect the input (keyCode: $prop)',
+      getIgnoredKeyCodesForType('date'),
+      function(keyCode) {
+        var inputType = 'date';
+
+        if (browserSupportsInputTypeAndEvent(inputType, 'input')) {
+          var mockValidity = {valid: true, badInput: false};
+          helper.compileInput('<input type="' + inputType + '" ng-model="val" />', mockValidity);
+          var inputElm = helper.inputElm;
+
+          expect(inputElm).toBeValid();
+
+          mockValidity.valid = false;
+          mockValidity.badInput = true;
+          inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
+          expect(inputElm).toBeValid();
+        }
+      }
+    );
 
 
     it('should listen for \'keyup\' only on browsers that support this input type', function() {
       var inputType = 'date';
 
       var shouldListenForKeyup = browserSupportsInputTypeAndEvent(inputType, 'input');
+      var keyCode = getKeyCodesForType(inputType)[0];
       var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
       var ctrl = inputElm.controller('ngModel');
       spyOn(ctrl, '$setViewValue');
 
-      inputElm.triggerHandler('keyup');
+      inputElm.triggerHandler({type: 'keyup', keyCode: keyCode});
 
       expect(ctrl.$setViewValue.callCount).toBe(shouldListenForKeyup ? 1 : 0);
     });
@@ -3085,5 +3377,35 @@ describe('input', function() {
     var supportsEvent = $sniffer.hasEvent(event);
 
     return supportsType && supportsEvent;
+  }
+
+  function getKeyCodesForType(type) {
+    var keyCodes = [];
+
+    (KEYS_PER_DATE_INPUT_TYPE[type] || []).forEach(function(keyOrRange) {
+      if (isArray(keyOrRange)) {
+        var min = keyOrRange[0];
+        var max = keyOrRange[1];
+
+        for (var i = min; i <= max; i++) {
+          keyCodes.push(i);
+        }
+      } else {
+        keyCodes.push(keyOrRange);
+      }
+    });
+
+    return keyCodes;
+  }
+
+  function getIgnoredKeyCodesForType(type) {
+    var keyCodes = [];
+
+    var notIgnored = getKeyCodesForType(type);
+    for (var i = 1; i <= 222; i++) {
+      if (notIgnored.indexOf(i) === -1) keyCodes.push(i);
+    }
+
+    return keyCodes;
   }
 });

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -659,31 +659,9 @@ describe('input', function() {
 
 
     it('should re-validate when partially editing the input value', function() {
-      // This testcase tests re-validation on interactions involved in the following scenario
-      // (on a browser that supports this type of input):
-      //
-      // 1. Initially empty field.
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      // 2. The user fills part of the value (e.g. the year) using the keyboard.
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: false, badInput: true, ...}
-      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
-      // 3. The user fills the value completely (using either the keyboard or the date-picker).
-      //    - `input.value`: '<some-valid-value>'
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      //    - 'input' event: Fired
-      // 4. The user deletes part of the value (e.g. the year) using the keyboard.
-      //    - `input.value`: ''   (since a partial value is invalid)
-      //    - `input.validity`: {valid: false, badInput: true, ...}
-      //    - 'input' event: Fired
-      // 5. The user deletes all parts of the value using the keyboard (i.e. clears the field).
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
-      //
-      // The problematic cases are (2) and (5), because there is a change in the validity state,
-      // but no 'input' event is fired to inform Angular of that change and the need to re-validate.
+      // This testcase simulates keyboard interactions that lead to a change in the validity state
+      // of the element, but no change in its value (thus no 'input' event).
+      // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
 
       var inputType = 'month';
 
@@ -938,31 +916,9 @@ describe('input', function() {
 
 
     it('should re-validate when partially editing the input value', function() {
-      // This testcase tests re-validation on interactions involved in the following scenario
-      // (on a browser that supports this type of input):
-      //
-      // 1. Initially empty field.
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      // 2. The user fills part of the value (e.g. the year) using the keyboard.
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: false, badInput: true, ...}
-      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
-      // 3. The user fills the value completely (using either the keyboard or the date-picker).
-      //    - `input.value`: '<some-valid-value>'
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      //    - 'input' event: Fired
-      // 4. The user deletes part of the value (e.g. the year) using the keyboard.
-      //    - `input.value`: ''   (since a partial value is invalid)
-      //    - `input.validity`: {valid: false, badInput: true, ...}
-      //    - 'input' event: Fired
-      // 5. The user deletes all parts of the value using the keyboard (i.e. clears the field).
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
-      //
-      // The problematic cases are (2) and (5), because there is a change in the validity state,
-      // but no 'input' event is fired to inform Angular of that change and the need to re-validate.
+      // This testcase simulates keyboard interactions that lead to a change in the validity state
+      // of the element, but no change in its value (thus no 'input' event).
+      // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
 
       var inputType = 'week';
 
@@ -1252,31 +1208,9 @@ describe('input', function() {
 
 
     it('should re-validate when partially editing the input value', function() {
-      // This testcase tests re-validation on interactions involved in the following scenario
-      // (on a browser that supports this type of input):
-      //
-      // 1. Initially empty field.
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      // 2. The user fills part of the value (e.g. the year) using the keyboard.
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: false, badInput: true, ...}
-      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
-      // 3. The user fills the value completely (using either the keyboard or the date-picker).
-      //    - `input.value`: '<some-valid-value>'
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      //    - 'input' event: Fired
-      // 4. The user deletes part of the value (e.g. the year) using the keyboard.
-      //    - `input.value`: ''   (since a partial value is invalid)
-      //    - `input.validity`: {valid: false, badInput: true, ...}
-      //    - 'input' event: Fired
-      // 5. The user deletes all parts of the value using the keyboard (i.e. clears the field).
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
-      //
-      // The problematic cases are (2) and (5), because there is a change in the validity state,
-      // but no 'input' event is fired to inform Angular of that change and the need to re-validate.
+      // This testcase simulates keyboard interactions that lead to a change in the validity state
+      // of the element, but no change in its value (thus no 'input' event).
+      // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
 
       var inputType = 'datetime-local';
 
@@ -1642,31 +1576,9 @@ describe('input', function() {
 
 
     it('should re-validate when partially editing the input value', function() {
-      // This testcase tests re-validation on interactions involved in the following scenario
-      // (on a browser that supports this type of input):
-      //
-      // 1. Initially empty field.
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      // 2. The user fills part of the value (e.g. the hours) using the keyboard.
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: false, badInput: true, ...}
-      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
-      // 3. The user fills the value completely (using either the keyboard or the buttons).
-      //    - `input.value`: '<some-valid-value>'
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      //    - 'input' event: Fired
-      // 4. The user deletes part of the value (e.g. the hours) using the keyboard.
-      //    - `input.value`: ''   (since a partial value is invalid)
-      //    - `input.validity`: {valid: false, badInput: true, ...}
-      //    - 'input' event: Fired
-      // 5. The user deletes all parts of the value using the keyboard (i.e. clears the field).
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
-      //
-      // The problematic cases are (2) and (5), because there is a change in the validity state,
-      // but no 'input' event is fired to inform Angular of that change and the need to re-validate.
+      // This testcase simulates keyboard interactions that lead to a change in the validity state
+      // of the element, but no change in its value (thus no 'input' event).
+      // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
 
       var inputType = 'time';
 
@@ -2007,31 +1919,9 @@ describe('input', function() {
 
 
     it('should re-validate when partially editing the input value', function() {
-      // This testcase tests re-validation on interactions involved in the following scenario
-      // (on a browser that supports this type of input):
-      //
-      // 1. Initially empty field.
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      // 2. The user fills part of the value (e.g. the year) using the keyboard.
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: false, badInput: true, ...}
-      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
-      // 3. The user fills the value completely (using either the keyboard or the date-picker).
-      //    - `input.value`: '<some-valid-value>'
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      //    - 'input' event: Fired
-      // 4. The user deletes part of the value (e.g. the year) using the keyboard.
-      //    - `input.value`: ''   (since a partial value is invalid)
-      //    - `input.validity`: {valid: false, badInput: true, ...}
-      //    - 'input' event: Fired
-      // 5. The user deletes all parts of the value using the keyboard (i.e. clears the field).
-      //    - `input.value`: ''
-      //    - `input.validity`: {valid: true, badInput: false, ...}
-      //    - 'input' event: Not fired   (since `input.value` hasn't changed)
-      //
-      // The problematic cases are (2) and (5), because there is a change in the validity state,
-      // but no 'input' event is fired to inform Angular of that change and the need to re-validate.
+      // This testcase simulates keyboard interactions that lead to a change in the validity state
+      // of the element, but no change in its value (thus no 'input' event).
+      // For a more detailed explanation, see: https://github.com/angular/angular.js/pull/12902
 
       var inputType = 'date';
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -707,21 +707,18 @@ describe('input', function() {
     });
 
 
-    it('should fire \'input\' event on \'keyup\' only on browsers that support this input type',
-      function() {
-        var inputType = 'month';
+    it('should listen for \'keyup\' only on browsers that support this input type', function() {
+      var inputType = 'month';
 
-        var inputEventExpectedToFire = browserSupportsInputTypeAndEvent(inputType, 'input');
-        var inputEventActuallyFired = false;
+      var shouldListenForKeyup = browserSupportsInputTypeAndEvent(inputType, 'input');
+      var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
+      var ctrl = inputElm.controller('ngModel');
+      spyOn(ctrl, '$setViewValue');
 
-        var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
-        inputElm.on('input', function() { inputEventActuallyFired = true; });
+      inputElm.triggerHandler('keyup');
 
-        browserTrigger(inputElm, 'keyup');
-
-        expect(inputEventActuallyFired).toBe(inputEventExpectedToFire);
-      }
-    );
+      expect(ctrl.$setViewValue.callCount).toBe(shouldListenForKeyup ? 1 : 0);
+    });
 
 
     describe('min', function() {
@@ -989,21 +986,18 @@ describe('input', function() {
     });
 
 
-    it('should fire \'input\' event on \'keyup\' only on browsers that support this input type',
-      function() {
-        var inputType = 'week';
+    it('should listen for \'keyup\' only on browsers that support this input type', function() {
+      var inputType = 'week';
 
-        var inputEventExpectedToFire = browserSupportsInputTypeAndEvent(inputType, 'input');
-        var inputEventActuallyFired = false;
+      var shouldListenForKeyup = browserSupportsInputTypeAndEvent(inputType, 'input');
+      var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
+      var ctrl = inputElm.controller('ngModel');
+      spyOn(ctrl, '$setViewValue');
 
-        var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
-        inputElm.on('input', function() { inputEventActuallyFired = true; });
+      inputElm.triggerHandler('keyup');
 
-        browserTrigger(inputElm, 'keyup');
-
-        expect(inputEventActuallyFired).toBe(inputEventExpectedToFire);
-      }
-    );
+      expect(ctrl.$setViewValue.callCount).toBe(shouldListenForKeyup ? 1 : 0);
+    });
 
 
     describe('min', function() {
@@ -1306,21 +1300,18 @@ describe('input', function() {
     });
 
 
-    it('should fire \'input\' event on \'keyup\' only on browsers that support this input type',
-      function() {
-        var inputType = 'datetime-local';
+    it('should listen for \'keyup\' only on browsers that support this input type', function() {
+      var inputType = 'datetime-local';
 
-        var inputEventExpectedToFire = browserSupportsInputTypeAndEvent(inputType, 'input');
-        var inputEventActuallyFired = false;
+      var shouldListenForKeyup = browserSupportsInputTypeAndEvent(inputType, 'input');
+      var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
+      var ctrl = inputElm.controller('ngModel');
+      spyOn(ctrl, '$setViewValue');
 
-        var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
-        inputElm.on('input', function() { inputEventActuallyFired = true; });
+      inputElm.triggerHandler('keyup');
 
-        browserTrigger(inputElm, 'keyup');
-
-        expect(inputEventActuallyFired).toBe(inputEventExpectedToFire);
-      }
-    );
+      expect(ctrl.$setViewValue.callCount).toBe(shouldListenForKeyup ? 1 : 0);
+    });
 
 
     describe('min', function() {
@@ -1699,21 +1690,18 @@ describe('input', function() {
     });
 
 
-    it('should fire \'input\' event on \'keyup\' only on browsers that support this input type',
-      function() {
-        var inputType = 'time';
+    it('should listen for \'keyup\' only on browsers that support this input type', function() {
+      var inputType = 'time';
 
-        var inputEventExpectedToFire = browserSupportsInputTypeAndEvent(inputType, 'input');
-        var inputEventActuallyFired = false;
+      var shouldListenForKeyup = browserSupportsInputTypeAndEvent(inputType, 'input');
+      var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
+      var ctrl = inputElm.controller('ngModel');
+      spyOn(ctrl, '$setViewValue');
 
-        var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
-        inputElm.on('input', function() { inputEventActuallyFired = true; });
+      inputElm.triggerHandler('keyup');
 
-        browserTrigger(inputElm, 'keyup');
-
-        expect(inputEventActuallyFired).toBe(inputEventExpectedToFire);
-      }
-    );
+      expect(ctrl.$setViewValue.callCount).toBe(shouldListenForKeyup ? 1 : 0);
+    });
 
 
     describe('min', function() {
@@ -2067,21 +2055,18 @@ describe('input', function() {
     });
 
 
-    it('should fire \'input\' event on \'keyup\' only on browsers that support this input type',
-      function() {
-        var inputType = 'date';
+    it('should listen for \'keyup\' only on browsers that support this input type', function() {
+      var inputType = 'date';
 
-        var inputEventExpectedToFire = browserSupportsInputTypeAndEvent(inputType, 'input');
-        var inputEventActuallyFired = false;
+      var shouldListenForKeyup = browserSupportsInputTypeAndEvent(inputType, 'input');
+      var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
+      var ctrl = inputElm.controller('ngModel');
+      spyOn(ctrl, '$setViewValue');
 
-        var inputElm = helper.compileInput('<input type="' + inputType + '" ng-model="val" />');
-        inputElm.on('input', function() { inputEventActuallyFired = true; });
+      inputElm.triggerHandler('keyup');
 
-        browserTrigger(inputElm, 'keyup');
-
-        expect(inputEventActuallyFired).toBe(inputEventExpectedToFire);
-      }
-    );
+      expect(ctrl.$setViewValue.callCount).toBe(shouldListenForKeyup ? 1 : 0);
+    });
 
 
     describe('min', function() {


### PR DESCRIPTION
In date-family input types (`date`, `datetime-local`, `month`, `time`, `week`), the user can interact with parts of the value (e.g. year, month, hours etc) independently. Neverhteless, the actual value of the element is empty (`''`) unless all parts are filled (and valid).

Thus, editing a signle part of the value may result in a change in the validity state of the `<input>` (see below), without an accompanying change in the actual value of the element. In such cases, no `input` event is fired by the browser to inform Angular of the change (and the need to re-validate).

---

The following scenario describes a series of interactions that would run into the problem (on a browser that supports the `date` input type):
1. Initially empty field.
   - `input.value`: ''
   - `input.validity`: {valid: true, badInput: false, ...}
2. The user fills part of the value (e.g. the year) using the keyboard.
   - `input.value`: ''
   - `input.validity`: {valid: false, badInput: true, ...}
   - 'input' event: Not fired   (since `input.value` hasn't changed)
3. The user fills the value completely (using either the keyboard or the
   date-picker).
   - `input.value`: '<some-valid-value>'
   - `input.validity`: {valid: true, badInput: false, ...}
   - 'input' event: Fired
4. The user deletes part of the value (e.g. the year) using the keyboard.
   - `input.value`: ''   (since a partial value is invalid)
   - `input.validity`: {valid: false, badInput: true, ...}
   - 'input' event: Fired
5. The user deletes all parts of the value using the keyboard (i.e. clears the field).
   - `input.value`: ''
   - `input.validity`: {valid: true, badInput: false, ...}
   - 'input' event: Not fired   (since `input.value` hasn't changed)

The problematic cases are (2) and (5), because there is a change in the validity state, but no 'input' event is fired to inform Angular of that change and the need to re-validate.

---

This commit fixes the issue by firing an `input` event on `keyup`, correctly triggering re-validation.

Fixes #12207
