### PR TITLE
fix: Use Date.now() instead of Event.timeStamp to detect animation end

### DIFF
--- a/src/ngAnimate/animateCss.js
+++ b/src/ngAnimate/animateCss.js
@@ -792,7 +792,7 @@ var $AnimateCssProvider = ['$animateProvider', function($animateProvider) {
       function onAnimationProgress(event) {
         event.stopPropagation();
         var ev = event.originalEvent || event;
-        var timeStamp = ev.$manualTimeStamp || ev.timeStamp || Date.now();
+        var timeStamp = ev.$manualTimeStamp || Date.now();
 
         /* Firefox (or possibly just Gecko) likes to not round values up
          * when a ms measurement is used for the animation */


### PR DESCRIPTION
Chrome and Firefox are planning to change event.timeStamp to be a
high resolution time instead of epoch time. This means that the
event.timeStamp will not longer be compatible with Date.now()[1, 2]

Instead we can use Date.now() at the moment when the event is
received by event listener instead.

This addresses  https://github.com/angular/angular.js/issues/13496

[1] http://crbug.com/538600
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1231619#c3
