### PR TITLE
chore(travis/build.sh): move ddescribe check before unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ branches:
 
 env:
   matrix:
+    - JOB=ci-checks
     - JOB=unit BROWSER_PROVIDER=saucelabs
     - JOB=docs-e2e BROWSER_PROVIDER=saucelabs
     - JOB=e2e TEST_TARGET=jqlite BROWSER_PROVIDER=saucelabs
@@ -51,11 +52,7 @@ install:
   - npm install
 
 before_script:
-  - mkdir -p $LOGS_DIR
-  - ./scripts/travis/start_browser_provider.sh
-  - npm install -g grunt-cli
-  - grunt package
-  - ./scripts/travis/wait_for_browser_provider.sh
+  - ./scripts/travis/before_build.sh
 
 script:
   - ./scripts/travis/build.sh

--- a/scripts/travis/before_build.sh
+++ b/scripts/travis/before_build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p $LOGS_DIR
+
+if [ $JOB != "ci-checks" ]; then
+  echo "start_browser_provider"
+  ./scripts/travis/start_browser_provider.sh
+fi
+
+npm install -g grunt-cli
+
+if [ $JOB != "ci-checks" ]; then
+  grunt package
+  echo "wait_for_browser_provider"
+  ./scripts/travis/wait_for_browser_provider.sh
+fi

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -5,7 +5,9 @@ set -e
 export BROWSER_STACK_ACCESS_KEY=`echo $BROWSER_STACK_ACCESS_KEY | rev`
 export SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
 
-if [ $JOB = "unit" ]; then
+if [ $JOB = "ci-checks" ]; then
+  grunt ci-checks
+elif [ $JOB = "unit" ]; then
   if [ "$BROWSER_PROVIDER" == "browserstack" ]; then
     BROWSERS="BS_Chrome,BS_Safari,BS_Firefox,BS_IE_9,BS_IE_10,BS_IE_11,BS_iOS"
   else
@@ -14,7 +16,6 @@ if [ $JOB = "unit" ]; then
 
   grunt test:promises-aplus
   grunt test:unit --browsers $BROWSERS --reporters dots
-  grunt ci-checks
   grunt tests:docs --browsers $BROWSERS --reporters dots
 elif [ $JOB = "docs-e2e" ]; then
   grunt test:travis-protractor --specs "docs/app/e2e/**/*.scenario.js"


### PR DESCRIPTION
This was changed as part of https://github.com/angular/angular.js/pull/9792.
While the logic is sound that style errors shouldn't block tests from
running, ddescribe should run before the tests.
Otherwise, when Travis exits with a warning after some browsers have run,
ddescribe doesn't get run and it doesn't immediately become apparent
that not all tests have run.
