### PR TITLE
docs - grammar change - tutorial/6 - Templating Links

### DIFF
--- a/docs/content/tutorial/step_06.ngdoc
+++ b/docs/content/tutorial/step_06.ngdoc
@@ -59,8 +59,8 @@ the element attribute.
 We also added phone images next to each record using an image tag with the {@link
 ng.directive:ngSrc ngSrc} directive. That directive prevents the
 browser from treating the Angular `{{ expression }}` markup literally, and initiating a request to
-invalid URL `http://localhost:8000/app/{{phone.imageUrl}}`, which it would have done if we had only
-specified an attribute binding in a regular `src` attribute (`<img src="{{phone.imageUrl}}">`).
+an invalid URL `http://localhost:8000/app/{{phone.imageUrl}}`, which it would have done if we had
+only specified an attribute binding in a regular `src` attribute (`<img src="{{phone.imageUrl}}">`).
 Using the `ngSrc` directive prevents the browser from making an http request to an invalid location.
 
 


### PR DESCRIPTION
Corrected the grammar on line 62 by adding the word 'an' which forced me to move 'only' down to line 63.
