### PR TITLE
refactor: single implementation of isPromiseLike()

### DIFF
--- a/lib/promises-aplus/promises-aplus-test-adapter.js
+++ b/lib/promises-aplus/promises-aplus-test-adapter.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var isFunction = function isFunction(value){return typeof value == 'function';};
-var isPromiseLike = function isPromiseLike(obj) {return obj && isFunction(obj.then);};
 var isObject = function isObject(value){return value != null && typeof value === 'object';};
 var isUndefined = function isUndefined(value) {return typeof value === 'undefined';};
 

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -674,7 +674,11 @@ function isBoolean(value) {
 
 
 function isPromiseLike(obj) {
-  return obj && isFunction(obj.then);
+  var then;
+  if (isObject(obj) || isFunction(obj)) {
+    then = obj && obj.then;
+  }
+  return isFunction(then) ? true : false;
 }
 
 

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -354,8 +354,8 @@ function qFactory(nextTick, exceptionHandler) {
       var that = this;
       var done = false;
       try {
-        if ((isObject(val) || isFunction(val))) then = val && val.then;
-        if (isFunction(then)) {
+        if(isPromiseLike(val)) {
+          then = val && val.then
           this.promise.$$state.status = -1;
           then.call(val, resolvePromise, rejectPromise, simpleBind(this, this.notify));
         } else {

--- a/src/ngAnimate/shared.js
+++ b/src/ngAnimate/shared.js
@@ -67,10 +67,6 @@ var ANIMATION_DURATION_PROP = ANIMATION_PROP + DURATION_KEY;
 var TRANSITION_DELAY_PROP = TRANSITION_PROP + DELAY_KEY;
 var TRANSITION_DURATION_PROP = TRANSITION_PROP + DURATION_KEY;
 
-var isPromiseLike = function(p) {
-  return p && p.then ? true : false;
-};
-
 function assertArg(arg, name, reason) {
   if (!arg) {
     throw ngMinErr('areq', "Argument '{0}' is {1}", (name || '?'), (reason || "required"));

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -7,6 +7,35 @@ describe('angular', function() {
     dealoc(element);
   });
 
+  describe('isPromiseLike', function() {
+    it('should work with undefined', function() {
+      expect(isPromiseLike(undefined)).toBeFalsy();
+    });
+
+    it('should work with functions', function() {
+      var a = function() {};
+      expect(isPromiseLike(a)).toBeFalsy();
+      a.then = 'not a function';
+      expect(isPromiseLike(a)).toBeFalsy();
+      a.then = function() {};
+      expect(isPromiseLike(a)).toBeTruthy();
+    });
+
+    it('should work with objects', function() {
+      var a = {};
+      expect(isPromiseLike(a)).toBeFalsy();
+      a.then = 'not a function';
+      expect(isPromiseLike(a)).toBeFalsy();
+      a.then = function() {};
+      expect(isPromiseLike(a)).toBeTruthy();
+    });
+
+    it('should return false for non-promise', function() {
+      var a = "Just a string";
+      expect(isPromiseLike(a)).toBeFalsy();
+    });
+  });
+
   describe('case', function() {
     it('should change case', function() {
       expect(lowercase('ABC90')).toEqual('abc90');


### PR DESCRIPTION
There are multiple different implementations of isPromiseLike(). Change them all to use the one from Angular.js and use the stricter implementation from $q.

Closes #13372
