### PR TITLE
refactor($compile): added component text when asserting directive name

### DIFF
--- a/docs/content/error/$compile/baddir.ngdoc
+++ b/docs/content/error/$compile/baddir.ngdoc
@@ -1,8 +1,8 @@
 @ngdoc error
 @name $compile:baddir
-@fullName Invalid Directive Name
+@fullName Invalid Directive/Component Name
 @description
 
-This error occurs when the name of a directive is not valid.
+This error occurs when the name of a directive or component is not valid.
 
-Directives must start with a lowercase character and must not contain leading or trailing whitespaces.
+Directives and Components must start with a lowercase character and must not contain leading or trailing whitespaces.

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -928,11 +928,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
   function assertValidDirectiveName(name) {
     var letter = name.charAt(0);
     if (!letter || letter !== lowercase(letter)) {
-      throw $compileMinErr('baddir', "Directive name '{0}' is invalid. The first character must be a lowercase letter", name);
+      throw $compileMinErr('baddir', "Directive/Component name '{0}' is invalid. The first character must be a lowercase letter", name);
     }
     if (name !== name.trim()) {
       throw $compileMinErr('baddir',
-            "Directive name '{0}' is invalid. The name should not contain leading or trailing whitespaces",
+            "Directive/Component name '{0}' is invalid. The name should not contain leading or trailing whitespaces",
             name);
     }
   }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -207,7 +207,7 @@ describe('$compile', function() {
       module(function() {
         expect(function() {
           directive('BadDirectiveName', function() { });
-        }).toThrowMinErr('$compile','baddir', "Directive name 'BadDirectiveName' is invalid. The first character must be a lowercase letter");
+        }).toThrowMinErr('$compile','baddir', "Directive/Component name 'BadDirectiveName' is invalid. The first character must be a lowercase letter");
       });
       inject(function($compile) {});
     });
@@ -217,7 +217,7 @@ describe('$compile', function() {
           expect(function() {
             directive(name, function() { });
           }).toThrowMinErr(
-            '$compile','baddir', 'Directive name \'' + name + '\' is invalid. ' +
+            '$compile','baddir', 'Directive/Component name \'' + name + '\' is invalid. ' +
             "The name should not contain leading or trailing whitespaces");
         }
         assertLeadingOrTrailingWhitespaceInDirectiveName(' leadingWhitespaceDirectiveName');


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Considering the Angular 1.5 introduction of components, when creating a component with an uppercase, the error thrown mentions a directive. This fix/update will provide the user information for when he has created an uppercased component (in general terms, not differentiating between directive and component).
- **What is the current behavior?** (You can also link to an open issue here)
  The error thrown includes the text: Directive name 'ThisExample' is invalid. The first character must be a lowercase letter
- **What is the new behavior (if this is a feature change)?**
  The error thrown includes the text: Directive/Component name 'ThisExample' is invalid. The first character must be a lowercase letter
- **Does this PR introduce a breaking change?**
  No.
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **Other information**:
