### PR TITLE
feat($http,$resource): statusText resolved in timeout promise

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -105,10 +105,12 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
             statusText);
       };
 
+      var timeoutStatusText;
+
       var requestError = function() {
         // The response is always empty
         // See https://xhr.spec.whatwg.org/#request-error-steps and https://fetch.spec.whatwg.org/#concept-network-error
-        completeRequest(callback, -1, null, null, '');
+        completeRequest(callback, -1, null, null, timeoutStatusText || '');
       };
 
       xhr.onerror = requestError;
@@ -145,7 +147,8 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
     }
 
 
-    function timeoutRequest() {
+    function timeoutRequest(statusText) {
+      timeoutStatusText = statusText;
       jsonpDone && jsonpDone();
       xhr && xhr.abort();
     }
@@ -155,7 +158,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
       if (isDefined(timeoutId)) {
         $browserDefer.cancel(timeoutId);
       }
-      jsonpDone = xhr = null;
+      jsonpDone = xhr = timeoutStatusText = null;
 
       callback(status, response, headersString, statusText);
       $browser.$$completeOutstandingRequest(noop);

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1350,11 +1350,7 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
         for (var i = 0, ii = responses.length; i < ii; i++) {
           if (responses[i] === handleResponse) {
             responses.splice(i, 1);
-            if (statusText) {
-                callback(-1, undefined, '', statusText);
-            } else {
-                callback(-1, undefined, '');
-            }
+            callback(-1, undefined, '', statusText);
             break;
           }
         }

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1346,11 +1346,15 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
                  copy(response[3] || ''));
       }
 
