### PR TITLE
test: fix ms edge failures

### DIFF
--- a/test/helpers/privateMocks.js
+++ b/test/helpers/privateMocks.js
@@ -40,7 +40,7 @@ function browserSupportsCssAnimations() {
   return true;
 }
 
-function createMockStyleSheet(doc) {
+function createMockStyleSheet(doc, prefix) {
   doc = doc ? doc[0] : document;
 
   var node = doc.createElement('style');
@@ -60,6 +60,18 @@ function createMockStyleSheet(doc) {
         }
         catch (e2) {}
       }
+    },
+
+    addPossiblyPrefixedRule: function(selector, styles) {
+      if (prefix) {
+        var prefixedStyles = styles.split(/\s*;\s*/g).map(function(style) {
+          return !style ? '' : prefix + style;
+        }).join('; ');
+
+        this.addRule(selector, prefixedStyles);
+      }
+
+      this.addRule(selector, styles);
     },
 
     destroy: function() {

--- a/test/helpers/privateMocks.js
+++ b/test/helpers/privateMocks.js
@@ -40,9 +40,8 @@ function browserSupportsCssAnimations() {
   return true;
 }
 
-function createMockStyleSheet(doc, wind) {
+function createMockStyleSheet(doc) {
   doc = doc ? doc[0] : document;
-  wind = wind || window;
 
   var node = doc.createElement('style');
   var head = doc.getElementsByTagName('head')[0];

--- a/test/helpers/privateMocksSpec.js
+++ b/test/helpers/privateMocksSpec.js
@@ -211,7 +211,7 @@ describe('private mocks', function() {
 
       var doc = $document[0];
       var count = doc.styleSheets.length;
-      var stylesheet = createMockStyleSheet($document, $window);
+      var stylesheet = createMockStyleSheet($document);
       var elm;
       runs(function() {
         expect(doc.styleSheets.length).toBe(count + 1);

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -230,6 +230,9 @@ describe('$compile', function() {
 
 
   describe('svg namespace transcludes', function() {
+    var ua = window.navigator.userAgent;
+    var isEdge = /Edge/.test(ua);
+
     // this method assumes some sort of sized SVG element is being inspected.
     function assertIsValidSvgCircle(elem) {
       expect(isUnknownElement(elem)).toBe(false);
@@ -300,17 +303,19 @@ describe('$compile', function() {
       }));
 
       // NOTE: This test may be redundant.
-      it('should handle custom svg containers that transclude to foreignObject' +
-         ' that transclude to custom svg containers that transclude to custom elements', inject(function() {
-        element = jqLite('<div><svg-container>' +
-            '<my-foreign-object><svg-container><svg-circle></svg-circle></svg-container></my-foreign-object>' +
-            '</svg-container></div>');
-        $compile(element.contents())($rootScope);
-        document.body.appendChild(element[0]);
+      if (!isEdge) {
+        it('should handle custom svg containers that transclude to foreignObject' +
+           ' that transclude to custom svg containers that transclude to custom elements', inject(function() {
+          element = jqLite('<div><svg-container>' +
+              '<my-foreign-object><svg-container><svg-circle></svg-circle></svg-container></my-foreign-object>' +
+              '</svg-container></div>');
+          $compile(element.contents())($rootScope);
+          document.body.appendChild(element[0]);
 
-        var circle = element.find('circle');
-        assertIsValidSvgCircle(circle[0]);
-      }));
+          var circle = element.find('circle');
+          assertIsValidSvgCircle(circle[0]);
+        }));
+      }
     }
 
     it('should handle directives with templates that manually add the transclude further down', inject(function() {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1196,7 +1196,7 @@ describe('input', function() {
 
       it('should validate if max is empty', function() {
         $rootScope.maxVal = undefined;
-        $rootScope.value = new Date(9999, 11, 31, 23, 59, 59);
+        $rootScope.value = new Date(3000, 11, 31, 23, 59, 59);
         $rootScope.$digest();
 
         expect($rootScope.form.alias.$error.max).toBeFalsy();

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -1491,11 +1491,11 @@ describe('ngRepeat animations', function() {
   }));
 
   it('should not change the position of the block that is being animated away via a leave animation',
-    inject(function($compile, $rootScope, $animate, $document, $window, $sniffer, $timeout) {
+    inject(function($compile, $rootScope, $animate, $document, $sniffer, $timeout) {
       if (!$sniffer.transitions) return;
 
       var item;
-      var ss = createMockStyleSheet($document, $window);
+      var ss = createMockStyleSheet($document);
 
       try {
 

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -88,7 +88,9 @@ describe('$sniffer', function() {
       inject(function($sniffer, $window) {
         var expectedPrefix;
         var ua = $window.navigator.userAgent.toLowerCase();
-        if (/chrome/i.test(ua) || /safari/i.test(ua) || /webkit/i.test(ua)) {
+        if (/edge/i.test(ua)) {
+          expectedPrefix = 'Ms';
+        } else if (/chrome/i.test(ua) || /safari/i.test(ua) || /webkit/i.test(ua)) {
           expectedPrefix = 'Webkit';
         } else if (/firefox/i.test(ua)) {
           expectedPrefix = 'Moz';

--- a/test/ngAnimate/animateCssDriverSpec.js
+++ b/test/ngAnimate/animateCssDriverSpec.js
@@ -69,11 +69,11 @@ describe("ngAnimate $$animateCssDriver", function() {
 
       element = jqLite('<div></div>');
 
-      return function($$animateCssDriver, $document, $window) {
+      return function($$animateCssDriver, $document) {
         driver = function(details, cb) {
           return $$animateCssDriver(details, cb || noop);
         };
-        ss = createMockStyleSheet($document, $window);
+        ss = createMockStyleSheet($document);
       };
     }));
 

--- a/test/ngAnimate/animateCssSpec.js
+++ b/test/ngAnimate/animateCssSpec.js
@@ -12,6 +12,13 @@ describe("ngAnimate $animateCss", function() {
         : expect(className).not.toMatch(regex);
   }
 
+  function getPossiblyPrefixedStyleValue(element, styleProp) {
+    var value = element.css(prefix + styleProp);
+    if (isUndefined(value)) value = element.css(styleProp);
+
+    return value;
+  }
+
   function keyframeProgress(element, duration, delay) {
     browserTrigger(element, 'animationend',
       { timeStamp: Date.now() + ((delay || 1) * 1000), elapsedTime: duration });
@@ -30,7 +37,8 @@ describe("ngAnimate $animateCss", function() {
   beforeEach(module(function() {
     return function($document, $sniffer, $$rAF, $animate) {
       prefix = '-' + $sniffer.vendorPrefix.toLowerCase() + '-';
-      ss = createMockStyleSheet($document);
+      ss = createMockStyleSheet($document, prefix);
+
       $animate.enabled(true);
       triggerAnimationStartFrame = function() {
         $$rAF.flush();
@@ -325,7 +333,7 @@ describe("ngAnimate $animateCss", function() {
         triggerAnimationStartFrame();
 
         runner.pause();
-        expect(element.css(prefix + 'animation-play-state')).toEqual('paused');
+        expect(getPossiblyPrefixedStyleValue(element, 'animation-play-state')).toEqual('paused');
         runner.resume();
         expect(element.attr('style')).toBeFalsy();
       }));
@@ -346,7 +354,7 @@ describe("ngAnimate $animateCss", function() {
         triggerAnimationStartFrame();
 
         runner.pause();
-        expect(element.css(prefix + 'animation-play-state')).toEqual('paused');
+        expect(getPossiblyPrefixedStyleValue(element, 'animation-play-state')).toEqual('paused');
         runner.end();
         expect(element.attr('style')).toBeFalsy();
       }));
@@ -784,8 +792,8 @@ describe("ngAnimate $animateCss", function() {
 
           jqLite($document[0].body).append($rootElement);
 
-          ss.addRule('.ng-enter-stagger', prefix + 'animation-delay:0.2s');
-          ss.addRule('.ng-enter', prefix + 'animation:my_animation 2s;');
+          ss.addPossiblyPrefixedRule('.ng-enter-stagger', 'animation-delay:0.2s');
+          ss.addPossiblyPrefixedRule('.ng-enter', 'animation:my_animation 2s;');
 
           var i, element, elements = [];
           for (i = 0; i < 5; i++) {
@@ -803,7 +811,7 @@ describe("ngAnimate $animateCss", function() {
             if (i === 0) { // the first element is always run right away
               expect(element.attr('style')).toBeFalsy();
             } else {
-              expect(element.css(prefix + 'animation-play-state')).toBe('paused');
+              expect(getPossiblyPrefixedStyleValue(element, 'animation-play-state')).toBe('paused');
             }
           }
         }));
@@ -879,7 +887,7 @@ describe("ngAnimate $animateCss", function() {
           jqLite($document[0].body).append($rootElement);
 
           ss.addRule('.ng-enter-stagger', 'transition-delay:0.2s');
-          ss.addRule('.transition-animation', prefix + 'animation:2s 5s my_animation;');
+          ss.addPossiblyPrefixedRule('.transition-animation', 'animation: 2s 5s my_animation;');
 
           for (var i = 0; i < 5; i++) {
             var elm = jqLite('<div class="transition-animation"></div>');
@@ -898,11 +906,11 @@ describe("ngAnimate $animateCss", function() {
 
           jqLite($document[0].body).append($rootElement);
 
-          ss.addRule('.ng-enter-stagger', 'transition-delay:0.5s;' +
-                                 prefix + 'animation-delay:1s');
+          ss.addPossiblyPrefixedRule('.ng-enter-stagger', 'transition-delay: 0.5s; ' +
+                                                          'animation-delay: 1s');
 
-          ss.addRule('.ng-enter', 'transition:10s linear all;' +
-                         prefix + 'animation:my_animation 20s');
+          ss.addPossiblyPrefixedRule('.ng-enter', 'transition: 10s linear all; ' +
+                                                  'animation: 20s my_animation');
 
           var i, elm, elements = [];
           for (i = 0; i < 5; i++) {
@@ -1258,14 +1266,14 @@ describe("ngAnimate $animateCss", function() {
           // At this point, the animation should still be running (closing timeout is 7500ms ... duration * 1.5 + delay => 7.5)
           $timeout.flush(7000);
 
-          expect(element.css(prefix + 'transition-delay')).toBe('3s');
-          expect(element.css(prefix + 'transition-duration')).toBe('3s');
+          expect(getPossiblyPrefixedStyleValue(element, 'transition-delay')).toBe('3s');
+          expect(getPossiblyPrefixedStyleValue(element, 'transition-duration')).toBe('3s');
 
           // Let's flush the remaining amount of time for the timeout timer to kick in
           $timeout.flush(500);
 
-          expect(element.css(prefix + 'transition-duration')).toBeOneOf('', '0s');
-          expect(element.css(prefix + 'transition-delay')).toBeOneOf('', '0s');
+          expect(getPossiblyPrefixedStyleValue(element, 'transition-duration')).toBeOneOf('', '0s');
+          expect(getPossiblyPrefixedStyleValue(element, 'transition-delay')).toBeOneOf('', '0s');
         }));
 
         it("should ignore a boolean options.delay value for the closing timeout",
@@ -1291,14 +1299,14 @@ describe("ngAnimate $animateCss", function() {
           // At this point, the animation should still be running (closing timeout is 4500ms ... duration * 1.5 => 4.5)
           $timeout.flush(4000);
 
-          expect(element.css(prefix + 'transition-delay')).toBeOneOf('initial', '0s');
-          expect(element.css(prefix + 'transition-duration')).toBe('3s');
+          expect(getPossiblyPrefixedStyleValue(element, 'transition-delay')).toBeOneOf('initial', '0s');
+          expect(getPossiblyPrefixedStyleValue(element, 'transition-duration')).toBe('3s');
 
           // Let's flush the remaining amount of time for the timeout timer to kick in
           $timeout.flush(500);
 
-          expect(element.css(prefix + 'transition-duration')).toBeOneOf('', '0s');
-          expect(element.css(prefix + 'transition-delay')).toBeOneOf('', '0s');
+          expect(getPossiblyPrefixedStyleValue(element, 'transition-duration')).toBeOneOf('', '0s');
+          expect(getPossiblyPrefixedStyleValue(element, 'transition-delay')).toBeOneOf('', '0s');
         }));
 
       });
@@ -2104,7 +2112,7 @@ describe("ngAnimate $animateCss", function() {
           triggerAnimationStartFrame();
 
 
-          expect(element.css(prefix + 'animation-duration')).toEqual('5s');
+          expect(getPossiblyPrefixedStyleValue(element, 'animation-duration')).toEqual('5s');
         }));
 
         it("should remove all inline keyframe styling when an animation completes if a custom duration was applied",
@@ -2145,7 +2153,7 @@ describe("ngAnimate $animateCss", function() {
           triggerAnimationStartFrame();
 
 
-          expect(element.css(prefix + 'animation-delay')).toEqual('5s');
+          expect(getPossiblyPrefixedStyleValue(element, 'animation-delay')).toEqual('5s');
 
           browserTrigger(element, 'animationend',
             { timeStamp: Date.now() + 5000, elapsedTime: 1.5 });
@@ -2299,7 +2307,7 @@ describe("ngAnimate $animateCss", function() {
           triggerAnimationStartFrame();
 
 
-          expect(element.css(prefix + 'animation-delay')).toEqual('400s');
+          expect(getPossiblyPrefixedStyleValue(element, 'animation-delay')).toEqual('400s');
           expect(element.attr('style')).not.toContain('transition-delay');
         }));
 
@@ -2323,7 +2331,7 @@ describe("ngAnimate $animateCss", function() {
           triggerAnimationStartFrame();
 
 
-          expect(element.css(prefix + 'animation-delay')).toEqual('10s');
+          expect(getPossiblyPrefixedStyleValue(element, 'animation-delay')).toEqual('10s');
           expect(element.css('transition-delay')).toEqual('10s');
         }));
 
@@ -2363,7 +2371,7 @@ describe("ngAnimate $animateCss", function() {
             var assertionsRun = false;
             classSpy = function() {
               assertionsRun = true;
-              expect(element.css(prefix + 'animation-delay')).toEqual('2s');
+              expect(getPossiblyPrefixedStyleValue(element, 'animation-delay')).toEqual('2s');
               expect(element.css('transition-delay')).toEqual('2s');
               expect(element).not.toHaveClass('superman');
             };
@@ -2397,8 +2405,8 @@ describe("ngAnimate $animateCss", function() {
         it("should consider a negative value when delay:true is used with a keyframe animation",
           inject(function($animateCss, $rootElement) {
 
-          ss.addRule('.ng-enter', prefix + 'animation:2s keyframe_animation; ' +
-                                  prefix + 'animation-delay: -1s;');
+          ss.addPossiblyPrefixedRule('.ng-enter', 'animation: 2s keyframe_animation; ' +
+                                                  'animation-delay: -1s;');
 
           var options = {
             delay: true,
@@ -2411,7 +2419,7 @@ describe("ngAnimate $animateCss", function() {
           animator.start();
           triggerAnimationStartFrame();
 
-          expect(element.css(prefix + 'animation-delay')).toContain('-1s');
+          expect(getPossiblyPrefixedStyleValue(element, 'animation-delay')).toContain('-1s');
         }));
 
         they("should consider a negative value when a negative option delay is provided for a $prop animation", {
@@ -2421,17 +2429,17 @@ describe("ngAnimate $animateCss", function() {
               css: 'transition:2s linear all'
             };
           },
-          'keyframe': function(prefix) {
+          'keyframe': function() {
             return {
-              prop: prefix + 'animation-delay',
-              css: prefix + 'animation:2s keyframe_animation'
+              prop: 'animation-delay',
+              css: 'animation: 2s keyframe_animation'
             };
           }
         }, function(testDetailsFactory) {
           inject(function($animateCss, $rootElement) {
             var testDetails = testDetailsFactory(prefix);
 
-            ss.addRule('.ng-enter', testDetails.css);
+            ss.addPossiblyPrefixedRule('.ng-enter', testDetails.css);
             var options = {
               delay: -2,
               event: 'enter',
@@ -2443,7 +2451,7 @@ describe("ngAnimate $animateCss", function() {
             animator.start();
             triggerAnimationStartFrame();
 
-            expect(element.css(testDetails.prop)).toContain('-2s');
+            expect(getPossiblyPrefixedStyleValue(element, testDetails.prop)).toContain('-2s');
           });
         });
 
@@ -2454,18 +2462,18 @@ describe("ngAnimate $animateCss", function() {
               css: 'transition:5s linear all; transition-delay: -2s'
             };
           },
-          'animation': function(prefix) {
+          'animation': function() {
             return {
               event: 'animationend',
-              css: prefix + 'animation:5s keyframe_animation; ' + prefix + 'animation-delay: -2s;'
+              css: 'animation: 5s keyframe_animation; animation-delay: -2s;'
             };
           }
         }, function(testDetailsFactory) {
           inject(function($animateCss, $rootElement) {
-            var testDetails = testDetailsFactory(prefix);
+            var testDetails = testDetailsFactory();
             var event = testDetails.event;
 
-            ss.addRule('.ng-enter', testDetails.css);
+            ss.addPossiblyPrefixedRule('.ng-enter', testDetails.css);
             var options = { event: 'enter', structural: true };
 
             var animator = $animateCss(element, options);
@@ -2571,15 +2579,15 @@ describe("ngAnimate $animateCss", function() {
           $animateCss(element, options).start();
           triggerAnimationStartFrame();
 
-          expect(element.css(prefix + 'transition-delay')).not.toEqual('4s');
-          expect(element.css(prefix + 'transition-duration')).not.toEqual('6s');
+          expect(getPossiblyPrefixedStyleValue(element, 'transition-delay')).not.toEqual('4s');
+          expect(getPossiblyPrefixedStyleValue(element, 'transition-duration')).not.toEqual('6s');
 
           options.to = { color: 'brown' };
           $animateCss(element, options).start();
           triggerAnimationStartFrame();
 
-          expect(element.css(prefix + 'transition-delay')).toEqual('4s');
-          expect(element.css(prefix + 'transition-duration')).toEqual('6s');
+          expect(getPossiblyPrefixedStyleValue(element, 'transition-delay')).toEqual('4s');
+          expect(getPossiblyPrefixedStyleValue(element, 'transition-duration')).toEqual('6s');
         }));
       });
 
@@ -2652,9 +2660,9 @@ describe("ngAnimate $animateCss", function() {
           triggerAnimationStartFrame();
 
 
-          expect(element.css(prefix + 'animation-delay')).toEqual('50s');
-          expect(element.css(prefix + 'animation-duration')).toEqual('5.5s');
-          expect(element.css(prefix + 'animation-name')).toEqual('my_animation');
+          expect(getPossiblyPrefixedStyleValue(element, 'animation-delay')).toEqual('50s');
+          expect(getPossiblyPrefixedStyleValue(element, 'animation-duration')).toEqual('5.5s');
+          expect(getPossiblyPrefixedStyleValue(element, 'animation-name')).toEqual('my_animation');
         }));
 
         it("should be able to execute the animation if it is the only provided value",
@@ -2669,9 +2677,9 @@ describe("ngAnimate $animateCss", function() {
           animator.start();
           triggerAnimationStartFrame();
 
-          expect(element.css(prefix + 'animation-delay')).toEqual('10s');
-          expect(element.css(prefix + 'animation-duration')).toEqual('5.5s');
-          expect(element.css(prefix + 'animation-name')).toEqual('my_animation');
+          expect(getPossiblyPrefixedStyleValue(element, 'animation-delay')).toEqual('10s');
+          expect(getPossiblyPrefixedStyleValue(element, 'animation-duration')).toEqual('5.5s');
+          expect(getPossiblyPrefixedStyleValue(element, 'animation-name')).toEqual('my_animation');
         }));
       });
 
@@ -2964,7 +2972,7 @@ describe("ngAnimate $animateCss", function() {
 
 
           expect(element.css('transition-duration')).toMatch('10s');
-          expect(element.css(prefix + 'animation-duration')).toEqual('10s');
+          expect(getPossiblyPrefixedStyleValue(element, 'animation-duration')).toEqual('10s');
         }));
       });
 
@@ -3004,7 +3012,7 @@ describe("ngAnimate $animateCss", function() {
           inject(function($animateCss) {
 
           ss.addRule('.red', 'transition: 1s linear all;');
-          ss.addRule('.blue', prefix + 'animation:my_keyframe 1s;');
+          ss.addPossiblyPrefixedRule('.blue', 'animation: 1s my_keyframe;');
           var easing = 'ease-out';
           var animator = $animateCss(element, { addClass: 'red blue', easing: easing });
           animator.start();

--- a/test/ngAnimate/animateCssSpec.js
+++ b/test/ngAnimate/animateCssSpec.js
@@ -28,9 +28,9 @@ describe("ngAnimate $animateCss", function() {
 
   var ss, prefix, triggerAnimationStartFrame;
   beforeEach(module(function() {
-    return function($document, $window, $sniffer, $$rAF, $animate) {
+    return function($document, $sniffer, $$rAF, $animate) {
       prefix = '-' + $sniffer.vendorPrefix.toLowerCase() + '-';
-      ss = createMockStyleSheet($document, $window);
+      ss = createMockStyleSheet($document);
       $animate.enabled(true);
       triggerAnimationStartFrame = function() {
         $$rAF.flush();

--- a/test/ngAnimate/integrationSpec.js
+++ b/test/ngAnimate/integrationSpec.js
@@ -7,10 +7,10 @@ describe('ngAnimate integration tests', function() {
 
   var element, html, ss;
   beforeEach(module(function() {
-    return function($rootElement, $document, $window, $animate) {
+    return function($rootElement, $document, $animate) {
       $animate.enabled(true);
 
-      ss = createMockStyleSheet($document, $window);
+      ss = createMockStyleSheet($document);
 
       var body = jqLite($document[0].body);
       html = function(element) {

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1866,8 +1866,8 @@ describe('ngMockE2E', function() {
         }
       });
 
-      return function($animate, $rootElement, $document, $rootScope, $window) {
-        ss = createMockStyleSheet($document, $window);
+      return function($animate, $rootElement, $document, $rootScope) {
+        ss = createMockStyleSheet($document);
 
         element = angular.element('<div class="animate"></div>');
         $rootElement.append(element);


### PR DESCRIPTION
This is a backport of #13686 to v1.4.x.
It includes exactly the same changes with the exception of the fixes to `$sanitizeSpec`, which do not apply to `v1.4.x` (and were omitted). Unit-tests pass on MS Edge.
