### PR TITLE
Fix ie 8659 (interpolation in extracted textNodes)

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2480,6 +2480,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               if (!hasCompileParent) compile.$$addBindingClass(parent);
               compile.$$addBindingInfo(parent, interpolateFn.expressions);
               scope.$watch(interpolateFn, function interpolateFnWatchAction(value) {
+                if (!node[0].nodeValue) {
+                  return;
+                }
                 node[0].nodeValue = value;
               });
             };

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2812,6 +2812,16 @@ describe('$compile', function() {
     );
 
 
+    it('should not throw when compiling and linking text bindings taken from a previously compiled element', inject(
+        function($rootScope, $compile) {
+          $rootScope.name = 'angular';
+          element = $compile('<div>text: {{name}}</div>')($rootScope);
+          var text = element.text();
+          element.html('').append($compile('<span>' + text +'</span>')($rootScope));
+          expect(function() {$rootScope.$digest()}).not.toThrow();
+        })
+    );
+
     it('should one-time bind if the expression starts with two colons', inject(
         function($rootScope, $compile) {
           $rootScope.name = 'angular';


### PR DESCRIPTION
This is to test a fix for issue #8659. Locally, it caused another test to fail.

~~There are a few more commits in here that should be, I'll check this out later~~
