### PR TITLE
docs(tutorial/11 - REST and Custom Services): edit tutorial copy to reflect source

### DIFF
--- a/docs/content/tutorial/step_11.ngdoc
+++ b/docs/content/tutorial/step_11.ngdoc
@@ -43,7 +43,7 @@ We are using [Bower][bower] to install client side dependencies.  This step upda
 ```
 
 The new dependency `"angular-resource": "1.4.x"` tells bower to install a version of the
-angular-resource component that is compatible with version 1.3.x.  We must ask bower to download
+angular-resource component that is compatible with version 1.4.x.  We must ask bower to download
 and install this dependency. We can do this by running:
 
 ```

--- a/docs/content/tutorial/step_11.ngdoc
+++ b/docs/content/tutorial/step_11.ngdoc
@@ -32,16 +32,17 @@ We are using [Bower][bower] to install client side dependencies.  This step upda
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "angular": "~1.3.0",
-    "angular-mocks": "~1.3.0",
+    "angular": "1.4.x",
+    "angular-mocks": "1.4.x",
+    "jquery": "~2.1.1",
     "bootstrap": "~3.1.1",
-    "angular-route": "~1.3.0",
-    "angular-resource": "~1.3.0"
+    "angular-route": "1.4.x",
+    "angular-resource": "1.4.x"
   }
 }
 ```
 
-The new dependency `"angular-resource": "~1.3.0"` tells bower to install a version of the
+The new dependency `"angular-resource": "1.4.x"` tells bower to install a version of the
 angular-resource component that is compatible with version 1.3.x.  We must ask bower to download
 and install this dependency. We can do this by running:
 


### PR DESCRIPTION
Code breaks if tutorial is followed without reset. bower.js exceprt copy does not match source. Change to reflect in text body.
