### PR TITLE
fix($compile): Fix namespace detection for achor elements

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1396,7 +1396,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       if (!node) {
         return 'html';
       } else {
-        return nodeName_(node) !== 'foreignobject' && node.toString().match(/SVG/) ? 'svg' : 'html';
+        return nodeName_(node) !== 'foreignobject' && toString.call(node).match(/SVG/) ? 'svg' : 'html';
       }
     }
 

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -281,7 +281,7 @@ var ngIncludeFillContentDirective = ['$compile',
       priority: -400,
       require: 'ngInclude',
       link: function(scope, $element, $attr, ctrl) {
-        if (/SVG/.test($element[0].toString())) {
+        if (toString.call($element[0]).match(/SVG/)) {
           // WebKit: https://bugs.webkit.org/show_bug.cgi?id=135698 --- SVG elements do not
           // support innerHTML, so detect this here and try to generate the contents
           // specially.

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -360,7 +360,6 @@ describe('$compile', function() {
     });
   });
 
-
   describe('compile phase', function() {
 
     it('should attach scope to the document node when it is compiled explicitly', inject(function($document) {
@@ -444,6 +443,15 @@ describe('$compile', function() {
       expect(element.html()).toBe("3");
     }));
 
+    it('transclusions should not detect parent anchor elements as SVGs', inject(function($compile, $rootScope) {
+      element = jqLite('<div><a href="/ID_SVG_ID">' +
+        '<span ng-if="true">Should render</span>' +
+        '</a></div>');
+      $compile(element.contents())($rootScope);
+      $rootScope.$digest();
+      document.body.appendChild(element[0]);
+      expect(element.find('span').text()).toContain('Should render');
+    }));
 
     describe('multiple directives per element', function() {
       it('should allow multiple directives per element', inject(function($compile, $rootScope, log) {


### PR DESCRIPTION
Fixed a bug where anchor elements with `SVG` in the href attribute got incorrectly detected as svgs. Seems the detection only happens when the anchor element has a child that needs to be transcluded.

Calling `node.toString()` on a anchor returns the `href` value instead of the expected `[object HTMLAnchorElement]`.

Added a test for this edge case.

Plunker to reproduce: http://plnkr.co/edit/OBgCS8phjTwMTFYwhk6D
