### PR TITLE
fix(loader): use false as default value of transclude in component helper

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -318,7 +318,7 @@ function setupModuleLoader(window) {
            *    - `bindings` – `{object=}` – Define DOM attribute binding to component properties.
            *      Component properties are always bound to the component controller and not to the scope.
            *    - `transclude` – `{boolean=}` – Whether {@link $compile#transclusion transclusion} is enabled.
-           *      Enabled by default.
+           *      Disabled by default.
            *    - `isolate` – `{boolean=}` – Whether the new scope is isolated. Isolated by default.
            *    - `restrict` - `{string=}` - String of subset of {@link ng.$compile#-restrict- EACM} which
            *      restricts the component to specific directive declaration style. If omitted, this defaults to 'E'.
@@ -331,7 +331,7 @@ function setupModuleLoader(window) {
            * definitions are very simple and do not require the complexity behind defining directives.
            * Component definitions usually consist only of the template and the controller backing it.
            * In order to make the definition easier, components enforce best practices like controllerAs
-           * and default behaviors like scope isolation, restrict to elements and allow transclusion.
+           * and default behaviors like scope isolation, restrict to elements.
            *
            * <br />
            * Here are a few examples of how you would usually define components:
@@ -420,7 +420,7 @@ function setupModuleLoader(window) {
                 controllerAs: identifierForController(options.controller) || options.controllerAs || name,
                 template: makeInjectable(template),
                 templateUrl: makeInjectable(options.templateUrl),
-                transclude: options.transclude === undefined ? true : options.transclude,
+                transclude: options.transclude === undefined ? false : options.transclude,
                 scope: options.isolate === false ? true : {},
                 bindToController: options.bindings || {},
                 restrict: options.restrict || 'E'

--- a/test/loaderSpec.js
+++ b/test/loaderSpec.js
@@ -121,7 +121,7 @@ describe('component', function() {
         controllerAs: 'myComponent',
         template: '',
         templateUrl: undefined,
-        transclude: true,
+        transclude: false,
         scope: {},
         bindToController: {},
         restrict: 'E'
@@ -136,7 +136,7 @@ describe('component', function() {
       controllerAs: 'ctrl',
       template: 'abc',
       templateUrl: 'def.html',
-      transclude: false,
+      transclude: true,
       isolate: false,
       bindings: {abc: '='},
       restrict: 'EA'
@@ -148,7 +148,7 @@ describe('component', function() {
         controllerAs: 'ctrl',
         template: 'abc',
         templateUrl: 'def.html',
-        transclude: false,
+        transclude: true,
         scope: true,
         bindToController: {abc: '='},
         restrict: 'EA'


### PR DESCRIPTION
Use false as default value of transclude in component helper.
The change is motivated by the fact that using transclude:true when not necessary made component
not usable in conjunction with structural directives requiring transclusion like ng-switch-when.

Closes: #13566

BREAKING CHANGE:
This is a breaking change compared to 1.5.0.rc.0 where transclude was true by default.
