### PR TITLE
feat($templateRequest): support configuration of accept headers

### DIFF
--- a/src/ng/templateRequest.js
+++ b/src/ng/templateRequest.js
@@ -3,26 +3,55 @@
 var $compileMinErr = minErr('$compile');
 
 /**
- * @ngdoc service
- * @name $templateRequest
- *
+ * @ngdoc provider
+ * @name $templateRequestProvider
  * @description
- * The `$templateRequest` service runs security checks then downloads the provided template using
- * `$http` and, upon success, stores the contents inside of `$templateCache`. If the HTTP request
- * fails or the response data of the HTTP request is empty, a `$compile` error will be thrown (the
- * exception can be thwarted by setting the 2nd parameter of the function to true). Note that the
- * contents of `$templateCache` are trusted, so the call to `$sce.getTrustedUrl(tpl)` is omitted
- * when `tpl` is of type string and `$templateCache` has the matching entry.
- *
- * @param {string|TrustedResourceUrl} tpl The HTTP request template URL
- * @param {boolean=} ignoreRequestError Whether or not to ignore the exception when the request fails or the template is empty
- *
- * @return {Promise} a promise for the HTTP response data of the given URL.
- *
- * @property {number} totalPendingRequests total amount of pending template requests being downloaded.
+ * Used to configure the Accept header that is sent to the server when requesting a template.
  */
 function $TemplateRequestProvider() {
+
+  var acceptHeaders;
+
+  /**
+   * @ngdoc method
+   * @name $templateRequestProvider#acceptHeaders
+   * @description
+   * The accept header to be sent to the server as part of the request.
+   * If this value is undefined then the default {@link $http} Accept header
+   * will be used.
+   *
+   * @param {string=} value new value for the Accept header.
+   * @returns {string|self} Returns the Accept header value when used as getter and self if used as setter.
+   */
+  this.acceptHeaders = function(val) {
+    if (val) {
+      acceptHeaders = val;
+      return this;
+    }
+    return acceptHeaders;
+  };
+
+  /**
+   * @ngdoc service
+   * @name $templateRequest
+   *
+   * @description
+   * The `$templateRequest` service runs security checks then downloads the provided template using
+   * `$http` and, upon success, stores the contents inside of `$templateCache`. If the HTTP request
+   * fails or the response data of the HTTP request is empty, a `$compile` error will be thrown (the
+   * exception can be thwarted by setting the 2nd parameter of the function to true). Note that the
+   * contents of `$templateCache` are trusted, so the call to `$sce.getTrustedUrl(tpl)` is omitted
+   * when `tpl` is of type string and `$templateCache` has the matching entry.
+   *
+   * @param {string|TrustedResourceUrl} tpl The HTTP request template URL
+   * @param {boolean=} ignoreRequestError Whether or not to ignore the exception when the request fails or the template is empty
+   *
+   * @return {Promise} a promise for the HTTP response data of the given URL.
+   *
+   * @property {number} totalPendingRequests total amount of pending template requests being downloaded.
+   */
   this.$get = ['$templateCache', '$http', '$q', '$sce', function($templateCache, $http, $q, $sce) {
+
     function handleRequestFn(tpl, ignoreRequestError) {
       handleRequestFn.totalPendingRequests++;
 
@@ -49,6 +78,10 @@ function $TemplateRequestProvider() {
         cache: $templateCache,
         transformResponse: transformResponse
       };
+
+      if (acceptHeaders) {
+        httpOptions.headers = { 'Accept': acceptHeaders };
+      }
 
       return $http.get(tpl, httpOptions)
         ['finally'](function() {

--- a/src/ng/templateRequest.js
+++ b/src/ng/templateRequest.js
@@ -10,25 +10,27 @@ var $compileMinErr = minErr('$compile');
  */
 function $TemplateRequestProvider() {
 
-  var acceptHeaders;
+  var httpOptions;
 
   /**
    * @ngdoc method
-   * @name $templateRequestProvider#acceptHeaders
+   * @name $templateRequestProvider#httpOptions
    * @description
-   * The accept header to be sent to the server as part of the request.
-   * If this value is undefined then the default {@link $http} Accept header
-   * will be used.
+   * The options to be passed to the $http service when making the request.
+   * You can use this to override options such as the Accept header for template requests.
    *
-   * @param {string=} value new value for the Accept header.
-   * @returns {string|self} Returns the Accept header value when used as getter and self if used as setter.
+   * The {$templateRequest} will set the `cache` and the `transformResponse` properties of the
+   * options if not overridden here.
+   *
+   * @param {string=} value new value for the {@link $http} options.
+   * @returns {string|self} Returns the {@link $http} options when used as getter and self if used as setter.
    */
-  this.acceptHeaders = function(val) {
+  this.httpOptions = function(val) {
     if (val) {
-      acceptHeaders = val;
+      httpOptions = val;
       return this;
     }
-    return acceptHeaders;
+    return httpOptions;
   };
 
   /**
@@ -42,6 +44,9 @@ function $TemplateRequestProvider() {
    * exception can be thwarted by setting the 2nd parameter of the function to true). Note that the
    * contents of `$templateCache` are trusted, so the call to `$sce.getTrustedUrl(tpl)` is omitted
    * when `tpl` is of type string and `$templateCache` has the matching entry.
+   *
+   * If you want to pass custom options to the `$http` service, such as setting the Accept header you
+   * can configure this via {@link $templateRequestProvider#httpOptions}.
    *
    * @param {string|TrustedResourceUrl} tpl The HTTP request template URL
    * @param {boolean=} ignoreRequestError Whether or not to ignore the exception when the request fails or the template is empty
@@ -74,16 +79,10 @@ function $TemplateRequestProvider() {
         transformResponse = null;
       }
 
-      var httpOptions = {
-        cache: $templateCache,
-        transformResponse: transformResponse
-      };
-
-      if (acceptHeaders) {
-        httpOptions.headers = { 'Accept': acceptHeaders };
-      }
-
-      return $http.get(tpl, httpOptions)
+      return $http.get(tpl, extend({
+          cache: $templateCache,
+          transformResponse: transformResponse
+        }, httpOptions))
         ['finally'](function() {
           handleRequestFn.totalPendingRequests--;
         })

--- a/test/ng/templateRequestSpec.js
+++ b/test/ng/templateRequestSpec.js
@@ -2,6 +2,51 @@
 
 describe('$templateRequest', function() {
 
+  describe('provider', function() {
+
+    describe('acceptHeaders', function() {
+
+      it('should default to undefined and fallback to $http accept headers', function() {
+
+        var defaultHeader;
+
+        module(function($templateRequestProvider, $httpProvider) {
+          defaultHeader = $httpProvider.defaults.headers.get || $httpProvider.defaults.headers.common;
+          expect($templateRequestProvider.acceptHeaders()).toBeUndefined();
+        });
+
+        inject(function($templateRequest, $httpBackend) {
+          $httpBackend.expectGET('tpl.html', defaultHeader).respond();
+          $templateRequest('tpl.html');
+          $httpBackend.verifyNoOutstandingExpectation();
+        });
+
+      });
+
+      it('should be configurable', function() {
+
+        var expectedHeader;
+
+        module(function($templateRequestProvider, $httpProvider) {
+
+          // Configure the standard $http headers to something unusual
+          $httpProvider.defaults.headers.get = { 'Other': 'header value' };
+          // Configure the template request service to provide a specific accept header
+          $templateRequestProvider.acceptHeaders('moo');
+
+          // Compute what we expect the actual header object to be
+          expectedHeader = extend($httpProvider.defaults.headers.get, {Accept: 'moo'});
+        });
+
+        inject(function($templateRequest, $httpBackend) {
+          $httpBackend.expectGET('tpl.html', expectedHeader).respond();
+          $templateRequest('tpl.html');
+          $httpBackend.verifyNoOutstandingExpectation();
+        });
+      });
+    });
+  });
+
   it('should download the provided template file',
     inject(function($rootScope, $templateRequest, $httpBackend) {
 

--- a/test/ng/templateRequestSpec.js
+++ b/test/ng/templateRequestSpec.js
@@ -31,8 +31,6 @@ describe('$templateRequest', function() {
 
         function someTransform() {}
 
-        var expectedHeader;
-
         module(function($templateRequestProvider, $httpProvider) {
 
           // Configure the template request service to provide  specific headers and transforms
@@ -51,6 +49,30 @@ describe('$templateRequest', function() {
             cache: $templateCache,
             transformResponse: [someTransform],
             headers: { Accept: 'moo' }
+          });
+        });
+      });
+
+
+      it('should be allow you to override the cache', function() {
+
+        var httpOptions = {};
+
+        module(function($templateRequestProvider, $httpProvider) {
+          $templateRequestProvider.httpOptions(httpOptions);
+        });
+
+        inject(function($templateRequest, $http, $cacheFactory) {
+          spyOn($http, 'get').andCallThrough();
+
+          var customCache = $cacheFactory('customCache');
+          httpOptions.cache = customCache;
+
+          $templateRequest('tpl.html');
+
+          expect($http.get).toHaveBeenCalledOnceWith('tpl.html', {
+            cache: customCache,
+            transformResponse: []
           });
         });
       });


### PR DESCRIPTION
It is now possible to configure the Accept header for template requests.
If a value is configured then this will override only the Accept property
of the headers that are passed.
If no value is configured then the request will use the default $http
Accept header.

Thanks to @luckycadow for help on this feature

Closes #11868
Closes #6860
