### PR TITLE
docs(guide/Internet Explorer Compatibility): Add ng-attr-type workaround for buttons in IE

### DIFF
--- a/docs/content/guide/ie.ngdoc
+++ b/docs/content/guide/ie.ngdoc
@@ -29,3 +29,6 @@ To ensure your Angular application works on IE please consider:
 
 1. Use `ng-style` tags instead of `style="{{ someCss }}"`. The latter works in Chrome and Firefox
    but does not work in Internet Explorer <= 11 (the most recent version at time of writing).
+2. For the `type` attribute of buttons, use `ng-attr-type` tags instead of 
+   `type="{{ someExpression }}"`.  If using the latter, Internet Explorer overwrites the expression
+   with `type="submit"` before Angular has a chance to interpolate it.


### PR DESCRIPTION
Resolves #14117
