### PR TITLE
feat($sanitize): enable amending allowed attributes in $sanitize

### DIFF
--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -141,11 +141,14 @@ var $sanitizeMinErr = angular.$$minErr('$sanitize');
  */
 function $SanitizeProvider() {
   var svgEnabled = false;
+  var addAttributes = "";
 
   this.$get = ['$$sanitizeUri', function($$sanitizeUri) {
     if (svgEnabled) {
       angular.extend(validElements, svgElements);
     }
+    var attrMap = toMap(addAttributes);
+    angular.extend(validAttrs, attrMap)
     return function(html) {
       var buf = [];
       htmlParser(html, htmlSanitizeWriter(buf, function(uri, isImage) {
@@ -155,6 +158,27 @@ function $SanitizeProvider() {
     };
   }];
 
+
+  /**
+   *
+   * @ngdoc method
+   * @name $sanitizeProvider#additionalAttributes
+   * @kind function
+   *
+   * @description
+   * Allows additional whitelisting of html (and other) attributes.
+   *
+   * @param {string=} comma separated string containing valid attributes.
+   */
+
+  this.additionalAttributes = function(attributes) {
+    if (angular.isDefined(attributes )) {
+      addAttributes = attributes;
+      return this;
+    } else {
+      return addAttributes;
+    }
+  };
 
   /**
    * @ngdoc method

--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -148,7 +148,7 @@ function $SanitizeProvider() {
       angular.extend(validElements, svgElements);
     }
     var attrMap = toMap(addAttributes);
-    angular.extend(validAttrs, attrMap)
+    angular.extend(validAttrs, attrMap);
     return function(html) {
       var buf = [];
       htmlParser(html, htmlSanitizeWriter(buf, function(uri, isImage) {


### PR DESCRIPTION
Provide additionalAttributes function in $sanitizeProvider. When called with a comma separated string of attributes, add these attributes to the list of allowed attributes.

This potentially allows the user to introduce changes that break the security guarantees of $sanitize.
