### PR TITLE
docs(select): add multiple attribute

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -187,6 +187,8 @@ var SelectController =
  *
  * @param {string} ngModel Assignable angular expression to data-bind to.
  * @param {string=} name Property name of the form under which the control is published.
+ * @param {string=} multiple Allows multiple options to be selected. The selected values will be bound to the model
+ * as an array.
  * @param {string=} required Sets `required` validation error key if the value is not entered.
  * @param {string=} ngRequired Adds required attribute and required validation constraint to
  * the element when the ngRequired expression evaluates to true. Use ngRequired instead of required


### PR DESCRIPTION
In the documentation of the [select](https://docs.angularjs.org/api/ng/directive/select) directive there is an example of multiple selection, but the multiple attribute is not listed as an argument, so I think it can be a bit confusing.
