### PR TITLE
fix(testabilityPatch): reset cache after memory leak detection

### DIFF
--- a/test/helpers/testabilityPatch.js
+++ b/test/helpers/testabilityPatch.js
@@ -1,4 +1,4 @@
-/* global jQuery: true, uid: true */
+/* global jQuery: true, uid: true, jqCache: true */
 'use strict';
 
 /**
@@ -12,6 +12,7 @@ if (window._jQuery) _jQuery.event.special.change = undefined;
 if (window.bindJQuery) bindJQuery();
 
 beforeEach(function() {
+
   // all this stuff is not needed for module tests, where jqlite and publishExternalAPI and jqLite are not global vars
   if (window.publishExternalAPI) {
     publishExternalAPI(angular);
@@ -28,7 +29,10 @@ beforeEach(function() {
 
     // reset to jQuery or default to us.
     bindJQuery();
-    jqLiteCacheSizeInit();
+
+    // Clear the cache to prevent memory leak failures from previous tests
+    // breaking subsequent tests unnecessarily
+    jqCache = jqLite.cache = {};
   }
 
   angular.element(document.body).empty().removeData();
@@ -84,7 +88,6 @@ afterEach(function() {
     }
   }
 
-
   // copied from Angular.js
   // we need this method here so that we can run module tests with wrapped angular.js
   function forEachSorted(obj, iterator, context) {
@@ -133,14 +136,7 @@ function dealoc(obj) {
 
 
 function jqLiteCacheSize() {
-  var size = 0;
-  forEach(jqLite.cache, function() { size++; });
-  return size - jqLiteCacheSize.initSize;
-}
-jqLiteCacheSize.initSize = 0;
-
-function jqLiteCacheSizeInit() {
-  jqLiteCacheSize.initSize = jqLiteCacheSize.initSize + jqLiteCacheSize();
+  return Object.keys(jqLite.cache).length;
 }
 
 


### PR DESCRIPTION
When you have a test failure in the angular.js project, which also causes a memory leak, such as a failure to dealocate an element or a scope, you often get a false-negative failure for every subsequent test. This change ensures that after such an error, the cache is reset so that subsequent tests can run normally.
