### PR TITLE
fix(ngMock): prevent memory leak due to data attached to `$rootElement`

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2602,16 +2602,10 @@ if (window.jasmine || window.mocha) {
     currentSpec = null;
 
     if (injector) {
-      var cleanUpElems = [originalRootElement];
-      var $rootElement = injector.get('$rootElement');
-      if ($rootElement !== originalRootElement) cleanUpElems.push($rootElement);
-      cleanUpElems.forEach(function(elem) {
-        // The `$rootElement` might not have been created or
-        // a mocked `$rootElement` might not have the standard methods
-        if (elem && elem.off) elem.off();
-        if (elem && elem.removeData) elem.removeData();
-      });
-      if (window.jQuery) window.jQuery.cleanData(cleanUpElems);
+      var cleanUpElems = [originalRootElement[0]];
+      var rootNode = injector.get('$rootElement')[0];
+      if (rootNode && (rootNode !== originalRootElement[0])) cleanUpElems.push(rootNode);
+      angular.element.cleanData(cleanUpElems);
 
       injector.get('$rootScope').$destroy();
     }

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -127,12 +127,12 @@ angular.mock.$Browser = function() {
 };
 angular.mock.$Browser.prototype = {
 
-/**
-  * @name $browser#poll
-  *
-  * @description
-  * run all fns in pollFns
-  */
+  /**
+   * @name $browser#poll
+   *
+   * @description
+   * run all fns in pollFns
+   */
   poll: function poll() {
     angular.forEach(this.pollFns, function(pollFn) {
       pollFn();
@@ -2089,10 +2089,12 @@ angular.mock.$RAFDecorator = ['$delegate', function($delegate) {
 /**
  *
  */
+var originalRootElement;
 angular.mock.$RootElementProvider = function() {
-  this.$get = function() {
-    return angular.element('<div ng-app></div>');
-  };
+  this.$get = ['$injector', function($injector) {
+    originalRootElement = angular.element('<div ng-app></div>').data('$injector', $injector);
+    return originalRootElement;
+  }];
 };
 
 /**
@@ -2600,7 +2602,17 @@ if (window.jasmine || window.mocha) {
     currentSpec = null;
 
     if (injector) {
-      injector.get('$rootElement').off();
+      var cleanUpElems = [originalRootElement];
+      var $rootElement = injector.get('$rootElement');
+      if ($rootElement !== originalRootElement) cleanUpElems.push($rootElement);
+      cleanUpElems.forEach(function(elem) {
+        // The `$rootElement` might not have been created or
+        // a mocked `$rootElement` might not have the standard methods
+        if (elem && elem.off) elem.off();
+        if (elem && elem.removeData) elem.removeData();
+      });
+      if (window.jQuery) window.jQuery.cleanData(cleanUpElems);
+
       injector.get('$rootScope').$destroy();
     }
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2579,6 +2579,7 @@ if (window.jasmine || window.mocha) {
 
 
   (window.beforeEach || window.setup)(function() {
+    originalRootElement = null;
     annotatedFunctions = [];
     currentSpec = this;
   });
@@ -2602,10 +2603,14 @@ if (window.jasmine || window.mocha) {
     currentSpec = null;
 
     if (injector) {
-      var cleanUpElems = [originalRootElement[0]];
-      var rootNode = injector.get('$rootElement')[0];
-      if (rootNode && (rootNode !== originalRootElement[0])) cleanUpElems.push(rootNode);
-      angular.element.cleanData(cleanUpElems);
+      // Ensure `$rootElement` is instantiated, before checking `originalRootElement`
+      var $rootElement = injector.get('$rootElement');
+      var rootNode = $rootElement && $rootElement[0];
+      var cleanUpNodes = !originalRootElement ? [] : [originalRootElement[0]];
+      if (rootNode && (!originalRootElement || rootNode !== originalRootElement[0])) {
+        cleanUpNodes.push(rootNode);
+      }
+      angular.element.cleanData(cleanUpNodes);
 
       injector.get('$rootScope').$destroy();
     }

--- a/test/helpers/testabilityPatch.js
+++ b/test/helpers/testabilityPatch.js
@@ -139,12 +139,8 @@ function dealoc(obj) {
   }
 
   function cleanup(element) {
-    element.off().removeData();
-    if (window.jQuery) {
-      // jQuery 2.x doesn't expose the cache storage; ensure all element data
-      // is removed during its cleanup.
-      jQuery.cleanData([element]);
-    }
+    angular.element.cleanData(element);
+
     // Note:  We aren't using element.contents() here.  Under jQuery, element.contents() can fail
     // for IFRAME elements.  jQuery explicitly uses (element.contentDocument ||
     // element.contentWindow.document) and both properties are null for IFRAMES that aren't attached

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -2448,9 +2448,9 @@ describe('`afterEach` clean-up', function() {
       // We want to verify the subsequent call, made by `angular-mocks`
       expect(prevCleanDataSpy.callCount).toBe(2);
 
-      var cleanUpElems = prevCleanDataSpy.calls[1].args[0];
-      expect(cleanUpElems.length).toBe(1);
-      expect(cleanUpElems[0]).toBe(prevRootElement[0]);
+      var cleanUpNodes = prevCleanDataSpy.calls[1].args[0];
+      expect(cleanUpNodes.length).toBe(1);
+      expect(cleanUpNodes[0]).toBe(prevRootElement[0]);
     });
   });
 
@@ -2498,10 +2498,32 @@ describe('`afterEach` clean-up', function() {
       // We want to verify the subsequent call, made by `angular-mocks`
       expect(prevCleanDataSpy.callCount).toBe(2);
 
-      var cleanUpElems = prevCleanDataSpy.calls[1].args[0];
-      expect(cleanUpElems.length).toBe(2);
-      expect(cleanUpElems[0]).toBe(prevOriginalRootElement[0]);
-      expect(cleanUpElems[1]).toBe(prevRootElement[0]);
+      var cleanUpNodes = prevCleanDataSpy.calls[1].args[0];
+      expect(cleanUpNodes.length).toBe(2);
+      expect(cleanUpNodes[0]).toBe(prevOriginalRootElement[0]);
+      expect(cleanUpNodes[1]).toBe(prevRootElement[0]);
+    });
+  });
+
+
+  describe('uninstantiated or falsy `$rootElement`', function() {
+    it('should not break if `$rootElement` was never instantiated', function() {
+      // Just an empty test to verify that `angular-mocks` doesn't break,
+      // when trying to clean up `$rootElement`, if `$rootElement` was never injected in the test
+      // (and thus never instantiated/created)
+
+      // Ensure the `$injector` is created - if there is no `$injector`, no clean-up takes places
+      inject(function() {});
+    });
+
+
+    it('should not break if the decorated `$rootElement` is falsy (e.g. `null`)', function() {
+      module(function($provide) {
+        $provide.value('$rootElement', null);
+      });
+
+      // Ensure the `$injector` is created - if there is no `$injector`, no clean-up takes places
+      inject(function() {});
     });
   });
 });


### PR DESCRIPTION
Starting with 88bb551, `ngMock` will attach the `$injector` to the `$rootElement`, but will never clean it up, resulting in a memory leak. Since a new `$rootElement` is created for every test, this leak causes Karma to crash on large test-suites.
The problem was not detected by our internal tests, because we do our own clean-up in
`testabilityPatch.js`.

This commit prevents the memory leak, by cleaning up all data attached to `$rootElement` after each test.

Fixes #14094
