### PR TITLE
Fix ngMock window.inject() error stack trace reporting on repeated or non-initial injection function calls for the 1.4.x branch (issue #13594)

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2521,8 +2521,6 @@ if (window.jasmine || window.mocha) {
             throw new ErrorAddingDeclarationLocationStack(e, errorForStack);
           }
           throw e;
-        } finally {
-          errorForStack = null;
         }
       }
     }

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -934,6 +934,9 @@ describe('ngMock', function() {
         return !!error.stack;
       })();
 
+      // function returned by inject(), when called outside of test spec
+      // context, may have stored state so do not reuse the result from this
+      // call in multiple test specs
       function testInjectCaller() {
         var shouldThrow;
         var injectingCall = (function internalInjectCaller() {

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -939,6 +939,9 @@ describe('ngMock', function() {
       // call in multiple test specs
       function testInjectCaller() {
         var shouldThrow;
+        // using an extra internalInjectCaller() wrapper here avoids stack trace
+        // constructed by some browsers (e.g. FireFox) from containing the name
+        // of the external caller function
         var injectingCall = (function internalInjectCaller() {
           return inject(function() {
             if (shouldThrow)

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -986,6 +986,28 @@ describe('ngMock', function() {
               }
             });
           });
+
+          describe('when called outside of test spec context', function() {
+            var injectingCall = testInjectCaller();
+
+            // regression test for issue #13594
+            // regression test for issue #13591 when run on IE10+ or PhantomJS
+            it('should update thrown Error stack when repeated inject callback invocations fail', function() {
+              injectingCall.setThrow(false);
+              injectingCall();  // initial call that will not throw
+              injectingCall.setThrow(true);
+              try {
+                injectingCall();  // non-initial call, but first failing one
+              } catch (e) {
+                expect(e.stack).toMatch('testInjectCaller');
+              }
+              try {
+                injectingCall();  // repeated failing call
+              } catch (e) {
+                expect(e.stack).toMatch('testInjectCaller');
+              }
+            });
+          });
         });
       }
     });

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -937,19 +937,28 @@ describe('ngMock', function() {
       // function returned by inject(), when called outside of test spec
       // context, may have stored state so do not reuse the result from this
       // call in multiple test specs
-      function testInjectCaller() {
-        var shouldThrow;
-        // using an extra internalInjectCaller() wrapper here avoids stack trace
-        // constructed by some browsers (e.g. FireFox) from containing the name
-        // of the external caller function
-        var injectingCall = (function internalInjectCaller() {
-          return inject(function() {
-            if (shouldThrow)
+      function testInjectCaller(injectionFunctionCount) {
+        var shouldThrow = [];
+        // using an extra named function wrapper around the Error throw avoids
+        // stack trace constructed by some browsers (e.g. FireFox) from
+        // containing the name of the external caller function
+        function injectionFunction(index) {
+          return function() {
+            if (shouldThrow[index])
               throw new Error();
-          });
-        })();
-        injectingCall.setThrow = function(value) {
-          shouldThrow = value;
+          };
+        }
+        var injectionFunctions = [];
+        for (var i = 0; i < (injectionFunctionCount || 1); ++i) {
+          injectionFunctions.push(injectionFunction(i));
+        }
+        var injectingCall = inject.apply(window, injectionFunctions);
+        injectingCall.setThrow = function(index, value) {
+          if (!isDefined(value)) {
+            value = index;
+            index = 0;
+          }
+          shouldThrow[index] = value;
         };
         return injectingCall;
       }
@@ -1003,6 +1012,22 @@ describe('ngMock', function() {
               }
               try {
                 injectingCall();  // repeated failing call
+              } catch (e) {
+                expect(e.stack).toMatch('testInjectCaller');
+              }
+            });
+          });
+
+          describe('when called outside of test spec context with multiple injected functions', function() {
+            var injectingCall = testInjectCaller(2);
+
+            // regression test for issue #13594
+            // regression test for issue #13591 when run on IE10+ or PhantomJS
+            it('should update thrown Error stack when second injected function fails', function() {
+              injectingCall.setThrow(0, false);
+              injectingCall.setThrow(1, true);
+              try {
+                injectingCall();
               } catch (e) {
                 expect(e.stack).toMatch('testInjectCaller');
               }

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -977,6 +977,7 @@ describe('ngMock', function() {
             var throwingInjectingCall = testInjectCaller();
             throwingInjectingCall.setThrow(true);
 
+            // regression test for issue #13591 when run on IE10+ or PhantomJS
             it('should update thrown Error stack trace with inject call location', function() {
               try {
                 throwingInjectingCall();

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -920,50 +920,67 @@ describe('ngMock', function() {
         }).toThrow('test message');
       }));
 
-      describe('error stack trace when called outside of spec context', function() {
-        // - Chrome, Firefox, Edge, Opera give us the stack trace as soon as an Error is created
-        // - IE10+, PhantomJS give us the stack trace only once the error is thrown
-        // - IE9 does not provide stack traces
-        var stackTraceSupported = (function() {
-          var error = new Error();
-          if (!error.stack) {
-            try {
-              throw error;
-            } catch (e) {}
-          }
-
-          return !!error.stack;
-        })();
-
-        function testCaller() {
-          return inject(function() {
-            throw new Error();
-          });
+      // - Chrome, Firefox, Edge, Opera give us the stack trace as soon as an Error is created
+      // - IE10+, PhantomJS give us the stack trace only once the error is thrown
+      // - IE9 does not provide stack traces
+      var stackTraceSupported = (function() {
+        var error = new Error();
+        if (!error.stack) {
+          try {
+            throw error;
+          } catch (e) {}
         }
-        var throwErrorFromInjectCallback = testCaller();
 
-        if (stackTraceSupported) {
-          describe('on browsers supporting stack traces', function() {
-            it('should update thrown Error stack trace with inject call location', function() {
-              try {
-                throwErrorFromInjectCallback();
-              } catch (e) {
-                expect(e.stack).toMatch('testCaller');
-              }
-            });
+        return !!error.stack;
+      })();
+
+      function testInjectCaller() {
+        var shouldThrow;
+        var injectingCall = (function internalInjectCaller() {
+          return inject(function() {
+            if (shouldThrow)
+              throw new Error();
           });
-        } else {
-          describe('on browsers not supporting stack traces', function() {
-            it('should not add stack trace information to thrown Error', function() {
+        })();
+        injectingCall.setThrow = function(value) {
+          shouldThrow = value;
+        };
+        return injectingCall;
+      }
+
+      if (!stackTraceSupported) {
+        describe('on browsers not supporting stack traces', function() {
+          describe('when called outside of test spec context', function() {
+            var injectingCall = testInjectCaller();
+
+            it('should not add stack trace information to thrown injection Error', function() {
+              injectingCall.setThrow(true);
               try {
-                throwErrorFromInjectCallback();
+                injectingCall();
               } catch (e) {
                 expect(e.stack).toBeUndefined();
               }
             });
           });
-        }
-      });
+        });
+      }
+
+      if (stackTraceSupported) {
+        describe('on browsers supporting stack traces', function() {
+          describe('when called outside of test spec context and initial inject callback invocation fails', function() {
+            var throwingInjectingCall = testInjectCaller();
+            throwingInjectingCall.setThrow(true);
+
+            it('should update thrown Error stack trace with inject call location', function() {
+              try {
+                throwingInjectingCall();
+              } catch (e) {
+                expect(e.stack).toMatch('testInjectCaller');
+              }
+            });
+          });
+        });
+      }
     });
   });
 


### PR DESCRIPTION
Fixes & adds tests for issue #13594 for the angular `1.4.x` branch.

Does the same work as pull request #13598 does on the angular `master` branch.

`window.inject()` function updates stack trace information for `Error` objects thrown from injection functions passed to it with stack trace for the `window.inject()` calling location. However this functionality was broken and did not work correctly in the following cases:
- when the same injection function gets called multiple times
- when more than one injection function is passed to a single `window.inject()` call and a non-initial one throws an `Error`

This pull request actually builds on and thus includes pull request #13592, as newly added test specs are integrated into the test structure set up by the base pull request. That's why you should first review & merge that pull request, or ignore its commits when reviewing this one.
