### PR TITLE
docs(ngModel.NgModelController): Example inputs behave the same when …

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -455,7 +455,6 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
    *       $scope.resetWithCancel = function(e) {
    *         if (e.keyCode == 27) {
    *           $scope.myForm.myInput1.$rollbackViewValue();
-   *           $scope.myValue = '';
    *         }
    *       };
    *       $scope.resetWithoutCancel = function(e) {


### PR DESCRIPTION
…they shouldn't.

The first input demonstrating $rollbackViewValue is meant to rollback the value, not make it blank. Code in it's current state makes both behave the same.
