### PR TITLE
docs(tutorial/7 - Routing) edit tutorial copy to reflect source

### DIFF
--- a/docs/content/tutorial/step_07.ngdoc
+++ b/docs/content/tutorial/step_07.ngdoc
@@ -37,12 +37,12 @@ We are using [Bower][bower] to install client-side dependencies.  This step upda
     "angular-mocks": "1.4.x",
     "jquery": "~2.1.1",
     "bootstrap": "~3.1.1",
-    "angular-route": "~1.4.0"
+    "angular-route": "1.4.x"
   }
 }
 ```
 
-The new dependency `"angular-route": "~1.4.0"` tells bower to install a version of the
+The new dependency `"angular-route": "1.4.x"` tells bower to install a version of the
 angular-route component that is compatible with version 1.4.x.  We must tell bower to download
 and install this dependency.
 


### PR DESCRIPTION
Code breaks if tutorial is followed without reset. bower.js exceprt copy does not match source. Change to reflect in text body.
