### PR TITLE
feat($compile): add custom annotations to the controller

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1106,6 +1106,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     forEach(options, function(val, key) {
       if (key.charAt(0) === '$') {
         factory[key] = val;
+        controller[key] = val;
       }
     });
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -10044,6 +10044,22 @@ describe('$compile', function() {
       }));
     });
 
+    it('should add additional annotations to the controller constructor', function() {
+      var myModule = angular.module('my', []).component('myComponent', {
+        $canActivate: 'canActivate',
+        $routeConfig: 'routeConfig',
+        $customAnnotation: 'XXX'
+      });
+      module('my');
+      inject(function(myComponentDirective) {
+        expect(myComponentDirective[0].controller).toEqual(jasmine.objectContaining({
+          $canActivate: 'canActivate',
+          $routeConfig: 'routeConfig',
+          $customAnnotation: 'XXX'
+        }));
+      });
+    });
+
     it('should return ddo with reasonable defaults', function() {
       angular.module('my', []).component('myComponent', {});
       module('my');


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  feat
- **What is the current behavior?** (You can also link to an open issue here)
  inconvenient
- **What is the new behavior (if this is a feature change)?**
  add custom annotations to the controller of component directives
- **Does this PR introduce a breaking change?**
  Nope
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **Other information**:

This means that we can access these annotations, such as
`$routeConfig` and `$routerCanActivate` without highjacking
the `ng` module.
