### PR TITLE
feat($compile): add $onDestroy directive lifecycle hook

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2427,7 +2427,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             controller.instance.$onInit();
           }
           if (isFunction(controller.instance.$onDestroy)) {
-            scope.$on('$destroy', controller.instance.$onDestroy);
+            scope.$on('$destroy', controller.instance.$onDestroy.bind(controller.instance));
           }
         });
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -296,6 +296,8 @@
  * * `$onInit` - Called on each controller after all the controllers on an element have been constructed and
  *   had their bindings initialized (and before the pre &amp; post linking functions for the directives on
  *   this element). This is a good place to put initialization code for your controller.
+ * * `$onDestroy` - Called when the controller's scope has been destroyed. This is a good place to put
+ * code for tearing down your controller and for example removing event listeners.
  *
  * #### `require`
  * Require another directive and inject its controller as the fourth argument to the linking function. The
@@ -2423,6 +2425,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         forEach(elementControllers, function(controller) {
           if (isFunction(controller.instance.$onInit)) {
             controller.instance.$onInit();
+          }
+          if (isFunction(controller.instance.$onDestroy)) {
+            scope.$on('$destroy', controller.instance.$onDestroy);
           }
         });
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -296,8 +296,8 @@
  * * `$onInit` - Called on each controller after all the controllers on an element have been constructed and
  *   had their bindings initialized (and before the pre &amp; post linking functions for the directives on
  *   this element). This is a good place to put initialization code for your controller.
- * * `$onDestroy` - Called when the controller's scope has been destroyed. This is a good place to put
- * code for tearing down your controller and for example removing event listeners.
+ * * `$onDestroy` - Called on each controller when the directive has been destroyed. This is a good place to put
+ * code for tearing down your controller like for example removing event listeners.
  *
  * #### `require`
  * Require another directive and inject its controller as the fourth argument to the linking function. The
@@ -2421,14 +2421,18 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           }
         });
 
-        // Trigger the `$onInit` method on all controllers that have one
+        // Trigger the `$onInit` method on all controllers that have one,
+        // and trigger `$onDestroy` method if present and when the element emits `$destroy` event
         forEach(elementControllers, function(controller) {
           if (isFunction(controller.instance.$onInit)) {
             controller.instance.$onInit();
           }
-          if (isFunction(controller.instance.$onDestroy)) {
-            scope.$on('$destroy', controller.instance.$onDestroy.bind(controller.instance));
-          }
+
+          $element.on('$destroy', function() {
+            if (isFunction(controller.instance.$onDestroy)) {
+              controller.instance.$onDestroy();
+            }
+          });
         });
 
         // PRELINKING

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4629,7 +4629,7 @@ describe('$compile', function() {
         expect(Controller.prototype.$onInit).toHaveBeenCalled();
         expect(Controller.prototype.$onDestroy).not.toHaveBeenCalled();
         expect(controllerCalled).toBe(true);
-        $rootScope.$destroy();
+        element.remove();
         expect(Controller.prototype.$onDestroy).toHaveBeenCalled();
 
       });
@@ -5357,7 +5357,7 @@ describe('$compile', function() {
       });
     });
 
