### PR TITLE
feat(ngAria[ngClick]): anchor should treat keypress as click

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -385,9 +385,9 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
           if ($aria.config('bindKeypress')) {
             elem.on('keypress', function(event) {
               var keyCode = event.which || event.keyCode;
-              var hasHref = (attr.href || attr.xlinkHref);
-              if ((keyCode === 32 || (keyCode === 13 && !hasHref)) && !attr.ngKeypress) {
-                elem[0].click();
+              var hasHref = attr.href || attr.xlinkHref;
+              if ((keyCode===13 || keyCode === 32) && !hasHref && !attr.ngKeypress) {
+                scope.$apply(callback);
               }
 
               function callback() {

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -377,6 +377,28 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
             });
           }
         }
+
+        if ($aria.config('bindKeypress') && isNodeOneOf(elem, ['A', 'BUTTON'])) {
+          elem.on('keypress', function(event) {
+            var keyCode = event.which || event.keyCode;
+
+            if (elem[0].nodeName==='A') {
+              var hasHref = elem.attr('href') != null && elem.attr('href') != '';
+              if ((keyCode === 13 && !hasHref) || keyCode === 32) {
+                scope.$apply(callback);
+              }
+            } 
+            else if (elem[0].nodeName==='BUTTON') {
+              if (keyCode === 32) {
+                scope.$apply(callback);
+              }
+            }
+            
+            function callback() {
+              fn(scope, { $event: event });
+            }
+          });
+        }
       };
     }
   };

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -386,7 +386,7 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
             elem.on('keypress', function(event) {
               var keyCode = event.which || event.keyCode;
               var hasHref = attr.href || attr.xlinkHref;
-              if ((keyCode===13 || keyCode === 32) && !hasHref && !attr.ngKeypress) {
+              if ((keyCode === 32 || keyCode === 13) && !hasHref && !attr.ngKeypress) {
                 scope.$apply(callback);
               }
 

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -378,25 +378,23 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
           }
         }
 
-        if ($aria.config('bindKeypress') && isNodeOneOf(elem, ['A', 'BUTTON'])) {
-          elem.on('keypress', function(event) {
-            var keyCode = event.which || event.keyCode;
-
-            if (elem[0].nodeName === 'A') {
-              var hasHref = elem.attr('href') != null && elem.attr('href') !== '';
-              if ((keyCode === 13 && !hasHref) || keyCode === 32) {
+        if (elem[0].nodeName === 'A') {
+          if ($aria.config('bindRoleForClick') && !attr.href && !attr.xlinkHref && !attr.role) {
+              elem.attr('role', 'link');
+          }
+          if($aria.config('bindKeypress')) {
+            elem.on('keypress', function(event) {
+              var keyCode = event.which || event.keyCode;
+              var hasHref = (attr.href || attr.xlinkHref);
+              if (keyCode === 32 && !hasHref && !attr.ngKeypress) {
                 scope.$apply(callback);
               }
-            } else if (elem[0].nodeName === 'BUTTON') {
-              if (keyCode === 32) {
-                scope.$apply(callback);
-              }
-            }
 
-            function callback() {
-              fn(scope, { $event: event });
-            }
-          });
+              function callback() {
+                fn(scope, { $event: event });
+              }
+            });
+          }
         }
       };
     }

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -386,7 +386,7 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
             elem.on('keypress', function(event) {
               var keyCode = event.which || event.keyCode;
               var hasHref = (attr.href || attr.xlinkHref);
-              if (keyCode === 32 && !hasHref && !attr.ngKeypress) {
+              if ((keyCode === 32 || (keyCode === 13 && !hasHref)) && !attr.ngKeypress) {
                 scope.$apply(callback);
               }
 

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -382,18 +382,17 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
           elem.on('keypress', function(event) {
             var keyCode = event.which || event.keyCode;
 
-            if (elem[0].nodeName==='A') {
-              var hasHref = elem.attr('href') != null && elem.attr('href') != '';
+            if (elem[0].nodeName === 'A') {
+              var hasHref = elem.attr('href') != null && elem.attr('href') !== '';
               if ((keyCode === 13 && !hasHref) || keyCode === 32) {
                 scope.$apply(callback);
               }
-            } 
-            else if (elem[0].nodeName==='BUTTON') {
+            } else if (elem[0].nodeName === 'BUTTON') {
               if (keyCode === 32) {
                 scope.$apply(callback);
               }
             }
-            
+
             function callback() {
               fn(scope, { $event: event });
             }

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -387,7 +387,7 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
               var keyCode = event.which || event.keyCode;
               var hasHref = (attr.href || attr.xlinkHref);
               if ((keyCode === 32 || (keyCode === 13 && !hasHref)) && !attr.ngKeypress) {
-                scope.$apply(callback);
+                elem[0].click();
               }
 
               function callback() {

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -382,7 +382,7 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
           if ($aria.config('bindRoleForClick') && !attr.href && !attr.xlinkHref && !attr.role) {
               elem.attr('role', 'link');
           }
-          if($aria.config('bindKeypress')) {
+          if ($aria.config('bindKeypress')) {
             elem.on('keypress', function(event) {
               var keyCode = event.which || event.keyCode;
               var hasHref = (attr.href || attr.xlinkHref);

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -755,6 +755,35 @@ describe('$aria', function() {
       element.triggerHandler({ type: 'keypress', keyCode: 13 });
       expect(element.text()).toBe('');
     });
+
+    it('should bind keypress to anchor elements without href defined', function() {
+      compileElement('<a ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
+      expect(element.text()).toBe('');
+      element.triggerHandler({ type: 'keypress', keyCode: 13 });
+      expect(element.text()).toBe('keypress13');
+    });
+
+    it('should bind keypress to anchor elements with empty href defined', function() {
+      compileElement('<a href="" ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
+      expect(element.text()).toBe('');
+      element.triggerHandler({ type: 'keypress', keyCode: 13 });
+      expect(element.text()).toBe('keypress13');
+    });
+
+    it('should not bind keypress to anchor elements with href defined', function() {
+      compileElement('<a href="http://somwehere" ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
+      expect(element.text()).toBe('');
+      element.triggerHandler({ type: 'keypress', keyCode: 13 });
+      expect(element.text()).toBe('');
+    });
+    
+    it('should bind space keypress to button elements', function() {
+      compileElement('<button ng-click="event = $event">{{event.type}}{{event.keyCode}}</button>');
+      expect(element.text()).toBe('');
+      element.triggerHandler({ type: 'keypress', keyCode: 32 });
+      expect(element.text()).toBe('keypress32');
+    });
+
   });
 
   describe('actions when bindRoleForClick is set to false', function() {

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -768,17 +768,26 @@ describe('$aria', function() {
       expect(element.text()).toBe('keypress32');
     });
 
-    it('should bind keypress to anchor elements when keypress is not falsy', function() {
+    it('should not bind keypress to anchor elements when keypress is not falsy', function() {
       compileElement('<a ng-keypress="event = null" ngclick="event = $event">{{event.type}}{{event.keyCode}}</a>');
       expect(element.text()).toBe('');
       element.triggerHandler({ type: 'keypress', keyCode: 32 });
       expect(element.text()).toBe('');
+      element.triggerHandler({ type: 'keypress', keyCode: 13 });
+      expect(element.text()).toBe('');
     });
 
-    it('should not bind keypress to anchor elements when href is not falsy', function() {
+    it('should bind SPACE keypress to anchor elements', function() {
       compileElement('<a href="http://somwehere" ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
       expect(element.text()).toBe('');
       element.triggerHandler({ type: 'keypress', keyCode: 32 });
+      expect(element.text()).toBe('keypress32');
+    });
+
+    it('should not bind ENTER keypress to anchor elements when href is not falsy', function() {
+      compileElement('<a href="http://somwehere" ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
+      expect(element.text()).toBe('');
+      element.triggerHandler({ type: 'keypress', keyCode: 13 });
       expect(element.text()).toBe('');
     });
   });

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -756,7 +756,7 @@ describe('$aria', function() {
       expect(element.text()).toBe('');
     });
 
-    it('should bind keypress to anchor elements when href is falsy', function() {
+    it('should apply role to anchor elements without href ', function() {
       compileElement('<a ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
       expect(element.attr('role')).toBe('link');
     });
@@ -765,7 +765,9 @@ describe('$aria', function() {
       compileElement('<a ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
       expect(element.text()).toBe('');
       element.triggerHandler({ type: 'keypress', keyCode: 32 });
-      expect(element.text()).toContain('click');
+      expect(element.text()).toBe('keypress32');
+      element.triggerHandler({ type: 'keypress', keyCode: 13 });
+      expect(element.text()).toBe('keypress13');
     });
 
     it('should not bind keypress to anchor elements when keypress is not falsy', function() {
@@ -777,8 +779,10 @@ describe('$aria', function() {
       expect(element.text()).toBe('');
     });
 
-    it('should not bind ENTER keypress to anchor elements when href is not falsy', function() {
+    it('should not bind keypress to anchor elements when href is not falsy', function() {
       compileElement('<a href="http://somwehere" ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
+      expect(element.text()).toBe('');
+      element.triggerHandler({ type: 'keypress', keyCode: 32 });
       expect(element.text()).toBe('');
       element.triggerHandler({ type: 'keypress', keyCode: 13 });
       expect(element.text()).toBe('');

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -776,7 +776,7 @@ describe('$aria', function() {
       element.triggerHandler({ type: 'keypress', keyCode: 13 });
       expect(element.text()).toBe('');
     });
-    
+
     it('should bind space keypress to button elements', function() {
       compileElement('<button ng-click="event = $event">{{event.type}}{{event.keyCode}}</button>');
       expect(element.text()).toBe('');

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -756,34 +756,31 @@ describe('$aria', function() {
       expect(element.text()).toBe('');
     });
 
-    it('should bind keypress to anchor elements without href defined', function() {
+    it('should bind keypress to anchor elements when href is falsy', function() {
       compileElement('<a ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
-      expect(element.text()).toBe('');
-      element.triggerHandler({ type: 'keypress', keyCode: 13 });
-      expect(element.text()).toBe('keypress13');
+      expect(element.attr('role')).toBe('link');
     });
 
-    it('should bind keypress to anchor elements with empty href defined', function() {
-      compileElement('<a href="" ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
-      expect(element.text()).toBe('');
-      element.triggerHandler({ type: 'keypress', keyCode: 13 });
-      expect(element.text()).toBe('keypress13');
-    });
-
-    it('should not bind keypress to anchor elements with href defined', function() {
-      compileElement('<a href="http://somwehere" ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
-      expect(element.text()).toBe('');
-      element.triggerHandler({ type: 'keypress', keyCode: 13 });
-      expect(element.text()).toBe('');
-    });
-
-    it('should bind space keypress to button elements', function() {
-      compileElement('<button ng-click="event = $event">{{event.type}}{{event.keyCode}}</button>');
+    it('should bind keypress to anchor elements when href is falsy', function() {
+      compileElement('<a ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
       expect(element.text()).toBe('');
       element.triggerHandler({ type: 'keypress', keyCode: 32 });
       expect(element.text()).toBe('keypress32');
     });
 
+    it('should bind keypress to anchor elements when keypress is not falsy', function() {
+      compileElement('<a ng-keypress="event = null" ngclick="event = $event">{{event.type}}{{event.keyCode}}</a>');
+      expect(element.text()).toBe('');
+      element.triggerHandler({ type: 'keypress', keyCode: 32 });
+      expect(element.text()).toBe('');
+    });
+
+    it('should not bind keypress to anchor elements when href is not falsy', function() {
+      compileElement('<a href="http://somwehere" ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
+      expect(element.text()).toBe('');
+      element.triggerHandler({ type: 'keypress', keyCode: 32 });
+      expect(element.text()).toBe('');
+    });
   });
 
   describe('actions when bindRoleForClick is set to false', function() {

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -765,7 +765,7 @@ describe('$aria', function() {
       compileElement('<a ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
       expect(element.text()).toBe('');
       element.triggerHandler({ type: 'keypress', keyCode: 32 });
-      expect(element.text()).toBe('keypress32');
+      expect(element.text()).toContain('click');
     });
 
     it('should not bind keypress to anchor elements when keypress is not falsy', function() {
@@ -775,13 +775,6 @@ describe('$aria', function() {
       expect(element.text()).toBe('');
       element.triggerHandler({ type: 'keypress', keyCode: 13 });
       expect(element.text()).toBe('');
-    });
-
-    it('should bind SPACE keypress to anchor elements', function() {
-      compileElement('<a href="http://somwehere" ng-click="event = $event">{{event.type}}{{event.keyCode}}</a>');
-      expect(element.text()).toBe('');
-      element.triggerHandler({ type: 'keypress', keyCode: 32 });
-      expect(element.text()).toBe('keypress32');
     });
 
     it('should not bind ENTER keypress to anchor elements when href is not falsy', function() {


### PR DESCRIPTION
Enhances ngAria to trigger ngClick for 'space' keypresses on anchor and button elements, and
for 'enter' keypresses on anchor elements when there is no value for the href attribute.

Closes https://github.com/angular/angular.js/issues/11053
