### PR TITLE
feat(ngMock): add sharedInjector() to angular.mock.module

### DIFF
--- a/docs/content/guide/unit-testing.ngdoc
+++ b/docs/content/guide/unit-testing.ngdoc
@@ -438,5 +438,42 @@ In tests, you can trigger a digest by calling a scope's {@link ng.$rootScope.Sco
 If you don't have a scope in your test, you can inject the {@link ng.$rootScope $rootScope} and call `$apply` on it.
 There is also an example of testing promises in the {@link ng.$q#testing `$q` service documentation}.
 
+## Using `beforeAll()`
+
+Jasmine's `beforeAll()` and mocha's `before()` hooks are often useful for sharing test setup - either to reduce test run-time or simply to make for more focussed test cases.
+
+By default, ngMock will create an injector per test case to ensure your tests do not affect each other. However, if we want to use `beforeAll()`, ngMock will have to create the injector before any test cases are run, and share that injector through all the cases for that `describe`. That is where {@link angular.mock.module.sharedInjector module.sharedInjector()} comes in. When it's called within a `describe` block, a single injector is shared between all hooks and test cases run in that block.
+
+In the example below we are testing a service that takes a long time to generate its answer. To avoid having all of the assertions we want to write in a single test case, {@link angular.mock.module.sharedInjector module.sharedInjector()} and Jasmine's `beforeAll()` are used to run the service only one. The test cases then all make assertions about the properties added to the service instance.
+
+```javascript
+describe("Deep Thought", function() {
+
+  module.sharedInjector();
+
+  beforeAll(module("UltimateQuestion"));
+
+  beforeAll(inject(function(DeepThought) {
+    expect(DeepThought.answer).toBe(undefined);
+    DeepThought.generateAnswer();
+  }));
+
+  it("has calculated the answer correctly", inject(function(DeepThought) {
+    // Because of sharedInjector, we have access to the instance of the DeepThought service 
+    // that was provided to the beforeAll() hook. Therefore we can test the generated answer
+    expect(DeepThought.answer).toBe(42);
+  }));
+
+  it("has calculated the answer within the expected time", inject(function(DeepThought) {
+    expect(DeepThought.runTimeMillennia).toBeLessThan(8000);
+  }));
+
+  it("has double checked the answer", inject(function(DeepThought) {
+    expect(DeepThought.absolutelySureItIsTheRightAnswer).toBe(true);
+  }));
+
+});
+```
+
 ## Sample project
 See the [angular-seed](https://github.com/angular/angular-seed) project for an example.


### PR DESCRIPTION
Allows users to opt-in to using a shared injector within a `describe()` context, via `angular.mock.module.sharedInjector()`.

This enables Jasmine 2.x/mocha's `beforeAll()`/`before()` hooks to be used with Angular, fixing issue #10238 as previously discussed.

Beyond the tests added to `angular-mocksSpec.js`, I've also created JSFiddles with the new behaviour working alongside:
- [Jasmine 2.x](https://jsfiddle.net/timruffles/h1u6hx6f/)
- [Mocha](https://jsfiddle.net/timruffles/Lfkzhdca/)
- [Jasmine 1.x](https://jsfiddle.net/timruffles/9299oxcx/) (to simply demonstrate it doesn't break anything - 1.x doesn't have beforeAll so can't use sharedInjector)

The verification tests above contain tests suggested by @lgalfaso. cc/@petebacondarwin. The unit tests added contain a little test framework stub, as it was nigh on impossible to test this feature without interference from the rest of the Angular test machinery. Testing inception!
