### PR TITLE
Added a comment on a misleading declaration on the $location guide

### DIFF
--- a/docs/content/guide/$location.ngdoc
+++ b/docs/content/guide/$location.ngdoc
@@ -391,6 +391,9 @@ In these examples we use `<base href="/base/index.html" />`
 
    .constant('initUrl', 'http://www.example.com/base/path?a=b#h')
    .constant('baseHref', '/base/index.html')
+   
+   // This will make the fake broser run with html5 support.
+   // Don't set this in your other projects.
    .value('$sniffer', { history: true })
 
    .controller("LocationController", function($scope, $location) {
@@ -540,6 +543,9 @@ In these examples we use `<base href="/base/index.html" />`
 
     .constant('initUrl', 'http://www.example.com/base/index.html#!/path?a=b#h')
     .constant('baseHref', '/base/index.html')
+    
+    // This will make the fake broser run with html5 support.
+    // Don't set this in your other projects.
     .value('$sniffer', { history: false })
 
     .config(function($locationProvider) {


### PR DESCRIPTION
When the guide is followed correctly, a seemingly innocuous $sniffer value is
 set on the module. For the new developer this is pretty normal.  But what is
completely hidden is that setting this value in that way, will silently prevent
all animations from ngAnimate. 
Unless the developer knows that the value is not intended to be modified
(it's an internal service after all, it usually never is) they might
end up breaking their animations unknowingly.
