### PR TITLE
docs(ngModel.NgModelController): Prevent model overwrite

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -164,7 +164,7 @@ is set to `true`. The parse error is stored in `ngModel.$error.parse`.
 
               // Specify how UI should be updated
               ngModel.$render = function() {
-                element.html($sce.getTrustedHtml(ngModel.$viewValue || ''));
+                element.html($sce.getTrustedHtml(ngModel.$viewValue || element.html()));
                 read(); // initialize
               };
 

--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -165,13 +165,13 @@ is set to `true`. The parse error is stored in `ngModel.$error.parse`.
               // Specify how UI should be updated
               ngModel.$render = function() {
                 element.html($sce.getTrustedHtml(ngModel.$viewValue || ''));
+                read(); // initialize
               };
 
               // Listen for change events to enable binding
               element.on('blur keyup change', function() {
                 scope.$evalAsync(read);
               });
-              read(); // initialize
 
               // Write data to the model
               function read() {


### PR DESCRIPTION
If there are default values in the model, they get overwritten at runtime because the read() function is initiating with a blank element and is assigning that to the model.
