### PR TITLE
feat(jqLite): add support for 'ngIndeterminate' as a boolean attribute

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -541,7 +541,7 @@ var JQLitePrototype = JQLite.prototype = {
 // value on get.
 //////////////////////////////////////////
 var BOOLEAN_ATTR = {};
-forEach('multiple,selected,checked,disabled,readOnly,required,open'.split(','), function(value) {
+forEach('multiple,selected,checked,disabled,readOnly,required,open,indeterminate'.split(','), function(value) {
   BOOLEAN_ATTR[lowercase(value)] = value;
 });
 var BOOLEAN_ELEMENTS = {};

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -611,14 +611,19 @@ describe('jqLite', function() {
       expect(jqLite('<select multiple="x">').attr('multiple')).toBe('multiple');
     });
 
-    it('should add/remove boolean attributes', function() {
-      var select = jqLite('<select>');
-      select.attr('multiple', false);
-      expect(select.attr('multiple')).toBeUndefined();
+    var attributes = 'multiple,selected,checked,disabled,readOnly,required,open'.split(',');
 
-      select.attr('multiple', true);
-      expect(select.attr('multiple')).toBe('multiple');
-    });
+    for(var i = 0; i < attributes.length; i++) {
+      var thisAttribute = attributes[i];
+      it('should add/remove boolean attributes', function() {
+        var select = jqLite('<select>');
+        select.attr(thisAttribute, false);
+        expect(select.attr(thisAttribute)).toBeUndefined();
+
+        select.attr(thisAttribute, true);
+        expect(select.attr(thisAttribute)).toBe(thisAttribute);
+      });
+    };
 
     it('should normalize the case of boolean attributes', function() {
       var input = jqLite('<input readonly>');

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -611,7 +611,7 @@ describe('jqLite', function() {
       expect(jqLite('<select multiple="x">').attr('multiple')).toBe('multiple');
     });
 
-    var attributes = 'multiple,selected,checked,disabled,readOnly,required,open'.split(',');
+    var attributes = 'multiple,selected,checked,disabled,readOnly,required,open,indeterminate'.split(',');
 
     for(var i = 0; i < attributes.length; i++) {
       var thisAttribute = attributes[i];


### PR DESCRIPTION
ng-indeterminate can be used in the same pattern as ng-readOnly, ng-checked, ng-multiple, etc.

Closes #1411

jsFiddle demo of this feature: http://jsfiddle.net/m6ruj542/
