### PR TITLE
fix(ngMock): trigger digest with `$httpBackend.verifyNoOutstandingRequest`

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1742,7 +1742,8 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
    *   afterEach($httpBackend.verifyNoOutstandingRequest);
    * ```
    */
-  $httpBackend.verifyNoOutstandingRequest = function() {
+  $httpBackend.verifyNoOutstandingRequest = function(digest) {
+    if (digest !== false) $rootScope.$digest();
     if (responses.length) {
       throw new Error('Unflushed requests: ' + responses.length);
     }


### PR DESCRIPTION
To be consistent with `$httpBackend.verifyNoOutstandingExpectation` and `$httpBackend.flush`
Fixes #13506 