-      function handleTimeout() {
+      function handleTimeout(statusText) {
         for (var i = 0, ii = responses.length; i < ii; i++) {
           if (responses[i] === handleResponse) {
             responses.splice(i, 1);
-            callback(-1, undefined, '');
+            if (statusText) {
+                callback(-1, undefined, '', statusText);
+            } else {
+                callback(-1, undefined, '');
+            }
             break;
           }
         }

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -658,7 +658,9 @@ angular.module('ngResource', ['ng']).
               httpConfig.timeout = timeoutDeferred.promise;
 
               if (numericTimeout) {
-                numericTimeoutPromise = $timeout(timeoutDeferred.resolve, numericTimeout);
+                numericTimeoutPromise = $timeout(function() {
+                    timeoutDeferred.resolve("timeout");
+                }, numericTimeout);
               }
             }
 
@@ -729,7 +731,12 @@ angular.module('ngResource', ['ng']).
               // - return the instance / collection
               value.$promise = promise;
               value.$resolved = false;
-              if (cancellable) value.$cancelRequest = timeoutDeferred.resolve;
+
+              if (cancellable) {
+                  value.$cancelRequest = function() {
+                      timeoutDeferred.resolve("cancelled");
+                  };
+              }
 
               return value;
             }

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -173,11 +173,34 @@ describe('$httpBackend', function() {
 
 
   it('should abort request on timeout promise resolution', inject(function($timeout) {
-    callback.andCallFake(function(status, response) {
+    callback.andCallFake(function(status, response, headers, statusText) {
       expect(status).toBe(-1);
+      expect(statusText).toBe('');
     });
 
     $backend('GET', '/url', null, callback, {}, $timeout(noop, 2000));
+    xhr = MockXhr.$$lastInstance;
+    spyOn(xhr, 'abort');
+
+    $timeout.flush();
+    expect(xhr.abort).toHaveBeenCalledOnce();
+
+    xhr.status = 0;
+    xhr.onabort();
+    expect(callback).toHaveBeenCalledOnce();
+  }));
+
+
+  it('should abort request on timeout promise resolution with statusText', inject(function($timeout) {
+    callback.andCallFake(function(status, response, headers, statusText) {
+      expect(status).toBe(-1);
+      expect(statusText).toBe('whatever');
+    });
+
+    $backend('GET', '/url', null, callback, {}, $timeout(function() {
+      return "whatever";
+    }, 2000));
+
     xhr = MockXhr.$$lastInstance;
     spyOn(xhr, 'abort');
 

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1393,7 +1393,7 @@ describe('ngMock', function() {
 
       canceler();  // simulate promise resolution
 
-      expect(callback).toHaveBeenCalledWith(-1, undefined, '');
+      expect(callback).toHaveBeenCalledWith(-1, undefined, '', undefined);
       hb.verifyNoOutstandingExpectation();
       hb.verifyNoOutstandingRequest();
     });
@@ -1423,7 +1423,7 @@ describe('ngMock', function() {
       hb('GET', '/url1', null, callback, null, 200);
       $timeout.flush(300);
 
-      expect(callback).toHaveBeenCalledWith(-1, undefined, '');
+      expect(callback).toHaveBeenCalledWith(-1, undefined, '', undefined);
       hb.verifyNoOutstandingExpectation();
       hb.verifyNoOutstandingRequest();
     }));

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1399,6 +1399,24 @@ describe('ngMock', function() {
     });
 
 
+    it('should abort requests when timeout promise resolves with statusText', function() {
+      hb.expect('GET', '/url1').respond(200);
+
+      var canceler, then = jasmine.createSpy('then').andCallFake(function(fn) {
+        canceler = fn;
+      });
+
+      hb('GET', '/url1', null, callback, null, {then: then});
+      expect(typeof canceler).toBe('function');
+
+      canceler('whatever');  // simulate promise resolution
+
+      expect(callback).toHaveBeenCalledWith(-1, undefined, '', 'whatever');
+      hb.verifyNoOutstandingExpectation();
+      hb.verifyNoOutstandingRequest();
+    });
+
+
     it('should abort requests when timeout passed as a numeric value', inject(function($timeout) {
       hb.expect('GET', '/url1').respond(200);
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1544,7 +1544,13 @@ describe('cancelling requests', function() {
       }
     });
 
-    CreditCard.get();
+    var creditCard = CreditCard.get();
+
+    creditCard.$promise.catch(function(err) {
+      expect(err.status).toEqual(-1);
+      expect(err.statusText).toEqual("timeout");
+    });
+
     $timeout.flush();
     expect($httpBackend.flush).toThrow(new Error('No pending request to flush !'));
 
@@ -1563,7 +1569,14 @@ describe('cancelling requests', function() {
       }
     });
 
-    CreditCard.get().$cancelRequest();
+    var creditCard = CreditCard.get();
+
+    creditCard.$promise.catch(function(err) {
+      expect(err.status).toEqual(-1);
+      expect(err.statusText).toEqual("cancelled");
+    });
+
+    creditCard.$cancelRequest();
     expect($httpBackend.flush).toThrow(new Error('No pending request to flush !'));
 
     CreditCard.get();
@@ -1581,7 +1594,14 @@ describe('cancelling requests', function() {
       }
     });
 
-    CreditCard.get().$cancelRequest();
+    var creditCard = CreditCard.get();
+
+    creditCard.$promise.catch(function(err) {
+        expect(err.status).toEqual(-1);
+        expect(err.statusText).toEqual("cancelled");
+    });
+
+    creditCard.$cancelRequest();
     expect($httpBackend.flush).toThrow(new Error('No pending request to flush !'));
 
     CreditCard.get();

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1544,19 +1544,23 @@ describe('cancelling requests', function() {
       }
     });
 
-    var creditCard = CreditCard.get();
-
-    creditCard.$promise.catch(function(err) {
+    var errorCB = jasmine.createSpy('error').andCallFake(function(err) {
       expect(err.status).toEqual(-1);
       expect(err.statusText).toEqual("timeout");
     });
 
+    var creditCard = CreditCard.get();
+
+    creditCard.$promise.catch(errorCB);
+
     $timeout.flush();
     expect($httpBackend.flush).toThrow(new Error('No pending request to flush !'));
+    expect(errorCB).toHaveBeenCalledOnce();
+    errorCB.reset();
 
     CreditCard.get();
     expect($httpBackend.flush).not.toThrow();
-
+    expect(errorCB).not.toHaveBeenCalled();
   });
 
   it('should cancel the request (if cancellable), when calling `$cancelRequest`', function() {
@@ -1569,18 +1573,23 @@ describe('cancelling requests', function() {
       }
     });
 
-    var creditCard = CreditCard.get();
-
-    creditCard.$promise.catch(function(err) {
+    var errorCB = jasmine.createSpy('error').andCallFake(function(err) {
       expect(err.status).toEqual(-1);
       expect(err.statusText).toEqual("cancelled");
     });
 
+    var creditCard = CreditCard.get();
+
+    creditCard.$promise.catch(errorCB);
+
     creditCard.$cancelRequest();
     expect($httpBackend.flush).toThrow(new Error('No pending request to flush !'));
+    expect(errorCB).toHaveBeenCalledOnce();
+    errorCB.reset();
 
     CreditCard.get();
     expect($httpBackend.flush).not.toThrow();
+    expect(errorCB).not.toHaveBeenCalled();
   });
 
   it('should cancel the request, when calling `$cancelRequest` in cancellable actions with timeout defined', function() {
@@ -1594,18 +1603,23 @@ describe('cancelling requests', function() {
       }
     });
 
+    var errorCB = jasmine.createSpy('error').andCallFake(function(err) {
+      expect(err.status).toEqual(-1);
+      expect(err.statusText).toEqual("cancelled");
+    });
+
     var creditCard = CreditCard.get();
 
-    creditCard.$promise.catch(function(err) {
-        expect(err.status).toEqual(-1);
-        expect(err.statusText).toEqual("cancelled");
-    });
+    creditCard.$promise.catch(errorCB);
 
     creditCard.$cancelRequest();
     expect($httpBackend.flush).toThrow(new Error('No pending request to flush !'));
+    expect(errorCB).toHaveBeenCalledOnce();
+    errorCB.reset();
 
     CreditCard.get();
     expect($httpBackend.flush).not.toThrow();
+    expect(errorCB).not.toHaveBeenCalled();
   });
 
   it('should reset `$cancelRequest` after the response arrives', function() {


### PR DESCRIPTION
Timeout-promise resolved value will be passed as response error statusText.

``` js
  var promise = $timeout(function() {
    return "something";
  }, 500);

  $http({
    method: 'GET',
    url: '...',
    timeout: promise
  }).catch(function(err) {
    console.log(err.status);  // -1
    console.log(err.statusText);  // something
  });
```

This feature will also help distinguish cancelled $resource requests
from timed-out $resource requests. Before, both cases resulted
with the same error object:
`{status: -1, statusText: '', ...}`
thus impossible to handle both cases in different way.

Now cancelled requests will come with statusText='cancelled',
and timed-out requests with statusText='timeout' in the error object.
