### PR TITLE
docs(guide/Components): Added missed fieldType integration

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -282,7 +282,7 @@ it upwards to the heroList component, which updates the original data.
 </file>
 <file name="editableField.html">
   <span ng-switch="$ctrl.editMode">
-    <input ng-switch-when="true" type="text" ng-model="$ctrl.fieldValue">
+    <input ng-switch-when="true" type="{{::$ctrl.fieldType}}" ng-model="$ctrl.fieldValue">
     <span ng-switch-default>{{$ctrl.fieldValue}}</span>
   </span>
   <button ng-click="$ctrl.handleModeChange()">{{$ctrl.editMode ? 'Save' : 'Edit'}}</button>

--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -282,7 +282,7 @@ it upwards to the heroList component, which updates the original data.
 </file>
 <file name="editableField.html">
   <span ng-switch="$ctrl.editMode">
-    <input ng-switch-when="true" type="{{::$ctrl.fieldType}}" ng-model="$ctrl.fieldValue">
+    <input ng-switch-when="true" type="{{$ctrl.fieldType}}" ng-model="$ctrl.fieldValue">
     <span ng-switch-default>{{$ctrl.fieldValue}}</span>
   </span>
   <button ng-click="$ctrl.handleModeChange()">{{$ctrl.editMode ? 'Save' : 'Edit'}}</button>


### PR DESCRIPTION
In the file `name="editableField.html"` was missed the `fieldType` property integration.
