### PR TITLE
Wait for browser async 1.5

### DIFF
--- a/src/ng/testability.js
+++ b/src/ng/testability.js
@@ -2,8 +2,8 @@
 
 
 function $$TestabilityProvider() {
-  this.$get = ['$rootScope', '$browser', '$location', '$window',
-       function($rootScope,   $browser,   $location, $window) {
+  this.$get = ['$rootScope', '$browser', '$location',
+       function($rootScope,   $browser,   $location) {
 
     /**
      * @name $testability

--- a/src/ng/testability.js
+++ b/src/ng/testability.js
@@ -2,8 +2,8 @@
 
 
 function $$TestabilityProvider() {
-  this.$get = ['$rootScope', '$browser', '$location',
-       function($rootScope,   $browser,   $location) {
+  this.$get = ['$rootScope', '$browser', '$location', '$window',
+       function($rootScope,   $browser,   $location, $window) {
 
     /**
      * @name $testability
@@ -109,7 +109,11 @@ function $$TestabilityProvider() {
      * @param {function} callback
      */
     testability.whenStable = function(callback) {
-      $browser.notifyWhenNoOutstandingRequests(callback);
+      // Register the callback asynchronously, so that services that trigger
+      // async callbacks have a chance to run.
+      $rootScope.$evalAsync(function() {
+        $browser.notifyWhenNoOutstandingRequests(callback);
+      });
     };
 
     return testability;

--- a/test/ng/testabilitySpec.js
+++ b/test/ng/testabilitySpec.js
@@ -188,7 +188,7 @@ describe('$$testability', function() {
   });
 
   describe('waiting for stability', function() {
-    it('should process callbacks immediately with no outstanding requests',
+    it('should process callbacks without waiting if there are no outstanding requests',
       inject(function($$testability, $timeout) {
         var callback = jasmine.createSpy('callback');
         runs(function() {


### PR DESCRIPTION
Makes whenStable() wait for outstanding browser requests asynchronously. If it waits synchronously, it will miss $http calls made in the current digest cycle.

Fixes #13782

I think this would also fix angular/protractor#789
