### PR TITLE
fix(ngOptions): unset [selected] on unselected empty option

### DIFF
--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -446,6 +446,9 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
       var removeEmptyOption = function() {
         if (!providedEmptyOption) {
           emptyOption.remove();
+        } else {
+          emptyOption.prop('selected', false);
+          emptyOption.attr('selected', false);
         }
       };
 

--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -447,8 +447,8 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
         if (!providedEmptyOption) {
           emptyOption.remove();
         } else {
+          emptyOption.removeAttr('selected');
           emptyOption.prop('selected', false);
-          emptyOption.attr('selected', false);
         }
       };
 

--- a/test/ng/directive/ngOptionsSpec.js
+++ b/test/ng/directive/ngOptionsSpec.js
@@ -2217,6 +2217,23 @@ describe('ngOptions', function() {
       dealoc(element);
     }));
 
+    // See issue #13331
+    it('should set [selected] to false when a genuine option is selected', function() {
+      scope.options = ['a'];
+      scope.model = '';
+      compile(
+          '<select ng-model="model" ng-options="opt for opt in options">' +
+            '<option value="">Empty Option</option>' +
+          '</select>');
+      var opt = element.find("option")[0];
+      expect(opt.hasAttribute('selected')).toBeTruthy();
+      expect(opt.selected).toBeTruthy();
+      scope.model = 'a';
+      scope.$digest();
+      expect(opt.hasAttribute('selected')).toBeFalsy();
+      expect(opt.selected).toBeFalsy();
+    });
+
   });
 
 


### PR DESCRIPTION
(Cleaned up version of #13331)

Firefox (verified on versions 38..42, Windows and Linux-AMD64) can get
confused about what option is selected after options ngOptions populates
the select control when it has a empty option that is ng-disabled.  It
appears to think both the empty option added by ngOptions and the one
selected by ngModel are selected.  The trigger seems to be angular
leaving the empty option both selected and disabled.

This patch works around the problem.
