### PR TITLE
fix(ngSanitize): Blacklist the attribyte `usemap`

### DIFF
--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -254,7 +254,7 @@ var validElements = angular.extend({},
                                    optionalEndTagElements);
 
 //Attributes that have href and hence need to be sanitized
-var uriAttrs = toMap("background,cite,href,longdesc,src,usemap,xlink:href");
+var uriAttrs = toMap("background,cite,href,longdesc,src,xlink:href");
 
 var htmlAttrs = toMap('abbr,align,alt,axis,bgcolor,border,cellpadding,cellspacing,class,clear,' +
     'color,cols,colspan,compact,coords,dir,face,headers,height,hreflang,hspace,' +

--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -153,6 +153,7 @@ describe('HTML', function() {
 
   it('should remove unsafe value', function() {
     expectHTML('<a href="javascript:alert()">').toEqual('<a></a>');
+    expectHTML('<img src="foo.gif" usemap="#foomap">').toEqual('<img src="foo.gif">');
   });
 
   it('should handle self closed elements', function() {


### PR DESCRIPTION
Given that the attribute `name` is blacklisted, the attribute `usemap` should be
blacklisted too.
