### PR TITLE
docs(guide/Unit Testing): a typo was fixed

### DIFF
--- a/docs/content/guide/unit-testing.ngdoc
+++ b/docs/content/guide/unit-testing.ngdoc
@@ -359,7 +359,7 @@ element, to which it can then insert the transcluded content into its template.
 
 Before compilation:
 ```html
-<div translude-directive>
+<div transclude-directive>
   Some transcluded content
 </div>
 ```


### PR DESCRIPTION
Nothing special, just typo
