### PR TITLE
fix($injector): is class detection

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -823,7 +823,7 @@ function createInjector(modulesToLoad, strictDi) {
 
     function isClass(func) {
       return typeof func === 'function'
-        && /^class\s/.test(Function.prototype.toString.call(func));
+        && /^class\s/.test(func.toString());
     }
 
     function invoke(fn, self, locals, serviceName) {


### PR DESCRIPTION
Use toString directly on the function to know if the function is a native class. This makes IE9 happy.
