### PR TITLE
fix($location): do not decode `%2F` codes in the path back to `/` characters

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -79,6 +79,7 @@
     "parseKeyValue": false,
     "toKeyValue": false,
     "encodeUriSegment": false,
+    "decodeUriSegment": false,
     "encodeUriQuery": false,
     "angularInit": false,
     "bootstrap": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -74,6 +74,7 @@
   parseKeyValue: true,
   toKeyValue: true,
   encodeUriSegment: true,
+  decodeUriSegment: true,
   encodeUriQuery: true,
   angularInit: true,
   bootstrap: true,
@@ -1338,9 +1339,21 @@ function toKeyValue(obj) {
  */
 function encodeUriSegment(val) {
   return encodeUriQuery(val, true).
+             replace(/%252F/gi, '%2F').
              replace(/%26/gi, '&').
              replace(/%3D/gi, '=').
              replace(/%2B/gi, '+');
+}
+
+
+/**
+ * We need our custom method because our segments may contain encoded forward slashes that should
+ * not be decoded.
+ */
+function decodeUriSegment(val) {
+  val = val.replace(/%2F/gi, '%252F');
+  val = decodeURIComponent(val);
+  return val;
 }
 
 

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -37,7 +37,7 @@ function parseAppUrl(relativeUrl, locationObj) {
     relativeUrl = '/' + relativeUrl;
   }
   var match = urlResolve(relativeUrl);
-  locationObj.$$path = decodeURIComponent(prefixed && match.pathname.charAt(0) === '/' ?
+  locationObj.$$path = decodeUriSegment(prefixed && match.pathname.charAt(0) === '/' ?
       match.pathname.substring(1) : match.pathname);
   locationObj.$$search = parseKeyValue(match.search);
   locationObj.$$hash = decodeURIComponent(match.hash);

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -2492,8 +2492,21 @@ describe('$location', function() {
       locationUrl = new LocationHashbangUrl('http://server/pre/index.html', 'http://server/pre/', '#');
 
       locationUrl.$$parse('http://server/pre/index.html#http%3A%2F%2Fexample.com%2F');
+      expect(locationUrl.url()).toBe('/http:%2F%2Fexample.com%2F');
+      expect(locationUrl.absUrl()).toBe('http://server/pre/index.html#/http:%2F%2Fexample.com%2F');
+
+      locationUrl.$$parse('http://server/pre/index.html#http://example.com/');
       expect(locationUrl.url()).toBe('/http://example.com/');
       expect(locationUrl.absUrl()).toBe('http://server/pre/index.html#/http://example.com/');
+    });
+
+
+    it('should not decode `%2F` codes into forward slashes in the location path', function() {
+      locationUrl = new LocationHashbangUrl('http://server/pre/index.html', 'http://server/pre/', '#');
+
+      locationUrl.$$parse('http://server/pre/index.html#/abc%2Fxyz');
+      expect(locationUrl.url()).toBe('/abc%2Fxyz');
+      expect(locationUrl.absUrl()).toBe('http://server/pre/index.html#/abc%2Fxyz');
     });
 
     it('should throw on url(urlString, stateObject)', function() {


### PR DESCRIPTION
If the user has purposefully encoded forward slashes into their $location path
(i.e. the bit after the hashbang), then we should not forceably decode it,
since if you want forward slashes you are allowed to place them in an
unencoded form straight into a hash segment of a URL

Closes #13245
