### PR TITLE
fix(copy): add support for copying `Blob` objects

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -913,6 +913,9 @@ function copy(source, destination) {
         var re = new RegExp(source.source, source.toString().match(/[^\/]*$/)[0]);
         re.lastIndex = source.lastIndex;
         return re;
+
+      case '[object Blob]':
+        return new source.constructor([source], {type: source.type});
     }
 
     if (isFunction(source.cloneNode)) {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -228,6 +228,18 @@ describe('angular', function() {
       }
     });
 
+    it('should handle Blob objects', function() {
+      if (typeof Blob !== 'undefined') {
+        var src = new Blob(['foo'], {type: 'bar'});
+        var dst = copy(src);
+
+        expect(dst).not.toBe(src);
+        expect(dst.size).toBe(3);
+        expect(dst.type).toBe('bar');
+        expect(isBlob(dst)).toBe(true);
+      }
+    });
+
     it("should throw an exception if a Uint8Array is the destination", function() {
       if (typeof Uint8Array !== 'undefined') {
         var src = new Uint8Array();

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1012,7 +1012,7 @@ describe('ngMock', function() {
 
 
     it('should be able to handle Blobs as mock data', function() {
-      if (typeof Blob !== 'udefined') {
+      if (typeof Blob !== 'undefined') {
         var mockBlob = new Blob(['{"foo":"bar"}'], {type: 'application/json'});
 
         hb.when('GET', '/url1').respond(200, mockBlob, {});

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1011,6 +1011,26 @@ describe('ngMock', function() {
     });
 
 
+    it('should be able to handle Blobs as mock data', function() {
+      if (typeof Blob !== 'udefined') {
+        var mockBlob = new Blob(['{"foo":"bar"}'], {type: 'application/json'});
+
+        hb.when('GET', '/url1').respond(200, mockBlob, {});
+
+        callback.andCallFake(function(status, response) {
+          expect(response).not.toBe(mockBlob);
+          expect(response.size).toBe(13);
+          expect(response.type).toBe('application/json');
+          expect(response.toString()).toBe('[object Blob]');
+        });
+
+        hb('GET', '/url1', null, callback);
+        hb.flush();
+        expect(callback).toHaveBeenCalledOnce();
+      }
+    });
+
+
     it('should throw error when unexpected request', function() {
       hb.when('GET', '/url1').respond(200, 'content');
       expect(function() {


### PR DESCRIPTION
Although `copy()` does not need to (and never will) support all kinds of objects, there is a (not uncommon) usecase for supporting `Blob` objects:

`ngMock`'s `$httpBackend` will return a copy of the response data (so that changes in one test won't affect others). Since returning `Blob` objects in response to HTTP requests is a valid usecase and since `ngMocks`'s `$httpBackend` will use `copy()` to create a copy of that data, it is reasonable to support `Blob` objects.
(I didn't run any benchmarks, but the additional check for the type of the copied element should have negligible impact, compared to the other stuff that `copy()` is doing.)

Fixes #9669
