### PR TITLE
ngTouch.ngClick: don't stop propagation, don't preventDefault

### DIFF
--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -156,8 +156,8 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     }
 
     // If we didn't find an allowable region, bust the click.
-    event.stopPropagation();
-    event.preventDefault();
+    // event.stopPropagation();
+    // event.preventDefault();
 
     // Blur focused form elements
     event.target && event.target.blur && event.target.blur();


### PR DESCRIPTION
The prevent default at this point changes the behavior of regular ng-click (only in mobile phone mode).
For example, if you have a dropdown and you click in an element that contains an ng-click the dropdown will no close automatically because there is external click events attached to the element.
