### PR TITLE
fix($compile): fix scoping for transclusion

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1661,7 +1661,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
      * @param previousCompileContext
      * @returns {Function}
      */
-    function compilationGenerator(eager, $compileNodes, transcludeFn, changeOuterScope, maxPriority, ignoreDirective, previousCompileContext) {
+    function compilationGenerator(eager, $compileNodes, transcludeFn, maxPriority, changeOuterScope, ignoreDirective, previousCompileContext) {
         if (eager) {
             return compile($compileNodes, transcludeFn, maxPriority, changeOuterScope, ignoreDirective, previousCompileContext);
         }
@@ -1821,8 +1821,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             compileNode = $compileNode[0];
             replaceWith(jqCollection, sliceArgs($template), compileNode);
 
-            childTranscludeFn = compilationGenerator(mightHaveMultipleTransclusionError, $template, transcludeFn, changeOuterScope,
-                                        terminalPriority, replaceDirective && replaceDirective.name, {
+            childTranscludeFn = compilationGenerator(mightHaveMultipleTransclusionError, $template, transcludeFn,
+                                        terminalPriority, changeOuterScope, replaceDirective && replaceDirective.name, {
                                           // Don't pass in:
                                           // - controllerDirectives - otherwise we'll create duplicates controllers
                                           // - newIsolateScopeDirective or templateDirective - combining templates with
@@ -1835,7 +1835,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           } else {
             $template = jqLite(jqLiteClone(compileNode)).contents();
             $compileNode.empty(); // clear contents
-            childTranscludeFn = compilationGenerator(mightHaveMultipleTransclusionError, $template, transcludeFn, changeOuterScope);
+            childTranscludeFn = compilationGenerator(mightHaveMultipleTransclusionError, $template, transcludeFn,
+                                          undefined, changeOuterScope);
           }
         }
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -5629,6 +5629,34 @@ describe('$compile', function() {
       });
 
 
+      //see issue https://github.com/angular/angular.js/issues/12936
+      it('should use the proper scope when being the root element of a replaced directive', function() {
+        module(function() {
+          directive('parent', valueFn({
+            scope: {},
+            replace: true,
+            template: '<div trans>{{x}}</div>',
+            link: function(scope, element, attr, ctrl) {
+              scope.x = 'iso';
+            }
+          }));
+          directive('trans', valueFn({
+            transclude: 'content',
+            link: function(scope, element, attr, ctrl, $transclude) {
+              $transclude(function(clone) {
+                element.append(clone);
+              });
+            }
+          }));
+        });
+        inject(function($rootScope, $compile) {
+          element = $compile('<parent></parent>')($rootScope);
+          $rootScope.x = 'root';
+          $rootScope.$apply();
+          expect(element.text()).toEqual('iso');
+        });
+      });
+
 
       it('should not leak if two "element" transclusions are on the same element (with debug info)', function() {
         if (jQuery) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -5632,7 +5632,7 @@ describe('$compile', function() {
       //see issue https://github.com/angular/angular.js/issues/12936
       it('should use the proper scope when being the root element of a replaced directive', function() {
         module(function() {
-          directive('parent', valueFn({
+          directive('isolate', valueFn({
             scope: {},
             replace: true,
             template: '<div trans>{{x}}</div>',
@@ -5650,10 +5650,39 @@ describe('$compile', function() {
           }));
         });
         inject(function($rootScope, $compile) {
-          element = $compile('<parent></parent>')($rootScope);
+          element = $compile('<isolate></isolate>')($rootScope);
           $rootScope.x = 'root';
           $rootScope.$apply();
           expect(element.text()).toEqual('iso');
+        });
+      });
+
+
+      //see issue https://github.com/angular/angular.js/issues/12936
+      it('should use the proper scope when being the root element of a replaced directive with child scope', function() {
+        module(function() {
+          directive('child', valueFn({
+            scope: true,
+            replace: true,
+            template: '<div trans>{{x}}</div>',
+            link: function(scope, element, attr, ctrl) {
+              scope.x = 'child';
+            }
+          }));
+          directive('trans', valueFn({
+            transclude: 'content',
+            link: function(scope, element, attr, ctrl, $transclude) {
+              $transclude(function(clone) {
+                element.append(clone);
+              });
+            }
+          }));
+        });
+        inject(function($rootScope, $compile) {
+          element = $compile('<child></child>')($rootScope);
+          $rootScope.x = 'root';
+          $rootScope.$apply();
+          expect(element.text()).toEqual('child');
         });
       });
 


### PR DESCRIPTION
Change the scope's prototype when a directive with transclude is at the root of a template of a replaced directive

Fix for the issue #12936 
