### PR TITLE
Feat: parse / format / validation for ngModel collection values

### DIFF
--- a/src/ng/directive/validators.js
+++ b/src/ng/directive/validators.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* global NgModelValidator: true */
+
 var requiredDirective = function() {
   return {
     restrict: 'A',
@@ -65,6 +67,7 @@ var maxlengthDirective = function() {
         maxlength = isNaN(intVal) ? -1 : intVal;
         ctrl.$validate();
       });
+
       ctrl.$validators.maxlength = function(modelValue, viewValue) {
         return (maxlength < 0) || ctrl.$isEmpty(viewValue) || (viewValue.length <= maxlength);
       };
@@ -84,6 +87,7 @@ var minlengthDirective = function() {
         minlength = toInt(value) || 0;
         ctrl.$validate();
       });
+
       ctrl.$validators.minlength = function(modelValue, viewValue) {
         return ctrl.$isEmpty(viewValue) || viewValue.length >= minlength;
       };

--- a/test/ng/directive/ngChangeSpec.js
+++ b/test/ng/directive/ngChangeSpec.js
@@ -58,4 +58,19 @@ describe('ngChange', function() {
     helper.changeInputValueTo('a');
     expect(inputElm.val()).toBe('b');
   });
+
+
+  it('should set the view if the model is changed by ngChange', function() {
+    $rootScope.reset = function() {
+      $rootScope.value = 'a';
+    };
+    $rootScope.value = 'a';
+    var input = helper.compileInput('<input type="text" ng-change="reset()" ng-model="value">');
+    var inputController = input.controller('ngModel');
+
+    $rootScope.$digest();
+
+    helper.changeInputValueTo('b');
+    expect(input.val()).toBe('a');
+  });
 });

--- a/test/ng/directive/ngListSpec.js
+++ b/test/ng/directive/ngListSpec.js
@@ -74,6 +74,18 @@ describe('ngList', function() {
     expect(inputElm).toBeValid();
   });
 
+
+  it('should update the view if a part of the collection changes', function() {
+    var inputElm = helper.compileInput('<input type="text" ng-list ng-model="list">');
+    helper.changeInputValueTo('a,b');
+    expect($rootScope.list).toEqual(['a','b']);
+
+    $rootScope.list[1] = 'c';
+    $rootScope.$digest();
+
+    expect(inputElm.val()).toEqual('a, c');
+  });
+
   describe('with a custom separator', function() {
     it('should split on the custom separator', function() {
       helper.compileInput('<input type="text" ng-model="list" ng-list=":" />');

--- a/test/ng/directive/validatorsSpec.js
+++ b/test/ng/directive/validatorsSpec.js
@@ -319,6 +319,25 @@ describe('validators', function() {
       expect(ctrl.$error.minlength).toBe(true);
       expect(ctrlNg.$error.minlength).toBe(true);
     }));
+
+    describe('collection validation', function() {
+
+      it('should validate the viewValue and not the individual values', function() {
+        var inputElm = helper.compileInput('<input type="text" minlength="10" ng-list ng-model="list">');
+        var ctrl = inputElm.controller('ngModel');
+        spyOn(ctrl.$validators, 'minlength').andCallThrough();
+
+        helper.changeInputValueTo('2,2');
+        expect(inputElm).toBeInvalid();
+        expect(ctrl.$error.minlength).toBe(true);
+        expect(ctrl.$validators.minlength.calls[0].args).toEqual([['2','2'], '2,2']);
+
+        helper.changeInputValueTo('20000,20000');
+        expect(inputElm).toBeValid();
+        expect(ctrl.$error.minlength).toBeFalsy();
+      });
+    });
+
   });
 
 
@@ -507,6 +526,24 @@ describe('validators', function() {
       expect(ctrl.$error.maxlength).toBe(true);
       expect(ctrlNg.$error.maxlength).toBe(true);
     }));
+
+    describe('collection validation', function() {
+
+      it('should validate the viewValue and not the individual values', function() {
+        var inputElm = helper.compileInput('<input type="text" maxlength="10" ng-list ng-model="list">');
+        var ctrl = inputElm.controller('ngModel');
+        spyOn(ctrl.$validators, 'maxlength').andCallThrough();
+
+        helper.changeInputValueTo('2,2');
+        expect(inputElm).toBeValid();
+        expect(ctrl.$error.maxlength).toBeFalsy();
+        expect(ctrl.$validators.maxlength.calls[0].args).toEqual([['2','2'], '2,2']);
+
+        helper.changeInputValueTo('20000,20000');
+        expect(inputElm).toBeInvalid();
+        expect(ctrl.$error.maxlength).toBe(true);
+      });
+    });
   });
 
 


### PR DESCRIPTION
Depends on https://github.com/angular/angular.js/pull/12783
This change has two goals:
1. introduce a way to specify that ngModel handles a collection instead of a single value
2. introduce support for parsing, formatting and validating (pfv) single collection items instead of the whole collection via a new API.
3. make ngList use $isCollection to enable view updates when part of the model collection changes

Regarding 1), it's currently a simple property $isCollection on the modelCtrl that does two things: it activates the deepWatch behavior, and informs the pfv that the model is a collection. 
TODO: move $isCollection to ngModelOptions?

Regarding 2). There's a new API for pfv that makes it possible to decide if the whole model or single collection items are handled. These are simple classes that are added to the $parsers, $formatters pipelines respectively $validators collection as before. Legacy pfv continue to  receive the whole collection as values for backward compat.
TODO: expose NgModelTransform, NgModelValidator to the public
