### PR TITLE
fix($compile): handle boolean attributes in `@` bindings

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3120,7 +3120,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               destination[scopeName] = attrs[attrName] = void 0;
             }
             attrs.$observe(attrName, function(value) {
-              if (isString(value)) {
+              if (isString(value) || isBoolean(value)) {
                 var oldValue = destination[scopeName];
                 recordChanges(scopeName, value, oldValue);
                 destination[scopeName] = value;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2712,6 +2712,25 @@ describe('$compile', function() {
                 expect(checkedVal).toEqual(true);
               });
             });
+
+            it('should handle updates to @ bindings on BOOLEAN attributes', function() {
+              var componentScope;
+              module(function($compileProvider) {
+                $compileProvider.directive('test', function() {
+                  return {
+                    scope: { checked: '@' },
+                    link: function(scope, element, attrs) {
+                      componentScope = scope;
+                      attrs.$set('checked',true);
+                    }
+                  };
+                });
+              });
+              inject(function($compile, $rootScope) {
+                $compile('<input test>')($rootScope);
+                expect(componentScope.checked).toEqual(true);
+              });
+            });
           });
 
 


### PR DESCRIPTION
Commit db5e0ff handles initial values of boolean attributes. The same
change needs to be applied inside the attrs.$observe() call.

(I'm not familiar with the angular.js codebase, so this may not be the right way to fix the issue. What I verified is that this fixes a regression with some production code which worked with angular.js 1.2.28 and 1.3.20 but failed with 1.4.7.
So feel free to replace this PR with some better fix, as you like.)
