### PR TITLE
removed ignored 'placeholder' attribute

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -182,7 +182,7 @@ var inputType = {
        <form name="myForm" ng-controller="DateController as dateCtrl">
           <label for="exampleInput">Pick a date in 2013:</label>
           <input type="date" id="exampleInput" name="input" ng-model="example.value"
-              placeholder="yyyy-MM-dd" min="2013-01-01" max="2013-12-31" required />
+              min="2013-01-01" max="2013-12-31" required />
           <div role="alert">
             <span class="error" ng-show="myForm.input.$error.required">
                 Required!</span>


### PR DESCRIPTION
input[type="date"] does not support the placeholder attribute (ref: http://www.w3schools.com/tags/att_input_placeholder.asp).

Also I present this as a contender for the smallest possible PR to this repo.

note: if this PR is acceptable, I expand it to include the remaining ignored placeholders in this file.
