### PR TITLE
fix($resource): fix parse errors on older Android WebViews

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -706,7 +706,7 @@ angular.module('ngResource', ['ng']).
               return $q.reject(response);
             });
 
-            promise.finally(function() {
+            promise['finally'](function() {
               value.$resolved = true;
               if (!isInstanceCall && cancellable) {
                 value.$cancelRequest = angular.noop;


### PR DESCRIPTION
Older Android WebViews (2.3) can't handle calling methods named after reserved keywords such as `.if()`, `.return()`, `.default()`, `.catch()`, `.finally()`.

Without this change it is impossible to run an app on an Android 2.3 device directly using Angular source code.

Bracket notation is already being used, for example in [$$AnimateAsyncRunFactoryProvider](https://github.com/angular/angular.js/blob/2cb1989d12f7fa3acaafb8d762c91b156edd8603/src/ng/animateRunner.js#L128-L134).

Related: #11455, #11051, #12610
