### PR TITLE
Fix $animate.pin() to work with nested elements

### DIFF
--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -586,6 +586,7 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
             parentHost = parentElement.data(NG_ANIMATE_PIN_DATA);
             if (parentHost) {
               parentElement = parentHost;
+              rootElementDetected = true;
             }
           }
         }

--- a/src/ngAnimate/shared.js
+++ b/src/ngAnimate/shared.js
@@ -73,6 +73,7 @@ var isPromiseLike = function(p) {
   return p && p.then ? true : false;
 };
 
+var ngMinErr = angular.$$minErr('ng');
 function assertArg(arg, name, reason) {
   if (!arg) {
     throw ngMinErr('areq', "Argument '{0}' is {1}", (name || '?'), (reason || "required"));

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1448,28 +1448,46 @@ describe("animations", function() {
     }));
 
 
-    it('should allow an element to be pinned elsewhere and still be available in animations',
-      inject(function($animate, $compile, $document, $rootElement, $rootScope) {
+    they('should animate an element inside a pinned element that is the $prop element',
+      ['same', 'parent', 'grandparent'],
+      function(elementRelation) {
+        inject(function($animate, $compile, $document, $rootElement, $rootScope) {
 
-      var innerParent = jqLite('<div></div>');
-      jqLite($document[0].body).append(innerParent);
-      innerParent.append($rootElement);
+        var pinElement, animateElement;
 
-      var element = jqLite('<div></div>');
-      jqLite($document[0].body).append(element);
+        var innerParent = jqLite('<div></div>');
+        jqLite($document[0].body).append(innerParent);
+        innerParent.append($rootElement);
 
-      $animate.addClass(element, 'red');
-      $rootScope.$digest();
-      expect(capturedAnimation).toBeFalsy();
+        switch (elementRelation) {
+          case 'same':
+            pinElement = jqLite('<div id="animate"></div>');
+            break;
+          case 'parent':
+            pinElement = jqLite('<div><div id="animate"></div></div>');
+            break;
+          case 'grandparent':
+            pinElement = jqLite('<div><div><div id="animate"></div></div></div>');
+            break;
+        }
 
-      $animate.pin(element, $rootElement);
+        jqLite($document[0].body).append(pinElement);
+        animateElement = jqLite($document[0].getElementById('animate'));
 
-      $animate.addClass(element, 'blue');
-      $rootScope.$digest();
-      expect(capturedAnimation).toBeTruthy();
+        $animate.addClass(animateElement, 'red');
+        $rootScope.$digest();
+        expect(capturedAnimation).toBeFalsy();
 
-      dealoc(element);
-    }));
+        // Pin the element to the app root to enable animations
+        $animate.pin(pinElement, $rootElement);
+
+        $animate.addClass(animateElement, 'blue');
+        $rootScope.$digest();
+        expect(capturedAnimation).toBeTruthy();
+
+        dealoc(pinElement);
+      });
+    });
 
     it('should adhere to the disabled state of the hosted parent when an element is pinned',
       inject(function($animate, $compile, $document, $rootElement, $rootScope) {

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1431,7 +1431,24 @@ describe("animations", function() {
       });
     }));
 
-    it('should allow an element to pinned elsewhere and still be available in animations',
+    it('should throw if the arguments are not elements',
+      inject(function($animate, $compile, $document, $rootScope, $rootElement) {
+
+      var element = jqLite('<div></div>');
+
+      expect(function() {
+        $animate.pin(element);
+      }).toThrowMinErr('ng', 'areq', 'Argument \'parentElement\' is not an element');
+
+      expect(function() {
+        $animate.pin(null, $rootElement);
+      }).toThrowMinErr('ng', 'areq', 'Argument \'element\' is not an element');
+
+      dealoc(element);
+    }));
+
+
+    it('should allow an element to be pinned elsewhere and still be available in animations',
       inject(function($animate, $compile, $document, $rootElement, $rootScope) {
 
       var innerParent = jqLite('<div></div>');


### PR DESCRIPTION
Given the following DOM structure:

```
- e1
  -e2
    -e3 <--- pin this
      e4 <-- animate this
```

the function that is responsible for finding the parent element that is pinned to the app root would find e3, set it as parent, but not indicate that a rootElement had been found.

The PR also contains a second commit that adds a test and fixes a use of minErr inside ngAnimate.
