### PR TITLE
fix($location): $locationchangesuccess not fires when browser location changes to URL which ends with# issue #12175  

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -918,16 +918,16 @@ function $LocationProvider() {
         var oldUrl = $location.absUrl();
         var oldState = $location.$$state;
         var defaultPrevented;
-
+		var trimNewUrl = trimEmptyHash(newUrl);
         $location.$$parse(newUrl);
         $location.$$state = newState;
 
-        defaultPrevented = $rootScope.$broadcast('$locationChangeStart', newUrl, oldUrl,
+        defaultPrevented = $rootScope.$broadcast('$locationChangeStart', trimNewUrl, oldUrl,
             newState, oldState).defaultPrevented;
 
         // if the location was changed by a `$locationChangeStart` handler then stop
         // processing this location change
-        if ($location.absUrl() !== newUrl) return;
+        if ($location.absUrl() !== trimNewUrl) return;
 
         if (defaultPrevented) {
           $location.$$parse(oldUrl);

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -2141,31 +2141,31 @@ describe('$location', function() {
       })
     );
 
-	it('should fire $locationChangeSuccess when browser location changes to URL which ends with #',
-		inject(function($location, $browser, $rootScope, $log) {
+    it('should fire $locationChangeSuccess when browser location changes to URL which ends with #',
+      inject(function($location, $browser, $rootScope, $log) {
         $location.url('/somepath');
         $rootScope.$apply();
 
         expect($browser.url()).toEqual('http://server/#/somepath');
         expect($location.url()).toEqual('/somepath');
-		
-		$rootScope.$on('$locationChangeStart', function(event, newUrl, oldUrl) {
+
+        $rootScope.$on('$locationChangeStart', function(event, newUrl, oldUrl) {
           $log.info('start', newUrl, oldUrl);
         });
-		$rootScope.$on('$locationChangeSuccess', function(event, newUrl, oldUrl) {
-        $log.info('after', newUrl, oldUrl);
-		});
+        $rootScope.$on('$locationChangeSuccess', function(event, newUrl, oldUrl) {
+          $log.info('after', newUrl, oldUrl);
+        });
 
-		$browser.url('http://server/#');
-		$browser.poll();
+        $browser.url('http://server/#');
+        $browser.poll();
 
-		expect($log.info.logs.shift()).
-			toEqual(['start', 'http://server/', 'http://server/#/somepath']);
-		expect($log.info.logs.shift()).
-			toEqual(['after', 'http://server/', 'http://server/#/somepath']);    
-		})
-	);
-	
+        expect($log.info.logs.shift()).
+          toEqual(['start', 'http://server/', 'http://server/#/somepath']);
+        expect($log.info.logs.shift()).
+          toEqual(['after', 'http://server/', 'http://server/#/somepath']);
+      })
+    );
+
     it('should allow redirect during browser url change',
       inject(function($location, $browser, $rootScope, $log) {
         $rootScope.$on('$locationChangeStart', function(event, newUrl, oldUrl) {

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -2141,6 +2141,31 @@ describe('$location', function() {
       })
     );
 
+	it('should fire $locationChangeSuccess when browser location changes to URL which ends with #',
+		inject(function($location, $browser, $rootScope, $log) {
+        $location.url('/somepath');
+        $rootScope.$apply();
+
+        expect($browser.url()).toEqual('http://server/#/somepath');
+        expect($location.url()).toEqual('/somepath');
+		
+		$rootScope.$on('$locationChangeStart', function(event, newUrl, oldUrl) {
+          $log.info('start', newUrl, oldUrl);
+        });
+		$rootScope.$on('$locationChangeSuccess', function(event, newUrl, oldUrl) {
+        $log.info('after', newUrl, oldUrl);
+		});
+
+		$browser.url('http://server/#');
+		$browser.poll();
+
+		expect($log.info.logs.shift()).
+			toEqual(['start', 'http://server/', 'http://server/#/somepath']);
+		expect($log.info.logs.shift()).
+			toEqual(['after', 'http://server/', 'http://server/#/somepath']);    
+		})
+	);
+	
     it('should allow redirect during browser url change',
       inject(function($location, $browser, $rootScope, $log) {
         $rootScope.$on('$locationChangeStart', function(event, newUrl, oldUrl) {


### PR DESCRIPTION
fix($location): $locationchangesuccess not fires when browser location changes to URL which ends with# issue #12175  
