### PR TITLE
Fix ngMock window.inject() error stack trace reporting on repeated or non-initial injection function calls for the master branch (issue #13594)

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2960,8 +2960,6 @@ angular.mock.$RootScopeDecorator = ['$delegate', function($delegate) {
             throw new ErrorAddingDeclarationLocationStack(e, errorForStack);
           }
           throw e;
-        } finally {
-          errorForStack = null;
         }
       }
     }

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -972,6 +972,7 @@ describe('ngMock', function() {
             var throwingInjectingCall = testInjectCaller();
             throwingInjectingCall.setThrow(true);
 
+            // regression test for issue #13591 when run on IE10+ or PhantomJS
             it('should update thrown Error stack trace with inject call location', function() {
               try {
                 throwingInjectingCall();

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -981,6 +981,28 @@ describe('ngMock', function() {
               }
             });
           });
+
+          describe('when called outside of test spec context', function() {
+            var injectingCall = testInjectCaller();
+
+            // regression test for issue #13594
+            // regression test for issue #13591 when run on IE10+ or PhantomJS
+            it('should update thrown Error stack when repeated inject callback invocations fail', function() {
+              injectingCall.setThrow(false);
+              injectingCall();  // initial call that will not throw
+              injectingCall.setThrow(true);
+              try {
+                injectingCall();  // non-initial call, but first failing one
+              } catch (e) {
+                expect(e.stack).toMatch('testInjectCaller');
+              }
+              try {
+                injectingCall();  // repeated failing call
+              } catch (e) {
+                expect(e.stack).toMatch('testInjectCaller');
+              }
+            });
+          });
         });
       }
     });

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -929,6 +929,9 @@ describe('ngMock', function() {
         return !!error.stack;
       })();
 
+      // function returned by inject(), when called outside of test spec
+      // context, may have stored state so do not reuse the result from this
+      // call in multiple test specs
       function testInjectCaller() {
         var shouldThrow;
         var injectingCall = (function internalInjectCaller() {

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -934,6 +934,9 @@ describe('ngMock', function() {
       // call in multiple test specs
       function testInjectCaller() {
         var shouldThrow;
+        // using an extra internalInjectCaller() wrapper here avoids stack trace
+        // constructed by some browsers (e.g. FireFox) from containing the name
+        // of the external caller function
         var injectingCall = (function internalInjectCaller() {
           return inject(function() {
             if (shouldThrow)


### PR DESCRIPTION
Fixes & adds tests for issue #13594 for the angular `master` branch.

Does the same work as pull request #13597 does on the angular `1.4.x` branch.

`window.inject()` function updates stack trace information for `Error` objects thrown from injection functions passed to it with stack trace for the `window.inject()` calling location. However this functionality was broken and did not work correctly in the following cases:
- when the same injection function gets called multiple times
- when more than one injection function is passed to a single `window.inject()` call and a non-initial one throws an `Error`

This pull request actually builds on and thus includes pull request #13593, as newly added test specs are integrated into the test structure set up by the base pull request. That's why you should first review & merge that pull request, or ignore its commits when reviewing this one.
