### PR TITLE
fix(ngAriaSpec): remove wrong input closing tag

### DIFF
--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -249,7 +249,7 @@ describe('$aria', function() {
     });
 
     it('should not add a role to a native checkbox', function() {
-      compileElement('<input type="checkbox" ng-model="val"></div>');
+      compileElement('<input type="checkbox" ng-model="val"/>');
       expect(element.attr('role')).toBe(undefined);
     });
 
@@ -259,7 +259,7 @@ describe('$aria', function() {
     });
 
     it('should not add a role to a native radio button', function() {
-      compileElement('<input type="radio" ng-model="val"></div>');
+      compileElement('<input type="radio" ng-model="val"/>');
       expect(element.attr('role')).toBe(undefined);
     });
 
@@ -269,7 +269,7 @@ describe('$aria', function() {
     });
 
     it('should not add a role to a native range input', function() {
-      compileElement('<input type="range" ng-model="val"></div>');
+      compileElement('<input type="range" ng-model="val"/>');
       expect(element.attr('role')).toBe(undefined);
     });
   });


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix  https://github.com/angular/angular.js/issues/14146
- **What is the current behavior?** (You can also link to an open issue here)
- **What is the new behavior (if this is a feature change)?**

remove wrong close div tag after input tag
- **Does this PR introduce a breaking change?**

No
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **Other information**:

remove wrong closed div tag after input element
fixes #14146
