### PR TITLE
f[eat|ix](select): support values added by ngValue

### DIFF
--- a/benchmarks/select-ng-value-bp/app.js
+++ b/benchmarks/select-ng-value-bp/app.js
@@ -1,0 +1,104 @@
+"use strict";
+
+/* globals angular, benchmarkSteps */
+
+var app = angular.module('selectBenchmark', []);
+
+app.config(function($compileProvider) {
+  if ($compileProvider.debugInfoEnabled) {
+    $compileProvider.debugInfoEnabled(false);
+  }
+});
+
+
+
+app.controller('DataController', function($scope, $element) {
+  $scope.groups = [];
+  $scope.count = 10000;
+
+  function changeOptions() {
+    $scope.groups = [];
+    var i = 0;
+    var group;
+    while(i < $scope.count) {
+      if (i % 100 === 0) {
+        group = {
+          name: 'group-' + $scope.groups.length,
+          items: []
+        };
+        $scope.groups.push(group);
+      }
+      group.items.push({
+        id: i,
+        label: 'item-' + i
+      });
+      i++;
+    }
+  }
+
+  var selectElement = $element.find('select');
+  console.log(selectElement);
+
+
+  benchmarkSteps.push({
+    name: 'add-options',
+    fn: function() {
+      $scope.$apply(function() {
+        $scope.count = 10000;
+        changeOptions();
+      });
+    }
+  });
+
+  benchmarkSteps.push({
+    name: 'set-model-1',
+    fn: function() {
+      $scope.$apply(function() {
+        $scope.x = $scope.groups[10].items[0];
+      });
+    }
+  });
+
+  benchmarkSteps.push({
+    name: 'set-model-2',
+    fn: function() {
+      $scope.$apply(function() {
+        $scope.x = $scope.groups[0].items[10];
+      });
+    }
+  });
+
+  benchmarkSteps.push({
+    name: 'remove-options',
+    fn: function() {
+      $scope.count = 100;
+      changeOptions();
+    }
+  });
+
+  benchmarkSteps.push({
+    name: 'add-options',
+    fn: function() {
+      $scope.$apply(function() {
+        $scope.count = 10000;
+        changeOptions();
+      });
+    }
+  });
+
+  benchmarkSteps.push({
+    name: 'set-view-1',
+    fn: function() {
+      selectElement.val('2000');
+      selectElement.triggerHandler('change');
+    }
+  });
+
+  benchmarkSteps.push({
+    name: 'set-view-2',
+    fn: function() {
+      selectElement.val('1000');
+      selectElement.triggerHandler('change');
+    }
+  });
+});

--- a/benchmarks/select-ng-value-bp/bp.conf.js
+++ b/benchmarks/select-ng-value-bp/bp.conf.js
@@ -1,0 +1,11 @@
+module.exports = function(config) {
+  config.set({
+    scripts: [    {
+      id: 'angular',
+      src: '/build/angular.js'
+    },
+    {
+      src: 'app.js',
+    }]
+  });
+};

--- a/benchmarks/select-ng-value-bp/main.html
+++ b/benchmarks/select-ng-value-bp/main.html
@@ -1,0 +1,15 @@
+<div ng-app="selectBenchmark" ng-cloak>
+  <div ng-controller="DataController">
+    <div class="container-fluid">
+      <p>
+        Tests the execution of a select with ngRepeat'ed options with ngValue for rendering during model
+        and option updates.
+      </p>
+      <select ng-model="x">
+        <optgroup ng-repeat="g in groups track by g.name" label="{{g.name}}">
+          <option ng-repeat="a in g.items track by a.id" ng-value="a">{{a.label}}</option>
+        </optgroup>
+      </select>
+    </div>
+  </div>
+</div>

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1743,10 +1743,8 @@ var CONSTANT_VALUE_REGEXP = /^(true|false|\d+)$/;
  * `ngValue` is useful when dynamically generating lists of radio buttons using
  * {@link ngRepeat `ngRepeat`}, as shown below.
  *
