### PR TITLE
docs(ngModelOptions): add missing user.data result for updateOn: blur example

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -1160,6 +1160,7 @@ var DEFAULT_REGEXP = /(\s+|^)default(\s+|$)/;
           </label><br />
         </form>
         <pre>user.name = <span ng-bind="user.name"></span></pre>
+        <pre>user.data = <span ng-bind="user.data"></span></pre>        
       </div>
     </file>
     <file name="app.js">

--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -1160,7 +1160,7 @@ var DEFAULT_REGEXP = /(\s+|^)default(\s+|$)/;
           </label><br />
         </form>
         <pre>user.name = <span ng-bind="user.name"></span></pre>
-        <pre>user.data = <span ng-bind="user.data"></span></pre>        
+        <pre>user.data = <span ng-bind="user.data"></span></pre>
       </div>
     </file>
     <file name="app.js">


### PR DESCRIPTION
In the `updateOn: blur` example, there is an input for `user.data` but the result is missing and nowhere to see how the value changes comparing to `user.name` which only gets updated on blur.
