### PR TITLE
refactor($compile): move check for interpolation of on-event attributes to compile time

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2534,18 +2534,18 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             startingTag(node));
       }
 
+      if (EVENT_HANDLER_ATTR_REGEXP.test(name)) {
+        throw $compileMinErr('nodomevents',
+            "Interpolations for HTML DOM event attributes are disallowed.  Please use the " +
+                "ng- versions (such as ng-click instead of onclick) instead.");
+      }
+
       directives.push({
         priority: 100,
         compile: function() {
             return {
               pre: function attrInterpolatePreLinkFn(scope, element, attr) {
                 var $$observers = (attr.$$observers || (attr.$$observers = createMap()));
-
-                if (EVENT_HANDLER_ATTR_REGEXP.test(name)) {
-                  throw $compileMinErr('nodomevents',
-                      "Interpolations for HTML DOM event attributes are disallowed.  Please use the " +
-                          "ng- versions (such as ng-click instead of onclick) instead.");
-                }
 
                 // If the attribute has changed since last $interpolate()ed
                 var newValue = attr[name];

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -7795,17 +7795,17 @@ describe('$compile', function() {
       // All interpolations are disallowed.
       $rootScope.onClickJs = "";
       expect(function() {
-          $compile('<button onclick="{{onClickJs}}"></script>')($rootScope);
+          $compile('<button onclick="{{onClickJs}}"></script>');
         }).toThrowMinErr(
           "$compile", "nodomevents", "Interpolations for HTML DOM event attributes are disallowed.  " +
           "Please use the ng- versions (such as ng-click instead of onclick) instead.");
       expect(function() {
-          $compile('<button ONCLICK="{{onClickJs}}"></script>')($rootScope);
+          $compile('<button ONCLICK="{{onClickJs}}"></script>');
         }).toThrowMinErr(
           "$compile", "nodomevents", "Interpolations for HTML DOM event attributes are disallowed.  " +
           "Please use the ng- versions (such as ng-click instead of onclick) instead.");
       expect(function() {
-          $compile('<button ng-attr-onclick="{{onClickJs}}"></script>')($rootScope);
+          $compile('<button ng-attr-onclick="{{onClickJs}}"></script>');
         }).toThrowMinErr(
           "$compile", "nodomevents", "Interpolations for HTML DOM event attributes are disallowed.  " +
           "Please use the ng- versions (such as ng-click instead of onclick) instead.");


### PR DESCRIPTION
BREAKING CHANGE:
Previously the nodomevents would be thrown at link time for any interpolation on\* event attributes. Now this will be throw at compile time similar to the selmulti error.

The breaking change should be rare, but is probably worth mentioning.  This makes the two interpolation errors consistent and avoids checking the same thing per link (which previously would log the same error per link).

The test changes are not necessary but do make them stricter and more like the selmulti error tests.
