### PR TITLE
docs($interpolateProvider): document XSS in $interpolate

### DIFF
--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -20,6 +20,14 @@ $interpolateMinErr.interr = function(text, err) {
  *
  * Used for configuring the interpolation markup. Defaults to `{{` and `}}`.
  *
+ * <div class="alert alert-danger">
+ * This feature is sometimes used to mix different markup languages, e.g. to wrap an Angular
+ * template within a Python Jinja template (or any other template language). Mixing templating
+ * languages is **very dangerous**. The embedding template language will not safely escape Angular
+ * expressions, so any user-controlled values in the template will cause Cross Site Scripting (XSS)
+ * security bugs!
+ * </div>
+ *
  * @example
 <example module="customInterpolationApp">
 <file name="index.html">


### PR DESCRIPTION
`$interpolateProvider.startSymbol` & friends are often used dangerously, to embed Angular templating in other templating languages. This change documents that that is a very dangerous practice.
