### PR TITLE
Firefox dual select workaround

### DIFF
--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -446,6 +446,9 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
       var removeEmptyOption = function() {
         if (!providedEmptyOption) {
           emptyOption.remove();
+        } else {
+          emptyOption.prop('selected', false);
+          emptyOption.attr('selected', false);
         }
       };
 

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1123,5 +1123,18 @@ describe('select', function() {
       }).toThrowMinErr('ng','badname', 'hasOwnProperty is not a valid "option value" name');
     });
 
+    it('should set providedEmptyOption.selected to false', function() {
+      scope.options = ['a'];
+      scope.model = '';
+      compile(
+          '<select ng-model="model" ng-options="opt for opt in options">' +
+            '<option id=empty_option value="">Empty Option</option>' +
+          '</select>');
+      expect(element.find("option").eq(0).attr("selected")).toBe("selected");
+      scope.model = 'a';
+      scope.$digest();
+      expect(element.find("option").eq(0).attr("selected")).toBe(undefined);
+    });
+
   });
 });

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1128,12 +1128,13 @@ describe('select', function() {
       scope.model = '';
       compile(
           '<select ng-model="model" ng-options="opt for opt in options">' +
-            '<option id=empty_option value="">Empty Option</option>' +
+            '<option id="empty_option" value="">Empty Option</option>' +
           '</select>');
-      expect(element.find("option").eq(0).attr("selected")).toBe("selected");
+      var opt = element.find("option")[0];
+      expect(!opt.getAttribute("selected")).toBe(false);
       scope.model = 'a';
       scope.$digest();
-      expect(element.find("option").eq(0).attr("selected")).toBe(undefined);
+      expect(!opt.getAttribute("selected")).toBe(true);
     });
 
   });


### PR DESCRIPTION
Firefox (verified on versions 38..42, Windows and Linux-AMD64) can get
confused about what option is selected after options ngOptions populates
the select control when it has a empty option that is ng-disabled.  It
appears to think both first option added by ngOptions and the one
selected by ngModel are selected.  The trigger seems to be angular
leaving the empty option both selected and disabled.

This patch works around the problem.
