### PR TITLE
test($log): fix up to work with Safari 9

### DIFF
--- a/test/ng/logSpec.js
+++ b/test/ng/logSpec.js
@@ -138,16 +138,26 @@ describe('$log', function() {
   describe('$log.error', function() {
     var e, $log, errorArgs;
 
-    beforeEach(function() {
-      e = new Error('');
-      e.message = undefined;
-      e.sourceURL = undefined;
-      e.line = undefined;
-      e.stack = undefined;
+    function TestError() {
+      Error.prototype.constructor.apply(this, arguments);
+      this.message = undefined;
+      this.sourceURL = undefined;
+      this.line = undefined;
+      this.stack = undefined;
+    }
+    TestError.prototype = Object.create(Error.prototype);
+    TestError.prototype.constructor = TestError;
 
-      $log = new $LogProvider().$get[1]({console:{error:function() {
-        errorArgs = [].slice.call(arguments, 0);
-      }}});
+    beforeEach(function() {
+      e = new TestError('');
+      var mockWindow = {
+        console: {
+          error: function() {
+            errorArgs = [].slice.call(arguments, 0);
+          }
+        }
+      };
+      $log = new $LogProvider().$get[1](mockWindow);
     });
 
 


### PR DESCRIPTION
On Safari 9.0.2, you are not allowed to write to `sourceUrl` or `line`
on a native Error object.

This commit uses a custom error instead.
