### PR TITLE
docs($cookiesProvider): Clarify cookie domain rules

### DIFF
--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -40,7 +40,7 @@ angular.module('ngCookies', ['ng']).
      *   if the current domain is not a sub-domain of this domain or equal to it.
      * - **expires** - `{string|Date}` - String of the form "Wdy, DD Mon YYYY HH:MM:SS GMT"
      *   or a Date object indicating the exact date/time this cookie will expire.
-     * - **secure** - `{boolean}` - `true` if the cookie will be available only through a
+     * - **secure** - `{boolean}` - If `true`, then the cookie will only be available through a
      *   secured connection.
      *
      * Note: By default, the address that appears in your `<base>` tag will be used as the path.

--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -34,16 +34,17 @@ angular.module('ngCookies', ['ng']).
      * The object may have following properties:
      *
      * - **path** - `{string}` - The cookie will be available only for this path and its
-     *   sub-paths. By default, this would be the URL that appears in your base tag.
+     *   sub-paths. By default, this is the URL that appears in your `<base>` tag.
      * - **domain** - `{string}` - The cookie will be available only for this domain and
-     *   its sub-domains. For obvious security reasons the user agent will not accept the
-     *   cookie if the current domain is not a sub domain or equals to the requested domain.
+     *   its sub-domains. For security reasons the user agent will not accept the cookie
+     *   if the current domain is not a sub-domain of this domain or equal to it.
      * - **expires** - `{string|Date}` - String of the form "Wdy, DD Mon YYYY HH:MM:SS GMT"
      *   or a Date object indicating the exact date/time this cookie will expire.
-     * - **secure** - `{boolean}` - The cookie will be available only in secured connection.
+     * - **secure** - `{boolean}` - `true` if the cookie will be available only through a
+     *   secured connection.
      *
-     * Note: by default the address that appears in your `<base>` tag will be used as path.
-     * This is important so that cookies will be visible for all routes in case html5mode is enabled
+     * Note: By default, the address that appears in your `<base>` tag will be used as the path.
+     * This is important so that cookies will be visible for all routes when html5mode is enabled.
      *
      **/
     var defaults = this.defaults = {};


### PR DESCRIPTION
Fixed a grammatical mistake ("equals to"), made hyphenation consistent, fixed punctuation and clarified the sentence structure.
