### PR TITLE
docs(tutorial/11 - REST and Custom Services): bower install, not npm

### DIFF
--- a/docs/content/tutorial/step_11.ngdoc
+++ b/docs/content/tutorial/step_11.ngdoc
@@ -47,14 +47,14 @@ angular-resource component that is compatible with version 1.4.x.  We must ask b
 and install this dependency. We can do this by running:
 
 ```
-npm install
+bower install
 ```
 
 <div class="alert alert-warning">
-  **Warning:** If a new version of Angular has been released since you last ran `npm install`, then you may have a
+  **Warning:** If a new version of Angular has been released since you last ran `bower install`, then you may have a
   problem with the `bower install` due to a conflict between the versions of angular.js that need to
   be installed.  If you get this then simply delete your `app/bower_components` folder before running
-  `npm install`.
+  `bower install`.
 </div>
 
 <div class="alert alert-info">


### PR DESCRIPTION
If we change the bower.json then we should run "bower install", not "npm install"
