### PR TITLE
fix($http): include interceptors as a part of $browser's outstandingRequest

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -375,8 +375,8 @@ function $HttpProvider() {
    **/
   var interceptorFactories = this.interceptors = [];
 
-  this.$get = ['$httpBackend', '$$cookieReader', '$cacheFactory', '$rootScope', '$q', '$injector', '$browser',
-      function($httpBackend, $$cookieReader, $cacheFactory, $rootScope, $q, $injector, $browser) {
+  this.$get = ['$browser', '$httpBackend', '$$cookieReader', '$cacheFactory', '$rootScope', '$q', '$injector',
+      function($browser, $httpBackend, $$cookieReader, $cacheFactory, $rootScope, $q, $injector) {
 
     var defaultCache = $cacheFactory('$http');
 
@@ -976,7 +976,6 @@ function $HttpProvider() {
       }
 
       promise.finally(completeOutstandingRequest);
-
 
       if (useLegacyPromise) {
         promise.success = function(fn) {

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -375,8 +375,8 @@ function $HttpProvider() {
    **/
   var interceptorFactories = this.interceptors = [];
 
-  this.$get = ['$httpBackend', '$$cookieReader', '$cacheFactory', '$rootScope', '$q', '$injector',
-      function($httpBackend, $$cookieReader, $cacheFactory, $rootScope, $q, $injector) {
+  this.$get = ['$httpBackend', '$$cookieReader', '$cacheFactory', '$rootScope', '$q', '$injector', '$browser',
+      function($httpBackend, $$cookieReader, $cacheFactory, $rootScope, $q, $injector, $browser) {
 
     var defaultCache = $cacheFactory('$http');
 
@@ -968,12 +968,18 @@ function $HttpProvider() {
         }
       });
 
+      $browser.$$incOutstandingRequestCount();
+
       while (chain.length) {
         var thenFn = chain.shift();
         var rejectFn = chain.shift();
 
         promise = promise.then(thenFn, rejectFn);
       }
+
+      promise.finally(function() {
+        $browser.$$completeOutstandingRequest(noop);
+      });
 
       if (useLegacyPromise) {
         promise.success = function(fn) {

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -55,7 +55,6 @@ function $HttpBackendProvider() {
 function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDocument) {
   // TODO(vojta): fix the signature
   return function(method, url, post, callback, headers, timeout, withCredentials, responseType) {
-    $browser.$$incOutstandingRequestCount();
     url = url || $browser.url();
 
     if (lowercase(method) == 'jsonp') {
@@ -158,7 +157,6 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
       jsonpDone = xhr = null;
 
       callback(status, response, headersString, statusText);
-      $browser.$$completeOutstandingRequest(noop);
     }
   };
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -37,8 +37,9 @@ angular.mock.$Browser = function() {
   self.pollFns = [];
 
   // TODO(vojta): remove this temporary api
-  self.$$completeOutstandingRequest = angular.noop;
-  self.$$incOutstandingRequestCount = angular.noop;
+  self.$$outstandingRequestCount = 0;
+  self.$$completeOutstandingRequest = function() { self.$$outstandingRequestCount--; };
+  self.$$incOutstandingRequestCount = function() { self.$$outstandingRequestCount++; };
 
 
   // register url polling fn

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -37,9 +37,8 @@ angular.mock.$Browser = function() {
   self.pollFns = [];
 
   // TODO(vojta): remove this temporary api
-  self.$$outstandingRequestCount = 0;
-  self.$$completeOutstandingRequest = function() { self.$$outstandingRequestCount--; };
-  self.$$incOutstandingRequestCount = function() { self.$$outstandingRequestCount++; };
+  self.$$completeOutstandingRequest = angular.noop;
+  self.$$incOutstandingRequestCount = angular.noop;
 
 
   // register url polling fn

--- a/test/e2e/fixtures/http/index.html
+++ b/test/e2e/fixtures/http/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html ng-app="test">
+  <div ng-controller="TestCtrl">
+      <p>{{text}}</p>
+  </div>
+  <script src="angular.js"></script>
+  <script src="script.js"></script>
+</html>

--- a/test/e2e/fixtures/http/script.js
+++ b/test/e2e/fixtures/http/script.js
@@ -1,0 +1,29 @@
+angular.module('test', [])
+  .controller('TestCtrl', function($scope, $http, $cacheFactory, $timeout) {
+    var cache = $cacheFactory('sites');
+    var siteUrl = "http://some.site";
+    cache.put(siteUrl, "Something");
+    $http.get(siteUrl, {cache: cache}).then(function(data) {
+      $scope.text = "Hello, world!";
+    });
+  })
+  .config(function($httpProvider) {
+    $httpProvider.interceptors.push(function($q, $window) {
+      return {
+       'request': function(config) {
+          return $q(function(resolve,reject) {
+            $window.setTimeout(function() {
+              resolve(config);
+            }, 50);
+          });
+        },
+        'response': function(response) {
+          return $q(function(resolve,reject) {
+            $window.setTimeout(function() {
+              resolve(response);
+            }, 50);
+          });
+        }
+      };
+    });
+  });

--- a/test/e2e/tests/httpSpec.js
+++ b/test/e2e/tests/httpSpec.js
@@ -1,0 +1,11 @@
+
+describe('$http', function() {
+  beforeEach(function() {
+    loadFixture("http").andWaitForAngular();
+  });
+
+  it('should have the interpolated text', function() {
+    expect(element(by.binding('text')).getText())
+        .toBe('Hello, world!');
+  });
+});

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1866,6 +1866,24 @@ describe('$http', function() {
         expect(paramSerializer({foo: 'foo', bar: ['bar', 'baz']})).toEqual('bar=bar&bar=baz&foo=foo');
       });
     });
+
+    describe('$browser outstandingRequests', function() {
+      var $browser;
+
+      beforeEach(inject(['$browser', function(browser) {
+        $browser = browser;
+      }]));
+
+      it('should update $brower outstandingRequestCount', function() {
+        $httpBackend.when('GET').respond(200);
+
+        expect($browser.$$outstandingRequestCount).toBe(0);
+        $http({method: 'GET', url: '/some'});
+        expect($browser.$$outstandingRequestCount).toBe(1);
+        $httpBackend.flush();
+        expect($browser.$$outstandingRequestCount).toBe(0);
+      });
+    });
   });
 
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1867,21 +1867,22 @@ describe('$http', function() {
       });
     });
 
-    describe('$browser outstandingRequests', function() {
-      var $browser;
+    describe('$browser\'s outstandingRequestCount', function() {
+      var incOutstandingRequestCountSpy, completeOutstandingRequestSpy;
 
-      beforeEach(inject(['$browser', function(browser) {
-        $browser = browser;
-      }]));
+      beforeEach(inject(function($browser) {
+        incOutstandingRequestCountSpy = spyOn($browser, '$$incOutstandingRequestCount').andCallThrough();
+        completeOutstandingRequestSpy = spyOn($browser, '$$completeOutstandingRequest').andCallThrough();
+      }));
 
-      it('should update $brower outstandingRequestCount', function() {
+      it('should update $browser outstandingRequestCount', function() {
         $httpBackend.when('GET').respond(200);
 
-        expect($browser.$$outstandingRequestCount).toBe(0);
+        expect(incOutstandingRequestCountSpy).not.toHaveBeenCalled();
         $http({method: 'GET', url: '/some'});
-        expect($browser.$$outstandingRequestCount).toBe(1);
+        expect(incOutstandingRequestCountSpy).toHaveBeenCalledOnce();
         $httpBackend.flush();
-        expect($browser.$$outstandingRequestCount).toBe(0);
+        expect(completeOutstandingRequestSpy).toHaveBeenCalledOnce();
       });
     });
   });

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1871,15 +1871,27 @@ describe('$http', function() {
       var incOutstandingRequestCountSpy, completeOutstandingRequestSpy;
 
       beforeEach(inject(function($browser) {
-        incOutstandingRequestCountSpy = spyOn($browser, '$$incOutstandingRequestCount').andCallThrough();
-        completeOutstandingRequestSpy = spyOn($browser, '$$completeOutstandingRequest').andCallThrough();
+        incOutstandingRequestCountSpy
+          = spyOn($browser, '$$incOutstandingRequestCount').andCallThrough();
+        completeOutstandingRequestSpy
+          = spyOn($browser, '$$completeOutstandingRequest').andCallThrough();
       }));
 
-      it('should update $browser outstandingRequestCount', function() {
+      it('should update $browser outstandingRequestCount on success', function() {
         $httpBackend.when('GET').respond(200);
 
         expect(incOutstandingRequestCountSpy).not.toHaveBeenCalled();
-        $http({method: 'GET', url: '/some'});
+        $http.get('');
+        expect(incOutstandingRequestCountSpy).toHaveBeenCalledOnce();
+        $httpBackend.flush();
+        expect(completeOutstandingRequestSpy).toHaveBeenCalledOnce();
+      });
+
+      it('should update $browser outstandingRequestCount on error', function() {
+        $httpBackend.when('GET').respond(500);
+
+        expect(incOutstandingRequestCountSpy).not.toHaveBeenCalled();
+        $http.get('');
         expect(incOutstandingRequestCountSpy).toHaveBeenCalledOnce();
         $httpBackend.flush();
         expect(completeOutstandingRequestSpy).toHaveBeenCalledOnce();


### PR DESCRIPTION
The issue is that using $http doesn't update $browser.outstandingRequestCount synchronously so that $browser.notifyWhenNoOutstandingRequests waits accordingly.
Configuring this synchronization with the promise chain updates the outstandingRequestCount correctly.

Fixes #13782
