### PR TITLE
fix(ngOptionsDirective): fix form pristine (use !equals function instead of !==  for issue 13211)

### DIFF
--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -733,7 +733,8 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
         // Check to see if the value has changed due to the update to the options
         if (!ngModelCtrl.$isEmpty(previousValue)) {
           var nextValue = selectCtrl.readValue();
-          if (!equals(previousValue, nextValue)) {
+          var isNotPrimitive = ngOptions.trackBy || multiple;
+          if (isNotPrimitive ? !equals(previousValue, nextValue) : previousValue !== nextValue) {
             ngModelCtrl.$setViewValue(nextValue);
             ngModelCtrl.$render();
           }

--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -733,7 +733,7 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
         // Check to see if the value has changed due to the update to the options
         if (!ngModelCtrl.$isEmpty(previousValue)) {
           var nextValue = selectCtrl.readValue();
-          if (ngOptions.trackBy ? !equals(previousValue, nextValue) : previousValue !== nextValue) {
+          if (!equals(previousValue, nextValue)) {
             ngModelCtrl.$setViewValue(nextValue);
             ngModelCtrl.$render();
           }


### PR DESCRIPTION
This pull request is related to Issue

https://github.com/angular/angular.js/issues/13211

it solves form $pristine and $dirty wrong values in case of multi select element 

prevoiusValue and nextValue are array for example

```
previousValue = [1,2]
nextValue = [1,2]
```

The are the same value but the === operator will return false because they are array
after some debugging i found that these lines cause the problem

```
if (!ngModelCtrl.$isEmpty(previousValue)) {
      var nextValue = selectCtrl.readValue();
      if (ngOptions.trackBy ? !equals(previousValue, nextValue) : previousValue !== nextValue) {
        ngModelCtrl.$setViewValue(nextValue);
        ngModelCtrl.$render();
      }
    }
```

what cause the problem is ngOptions.trackBy is undefined and 
(previousValue !== nextValue) i will be true becuase [1,2] !== [1,2]
