### PR TITLE
WIP fix(ngRoute): Attach resolved locals before controller instantiation

### DIFF
--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -268,6 +268,8 @@ function ngViewFillContentFactory($compile, $controller, $route) {
 
       var link = $compile($element.contents());
 
+      scope[current.resolveAs || '$resolve'] = locals;
+
       if (current.controller) {
         locals.$scope = scope;
         var controller = $controller(current.controller, locals);
@@ -277,7 +279,6 @@ function ngViewFillContentFactory($compile, $controller, $route) {
         $element.data('$ngControllerController', controller);
         $element.children().data('$ngControllerController', controller);
       }
-      scope[current.resolveAs || '$resolve'] = locals;
 
       link(scope);
     }

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -160,6 +160,61 @@ describe('ngView', function() {
     });
   });
 
+  it('should reference resolved locals via $scope.$resolve in controller', function() {
+    var controllerScope,
+        Ctrl = function($scope) {
+          controllerScope = $scope;
+          controllerScope.mutated = $scope.$resolve.name + 'bar';
+        };
+
+    module(function($routeProvider) {
+      $routeProvider.when('/foo', {
+        resolve: {
+          name: function() {
+            return 'foo';
+          }
+        },
+        template: '<div>{{mutated}}</div>',
+        controller: Ctrl
+      });
+    });
+
+    inject(function($location, $rootScope) {
+      $location.path('/foo');
+      $rootScope.$digest();
+      expect(element.text()).toEqual('foobar');
+    });
+
+  });
+
+  it('should reference resolved locals via alias in controller using resolveAs', function() {
+    var controllerScope,
+        Ctrl = function($scope) {
+          controllerScope = $scope;
+          controllerScope.mutated = $scope.myResolve.name + 'bar';
+        };
+
+    module(function($routeProvider) {
+      $routeProvider.when('/foo', {
+        resolveAs: 'myResolve',
+        resolve: {
+          name: function() {
+            return 'foo';
+          }
+        },
+        template: '<div>{{mutated}}</div>',
+        controller: Ctrl
+      });
+    });
+
+    inject(function($location, $rootScope) {
+      $location.path('/foo');
+      $rootScope.$digest();
+      expect(element.text()).toEqual('foobar');
+    });
+
+  });
+
 
   it('should load content via xhr when route changes', function() {
     module(function($routeProvider) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Bug fix. Fixes #14134 
- **What is the current behavior?** (You can also link to an open issue here)
  #14134
- **What is the new behavior (if this is a feature change)?**
  Add the `$resolve` property to the route scope prior to instantiating the controller
- **Does this PR introduce a breaking change?**
  no
- **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **Other information**:

Resolved locals are attached to route scope as `$resolve` or the
`resolveAs` string prior to instantiation of the routes controller
so the properties are available in the controller as `$scope.$resolve`.

Fixes #14134
