### PR TITLE
docs(tutorial/10 - Event Handlers): missing unit test

### DIFF
--- a/docs/content/tutorial/step_10.ngdoc
+++ b/docs/content/tutorial/step_10.ngdoc
@@ -138,7 +138,9 @@ __`test/unit/controllersSpec.js`:__
       expect(scope.phone).toBeUndefined();
       $httpBackend.flush();
 
-      expect(scope.phone).toEqual(xyzPhoneData());
+      var xyzPhoneInstance = xyzPhoneData();
+      expect(scope.phone).toEqual(xyzPhoneInstance);
+      expect(scope.mainImageUrl).toEqual(xyzPhoneInstance.images[0]);
     });
   });
 ```


### PR DESCRIPTION
In the doc there stands "You also have to refactor one of your unit tests because of the addition of the `mainImageUrl`
model property" but the spec was missing the test of `mainImageUrl`
