### PR TITLE
Avoid browser input[number] defaults

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -748,6 +748,7 @@ var inputType = {
       </example>
    */
   'number': numberInputType,
+  'text-number': numberInputType,
 
 
   /**


### PR DESCRIPTION
Is there a way to use  <input type="number" ng-model="vm.foo" /> syntax but WITHOUT usa type=number?
I have some quircks with spinner, mouse wheel and so on.

The patched code will works, but I'm lookin for a external solution
