### PR TITLE
fix($httpBackend): make verifyNoOutstandingRequest work as expected

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1743,6 +1743,14 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
    * ```
    */
   $httpBackend.verifyNoOutstandingRequest = function() {
+    // Flush outstanding tasks first,
+    // otherwise outstanding requests made by $http will not get noticed.
+    try {
+      $timeout.flush();
+    }
+    catch (e) {
+      // Catch any exceptions thrown, and continue to check responses
+    }
     if (responses.length) {
       throw new Error('Unflushed requests: ' + responses.length);
     }

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -937,11 +937,12 @@ describe('ngMock', function() {
 
 
   describe('$httpBackend', function() {
-    var hb, callback, realBackendSpy;
+    var hb, callback, realBackendSpy, $http;
 
-    beforeEach(inject(function($httpBackend) {
+    beforeEach(inject(function($httpBackend, _$http_) {
       callback = jasmine.createSpy('callback');
       hb = $httpBackend;
+      $http = _$http_;
     }));
 
     it('should provide "expect" methods for each HTTP verb', function() {
@@ -1479,10 +1480,11 @@ describe('ngMock', function() {
       it('should throw exception if not all requests were flushed', function() {
         hb.when('GET').respond(200);
         hb('GET', '/some', null, noop, {});
+        $http.get('/some');
 
         expect(function() {
           hb.verifyNoOutstandingRequest();
-        }).toThrow('Unflushed requests: 1');
+        }).toThrow('Unflushed requests: 2');
       });
     });
 


### PR DESCRIPTION
Make $httpBackend::verifyNoOutstandingRequest catch unflushed requests made by $http.

Closes #5453
