### PR TITLE
fix(after): check parentNode is not null

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -961,6 +961,11 @@ forEach({
   },
 
   after: function(element, newElement) {
+    if (!element.parentNode) {
+      // may happen with nodes using ngInclude
+      return;
+    }
+
     var index = element, parent = element.parentNode;
     newElement = new JQLite(newElement);
 


### PR DESCRIPTION
Hi Angular team,

I have been through an error raised by JQLite, lastly, using ngInclude in a uiView node (from ui-router). 

**Version** The error is raised in my ionic project (angular 1.4.3) but also with the last version of Angular 1.4.8 (at the time being). 

**Browser** I could reproduce the case with both Chrome and Firefox.

**System** Linux (Debian 8.2), Windows (8.1 and 10)

**Reproducable** Always

```
TypeError: Cannot read property 'insertBefore' of null
    at forEach.after (https://code.angularjs.org/1.4.8/angular.js:3498:13)
    at Object.JQLite.(anonymous function) [as after] (https://code.angularjs.org/1.4.8/angular.js:3582:17)
    at domInsert (https://code.angularjs.org/1.4.8/angular.js:5095:35)
    at Object.enter (https://code.angularjs.org/1.4.8/angular.js:5258:9)
    at https://code.angularjs.org/1.4.8/angular.js:24404:26
    at publicLinkFn (https://code.angularjs.org/1.4.8/angular.js:7610:29)
    at boundTranscludeFn (https://code.angularjs.org/1.4.8/angular.js:7749:16)
    at controllersBoundTransclude (https://code.angularjs.org/1.4.8/angular.js:8362:18)
    at https://code.angularjs.org/1.4.8/angular.js:24402:27
    at processQueue (https://code.angularjs.org/1.4.8/angular.js:14792:28)
```

**Demo** Here is a plunker reproducing the issue: http://plnkr.co/jLspFZOTvkevx25KgxEp

And the case is as follows:
Using a ngInclude node in a uiView node in order to display a default content. 

``` html
<div ui-view="myPage">
  <div ng-include="'default-view.html'"></div>
</div>
```

Ther error is raised (in Angular's JQLite) when navigating to a route displaying an other content for the uiView.
