### PR TITLE
feat(NgRoute): allow resolve promises on routeUpdate event

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1628,7 +1628,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
     compile.$$createComment = function(directiveName, comment) {
       var content = '';
-
       if (debugInfoEnabled) {
         content = ' ';
         content += (directiveName || '');
@@ -1636,7 +1635,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         content += comment ? ' ' + comment : '';
         content += ' ';
       }
-
       return window.document.createComment(content);
     };
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1629,11 +1629,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     compile.$$createComment = function(directiveName, comment) {
       var content = '';
       if (debugInfoEnabled) {
-        content = ' ';
-        content += (directiveName || '');
-        content += ':';
-        content += comment ? ' ' + comment : '';
-        content += ' ';
+        content = ' ' + (directiveName || '') + ': ';
+        if (comment) content += comment + ' ';
       }
       return window.document.createComment(content);
     };

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1628,10 +1628,15 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
     compile.$$createComment = function(directiveName, comment) {
       var content = '';
+
       if (debugInfoEnabled) {
-        content = ' ' + (directiveName || '') + ': ';
-        if (comment) content += comment + ' ';
+        content = ' ';
+        content += (directiveName || '');
+        content += ':';
+        content += comment ? ' ' + comment : '';
+        content += ' ';
       }
+
       return window.document.createComment(content);
     };
 

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -582,13 +582,13 @@ function $RouteProvider() {
     }
 
     function buildResolvePromises(resolve) {
-      var locals = angular.extend({}, resolve);
-      angular.forEach(locals, function(value, key) {
-        locals[key] = angular.isString(value) ?
+      var resolvePromises = angular.extend({}, resolve);
+      angular.forEach(resolvePromises, function(value, key) {
+        resolvePromises[key] = angular.isString(value) ?
             $injector.get(value) : $injector.invoke(value, null, null, key);
       });
 
-      return locals;
+      return resolvePromises;
     }
 
     function commitRoute() {

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -581,25 +581,14 @@ function $RouteProvider() {
       }
     }
 
-    function buildResolvePromises(resolve) {
-      var resolvePromises = angular.extend({}, resolve);
-      angular.forEach(resolvePromises, function(value, key) {
-        resolvePromises[key] = angular.isString(value) ?
-            $injector.get(value) : $injector.invoke(value, null, null, key);
-      });
-
-      return resolvePromises;
-    }
-
     function commitRoute() {
       var lastRoute = $route.current;
       var nextRoute = preparedRoute;
-      var resolvePromises;
 
       if (preparedRouteIsUpdateOnly) {
-        resolvePromises = buildResolvePromises(nextRoute.$$route.resolve);
-
-        $q.all(resolvePromises).then(function() {
+        $q.when(nextRoute).
+        then(resolveLocals).
+        then(function() {
           lastRoute.params = nextRoute.params;
           angular.copy(lastRoute.params, $routeParams);
           $rootScope.$broadcast('$routeUpdate', lastRoute);

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -1208,9 +1208,9 @@ describe('$route', function() {
         $location.path('/foo');
         $rootScope.$digest();
         expect(routeChange).toHaveBeenCalled();
-        expect(routeChange.callCount).toBe(1);
+        expect(routeChange).toHaveBeenCalledTimes(1);
         expect(routeUpdate).not.toHaveBeenCalled();
-        routeChange.reset();
+        routeChange.calls.reset();
 
         // don't trigger reload and routeUpdate
         $location.search({foo: 'bar'});


### PR DESCRIPTION
When using the reloadOnSearch defined as false, if you have a resolve property for that path the promise will not be invoked. My pull request is to enable that functionality, in our product we have a scenario where we need this feature I hope that this could help somebody else
