### PR TITLE
Interpoilate directive controller name

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2083,7 +2083,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
           var controller = directive.controller;
           if (controller == '@') {
-            controller = attrs[directive.name];
+            controller = $interpolate(attrs[directive.name])(locals.$scope);
           }
 
           var controllerInstance = $controller(controller, locals, true, directive.controllerAs);


### PR DESCRIPTION
In directive `xDir` directive if you have:

``` javascript
restrict: 'E',
scope: true,
controller: '@',
name: 'component',
```

Then you shall be able to pass controller name dynamically, like:

``` html
<x-dir component="{{'a' + 'b'}}"></x-dir>
```

This way I'll be able to use `ab` controller in directive.
