### PR TITLE
Add a public "has" method to the Controller class, to check the existence of a given controller

### DIFF
--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -29,6 +29,15 @@ function $ControllerProvider() {
 
   /**
    * @ngdoc method
+   * @name $controllerProvider#has
+   * @param {string} name Controller name to check.
+   */
+  this.has = function(name) {
+    return controllers.hasOwnProperty(name);
+  };
+
+  /**
+   * @ngdoc method
    * @name $controllerProvider#register
    * @param {string|Object} name Controller name, or an object map of controllers where the keys are
    *    the names and the values are the constructors.

--- a/test/ng/controllerSpec.js
+++ b/test/ng/controllerSpec.js
@@ -57,6 +57,21 @@ describe('$controller', function() {
       expect(ctrl instanceof BarCtrl).toBe(true);
     });
 
+    it('should return true when having an existing controller, should return false otherwise', function() {
+      $controllerProvider.register('FooCtrl', noop);
+      $controllerProvider.register('BarCtrl', ['dep1', 'dep2', noop]);
+      $controllerProvider.register({
+        'BazCtrl': noop,
+        'QuxCtrl': ['dep1', 'dep2', noop]
+      });
+
+      expect($controllerProvider.has('FooCtrl')).toBe(true);
+      expect($controllerProvider.has('BarCtrl')).toBe(true);
+      expect($controllerProvider.has('BazCtrl')).toBe(true);
+      expect($controllerProvider.has('QuxCtrl')).toBe(true);
+
+      expect($controllerProvider.has('UnknownCtrl')).toBe(false);
+    });
 
     it('should allow registration of controllers annotated with arrays', function() {
       var FooCtrl = function($scope) { $scope.foo = 'bar'; },


### PR DESCRIPTION
I haven't written any test. The `npm install` failed here and I've been unable to test anything. (Seems like it fails on gyp-rebuild with my WIndows 8.1...)

The PR is quite small. if someone with a proper setup could just add some test for it, it would be nice.

https://github.com/angular/angular.js/issues/13951
