### PR TITLE
fix(ngRoute): make route.resolve count as a pending request

### DIFF
--- a/test/e2e/fixtures/ng-route-promise/index.html
+++ b/test/e2e/fixtures/ng-route-promise/index.html
@@ -1,0 +1,9 @@
+<html ng-app="lettersApp">
+  <body>
+    <div ng-view></div>
+
+    <script src="angular.js"></script>
+    <script src="angular-route.js"></script>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/test/e2e/fixtures/ng-route-promise/script.js
+++ b/test/e2e/fixtures/ng-route-promise/script.js
@@ -1,0 +1,43 @@
+'use strict';
+
+angular.
+  module('lettersApp', ['ngRoute']).
+  config(function($routeProvider) {
+    $routeProvider.
+      otherwise(resolveRedirectTo('/foo1')).
+      when('/foo1', resolveRedirectTo('/bar1')).
+      when('/bar1', resolveRedirectTo('/baz1')).
+      when('/baz1', resolveRedirectTo('/qux1')).
+      when('/qux1', {
+        template: '<ul><li ng-repeat="letter in $resolve.letters">{{ letter }}</li></ul>',
+        resolve: resolveLetters()
+      }).
+      when('/foo2', resolveRedirectTo('/bar2')).
+      when('/bar2', resolveRedirectTo('/baz2')).
+      when('/baz2', resolveRedirectTo('/qux2')).
+      when('/qux2', {
+        template: '{{ $resolve.letters.length }}',
+        resolve: resolveLetters()
+      });
+
+    // Helpers
+    function resolveLetters() {
+      return {
+        letters: function($q) {
+          return $q(function(resolve) {
+            window.setTimeout(resolve, 1000, ['a', 'b', 'c', 'd', 'e']);
+          });
+        }
+      };
+    }
+
+    function resolveRedirectTo(path) {
+      return {
+        resolveRedirectTo: function($q) {
+          return $q(function(resolve) {
+            window.setTimeout(resolve, 250, path);
+          });
+        }
+      };
+    }
+  });

--- a/test/e2e/tests/ng-route-promise.spec.js
+++ b/test/e2e/tests/ng-route-promise.spec.js
@@ -1,0 +1,33 @@
+'use strict';
+
+describe('ngRoute promises', function() {
+  beforeEach(function() {
+    loadFixture('ng-route-promise');
+  });
+
+  it('should wait for route promises', function() {
+    expect(element.all(by.tagName('li')).count()).toBe(5);
+  });
+
+  it('should time out if the promise takes long enough', function() {
+    // Don't try this at home kids, I'm a protractor dev
+    browser.manage().timeouts().setScriptTimeout(1500);
+    browser.waitForAngular().then(function() {
+      fail('waitForAngular() should have timed out, but didn\'t');
+    }, function(error) {
+      expect(error.message).toContain('Timed out waiting for asynchronous Angular tasks to finish');
+    });
+  });
+
+  it('should wait for route promises when navigating to another route', function() {
+    browser.setLocation('/foo2');
+    expect(element(by.tagName('body')).getText()).toBe('5');
+  });
+
+  afterEach(function(done) {
+    // Restore old timeout limit
+    browser.getProcessedConfig().then(function(config) {
+      return browser.manage().timeouts().setScriptTimeout(config.allScriptsTimeout);
+    }).then(done);
+  });
+});


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Make angular count pending [`resolve`](https://github.com/angular/angular.js/blob/master/src/ngRoute/route.js#L96) values as pending request, for the purposes of making `whenStable` more accurate.
- **What is the current behavior?** (You can also link to an open issue here)

Currently, if someone uses promises to asynchronously set a `resolve`, this is not counted as a pending request.  The result is that callbacks to `whenStable` can be invoked before these variables are available.  This was causing protractor users problems (see https://github.com/angular/protractor/issues/789#issuecomment-190983200 for details)
- **What is the new behavior (if this is a feature change)?**

Waiting for these variables now counts as a pending request.
- **Does this PR introduce a breaking change?**

I guess you could imagine a breaking change where someone wanted a `whenStable` callback to be invoked before the variables resolved.
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Not sure tests are necessary for such a small change.  And since this brings behavior in line with user expectations not sure about the docs either.
- **Other information**:
