### PR TITLE
Directives link API documentation did not describe or mention the controller param.

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -587,15 +587,24 @@ want to reuse throughout your app.
 In this example we will build a directive that displays the current time.
 Once a second, it updates the DOM to reflect the current time.
 
-Directives that want to modify the DOM typically use the `link` option, which is documented on the {@link ng.$compile `$compile` API} page.
-`link` takes a function with the following signature, `function link(scope, element, attrs, controller, transcludeFn) { ... }`, where:
+Directives that want to modify the DOM typically use the `link` option to register DOM listeners
+as well as update the DOM. It is executed after the template has been cloned and is where
+directive logic will be put.
+
+ `link` takes a function with the following signature,
+`function link(scope, element, attrs, controller, transcludeFn) { ... }`, where:
 
 * `scope` is an Angular scope object.
 * `element` is the jqLite-wrapped element that this directive matches.
 * `attrs` is a hash object with key-value pairs of normalized attribute names and their
   corresponding attribute values.
-* `controller` is the controller for the directive, if defined.
-* `transcludeFn` is a transclude linking function pre-bound to the correct translusion scope.
+* `controller` is the directive's required controller instance(s) or it's own controller (if any).
+  The exact value depends on the directive's require property.
+* `transcludeFn` is a transclude linking function pre-bound to the correct transclusion scope.
+
+<div class="alert alert-info">
+For full detail on the `link` method refer to the {@link ng.$compile `$compile` API} page.
+</div>
 
 In our `link` function, we want to update the displayed time once a second, or whenever a user
 changes the time formatting string that our directive binds to. We will use the `$interval` service

--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -588,13 +588,14 @@ In this example we will build a directive that displays the current time.
 Once a second, it updates the DOM to reflect the current time.
 
 Directives that want to modify the DOM typically use the `link` option.
-`link` takes a function with the following signature, `function link(scope, element, attrs) { ... }`
+`link` takes a function with the following signature, `function link(scope, element, attrs, controller) { ... }`
 where:
 
 * `scope` is an Angular scope object.
 * `element` is the jqLite-wrapped element that this directive matches.
 * `attrs` is a hash object with key-value pairs of normalized attribute names and their
   corresponding attribute values.
+* `controller` is the controller for the directive, if defined
 
 In our `link` function, we want to update the displayed time once a second, or whenever a user
 changes the time formatting string that our directive binds to. We will use the `$interval` service

--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -587,15 +587,15 @@ want to reuse throughout your app.
 In this example we will build a directive that displays the current time.
 Once a second, it updates the DOM to reflect the current time.
 
-Directives that want to modify the DOM typically use the `link` option.
-`link` takes a function with the following signature, `function link(scope, element, attrs, controller) { ... }`
-where:
+Directives that want to modify the DOM typically use the `link` option, which is documented on the {@link ng.$compile `$compile` API} page.
+`link` takes a function with the following signature, `function link(scope, element, attrs, controller, transcludeFn) { ... }`, where:
 
 * `scope` is an Angular scope object.
 * `element` is the jqLite-wrapped element that this directive matches.
 * `attrs` is a hash object with key-value pairs of normalized attribute names and their
   corresponding attribute values.
-* `controller` is the controller for the directive, if defined
+* `controller` is the controller for the directive, if defined.
+* `transcludeFn` is a transclude linking function pre-bound to the correct translusion scope.
 
 In our `link` function, we want to update the displayed time once a second, or whenever a user
 changes the time formatting string that our directive binds to. We will use the `$interval` service
@@ -998,7 +998,7 @@ angular.module('docsTabsExample', [])
       scope: {
         title: '@'
       },
-      link: function(scope, element, attrs, controllers) {
+      link: function(scope, element, attrs, controllers, transcludeFn) {
         var tabsCtrl = controllers[0],
             modelCtrl = controllers[1];
 

--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -603,7 +603,7 @@ directive logic will be put.
 * `transcludeFn` is a transclude linking function pre-bound to the correct transclusion scope.
 
 <div class="alert alert-info">
-For full detail on the `link` method refer to the {@link ng.$compile `$compile` API} page.
+For full detail on the `link` method refer to the {@link ng.$compile#-link- `$compile` API} page.
 </div>
 
 In our `link` function, we want to update the displayed time once a second, or whenever a user


### PR DESCRIPTION
The 4th param for link() was not defined in the api doc, but used in the examples. This change adds the param and describes it.
