### PR TITLE
docs(loader): use type in return tag

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -76,7 +76,7 @@ function setupModuleLoader(window) {
      *        unspecified then the module is being retrieved for further configuration.
      * @param {Function=} configFn Optional configuration function for the module. Same as
      *        {@link angular.Module#config Module#config()}.
-     * @returns {module} new module with the {@link angular.Module} api.
+     * @returns {angular.Module} new module with the {@link angular.Module} api.
      */
     return function module(name, requires, configFn) {
       var assertNotHasOwnProperty = function(name, context) {


### PR DESCRIPTION
I've found that `@returns {angular.Module}` was intentionally changed to `@returns {module}` by commit 3f98d6ac990fd514065bfff04711ac97a5a2ae4d, but this looks incorrect to me. `angular.Module` is a valid type, could you please explain why is it not suitable?
