### PR TITLE
docs(error/nobase): show <base> tag

### DIFF
--- a/docs/content/error/$location/nobase.ngdoc
+++ b/docs/content/error/$location/nobase.ngdoc
@@ -1,6 +1,6 @@
 @ngdoc error
 @name $location:nobase
-@fullName $location in HTML5 mode requires a `<base>` tag to be present!
+@fullName $location in HTML5 mode requires a &lt;base&gt; tag to be present!
 @description
 
 If you configure {@link ng.$location `$location`} to use


### PR DESCRIPTION
The <base> tag was missing from the doc page - this change (presumes) to fix that and escape the tag in the title.

<img width="1189" alt="screen shot 2016-02-12 at 11 39 29" src="https://cloud.githubusercontent.com/assets/13700/13005923/62b3f3c4-d17d-11e5-9b89-e5d4302076d6.png">
