### PR TITLE
fix(ngAria): don't attach roles to native controls

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -221,8 +221,8 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
   function shouldAttachRole(role, elem) {
     // if element does not have role attribute
     // AND element type is equal to role (if custom element has a type equaling shape) <-- remove?
-    // AND element is not INPUT
-    return !elem.attr('role') && (elem.attr('type') === role) && (elem[0].nodeName !== 'INPUT');
+    // AND element is not in nodeBlackList
+    return !elem.attr('role') && (elem.attr('type') === role) && !isNodeOneOf(elem, nodeBlackList);
   }
 
   function getShape(attr, elem) {

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -272,6 +272,18 @@ describe('$aria', function() {
       compileElement('<input type="range" ng-model="val"></div>');
       expect(element.attr('role')).toBe(undefined);
     });
+
+    they('should not add role to native $prop controls', {
+      select: '<select type="checkbox" ng-model="val"></select>',
+      textarea: '<textarea type="checkbox" ng-model="val"></textarea>',
+      button: '<button ng-click="doClick()"></button>',
+      summary: '<summary ng-click="doClick()"></summary>',
+      details: '<details ng-click="doClick()"></details>',
+      a: '<a ng-click="doClick()"></a>'
+    }, function(tmpl) {
+      var element = $compile(tmpl)(scope);
+      expect(element.attr('role')).toBeUndefined();
+    });
   });
 
   describe('aria-checked when disabled', function() {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  fix
- **What is the current behavior?** (You can also link to an open issue here)

attach roles to these native element (textarea, select, button)
- **What is the new behavior (if this is a feature change)?**

don't attach roles to these native these element (textarea, select, button)
- **Does this PR introduce a breaking change?**

no
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **Other information**:

don't add roles to (textarea, button, select, input)
fix #14076
