### PR TITLE
fix(ngOptions): add ngEmptyValue attribute to ngOptions

### DIFF
--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -493,7 +493,8 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
           }
         };
 
-        var emptyValueParseFn = 'ngEmptyValue' in attr && attr.ngEmptyValue.length > 0 && $parse(attr.ngEmptyValue);
+        var emptyValueParseFn = 'ngEmptyValue' in attr && attr.ngEmptyValue.length > 0
+                                && $parse(attr.ngEmptyValue);
 
         selectCtrl.readValue = function readNgOptionsValue() {
 

--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -493,10 +493,12 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
           }
         };
 
+        var emptyValueParseFn = 'ngEmptyValue' in attr && attr.ngEmptyValue.length > 0 && $parse(attr.ngEmptyValue);
+
         selectCtrl.readValue = function readNgOptionsValue() {
 
           // Allow a default value to be substituted for any options with empty values
-          if (selectElement.val() === '') return $parse(attr.ngEmptyValue)(scope);
+          if (selectElement.val() === '' && emptyValueParseFn) return emptyValueParseFn(scope);
 
           var selectedOption = options.selectValueMap[selectElement.val()];
 

--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -31,6 +31,9 @@ var ngOptionsMinErr = minErr('ngOptions');
  * be nested into the `<select>` element. This element will then represent the `null` or "not selected"
  * option. See example below for demonstration.
  *
+ * Additionally, a default value can be specified for empty options using the `ng-empty-value` attribute.
+ * See Usage section for more details.
+ *
  * ## Complex Models (objects or collections)
  *
  * By default, `ngModel` watches the model by reference, not value. This is important to know when
@@ -155,6 +158,9 @@ var ngOptionsMinErr = minErr('ngOptions');
  *      used to identify the objects in the array. The `trackexpr` will most likely refer to the
  *     `value` variable (e.g. `value.propertyName`). With this the selection is preserved
  *      even when the options are recreated (e.g. reloaded from the server).
+ *
+ * @param {expression=} ngEmptyValue When an option with empty value is selected, whether hardcoded or created
+ *    with ngOptions, the associated ngModel will be assigned the result of this expression.
  *
  * @example
     <example module="selectExample">
@@ -488,6 +494,9 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
         };
 
         selectCtrl.readValue = function readNgOptionsValue() {
+
+          // Allow a default value to be substituted for any options with empty values
+          if (selectElement.val() === '') return $parse(attr.ngEmptyValue)(scope);
 
           var selectedOption = options.selectValueMap[selectElement.val()];
 

--- a/test/ng/directive/ngOptionsSpec.js
+++ b/test/ng/directive/ngOptionsSpec.js
@@ -2143,6 +2143,26 @@ describe('ngOptions', function() {
       expect(scope.selected).toEqual([]);
     });
 
+    it('should be possible to specify a value for empty options', function() {
+      var html = '<select ng-model="someModel" ng-options="c for c in choices" ng-empty-value="someVar">' +
+                   '<option value="">Choose One</option>' +
+                 '</select>';
+      compile(html);
+      scope.$apply(function() {
+        scope.choices = ['A','B','C'];
+        scope.someModel = "";
+        scope.someVar = "foo";
+      });
+      //current implementation only works if select is not pristine, so we click it back and forth
+      setSelectValue(element, 3);
+      setSelectValue(element, 0);
+
+      //make sure the empty value is being evaluated as an Angular expression
+      expect(scope.someModel).toBe("foo");
+
+      dealoc(element);
+
+    });
 
     it('should be possible to use ngIf in the blank option', function() {
       var option;

--- a/test/ng/directive/ngOptionsSpec.js
+++ b/test/ng/directive/ngOptionsSpec.js
@@ -2144,13 +2144,15 @@ describe('ngOptions', function() {
     });
 
     it('should be possible to specify a value for empty options', function() {
-      var html = '<select ng-model="someModel" ng-options="c for c in choices" ng-empty-value="someVar">' +
-                   '<option value="">Choose One</option>' +
-                 '</select>';
-      compile(html);
+      createSelect({
+        'ng-model':'selected',
+        'ng-empty-value': 'someVar',
+        'ng-options':'c for c in choices'
+      }, true);
+
       scope.$apply(function() {
         scope.choices = ['A','B','C'];
-        scope.someModel = "";
+        scope.selected = "";
         scope.someVar = "foo";
       });
       //current implementation only works if select is not pristine, so we click it back and forth
@@ -2158,9 +2160,17 @@ describe('ngOptions', function() {
       setSelectValue(element, 0);
 
       //make sure the empty value is being evaluated as an Angular expression
-      expect(scope.someModel).toBe("foo");
+      expect(scope.selected).toBe("foo");
 
-      dealoc(element);
+      //make sure a change to the value given in ng-empty-value also changes the model
+      scope.$apply(function() {
+        scope.someVar = "bar";
+      });
+
+      setSelectValue(element, 3);
+      setSelectValue(element, 0);
+
+      expect(scope.selected).toBe("bar");
 
     });
 


### PR DESCRIPTION
Reference: angular#13334

This would allow an additional attribute on ng-options to provide a default value for options that lack values.
