### PR TITLE
fix($sanitize): blacklist SVG `<use>` elements

### DIFF
--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -242,7 +242,7 @@ var inlineElements = angular.extend({}, optionalEndTagInlineElements, toMap("a,a
 // They can potentially allow for arbitrary javascript to be executed. See #11290
 var svgElements = toMap("circle,defs,desc,ellipse,font-face,font-face-name,font-face-src,g,glyph," +
         "hkern,image,linearGradient,line,marker,metadata,missing-glyph,mpath,path,polygon,polyline," +
-        "radialGradient,rect,stop,svg,switch,text,title,tspan,use");
+        "radialGradient,rect,stop,svg,switch,text,title,tspan");
 
 // Blocked Elements (will be stripped)
 var blockedElements = toMap("script,style");

--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -292,6 +292,13 @@ describe('HTML', function() {
                    '<svg xmlns="http://www.w3.org/2000/svg"><a xlink:href="?" xmlns:xlink="http://www.w3.org/1999/xlink"><circle r="400"></circle></a></svg>',
                    '<svg xmlns="http://www.w3.org/2000/svg"><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="?"><circle r="400"></circle></a></svg>');
     });
+
+    it('should not accept SVG `use` tags', function() {
+      expectHTML('<svg><use xlink:href="test.svg#xss" /></svg>')
+        .toBeOneOf('<svg></svg>',
+                   '<svg xmlns:xlink="http://www.w3.org/1999/xlink"></svg>',
+                   '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    });
   });
 
 


### PR DESCRIPTION
The use element can reference external svg's (same origin) and can include
xlink javascript urls or foreign object that can execute xss.

This change disallows `<use>` elements in sanitized SVG markup.

An example of a malicious SVG document would be:

SVG to sanitize:

```
<svg><use xlink:href="test.svg#xss" /></svg>
```

External SVG file (test.svg)

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<svg xmlns:svg="http://www.w3.org/2000/svg"
   xmlns="http://www.w3.org/2000/svg" width="100"
   height="100"
   id="xss">
<a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="javascript:alert(1)">
  <circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" />
</a>
</svg>
```

Here the SVG to sanitize loads in the `test.svg` file via the `<use>` element.
The sanitizer is not able to parse this file, which contains malicious
executable mark-up.

This can only be taken advantage of if the external file is available via the
same origin restrictions in place.
