### PR TITLE
feat(filter): uncurrency filter

### DIFF
--- a/i18n/e2e/i18n-e2e.js
+++ b/i18n/e2e/i18n-e2e.js
@@ -9,6 +9,7 @@ describe("localized filters", function() {
       expect(binding('input | date:"longDate"')).toBe("3 de junio de 1977");
       expect(binding('input | number')).toBe('234.234.443.432');
       expect(binding('input | currency')).toBe('€\u00a0234.234.443.432,00');
+      expect(binding('input | currency | uncurrency')).toBe(234234443432);
     });
   });
 
@@ -22,6 +23,7 @@ describe("localized filters", function() {
       expect(binding('input | date:"longDate"')).toBe("3. června 1977");
       expect(binding('input | number')).toBe('234\u00a0234\u00a0443\u00a0432');
       expect(binding('input | currency')).toBe('234\u00a0234\u00a0443\u00a0432,00\u00a0K\u010d');
+      expect(binding('input | currency | uncurrency')).toBe(234234443432);
     });
   });
 
@@ -35,6 +37,7 @@ describe("localized filters", function() {
       expect(binding('input | date:"longDate"')).toBe("3. Juni 1977");
       expect(binding('input | number')).toBe('234.234.443.432');
       expect(binding('input | currency')).toBe('234.234.443.432,00\u00a0€');
+      expect(binding('input | currency | uncurrency')).toBe(234234443432);
     });
   });
 
@@ -48,6 +51,7 @@ describe("localized filters", function() {
       expect(binding('input | date:"longDate"')).toBe("June 3, 1977");
       expect(binding('input | number')).toBe('234,234,443,432');
       expect(binding('input | currency')).toBe('$234,234,443,432.00');
+      expect(binding('input | currency | uncurrency')).toBe(234234443432);
     });
 
 
@@ -103,6 +107,7 @@ describe("localized filters", function() {
       expect(binding('input | date:"longDate"')).toBe("3. júna 1977");
       expect(binding('input | number')).toBe('234\u00a0234\u00a0443\u00a0432');
       expect(binding('input | currency')).toBe('234\u00a0234\u00a0443\u00a0432,00\u00a0Sk');
+      expect(binding('input | currency | uncurrency')).toBe(234234443432);
     });
 
 
@@ -142,6 +147,7 @@ describe("localized filters", function() {
       expect(binding('input | date:"longDate"')).toBe("1977年6月3日");
       expect(binding('input | number')).toBe('234,234,443,432');
       expect(binding('input | currency')).toBe('¥234,234,443,432.00');
+      expect(binding('input | currency | uncurrency')).toBe(234234443432);
     });
 
 

--- a/i18n/e2e/localeTest_cs.html
+++ b/i18n/e2e/localeTest_cs.html
@@ -17,5 +17,6 @@
     date: {{input | date:"longDate"}}<br>
     number: {{input | number}}<br>
     currency: {{input | currency }}
+    uncurrency: {{input | currency | uncurrency }}
   </body>
 </html>

--- a/i18n/e2e/localeTest_de.html
+++ b/i18n/e2e/localeTest_de.html
@@ -17,5 +17,6 @@
     date: {{input | date:"longDate"}}<br>
     number: {{input | number}}<br>
     currency: {{input | currency }}
+    uncurrency: {{input | currency | uncurrency }}
   </body>
 </html>

--- a/i18n/e2e/localeTest_en.html
+++ b/i18n/e2e/localeTest_en.html
@@ -24,6 +24,7 @@
     date(longDate): {{input | date:"longDate"}}<br>
     number: {{input | number}}<br>
     currency: {{input | currency }}
+    uncurrency: {{input | currency | uncurrency }}
     <hr/>
     <h3>Pluralization demo:</h3>
     <input type="text" ng-model="plInput"><br>

--- a/i18n/e2e/localeTest_es.html
+++ b/i18n/e2e/localeTest_es.html
@@ -17,5 +17,6 @@
     date: {{input | date:"longDate"}}<br>
     number: {{input | number}}<br>
     currency: {{input | currency }}
+    uncurrency: {{input | currency | uncurrency }}
   </body>
 </html>

--- a/i18n/e2e/localeTest_sk.html
+++ b/i18n/e2e/localeTest_sk.html
@@ -18,6 +18,7 @@
     date: {{input | date:"longDate"}}<br>
     number: {{input | number}}<br>
     currency: {{input | currency }}
+    uncurrency: {{input | currency | uncurrency }}
     <hr/>
     <input type="text" ng-model="plInput"><br>
     <ng-pluralize count="plInput"

--- a/i18n/e2e/localeTest_zh.html
+++ b/i18n/e2e/localeTest_zh.html
@@ -22,6 +22,7 @@
     date(longDate): {{input | date:"longDate"}}<br>
     number: {{input | number}}<br>
     currency: {{input | currency }}
+    uncurrency: {{input | currency | uncurrency }}
     <hr/>
     <h3>Pluralization demo:</h3>
     <input type="text" ng-model="plInput"><br>

--- a/src/ng/filter.js
+++ b/src/ng/filter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 /* global currencyFilter: true,
+ uncurrencyFilter: true,
  dateFilter: true,
  filterFilter: true,
  jsonFilter: true,
@@ -142,6 +143,7 @@ function $FilterProvider($provide) {
 
   /* global
     currencyFilter: false,
+    uncurrencyFilter: false,
     dateFilter: false,
     filterFilter: false,
     jsonFilter: false,
@@ -153,6 +155,7 @@ function $FilterProvider($provide) {
   */
 
   register('currency', currencyFilter);
+  register('uncurrency', uncurrencyFilter);
   register('date', dateFilter);
   register('filter', filterFilter);
   register('json', jsonFilter);

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -164,6 +164,36 @@ describe('filters', function() {
     }));
   });
 
+  describe('uncurrency', function() {
+    var uncurrency;
+
+    beforeEach(function() {
+      uncurrency = filter('uncurrency');
+    });
+
+    // mostly from https://github.com/openexchangerates/accounting.js/blob/master/tests/jasmine/core/unformatSpec.js which is Copyright (c) 2014 Open Exchange Rates
+    it('should remove padding special chars', function() {
+      expect(uncurrency('$ 123,456')).toBe(123456);
+      expect(uncurrency('$ 123,456.78')).toBe(123456.78);
+      expect(uncurrency('&*()$ 123,456')).toBe(123456);
+      expect(uncurrency(';$@#$%^&123,456.78')).toBe(123456.78);
+    });
+
+    it('should work with negative numbers', function() {
+      expect(uncurrency('$ -123,456')).toBe(-123456);
+      expect(uncurrency('$ -123,456.78')).toBe(-123456.78);
+      expect(uncurrency('&*()$ -123,456')).toBe(-123456);
+      expect(uncurrency(';$@#$%^&-123,456.78')).toBe(-123456.78);
+    });
+
+    it('should accept different decimal separators', function() {
+      expect(uncurrency('$ 123,456', ',')).toBe(123.456);
+      expect(uncurrency('$ 123456|78', '|')).toBe(123456.78);
+      expect(uncurrency('&*()$ 123>456', '>')).toBe(123.456);
+      expect(uncurrency(';$@#$%^&123,456\'78', '\'')).toBe(123456.78);
+    });
+  });
+
   describe('number', function() {
     var number;
 


### PR DESCRIPTION
New filter to convert formatted currency string to unformatted number.
This code is heavily based on [Open Exchange Rates's
accounting.js](https://github.com/openexchangerates/accounting.js)
unformat function which is Copyright (c) 2014 Open Exchange Rates.
