### PR TITLE
chore(build): add a validation step for angularFiles

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,9 @@ var files = require('./angularFiles').files;
 var util = require('./lib/grunt/utils.js');
 var versionInfo = require('./lib/versions/version-info');
 var path = require('path');
+var fs = require('fs');
 var e2e = require('./test/e2e/tools');
+var glob = require("glob");
 
 module.exports = function(grunt) {
   //grunt plugins
@@ -339,6 +341,56 @@ module.exports = function(grunt) {
     grunt.task.run('shell:npm-install');
   }
 
+  grunt.registerTask('validate-angular-files', function() {
+    var combinedFiles = Object.assign({}, files.angularModules);
+    combinedFiles.ng = files.angularSrc;
+    combinedFiles.angularLoader = files.angularLoader;
+
+    var errorsDetected = false;
+    var directories = [];
+    var detectedFiles = {
+      "src/ng/rootElement.js": true
+    };
+
+    for (var section in combinedFiles) {
+      var sectionFiles = combinedFiles[section];
+
+      if (section != "angularLoader") {
+        directories.push("src/" + section);
+      }
+
+      console.log("Validating " + sectionFiles.length + " files from the \"" + section + "\" module");
+
+      sectionFiles.forEach(function(file) {
+        detectedFiles[file] = true;
+
+        if (!fs.existsSync(file)) {
+          grunt.log.error(file + " does not exist in the local file structure");
+          errorsDetected = true;
+        }
+      });
+    }
+
+    directories.forEach(function(directory) {
+      glob.sync(directory + "/**/*").forEach(function(filePath) {
+        if (!fs.lstatSync(filePath).isDirectory()) {
+          var fileName = path.basename(filePath);
+          var isHiddenFile = fileName[0] == ".";
+          if (!isHiddenFile && !detectedFiles[filePath]) {
+            grunt.log.error(filePath + " exists in the local file structure but isn't used by any module");
+            errorsDetected = true;
+          }
+        }
+      });
+    });
+
+    if (errorsDetected) {
+      throw new Error("Not all files were properly detected the local file structure");
+    } else {
+      console.log("All files were detected successfully!");
+    }
+  });
+
   //alias tasks
   grunt.registerTask('test', 'Run unit, docs and e2e tests with Karma', ['jshint', 'jscs', 'package','test:unit','test:promises-aplus', 'tests:docs', 'test:protractor']);
   grunt.registerTask('test:jqlite', 'Run the unit tests with Karma' , ['tests:jqlite']);
@@ -354,7 +406,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('minify', ['bower','clean', 'build', 'minall']);
   grunt.registerTask('webserver', ['connect:devserver']);
-  grunt.registerTask('package', ['bower','clean', 'buildall', 'minall', 'collect-errors', 'docs', 'copy', 'write', 'compress']);
+  grunt.registerTask('package', ['bower', 'validate-angular-files','clean', 'buildall', 'minall', 'collect-errors', 'docs', 'copy', 'write', 'compress']);
   grunt.registerTask('ci-checks', ['ddescribe-iit', 'merge-conflict', 'jshint', 'jscs']);
   grunt.registerTask('default', ['package']);
 };

--- a/angularFiles.js
+++ b/angularFiles.js
@@ -85,7 +85,7 @@ var angularFiles = {
   ],
 
   'angularLoader': [
-    'stringify.js',
+    'src/stringify.js',
     'src/minErr.js',
     'src/loader.js'
   ],

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dgeni": "^0.4.0",
     "dgeni-packages": "^0.11.0",
     "event-stream": "~3.1.0",
+    "glob": "^6.0.1",
     "grunt": "~0.4.2",
     "grunt-bump": "~0.0.13",
     "grunt-contrib-clean": "~0.6.0",


### PR DESCRIPTION
The output looks like this (when passing):

``` bash
Running "validate-angular-files" task
Validating 13 files from the 'ngAnimate' module
Validating 5 files from the 'ngCookies' module
Validating 7 files from the 'ngMessageFormat' module
Validating 3 files from the 'ngMessages' module
Validating 3 files from the 'ngResource' module
Validating 5 files from the 'ngRoute' module
Validating 4 files from the 'ngSanitize' module
Validating 3 files from the 'ngMock' module
Validating 6 files from the 'ngTouch' module
Validating 3 files from the 'ngAria' module
Validating 76 files from the 'ng' module
Validating 5 files from the 'angularLoader' module
All files were detected successfully!
```

When failing (when a file is referenced in a module but doesn't exist in the local filesystem):

``` bash
Running "validate-angular-files" task
Validating 14 files from the 'ngAnimate' module
>> src/ngAnimate/referenced-but-missing-file.js does not exist in the local file structure
Validating 5 files from the 'ngCookies' module
Validating 7 files from the 'ngMessageFormat' module
Validating 3 files from the 'ngMessages' module
Validating 3 files from the 'ngResource' module
Validating 5 files from the 'ngRoute' module
Validating 4 files from the 'ngSanitize' module
Validating 3 files from the 'ngMock' module
Validating 6 files from the 'ngTouch' module
Validating 3 files from the 'ngAria' module
Validating 76 files from the 'ng' module
Validating 5 files from the 'angularLoader' module
Warning: Not all files were properly detected the local file structure Use --force to continue.
```

When failing (when a file exists locally but isn't used in any module):

``` bash
Running "validate-angular-files" task
Validating 13 files from the 'ngAnimate' module
Validating 5 files from the 'ngCookies' module
Validating 7 files from the 'ngMessageFormat' module
Validating 3 files from the 'ngMessages' module
Validating 3 files from the 'ngResource' module
Validating 5 files from the 'ngRoute' module
Validating 4 files from the 'ngSanitize' module
Validating 3 files from the 'ngMock' module
Validating 6 files from the 'ngTouch' module
Validating 3 files from the 'ngAria' module
Validating 76 files from the 'ng' module
Validating 5 files from the 'angularLoader' module
>> src/ngAnimate/missing-file exists in the local file structure but isn't used by any module
Warning: Not all files were properly detected the local file structure Use --force to continue.
```
