### PR TITLE
fix(Angular.js): use cookie instead of window.name to load with debug…

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1578,7 +1578,6 @@ function bootstrap(element, modules, config) {
   var defaultConfig = {
     strictDi: false
   };
-
   config = extend(defaultConfig, config);
   var doBootstrap = function() {
     element = jqLite(element);

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1578,6 +1578,7 @@ function bootstrap(element, modules, config) {
   var defaultConfig = {
     strictDi: false
   };
+
   config = extend(defaultConfig, config);
   var doBootstrap = function() {
     element = jqLite(element);
@@ -1616,19 +1617,19 @@ function bootstrap(element, modules, config) {
     return injector;
   };
 
-  var NG_ENABLE_DEBUG_INFO = /^NG_ENABLE_DEBUG_INFO!/;
-  var NG_DEFER_BOOTSTRAP = /^NG_DEFER_BOOTSTRAP!/;
+  var NG_ENABLE_DEBUG_INFO = /\bNG_ENABLE_DEBUG_INFO!=true\b/;
+  var NG_DEFER_BOOTSTRAP = /\bNG_DEFER_BOOTSTRAP!=true\b/;
 
-  if (window && NG_ENABLE_DEBUG_INFO.test(window.name)) {
+  if (document && NG_ENABLE_DEBUG_INFO.test(document.cookie)) {
     config.debugInfoEnabled = true;
-    window.name = window.name.replace(NG_ENABLE_DEBUG_INFO, '');
+    document.cookie = 'NG_ENABLE_DEBUG_INFO!=false;expires=Thu, 01 Jan 1970 00:00:01 GMT';
   }
 
-  if (window && !NG_DEFER_BOOTSTRAP.test(window.name)) {
+  if (document && !NG_DEFER_BOOTSTRAP.test(document.cookie)) {
     return doBootstrap();
   }
 
-  window.name = window.name.replace(NG_DEFER_BOOTSTRAP, '');
+  document.cookie = 'NG_DEFER_BOOTSTRAP!=false;expires=Thu, 01 Jan 1970 00:00:01 GMT';
   angular.resumeBootstrap = function(extraModules) {
     forEach(extraModules, function(module) {
       modules.push(module);
@@ -1652,7 +1653,7 @@ function bootstrap(element, modules, config) {
  * See {@link ng.$compileProvider#debugInfoEnabled} for more.
  */
 function reloadWithDebugInfo() {
-  window.name = 'NG_ENABLE_DEBUG_INFO!' + window.name;
+  document.cookie = 'NG_ENABLE_DEBUG_INFO!=true';
   window.location.reload();
 }
 

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1826,6 +1826,7 @@ describe('angular', function() {
 
         expect(element.html()).toBe('3');
         expect(/\bNG_DEFER_BOOTSTRAP!=true\b/.test(document.cookie)).toBeFalsy();
+<<<<<<< HEAD
       });
     });
 
@@ -1870,7 +1871,62 @@ describe('angular', function() {
         bootstrap(element);
         
         expect(document.cookie).toEqual('');
+=======
+>>>>>>> fix(Angular.js): use cookie instead of window.name to load with debug info
       });
+    });
+
+    describe('reloadWithDebugInfo', function() {
+      var element;
+
+      beforeEach(function() {
+        element = jqLite('<div>{{1+2}}</div>');
+      });
+
+      afterEach(function() {
+        dealoc(element);
+      });
+
+      it('should not change the configuration when the cookie is not set', function() {
+        var compileProvider = null;
+
+        bootstrap(element, [disableDebugAndGetProvider]);
+        expect(compileProvider.debugInfoEnabled()).toBeFalsy();
+
+        function disableDebugAndGetProvider($compileProvider) {
+          $compileProvider.debugInfoEnabled(false);
+          compileProvider = $compileProvider;
+        }
+      });
+
+      it('should enable debug if the cookie is set', function() {
+        var compileProvider = null;
+
+        document.cookie = 'NG_ENABLE_DEBUG_INFO!=true';
+        bootstrap(element, [getCompileProvider]);
+
+        expect(compileProvider.debugInfoEnabled()).toBeTruthy();
+
+        function getCompileProvider($compileProvider) {
+          compileProvider = $compileProvider;
+        }
+      });
+
+      it('should remove the cookie', function() {
+        document.cookie = 'NG_ENABLE_DEBUG_INFO!=true';
+        bootstrap(element);
+        expect(document.cookie).toEqual('');
+      });
+    });
+  });
+
+  describe('reloadWithDebugInfo', function() {
+
+    it('should create a cookie', function() {
+      angular.reloadWithDebugInfo();
+      expect(/\bNG_ENABLE_DEBUG_INFO!=true\b/.test(document.cookie)).toBeTruthy();
+
+      // it should also reload the window, but we can not test that, as window.location can not be spied upon
     });
   });
 

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1920,16 +1920,6 @@ describe('angular', function() {
     });
   });
 
-  describe('reloadWithDebugInfo', function() {
-
-    it('should create a cookie', function() {
-      angular.reloadWithDebugInfo();
-      expect(/\bNG_ENABLE_DEBUG_INFO!=true\b/.test(document.cookie)).toBeTruthy();
-
-      // it should also reload the window, but we can not test that, as window.location can not be spied upon
-    });
-  });
-
 
   describe('startingElementHtml', function() {
     it('should show starting element tag only', function() {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1915,6 +1915,7 @@ describe('angular', function() {
       it('should remove the cookie', function() {
         document.cookie = 'NG_ENABLE_DEBUG_INFO!=true';
         bootstrap(element);
+        
         expect(document.cookie).toEqual('');
       });
     });

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1868,6 +1868,7 @@ describe('angular', function() {
       it('should remove the cookie', function() {
         document.cookie = 'NG_ENABLE_DEBUG_INFO!=true';
         bootstrap(element);
+        
         expect(document.cookie).toEqual('');
       });
     });

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1826,7 +1826,6 @@ describe('angular', function() {
 
         expect(element.html()).toBe('3');
         expect(/\bNG_DEFER_BOOTSTRAP!=true\b/.test(document.cookie)).toBeFalsy();
-<<<<<<< HEAD
       });
     });
 
@@ -1869,10 +1868,8 @@ describe('angular', function() {
       it('should remove the cookie', function() {
         document.cookie = 'NG_ENABLE_DEBUG_INFO!=true';
         bootstrap(element);
-        
+
         expect(document.cookie).toEqual('');
-=======
->>>>>>> fix(Angular.js): use cookie instead of window.name to load with debug info
       });
     });
 
@@ -1915,7 +1912,7 @@ describe('angular', function() {
       it('should remove the cookie', function() {
         document.cookie = 'NG_ENABLE_DEBUG_INFO!=true';
         bootstrap(element);
-        
+
         expect(document.cookie).toEqual('');
       });
     });

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1873,16 +1873,6 @@ describe('angular', function() {
     });
   });
 
-  describe('reloadWithDebugInfo', function() {
-
-    it('should create a cookie', function() {
-      angular.reloadWithDebugInfo();
-      expect(/\bNG_ENABLE_DEBUG_INFO!=true\b/.test(document.cookie)).toBeTruthy();
-
-      // it should also reload the window, but we can not test that, as window.location can not be spied upon
-    });
-  });
-
 
   describe('startingElementHtml', function() {
     it('should show starting element tag only', function() {


### PR DESCRIPTION
… info

Use cookie to store a check if the application needs to be loaded with debug info, instead of using window.name. As window.name can be used alread (and be overwritten on page load)
Fixes issue #13031
