### PR TITLE
fix(select): handle corner case of adding options via a custom directive

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -81,7 +81,7 @@ var SelectController =
   // Tell the select control that an option, with the given value, has been added
   self.addOption = function(value, element) {
     // Skip comment nodes, as they only pollute the `optionsMap`
-    if (element.prop('nodeType') === NODE_TYPE_COMMENT) return;
+    if (element[0].nodeType === NODE_TYPE_COMMENT) return;
 
     assertNotHasOwnProperty(value, '"option value"');
     if (value === '') {

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -6,9 +6,8 @@ function chromeHack(optionElement) {
   // Workaround for https://code.google.com/p/chromium/issues/detail?id=381459
   // Adding an <option selected="selected"> element to a <select required="required"> should
   // automatically select the new element
-  var optionNode = optionElement[0];
-  if (optionNode.hasAttribute && optionNode.hasAttribute('selected')) {
-    optionNode.selected = true;
+  if (optionElement[0].hasAttribute('selected')) {
+    optionElement[0].selected = true;
   }
 }
 
@@ -81,6 +80,9 @@ var SelectController =
 
   // Tell the select control that an option, with the given value, has been added
   self.addOption = function(value, element) {
+    // Skip comment nodes, as they only pollute the `optionsMap`
+    if (element.prop('nodeType') === NODE_TYPE_COMMENT) return;
+
     assertNotHasOwnProperty(value, '"option value"');
     if (value === '') {
       self.emptyOption = element;
@@ -453,7 +455,6 @@ var optionDirective = ['$interpolate', function($interpolate) {
     restrict: 'E',
     priority: 100,
     compile: function(element, attr) {
-
       if (isDefined(attr.value)) {
         // If the value attribute is defined, check if it contains an interpolation
         var interpolateValueFn = $interpolate(attr.value, true);
@@ -467,7 +468,6 @@ var optionDirective = ['$interpolate', function($interpolate) {
       }
 
       return function(scope, element, attr) {
-
         // This is an optimization over using ^^ since we don't want to have to search
         // all the way to the root of the DOM for every single option element
         var selectCtrlName = '$selectController',

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -6,8 +6,9 @@ function chromeHack(optionElement) {
   // Workaround for https://code.google.com/p/chromium/issues/detail?id=381459
   // Adding an <option selected="selected"> element to a <select required="required"> should
   // automatically select the new element
-  if (optionElement[0].hasAttribute('selected')) {
-    optionElement[0].selected = true;
+  var optionNode = optionElement[0];
+  if (optionNode.hasAttribute && optionNode.hasAttribute('selected')) {
+    optionNode.selected = true;
   }
 }
 

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -44,6 +44,17 @@ describe('select', function() {
         }
       };
     });
+
+    $compileProvider.directive('myOptions', function() {
+      return {
+        scope: {myOptions: '='},
+        replace: true,
+        template:
+            '<option value="{{ ::option.value }}" ng-repeat="option in ::myOptions">' +
+              '{{ ::options.label }}' +
+            '</option>'
+      };
+    });
   }));
 
   beforeEach(inject(function($rootScope, _$compile_) {
@@ -313,7 +324,7 @@ describe('select', function() {
       });
 
 
-    it('should cope with a dynamic empty option added to a static empty option', function() {
+      it('should cope with a dynamic empty option added to a static empty option', function() {
         scope.dynamicOptions = [];
         scope.robot = 'x';
         compile('<select ng-model="robot">' +
@@ -340,7 +351,7 @@ describe('select', function() {
         scope.dynamicOptions = [];
         scope.$digest();
         expect(element).toEqualSelect(['']);
-    });
+      });
 
       it('should select the empty option when model is undefined', function() {
         compile('<select ng-model="robot">' +
@@ -611,6 +622,24 @@ describe('select', function() {
 
     });
 
+
+    it('should not break when adding options via a directive with `replace: true` '
+        + 'and a structural directive in its template',
+      function() {
+        scope.options = [
+          {value: '1', label: 'Option 1'},
+          {value: '2', label: 'Option 2'},
+          {value: '3', label: 'Option 3'}
+        ];
+
+        expect(function() {
+          compile(
+              '<select ng-model="mySelect">' +
+                '<option my-options="options"></option>' +
+              '</select>');
+        }).not.toThrow();
+      }
+    );
   });
 
 

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -50,8 +50,8 @@ describe('select', function() {
         scope: {myOptions: '='},
         replace: true,
         template:
-            '<option value="{{ ::option.value }}" ng-repeat="option in ::myOptions">' +
-              '{{ ::options.label }}' +
+            '<option value="{{ option.value }}" ng-repeat="option in myOptions">' +
+              '{{ options.label }}' +
             '</option>'
       };
     });
@@ -631,13 +631,9 @@ describe('select', function() {
           {value: '2', label: 'Option 2'},
           {value: '3', label: 'Option 3'}
         ];
+        compile('<select ng-model="mySelect"><option my-options="options"></option></select>');
 
-        expect(function() {
-          compile(
-              '<select ng-model="mySelect">' +
-                '<option my-options="options"></option>' +
-              '</select>');
-        }).not.toThrow();
+        expect(element).toEqualSelect([unknownValue()], '1', '2', '3');
       }
     );
   });


### PR DESCRIPTION
Under specific circumstances (e.g. adding options via a directive with `replace: true` and a structural directive in its template), an error occurred when trying to call `hasAttribute()` on a comment node (which doesn't support that method).
This commit fixes it by first checking if `hasAttribute()` is available.

Fixes #13874
