### PR TITLE
feat(resource): Pass parameter object to params that are functions

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -134,7 +134,7 @@ function shallowClearAndCopy(src, dst) {
  *   - **`params`** – {Object=} – Optional set of pre-bound parameters for this action. If any of
  *     the parameter value is a function, it will be executed every time when a param value needs to
  *     be obtained for a request (unless the param was overridden). The function will be passed two
- *     parameters, a hash of the parameter keys with values and the body for `POST`, `PUT`, and 
+ *     parameters, a hash of the parameter keys with values and the body for `POST`, `PUT`, and
  *    `PATCH` requests. The second parameter will be undefined for all other requests.
  *   - **`url`** – {string} – action specific `url` override. The url templating is supported just
  *     like for the resource-level urls.

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -102,7 +102,9 @@ function shallowClearAndCopy(src, dst) {
  * @param {Object=} paramDefaults Default values for `url` parameters. These can be overridden in
  *   `actions` methods. If a parameter value is a function, it will be executed every time
  *   when a param value needs to be obtained for a request (unless the param was overridden). The
- *   function will be passed a hash of the parameter keys and values.
+ *   function will be passed two parameters, a hash of the parameter keys with values and the body
+ *   for `POST`, `PUT`, and `PATCH` requests. The second parameter will be undefined for all other
+ *   requests.
  *
  *   Each key value in the parameter object is first bound to url template if present and then any
  *   excess keys are appended to the url search query after the `?`.
@@ -131,8 +133,9 @@ function shallowClearAndCopy(src, dst) {
  *     `DELETE`, `JSONP`, etc).
  *   - **`params`** – {Object=} – Optional set of pre-bound parameters for this action. If any of
  *     the parameter value is a function, it will be executed every time when a param value needs to
- *     be obtained for a request (unless the param was overridden). The function will be passed a
- *     hash of the parameter keys and values.
+ *     be obtained for a request (unless the param was overridden). The function will be passed two
+ *     parameters, a hash of the parameter keys with values and the body for `POST`, `PUT`, and 
+ *    `PATCH` requests. The second parameter will be undefined for all other requests.
  *   - **`url`** – {string} – action specific `url` override. The url templating is supported just
  *     like for the resource-level urls.
  *   - **`isArray`** – {boolean=} – If true then the returned object for this action is an array,

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -553,7 +553,7 @@ angular.module('ngResource', ['ng']).
           var ids = {};
           actionParams = extend({}, paramDefaults, actionParams);
           forEach(actionParams, function(value, key) {
-            if (isFunction(value)) { value = value(actionParams); }
+            if (isFunction(value)) { value = value(actionParams, data); }
             ids[key] = value && value.charAt && value.charAt(0) == '@' ?
               lookupDottedPath(data, value.substr(1)) : value;
           });

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -101,7 +101,8 @@ function shallowClearAndCopy(src, dst) {
  *
  * @param {Object=} paramDefaults Default values for `url` parameters. These can be overridden in
  *   `actions` methods. If a parameter value is a function, it will be executed every time
- *   when a param value needs to be obtained for a request (unless the param was overridden).
+ *   when a param value needs to be obtained for a request (unless the param was overridden). The
+ *   function will be passed a hash of the parameter keys and values.
  *
  *   Each key value in the parameter object is first bound to url template if present and then any
  *   excess keys are appended to the url search query after the `?`.
@@ -130,7 +131,8 @@ function shallowClearAndCopy(src, dst) {
  *     `DELETE`, `JSONP`, etc).
  *   - **`params`** – {Object=} – Optional set of pre-bound parameters for this action. If any of
  *     the parameter value is a function, it will be executed every time when a param value needs to
- *     be obtained for a request (unless the param was overridden).
+ *     be obtained for a request (unless the param was overridden). The function will be passed a
+ *     hash of the parameter keys and values.
  *   - **`url`** – {string} – action specific `url` override. The url templating is supported just
  *     like for the resource-level urls.
  *   - **`isArray`** – {boolean=} – If true then the returned object for this action is an array,
@@ -551,7 +553,7 @@ angular.module('ngResource', ['ng']).
           var ids = {};
           actionParams = extend({}, paramDefaults, actionParams);
           forEach(actionParams, function(value, key) {
-            if (isFunction(value)) { value = value(); }
+            if (isFunction(value)) { value = value(actionParams); }
             ids[key] = value && value.charAt && value.charAt(0) == '@' ?
               lookupDottedPath(data, value.substr(1)) : value;
           });

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -403,6 +403,35 @@ describe("basic usage", function() {
     inst.$post();
   });
 
+  it("should build resource by passing parameter values to functions in action params", function() {
+    $httpBackend.expect('GET', '/C/Customer/123').respond({id: 'abc'});
+    var TypeItem = $resource('/:typeAbbr/:type/:typeId', {
+      type: 'Customer',
+      typeAbbr: 'P'
+    },{get: {method: 'GET', params: {
+      typeAbbr: function(params) {
+          return params.type.substring(0,1);
+      }
+    }}});
+    var item = TypeItem.get({type: 'Customer', typeId: 123});
+
+    $httpBackend.flush();
+    expect(item).toEqualData({id: 'abc'});
+  });
+
+  it("should build resource by passing parameter values to functions in default params", function() {
+    $httpBackend.expect('GET', '/C/Customer/123').respond({id: 'abc'});
+    var TypeItem = $resource('/:typeAbbr/:type/:typeId', {
+      type: 'Customer',
+      typeAbbr: function(params) {
+          return params.type.substring(0,1);
+      }
+    },{get: {method: 'GET'}});
+    var item = TypeItem.get({type: 'Customer', typeId: 123});
+
+    $httpBackend.flush();
+    expect(item).toEqualData({id: 'abc'});
+  });
 
   it('should not throw TypeError on null default params', function() {
     $httpBackend.expect('GET', '/Path').respond('{}');

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -403,31 +403,39 @@ describe("basic usage", function() {
     inst.$post();
   });
 
-  it("should build resource by passing parameter values to functions in action params", function() {
-    $httpBackend.expect('GET', '/C/Customer/123').respond({id: 'abc'});
-    var TypeItem = $resource('/:typeAbbr/:type/:typeId', {
-      type: 'Customer',
-      typeAbbr: 'P'
-    },{get: {method: 'GET', params: {
-      typeAbbr: function(params) {
-          return params.type.substring(0,1);
+  it("should build resource by passing values to functions in action params", function() {
+    $httpBackend.expect('POST', '/C/Customer/123').respond({id: 'abc'});
+    var TypeItem = $resource('/:typeAbrev/:type/:id', {
+      type: 'Customer'
+    },{
+      create: {method: 'POST', params: {
+        id: function(paramDefaults, data) {
+          return data.customerId;
+        },
+        typeAbrev: function(paramDefaults, data) {
+          return paramDefaults.type.substring(0,1);
+        }
       }
-    }}});
-    var item = TypeItem.get({type: 'Customer', typeId: 123});
+    }});
+    var item = TypeItem.create({customerId: 123});
 
     $httpBackend.flush();
     expect(item).toEqualData({id: 'abc'});
   });
 
-  it("should build resource by passing parameter values to functions in default params", function() {
-    $httpBackend.expect('GET', '/C/Customer/123').respond({id: 'abc'});
-    var TypeItem = $resource('/:typeAbbr/:type/:typeId', {
-      type: 'Customer',
-      typeAbbr: function(params) {
-          return params.type.substring(0,1);
+  it("should build resource by passing values to functions in default params", function() {
+    $httpBackend.expect('POST', '/C/Customer/123').respond({id: 'abc'});
+    var TypeItem = $resource('/:typeAbrev/:type/:id', {
+      id: function(paramDefaults, data) {
+        return data.customerId;
+      },
+      typeAbrev: function(paramDefaults, data) {
+        return paramDefaults.type.substring(0,1);
       }
-    },{get: {method: 'GET'}});
-    var item = TypeItem.get({type: 'Customer', typeId: 123});
+    },{create: {method: 'POST', params: {
+      type: 'Customer'
+    }}});
+    var item = TypeItem.create({customerId: 123});
 
     $httpBackend.flush();
     expect(item).toEqualData({id: 'abc'});


### PR DESCRIPTION
When defining default or action-specific resource parameters using functions, the parameter object will be passed into each of the functions. This parameter object can then optionally be used when deriving and returning the parameter value. 

Closes https://github.com/angular/angular.js/issues/8608
