### PR TITLE
docs(tutorial/2 - Angular Templates): Running unit test without Firef…

### DIFF
--- a/docs/content/tutorial/step_02.ngdoc
+++ b/docs/content/tutorial/step_02.ngdoc
@@ -195,13 +195,28 @@ to ensure that Karma and its necessary plugins are installed. You can do this by
 
 To run the tests, and then watch the files for changes: `npm test`.
 
-* Karma will start new instances of Chrome and Firefox browser automatically. Just ignore them and let them run in
+* Karma will start new instances of Chrome and Firefox browsers automatically. Just ignore them and let them run in
    the background. Karma will use these browsers for test execution.
-* If you only have Chrome browser installed on your machine, make sure to update the karma configuration file before 
-   running the test. Update `unit/test/karma.conf.js` file to only include Chrome browser:
-   
+* If you only have one browser installed on your machine (either Chrome or Firefox browser), make sure to update the 
+   karma configuration file before running the test. Locate the configuration file in `test/karma.conf.js`, then
+   update the property of `browsers` to suit with the one you have in your machine.
+  
+  If you only have Chrome browser installed: 
   <pre>
-    browsers: ['Chrome']
+    ...
+    frameworks: ['jasmine'],
+    
+    browsers: ['Chrome'],
+    ...
+  </pre>
+  
+  Or if you only have Firefox browser installed:
+  <pre>
+    ...
+    frameworks: ['jasmine'],
+    
+    browsers: ['Firefox'],
+    ...
   </pre>
   
 * You should see the following or similar output in the terminal:

--- a/docs/content/tutorial/step_02.ngdoc
+++ b/docs/content/tutorial/step_02.ngdoc
@@ -195,8 +195,15 @@ to ensure that Karma and its necessary plugins are installed. You can do this by
 
 To run the tests, and then watch the files for changes: `npm test`.
 
-* Karma will start a new instance of Chrome browser automatically. Just ignore it and let it run in
-   the background. Karma will use this browser for test execution.
+* Karma will start new instances of Chrome and Firefox browser automatically. Just ignore them and let them run in
+   the background. Karma will use these browsers for test execution.
+* If you only have Chrome browser installed on your machine, make sure to update the karma configuration file before 
+   running the test. Update `unit/test/karma.conf.js` file to only include Chrome browser:
+   
+  <pre>
+    browsers: ['Chrome']
+  </pre>
+  
 * You should see the following or similar output in the terminal:
 
   <pre>


### PR DESCRIPTION
Running unit test without having Firefox installed throws error

I am following the tutorial on AngularJS website https://docs.angularjs.org/tutorial/step_02. However I got an error when running the provided unit test without having Firefox browser installed on my machine.

Console output:

```
INFO [karma]: Karma v0.12.37 server started at http://localhost:9876/
INFO [launcher]: Starting browser Chrome
INFO [launcher]: Starting browser Firefox
ERROR [launcher]: Cannot start Firefox
    Can not find the binary /Applications/Firefox.app/Contents/MacOS/firefox-bin
    Please set env variable FIREFOX_BIN
INFO [Chrome 46.0.2490 (Mac OS X 10.11.0)]: Connected on socket zZ0c0QemlSHXzVaqVGqC with id 90305753
```

I guess it will be much clearer if we also pointed out these browsers requirement on the tutorial documentation.
