### PR TITLE
docs($resource): Corrected wrong character

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -93,7 +93,7 @@ function shallowClearAndCopy(src, dst) {
  *   `$resource('http://example.com/resource.json')` or `$resource('http://example.com/:id.json')`
  *   or even `$resource('http://example.com/resource/:resource_id.:format')`
  *   If the parameter before the suffix is empty, :resource_id in this case, then the `/.` will be
- *   collapsed down to a single `.`.  If you need this sequence to appear and not collapse then you
+ *   collapsed down to a single `/`.  If you need this sequence to appear and not collapse then you
  *   can escape it with `/\.`.
  *
  * @param {Object=} paramDefaults Default values for `url` parameters. These can be overridden in


### PR DESCRIPTION
I believe the correct description of the behavior when parameters before suffixes are empty is that `/.` will be collapsed down to a single `/` - not a single '.'.
