### PR TITLE
only call console.log when window.console exists

### DIFF
--- a/src/angular.bind.js
+++ b/src/angular.bind.js
@@ -1,6 +1,8 @@
 if (window.angular.bootstrap) {
   //AngularJS is already loaded, so we can return here...
-  console.log('WARNING: Tried to load angular more than once.');
+  if (!!window.console) {
+    console.log('WARNING: Tried to load angular more than once.');
+  }
   return;
 }
 


### PR DESCRIPTION
issue #14006 - `window.console` only exists in IE 8 & 9 when the devtools are open
