### PR TITLE
fix(jqLite): don't deregister all listeners when calling off with ''

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -312,7 +312,7 @@ function jqLiteOff(element, type, fn, unsupported) {
 
   if (!handle) return; //no listeners registered
 
-  if (!type) {
+  if (isUndefined(type)) {
     for (type in events) {
       if (type !== '$destroy') {
         removeEventListenerFn(element, type, handle);

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1345,6 +1345,29 @@ describe('jqLite', function() {
       expect(mouseoverSpy).not.toHaveBeenCalled();
     });
 
+    it('should not deregister any listeners when called with empty string', function() {
+      var aElem = jqLite(a),
+          clickSpy = jasmine.createSpy('click'),
+          mouseoverSpy = jasmine.createSpy('mouseover');
+
+      aElem.on('click', clickSpy);
+      aElem.on('mouseover', mouseoverSpy);
+
+      browserTrigger(a, 'click');
+      expect(clickSpy).toHaveBeenCalledOnce();
+      browserTrigger(a, 'mouseover');
+      expect(mouseoverSpy).toHaveBeenCalledOnce();
+
+      clickSpy.reset();
+      mouseoverSpy.reset();
+
+      aElem.off('');
+
+      browserTrigger(a, 'click');
+      expect(clickSpy).toHaveBeenCalledOnce();
+      browserTrigger(a, 'mouseover');
+      expect(mouseoverSpy).toHaveBeenCalledOnce();
+    });
 
     it('should deregister listeners for specific type', function() {
       var aElem = jqLite(a),


### PR DESCRIPTION
.off should only deregister all events when the first argument is undefined.
