### PR TITLE
fixes #12082 (ngTouch regression since 1.3)

### DIFF
--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -109,6 +109,10 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
   // Returns true if the click should be allowed.
   // Splices out the allowable region from the list after it has been used.
   function checkAllowableRegions(touchCoordinates, x, y) {
+    if (!touchCoordinates.length) {
+      return true; // If not coordinates that means we do not have a ghost click so bypass the check
+    }
+
     for (var i = 0; i < touchCoordinates.length; i += 2) {
       if (hit(touchCoordinates[i], touchCoordinates[i + 1], x, y)) {
         touchCoordinates.splice(i, i + 2);
@@ -260,7 +264,7 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
         }
 
         if (!angular.isDefined(attr.disabled) || attr.disabled === false) {
-          element.triggerHandler('click', [event]);
+          element.triggerHandler('click', [originalEvent]);
         }
       }
 


### PR DESCRIPTION
Send original event to triggerHandler and bypass prevent ghost click if no coordinates.

If there is anchor with ng-click on it the click event was not triggering.

fixes #12082 
