### PR TITLE
refactor(ngAria): remove unused `$parse` from `ngModel` directive

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -212,7 +212,7 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
 .directive('ngRequired', ['$aria', function($aria) {
   return $aria.$$watchExpr('ngRequired', 'aria-required', nodeBlackList, false);
 }])
-.directive('ngModel', ['$aria', '$parse', function($aria, $parse) {
+.directive('ngModel', ['$aria', function($aria) {
 
   function shouldAttachAttr(attr, normalizedAttr, elem, allowBlacklistEls) {
     return $aria.config(normalizedAttr) && !elem.attr(attr) && (allowBlacklistEls || !isNodeOneOf(elem, nodeBlackList));


### PR DESCRIPTION
mentioned in https://github.com/angular/angular.js/commit/d06431e5309bb0125588877451dc79b935808134#commitcomment-15871053

cc @gkalpak 
