### PR TITLE
fix($parse): handle interceptors with `undefined` expressions

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1775,7 +1775,7 @@ function $ParseProvider() {
           return addInterceptor(exp, interceptorFn);
 
         default:
-          return noop;
+          return addInterceptor(noop, interceptorFn);
       }
     };
 

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3165,6 +3165,17 @@ describe('parser', function() {
           expect(called).toBe(true);
         }));
 
+        it('should invoke interceptors when the expression is `undefined`', inject(function($parse) {
+          var called = false;
+          function interceptor(v) {
+            called = true;
+            return v;
+          }
+          scope.$watch($parse(undefined, interceptor));
+          scope.$digest();
+          expect(called).toBe(true);
+        }));
+
         it('should treat filters with constant input as constants', inject(function($parse) {
           var filterCalls = 0;
           $filterProvider.register('foo', valueFn(function(input) {


### PR DESCRIPTION
When calling `$parse` with `undefined` as the expression and with an interceptor, then when the function is evaluated, then call the interceptor

Closes: #13367
