### PR TITLE
ngRoute: pass $resolve as local to route controller

### DIFF
--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -268,6 +268,8 @@ function ngViewFillContentFactory($compile, $controller, $route) {
 
       var link = $compile($element.contents());
 
+      scope[current.resolveAs || '$resolve'] = locals;
+
       if (current.controller) {
         locals.$scope = scope;
         var controller = $controller(current.controller, locals);
@@ -277,7 +279,6 @@ function ngViewFillContentFactory($compile, $controller, $route) {
         $element.data('$ngControllerController', controller);
         $element.children().data('$ngControllerController', controller);
       }
-      scope[current.resolveAs || '$resolve'] = locals;
 
       link(scope);
     }

--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -262,15 +262,17 @@ function ngViewFillContentFactory($compile, $controller, $route) {
     priority: -400,
     link: function(scope, $element) {
       var current = $route.current,
-          locals = current.locals;
+          locals = current.locals,
+          resolveAs = current.resolveAs || '$resolve';
 
       $element.html(locals.$template);
 
       var link = $compile($element.contents());
 
-      scope[current.resolveAs || '$resolve'] = locals;
+      scope[resolveAs] = locals;
 
       if (current.controller) {
+        locals[resolveAs] = locals;
         locals.$scope = scope;
         var controller = $controller(current.controller, locals);
         if (current.controllerAs) {

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -215,6 +215,59 @@ describe('ngView', function() {
 
   });
 
+  it('should inject resolved locals into controller', function() {
+    var controllerScope,
+        Ctrl = function($scope, $resolve) {
+          controllerScope = $scope;
+          controllerScope.name = $resolve.name;
+        };
+
+    module(function($routeProvider) {
+      $routeProvider.when('/foo', {
+        resolve: {
+          name: function() {
+            return 'foobar';
+          }
+        },
+        template: '<div>{{name}}</div>',
+        controller: Ctrl
+      });
+    });
+
+    inject(function($location, $rootScope) {
+      $location.path('/foo');
+      $rootScope.$digest();
+      expect(element.text()).toEqual('foobar');
+    });
+  });
+
+  it('should inject resolved locals via alias into controller using resolveAs', function() {
+    var controllerScope,
+        Ctrl = function($scope, myResolve) {
+          controllerScope = $scope;
+          controllerScope.name = myResolve.name;
+        };
+
+    module(function($routeProvider) {
+      $routeProvider.when('/foo', {
+        resolveAs: 'myResolve',
+        resolve: {
+          name: function() {
+            return 'foobar';
+          }
+        },
+        template: '<div>{{name}}</div>',
+        controller: Ctrl
+      });
+    });
+
+    inject(function($location, $rootScope) {
+      $location.path('/foo');
+      $rootScope.$digest();
+      expect(element.text()).toEqual('foobar');
+    });
+  });
+
 
   it('should load content via xhr when route changes', function() {
     module(function($routeProvider) {

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -160,6 +160,61 @@ describe('ngView', function() {
     });
   });
 
+  it('should reference resolved locals via $scope.$resolve in controller', function() {
+    var controllerScope,
+        Ctrl = function($scope) {
+          controllerScope = $scope;
+          controllerScope.mutated = $scope.$resolve.name + 'bar';
+        };
+
+    module(function($routeProvider) {
+      $routeProvider.when('/foo', {
+        resolve: {
+          name: function() {
+            return 'foo';
+          }
+        },
+        template: '<div>{{mutated}}</div>',
+        controller: Ctrl
+      });
+    });
+
+    inject(function($location, $rootScope) {
+      $location.path('/foo');
+      $rootScope.$digest();
+      expect(element.text()).toEqual('foobar');
+    });
+
+  });
+
+  it('should reference resolved locals via alias in controller using resolveAs', function() {
+    var controllerScope,
+        Ctrl = function($scope) {
+          controllerScope = $scope;
+          controllerScope.mutated = $scope.myResolve.name + 'bar';
+        };
+
+    module(function($routeProvider) {
+      $routeProvider.when('/foo', {
+        resolveAs: 'myResolve',
+        resolve: {
+          name: function() {
+            return 'foo';
+          }
+        },
+        template: '<div>{{mutated}}</div>',
+        controller: Ctrl
+      });
+    });
+
+    inject(function($location, $rootScope) {
+      $location.path('/foo');
+      $rootScope.$digest();
+      expect(element.text()).toEqual('foobar');
+    });
+
+  });
+
 
   it('should load content via xhr when route changes', function() {
     module(function($routeProvider) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  feat(ngRoute): add `$resolve` (or `resolveAs` string) as injectable into the controller
- **What is the current behavior?** (You can also link to an open issue here)
  Currently the resolved locals are added as a property on the route scope. #14135 would allow those to be accessed in the controller by injecting the `$scope`. 
- **What is the new behavior (if this is a feature change)?**
  This PR would allow injecting just `$resolve` (or whatever `resolveAs` is set to) in the case that the `controllerAs` syntax is being used and the developer wants access to the resolved locals without injecting the entire `$scope`
- **Does this PR introduce a breaking change?**
  No
- **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **Other information**:
  Due to the nature of this PR (needing the resolved locals to be available at the time the controller is instantiated), it is dependent on the same change as #14135 and thus was branched from there. It wouldn't make sense to accept this PR and not #14135, but in the case that it's decided this is not wanted, I separated this code.
