### PR TITLE
docs(number): fix use of undefined decimalPlaces

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -89,7 +89,7 @@ function currencyFilter($locale) {
  * @param {(number|string)=} fractionSize Number of decimal places to round the number to.
  * If this is not provided then the fraction size is computed from the current locale's number
  * formatting pattern. In the case of the default locale, it will be 3.
- * @returns {string} Number rounded to decimalPlaces and places a “,” after each third digit.
+ * @returns {string} Number rounded to fractionSize and places a “,” after each third digit.
  *
  * @example
    <example module="numberFilterExample">


### PR DESCRIPTION
Replace `decimalPlaces` with `fractionSize`, as `decimalPlaces` isn't defined anywhere and is most likely meant to be `fractionSize`.
