### PR TITLE
fix(form): make ngForm $pristine after nested control.$setPristine() (brute force version)

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -279,16 +279,9 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
 
   // Private API: update form pristine-ness
   form.$$updatePristine = function() {
-    var isPristine = true,
-        controlsLength = controls.length,
-        i;
-
-    for (i = 0; i < controlsLength; i++) {
-      if (!controls[i].$pristine) {
-        isPristine = false;
-        break;
-      }
-    }
+    var isPristine = controls.every(function(control) {
+      return control.$pristine;
+    });
 
     if (isPristine) {
       // All the nested controls are already pristine.

--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -383,6 +383,7 @@ var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$
     ctrl.$pristine = true;
     $animate.removeClass($element, DIRTY_CLASS);
     $animate.addClass($element, PRISTINE_CLASS);
+    ctrl.$$parentForm.$$updatePristine();
   };
 
   /**

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -714,7 +714,8 @@ describe('form', function() {
       expect(form.$error.maxlength[0].$name).toBe('childform');
 
       inputController.$setPristine();
-      expect(form.$dirty).toBe(true);
+      // this assertion prevents to propagate prestine to the parent form
+      // expect(form.$dirty).toBe(true);
 
       form.$setPristine();
 
@@ -1042,6 +1043,80 @@ describe('form', function() {
       expect(nestedInput).toBePristine();
       expect(nestedInputCtrl.$pristine).toBe(true);
       expect(nestedInputCtrl.$dirty).toBe(false);
+    });
+
+    it('should propagate pristine-ness to the parent form', function() {
+      doc = $compile(
+          '<form name="parentForm">' +
+            '<div ng-form name="childForm"></div>' +
+          '</form>')(scope);
+
+      var parentForm = doc,
+          childForm = parentForm.find('div').eq(0),
+          childFormCtrl = scope.childForm;
+
+      childFormCtrl.$setDirty();
+      scope.$apply();
+      expect(parentForm).not.toBePristine();
+
+      childFormCtrl.$setPristine();
+      scope.$apply();
+      expect(childForm).toBePristine();
+      expect(parentForm).toBePristine();
+    });
+
+    it('should be pristine if all the nested controls are pristine', function() {
+      doc = $compile(
+          '<form name="form">' +
+            '<input ng-model="inputModel1" name="input1">' +
+            '<input ng-model="inputModel2" name="input2">' +
+          '</form>')(scope);
+
+      var form = doc,
+          formCtrl = scope.form,
+          input1 = form.find('input').eq(0),
+          input2 = form.find('input').eq(1),
+          inputCtrl1 = input1.controller('ngModel'),
+          inputCtrl2 = input2.controller('ngModel');
+
+      inputCtrl1.$setDirty();
+      inputCtrl2.$setDirty();
+      scope.$apply();
+      expect(form).not.toBePristine();
+
+      inputCtrl1.$setPristine();
+      scope.$apply();
+      expect(form).not.toBePristine();
+
+      inputCtrl2.$setPristine();
+      scope.$apply();
+      expect(form).toBePristine();
+    });
+
+    it('should be pristine if all the nested forms are pristine', function() {
+      doc = $compile(
+          '<form name="form">' +
+            '<div ng-form name="childForm1"></div>' +
+            '<div ng-form name="childForm2"></div>' +
+          '</form>')(scope);
+
+      var form = doc,
+          formCtrl = scope.form,
+          childFormCtrl1 = scope.childForm1,
+          childFormCtrl2 = scope.childForm2;
+
+      childFormCtrl1.$setDirty();
+      childFormCtrl2.$setDirty();
+      scope.$apply();
+      expect(form).not.toBePristine();
+
+      childFormCtrl1.$setPristine();
+      scope.$apply();
+      expect(form).not.toBePristine();
+
+      childFormCtrl2.$setPristine();
+      scope.$apply();
+      expect(form).toBePristine();
     });
   });
 

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -15,7 +15,8 @@ describe('ngModel', function() {
         $$setPending: jasmine.createSpy('$$setPending'),
         $setValidity: jasmine.createSpy('$setValidity'),
         $setDirty: jasmine.createSpy('$setDirty'),
-        $$clearControlValidity: noop
+        $$clearControlValidity: noop,
+        $$updatePristine: jasmine.createSpy('$$updatePristine')
       };
 
       element = jqLite('<form><input></form>');
@@ -144,6 +145,11 @@ describe('ngModel', function() {
         ctrl.$setPristine();
         expect(ctrl.$dirty).toBe(false);
         expect(ctrl.$pristine).toBe(true);
+      });
+
+      it('should propagate pristine to the parent form', function() {
+        ctrl.$setPristine();
+        expect(parentFormCtrl.$$updatePristine).toHaveBeenCalledOnce();
       });
     });
 


### PR DESCRIPTION
When calling $setPristine on the nested form or control,
form becomes $pristine if all the nested controls are pristine

Closes #13715
