### PR TITLE
feat($parse): Allow user-defined literals

### DIFF
--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -223,7 +223,7 @@ describe('parser', function() {
       /* global AST: false */
       createAst = function() {
         var lexer = new Lexer({csp: false});
-        var ast = new AST(lexer, {csp: false});
+        var ast = new AST(lexer, {csp: false, literals: {'true': true, 'false': false, 'undefined': undefined, 'null': null}});
         return ast.ast.apply(ast, arguments);
       };
     });
@@ -1680,6 +1680,19 @@ describe('parser', function() {
   beforeEach(module(['$filterProvider', function(filterProvider) {
     $filterProvider = filterProvider;
   }]));
+
+  forEach([true, false], function(cspEnabled) {
+    beforeEach(module(['$parseProvider', function(parseProvider) {
+      parseProvider.addLiteral('Infinity', Infinity);
+    }]));
+
+    it('should allow extending literals with csp ' + cspEnabled, inject(function($rootScope) {
+      expect($rootScope.$eval("Infinity")).toEqual(Infinity);
+      expect($rootScope.$eval("-Infinity")).toEqual(-Infinity);
+      expect(function() {$rootScope.$eval("Infinity = 1");}).toThrow();
+      expect($rootScope.$eval("Infinity")).toEqual(Infinity);
+    }));
+  });
 
   forEach([true, false], function(cspEnabled) {
     describe('csp: ' + cspEnabled, function() {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Feature
- **What is the current behavior?** (You can also link to an open issue here)
  It is not possible to add user-defined literals.
- **What is the new behavior (if this is a feature change)?**
  It is possible to have user-defined literals like `Infinity` and `NaN`
- **Does this PR introduce a breaking change?**
  No
- **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- **Other information**:

Allow user-defined literals.

Close: #9504
Close: #9492
