### PR TITLE
fix($http): immediatelly increment $browser's `outstandingRequestCount`

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -55,7 +55,6 @@ function $HttpBackendProvider() {
 function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDocument) {
   // TODO(vojta): fix the signature
   return function(method, url, post, callback, headers, timeout, withCredentials, responseType) {
-    $browser.$$incOutstandingRequestCount();
     url = url || $browser.url();
 
     if (lowercase(method) == 'jsonp') {
@@ -158,7 +157,6 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
       jsonpDone = xhr = null;
 
       callback(status, response, headersString, statusText);
-      $browser.$$completeOutstandingRequest(noop);
     }
   };
 


### PR DESCRIPTION
This allows protractor to more reliably detect when all outstanding requests have been completed.

Fixes #13782
Closes #13862
