### PR TITLE
refactor($interval): do not use `notify` to trigger the callback

### DIFF
--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -2,8 +2,8 @@
 
 
 function $IntervalProvider() {
-  this.$get = ['$rootScope', '$window', '$q', '$$q',
-       function($rootScope,   $window,   $q,   $$q) {
+  this.$get = ['$rootScope', '$window', '$q', '$$q', '$browser',
+       function($rootScope,   $window,   $q,   $$q,   $browser) {
     var intervals = {};
 
 
@@ -144,11 +144,12 @@ function $IntervalProvider() {
 
       count = isDefined(count) ? count : 0;
 
-      promise.then(null, null, (!hasParams) ? fn : function() {
-        fn.apply(null, args);
-      });
-
       promise.$$intervalId = setInterval(function tick() {
+        if (skipApply) {
+          $browser.defer(callback);
+        } else {
+          $rootScope.$evalAsync(callback);
+        }
         deferred.notify(iteration++);
 
         if (count > 0 && iteration >= count) {
@@ -164,6 +165,14 @@ function $IntervalProvider() {
       intervals[promise.$$intervalId] = deferred;
 
       return promise;
+
+      function callback() {
+        if (!hasParams) {
+          fn(iteration);
+        } else {
+          fn.apply(null, args);
+        }
+      }
     }
 
 

--- a/test/ng/intervalSpec.js
+++ b/test/ng/intervalSpec.js
@@ -115,6 +115,35 @@ describe('$interval', function() {
   }));
 
 
+  it('should not depend on `notify` to trigger the callback call', function() {
+    module(function($provide) {
+      $provide.decorator('$q', function($delegate) {
+        function replacement() {}
+        replacement.defer = function() {
+          var result = $delegate.defer();
+          result.notify = noop;
+          return result;
+        };
+        return replacement;
+      });
+    });
+
+    inject(function($interval, $window) {
+      var counter = 0;
+      $interval(function() { counter++; }, 1000);
+
+      expect(counter).toBe(0);
+
+      $window.flush(1000);
+      expect(counter).toBe(1);
+
+      $window.flush(1000);
+
+      expect(counter).toBe(2);
+    });
+  });
+
+
   it('should allow you to specify the delay time', inject(function($interval, $window) {
     var counter = 0;
     $interval(function() { counter++; }, 123);


### PR DESCRIPTION
Do not use `$q.notify` to trigger the callback. This allows `$q` to be replaced
with another Promise/A+ compilant library

Note: this PR is not enough to close #12533, but should solve the main issue in trying to use Bluebird as a replacement of `$q`
