### PR TITLE
Component controller

### DIFF
--- a/docs/content/error/$componentController/multicomp.ngdoc
+++ b/docs/content/error/$componentController/multicomp.ngdoc
@@ -1,0 +1,17 @@
+@ngdoc error
+@name $componentController:multicomp
+@fullName Multiple components defined
+@description
+
+This error occurs when multiple components or component-like directives
+are defined with the same name, and processing them would result in a 
+collision or an unsupported configuration.
+
+
+To resolve this issue remove one of the directives or controllers which is causing the collision.
+
+Component-like directives are those that:
+
+* Have a controller
+* Have defined controllerAs
+* Have restrict to 'E'

--- a/docs/content/error/$componentController/nocomp.ngdoc
+++ b/docs/content/error/$componentController/nocomp.ngdoc
@@ -1,0 +1,11 @@
+@ngdoc error
+@name $componentController:nocomp
+@fullName No component available
+@description
+
+This error occurs when it is requested a component that it is not defined.
+
+
+To resolve this issue create the component which the requested name or change 
+the name to match an existing component name.
+

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -928,7 +928,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     return this;
   };
 
-  this.$$componentControllers = createMap();
   /**
    * @ngdoc method
    * @name $compileProvider#component
@@ -1054,8 +1053,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    */
   this.component = function registerComponent(name, options) {
     var controller = options.controller || function() {};
-    var ident = identifierForController(options.controller) || options.controllerAs || '$ctrl';
-    this.$$componentControllers[name] = { controller: controller, ident: ident};
 
     function factory($injector) {
       function makeInjectable(fn) {
@@ -1071,7 +1068,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       var template = (!options.template && !options.templateUrl ? '' : options.template);
       return {
         controller: controller,
-        controllerAs: ident,
+        controllerAs: identifierForController(options.controller) || options.controllerAs || '$ctrl',
         template: makeInjectable(template),
         templateUrl: makeInjectable(options.templateUrl),
         transclude: options.transclude,

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2189,8 +2189,8 @@ angular.mock.$ComponentControllerProvider = ['$compileProvider', function($compi
         var directives = $injector.get(componentName + 'Directive');
         // look for those directives that are components
         var candidateDirectives = directives.filter(function(directiveInfo) {
-          // components have controller, controllerAs and restrict:'E' compatible
-          return directiveInfo.controller && directiveInfo.controllerAs && directiveInfo.restrict.indexOf('E') >= 0;
+          // components have controller, controllerAs and restrict:'E'
+          return directiveInfo.controller && directiveInfo.controllerAs && directiveInfo.restrict === 'E';
         });
         // check if valid directives found
         if (candidateDirectives.length === 0) {

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2182,6 +2182,7 @@ angular.mock.$ControllerDecorator = ['$delegate', function($delegate) {
  * @return {Object} Instance of requested controller.
  */
 angular.mock.$ComponentControllerProvider = ['$compileProvider', function($compileProvider) {
+  var minErr = angular.$$minErr('$componentController');
   return {
     $get: ['$controller','$injector', function($controller,$injector) {
       return function $componentController(componentName, locals, bindings, ident) {
@@ -2194,10 +2195,10 @@ angular.mock.$ComponentControllerProvider = ['$compileProvider', function($compi
         });
         // check if valid directives found
         if (candidateDirectives.length === 0) {
-          throw new Error('No component found');
+          throw minErr('nocomp','No \'{0}\' component found', componentName);
         }
         if (candidateDirectives.length > 1) {
-          throw new Error('Too many components found');
+          throw minErr('multicomp','Found {0} directive candidates for component \'{1}\'', candidateDirectives.length, componentName);
         }
         // get the info of the component
         var directiveInfo = candidateDirectives[0];

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2183,10 +2183,10 @@ angular.mock.$ControllerDecorator = ['$delegate', function($delegate) {
  */
 angular.mock.$ComponentControllerProvider = ['$compileProvider', function($compileProvider) {
   return {
-    $get: ['$controller', function($controller) {
+    $get: ['$controller','$injector', function($controller,$injector) {
       return function $componentController(componentName, locals, bindings, ident) {
-        var controllerInfo = $compileProvider.$$componentControllers[componentName];
-        return $controller(controllerInfo.controller, locals, bindings, ident || controllerInfo.ident);
+        var directiveInfo = $injector.get(componentName + 'Directive')[0];
+        return $controller(directiveInfo.controller, locals, bindings, ident || directiveInfo.controllerAs);
       };
     }]
   };

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2185,7 +2185,22 @@ angular.mock.$ComponentControllerProvider = ['$compileProvider', function($compi
   return {
     $get: ['$controller','$injector', function($controller,$injector) {
       return function $componentController(componentName, locals, bindings, ident) {
-        var directiveInfo = $injector.get(componentName + 'Directive')[0];
+        // get all directives associated to the component name
+        var directives = $injector.get(componentName + 'Directive');
+        // look for those directives that are components
+        var candidateDirectives = directives.filter(function(directiveInfo) {
+          // components have controller, controllerAs and restrict:'E' compatible
+          return directiveInfo.controller && directiveInfo.controllerAs && directiveInfo.restrict.indexOf('E') >= 0;
+        });
+        // check if valid directives found
+        if (candidateDirectives.length === 0) {
+          throw new Error('No component found');
+        }
+        if (candidateDirectives.length > 1) {
+          throw new Error('Too many components found');
+        }
+        // get the info of the component
+        var directiveInfo = candidateDirectives[0];
         return $controller(directiveInfo.controller, locals, bindings, ident || directiveInfo.controllerAs);
       };
     }]

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -2028,7 +2028,7 @@ describe('ngMock', function() {
       inject(function($componentController, $rootScope) {
         expect(function() {
           $componentController('test', { $scope: {} });
-        }).toThrow('No component found');
+        }).toThrowMinErr('$componentController','nocomp', "No 'test' component found");
       });
     });
 
@@ -2054,7 +2054,7 @@ describe('ngMock', function() {
         expect(function() {
           var $scope = {};
           $componentController('test', { $scope: $scope, a: 'A', b: 'B' }, { x: 'X', y: 'Y' });
-        }).toThrow('Too many components found');
+        }).toThrowMinErr('$componentController','multicomp',"Found 2 directive candidates for component 'test'");
       });
     });
   });

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1939,7 +1939,7 @@ describe('ngMock', function() {
       });
     });
 
-    it('should instantiate the controller of the restrict:\'E\' component if there are more directives with the same name but not \'E\' restrictness', function() {
+    it('should instantiate the controller of the restrict:\'E\' component if there are more directives with the same name but not restricted to \'E\'', function() {
       function TestController() {
         this.r = 6779;
       }
@@ -1957,7 +1957,7 @@ describe('ngMock', function() {
       });
     });
 
-    it('should instantiate the controller of the restrict:\'E\' component if there are more directives with the same name and \'E\' restrictness but no controller', function() {
+    it('should instantiate the controller of the restrict:\'E\' component if there are more directives with the same name and restricted to \'E\' but no controller', function() {
       function TestController() {
         this.r = 22926;
       }
@@ -1975,7 +1975,7 @@ describe('ngMock', function() {
       });
     });
 
-    it('should instantiate the controller of the directive with controller if there are more directives', function() {
+    it('should instantiate the controller of the directive with controller, controllerAs and restrict:\'E\' if there are more directives', function() {
       function TestController() {
         this.r = 18842;
       }
@@ -1985,6 +1985,7 @@ describe('ngMock', function() {
         });
         $compileProvider.directive('test', function() {
           return {
+            restrict: 'E',
             controller: TestController,
             controllerAs: '$ctrl'
           };
@@ -1996,7 +1997,7 @@ describe('ngMock', function() {
       });
     });
 
-    it('should fail if there is no directive with restrict:\'E\' compatible and controller', function() {
+    it('should fail if there is no directive with restrict:\'E\' and controller', function() {
       function TestController() {
         this.r = 31145;
       }
@@ -2011,6 +2012,13 @@ describe('ngMock', function() {
           return {
             restrict: 'E',
             controller: TestController
+          };
+        });
+        $compileProvider.directive('test', function() {
+          return {
+            restrict: 'EA',
+            controller: TestController,
+            controllerAs: '$ctrl'
           };
         });
         $compileProvider.directive('test', function() {
@@ -2033,6 +2041,7 @@ describe('ngMock', function() {
       module(function($compileProvider) {
         $compileProvider.directive('test', function() {
           return {
+            restrict: 'E',
             controller: TestController,
             controllerAs: '$ctrl'
           };

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1938,6 +1938,116 @@ describe('ngMock', function() {
         expect($scope.testCtrl).toBe(ctrl);
       });
     });
+
+    it('should instantiate the controller of the restrict:\'E\' component if there are more directives with the same name but not \'E\' restrictness', function() {
+      function TestController() {
+        this.r = 6779;
+      }
+      module(function($compileProvider) {
+        $compileProvider.directive('test', function() {
+          return { restrict: 'A' };
+        });
+        $compileProvider.component('test', {
+          controller: TestController
+        });
+      });
+      inject(function($componentController, $rootScope) {
+        var ctrl = $componentController('test', { $scope: {} });
+        expect(ctrl).toEqual({ r: 6779 });
+      });
+    });
+
+    it('should instantiate the controller of the restrict:\'E\' component if there are more directives with the same name and \'E\' restrictness but no controller', function() {
+      function TestController() {
+        this.r = 22926;
+      }
+      module(function($compileProvider) {
+        $compileProvider.directive('test', function() {
+          return { restrict: 'E' };
+        });
+        $compileProvider.component('test', {
+          controller: TestController
+        });
+      });
+      inject(function($componentController, $rootScope) {
+        var ctrl = $componentController('test', { $scope: {} });
+        expect(ctrl).toEqual({ r: 22926 });
+      });
+    });
+
+    it('should instantiate the controller of the directive with controller if there are more directives', function() {
+      function TestController() {
+        this.r = 18842;
+      }
+      module(function($compileProvider) {
+        $compileProvider.directive('test', function() {
+          return { };
+        });
+        $compileProvider.directive('test', function() {
+          return { 
+            controller: TestController,
+            controllerAs: '$ctrl'
+          };
+        });
+      });
+      inject(function($componentController, $rootScope) {
+        var ctrl = $componentController('test', { $scope: {} });
+        expect(ctrl).toEqual({ r: 18842 });
+      });
+    });
+
+    it('should fail if there is no directive with restrict:\'E\' compatible and controller', function() {
+      function TestController() {
+        this.r = 31145;
+      }
+      module(function($compileProvider) {
+        $compileProvider.directive('test', function() {
+          return {
+            restrict: 'AC',
+            controller: TestController
+          };
+        });
+        $compileProvider.directive('test', function() {
+          return {
+            restrict: 'E',
+            controller: TestController
+          };
+        });
+        $compileProvider.directive('test', function() {
+          return { restrict: 'E' };
+        });
+      });
+      inject(function($componentController, $rootScope) {
+        expect(function() {
+          $componentController('test', { $scope: {} });
+        }).toThrow('No component found');
+      });
+    });
+
+    it('should fail if there more than two components with same name', function() {
+      function TestController($scope, a, b) {
+        this.$scope = $scope;
+        this.a = a;
+        this.b = b;
+      }
+      module(function($compileProvider) {
+        $compileProvider.directive('test', function() {
+          return {
+            controller: TestController,
+            controllerAs: '$ctrl'
+          };
+        });
+        $compileProvider.component('test', {
+          controller: TestController
+        });
+      });
+      inject(function($componentController, $rootScope) {
+        expect(function() {
+          var $scope = {};
+          $componentController('test', { $scope: $scope, a: 'A', b: 'B' }, { x: 'X', y: 'Y' });
+        }).toThrow('Too many components found');
+      });
+    });
   });
 });
 

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1984,7 +1984,7 @@ describe('ngMock', function() {
           return { };
         });
         $compileProvider.directive('test', function() {
-          return { 
+          return {
             controller: TestController,
             controllerAs: '$ctrl'
           };


### PR DESCRIPTION
See PR: https://github.com/angular/angular.js/pull/13732
See Issue: #13683 

Now `$componentController` looks for the directive that represents a component which is the one that satisfies:
- it has at least restrict:'E' (other are valid if they contain 'E')
- it has controller
- it has controllerAs.

Tests are added to evaluate under multiple scenarios commented in the original thread.

PS: I created the new PR to solve conflicts with minimum "_dirtiness_".
