### PR TITLE
fix(ngInclude): add a return in a promise handler

### DIFF
--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -252,6 +252,7 @@ var ngIncludeDirective = ['$templateRequest', '$anchorScroll', '$animate',
 
               currentScope.$emit('$includeContentLoaded', src);
               scope.$eval(onloadExp);
+              return null;
             }, function() {
               if (thisChangeId === changeCounter) {
                 cleanupLastIncludeContent();


### PR DESCRIPTION
Since bluebird 3, when a promise is created within another promise handler, and nothing is returned from it, the library prints a warning.

See related issue https://github.com/petkaantonov/bluebird/issues/846
