### PR TITLE
feat($locale): Include original locale ID in $locale

### DIFF
--- a/i18n/src/closureI18nExtractor.js
+++ b/i18n/src/closureI18nExtractor.js
@@ -161,6 +161,7 @@ function outputLocale(localeInfo, localeID) {
   if (!localeObj.DATETIME_FORMATS) {
     localeObj.DATETIME_FORMATS = fallBackObj.DATETIME_FORMATS;
   }
+  localeObj.localeID = localeID;
   localeObj.id = correctedLocaleId(localeID);
 
   var getDecimals = [


### PR DESCRIPTION
Most systems use _IETF language tag_ codes which are typically a combination of the ISO 639 language code and ISO 3166-1 country code with an underscore or hyphen delimiter. For example `en_US`, `en_AU`, etc.

Whilst the `$locale.id` comes close, the lowercase format makes it impossible to transform to an IETF tag reliably. For example, it would be impossible to deduce `en_Dsrt_US` from `en-dsrt-us`.

It would be very handy for communicating with external systems to be able to pass the IETF tag format, at least with the character casing intact.
