### PR TITLE
Fix documentation: add closing parenthesis

### DIFF
--- a/docs/content/tutorial/step_02.ngdoc
+++ b/docs/content/tutorial/step_02.ngdoc
@@ -61,7 +61,7 @@ by the value of the expressions.
 We have added a new directive, called `ng-controller`, which attaches a `PhoneListCtrl`
 __controller__ to the &lt;body&gt; tag.  At this point:
 
-* The expressions in curly braces (`{{phone.name}}` and `{{phone.snippet}}` denote
+* The expressions in curly braces (`{{phone.name}}` and `{{phone.snippet}}`) denote
 bindings, which are referring to our application model, which is set up in our `PhoneListCtrl`
 controller.
 


### PR DESCRIPTION
closing parenthesis is missing to **docs/content/tutorial/step_02.ngdoc**
