### PR TITLE
fix(ngAria): bind to `keydown` instead of `keypress` in `ngClick`

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -114,7 +114,7 @@ function $AriaProvider() {
    *  - **ariaValue** – `{boolean}` – Enables/disables aria-valuemin, aria-valuemax and aria-valuenow tags
    *  - **tabindex** – `{boolean}` – Enables/disables tabindex tags
    *  - **bindKeydown** – `{boolean}` – Enables/disables keydown event binding on `div` and
-   *    `li;` elements with ng-click
+   *    `li` elements with ng-click
    *  - **bindRoleForClick** – `{boolean}` – Adds role=button to non-interactive elements like `div`
    *    using ng-click, making them more accessible to users of assistive technologies
    *

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -96,7 +96,7 @@ function $AriaProvider() {
     ariaInvalid: true,
     ariaValue: true,
     tabindex: true,
-    bindKeypress: true,
+    bindKeydown: true,
     bindRoleForClick: true
   };
 
@@ -113,8 +113,8 @@ function $AriaProvider() {
    *  - **ariaInvalid** – `{boolean}` – Enables/disables aria-invalid tags
    *  - **ariaValue** – `{boolean}` – Enables/disables aria-valuemin, aria-valuemax and aria-valuenow tags
    *  - **tabindex** – `{boolean}` – Enables/disables tabindex tags
-   *  - **bindKeypress** – `{boolean}` – Enables/disables keypress event binding on `div` and
-   *    `li` elements with ng-click
+   *  - **bindKeydown** – `{boolean}` – Enables/disables keydown event binding on `div` and
+   *    `li;` elements with ng-click
    *  - **bindRoleForClick** – `{boolean}` – Adds role=button to non-interactive elements like `div`
    *    using ng-click, making them more accessible to users of assistive technologies
    *
@@ -364,8 +364,8 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
             elem.attr('tabindex', 0);
           }
 
-          if ($aria.config('bindKeypress') && !attr.ngKeypress) {
-            elem.on('keypress', function(event) {
+          if ($aria.config('bindKeydown') && !attr.ngKeypress) {
+            elem.on('keydown', function(event) {
               var keyCode = event.which || event.keyCode;
               if (keyCode === 32 || keyCode === 13) {
                 scope.$apply(callback);

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -364,7 +364,7 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
             elem.attr('tabindex', 0);
           }
 
-          if ($aria.config('bindKeydown') && !attr.ngKeypress) {
+          if ($aria.config('bindKeydown') && !attr.ngKeydown) {
             elem.on('keydown', function(event) {
               var keyCode = event.which || event.keyCode;
               if (keyCode === 32 || keyCode === 13) {

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -32,7 +32,7 @@
  * | {@link ng.directive:ngHide ngHide}          | aria-hidden                                                                            |
  * | {@link ng.directive:ngDblclick ngDblclick}  | tabindex                                                                               |
  * | {@link module:ngMessages ngMessages}        | aria-live                                                                              |
- * | {@link ng.directive:ngClick ngClick}        | tabindex, keydown event, button role                                                  |
+ * | {@link ng.directive:ngClick ngClick}        | tabindex, keydown event, keyup event, keypress event, button role                      |
  *
  * Find out more information about each directive by reading the
  * {@link guide/accessibility ngAria Developer Guide}.
@@ -96,7 +96,7 @@ function $AriaProvider() {
     ariaInvalid: true,
     ariaValue: true,
     tabindex: true,
-    bindKeydown: true,
+    bindKeyEvents: true,
     bindRoleForClick: true
   };
 
@@ -113,7 +113,7 @@ function $AriaProvider() {
    *  - **ariaInvalid** – `{boolean}` – Enables/disables aria-invalid tags
    *  - **ariaValue** – `{boolean}` – Enables/disables aria-valuemin, aria-valuemax and aria-valuenow tags
    *  - **tabindex** – `{boolean}` – Enables/disables tabindex tags
-   *  - **bindKeydown** – `{boolean}` – Enables/disables keydown event binding on `div` and
+   *  - **bindKeyEvents** – `{boolean}` – Enables/disables keyboard event binding on `div` and
    *    `li` elements with ng-click
    *  - **bindRoleForClick** – `{boolean}` – Adds role=button to non-interactive elements like `div`
    *    using ng-click, making them more accessible to users of assistive technologies
@@ -364,7 +364,7 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
             elem.attr('tabindex', 0);
           }
 
-          if ($aria.config('bindKeydown') && !attr.ngKeypress) {
+          if ($aria.config('bindKeyEvents') && !attr.ngKeypress && !attr.ngKeydown && !attr.ngKeyup) {
             elem.on('keydown', function(event) {
               var keyCode = event.which || event.keyCode;
               if (keyCode === 32 || keyCode === 13) {

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -32,7 +32,7 @@
  * | {@link ng.directive:ngHide ngHide}          | aria-hidden                                                                            |
  * | {@link ng.directive:ngDblclick ngDblclick}  | tabindex                                                                               |
  * | {@link module:ngMessages ngMessages}        | aria-live                                                                              |
- * | {@link ng.directive:ngClick ngClick}        | tabindex, keypress event, button role                                                  |
+ * | {@link ng.directive:ngClick ngClick}        | tabindex, keydown event, button role                                                  |
  *
  * Find out more information about each directive by reading the
  * {@link guide/accessibility ngAria Developer Guide}.
@@ -364,7 +364,7 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
             elem.attr('tabindex', 0);
           }
 
-          if ($aria.config('bindKeydown') && !attr.ngKeydown) {
+          if ($aria.config('bindKeydown') && !attr.ngKeypress) {
             elem.on('keydown', function(event) {
               var keyCode = event.which || event.keyCode;
               if (keyCode === 32 || keyCode === 13) {

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -608,8 +608,8 @@ describe('$aria', function() {
       var divElement = elements.find('div');
       var liElement = elements.find('li');
 
-      divElement.triggerHandler({type: 'keypress', keyCode: 32});
-      liElement.triggerHandler({type: 'keypress', keyCode: 32});
+      divElement.triggerHandler({type: 'keydown', keyCode: 32});
+      liElement.triggerHandler({type: 'keydown', keyCode: 32});
 
       expect(clickFn).toHaveBeenCalledWith('div');
       expect(clickFn).toHaveBeenCalledWith('li');
@@ -630,32 +630,18 @@ describe('$aria', function() {
       var divElement = elements.find('div');
       var liElement = elements.find('li');
 
-      divElement.triggerHandler({type: 'keypress', which: 32});
-      liElement.triggerHandler({type: 'keypress', which: 32});
+      divElement.triggerHandler({type: 'keydown', which: 32});
+      liElement.triggerHandler({type: 'keydown', which: 32});
 
       expect(clickFn).toHaveBeenCalledWith('div');
       expect(clickFn).toHaveBeenCalledWith('li');
     });
 
-    it('should not override existing ng-keypress', function() {
-      scope.someOtherAction = function() {};
-      var keypressFn = spyOn(scope, 'someOtherAction');
-
-      scope.someAction = function() {};
-      clickFn = spyOn(scope, 'someAction');
-      compileElement('<div ng-click="someAction()" ng-keypress="someOtherAction()" tabindex="0"></div>');
-
-      element.triggerHandler({type: 'keypress', keyCode: 32});
-
-      expect(clickFn).not.toHaveBeenCalled();
-      expect(keypressFn).toHaveBeenCalled();
-    });
-
-    it('should update bindings when keypress handled', function() {
+    it('should update bindings when keydown handled', function() {
       compileElement('<div ng-click="text = \'clicked!\'">{{text}}</div>');
       expect(element.text()).toBe('');
       spyOn(scope.$root, '$digest').andCallThrough();
-      element.triggerHandler({ type: 'keypress', keyCode: 13 });
+      element.triggerHandler({ type: 'keydown', keyCode: 13 });
       expect(element.text()).toBe('clicked!');
       expect(scope.$root.$digest).toHaveBeenCalledOnce();
     });
@@ -664,14 +650,14 @@ describe('$aria', function() {
       compileElement('<div ng-click="event = $event">{{event.type}}' +
                       '{{event.keyCode}}</div>');
       expect(element.text()).toBe('');
-      element.triggerHandler({ type: 'keypress', keyCode: 13 });
-      expect(element.text()).toBe('keypress13');
+      element.triggerHandler({ type: 'keydown', keyCode: 13 });
+      expect(element.text()).toBe('keydown13');
     });
 
-    it('should not bind keypress to elements not in the default config', function() {
+    it('should not bind keydown to elements not in the default config', function() {
       compileElement('<button ng-click="event = $event">{{event.type}}{{event.keyCode}}</button>');
       expect(element.text()).toBe('');
-      element.triggerHandler({ type: 'keypress', keyCode: 13 });
+      element.triggerHandler({ type: 'keydown', keyCode: 13 });
       expect(element.text()).toBe('');
     });
   });
@@ -688,9 +674,9 @@ describe('$aria', function() {
     });
   });
 
-  describe('actions when bindKeypress is set to false', function() {
+  describe('actions when bindKeydown is set to false', function() {
     beforeEach(configAriaProvider({
-      bindKeypress: false
+      bindKeydown: false
     }));
     beforeEach(injectScopeAndCompiler);
 
@@ -700,7 +686,7 @@ describe('$aria', function() {
 
       element = $compile('<div ng-click="someAction()" tabindex="0"></div>')(scope);
 
-      element.triggerHandler({type: 'keypress', keyCode: 32});
+      element.triggerHandler({type: 'keydown', keyCode: 32});
 
       expect(clickFn).not.toHaveBeenCalled();
     });

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -637,7 +637,7 @@ describe('$aria', function() {
       expect(clickFn).toHaveBeenCalledWith('li');
     });
 
-    it('should not override existing ng-keydown', function() {
+    it('should not bind to key events if there is existing ng-keydown', function() {
       scope.someOtherAction = function() {};
       var keydownFn = spyOn(scope, 'someOtherAction');
 
@@ -649,6 +649,34 @@ describe('$aria', function() {
 
       expect(clickFn).not.toHaveBeenCalled();
       expect(keydownFn).toHaveBeenCalled();
+    });
+
+    it('should not bind to key events if there is existing ng-keyup', function() {
+      scope.someOtherAction = function() {};
+      var keyupFn = spyOn(scope, 'someOtherAction');
+
+      scope.someAction = function() {};
+      clickFn = spyOn(scope, 'someAction');
+      compileElement('<div ng-click="someAction()" ng-keyup="someOtherAction()" tabindex="0"></div>');
+
+      element.triggerHandler({type: 'keyup', keyCode: 32});
+
+      expect(clickFn).not.toHaveBeenCalled();
+      expect(keyupFn).toHaveBeenCalled();
+    });
+
+    it('should not bind to key events if there is existing ng-keypress', function() {
+      scope.someOtherAction = function() {};
+      var keypressFn = spyOn(scope, 'someOtherAction');
+
+      scope.someAction = function() {};
+      clickFn = spyOn(scope, 'someAction');
+      compileElement('<div ng-click="someAction()" ng-keypress="someOtherAction()" tabindex="0"></div>');
+
+      element.triggerHandler({type: 'keypress', keyCode: 32});
+
+      expect(clickFn).not.toHaveBeenCalled();
+      expect(keypressFn).toHaveBeenCalled();
     });
 
     it('should update bindings when keydown handled', function() {
@@ -688,9 +716,9 @@ describe('$aria', function() {
     });
   });
 
-  describe('actions when bindKeydown is set to false', function() {
+  describe('actions when bindKeyEvents is set to false', function() {
     beforeEach(configAriaProvider({
-      bindKeydown: false
+      bindKeyEvents: false
     }));
     beforeEach(injectScopeAndCompiler);
 
@@ -701,6 +729,8 @@ describe('$aria', function() {
       element = $compile('<div ng-click="someAction()" tabindex="0"></div>')(scope);
 
       element.triggerHandler({type: 'keydown', keyCode: 32});
+      element.triggerHandler({type: 'keypress', keyCode: 32});
+      element.triggerHandler({type: 'keyup', keyCode: 32});
 
       expect(clickFn).not.toHaveBeenCalled();
     });

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -637,6 +637,20 @@ describe('$aria', function() {
       expect(clickFn).toHaveBeenCalledWith('li');
     });
 
+    it('should not override existing ng-keydown', function() {
+      scope.someOtherAction = function() {};
+      var keydownFn = spyOn(scope, 'someOtherAction');
+
+      scope.someAction = function() {};
+      clickFn = spyOn(scope, 'someAction');
+      compileElement('<div ng-click="someAction()" ng-keydown="someOtherAction()" tabindex="0"></div>');
+
+      element.triggerHandler({type: 'keydown', keyCode: 32});
+
+      expect(clickFn).not.toHaveBeenCalled();
+      expect(keydownFn).toHaveBeenCalled();
+    });
+
     it('should update bindings when keydown handled', function() {
       compileElement('<div ng-click="text = \'clicked!\'">{{text}}</div>');
       expect(element.text()).toBe('');


### PR DESCRIPTION
The ngAria keyboard support for html elements used as button now binds to the keydown
event instead of keypress to better emulate behavior of native buttons.

BREAKING CHANGE: The ngAria configuration flag that controls binding to keyboard input
has been renamed from `bindKeypress` to `bindKeydown` so that it accurately describes the
implemented behavior.

Closes #14063
