### PR TITLE
fix($compile): allow compile data to be GCed after a non-clone linking

### DIFF
--- a/docs/content/error/$compile/multilink.ngdoc
+++ b/docs/content/error/$compile/multilink.ngdoc
@@ -1,0 +1,27 @@
+@ngdoc error
+@name $compile:multilink
+@fullName Linking Element Multiple Times
+@description
+
+This error occurs when a single element is linked more then once.
+
+For example, if an element is compiled and linked twice without cloning:
+```
+  var linker = $compile(template);
+  linker($scope); //=> ok
+  linker($scope); //=> multilink error
+```
+
+Linking an element as a clone multiple times is ok:
+```
+  var linker = $compile(template);
+  linker($scope, function() { ... });     //=> ok
+  linker($scope, function() { ... });     //=> ok
+```
+
+However once an element has been linked it can not be re-linked as a clone:
+```
+  var linker = $compile(template);
+  linker($scope);                       //=> ok
+  linker($scope, function() { ... });   //=> multilink error
+```

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1817,6 +1817,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       compile.$$addScopeClass($compileNodes);
       var namespace = null;
       return function publicLinkFn(scope, cloneConnectFn, options) {
+        if (!$compileNodes) {
+          throw $compileMinErr('multilink', 'This element has already been linked.');
+        }
         assertArg(scope, 'scope');
 
         if (previousCompileContext && previousCompileContext.needsNewScope) {
@@ -1871,6 +1874,10 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
         if (cloneConnectFn) cloneConnectFn($linkNode, scope);
         if (compositeLinkFn) compositeLinkFn(scope, $linkNode, $linkNode, parentBoundTranscludeFn);
+
+        if (!cloneConnectFn) {
+          $compileNodes = compositeLinkFn = null;
+        }
         return $linkNode;
       };
     }


### PR DESCRIPTION
This does two things:
- nulls out some data when a non-cloning ~~transclude~~ link completes to allow mainly the ~~`boundTranscludeFn` func/closure~~ `$compileNodes`/`compositeLinkFn` to be GCed
- throws if that ~~transclude~~ link is executed again since that would either re-link the same element or clone the linked element
