### PR TITLE
doc Fix typo component.ngdoc

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -269,7 +269,7 @@ it upwards to the heroList component, which updates it.
   <hr>
   <div>
     Name: {{$ctrl.hero.name}}<br>
-    Location: <editable-field field-value="{{$ctrl.hero.location}}" field-type="text" on-update="$ctrl.update('name', value)"></editable-field><br>
+    Location: <editable-field field-value="{{$ctrl.hero.location}}" field-type="text" on-update="$ctrl.update('location', value)"></editable-field><br>
     <button ng-click="$ctrl.onDelete({hero: $ctrl.hero})">Delete</button>
   </div>
 </file>


### PR DESCRIPTION
The wrong field name was being passed into the `$ctrl.update` call in `heroDetail.html` resulting in the wrong behavior (`name` was being updated instead of `location`)
