### PR TITLE
Fix AngularJS Polish number grouping separator (should be nothing instead of space).

### DIFF
--- a/src/ngLocale/angular-locale_pl-pl.js
+++ b/src/ngLocale/angular-locale_pl-pl.js
@@ -96,11 +96,11 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "z\u0142",
     "DECIMAL_SEP": ",",
-    "GROUP_SEP": "",
+    "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {
         "gSize": 3,
-        "lgSize": 3,
+        "lgSize": 4,
         "maxFrac": 3,
         "minFrac": 0,
         "minInt": 1,
@@ -111,7 +111,7 @@ $provide.value("$locale", {
       },
       {
         "gSize": 3,
-        "lgSize": 3,
+        "lgSize": 4,
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,

--- a/src/ngLocale/angular-locale_pl-pl.js
+++ b/src/ngLocale/angular-locale_pl-pl.js
@@ -96,7 +96,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "z\u0142",
     "DECIMAL_SEP": ",",
-    "GROUP_SEP": "\u00a0",
+    "GROUP_SEP": "",
     "PATTERNS": [
       {
         "gSize": 3,

--- a/src/ngLocale/angular-locale_pl.js
+++ b/src/ngLocale/angular-locale_pl.js
@@ -96,11 +96,11 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "z\u0142",
     "DECIMAL_SEP": ",",
-    "GROUP_SEP": "",
+    "GROUP_SEP": "\u00a0",
     "PATTERNS": [
       {
         "gSize": 3,
-        "lgSize": 3,
+        "lgSize": 4,
         "maxFrac": 3,
         "minFrac": 0,
         "minInt": 1,
@@ -111,7 +111,7 @@ $provide.value("$locale", {
       },
       {
         "gSize": 3,
-        "lgSize": 3,
+        "lgSize": 4,
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,

--- a/src/ngLocale/angular-locale_pl.js
+++ b/src/ngLocale/angular-locale_pl.js
@@ -96,7 +96,7 @@ $provide.value("$locale", {
   "NUMBER_FORMATS": {
     "CURRENCY_SYM": "z\u0142",
     "DECIMAL_SEP": ",",
-    "GROUP_SEP": "\u00a0",
+    "GROUP_SEP": "",
     "PATTERNS": [
       {
         "gSize": 3,


### PR DESCRIPTION
Fix AngularJS Polish number grouping separator (should be nothing instead of space).
