### PR TITLE
fix(ngAria): remove tabindex from radio buttons

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -235,7 +235,8 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
           }
         },
         post: function(scope, elem, attr, ngModel) {
-          var needsTabIndex = shouldAttachAttr('tabindex', 'tabindex', elem);
+          var needsTabIndex = shouldAttachAttr('tabindex', 'tabindex', elem)
+                                && !isNodeOneOf(elem, nodeBlackList);
 
           function ngAriaWatchModelValue() {
             return ngModel.$modelValue;

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -616,16 +616,18 @@ describe('$aria', function() {
   describe('tabindex', function() {
     beforeEach(injectScopeAndCompiler);
 
-    it('should not attach to native controls', function() {
-      var element = [
-        $compile("<button ng-click='something'></button>")(scope),
-        $compile("<a ng-href='#/something'>")(scope),
-        $compile("<input ng-model='val'>")(scope),
-        $compile("<textarea ng-model='val'></textarea>")(scope),
-        $compile("<select ng-model='val'></select>")(scope),
-        $compile("<details ng-model='val'></details>")(scope)
-      ];
-      expectAriaAttrOnEachElement(element, 'tabindex', undefined);
+    they('should not attach to native control $prop with ng-model', {
+      'button': "<button ng-click='something'></button>",
+      'a': "<a ng-href='#/something'>",
+      'input[text]': "<input type='text' ng-model='val'>",
+      'input[radio]': "<input type='radio' ng-model='val'>",
+      'input[checkbox]': "<input type='checkbox' ng-model='val'>",
+      'textarea': "<textarea ng-model='val'></textarea>",
+      'select': "<select ng-model='val'></select>",
+      'details': "<details ng-model='val'></details>"
+    }, function(html) {
+        compileElement(html);
+        expect(element.attr('tabindex')).toBeUndefined();
     });
 
     it('should not attach to random ng-model elements', function() {


### PR DESCRIPTION
There was some funky stuff going on when ngModel was set to null, which I fixed by adding a nodeBlackList check to the method setting tabindex. 

The logic added to `needsTabIndex` should eventually be moved into the `shouldAttachAttr` function but it will require refactoring of other directives, so I decided to wait on that. 

Closes #12492
