### PR TITLE
feat(ngMock): improve $httpBackend mock

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1136,6 +1136,7 @@ angular.mock.$HttpBackendProvider = function() {
 function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
   var definitions = [],
       expectations = [],
+      notCalledExpectations = [],
       responses = [],
       responsesPush = angular.bind(responses, responses.push),
       copy = angular.copy;
@@ -1185,6 +1186,10 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
           }
         }
       }
+    }
+
+    if (notCalledExpectations.some(function(exp) { return exp.match(method, url, data, headers); })) {
+      throw new Error('Request should not be called: ' + method + ' ' + url);
     }
 
     if (expectation && expectation.match(method, url)) {
@@ -1393,6 +1398,14 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
         chain = {
           respond: function(status, data, headers, statusText) {
             expectation.response = createResponse(status, data, headers, statusText);
+            return chain;
+          },
+          haveNotBeenCalled: function() {
+            var index = expectations.indexOf(expectation);
+            if (index > -1) {
+              expectations.splice(index, 1);
+            }
+            notCalledExpectations.push(expectation);
             return chain;
           }
         };

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1284,6 +1284,100 @@ describe('ngMock', function() {
       });
     });
 
+    describe('expect().haveNotBeenCalled', function() {
+      it("function won't be called", function() {
+        hb.expect('GET', '/some').haveNotBeenCalled();
+
+        expect(function() {
+          hb.verifyNoOutstandingExpectation();
+        }).not.toThrow();
+      });
+
+
+      it("should throw exception if not expected function will be called", function() {
+        hb.expect('GET', '/some').haveNotBeenCalled();
+
+        expect(function() {
+          hb('GET', '/some', null, noop);
+        }).toThrow('Request should not be called: GET /some');
+      });
+
+
+      it("should throw exception if not expected function will be called after expected one", function() {
+        hb.expect('GET', '/some1').respond(200, {});
+        hb.expect('GET', '/some2').haveNotBeenCalled();
+
+        expect(function() {
+          hb('GET', '/some1', {}, noop);
+          hb('GET', '/some2', {}, noop);
+        }).toThrow('Request should not be called: GET /some2');
+      });
+
+
+      it("should throw exception if not expected function will be called regardless of sequence", function() {
+        hb.expect('GET', '/some1').haveNotBeenCalled();
+        hb.expect('GET', '/some2').haveNotBeenCalled();
+        hb.expect('GET', '/some3').respond(200, {});
+
+        expect(function() {
+          hb('GET', '/some3', {}, noop);
+          hb('GET', '/some2', {}, noop);
+        }).toThrow('Request should not be called: GET /some2');
+      });
+
+
+      it("function is expected and not expected in the same time, and called", function() {
+        hb.expect('GET', '/some1').respond(200, {});
+        hb.expect('GET', '/some1').haveNotBeenCalled();
+
+        expect(function() {
+          hb('GET', '/some1', {}, noop);
+        }).toThrow('Request should not be called: GET /some1');
+      });
+
+
+      it("function is expected and not expected in the same time, and not called", function() {
+        hb.expect('GET', '/some1').respond(200, {});
+        hb.expect('GET', '/some1').haveNotBeenCalled();
+
+        expect(function() {
+          hb.verifyNoOutstandingExpectation();
+        }).toThrow('Unsatisfied requests: GET /some1');
+      });
+
+
+      it("the same url is expected and not expected with different data", function() {
+        hb.expect('GET', '/some1', {id: 1}).respond(200, {});
+        hb.expect('GET', '/some1', {id: 2}).haveNotBeenCalled();
+
+        expect(function() {
+          hb('GET', '/some1', {id: 1}, noop);
+        }).not.toThrow();
+      });
+
+
+      it("the same url is expected and not expected with different headers", function() {
+        hb.expect('GET', '/some1', {id: 1}, {header: 1}).respond(200, {});
+        hb.expect('GET', '/some1', {id: 1}, {header: 2}).haveNotBeenCalled();
+
+        expect(function() {
+          hb('GET', '/some1', {id: 1}, noop, {header: 1});
+        }).not.toThrow();
+      });
+
+
+      it("should skip not expected function", function() {
+        hb.expect('GET', '/some1').respond(200, {});
+        hb.expect('GET', '/some2').haveNotBeenCalled();
+        hb.expect('GET', '/some3').respond(200, {});
+
+        expect(function() {
+          hb('GET', '/some1', {}, noop);
+          hb('GET', '/some3', {}, noop);
+          hb.verifyNoOutstandingExpectation();
+        }).not.toThrow();
+      });
+    });
 
     describe('flush()', function() {
       it('flush() should flush requests fired during callbacks', function() {


### PR DESCRIPTION
In $httpBackend mock were no possibility to expect that specific function won't be called.
Added haveNotBeenCalled function to the $httpBackend mock expectation.

Closes #12399
