### PR TITLE
docs(input): ngPattern validates against view value

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1549,7 +1549,7 @@ function checkboxInputType(scope, element, attr, ctrl, $sniffer, $browser, $filt
  * @param {number=} ngMaxlength Sets `maxlength` validation error key if the value is longer than
  *    maxlength. Setting the attribute to a negative or non-numeric value, allows view values of any
  *    length.
- * @param {string=} ngPattern Sets `pattern` validation error key if the ngModel value does not match
+ * @param {string=} ngPattern Sets `pattern` validation error key if the view value does not match
  *    a RegExp found by evaluating the Angular expression given in the attribute value.
  *    If the expression evaluates to a RegExp object, then this is used directly.
  *    If the expression evaluates to a string, then it will be converted to a RegExp


### PR DESCRIPTION
ngPattern doesn't validate modelValue any more,  it validates the viewValue. (https://github.com/angular/angular.js/pull/12640/files#diff-fd9d2cc2d19609321aa0bd5cfa6b3444R46). 

I think it's worth mentioning explicitly, reading "ngModel value", I assumed it was referring to the modelValue.
