### PR TITLE
fix(input): fix URL validation being too strict

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -12,7 +12,18 @@
 // Regex code is obtained from SO: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime#answer-3143231
 var ISO_DATE_REGEXP = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/;
 // See valid URLs in RFC3987 (http://tools.ietf.org/html/rfc3987)
-var URL_REGEXP = /^[A-Za-z][A-Za-z\d.+-]*:\/*(?:\w+(?::\w+)?@)?[^\s/]+(?::\d+)?(?:\/[\w#!:.?+=&%@\-/[\]$'()*,;~]*)?$/;
+// Note: We are being more lenient, because browsers are too.
+//   1. Scheme
+//   2. Slashes
+//   3. Username
+//   4. Password
+//   5. Hostname
+//   6. Port
+//   7. Path
+//   8. Query
+//   9. Fragment
+//                 1111111111111111 222   333333    44444        555555555555555555555555    666     77777777     8888888     999
+var URL_REGEXP = /^[a-z][a-z\d.+-]*:\/*(?:[^:@]+(?::[^@]+)?@)?(?:[^\s:/?#]+|\[[a-f\d:]+\])(?::\d+)?(?:\/[^?#]*)?(?:\?[^#]*)?(?:#.*)?$/i;
 var EMAIL_REGEXP = /^[a-z0-9!#$%&'*+\/=?^_`{|}~.-]+@[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i;
 var NUMBER_REGEXP = /^\s*(\-|\+)?(\d+|(\d*(\.\d*)))([eE][+-]?\d+)?\s*$/;
 var DATE_REGEXP = /^(\d{4})-(\d{2})-(\d{2})$/;

--- a/test/helpers/privateMocks.js
+++ b/test/helpers/privateMocks.js
@@ -11,7 +11,7 @@ function baseThey(msg, vals, spec, itFn) {
   var valsIsArray = angular.isArray(vals);
 
   angular.forEach(vals, function(val, key) {
-    var m = msg.replace(/\$prop/g, angular.toJson(valsIsArray ? val : key));
+    var m = msg.split('$prop').join(angular.toJson(valsIsArray ? val : key));
     itFn(m, function() {
       /* jshint -W040 : ignore possible strict violation due to use of this */
       spec.call(this, val);

--- a/test/helpers/privateMocksSpec.js
+++ b/test/helpers/privateMocksSpec.js
@@ -22,6 +22,13 @@ describe('private mocks', function() {
         expect(window.it).toHaveBeenCalledWith('should fight "fire" with "fire"', jasmine.any(Function));
       });
 
+      it('should handle replacement strings containing `$&` correctly', function() {
+        spyOn(window, 'it');
+
+        they('should replace dollar-prop with $prop', ['$&']);
+        expect(window.it).toHaveBeenCalledWith('should replace dollar-prop with "$&"', jasmine.any(Function));
+      });
+
       it('should pass each item in an array to the handler', function() {
         var handlerSpy = jasmine.createSpy('handler');
         spyOn(window, 'it').andCallFake(function(msg, handler) {


### PR DESCRIPTION
Background:
Prior to ffb6b2f, there was a bug in `URL_REGEXP`, trying to match the hostname as `\S+` (meaning
any non-space character). This resulted in never actually validating the structure of the URL (e.g.
segments such as port, path, query, fragment).
Then ffb6b2f and subsequently e4bb838 fixed that bug, but revealed `URL_REGEXP`'s "strictness" wrt
certain parts of the URL.

Since browsers are too lenient when it comes to URL validation, this commit relaxes the "strictness"
of `URL_REGEXP`, focusing more on the general structure, than on the specific characters allowed in
each segment.

Note 1: `URL_REGEXP` still seems to be stricter than browsers in some cases.
Note 2: Browsers don't always agree on what is a valid URL and what isn't.

Fixes #13528
