### PR TITLE
Add $location.setBaseHref()

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -158,6 +158,15 @@ function LocationHtml5Url(appBase, appBaseNoFile, basePrefix) {
     }
     return !!rewrittenUrl;
   };
+
+  /**
+   * Sets the appBase and appBaseNoFile members to use a new base href.
+   * @private
+   */
+  this.$$setBaseHref = function(baseHref) {
+    appBase = serverBase(this.absUrl()) + (baseHref || '/');
+    appBaseNoFile = stripFile(appBase);
+  };
 }
 
 
@@ -641,6 +650,34 @@ forEach([LocationHashbangInHtml5Url, LocationHashbangUrl, LocationHtml5Url], fun
     // but we're changing the $$state reference to $browser.state() during the $digest
     // so the modification window is narrow.
     this.$$state = isUndefined(state) ? null : state;
+
+    return this;
+  };
+
+  /**
+   * @ngdoc method
+   * @name $location#setBaseHref
+   *
+   * @description
+   * This method is a setter only.
+   *
+   * Change the base href (therefore the app base) that $location uses.
+   * Useful for cases where the URL needs to change to something outside the current base without triggering a refresh.
+   *
+   * NOTE: This method is supported only in HTML5 mode and only in browsers supporting
+   * the HTML5 History API. It doesn't seem to have an obvious use case outside of that,
+   * as changing the base href otherwise would also cause a page refresh.
+   *
+   * @param {string=} baseHref the new base href to use
+   * @return {object} $location service
+   */
+  Location.prototype.setBaseHref = function(baseHref) {
+    if (Location !== LocationHtml5Url || !this.$$html5) {
+      throw $locationMinErr('nobasehref', 'Setting the app base href is available only ' +
+        'in HTML5 mode and only in browsers supporting HTML5 History API');
+    }
+
+    this.$$setBaseHref(baseHref);
 
     return this;
   };

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -111,6 +111,14 @@ describe('$location', function() {
       expect(locationUrl.path()).toBe('/');
     });
 
+    it('path() should respect an overridden base href', function() {
+      var locationUrl = createLocationHtml5Url();
+      locationUrl.setBaseHref('/new-base/');
+      locationUrl.path('/foo');
+      expect(locationUrl.absUrl()).toBe('http://www.domain.com:9877/new-base/foo?search=a&b=c&d#hash');
+    });
+
+
     it('search() should accept string', function() {
       var locationUrl = createLocationHtml5Url();
       locationUrl.search('x=y&c');
@@ -207,6 +215,13 @@ describe('$location', function() {
       }).toThrowMinErr('$location', 'isrcharg', 'The first argument of the `$location#search()` call must be a string or an object.');
     });
 
+    it('search() should respect an overridden base href', function() {
+      var locationUrl = createLocationHtml5Url();
+      locationUrl.setBaseHref('/new-base/');
+      locationUrl.search({fizz: 'buzz'});
+      expect(locationUrl.absUrl()).toBe('http://www.domain.com:9877/new-base/path/b?fizz=buzz#hash');
+    });
+
 
     it('hash() should change hash fragment', function() {
       var locationUrl = createLocationHtml5Url();
@@ -235,6 +250,13 @@ describe('$location', function() {
       locationUrl.hash(null);
       expect(locationUrl.hash()).toBe('');
       expect(locationUrl.absUrl()).toBe('http://www.domain.com:9877/path/b?search=a&b=c&d');
+    });
+
+    it('hash() should respect an overridden base href', function() {
+      var locationUrl = createLocationHtml5Url();
+      locationUrl.setBaseHref('/new-base/');
+      locationUrl.hash('new-hash');
+      expect(locationUrl.absUrl()).toBe('http://www.domain.com:9877/new-base/path/b?search=a&b=c&d#new-hash');
     });
 
 
@@ -285,6 +307,13 @@ describe('$location', function() {
       expect(locationUrl.path()).toBe('/');
       expect(locationUrl.search()).toEqual({});
       expect(locationUrl.hash()).toBe('');
+    });
+
+    it('url() should respect an overridden base href', function() {
+      var locationUrl = createLocationHtml5Url();
+      locationUrl.setBaseHref('/new-base/');
+      locationUrl.url('/some/path?a=b&c=d#hhh');
+      expect(locationUrl.absUrl()).toBe('http://www.domain.com:9877/new-base/some/path?a=b&c=d#hhh');
     });
 
 
@@ -2482,6 +2511,11 @@ describe('$location', function() {
       expect(locationUrl.url()).toBe('');
       expect(locationUrl.absUrl()).toBe('http://server/next/index.html');
     });
+
+    it('should throw on setBaseHref(newBaseHref)', function() {
+      locationUrl = new LocationHashbangUrl('http://server/pre/index.html', 'http://server/pre/', '#');
+      expectThrowOnSetBaseHref(locationUrl);
+    });
   });
 
 
@@ -2511,6 +2545,10 @@ describe('$location', function() {
 
     it('should throw on url(urlString, stateObject)', function() {
       expectThrowOnStateChange(locationUrl);
+    });
+
+    it('should throw on setBaseHref(newBaseHref)', function() {
+      expectThrowOnSetBaseHref(locationUrl);
     });
   });
 
@@ -2596,6 +2634,12 @@ describe('$location', function() {
     );
   }
 
+  function expectThrowOnSetBaseHref(location) {
+    expect(function() {
+      location.setBaseHref('/new-base/');
+    }).toThrowMinErr('$location', 'nobasehref', 'Setting the app base href is available only ' +
+      'in HTML5 mode and only in browsers supporting HTML5 History API');
+  }
 
   function parseLinkAndReturn(location, url, relHref) {
     if (location.$$parseLinkUrl(url, relHref)) {


### PR DESCRIPTION
I'd like to add a method to $location service to allow apps to set the base href of the app to something different than what's been specified in the <base href="/app/base/"> tag on the page. This method is only supported in full HTML5 mode. This will let developers update the page URL via $location to something outside the current app base without causing the page to reload.

To give a more concrete example, I have an angular app running in a subdirectory, let's just pretend it's "http://www.domain.com/angular-app/list". The base href for the app is set to "/angular-app/". When a user clicks a button, I want to show a popup modal and update the current URL to "http://www.domain.com/other-app/123". Currently I can't do this via $location without causing the page to refresh.

With this change, I can call:

``` javascript
showModal();
$location.setBaseHref('/other-app/').path('123');
```

If the user closes the modal, I can go back to the previous URL by calling:

``` javascript
$location.setBaseHref('/angular-app/').path('list');
```

I realize this is a hack and could be dangerous/error-prone if not used correctly. But I haven't found any other clean way to solve the scenario I described above. I've been using this hack in my own copy of angular for a few months and it seems to work (at least for my purposes). I figured it might help someone else in a similar situation.

Thanks.
