### PR TITLE
Fix TypeError: tapElement.blur is not a function

### DIFF
--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -255,7 +255,7 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
         // Blur the focused element (the button, probably) before firing the callback.
         // This doesn't work perfectly on Android Chrome, but seems to work elsewhere.
         // I couldn't get anything to work reliably on Android Chrome.
-        if (tapElement) {
+        if (tapElement && angular.isFunction(tapElement.blur)) {
           tapElement.blur();
         }
 


### PR DESCRIPTION
Hi,

I ran into the same issue than #11261 with the following HTML:

``` html
<span ng-click="scrollService.goToSection('my-section')">
  <svg><use xlink:href="#my-icon"></use></svg>
  Title
</span>
```

On Firefox mobile, when i tap onto the SVG icon, i get the following error which breaks the event handler:

```
TypeError: tapElement.blur is not a function
```

The tap element is a SVG node that does not have a 'blur' function.

This commit fixes the issue for me.

Regards
