### PR TITLE
Add request and requestError interception in ngResource

### DIFF
--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -3,7 +3,7 @@
 describe("resource", function() {
 
 describe("basic usage", function() {
-  var $resource, CreditCard, callback, $httpBackend, resourceProvider;
+  var $resource, CreditCard, callback, $httpBackend, resourceProvider, $q;
 
   beforeEach(module('ngResource'));
 
@@ -14,6 +14,7 @@ describe("basic usage", function() {
   beforeEach(inject(function($injector) {
     $httpBackend = $injector.get('$httpBackend');
     $resource = $injector.get('$resource');
+    $q = $injector.get('$q');
     CreditCard = $resource('/CreditCard/:id:verb', {id:'@id.key'}, {
       charge:{
         method:'post',
@@ -978,6 +979,188 @@ describe("basic usage", function() {
       });
     });
 
+
+    describe('requestInterceptor', function() {
+      var rejectReason = {'lol':'cat'};
+      var successSpy, failureSpy;
+
+      beforeEach(function() {
+        successSpy = jasmine.createSpy('successSpy');
+        failureSpy = jasmine.createSpy('failureSpy');
+      });
+
+      it('should allow per action request interceptor that gets full configuration', function() {
+        var CreditCard = $resource('/CreditCard', {}, {
+          query: {
+            method: 'get',
+            isArray: true,
+            interceptor: {
+              request: function(httpConfig) {
+                callback(httpConfig);
+                return httpConfig;
+              }
+            }
+          }
+        });
+
+        $httpBackend.expect('GET', '/CreditCard').respond([{id: 1}]);
+
+        var resource = CreditCard.query();
+        resource.$promise.then(successSpy, failureSpy);
+
+        $httpBackend.flush();
+        expect(callback).toHaveBeenCalledOnce();
+        expect(successSpy).toHaveBeenCalledOnce();
+        expect(failureSpy).not.toHaveBeenCalled();
+
+        expect(callback).toHaveBeenCalledWith({
+          'method': 'get',
+          'url': '/CreditCard'
+        });
+      });
+
+      it('should call $http with the value returned from requestInterceptor', function() {
+        var CreditCard = $resource('/CreditCard', {}, {
+          query: {
+            method: 'get',
+            isArray: true,
+            interceptor: {
+              request: function(httpConfig) {
+                httpConfig.url = '/DebitCard';
+                return httpConfig;
+              }
+            }
+          }
+        });
+
+        $httpBackend.expect('GET', '/DebitCard').respond([{id: 1}]);
+
+        var resource = CreditCard.query();
+        resource.$promise.then(successSpy, failureSpy);
+
+        $httpBackend.flush();
+        expect(successSpy).toHaveBeenCalledOnce();
+        expect(failureSpy).not.toHaveBeenCalled();
+      });
+
+      it('should abort the operation if the requestInterceptor rejects the operation', function() {
+        var CreditCard = $resource('/CreditCard', {}, {
+          query: {
+            method: 'get',
+            isArray: true,
+            interceptor: {
+              request: function() {
+                return $q.reject(rejectReason);
+              }
+            }
+          }
+        });
+
+        var resource = CreditCard.query();
+        resource.$promise.then(successSpy, failureSpy);
+
+        // Make sure all promises resolve.
+        $rootScope.$apply();
+
+        // Ensure the resource promise was rejected
+        expect(resource.$resolved).toBeTruthy();
+        expect(successSpy).not.toHaveBeenCalled();
+        expect(failureSpy).toHaveBeenCalledOnce();
+        expect(failureSpy).toHaveBeenCalledWith(rejectReason);
+
+        // Ensure that no requests were made.
+        $httpBackend.verifyNoOutstandingRequest();
+      });
+
+      it('should call requestErrorInterceptor if requestInterceptor rejects the operation', function() {
+        var CreditCard = $resource('/CreditCard', {}, {
+          query: {
+            method: 'get',
+            isArray: true,
+            interceptor: {
+              request: function() {
+                return $q.reject(rejectReason);
+              },
+              requestError: function(rejection) {
+                callback(rejection);
+                return $q.reject(rejection);
+              }
+            }
+          }
+        });
+
+        var resource = CreditCard.query();
+        resource.$promise.then(successSpy, failureSpy);
+        $rootScope.$digest();
+
+        expect(callback).toHaveBeenCalledOnce();
+        expect(callback).toHaveBeenCalledWith(rejectReason);
+        expect(successSpy).not.toHaveBeenCalled();
+        expect(failureSpy).toHaveBeenCalledOnce();
+        expect(failureSpy).toHaveBeenCalledWith(rejectReason);
+
+        // Ensure that no requests were made.
+        $httpBackend.verifyNoOutstandingRequest();
+      });
+
+      it('should abort the operation if a requestErrorInterceptor rejects the operation', function() {
+          var CreditCard = $resource('/CreditCard', {}, {
+            query: {
+              method: 'get',
+              isArray: true,
+              interceptor: {
+                request: function() {
+                  return $q.reject(rejectReason);
+                },
+                requestError: function(rejection) {
+                  return $q.reject(rejection);
+                }
+              }
+            }
+          });
+
+          var resource = CreditCard.query();
+          resource.$promise.then(successSpy, failureSpy);
+          $rootScope.$apply();
+
+          expect(resource.$resolved).toBeTruthy();
+          expect(successSpy).not.toHaveBeenCalled();
+          expect(failureSpy).toHaveBeenCalledOnce();
+          expect(failureSpy).toHaveBeenCalledWith(rejectReason);
+
+          // Ensure that no requests were made.
+          $httpBackend.verifyNoOutstandingRequest();
+        });
+
+      it('should continue the operation if a requestErrorInterceptor rescues it', function() {
+        var CreditCard = $resource('/CreditCard', {}, {
+          query: {
+            method: 'get',
+            isArray: true,
+            interceptor: {
+              request: function(httpConfig) {
+                return $q.reject(httpConfig);
+              },
+              requestError: function(httpConfig) {
+                return $q.resolve(httpConfig);
+              }
+            }
+          }
+        });
+
+        $httpBackend.expect('GET', '/CreditCard').respond([{id: 1}]);
+
+        var resource = CreditCard.query();
+        resource.$promise.then(successSpy, failureSpy);
+        $httpBackend.flush();
+
+        expect(resource.$resolved).toBeTruthy();
+        expect(successSpy).toHaveBeenCalledOnce();
+        expect(failureSpy).not.toHaveBeenCalled();
+        $httpBackend.verifyNoOutstandingRequest();
+      });
+    });
+
     it('should allow per action response interceptor that gets full response', function() {
       CreditCard = $resource('/CreditCard', {}, {
         query: {
@@ -1318,7 +1501,7 @@ describe("basic usage", function() {
 });
 
 describe('errors', function() {
-  var $httpBackend, $resource, $q;
+  var $httpBackend, $resource, $q, $rootScope;
 
   beforeEach(module(function($exceptionHandlerProvider) {
     $exceptionHandlerProvider.mode('log');
@@ -1330,6 +1513,7 @@ describe('errors', function() {
     $httpBackend = $injector.get('$httpBackend');
     $resource = $injector.get('$resource');
     $q = $injector.get('$q');
+    $rootScope = $injector.get('$rootScope');
   }));
 
 
@@ -1366,6 +1550,78 @@ describe('errors', function() {
         /^\[\$resource:badcfg\] Error in resource configuration for action `get`\. Expected response to contain an object but got an array \(Request: GET \/Customer\/123\)/
       );
   });
+
+  describe('requestInterceptor', function() {
+    var rejectReason = {'lol':'cat'};
+    var successSpy, failureSpy, callback;
+
+    beforeEach(function() {
+      successSpy = jasmine.createSpy('successSpy');
+      failureSpy = jasmine.createSpy('failureSpy');
+      callback = jasmine.createSpy();
+    });
+
+    it('should call requestErrorInterceptor if requestInterceptor throws an error', function() {
+      var CreditCard = $resource('/CreditCard', {}, {
+        query: {
+          method: 'get',
+          isArray: true,
+          interceptor: {
+            request: function() {
+              throw rejectReason;
+            },
+            requestError: function(rejection) {
+              callback(rejection);
+              return $q.reject(rejection);
+            }
+          }
+        }
+      });
+
+      var resource = CreditCard.query();
+      resource.$promise.then(successSpy, failureSpy);
+      $rootScope.$apply();
+
+      expect(callback).toHaveBeenCalledOnce();
+      expect(callback).toHaveBeenCalledWith(rejectReason);
+      expect(successSpy).not.toHaveBeenCalled();
+      expect(failureSpy).toHaveBeenCalledOnce();
+      expect(failureSpy).toHaveBeenCalledWith(rejectReason);
+
+      // Ensure that no requests were made.
+      $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    it('should abort the operation if a requestErrorInterceptor throws an exception', function() {
+      var CreditCard = $resource('/CreditCard', {}, {
+        query: {
+          method: 'get',
+          isArray: true,
+          interceptor: {
+            request: function() {
+              return $q.reject();
+            },
+            requestError: function() {
+              throw rejectReason;
+            }
+          }
+        }
+      });
+
+      var resource = CreditCard.query();
+      resource.$promise.then(successSpy, failureSpy);
+      $rootScope.$apply();
+
+      expect(resource.$resolved).toBeTruthy();
+      expect(successSpy).not.toHaveBeenCalled();
+      expect(failureSpy).toHaveBeenCalledOnce();
+      expect(failureSpy).toHaveBeenCalledWith(rejectReason);
+
+      // Ensure that no requests were made.
+      $httpBackend.verifyNoOutstandingRequest();
+    });
+  });
+
 });
 
 describe('cancelling requests', function() {
@@ -1430,7 +1686,7 @@ describe('cancelling requests', function() {
   );
 
   it('should use `cancellable` value if passed a non-numeric `timeout` in an action',
-    inject(function($log, $q) {
+    inject(function($log, $q, $rootScope) {
       spyOn($log, 'debug');
       $httpBackend.whenGET('/CreditCard').respond({});
 
@@ -1443,6 +1699,7 @@ describe('cancelling requests', function() {
       });
 
       var creditCard = CreditCard.get();
+      $rootScope.$apply();
       expect(creditCard.$cancelRequest).toBeDefined();
       expect(httpSpy.calls.argsFor(0)[0].timeout).toEqual(jasmine.any($q));
       expect(httpSpy.calls.argsFor(0)[0].timeout.then).toBeDefined();


### PR DESCRIPTION
This patch adds request and requestError interception for ngResource actions,
as per the documentation found for $http interceptors. It is important to
note that returning an error at this stage of the request - before the
call to $http - will completely bypass any global interceptors and/or recovery
handlers, as those are added to a separate context. This is intentional; intercepting
a request before it is passed to the HTTP stack indicates that the resource itself
has made a decision, and that it accepts the responsibility for recovery.

Closes #5146
