### PR TITLE
Fixes the issue "ng-bind not working correctly with <textarea> & <input> elements.

### DIFF
--- a/src/ng/directive/ngBind.js
+++ b/src/ng/directive/ngBind.js
@@ -60,7 +60,7 @@ var ngBindDirective = ['$compile', function($compile) {
         $compile.$$addBindingInfo(element, attr.ngBind);
         element = element[0];
         scope.$watch(attr.ngBind, function ngBindWatchAction(value) {
-          element.textContent = isUndefined(value) ? '' : value;
+          element.textContent = element.value = isUndefined(value) ? '' : value;
         });
       };
     }


### PR DESCRIPTION
This issue mostly occurs in chrome because the current ng-bind does not update 'value' property of element. [IE somehow updates the property automatically]
Eg. can be found at plunk : http://plnkr.co/edit/w89iACaEl5fgJIo0svkh?p=preview
When using the ng-bind directive on `<textarea>` , the results are strange , But when using the modified version of ng-bind directive => 'ng-text-area-bind' it works as expected.
