### PR TITLE
refactor(ngMock): make `ngMock` minification-safe

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2648,11 +2648,11 @@ if (window.jasmine || window.mocha) {
         var fn, modules = currentSpec.$modules || (currentSpec.$modules = []);
         angular.forEach(moduleFns, function(module) {
           if (angular.isObject(module) && !angular.isArray(module)) {
-            fn = function($provide) {
+            fn = ['$provide', function($provide) {
               angular.forEach(module, function(value, key) {
                 $provide.value(key, value);
               });
-            };
+            }];
           } else {
             fn = module;
           }
@@ -2773,9 +2773,9 @@ if (window.jasmine || window.mocha) {
     function workFn() {
       var modules = currentSpec.$modules || [];
       var strictDi = !!currentSpec.$injectorStrict;
-      modules.unshift(function($injector) {
+      modules.unshift(['$injector', function($injector) {
         currentSpec.$providerInjector = $injector;
-      });
+      }]);
       modules.unshift('ngMock');
       modules.unshift('ng');
       var injector = currentSpec.$injector;


### PR DESCRIPTION
It is not common, but some workflows result in `angular-mocks` being minified.

Fixes #13542
