### PR TITLE
Fix ngMock window.inject() stack trace reporting on PhanthomJS for master branch

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2899,6 +2899,15 @@ angular.mock.$RootScopeDecorator = ['$delegate', function($delegate) {
   window.inject = angular.mock.inject = function() {
     var blockFns = Array.prototype.slice.call(arguments, 0);
     var errorForStack = new Error('Declaration Location');
+    // some browsers, e.g. PhanthomJS, do not set a new error object's stack
+    // information until it has been thrown
+    if (!errorForStack.stack) {
+      try {
+        throw errorForStack;
+      } catch (e) {
+        errorForStack = e;
+      }
+    }
     return wasInjectorCreated() ? workFn.call(currentSpec) : workFn;
     /////////////////////
     function workFn() {


### PR DESCRIPTION
Fixes & adds a tests for issue #13591 for the angular `master` branch.

This does the same work as pull request #13592 does on the angular `1.4.x` branch.
