### PR TITLE
fix($animateCss): remove animation end event listeners on close

### DIFF
--- a/test/ngAnimate/.jshintrc
+++ b/test/ngAnimate/.jshintrc
@@ -8,6 +8,10 @@
     "applyAnimationStyles": false,
     "applyAnimationFromStyles": false,
     "applyAnimationToStyles": false,
-    "applyAnimationClassesFactory": false
+    "applyAnimationClassesFactory": false,
+    "TRANSITIONEND_EVENT": false,
+    "TRANSITION_PROP": false,
+    "ANIMATION_PROP": false,
+    "ANIMATIONEND_EVENT": false
   }
 }


### PR DESCRIPTION
Previously the transition/animation end events were not removed when the
animation was closed. This normally didn't matter, because
the close function knows the animation are closed and won't do work
twice.
However, the listeners themselves do computation that could fail when
the event was missing some data, for example when the event was
triggered instead of natural.

Closes #10387
