### PR TITLE
docs($resource): fix mixed singular/plural

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -99,7 +99,7 @@ function shallowClearAndCopy(src, dst) {
  *   can escape it with `/\.`.
  *
  * @param {Object=} paramDefaults Default values for `url` parameters. These can be overridden in
- *   `actions` methods. If any of the parameter value is a function, it will be executed every time
+ *   `actions` methods. If a parameter value is a function, it will be executed every time
  *   when a param value needs to be obtained for a request (unless the param was overridden).
  *
  *   Each key value in the parameter object is first bound to url template if present and then any


### PR DESCRIPTION
fix "any of the parameter value" to be singular to match the rest of the text block
