### PR TITLE
feat($compile): Allow ES6 classes as controllers with `bindToController: true`

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -821,6 +821,14 @@ function createInjector(modulesToLoad, strictDi) {
       return args;
     }
 
+    function isClass(func) {
+      // IE 9-11 do not support classes and IE9 leaks with the code below.
+      if (msie <= 11) {
+        return false;
+      }
+      return typeof func === 'function'
+        && /^class\s/.test(Function.prototype.toString.call(func));
+    }
 
     function invoke(fn, self, locals, serviceName) {
       if (typeof locals === 'string') {
@@ -833,9 +841,16 @@ function createInjector(modulesToLoad, strictDi) {
         fn = fn[fn.length - 1];
       }
 
-      // http://jsperf.com/angularjs-invoke-apply-vs-switch
-      // #5388
-      return fn.apply(self, args);
+      if (!isClass(fn)) {
+        // http://jsperf.com/angularjs-invoke-apply-vs-switch
+        // #5388
+        return fn.apply(self, args);
+      } else {
+        args.unshift(null);
+        /*jshint -W058 */ // Applying a constructor without immediate parentheses is the point here.
+        return new (Function.prototype.bind.apply(fn, args));
+        /*jshint +W058 */
+      }
     }
 
 
@@ -845,7 +860,7 @@ function createInjector(modulesToLoad, strictDi) {
       var ctor = (isArray(Type) ? Type[Type.length - 1] : Type);
       var args = injectionArgs(Type, locals, serviceName);
       // Empty object at position 0 is ignored for invocation with `new`, but required.
-      args.unshift({});
+      args.unshift(null);
       /*jshint -W058 */ // Applying a constructor without immediate parentheses is the point here.
       return new (Function.prototype.bind.apply(ctor, args));
       /*jshint +W058 */

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -214,7 +214,7 @@
  * #### `bindToController`
  * When an isolate scope is used for a component (see above), and `controllerAs` is used, `bindToController: true` will
  * allow a component to have its properties bound to the controller, rather than to scope. When the controller
- * is instantiated, the initial values of the isolate scope bindings are already available.
+ * is instantiated, the initial values of the isolate scope bindings will be available if the controller is not an ES6 class.
  *
  * #### `controller`
  * Controller constructor function. The controller is instantiated before the


### PR DESCRIPTION
Modify `$injector.invoke` so ES6 classes would be invoked using `new`

Closes: #13510
Closes: #13540
