### PR TITLE
improve even odd checking and avoid substr call where unnecessary

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -69,7 +69,7 @@ function classDirective(name, selector) {
         }
 
         function ngClassWatchAction(newVal) {
-          if (selector === true || scope.$index % 2 === selector) {
+          if (selector === true || (scope.$index & 1) === selector) {
             var newClasses = arrayClasses(newVal || []);
             if (!oldVal) {
               addClasses(newClasses);

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -69,7 +69,7 @@ function classDirective(name, selector) {
         }
 
         function ngClassWatchAction(newVal) {
-          if (selector === true || (scope.$index & 1) === selector) {
+          if (selector === true || (scope.$index & 1) === selector) { // jshint ignore:line
             var newClasses = arrayClasses(newVal || []);
             if (!oldVal) {
               addClasses(newClasses);

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -32,7 +32,7 @@ function $SnifferProvider() {
       for (var prop in bodyStyle) {
         if (match = vendorRegex.exec(prop)) {
           vendorPrefix = match[0];
-          vendorPrefix = vendorPrefix.substr(0, 1).toUpperCase() + vendorPrefix.substr(1);
+          vendorPrefix = vendorPrefix[0].toUpperCase() + vendorPrefix.substr(1);
           break;
         }
       }


### PR DESCRIPTION
I would propose two slight optimizations:

1) You should avoid call to substr if not necessary, so instead vendorPrefix.substr(0, 1), use vendorPrefix[0] which is cheaper and semantically equivalent. 

2) As explained in [https://github.com/angular/angular.js/pull/4359](4359), adapt even odd checking in ngClass
