### PR TITLE
perf(copy): use ES6 Map to track source/destination objects

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -743,7 +743,9 @@ function arrayRemove(array, value) {
   return index;
 }
 
-
+// A minimal ES6 Map implementation.
+// Should be bug/feature equivelent to the native implementations of supported browsers.
+// See https://kangax.github.io/compat-table/es6/#test-Map
 function ES6MapShim() {
   this._keys = [];
   this._values = [];
@@ -771,29 +773,15 @@ ES6MapShim.prototype = {
     }
     this._keys[idx] = key;
     this._values[idx] = value;
-    return this;
+
+    // Support: IE11
+    // Do not `return this` to simulate the partial IE11 implementation
   }
 };
 
-function testES6Map(Map) {
-  var m, o = {};
-  return isFunction(Map) && (m = new Map())
-
-    // Required functions
-    && isFunction(m.get) && isFunction(m.set)
-
-    // Number keys, must not call toString
-    && m.get(1) === undefined
-    && m.set(1, o) === m
-    && m.get(1) === o
-    && m.get('1') === undefined
-
-    // Object keys, must use instance as key and not call toString
-    && m.set(o, 2) === m && m.get(o) === 2
-    && m.get({}) === undefined;
-}
-
-var ES6Map = testES6Map(window.Map) ? window.Map : ES6MapShim;
+var ES6Map = isFunction(window.Map) && toString.call(window.Map.prototype) === '[object Map]'
+  ? window.Map
+  : ES6MapShim;
 
 /**
  * @ngdoc function

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -747,18 +747,27 @@ function arrayRemove(array, value) {
 function ES6MapShim() {
   this._keys = [];
   this._values = [];
+  this._lastKey = NaN;
+  this._lastIndex = -1;
 }
 ES6MapShim.prototype = {
+  _idx: function(key) {
+    if (key === this._lastKey) {
+      return this._lastIndex;
+    }
+    return (this._lastIndex = (this._keys.indexOf(this._lastKey = key)));
+  },
   get: function(key) {
-    var idx = this._keys.indexOf(key);
+    var idx = this._idx(key);
     if (idx !== -1) {
       return this._values[idx];
     }
   },
   set: function(key, value) {
-    var idx = this._keys.indexOf(key);
+    var idx = this._idx(key);
     if (idx === -1) {
-      idx = this._keys.length;
+      idx = this._lastIndex = this._keys.length;
+      this._lastKey = key;
     }
     this._keys[idx] = key;
     this._values[idx] = value;

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -103,6 +103,8 @@
     "getBlockNodes": false,
     "createMap": false,
     "VALIDITY_STATE_PROPERTY": true,
+    "testES6Map": true,
+    "ES6MapShim": true,
 
     /* AngularPublic.js */
     "version": false,

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -25,6 +25,39 @@ describe('angular', function() {
     });
   });
 
+  describe('ES6Map', function() {
+    it('should test for bad Map objects', function() {
+      expect(testES6Map()).toBe(false);
+      expect(testES6Map(null)).toBe(false);
+      expect(testES6Map(3)).toBe(false);
+      expect(testES6Map({})).toBe(false);
+    });
+
+    it('should test for bad Map shims', function() {
+      function NoMethods() {}
+
+      function ToStringOnKeys() {
+        this._vals = {};
+      }
+      ToStringOnKeys.prototype = {
+        get: function(key) {
+          return this._vals[key];
+        },
+        set: function(key, val) {
+          this._vals[key] = val;
+          return this;
+        }
+      };
+
+      expect(testES6Map(NoMethods)).toBe(false);
+      expect(testES6Map(ToStringOnKeys)).toBe(false);
+    });
+
+    it('should pass the ES6Map test with ES6MapShim', function() {
+      expect(testES6Map(ES6MapShim)).toBe(true);
+    });
+  });
+
   describe('copy', function() {
     it('should return same object', function() {
       var obj = {};

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -25,39 +25,6 @@ describe('angular', function() {
     });
   });
 
-  describe('ES6Map', function() {
-    it('should test for bad Map objects', function() {
-      expect(testES6Map()).toBe(false);
-      expect(testES6Map(null)).toBe(false);
-      expect(testES6Map(3)).toBe(false);
-      expect(testES6Map({})).toBe(false);
-    });
-
-    it('should test for bad Map shims', function() {
-      function NoMethods() {}
-
-      function ToStringOnKeys() {
-        this._vals = {};
-      }
-      ToStringOnKeys.prototype = {
-        get: function(key) {
-          return this._vals[key];
-        },
-        set: function(key, val) {
-          this._vals[key] = val;
-          return this;
-        }
-      };
-
-      expect(testES6Map(NoMethods)).toBe(false);
-      expect(testES6Map(ToStringOnKeys)).toBe(false);
-    });
-
-    it('should pass the ES6Map test with ES6MapShim', function() {
-      expect(testES6Map(ES6MapShim)).toBe(true);
-    });
-  });
-
   describe('copy', function() {
     it('should return same object', function() {
       var obj = {};


### PR DESCRIPTION
@lgalfaso here's the ES6 Map change I promised.

When running f7bf118ecaaab16ed8b3d16febb0ee6bb1d6749c the larger objects are 10-20% faster, but the smaller objects are a bit slower (0-25%, but the times are so small I don't think this means much). On my box that meant the larger objects were ~400ms faster, the smaller were 1-3ms slower.  Memory usage also goes down 15-30% (30 on the more complicated cases, 15 on the simpler ones).

When using the shim (manually enabling it on chrome) the larger objects are 20-25% slower, the smaller objects are a bit slower just like when using the native `Map`.  This is because the shim causes an extra `indexOf` call compared to before this change (one on `get`, a second on `set`).  This extra `indexOf` could be avoided if we remove the check if the key already exists in the shim `set` method, but then this wouldn't be a proper `Map` shim (or add a magic 3rd param to `set` called "iAlreadyKnowTheKeyDoesNotExist` and always pass true? :P). EDIT: 105dd5d9b2676eb547fd85319b4dadb2dac0a6eb removes this extra 20-25% when using the shim

Note that while profiling `isTypedArray` is what stands out the most, not `Map` or `indexOf`, see #12054.
