### PR TITLE
Update animateCss.js to not remove events from elements

### DIFF
--- a/src/ngAnimate/animateCss.js
+++ b/src/ngAnimate/animateCss.js
@@ -750,7 +750,7 @@ var $AnimateCssProvider = ['$animateProvider', function($animateProvider) {
         }
 
         // Remove the transitionend / animationend listener(s)
-        if (events) {
+        if (events && events.length) {
           element.off(events.join(' '), onAnimationProgress);
         }
 


### PR DESCRIPTION
animateCss currently removes all events from and element during close().  We should check if any animationend events have occured by checking the length of the events array, rather than its truthiness.
