### PR TITLE
fix($compile): support merging special attribute names in `replace` d…

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -989,6 +989,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     function($injector,   $interpolate,   $exceptionHandler,   $templateRequest,   $parse,
              $controller,   $rootScope,   $document,   $sce,   $animate,   $$sanitizeUri) {
 
+    var SIMPLE_ATTR_NAME = /^\w/;
+    var QUOTE_REGEX = /'/g;
+    var specialAttrHolder = document.createElement('div');
     var Attributes = function(element, attributesToCopy) {
       if (attributesToCopy) {
         var keys = Object.keys(attributesToCopy);
@@ -1168,7 +1171,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           if (value === null || isUndefined(value)) {
             this.$$element.removeAttr(attrName);
           } else {
-            this.$$element.attr(attrName, value);
+            if (SIMPLE_ATTR_NAME.test(attrName)) {
+              this.$$element.attr(attrName, value);
+            } else {
+              setSpecialAttr(this.$$element[0], attrName, value);
+            }
           }
         }
 
@@ -1221,6 +1228,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       }
     };
 
+    function setSpecialAttr(element, attrName, value) {
+      specialAttrHolder.innerHTML = "<span " + attrName + "='" + (value || '').replace(QUOTE_REGEX, '&quot;') + "'>";
+      var attribute = specialAttrHolder.firstChild.attributes[0].cloneNode();
+      element.attributes.setNamedItem(attribute);
+    }
 
     function safeAddClass($element, className) {
       try {

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -990,7 +990,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
              $controller,   $rootScope,   $document,   $sce,   $animate,   $$sanitizeUri) {
 
     var SIMPLE_ATTR_NAME = /^\w/;
-    var QUOTE_REGEX = /'/g;
     var specialAttrHolder = document.createElement('div');
     var Attributes = function(element, attributesToCopy) {
       if (attributesToCopy) {
@@ -1229,7 +1228,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     };
 
     function setSpecialAttr(element, attrName, value) {
-      // Attributes names that do not start with letters cannot be set using `setAttribute`
+      // Attributes names that do not start with letters (such as `(click)`) cannot be set using `setAttribute`
       // so we have to jump through some hoops to get such an attribute
       // https://github.com/angular/angular.js/pull/13318
       specialAttrHolder.innerHTML = "<span " + attrName + ">";

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1229,8 +1229,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     };
 
     function setSpecialAttr(element, attrName, value) {
-      specialAttrHolder.innerHTML = "<span " + attrName + "='" + (value || '').replace(QUOTE_REGEX, '&quot;') + "'>";
-      var attribute = specialAttrHolder.firstChild.attributes[0].cloneNode();
+      specialAttrHolder.innerHTML = "<span " + attrName + "='" + (value || '').replace(QUOTE_REGEX, '&quot;') + "'>"
+      var span = specialAttrHolder.firstChild;
+      var attribute = span.attributes[0];
+      // We have to remove the attribute from the holder element before we can add it to the destination element
+      span.removeAttribute(attrName);
       element.attributes.setNamedItem(attribute);
     }
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1229,11 +1229,15 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     };
 
     function setSpecialAttr(element, attrName, value) {
-      specialAttrHolder.innerHTML = "<span " + attrName + "='" + (value || '').replace(QUOTE_REGEX, '&quot;') + "'>"
+      // Attributes names that do not start with letters cannot be set using `setAttribute`
+      // so we have to jump through some hoops to get such an attribute
+      // https://github.com/angular/angular.js/pull/13318
+      specialAttrHolder.innerHTML = "<span " + attrName + ">";
       var span = specialAttrHolder.firstChild;
       var attribute = span.attributes[0];
       // We have to remove the attribute from the holder element before we can add it to the destination element
       span.removeAttribute(attrName);
+      attribute.value = value;
       element.attributes.setNamedItem(attribute);
     }
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1232,10 +1232,10 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       // so we have to jump through some hoops to get such an attribute
       // https://github.com/angular/angular.js/pull/13318
       specialAttrHolder.innerHTML = "<span " + attrName + ">";
-      var span = specialAttrHolder.firstChild;
-      var attribute = span.attributes[0];
-      // We have to remove the attribute from the holder element before we can add it to the destination element
-      span.removeAttribute(attrName);
+      var attributes = specialAttrHolder.firstChild.attributes;
+      var attribute = attributes[0];
+      // We have to remove the attribute from its container element before we can add it to the destination element
+      attributes.removeNamedItem(attribute.name);
       attribute.value = value;
       element.attributes.setNamedItem(attribute);
     }

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1232,12 +1232,25 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       // so we have to jump through some hoops to get such an attribute
       // https://github.com/angular/angular.js/pull/13318
       specialAttrHolder.innerHTML = "<span " + attrName + ">";
+      console.log('holder');
+      console.log(specialAttrHolder);
       var attributes = specialAttrHolder.firstChild.attributes;
       var attribute = attributes[0];
+      console.log('attribute');
+      console.log(attribute, attribute.name, attribute.value);
       // We have to remove the attribute from its container element before we can add it to the destination element
       attributes.removeNamedItem(attribute.name);
       attribute.value = value;
+      console.log('attribute with value');
+      console.log(attribute, attribute.name, attribute.value);
       element.attributes.setNamedItem(attribute);
+      console.log('element attributes');
+      for(var i=0; i< element.attributes.length; i++) {
+        var attribute = element.attributes[i];
+        console.log(attribute, attribute.name, attribute.value);
+      }
+      console.log('element');
+      console.log(element);
     }
 
     function safeAddClass($element, className) {

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1232,25 +1232,12 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       // so we have to jump through some hoops to get such an attribute
       // https://github.com/angular/angular.js/pull/13318
       specialAttrHolder.innerHTML = "<span " + attrName + ">";
-      console.log('holder');
-      console.log(specialAttrHolder);
       var attributes = specialAttrHolder.firstChild.attributes;
       var attribute = attributes[0];
-      console.log('attribute');
-      console.log(attribute, attribute.name, attribute.value);
       // We have to remove the attribute from its container element before we can add it to the destination element
       attributes.removeNamedItem(attribute.name);
       attribute.value = value;
-      console.log('attribute with value');
-      console.log(attribute, attribute.name, attribute.value);
       element.attributes.setNamedItem(attribute);
-      console.log('element attributes');
-      for(var i=0; i< element.attributes.length; i++) {
-        var attribute = element.attributes[i];
-        console.log(attribute, attribute.name, attribute.value);
-      }
-      console.log('element');
-      console.log(element);
     }
 
     function safeAddClass($element, className) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -871,8 +871,10 @@ describe('$compile', function() {
 
         iit('should correctly merge attributes that contain special characters', inject(function($compile, $rootScope) {
           element = $compile(
-            '<div><div replace Ω="omega"></div><div>')($rootScope);
+            '<div><div replace (click)="doSomething()" [value]="someExpression" Ω="omega"></div><div>')($rootScope);
           var div = element.find('div');
+          expect(div.attr('(click)')).toEqual('doSomething()');
+          expect(div.attr('[value]')).toEqual('someExpression');
           expect(div.attr('Ω')).toEqual('omega');
         }));
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -869,7 +869,7 @@ describe('$compile', function() {
         }));
 
 