- * Likewise, `ngValue` can be used to generate `<option>` elements for
- * the {@link select `select`} element. In that case however, only strings are supported
- * for the `value `attribute, so the resulting `ngModel` will always be a string.
- * Support for `select` models with non-string values is available via `ngOptions`.
+ * Likewise, `ngValue` can be used to set the value of `<option>` elements for
+ * the {@link select `select`} element.
  *
  * @element input
  * @param {string=} ngValue angular expression, whose value will be bound to the `value` attribute

--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -15,13 +15,12 @@ var ngOptionsMinErr = minErr('ngOptions');
  * elements for the `<select>` element using the array or object obtained by evaluating the
  * `ngOptions` comprehension expression.
  *
- * In many cases, `ngRepeat` can be used on `<option>` elements instead of `ngOptions` to achieve a
- * similar result. However, `ngOptions` provides some benefits such as reducing memory and
- * increasing speed by not creating a new scope for each repeated instance, as well as providing
- * more flexibility in how the `<select>`'s model is assigned via the `select` **`as`** part of the
- * comprehension expression. `ngOptions` should be used when the `<select>` model needs to be bound
- *  to a non-string value. This is because an option element can only be bound to string values at
- * present.
+ * In many cases, `ngRepeat` can be used on `<option>` elements instead of {@link ng.directive:ngOptions
+ * ngOptions} to achieve a similar result. However, `ngOptions` provides some benefits:
+ * - more flexibility in how the `<select>`'s model is assigned via the `select` **`as`** part of the
+ * comprehension expression
+ * - reduced memory consumption by not creating a new scope for each repeated instance
+ * - increased render speed by creating the options in a documentFragment instead of individually
  *
  * When an item in the `<select>` menu is selected, the array element or object property
  * represented by the selected option will be bound to the model identified by the `ngModel`

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -36,6 +36,12 @@ var SelectController =
     $element.val(unknownVal);
   };
 
+  self.updateUnknownOption = function(val) {
+    var unknownVal = '? ' + hashKey(val) + ' ?';
+    self.unknownOption.val(unknownVal);
+    $element.val(unknownVal);
+  };
+
   $scope.$on('$destroy', function() {
     // disable unknown option so that we don't do work when the whole select is being destroyed
     self.renderUnknownOption = noop;
@@ -74,6 +80,8 @@ var SelectController =
       if (value == null && self.emptyOption) {
         self.removeUnknownOption();
         $element.val('');
+      } else if (self.unknownOption.parent().length) {
+        self.updateUnknownOption(value);
       } else {
         self.renderUnknownOption(value);
       }

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -629,20 +629,27 @@ describe('select', function() {
           scope.$apply(function() {
             scope.robots.pop();
           });
-          expect(element).toEqualSelect([unknownValue('r2d2')], 'c3p0');
-          expect(scope.robot).toBe('r2d2');
+          expect(element).toEqualSelect([unknownValue(null)], 'c3p0');
+          expect(scope.robot).toBe(null);
 
           scope.$apply(function() {
             scope.robots.unshift('r2d2');
           });
+          expect(element).toEqualSelect([unknownValue(null)], 'r2d2', 'c3p0');
+          expect(scope.robot).toBe(null);
+
+          scope.$apply(function() {
+            scope.robot = 'r2d2';
+          });
+
           expect(element).toEqualSelect(['r2d2'], 'c3p0');
-          expect(scope.robot).toBe('r2d2');
 
           scope.$apply(function() {
             delete scope.robots;
           });
-          expect(element).toEqualSelect([unknownValue('r2d2')]);
-          expect(scope.robot).toBe('r2d2');
+
+          expect(element).toEqualSelect([unknownValue(null)]);
+          expect(scope.robot).toBe(null);
         });
       });
 
@@ -1452,8 +1459,739 @@ describe('select', function() {
 
       });
 
