### PR TITLE
docs(guide/Expressions): fixes about void and new operator usage

### DIFF
--- a/docs/content/guide/expression.ngdoc
+++ b/docs/content/guide/expression.ngdoc
@@ -34,10 +34,10 @@ Angular expressions are like JavaScript expressions with the following differenc
 
   * **No RegExp Creation With Literal Notation:** You cannot create regular expressions
     in an Angular expression.
-    
-  * **No object creation with new operator:** You cannot use `new` operator in an Angular expression.
 
-  * **No Comma Operator:** You cannot use `,` in an Angular expression.
+  * **No Object Creation With New Operator:** You cannot use `new` operator in an Angular expression.
+
+  * **No Comma And Void Operators:** You cannot use `,` or `void` operators in an Angular expression.
 
   * **Filters:** You can use {@link guide/filter filters} within expressions to format data before
     displaying it.

--- a/docs/content/guide/expression.ngdoc
+++ b/docs/content/guide/expression.ngdoc
@@ -34,8 +34,10 @@ Angular expressions are like JavaScript expressions with the following differenc
 
   * **No RegExp Creation With Literal Notation:** You cannot create regular expressions
     in an Angular expression.
+    
+  * **No object creation with new operator:** You cannot use `new` operator in an Angular expression.
 
-  * **No Comma And Void Operators:** You cannot use `,` or `void` in an Angular expression.
+  * **No Comma Operator:** You cannot use `,` in an Angular expression.
 
   * **Filters:** You can use {@link guide/filter filters} within expressions to format data before
     displaying it.


### PR DESCRIPTION
1. `void` operator works in angular expressions in all 1.x versions of Angular. For example: expression {{void(2+3)+'x'}} is being interpolated into 'x' without any errors. Documentation incorrectly states that this is impossible.
2. You cannot create new objects inside Angular expressions. For example: {{ new Date() }} expression fails.
