### PR TITLE
feat(numberFilter.formatNumber): add min group size to number patterns

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -183,25 +183,31 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
     var whole = fraction[0];
     fraction = fraction[1] || '';
 
-    var i, pos = 0,
-        lgroup = pattern.lgSize,
-        group = pattern.gSize;
+    // format whole part.
+    var gMinSize = pattern.gMinSize || pattern.gSize;
+    if (whole.length < gMinSize) {
+      formatedText += whole;
+    } else {
+      var i, pos = 0,
+          lgroup = pattern.lgSize,
+          group = pattern.gSize;
 
-    if (whole.length >= (lgroup + group)) {
-      pos = whole.length - lgroup;
-      for (i = 0; i < pos; i++) {
-        if ((pos - i) % group === 0 && i !== 0) {
+      if (whole.length >= (lgroup + group)) {
+        pos = whole.length - lgroup;
+        for (i = 0; i < pos; i++) {
+          if ((pos - i) % group === 0 && i !== 0) {
+            formatedText += groupSep;
+          }
+          formatedText += whole.charAt(i);
+        }
+      }
+
+      for (i = pos; i < whole.length; i++) {
+        if ((whole.length - i) % lgroup === 0 && i !== 0) {
           formatedText += groupSep;
         }
         formatedText += whole.charAt(i);
       }
-    }
-
-    for (i = pos; i < whole.length; i++) {
-      if ((whole.length - i) % lgroup === 0 && i !== 0) {
-        formatedText += groupSep;
-      }
-      formatedText += whole.charAt(i);
     }
 
     // format fraction part.

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -57,6 +57,14 @@ describe('filters', function() {
       pattern.maxFrac = 4;
       num = formatNumber(1.11119, pattern, ',', '.');
       expect(num).toBe('1.1112');
+
+      pattern.gMinSize = 5;
+      num = formatNumber(1234567.89, pattern, ',', '.');
+      expect(num).toBe('12,34,567.89');
+      num = formatNumber(12345.67, pattern, ',', '.');
+      expect(num).toBe('12,345.67');
+      num = formatNumber(1234.56, pattern, ',', '.');
+      expect(num).toBe('1234.56');
     });
 
     it('should format according different separators', function() {


### PR DESCRIPTION
The whole part of Polish numbers are grouped in 3's separated with a space
(and a comma for the decimal separator), but only after there are at least
5 digits in the whole part -
https://pl.wikipedia.org/wiki/Separator_dziesi%C4%99tny:
 3,14
 0,178011392519
 157,3567
 5348,26
 25 772,1
 9 212 345,576213
This change adds a new optional number format property, gMinSize, which if
set causes the whole part of a number to only be grouped if it is greater
than or equal to gMinSize. A separate pull request will be applied to the
I18N project directly to set gMinSize to 5 for Polish locales.
