### PR TITLE
docs(input[number]): describe your change...

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -677,8 +677,8 @@ var inputType = {
    *
    * @param {string} ngModel Assignable angular expression to data-bind to.
    * @param {string=} name Property name of the form under which the control is published.
-   * @param {string=} min Sets the `min` validation error key if the value entered is less than `min`.
-   * @param {string=} max Sets the `max` validation error key if the value entered is greater than `max`.
+   * @param {number=} min Sets the `min` validation error key if the value entered is less than `min`.
+   * @param {number=} max Sets the `max` validation error key if the value entered is greater than `max`.
    * @param {string=} required Sets `required` validation error key if the value is not entered.
    * @param {string=} ngRequired Adds `required` attribute and `required` validation constraint to
    *    the element when the ngRequired expression evaluates to true. Use `ngRequired` instead of


### PR DESCRIPTION
Changed `input[type=number]` min and max attributes to take `number` rather than `string`.

Apologies if I'm confused about this, perhaps since they can take dates or numbers it needs to be a string? (or something?)
