### PR TITLE
remove unnecessary return of 'refresh'

### DIFF
--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -348,8 +348,7 @@ The following example shows how this is done with Angular:
 
         return {
           currencies: currencies,
-          convert: convert,
-          refresh: refresh
+          convert: convert
         };
       }]);
   </file>


### PR DESCRIPTION
It is not necessary to return a value for refresh in this example.
