### PR TITLE
feat(ngMock): destroy $rootScope after each test

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2480,6 +2480,7 @@ if (window.jasmine || window.mocha) {
 
     if (injector) {
       injector.get('$rootElement').off();
+      injector.get('$rootScope').$destroy();
     }
 
     // clean up jquery's fragment cache

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1650,6 +1650,21 @@ describe('ngMock', function() {
   });
 
 
+  describe('$rootScope', function() {
+    var destroyed = false;
+
+    it('should destroy $rootScope after each test', inject(function($rootScope) {
+      $rootScope.$on('$destroy', function() {
+        destroyed = true;
+      });
+    }));
+
+    it('should have destroyed the $rootScope from the previous test', function() {
+      expect(destroyed).toBe(true);
+    });
+  });
+
+
   describe('$rootScopeDecorator', function() {
 
     describe('$countChildScopes', function() {


### PR DESCRIPTION
Previously $rootScope would be new for each test, but old $rootScopes would never be destroyed.
Now that we are able to destroy the $rootScope, doing so provides an opportunity for code to clean
up things like long-lived event handlers between tests.
