### PR TITLE
chore(contributing): add commitizen commit message formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,8 @@ We have very precise rules over how our git commit messages can be formatted.  T
 readable messages** that are easy to follow when looking through the **project history**.  But also,
 we use the git commit messages to **generate the AngularJS change log**.
 
+The commit message formatting can be added using a typical git workflow or through the use of a CLI wizard ([Commitizen](https://github.com/commitizen/cz-cli)). To use the wizard, run `npm run commit` in your terminal after staging your changes in git.
+
 ### Commit Message Format
 Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
 format that includes a **type**, a **scope** and a **subject**:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "engineStrict": true,
   "scripts": {
     "preinstall": "node scripts/npm/check-node-modules.js --purge",
-    "postinstall": "node scripts/npm/copy-npm-shrinkwrap.js"
+    "postinstall": "node scripts/npm/copy-npm-shrinkwrap.js",
+    "commit": "git-cz"
   },
   "devDependencies": {
     "angular-benchpress": "0.x.x",
@@ -24,6 +25,8 @@
     "browserstacktunnel-wrapper": "~1.3.1",
     "canonical-path": "0.0.2",
     "cheerio": "^0.17.0",
+    "commitizen": "^2.3.0",
+    "cz-conventional-changelog": "1.1.4",
     "dgeni": "^0.4.0",
     "dgeni-packages": "^0.10.0",
     "event-stream": "~3.1.0",
@@ -80,5 +83,10 @@
       "url": "https://github.com/angular/angular.js/blob/master/LICENSE"
     }
   ],
-  "dependencies": {}
+  "dependencies": {},
+  "config": {
+    "commitizen": {
+      "path": "node_modules/cz-conventional-changelog"
+    }
+  }
 }


### PR DESCRIPTION
This adds `npm run commit` to package.json scripts to assist in formatting git commit messages with [commitizen](https://github.com/commitizen/cz-cli).

Closes #12730
