### PR TITLE
docs: docs(guide/Animations): Fixed a typo in Animations doc `app.cofig`

### DIFF
--- a/docs/content/guide/animations.ngdoc
+++ b/docs/content/guide/animations.ngdoc
@@ -309,7 +309,7 @@ allows a lot of flexibility - you can either allow animations only for specific 
 you are working with 3rd party animations), or exclude specific classes from getting animated.
 
 ```js
-app.cofig($animateProvider) {
+app.config($animateProvider) {
   $animateProvider.classNameFilter(/animate-/);
 });
 ```


### PR DESCRIPTION
line 312 fixed a typo : `app.config` instead of `app.cofig`
