### PR TITLE
fix($http): properly synchronize $browser outstandingRequestCount

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -375,8 +375,8 @@ function $HttpProvider() {
    **/
   var interceptorFactories = this.interceptors = [];
 
-  this.$get = ['$httpBackend', '$$cookieReader', '$cacheFactory', '$rootScope', '$q', '$injector',
-      function($httpBackend, $$cookieReader, $cacheFactory, $rootScope, $q, $injector) {
+  this.$get = ['$httpBackend', '$$cookieReader', '$cacheFactory', '$rootScope', '$q', '$injector', '$browser',
+      function($httpBackend, $$cookieReader, $cacheFactory, $rootScope, $q, $injector, $browser) {
 
     var defaultCache = $cacheFactory('$http');
 
@@ -968,12 +968,18 @@ function $HttpProvider() {
         }
       });
 
+      $browser.$$incOutstandingRequestCount();
+
       while (chain.length) {
         var thenFn = chain.shift();
         var rejectFn = chain.shift();
 
         promise = promise.then(thenFn, rejectFn);
       }
+
+      promise.finally(function() {
+        $browser.$$completeOutstandingRequest(noop);
+      });
 
       if (useLegacyPromise) {
         promise.success = function(fn) {

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -55,7 +55,6 @@ function $HttpBackendProvider() {
 function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDocument) {
   // TODO(vojta): fix the signature
   return function(method, url, post, callback, headers, timeout, withCredentials, responseType) {
-    $browser.$$incOutstandingRequestCount();
     url = url || $browser.url();
 
     if (lowercase(method) == 'jsonp') {
@@ -158,7 +157,6 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
       jsonpDone = xhr = null;
 
       callback(status, response, headersString, statusText);
-      $browser.$$completeOutstandingRequest(noop);
     }
   };
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -37,8 +37,9 @@ angular.mock.$Browser = function() {
   self.pollFns = [];
 
   // TODO(vojta): remove this temporary api
-  self.$$completeOutstandingRequest = angular.noop;
-  self.$$incOutstandingRequestCount = angular.noop;
+  self.$$outstandingRequestCount = 0;
+  self.$$completeOutstandingRequest = function() { self.$$outstandingRequestCount--; };
+  self.$$incOutstandingRequestCount = function() { self.$$outstandingRequestCount++; };
 
 
   // register url polling fn

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1866,6 +1866,24 @@ describe('$http', function() {
         expect(paramSerializer({foo: 'foo', bar: ['bar', 'baz']})).toEqual('bar=bar&bar=baz&foo=foo');
       });
     });
+
+    describe('$browser outstandingRequests', function() {
+      var $browser;
+
+      beforeEach(inject(['$browser', function(browser) {
+        $browser = browser;
+      }]));
+
+      it('should update $brower outstandingRequestCount', function() {
+        $httpBackend.when('GET').respond(200);
+
+        expect($browser.$$outstandingRequestCount).toBe(0);
+        $http({method: 'GET', url: '/some'});
+        expect($browser.$$outstandingRequestCount).toBe(1);
+        $httpBackend.flush();
+        expect($browser.$$outstandingRequestCount).toBe(0);
+      });
+    });
   });
 
 


### PR DESCRIPTION
The issue is that using $http doesn't update $browser.outstandingRequestCount synchronously so that $browser.notifyWhenNoOutstandingRequests waits accordingly.
Configuring this synchronization with the promise chain updates the outstandingRequestCount correctly.

Closes #13782
