### PR TITLE
use forEach instead of Object.keys in compiler Attributes constructor

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1193,13 +1193,10 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     var specialAttrHolder = document.createElement('div');
     var Attributes = function(element, attributesToCopy) {
       if (attributesToCopy) {
-        var keys = Object.keys(attributesToCopy);
-        var i, l, key;
-
-        for (i = 0, l = keys.length; i < l; i++) {
-          key = keys[i];
-          this[key] = attributesToCopy[key];
-        }
+        var self = this;
+        forEach(attributesToCopy, function(value, key) {
+          self[key] = value;
+        });
       } else {
         this.$attr = {};
       }

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1193,10 +1193,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     var specialAttrHolder = document.createElement('div');
     var Attributes = function(element, attributesToCopy) {
       if (attributesToCopy) {
-        var self = this;
         forEach(attributesToCopy, function(value, key) {
-          self[key] = value;
-        });
+          this[key] = value;
+        }, this);
       } else {
         this.$attr = {};
       }


### PR DESCRIPTION
use forEach instead of Object.keys in compiler Attributes constructor
