### PR TITLE
docs(ngModel.NgModelController): fix mistake in example

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -90,11 +90,11 @@ is set to `true`. The parse error is stored in `ngModel.$error.parse`.
  *   // Lookup user by username
  *   return $http.get('/api/users/' + value).
  *      then(function resolved() {
- *        //username exists, this means validation fails
- *        return $q.reject('exists');
- *      }, function rejected() {
- *        //username does not exist, therefore this validation passes
+ *        // Username does not exist, therefore this validation passes
  *        return true;
+ *      }, function rejected() {
+ *        // Username exists, this means validation fails
+ *        return $q.reject('exists');
  *      });
  * };
  * ```


### PR DESCRIPTION
The bodies of `resolved` and `rejected` callbacks were in wrong order.
