### PR TITLE
feat($resource): add support for timeout in cancellable actions

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -593,7 +593,6 @@ angular.module('ngResource', ['ng']).
           } else {
             if(cancellable) {
               simulatedTimeout = action.timeout;
-              delete action.timeout;
             }
           }
 
@@ -665,11 +664,7 @@ angular.module('ngResource', ['ng']).
               httpConfig.timeout = timeoutDeferred.promise;
 
               if(simulatedTimeout) {
-                simulatedTimeoutPromise = $timeout(function() {
-                  if(timeoutDeferred) {
-                    timeoutDeferred.resolve();
-                  }
-                }, simulatedTimeout);
+                simulatedTimeoutPromise = $timeout(timeoutDeferred.resolve, simulatedTimeout);
               }
             }
 
@@ -723,6 +718,7 @@ angular.module('ngResource', ['ng']).
                 value.$cancelRequest = angular.noop;
                 timeoutDeferred = httpConfig.timeout = null;
                 $timeout.cancel(simulatedTimeoutPromise);
+                simulatedTimeoutPromise = null;
               }
             });
 

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -65,6 +65,7 @@ function shallowClearAndCopy(src, dst) {
  * @requires $http
  * @requires ng.$log
  * @requires $q
+ * @requires $timeout
  *
  * @description
  * A factory which creates a resource object that lets you interact with
@@ -160,7 +161,6 @@ function shallowClearAndCopy(src, dst) {
  *     will be cancelled (if not already completed) by calling `$cancelRequest()` on the call's
  *     return value. Calling `$cancelRequest()` for a non-cancellable or an already
  *     completed/cancelled request will have no effect.<br />
- *     **Note:** If a timeout is specified in millisecondes, `cancellable` is ignored.
  *   - **`withCredentials`** - `{boolean}` - whether to set the `withCredentials` flag on the
  *     XHR object. See
  *     [requests with credentials](https://developer.mozilla.org/en/http_access_control#section_5)
@@ -416,7 +416,7 @@ angular.module('ngResource', ['ng']).
       }
     };
 
-    this.$get = ['$http', '$log', '$q', function($http, $log, $q) {
+    this.$get = ['$http', '$log', '$q', '$timeout', function($http, $log, $q, $timeout) {
 
       var noop = angular.noop,
         forEach = angular.forEach,
@@ -575,7 +575,11 @@ angular.module('ngResource', ['ng']).
 
         forEach(actions, function(action, name) {
           var hasBody = /^(POST|PUT|PATCH)$/i.test(action.method);
-          var cancellable = false;
+          var cancellable = angular.isDefined(action.cancellable) ? action.cancellable :
+            (options && angular.isDefined(options.cancellable)) ? options.cancellable :
+              provider.defaults.cancellable;
+
+          var simulatedTimeout;
 
           if (!angular.isNumber(action.timeout)) {
             if (action.timeout) {
@@ -586,9 +590,11 @@ angular.module('ngResource', ['ng']).
                          'requests, you should use the `cancellable` option.');
               delete action.timeout;
             }
-            cancellable = angular.isDefined(action.cancellable) ? action.cancellable :
-                         (options && angular.isDefined(options.cancellable)) ? options.cancellable :
-                         provider.defaults.cancellable;
+          } else {
+            if(cancellable) {
+              simulatedTimeout = action.timeout;
+              delete action.timeout;
+            }
           }
 
           Resource[name] = function(a1, a2, a3, a4) {
@@ -639,6 +645,7 @@ angular.module('ngResource', ['ng']).
             var responseErrorInterceptor = action.interceptor && action.interceptor.responseError ||
               undefined;
             var timeoutDeferred;
+            var simulatedTimeoutPromise;
 
             forEach(action, function(value, key) {
               switch (key) {
@@ -656,6 +663,14 @@ angular.module('ngResource', ['ng']).
             if (!isInstanceCall && cancellable) {
               timeoutDeferred = $q.defer();
               httpConfig.timeout = timeoutDeferred.promise;
+
+              if(simulatedTimeout) {
+                simulatedTimeoutPromise = $timeout(function() {
+                  if(timeoutDeferred) {
+                    timeoutDeferred.resolve();
+                  }
+                }, simulatedTimeout);
+              }
             }
 
             if (hasBody) httpConfig.data = data;
@@ -707,6 +722,7 @@ angular.module('ngResource', ['ng']).
               if (!isInstanceCall && cancellable) {
                 value.$cancelRequest = angular.noop;
                 timeoutDeferred = httpConfig.timeout = null;
+                $timeout.cancel(simulatedTimeoutPromise);
               }
             });
 


### PR DESCRIPTION
Old behavior: actions can be either cancellable or have a numeric timeout.
When having both defined, cancellable was ignored.
With this commit: it's possible for actions to have both cancellable:true
and numeric timeout defined.

Example usage:

``` js
var Post = $resource('/posts/:id', {id: '@id'}, {
  get: {
    method: 'GET',
    cancellable: true,
    timeout: 10000
  }
});

var currentPost = Post.get({id: 1});
...
// the next request can cancel the previous one
currentPost.$cancelRequest();
currentPost = Post.get({id: 2});

// any of those requests will also timeout, if the response
// doesn't come within 10 seconds
```
