### PR TITLE
Fix several syntax errors in code examples

### DIFF
--- a/src/ngAnimate/module.js
+++ b/src/ngAnimate/module.js
@@ -290,7 +290,7 @@
  *       jQuery(element).fadeOut(1000, doneFn);
  *     }
  *   }
- * }]
+ * }]);
  * ```
  *
  * The nice thing about JS-based animations is that we can inject other services and make use of advanced animation libraries such as
@@ -321,7 +321,7 @@
  *       // do some cool animation and call the doneFn
  *     }
  *   }
- * }]
+ * }]);
  * ```
  *
  * ## CSS + JS Animations Together
@@ -343,7 +343,7 @@
  *       jQuery(element).slideIn(1000, doneFn);
  *     }
  *   }
- * }]
+ * }]);
  * ```
  *
  * ```css
@@ -372,7 +372,7 @@
 *        runner.done(doneFn);
  *     }
  *   }
- * }]
+ * }]);
  * ```
  *
  * The nice thing here is that we can save bandwidth by sticking to our CSS-based animation code and we don't need to rely on a 3rd-party animation framework.
@@ -396,7 +396,7 @@
  *       runner.done(doneFn);
  *     }
  *   }
- * }]
+ * }]);
  * ```
  *
  * Now we can fill in the rest via our transition CSS code:


### PR DESCRIPTION
Fix several syntax errors in code examples in ngAnimate directive documentation
