### PR TITLE
Bugfix - Typos

### DIFF
--- a/docs/app/assets/css/docs.css
+++ b/docs/app/assets/css/docs.css
@@ -124,7 +124,7 @@ h1,h2,h3,h4,h5,h6 {
   font-size:1.2em;
   padding:0;
   margin:0;
-  border-bottom:1px soild #aaa;
+  border-bottom:1px solid #aaa;
   margin-bottom:5px;
 }
 

--- a/docs/config/templates/runnableExample.template.html
+++ b/docs/config/templates/runnableExample.template.html
@@ -1,4 +1,4 @@
-{# Be aware that we need these extra new lines here or marked will not realise that the <div>
+{# Be aware that we need these extra new lines here or marked will not realize that the <div>
    is HTML and wrap each line in a <p> - thus breaking the HTML #}
 
 <div>
@@ -24,5 +24,5 @@
   </div>
 </div>
 
-{# Be aware that we need these extra new lines here or marked will not realise that the <div>
+{# Be aware that we need these extra new lines here or marked will not realize that the <div>
    above is HTML and wrap each line in a <p> - thus breaking the HTML #}

--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -593,7 +593,7 @@ function annotate(fn, strictDi, name) {
  * @description
  *
  * Register a **service decorator** with the {@link auto.$injector $injector}. A service decorator
- * intercepts the creation of a service, allowing it to override or modify the behaviour of the
+ * intercepts the creation of a service, allowing it to override or modify the behavior of the
  * service. The object returned by the decorator may be the original service, or a new service
  * object which replaces or wraps and delegates to the original service.
  *

--- a/test/ng/animateSpec.js
+++ b/test/ng/animateSpec.js
@@ -122,7 +122,7 @@ describe("$animate", function() {
       });
       inject(function() {
         // by using hasOwnProperty we know for sure that the lookup object is an empty object
-        // instead of inhertiting properties from its original prototype.
+        // instead of inheriting properties from its original prototype.
         expect(provider.$$registeredAnimations.hasOwnProperty).toBeFalsy();
 
         provider.register('.filter', noop);

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3944,7 +3944,7 @@ describe('$compile', function() {
 
         compile('<div><span my-component ref="name">');
 
-        //change both sides to the same item withing the same digest cycle
+        //change both sides to the same item within the same digest cycle
         componentScope.ref = 'same';
         $rootScope.name = 'same';
         $rootScope.$apply();
@@ -6213,7 +6213,7 @@ describe('$compile', function() {
             var currentCleanData = jQuery.cleanData;
             jQuery.cleanData = function(elems) {
               cleanedCount += elems.length;
-              // Don't return the output and expicitly pass only the first parameter
+              // Don't return the output and explicitly pass only the first parameter
               // so that we're sure we're not relying on either of them. jQuery UI patch
               // behaves in this way.
               currentCleanData(elems);

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -885,7 +885,7 @@ describe('form', function() {
       expect(doc.hasClass('ng-valid-another')).toBe(true);
       expect(doc.hasClass('ng-invalid-another')).toBe(false);
 
-      // validators are skipped, e.g. becuase of a parser error
+      // validators are skipped, e.g. because of a parser error
       control.$setValidity('error', null);
       control.$setValidity('another', null);
       scope.$digest();

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -122,7 +122,7 @@ describe('input', function() {
     //  focus (which visually removes the placeholder value): focusin focus *input*
     //  blur (which visually creates the placeholder value):  focusout *input* blur
     //However none of these occur if the placeholder is not visible at the time of the event.
-    //These tests try simulate various scenerios which do/do-not fire the extra input event
+    //These tests try simulate various scenarios which do/do-not fire the extra input event
 
     it('should not dirty the model on an input event in response to a placeholder change', function() {
       var inputElm = helper.compileInput('<input type="text" placeholder="Test" attr-capture ng-model="unsetValue" name="name" />');

--- a/test/ng/directive/ngSwitchSpec.js
+++ b/test/ng/directive/ngSwitchSpec.js
@@ -273,7 +273,7 @@ describe('ngSwitch', function() {
       '</div>')($rootScope);
     $rootScope.$apply();
 
-    // element now contains only empty repeater. this element is dealocated by local afterEach.
+    // element now contains only empty repeater. this element is deallocated by local afterEach.
     // afterwards a global afterEach will check for leaks in jq data cache object
   }));
 

--- a/test/ng/filter/filterSpec.js
+++ b/test/ng/filter/filterSpec.js
@@ -315,7 +315,7 @@ describe('Filter: filter', function() {
     expect(filter(items, expr, true).length).toBe(1);
     expect(filter(items, expr, true)[0]).toBe(items[0]);
 
-    // Inherited function proprties
+    // Inherited function properties
     function Expr(text) {
         this.text = text;
     }

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -352,7 +352,7 @@ describe('$http', function() {
 
 
       it('should not encode @ in url params', function() {
-        //encodeURIComponent is too agressive and doesn't follow http://www.ietf.org/rfc/rfc3986.txt
+        //encodeURIComponent is too aggressive and doesn't follow http://www.ietf.org/rfc/rfc3986.txt
         //with regards to the character set (pchar) allowed in path segments
         //so we need this test to make sure that we don't over-encode the params and break stuff
         //like buzz api which uses @self
@@ -1085,7 +1085,7 @@ describe('$http', function() {
             };
 
             // I'm really sorry for doing this :-D
-            // Unfortunatelly I don't know how to trick toString.apply(obj) comparison
+            // Unfortunately I don't know how to trick toString.apply(obj) comparison
             spyOn(window, 'isFile').andReturn(true);
 
             $httpBackend.expect('POST', '/some', file).respond('');

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -188,7 +188,7 @@ describe('Scope', function() {
       expect(child1.$$watchersCount).toBe(1);
       expect($rootScope.$$watchersCount).toBe(2);
 
-      // Execute everything a second time to be sure that calling the remove funciton
+      // Execute everything a second time to be sure that calling the remove function
       // several times, it only decrements the counter once
       remove2();
       expect(child2.$$watchersCount).toBe(1);

--- a/test/ngAnimate/animateCssDriverSpec.js
+++ b/test/ngAnimate/animateCssDriverSpec.js
@@ -132,7 +132,7 @@ describe("ngAnimate $$animateCssDriver", function() {
           var doc = $document[0];
 
           // there is one test in here that expects the rootElement
-          // to superceed the body node
+          // to supersede the body node
           if (!$rootElement[0].contains(doc.body)) {
             // we need to do this so that style detection works
             jqLite(doc.body).append($rootElement);

--- a/test/ngAnimate/animateCssSpec.js
+++ b/test/ngAnimate/animateCssSpec.js
@@ -1261,7 +1261,7 @@ describe("ngAnimate $animateCss", function() {
           expect(element.css(prefix + 'transition-delay')).toBe('3s');
           expect(element.css(prefix + 'transition-duration')).toBe('3s');
 
-          // Let's flush the remaining amout of time for the timeout timer to kick in
+          // Let's flush the remaining amount of time for the timeout timer to kick in
           $timeout.flush(500);
 
           expect(element.css(prefix + 'transition-duration')).toBeOneOf('', '0s');
@@ -1294,7 +1294,7 @@ describe("ngAnimate $animateCss", function() {
           expect(element.css(prefix + 'transition-delay')).toBeOneOf('initial', '0s');
           expect(element.css(prefix + 'transition-duration')).toBe('3s');
 
-          // Let's flush the remaining amout of time for the timeout timer to kick in
+          // Let's flush the remaining amount of time for the timeout timer to kick in
           $timeout.flush(500);
 
           expect(element.css(prefix + 'transition-duration')).toBeOneOf('', '0s');

--- a/test/ngMessages/messagesSpec.js
+++ b/test/ngMessages/messagesSpec.js
@@ -511,7 +511,7 @@ describe('ngMessages', function() {
 
         var elements = element[0].querySelectorAll('[ng-repeat]');
 
-        // all three collections should have atleast one error showing up
+        // all three collections should have at least one error showing up
         expect(messageChildren(element).length).toBe(3);
         expect(messageChildren(elements[0]).length).toBe(1);
         expect(messageChildren(elements[1]).length).toBe(1);

--- a/test/ngScenario/e2e/widgets.html
+++ b/test/ngScenario/e2e/widgets.html
@@ -42,7 +42,7 @@
         <td>checkbox</td>
         <td ng-init="checkbox={'tea': true, 'coffee': false}">
          <input type="checkbox" ng-model="checkbox.tea" value="on"/> Tea<br/>
-         <input type="checkbox" ng-model="checkbox.coffee" value="on"/> Coffe
+         <input type="checkbox" ng-model="checkbox.coffee" value="on"/> Coffee
         </td>
         <td>
           <pre>checkbox={{checkbox}}</pre>

--- a/test/ngTouch/directive/ngClickSpec.js
+++ b/test/ngTouch/directive/ngClickSpec.js
@@ -315,7 +315,7 @@ describe('ngClick (touch)', function() {
       expect($rootScope.count1).toBe(1);
 
       time = 90;
-      // Verify that it is blured so we don't get soft-keyboard
+      // Verify that it is blurred so we don't get soft-keyboard
       element1[0].blur = jasmine.createSpy('blur');
       browserTrigger(element1, 'click',{
         keys: [],


### PR DESCRIPTION
Here is another one typo-crusher PR!

Most notable this time - `./test` directory. Also fixed one rogue CSS rule: `soild` -> `solid`.
