### PR TITLE
feat(ngRoute): add console logging for $routeChangeError events

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -249,7 +249,8 @@ function $RouteProvider() {
                '$injector',
                '$templateRequest',
                '$sce',
-      function($rootScope, $location, $routeParams, $q, $injector, $templateRequest, $sce) {
+               '$log',
+      function($rootScope, $location, $routeParams, $q, $injector, $templateRequest, $sce, $log) {
 
     /**
      * @ngdoc service
@@ -615,13 +616,8 @@ function $RouteProvider() {
             }
           }, function(error) {
             if (nextRoute == $route.current) {
-              // If nothing's listening for a $routeChangeError event, we log it in the console
-              //  to aid in debugging
-              if ($rootScope.$$listenerCount['$routeChangeError'] === 0) {
-                $log.debug('No listeners found for $routeChangeError: '+ error);
-              } else {
-                $rootScope.$broadcast('$routeChangeError', nextRoute, lastRoute, error);
-              }
+              $log.debug('A $routeChangeError has happened: ' + error);
+              $rootScope.$broadcast('$routeChangeError', nextRoute, lastRoute, error);
             }
           });
       }

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -616,9 +616,8 @@ function $RouteProvider() {
             }
           }, function(error) {
             if (nextRoute == $route.current) {
-              $log.debug('No listeners found for $routeChangeError: ' + error);
+              $log.debug('A $routeChangeError has happened: ' + error);
               $rootScope.$broadcast('$routeChangeError', nextRoute, lastRoute, error);
-              }
             }
           });
       }

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -249,8 +249,7 @@ function $RouteProvider() {
                '$injector',
                '$templateRequest',
                '$sce',
-               '$log',
-      function($rootScope, $location, $routeParams, $q, $injector, $templateRequest, $sce, $log) {
+      function($rootScope, $location, $routeParams, $q, $injector, $templateRequest, $sce) {
 
     /**
      * @ngdoc service
@@ -616,8 +615,13 @@ function $RouteProvider() {
             }
           }, function(error) {
             if (nextRoute == $route.current) {
-              $log.debug('A $routeChangeError has happened: ' + error);
-              $rootScope.$broadcast('$routeChangeError', nextRoute, lastRoute, error);
+              // If nothing's listening for a $routeChangeError event, we log it in the console
+              //  to aid in debugging
+              if ($rootScope.$$listenerCount['$routeChangeError'] === 0) {
+                $log.debug('No listeners found for $routeChangeError: '+ error);
+              } else {
+                $rootScope.$broadcast('$routeChangeError', nextRoute, lastRoute, error);
+              }
             }
           });
       }

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -249,7 +249,8 @@ function $RouteProvider() {
                '$injector',
                '$templateRequest',
                '$sce',
-      function($rootScope, $location, $routeParams, $q, $injector, $templateRequest, $sce) {
+               '$log',
+      function($rootScope, $location, $routeParams, $q, $injector, $templateRequest, $sce, $log) {
 
     /**
      * @ngdoc service
@@ -615,7 +616,9 @@ function $RouteProvider() {
             }
           }, function(error) {
             if (nextRoute == $route.current) {
+              $log.debug('No listeners found for $routeChangeError: ' + error);
               $rootScope.$broadcast('$routeChangeError', nextRoute, lastRoute, error);
+              }
             }
           });
       }

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -677,7 +677,7 @@ describe('$route', function() {
         } });
       });
 
-      inject(function($location, $route, $rootScope, $log) {
+      inject(function($location, $route, $rootScope) {
         var log = '';
 
         $rootScope.$on('$routeChangeStart', function() { log += 'before();'; });
@@ -690,7 +690,6 @@ describe('$route', function() {
         deferA.reject('MyError');
         $rootScope.$digest();
         expect(log).toEqual('before();failed(MyError);');
-        $log.reset();
       });
     });
 
@@ -824,7 +823,7 @@ describe('$route', function() {
           when('/r3', { templateUrl: 'r3.html' });
       });
 
-      inject(function($route, $httpBackend, $location, $rootScope, $exceptionHandler, $log) {
+      inject(function($route, $httpBackend, $location, $rootScope, $exceptionHandler) {
         $httpBackend.expectGET('r1.html').respond(404, 'R1');
         $location.path('/r1');
         $rootScope.$digest();
@@ -845,7 +844,6 @@ describe('$route', function() {
 
         $httpBackend.flush();
         expect($exceptionHandler.errors.length).toBe(0);
-        $log.reset();
       });
     });
 
@@ -863,11 +861,10 @@ describe('$route', function() {
         });
       });
 
-      inject(function($location, $route, $rootScope, $exceptionHandler, $log) {
+      inject(function($location, $route, $rootScope, $exceptionHandler) {
         $location.path('/locals');
         $rootScope.$digest();
         expect($exceptionHandler.errors).toEqual([myError]);
-        $log.reset();
       });
     });
   });

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -698,7 +698,7 @@ describe('$route', function() {
       });
     });
 
-    it ('should log an error when $routeChangeError is fired', function() {
+    it('should log an error when $routeChangeError is fired', function() {
       var deferA;
       module(function($provide, $routeProvider) {
         $routeProvider.when('/path', { template: 'foo', resolve: {
@@ -714,8 +714,8 @@ describe('$route', function() {
         deferA.reject('fooError');
         $rootScope.$digest();
 
-        expect($log.debug.logs[0][0]).toEqual('A $routeChangeError has happened: fooError')
-      })
+        expect($log.debug.logs[0][0]).toEqual('A $routeChangeError has happened: fooError');
+      });
     });
 
 

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -603,6 +603,11 @@ describe('$route', function() {
 
 
   describe('events', function() {
+
+    afterEach(inject(function($log) {
+      $log.reset();
+    }));
+
     it('should not fire $routeChangeStart/Success during bootstrap (if no route)', function() {
       var routeChangeSpy = jasmine.createSpy('route change');
 
@@ -691,6 +696,26 @@ describe('$route', function() {
         $rootScope.$digest();
         expect(log).toEqual('before();failed(MyError);');
       });
+    });
+
+    it ('should log an error when $routeChangeError is fired', function() {
+      var deferA;
+      module(function($provide, $routeProvider) {
+        $routeProvider.when('/path', { template: 'foo', resolve: {
+          a: function($q) {
+            deferA = $q.defer();
+            return deferA.promise;
+          }
+        } });
+      });
+      inject(function($location,$log,$route,$rootScope) {
+        $location.path('/path');
+        $rootScope.$digest();
+        deferA.reject('fooError');
+        $rootScope.$digest();
+
+        expect($log.debug.logs[0][0]).toEqual('A $routeChangeError has happened: fooError')
+      })
     });
 
 

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -677,7 +677,7 @@ describe('$route', function() {
         } });
       });
 
-      inject(function($location, $route, $rootScope) {
+      inject(function($location, $route, $rootScope, $log) {
         var log = '';
 
         $rootScope.$on('$routeChangeStart', function() { log += 'before();'; });
@@ -690,6 +690,7 @@ describe('$route', function() {
         deferA.reject('MyError');
         $rootScope.$digest();
         expect(log).toEqual('before();failed(MyError);');
+        $log.reset();
       });
     });
 
@@ -823,7 +824,7 @@ describe('$route', function() {
           when('/r3', { templateUrl: 'r3.html' });
       });
 
-      inject(function($route, $httpBackend, $location, $rootScope, $exceptionHandler) {
+      inject(function($route, $httpBackend, $location, $rootScope, $exceptionHandler, $log) {
         $httpBackend.expectGET('r1.html').respond(404, 'R1');
         $location.path('/r1');
         $rootScope.$digest();
@@ -844,6 +845,7 @@ describe('$route', function() {
 
         $httpBackend.flush();
         expect($exceptionHandler.errors.length).toBe(0);
+        $log.reset();
       });
     });
 
@@ -861,10 +863,11 @@ describe('$route', function() {
         });
       });
 
-      inject(function($location, $route, $rootScope, $exceptionHandler) {
+      inject(function($location, $route, $rootScope, $exceptionHandler, $log) {
         $location.path('/locals');
         $rootScope.$digest();
         expect($exceptionHandler.errors).toEqual([myError]);
+        $log.reset();
       });
     });
   });


### PR DESCRIPTION
when no listeners are found for a $routeChangeError event, log the error to the console to aid in debugging

Closes: #13563
