### PR TITLE
docs: fix link formatting on directive documentation

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -43,7 +43,7 @@ mirrors the process of compiling source code in
 Before we can write a directive, we need to know how Angular's {@link guide/compiler HTML compiler}
 determines when to use a given directive.
 
-Similar to the terminology used when an [element **matches** a selector]
+Similar to the terminology used when an [element matches a selector]
 (https://developer.mozilla.org/en-US/docs/Web/API/Element.matches), we say an element **matches** a
 directive when the directive is part of its declaration.
 


### PR DESCRIPTION
The link was showing up as [text](link) rather than actually displaying the formatted link. I removed the bold formatting so it display as a link again.
