### PR TITLE
Not a 'real' PR, but a demo for #13108

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -1269,7 +1269,8 @@ function $HttpProvider() {
         }
 
         if (useApplyAsync) {
-          $rootScope.$applyAsync(resolveHttpPromise);
+          // $rootScope.$applyAsync(resolveHttpPromise);
+          resolveHttpPromise();
         } else {
           resolveHttpPromise();
           if (!$rootScope.$$phase) $rootScope.$apply();

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1928,7 +1928,7 @@ describe('$http with $applyAsync', function() {
     $rootScope.$digest();
 
     $httpBackend.flush(null, false);
-    expect($rootScope.$applyAsync).toHaveBeenCalledOnce();
+    // expect($rootScope.$applyAsync).toHaveBeenCalledOnce();
     expect(handler).not.toHaveBeenCalled();
 
     $browser.defer.flush();


### PR DESCRIPTION
@gkalpak please check out this branch and run `grunt test:unit`. You'll see that removing the `$apply`/`$applyAsync` call has the same effect as using `$applyAsync`.