-    it('should call `controller.$onDestroy`, if provided when the controllers is destroyed', function() {
+    it('should call `controller.$onDestroy`, if provided when the element is removed', function() {
 
       function check() {
         /*jshint validthis:true */
@@ -5377,9 +5377,55 @@ describe('$compile', function() {
       module('my');
       inject(function($compile, $rootScope) {
         element = $compile('<div d1 d2></div>')($rootScope);
-        $rootScope.$destroy();
+        element.remove();
         expect(Controller1.prototype.$onDestroy).toHaveBeenCalledOnce();
         expect(Controller2.prototype.$onDestroy).toHaveBeenCalledOnce();
+      });
+    });
+
+    it('should call `controller.$onDestroy`, if provided when the directive is removed using ngIf', function() {
+
+      function check() {
+        /*jshint validthis:true */
+        expect(this.element.controller('d1').id).toEqual(1);
+      }
+
+      function Controller1($element) { this.id = 1; this.element = $element; }
+      Controller1.prototype.$onDestroy = jasmine.createSpy('$onDestroy').andCallFake(check);
+
+      angular.module('my', [])
+        .directive('d1', valueFn({ controller: Controller1 }));
+
+      module('my');
+      inject(function($compile, $rootScope) {
+        element = $compile('<div><div ng-if="t"><d1></d1></div></div>')($rootScope);
+        $rootScope.t = true;
+        $rootScope.$apply();
+
+        $rootScope.t = false;
+        $rootScope.$apply();
+
+        expect(Controller1.prototype.$onDestroy).toHaveBeenCalledOnce();
+      });
+    });
+
+    it('should call `controller.$onDestroy`, when provided after controller initialization', function() {
+
+      function Controller1() {
+        this.setDestroy = function() {
+          Controller1.prototype.$onDestroy = jasmine.createSpy('$onDestroy');
+        };
+      }
+
+      angular.module('my', [])
+        .directive('d1', valueFn({ controller: Controller1 }));
+
+      module('my');
+      inject(function($compile, $rootScope) {
+        element = $compile('<div d1></div>')($rootScope);
+        element.controller('d1').setDestroy();
+        element.remove();
+        expect(Controller1.prototype.$onDestroy).toHaveBeenCalledOnce();
       });
     });
 
@@ -5807,7 +5853,7 @@ describe('$compile', function() {
         expect(MeController.prototype.$onDestroy).not.toHaveBeenCalled();
         expect(parentController).toEqual(jasmine.any(ParentController));
         expect(siblingController).toEqual(jasmine.any(SiblingController));
-        $rootScope.$destroy();
+        element.remove();
         expect(MeController.prototype.$onDestroy).toHaveBeenCalled();
 
       });
@@ -5825,7 +5871,6 @@ describe('$compile', function() {
         siblingController = this.friend;
       };
       spyOn(MeController.prototype, '$onInit').andCallThrough();
-
       MeController.prototype.$onDestroy = function() {};
       spyOn(MeController.prototype, '$onDestroy').andCallThrough();
 
@@ -5858,7 +5903,7 @@ describe('$compile', function() {
         expect(MeController.prototype.$onDestroy).not.toHaveBeenCalled();
         expect(parentController).toBeUndefined();
         expect(siblingController).toBeUndefined();
-        $rootScope.$destroy();
+        element.remove();
         expect(MeController.prototype.$onDestroy).toHaveBeenCalled();
 
       });
@@ -5915,7 +5960,7 @@ describe('$compile', function() {
         expect(meController.$onDestroy).not.toHaveBeenCalled();
         expect(parentController).toEqual(jasmine.any(ParentController));
         expect(siblingController).toEqual(jasmine.any(SiblingController));
-        $rootScope.$destroy();
+        element.remove();
         expect(meController.$onDestroy).toHaveBeenCalled();
       });
     });

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -5359,13 +5359,16 @@ describe('$compile', function() {
 
     it('should call `controller.$onDestroy`, if provided when the controllers is destroyed', function() {
 
+      function check() {
+        /*jshint validthis:true */
+        expect(this.element.controller('d1').id).toEqual(1);
+        expect(this.element.controller('d2').id).toEqual(2);
+      }
       function Controller1($element) { this.id = 1; this.element = $element; }
-      Controller1.prototype.$onDestroy = function() {};
-      spyOn(Controller1.prototype, '$onDestroy').andCallThrough();
+      Controller1.prototype.$onDestroy = jasmine.createSpy('$onDestroy').andCallFake(check);
 
       function Controller2($element) { this.id = 2; this.element = $element; }
-      Controller2.prototype.$onDestroy = function() {};
-      spyOn(Controller2.prototype, '$onDestroy').andCallThrough();
+      Controller2.prototype.$onDestroy = jasmine.createSpy('$onDestroy').andCallFake(check);
 
       angular.module('my', [])
         .directive('d1', valueFn({ controller: Controller1 }))


### PR DESCRIPTION
This PR introduces a new $onDestroy lifecycle hook for directives. This hook matches the destroy hook that's present in Angular 2. 

Closes #14020
