### PR TITLE
feat(ngView): reference resolved locals in scope

### DIFF
--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -275,6 +275,7 @@ function ngViewFillContentFactory($compile, $controller, $route) {
         $element.data('$ngControllerController', controller);
         $element.children().data('$ngControllerController', controller);
       }
+      scope[current.resolveAs || '$resolve'] = locals;
 
       link(scope);
     }

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -120,6 +120,47 @@ describe('ngView', function() {
   });
 
 
+  it('should reference resolved locals in scope', function() {
+    module(function($routeProvider) {
+      $routeProvider.when('/foo', {
+        resolve: {
+          name: function() {
+            return 'shahar';
+          }
+        },
+        template: '<div>{{$resolve.name}}</div>'
+      });
+    });
+
+    inject(function($location, $rootScope) {
+      $location.path('/foo');
+      $rootScope.$digest();
+      expect(element.text()).toEqual('shahar');
+    });
+  });
+
+
+  it('should allow to provide an alias for resolved locals using resolveAs', function() {
+    module(function($routeProvider) {
+      $routeProvider.when('/foo', {
+        resolveAs: 'myResolve',
+        resolve: {
+          name: function() {
+            return 'shahar';
+          }
+        },
+        template: '<div>{{myResolve.name}}</div>'
+      });
+    });
+
+    inject(function($location, $rootScope) {
+      $location.path('/foo');
+      $rootScope.$digest();
+      expect(element.text()).toEqual('shahar');
+    });
+  });
+
+
   it('should load content via xhr when route changes', function() {
     module(function($routeProvider) {
       $routeProvider.when('/foo', {templateUrl: 'myUrl1'});


### PR DESCRIPTION
this will make it easier to use ng-route with component pattern by being able to configure something like `$routeProvider.when('/', {resolve: {items: ($http) => $http.get(...)}, template: '<my-app items="resolve.items" />'});` and not having to configure a dummy controller that puts the resolved values on the scope.
