### PR TITLE
docs(guide/Conceptual Overview): $http.success is deprecated

### DIFF
--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -334,9 +334,9 @@ The following example shows how this is done with Angular:
         var refresh = function() {
           var url = YAHOO_FINANCE_URL_PATTERN.
                      replace('PAIRS', 'USD' + currencies.join('","USD'));
-          return $http.jsonp(url).success(function(data) {
+          return $http.jsonp(url).then(function(response) {
             var newUsdToForeignRates = {};
-            angular.forEach(data.query.results.rate, function(rate) {
+            angular.forEach(response.data.query.results.rate, function(rate) {
               var currency = rate.id.substring(3,6);
               newUsdToForeignRates[currency] = window.parseFloat(rate.Rate);
             });


### PR DESCRIPTION
Using the standard then method instead success, because success is deprecated