+    });
+
+    describe('updating the model and selection when option elements are manipulated', function() {
+
+      they('should set the model to null when the currently selected option with $prop is removed',
+        ['ngValue', 'interpolatedValue', 'interpolatedText'], function(prop) {
+
+          var A = { name: 'A'}, B = { name: 'B'}, C = { name: 'C'};
+
+          scope.options = [A, B, C];
+          scope.obj = {};
+
+          var optionString = '';
+
+          switch (prop) {
+            case 'ngValue':
+              optionString = '<option ng-repeat="option in options" ng-value="option">{{$index}}</option>';
+              break;
+            case 'interpolatedValue':
+              optionString = '<option ng-repeat="option in options" value="{{option.name}}">{{$index}}</option>';
+              break;
+            case 'interpolatedText':
+              optionString = '<option ng-repeat="option in options">{{option.name}}</option>';
+              break;
+          }
+
+          compile(
+            '<select ng-model="obj.value">' +
+              optionString +
+            '</select>'
+          );
+
+          var optionElements = element.find('option');
+          expect(optionElements.length).toEqual(4);
+          browserTrigger(optionElements.eq(0));
+
+          optionElements = element.find('option');
+          expect(optionElements.length).toEqual(3);
+          expect(scope.obj.value).toBe(prop === 'ngValue' ? A : 'A');
+
+          scope.options.shift();
+          scope.$digest();
+
+          optionElements = element.find('option');
+          expect(optionElements.length).toEqual(3);
+          expect(scope.obj.value).toBe(null);
+          expect(element.val()).toBe('? object:null ?');
+      });
+
+
+      they('should set the model to null when the currently selected option with $prop changes its value',
+        [
+          'ngValue',
+          'interpolatedValue',
+          'interpolatedText'
+        ], function(prop) {
+
+          var A = { name: 'A'}, B = { name: 'B'}, C = { name: 'C'};
+
+          scope.options = [A, B, C];
+          scope.obj = {};
+
+          var optionString = '';
+
+          switch (prop) {
+            case 'ngValue':
+              optionString = '<option ng-repeat="option in options" ng-value="option.name">{{$index}}</option>';
+              break;
+            case 'interpolatedValue':
+              optionString = '<option ng-repeat="option in options" value="{{option.name}}">{{$index}}</option>';
+              break;
+            case 'interpolatedText':
+              optionString = '<option ng-repeat="option in options">{{option.name}}</option>';
+              break;
+          }
+
+          compile(
+            '<select ng-model="obj.value">' +
+              optionString +
+            '</select>'
+          );
+
+          var optionElements = element.find('option');
+          expect(optionElements.length).toEqual(4);
+          browserTrigger(optionElements.eq(0));
+
+          optionElements = element.find('option');
+          expect(optionElements.length).toEqual(3);
+          expect(scope.obj.value).toBe('A');
+
+          A.name = 'X';
+          scope.$digest();
+
+          optionElements = element.find('option');
+          expect(optionElements.length).toEqual(4);
+          expect(scope.obj.value).toBe(null);
+          expect(element.val()).toBe('? string:A ?');
+      });
+
+
+      they('should set the model to null when the currently selected option with $prop is disabled',
+        [
+          'ngValue',
+          'interpolatedValue',
+          'interpolatedText'
+        ], function(prop) {
+
+          var A = { name: 'A'}, B = { name: 'B'}, C = { name: 'C'};
+
+          scope.options = [A, B, C];
+          scope.obj = {};
+
+          var optionString = '';
+
+          switch (prop) {
+            case 'ngValue':
+              optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled" ng-value="option.name">{{$index}}</option>';
+              break;
+            case 'interpolatedValue':
+              optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled" value="{{option.name}}">{{$index}}</option>';
+              break;
+            case 'interpolatedText':
+              optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled">{{option.name}}</option>';
+              break;
+          }
+
+          compile(
+            '<select ng-model="obj.value">' +
+              optionString +
+            '</select>'
+          );
+
+          var optionElements = element.find('option');
+          expect(optionElements.length).toEqual(4);
+          browserTrigger(optionElements.eq(0));
+
+          optionElements = element.find('option');
+          expect(optionElements.length).toEqual(3);
+          expect(scope.obj.value).toBe('A');
+
+          A.disabled = true;
+          scope.$digest();
+
+          optionElements = element.find('option');
+          expect(optionElements.length).toEqual(4);
+          expect(scope.obj.value).toBe(null);
+          expect(element.val()).toBe('? object:null ?');
+      });
+
+
+      they('should select a disabled option with $prop when the model is set to the matching value',
+        [
+          'ngValue',
+          'interpolatedValue',
+          'interpolatedText'
+        ], function(prop) {
+
+          var A = { name: 'A'}, B = { name: 'B'}, C = { name: 'C'};
+
+          scope.options = [A, B, C];
+          scope.obj = {};
+
+          var optionString = '';
+
+          switch (prop) {
+            case 'ngValue':
+              optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled" ng-value="option.name">{{$index}}</option>';
+              break;
+            case 'interpolatedValue':
+              optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled" value="{{option.name}}">{{$index}}</option>';
+              break;
+            case 'interpolatedText':
+              optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled">{{option.name}}</option>';
+              break;
+          }
+
+          compile(
+            '<select ng-model="obj.value">' +
+              optionString +
+            '</select>'
+          );
+
+          var optionElements = element.find('option');
+          expect(optionElements.length).toEqual(4);
+          expect(optionElements[0].value).toEqual(unknownValue(undefined));
+
+          B.disabled = true;
+          scope.$digest();
+
+          optionElements = element.find('option');
+          expect(optionElements.length).toEqual(4);
+          expect(optionElements[0].value).toEqual(unknownValue(undefined));
+
+          scope.obj.value = 'B';
+          scope.$digest();
+
+          optionElements = element.find('option');
+          expect(optionElements.length).toEqual(3);
+          expect(scope.obj.value).toBe('B');
+          // jQuery returns null for val() when the option is disabled, see
+          // https://bugs.jquery.com/ticket/13097
+          expect(element[0].value).toBe(prop === 'ngValue' ? 'string:B' : 'B');
+          expect(optionElements.eq(1).prop('selected')).toBe(true);
+      });
+
+
+      they('should ignore an option with $prop that becomes enabled and does not match the model',
+        [
+          'ngValue',
+          'interpolatedValue',
+          'interpolatedText'
+        ], function(prop) {
+
+          var A = { name: 'A'}, B = { name: 'B'}, C = { name: 'C'};
+
+          scope.options = [A, B, C];
+          scope.obj = {};
+
+          var optionString = '';
+
+          switch (prop) {
+            case 'ngValue':
+              optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled" ng-value="option.name">{{$index}}</option>';
+              break;
+            case 'interpolatedValue':
+              optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled" value="{{option.name}}">{{$index}}</option>';
+              break;
+            case 'interpolatedText':
+              optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled">{{option.name}}</option>';
+              break;
+          }
+
+          compile(
+            '<select ng-model="obj.value">' +
+              optionString +
+            '</select>'
+          );
+
+          var optionElements = element.find('option');
+          expect(optionElements.length).toEqual(4);
+          browserTrigger(optionElements.eq(0));
+
+          optionElements = element.find('option');
+          expect(optionElements.length).toEqual(3);
+          expect(scope.obj.value).toBe('A');
+
+          A.disabled = true;
+          scope.$digest();
+
+          optionElements = element.find('option');
+          expect(optionElements.length).toEqual(4);
+          expect(scope.obj.value).toBe(null);
+          expect(element.val()).toBe('? object:null ?');
+
+          A.disabled = false;
+          scope.$digest();
+
+          optionElements = element.find('option');
+          expect(optionElements.length).toEqual(4);
+          expect(scope.obj.value).toBe(null);
+          expect(element.val()).toBe('? object:null ?');
+      });
+
+
+      they('should select a newly added option with $prop when it matches the current model',
+        [
+          'ngValue',
+          'interpolatedValue',
+          'interpolatedText'
+        ], function(prop) {
+
+          var A = { name: 'A'}, B = { name: 'B'}, C = { name: 'C'};
+
+          scope.options = [A, B];
+          scope.obj = {
+            value: prop === 'ngValue' ? C : 'C'
+          };
+
+          var optionString = '';
+
+          switch (prop) {
+            case 'ngValue':
+              optionString = '<option ng-repeat="option in options" ng-value="option">{{$index}}</option>';
+              break;
+            case 'interpolatedValue':
+              optionString = '<option ng-repeat="option in options" value="{{option.name}}">{{$index}}</option>';
+              break;
+            case 'interpolatedText':
+              optionString = '<option ng-repeat="option in options">{{option.name}}</option>';
+              break;
+          }
+
+          compile(
+            '<select ng-model="obj.value">' +
+              optionString +
+            '</select>'
+          );
+
+          var optionElements = element.find('option');
+          expect(optionElements.length).toEqual(3);
+
+          scope.options.push(C);
+          scope.$digest();
+
+          optionElements = element.find('option');
+          expect(element.val()).toBe(prop === 'ngValue' ? 'object:4' : 'C');
+          expect(optionElements.length).toEqual(3);
+          expect(optionElements[2].selected).toBe(true);
+          expect(scope.obj.value).toEqual(prop === 'ngValue' ? {name: 'C', $$hashKey: 'object:4'} : 'C');
+      });
+
+
+      they('should keep selection and model when repeated options with track by are replaced with equal options',
+        [
+          'ngValue',
+          'interpolatedValue',
+          'interpolatedText'
+        ], function(prop) {
+
+          var A = { name: 'A'}, B = { name: 'B'}, C = { name: 'C'};
+
+          scope.options = [A, B, C];
+          scope.obj = {
+            value: 'C'
+          };
+
+          var optionString = '';
+
+          switch (prop) {
+            case 'ngValue':
+              optionString = '<option ng-repeat="option in options track by option.name" ng-value="option.name">{{$index}}</option>';
+              break;
+            case 'interpolatedValue':
+              optionString = '<option ng-repeat="option in options track by option.name" value="{{option.name}}">{{$index}}</option>';
+              break;
+            case 'interpolatedText':
+              optionString = '<option ng-repeat="option in options track by option.name">{{option.name}}</option>';
+              break;
+          }
+
+          compile(
+            '<select ng-model="obj.value">' +
+              optionString +
+            '</select>'
+          );
+
+          var optionElements = element.find('option');
+          expect(optionElements.length).toEqual(3);
+
+          scope.obj.value = 'C';
+          scope.$digest();
+
+          optionElements = element.find('option');
+          expect(element.val()).toBe(prop === 'ngValue' ? 'string:C' : 'C');
+          expect(optionElements.length).toEqual(3);
+          expect(optionElements[2].selected).toBe(true);
+          expect(scope.obj.value).toBe('C');
+
+          scope.options = [
+            {name: 'A'},
+            {name: 'B'},
+            {name: 'C'}
+          ];
+          scope.$digest();
+
+          optionElements = element.find('option');
+          expect(element.val()).toBe(prop === 'ngValue' ? 'string:C' : 'C');
+          expect(optionElements.length).toEqual(3);
+          expect(optionElements[2].selected).toBe(true);
+          expect(scope.obj.value).toBe('C');
+      });
+
+      describe('when multiple', function() {
+
+        they('should set the model to null when the currently selected option with $prop is removed',
+          [
+            'ngValue',
+            'interpolatedValue',
+            'interpolatedText'
+          ], function(prop) {
+
+            var A = { name: 'A'}, B = { name: 'B'}, C = { name: 'C'};
+
+            scope.options = [A, B, C];
+            scope.obj = {};
+
+            var optionString = '';
+
+            switch (prop) {
+              case 'ngValue':
+                optionString = '<option ng-repeat="option in options" ng-value="option">{{$index}}</option>';
+                break;
+              case 'interpolatedValue':
+                optionString = '<option ng-repeat="option in options" value="{{option.name}}">{{$index}}</option>';
+                break;
+              case 'interpolatedText':
+                optionString = '<option ng-repeat="option in options">{{option.name}}</option>';
+                break;
+            }
+
+            compile(
+              '<select ng-model="obj.value" multiple>' +
+                optionString +
+              '</select>'
+            );
+
+            var ngModelCtrl = element.controller('ngModel');
+            var ngModelCtrlSpy = spyOn(ngModelCtrl, '$setViewValue').and.callThrough();
+
+            var optionElements = element.find('option');
+            expect(optionElements.length).toEqual(3);
+
+            optionElements.eq(0).prop('selected', true);
+            optionElements.eq(2).prop('selected', true);
+            browserTrigger(element);
+
+            optionElements = element.find('option');
+            expect(optionElements.length).toEqual(3);
+            expect(scope.obj.value).toEqual(prop === 'ngValue' ? [A, C] : ['A', 'C']);
+
+
+            ngModelCtrlSpy.calls.reset();
+            scope.options.shift();
+            scope.options.pop();
+            scope.$digest();
+
+            optionElements = element.find('option');
+            expect(optionElements.length).toEqual(1);
+            expect(scope.obj.value).toEqual([]);
+            expect(element.val()).toBe(null);
+            expect(ngModelCtrlSpy).toHaveBeenCalledTimes(1);
+        });
+
+        they('should set the model to null when the currently selected option with $prop changes its value',
+          [
+            'ngValue',
+            'interpolatedValue',
+            'interpolatedText'
+          ], function(prop) {
+
+            var A = { name: 'A'}, B = { name: 'B'}, C = { name: 'C'};
+
+            scope.options = [A, B, C];
+            scope.obj = {};
+
+            var optionString = '';
+
+            switch (prop) {
+              case 'ngValue':
+                optionString = '<option ng-repeat="option in options" ng-value="option.name">{{$index}}</option>';
+                break;
+              case 'interpolatedValue':
+                optionString = '<option ng-repeat="option in options" value="{{option.name}}">{{$index}}</option>';
+                break;
+              case 'interpolatedText':
+                optionString = '<option ng-repeat="option in options">{{option.name}}</option>';
+                break;
+            }
+
+            compile(
+              '<select ng-model="obj.value" multiple>' +
+                optionString +
+              '</select>'
+            );
+
+            var ngModelCtrl = element.controller('ngModel');
+            var ngModelCtrlSpy = spyOn(ngModelCtrl, '$setViewValue').and.callThrough();
+
+            var optionElements = element.find('option');
+            expect(optionElements.length).toEqual(3);
+
+            optionElements.eq(0).prop('selected', true);
+            optionElements.eq(2).prop('selected', true);
+            browserTrigger(element);
+
+            optionElements = element.find('option');
+            expect(optionElements.length).toEqual(3);
+            expect(scope.obj.value).toEqual(['A', 'C']);
+
+            ngModelCtrlSpy.calls.reset();
+            A.name = 'X';
+            C.name = 'Z';
+            scope.$digest();
+
+            optionElements = element.find('option');
+            expect(optionElements.length).toEqual(3);
+            expect(scope.obj.value).toEqual([]);
+            expect(element.val()).toBe(null);
+            expect(ngModelCtrlSpy).toHaveBeenCalledTimes(1);
+
+        });
+
+        they('should set the model to null when the currently selected option with $prop becomes disabled',
+          [
+            'ngValue',
+            'interpolatedValue',
+            'interpolatedText'
+          ], function(prop) {
+
+            var A = { name: 'A'}, B = { name: 'B'}, C = { name: 'C'}, D = { name: 'D'};
+
+            scope.options = [A, B, C, D];
+            scope.obj = {};
+
+            var optionString = '';
+
+            switch (prop) {
+              case 'ngValue':
+                optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled" ng-value="option.name">{{$index}}</option>';
+                break;
+              case 'interpolatedValue':
+                optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled" value="{{option.name}}">{{$index}}</option>';
+                break;
+              case 'interpolatedText':
+                optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled">{{option.name}}</option>';
+                break;
+            }
+
+            compile(
+              '<select ng-model="obj.value" multiple>' +
+                optionString +
+              '</select>'
+            );
+
+            var ngModelCtrl = element.controller('ngModel');
+            var ngModelCtrlSpy = spyOn(ngModelCtrl, '$setViewValue').and.callThrough();
+
+            var optionElements = element.find('option');
+            expect(optionElements.length).toEqual(4);
+
+            optionElements.eq(0).prop('selected', true);
+            optionElements.eq(2).prop('selected', true);
+            optionElements.eq(3).prop('selected', true);
+            browserTrigger(element);
+
+            optionElements = element.find('option');
+            expect(optionElements.length).toEqual(4);
+            expect(scope.obj.value).toEqual(['A', 'C', 'D']);
+
+            ngModelCtrlSpy.calls.reset();
+            A.disabled = true;
+            C.disabled = true;
+            scope.$digest();
+
+            optionElements = element.find('option');
+            expect(optionElements.length).toEqual(4);
+            expect(scope.obj.value).toEqual(['D']);
+            expect(element.val()).toEqual(prop === 'ngValue' ? ['string:D'] : ['D']);
+            expect(ngModelCtrlSpy).toHaveBeenCalledTimes(1);
+        });
+
+
+        they('should select disabled options with $prop when the model is set to matching values',
+          [
+            'ngValue',
+            'interpolatedValue',
+            'interpolatedText'
+          ], function(prop) {
+
+            var A = { name: 'A'}, B = { name: 'B'}, C = { name: 'C'}, D = {name: 'D'};
+
+            scope.options = [A, B, C, D];
+            scope.obj = {};
+
+            var optionString = '';
+
+            switch (prop) {
+              case 'ngValue':
+                optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled" ng-value="option">{{$index}}</option>';
+                break;
+              case 'interpolatedValue':
+                optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled" value="{{option.name}}">{{$index}}</option>';
+                break;
+              case 'interpolatedText':
+                optionString = '<option ng-repeat="option in options" ng-disabled="option.disabled">{{option.name}}</option>';
+                break;
+            }
+
+            compile(
+              '<select ng-model="obj.value" multiple>' +
+                optionString +
+              '</select>'
+            );
+
+            var optionElements = element.find('option');
+            expect(optionElements.length).toEqual(4);
+            expect(element[0].value).toBe('');
+
+            A.disabled = true;
+            D.disabled = true;
+            scope.$digest();
+
+            optionElements = element.find('option');
+            expect(optionElements.length).toEqual(4);
+            expect(element[0].value).toBe('');
+
+            scope.obj.value = prop === 'ngValue' ? [A, C, D] : ['A', 'C', 'D'];
+            scope.$digest();
+
+            optionElements = element.find('option');
+            expect(optionElements.length).toEqual(4);
+            expect(scope.obj.value).toEqual(prop === 'ngValue' ?
+              [
+                {name: 'A', $$hashKey: 'object:4', disabled: true},
+                {name: 'C', $$hashKey: 'object:6'},
+                {name: 'D', $$hashKey: 'object:7', disabled: true}
+              ] :
+              ['A', 'C', 'D']
+            );
+
+            expect(optionElements.eq(0).prop('selected')).toBe(true);
+            expect(optionElements.eq(2).prop('selected')).toBe(true);
+            expect(optionElements.eq(3).prop('selected')).toBe(true);
+        });
+
+        they('should select a newly added option with $prop when it matches the current model',
+          [
+            'ngValue',
+            'interpolatedValue',
+            'interpolatedText'
+          ], function(prop) {
+
+            var A = { name: 'A'}, B = { name: 'B'}, C = { name: 'C'};
+
+            scope.options = [A, B];
+            scope.obj = {
+              value: prop === 'ngValue' ? [B, C] : ['B', 'C']
+            };
+
+            var optionString = '';
+
+            switch (prop) {
+              case 'ngValue':
+                optionString = '<option ng-repeat="option in options" ng-value="option">{{$index}}</option>';
+                break;
+              case 'interpolatedValue':
+                optionString = '<option ng-repeat="option in options" value="{{option.name}}">{{$index}}</option>';
+                break;
+              case 'interpolatedText':
+                optionString = '<option ng-repeat="option in options">{{option.name}}</option>';
+                break;
+            }
+
+            compile(
+              '<select ng-model="obj.value" multiple>' +
+                optionString +
+              '</select>'
+            );
+
+            var optionElements = element.find('option');
+            expect(optionElements.length).toEqual(2);
+            expect(optionElements.eq(1).prop('selected')).toBe(true);
+
+            scope.options.push(C);
+            scope.$digest();
+
+            optionElements = element.find('option');
+            expect(element.val()).toEqual(prop === 'ngValue' ? ['object:4', 'object:5'] : ['B', 'C']);
+            expect(optionElements.length).toEqual(3);
+            expect(optionElements[1].selected).toBe(true);
+            expect(optionElements[2].selected).toBe(true);
+            expect(scope.obj.value).toEqual(prop === 'ngValue' ?
+              [{ name: 'B', $$hashKey: 'object:4'},
+                {name: 'C', $$hashKey: 'object:5'}] :
+              ['B', 'C']);
+        });
+
+        they('should keep selection and model when a repeated options with track by are replaced with equal options',
+          [
+            'ngValue',
+            'interpolatedValue',
+            'interpolatedText'
+          ], function(prop) {
+
+            var A = { name: 'A'}, B = { name: 'B'}, C = { name: 'C'};
+
+            scope.options = [A, B, C];
+            scope.obj = {
+              value: 'C'
+            };
+
+            var optionString = '';
+
+            switch (prop) {
+              case 'ngValue':
+                optionString = '<option ng-repeat="option in options track by option.name" ng-value="option.name">{{$index}}</option>';
+                break;
+              case 'interpolatedValue':
+                optionString = '<option ng-repeat="option in options track by option.name" value="{{option.name}}">{{$index}}</option>';
+                break;
+              case 'interpolatedText':
+                optionString = '<option ng-repeat="option in options track by option.name">{{option.name}}</option>';
+                break;
+            }
+
+            compile(
+              '<select ng-model="obj.value" multiple>' +
+                optionString +
+              '</select>'
+            );
+
+            var optionElements = element.find('option');
+            expect(optionElements.length).toEqual(3);
+
+            scope.obj.value = ['B', 'C'];
+            scope.$digest();
+
+            optionElements = element.find('option');
+            expect(element.val()).toEqual(prop === 'ngValue' ? ['string:B', 'string:C'] : ['B', 'C']);
+            expect(optionElements.length).toEqual(3);
+            expect(optionElements[1].selected).toBe(true);
+            expect(optionElements[2].selected).toBe(true);
+            expect(scope.obj.value).toEqual(['B', 'C']);
+
+            scope.options = [
+              {name: 'A'},
+              {name: 'B'},
+              {name: 'C'}
+            ];
+            scope.$digest();
+
+            optionElements = element.find('option');
+            expect(element.val()).toEqual(prop === 'ngValue' ? ['string:B', 'string:C'] : ['B', 'C']);
+            expect(optionElements.length).toEqual(3);
+            expect(optionElements[1].selected).toBe(true);
+            expect(optionElements[2].selected).toBe(true);
+            expect(scope.obj.value).toEqual(['B', 'C']);
+        });
+
+      });
 
     });
+
 
   });
 });


### PR DESCRIPTION
select elements with ngModel will now set ngModel to option values added by ngValue.
This allows setting values of any type without the use of ngOptions.

Interpolations inside attributes can only be strings, but the ngValue directive uses attrs.$set,
which does not follow any type restriction. Any $observe on the value attribute will therefore receive
the original value (result of ngValue expression). However, when a user selects an option, the browser
sets the select value to the actual option's value attribute, which is still always a string.
For that reason, when option are added by ngValue, we set the hashed value of the original value in
the value attribute and store the actual value in an extra map. When the select value changes, we
read access the actual value via the hashed select value.

Closes #9842
Closes #6297
- [ ] Test that it takes precedence over interpolated option / option text
- [x] Test for multiple selections
- [x] Fix failing Chrome tests
- [ ] Docs

Talking points:
- The implementation works reasonably well, although it's a bit ~~hacky~~special
- With ngValue, option values are hash values, not the real values (which makes sense, but might be confusing)
- ~~afaik angular 2 suffers from the same problem as ng1 right now~~
