### PR TITLE
WIP - feat(ngPattern): parse "stringified" regular expressions to `RegExp` Objects

### DIFF
--- a/test/ng/directive/validatorsSpec.js
+++ b/test/ng/directive/validatorsSpec.js
@@ -127,7 +127,7 @@ describe('validators', function() {
 
 
     it('should register "pattern" with the model validations when the pattern attribute is used', function() {
-      var inputElm = helper.compileInput('<input type="text" name="input" ng-model="value" pattern="^\\d+$" />');
+      var inputElm = helper.compileInput('<input type="text" name="input" ng-model="value" pattern="\\d+" />');
 
       helper.changeInputValueTo('abcd');
       expect(inputElm).toBeInvalid();
@@ -160,38 +160,6 @@ describe('validators', function() {
 
     it('should be invalid if entire string does not match pattern', function() {
       var inputElm = helper.compileInput('<input type="text" name="test" ng-model="value" pattern="\\d{4}">');
-      helper.changeInputValueTo('1234');
-      expect($rootScope.form.test.$error.pattern).not.toBe(true);
-      expect(inputElm).toBeValid();
-
-      helper.changeInputValueTo('123');
-      expect($rootScope.form.test.$error.pattern).toBe(true);
-      expect(inputElm).not.toBeValid();
-
-      helper.changeInputValueTo('12345');
-      expect($rootScope.form.test.$error.pattern).toBe(true);
-      expect(inputElm).not.toBeValid();
-    });
-
-
-    it('should be cope with patterns that start with ^', function() {
-      var inputElm = helper.compileInput('<input type="text" name="test" ng-model="value" pattern="^\\d{4}">');
-      helper.changeInputValueTo('1234');
-      expect($rootScope.form.test.$error.pattern).not.toBe(true);
-      expect(inputElm).toBeValid();
-
-      helper.changeInputValueTo('123');
-      expect($rootScope.form.test.$error.pattern).toBe(true);
-      expect(inputElm).not.toBeValid();
-
-      helper.changeInputValueTo('12345');
-      expect($rootScope.form.test.$error.pattern).toBe(true);
-      expect(inputElm).not.toBeValid();
-    });
-
-
-    it('should be cope with patterns that end with $', function() {
-      var inputElm = helper.compileInput('<input type="text" name="test" ng-model="value" pattern="\\d{4}$">');
       helper.changeInputValueTo('1234');
       expect($rootScope.form.test.$error.pattern).not.toBe(true);
       expect(inputElm).toBeValid();

--- a/test/ng/directive/validatorsSpec.js
+++ b/test/ng/directive/validatorsSpec.js
@@ -174,6 +174,18 @@ describe('validators', function() {
     });
 
 
+    it('should parse stringified RegExps on ngPattern scope value', function() {
+      helper.compileInput('<input type="text" ng-model="value" ng-pattern="regExp" />');
+      helper.changeInputValueTo('1234');
+
+      $rootScope.$apply(function(s) { s.regExp = /^\d{3}$/; });
+      expect(helper.inputElm).toBeInvalid();
+
+      $rootScope.$apply(function(s) { s.regExp = '/^\\d{4}$/'; });
+      expect(helper.inputElm).toBeValid();
+    });
+
+
     it('should validate the viewValue and not the modelValue', function() {
       var inputElm = helper.compileInput('<input type="text" name="test" ng-model="value" pattern="\\d{4}">');
       var ctrl = inputElm.controller('ngModel');


### PR DESCRIPTION
Previously, `ngPattern`'s expression value was expected to be a `RegExp` Object. This made it difficult to use string representations of regular expressions (e.g. fetched from the backend) as values for `ngPattern` expressions.

This commit adds the ability to recognize and parse string values into `RegExp` Objects. If the value cannot be parsed into a `RegExp` Object, it behaves the same as before.

Fixes #12913

---

This is a POC to get some feedback/see what people think.

TODO:
- [ ] Update the docs.
- [ ] Add a BC notice to the commit message (if necessary).
## 

Possible BREAKING CHANGE:

Assuming `ng-pattern="pat"` and `$scope.pat = '/123/'`:

**Before:**
Would match a literal `/123/` as input value.

**After:**
Will be parsed into a `RegExp` and match any value containing `123`.
In order to match a literal `/123/` as input value, one can use `$scope = '\/123/'`.
