### PR TITLE
fix($resource): remove (broken) support for promises as `timeout`

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -568,17 +568,8 @@ angular.module('ngResource', ['ng']).
               undefined;
 
             forEach(action, function(value, key) {
-              switch (key) {
-                default:
-                  httpConfig[key] = copy(value);
-                  break;
-                case 'params':
-                case 'isArray':
-                case 'interceptor':
-                  break;
-                case 'timeout':
-                  httpConfig[key] = value;
-                  break;
+              if (key != 'params' && key != 'isArray' && key != 'interceptor') {
+                httpConfig[key] = copy(value);
               }
             });
 

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -150,8 +150,11 @@ function shallowClearAndCopy(src, dst) {
  *     GET request, otherwise if a cache instance built with
  *     {@link ng.$cacheFactory $cacheFactory}, this cache will be used for
  *     caching.
- *   - **`timeout`** – `{number|Promise}` – timeout in milliseconds, or {@link ng.$q promise} that
- *     should abort the request when resolved.
+ *   - **`timeout`** – `{number}` – timeout in milliseconds.<br />
+ *     **Note:** In contrast to {@link ng.$http#usage $http.config}, {@link ng.$q promises} are
+ *     **not** supported in $resource, because the same value would be used for multiple requests.
+ *     If you need support for cancellable $resource actions, you should upgrade to version 1.5 or
+ *     higher.
  *   - **`withCredentials`** - `{boolean}` - whether to set the `withCredentials` flag on the
  *     XHR object. See
  *     [requests with credentials](https://developer.mozilla.org/en/http_access_control#section_5)

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -368,7 +368,7 @@ angular.module('ngResource', ['ng']).
       }
     };
 
-    this.$get = ['$http', '$q', function($http, $q) {
+    this.$get = ['$http', '$log', '$q', function($http, $log, $q) {
 
       var noop = angular.noop,
         forEach = angular.forEach,
@@ -578,6 +578,16 @@ angular.module('ngResource', ['ng']).
                 case 'params':
                 case 'isArray':
                 case 'interceptor':
+                  break;
+                case 'timeout':
+                  if (value && !angular.isNumber(value)) {
+                    $log.debug('ngResource:\n' +
+                        '  Only numeric values are allowed as `timeout`.\n' +
+                        '  Promises are not supported in $resource, because the same value would ' +
+                        'be used for multiple requests.\n' +
+                        '  If you need support for cancellable $resource actions, you should ' +
+                        'upgrade to version 1.5 or higher.');
+                  }
                   break;
               }
             });

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -568,8 +568,14 @@ angular.module('ngResource', ['ng']).
               undefined;
 
             forEach(action, function(value, key) {
-              if (key != 'params' && key != 'isArray' && key != 'interceptor') {
-                httpConfig[key] = copy(value);
+              switch (key) {
+                default:
+                  httpConfig[key] = copy(value);
+                  break;
+                case 'params':
+                case 'isArray':
+                case 'interceptor':
+                  break;
               }
             });
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1308,7 +1308,7 @@ describe("resource", function() {
 });
 
 describe('resource', function() {
-  var $httpBackend, $resource, $q;
+  var $httpBackend, $resource;
 
   beforeEach(module(function($exceptionHandlerProvider) {
     $exceptionHandlerProvider.mode('log');
@@ -1319,7 +1319,6 @@ describe('resource', function() {
   beforeEach(inject(function($injector) {
     $httpBackend = $injector.get('$httpBackend');
     $resource = $injector.get('$resource');
-    $q = $injector.get('$q');
   }));
 
 
@@ -1355,35 +1354,6 @@ describe('resource', function() {
     expect(failureSpy.mostRecentCall.args[0]).toMatch(
         /^\[\$resource:badcfg\] Error in resource configuration for action `get`\. Expected response to contain an object but got an array \(Request: GET \/Customer\/123\)/
       );
-  });
-
-  it('should cancel the request if timeout promise is resolved', function() {
-    var canceler = $q.defer();
-
-    $httpBackend.when('GET', '/CreditCard').respond({data: '123'});
-
-    var CreditCard = $resource('/CreditCard', {}, {
-      query: {
-        method: 'GET',
-        timeout: canceler.promise
-      }
-    });
-
-    CreditCard.query();
-
-    canceler.resolve();
-    expect($httpBackend.flush).toThrow(new Error("No pending request to flush !"));
-
-    canceler = $q.defer();
-    CreditCard = $resource('/CreditCard', {}, {
-      query: {
-        method: 'GET',
-        timeout: canceler.promise
-      }
-    });
-
-    CreditCard.query();
-    expect($httpBackend.flush).not.toThrow();
   });
 
 


### PR DESCRIPTION
This fixes #13393 by:
1. Reverting 7170f9d.
2. Update the docs to note that promise as timeout is not supported.
3. Log a warning when someone tries to use it.

The commits could/should be squashed before merging. We probably need a BC notice (since the broken support for promises as `timeout` has sneaked into `v1.4.8`, right ?
