### PR TITLE
fix($rootScope): Set no context when calling listeners

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -744,7 +744,7 @@ function $RootScopeProvider() {
        *
        */
       $digest: function() {
-        var watch, value, last,
+        var watch, value, last, fn, get,
             watchers,
             length,
             dirty, ttl = TTL,
@@ -790,7 +790,8 @@ function $RootScopeProvider() {
                   // Most common watches are on primitives, in which case we can short
                   // circuit it with === operator, only when === fails do we use .equals
                   if (watch) {
-                    if ((value = watch.get(current)) !== (last = watch.last) &&
+                    get = watch.get;
+                    if ((value = get(current)) !== (last = watch.last) &&
                         !(watch.eq
                             ? equals(value, last)
                             : (typeof value === 'number' && typeof last === 'number'
@@ -798,7 +799,8 @@ function $RootScopeProvider() {
                       dirty = true;
                       lastDirtyWatch = watch;
                       watch.last = watch.eq ? copy(value, null) : value;
-                      watch.fn(value, ((last === initWatchVal) ? value : last), current);
+                      fn = watch.fn;
+                      fn(value, ((last === initWatchVal) ? value : last), current);
                       if (ttl < 5) {
                         logIdx = 4 - ttl;
                         if (!watchLog[logIdx]) watchLog[logIdx] = [];

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -117,6 +117,20 @@ describe('Scope', function() {
     }));
 
 
+    it('should not expose the `inner working of watch', inject(function($rootScope) {
+      function Getter() {
+        expect(this).toBeUndefined();
+        return 'foo';
+      }
+      function Listener() {
+        expect(this).toBeUndefined();
+      }
+      if (msie < 10) return;
+      $rootScope.$watch(Getter, Listener);
+      $rootScope.$digest();
+    }));
+
+
     it('should watch and fire on expression change', inject(function($rootScope) {
       var spy = jasmine.createSpy();
       $rootScope.$watch('name.first', spy);


### PR DESCRIPTION
When calling a listener, do not expose the inner workings with `this`.
