### PR TITLE
docs($cacheFactory.Cache): Providing more clarity about the cache obj…

### DIFF
--- a/src/ng/cacheFactory.js
+++ b/src/ng/cacheFactory.js
@@ -106,9 +106,9 @@ function $CacheFactoryProvider() {
        * @description
        * A cache object used to store and retrieve data, primarily used by
        * {@link $http $http} and the {@link ng.directive:script script} directive to cache
-       * templates and other data. Do not confuse this cache object with the browser cache. 
-       * It is a standard Javascript heap memory object. Hence, refreshing the page will also 
-       * reinitialize this cache object's values. 
+       * templates and other data. Do not confuse this cache object with the browser cache.
+       * It is a standard Javascript heap memory object. Hence, refreshing the page will also
+       * reinitialize this cache object's values.
        *
        * ```js
        *  angular.module('superCache')

--- a/src/ng/cacheFactory.js
+++ b/src/ng/cacheFactory.js
@@ -106,7 +106,9 @@ function $CacheFactoryProvider() {
        * @description
        * A cache object used to store and retrieve data, primarily used by
        * {@link $http $http} and the {@link ng.directive:script script} directive to cache
-       * templates and other data.
+       * templates and other data. Do not confuse this cache object with the browser cache. 
+       * It is a standard Javascript heap memory object. Hence, refreshing the page will also 
+       * reinitialize this cache object's values. 
        *
        * ```js
        *  angular.module('superCache')


### PR DESCRIPTION
Many AngularJS users/developers are confused with the names $cacheFactory.Cache, $templateCache, etc. They strongly believe that it is the browser's native cache. Hence, this part of the doc requires immediate updation. 

References: 
https://github.com/angular/angular.js/blob/v1.4.8/src/Angular.js#L1834
https://github.com/angular/angular.js/blob/v1.4.8/src/ng/cacheFactory.js#L96
https://github.com/angular/angular.js/blob/v1.4.8/src/ng/cacheFactory.js#L242
