### PR TITLE
docs(ngTransclude): name value pair were the wrong way round

### DIFF
--- a/src/ng/directive/ngTransclude.js
+++ b/src/ng/directive/ngTransclude.js
@@ -126,9 +126,9 @@
  *        return {
  *          restrict: 'E',
  *          transclude: {
- *            'title': '?paneTitle',
- *            'body': 'paneBody',
- *            'footer': '?paneFooter'
+ *            'paneTitle': '?title',
+ *            'paneBody': 'body',
+ *            'paneFooter': '?footer'
  *          },
  *          template: '<div style="border: 1px solid black;">' +
  *                      '<div class="title" ng-transclude="title">Fallback Title</div>' +


### PR DESCRIPTION
The plunker associated with multiple transcludes fails because of this error.