-        iit('should correctly merge attributes that contain special characters', inject(function($compile, $rootScope) {
+        it('should correctly merge attributes that contain special characters', inject(function($compile, $rootScope) {
           element = $compile(
             '<div><div replace (click)="doSomething()" [value]="someExpression" Ω="omega"></div><div>')($rootScope);
           var div = element.find('div');

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -868,6 +868,16 @@ describe('$compile', function() {
           expect(div.attr('id')).toEqual('myid');
         }));
 
+
+        it('should correctly merge attributes that contain special characters', inject(function($compile, $rootScope) {
+          element = $compile(
+            '<div><div replace (click)="doSomething()" [value]="someExpression"></div><div>')($rootScope);
+          var div = element.find('div');
+          expect(div.attr('(click)')).toEqual('doSomething()');
+          expect(div.attr('[value]')).toEqual('someExpression');
+        }));
+
+
         it('should prevent multiple templates per element', inject(function($compile) {
           try {
             $compile('<div><span replace class="replace"></span></div>');

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -871,11 +871,11 @@ describe('$compile', function() {
 
         it('should correctly merge attributes that contain special characters', inject(function($compile, $rootScope) {
           element = $compile(
-            '<div><div replace (click)="doSomething()" [value]="someExpression" Ω="omega"></div><div>')($rootScope);
+            '<div><div replace (click)="doSomething()" [value]="someExpression" ω="omega"></div><div>')($rootScope);
           var div = element.find('div');
           expect(div.attr('(click)')).toEqual('doSomething()');
           expect(div.attr('[value]')).toEqual('someExpression');
-          expect(div.attr('Ω')).toEqual('omega');
+          expect(div.attr('ω')).toEqual('omega');
         }));
 
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -869,12 +869,10 @@ describe('$compile', function() {
         }));
 
 
-        it('should correctly merge attributes that contain special characters', inject(function($compile, $rootScope) {
+        iit('should correctly merge attributes that contain special characters', inject(function($compile, $rootScope) {
           element = $compile(
-            '<div><div replace (click)="doSomething()" [value]="someExpression" Ω="omega"></div><div>')($rootScope);
+            '<div><div replace Ω="omega"></div><div>')($rootScope);
           var div = element.find('div');
-          expect(div.attr('(click)')).toEqual('doSomething()');
-          expect(div.attr('[value]')).toEqual('someExpression');
           expect(div.attr('Ω')).toEqual('omega');
         }));
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -871,10 +871,11 @@ describe('$compile', function() {
 
         it('should correctly merge attributes that contain special characters', inject(function($compile, $rootScope) {
           element = $compile(
-            '<div><div replace (click)="doSomething()" [value]="someExpression"></div><div>')($rootScope);
+            '<div><div replace (click)="doSomething()" [value]="someExpression" Ω="omega"></div><div>')($rootScope);
           var div = element.find('div');
           expect(div.attr('(click)')).toEqual('doSomething()');
           expect(div.attr('[value]')).toEqual('someExpression');
+          expect(div.attr('Ω')).toEqual('omega');
         }));
 
 


### PR DESCRIPTION
…irectives

When compiling a `replace` directive, the compiler merges the attributes from
the replaced element onto the template element.

Unfortunately, `setAttribute` and other related DOM methods do not allow certain
attribute names - in particular Angular 2 style names such as `(click)` and `[value]`.

This is relevant when using ngForward with Angular Material, since the `mgButton`
directive uses `replace` and in the former you often use `(click)`.

This fixes the problem but for those special attributes the speed is considerably
slow.

Closes #13317
