### PR TITLE
fix($location): absUrl() does not return undefined for base href and …

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -324,6 +324,11 @@ function LocationHashbangInHtml5Url(appBase, appBaseNoFile, hashPrefix) {
 
 
 var locationPrototype = {
+  /**
+   * Ensure absolute URL is initialized.
+   * @private
+   */
+  $$absUrl: '',
 
   /**
    * Are we in html5 mode?


### PR DESCRIPTION
…html5Mode

$location's absUrl incorrectly returned undefined when using base href and html5Mode. Initializaing it to fix this issue.

Closes #11091
