### PR TITLE
Fix broken expectation in Safari for serializing invalid dates.

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1195,7 +1195,12 @@ function toJson(obj, pretty) {
   if (!isNumber(pretty)) {
     pretty = pretty ? 2 : null;
   }
-  return JSON.stringify(obj, toJsonReplacer, pretty);
+  try {
+    return JSON.stringify(obj, toJsonReplacer, pretty);
+  } catch (RangeError) {
+    // In Safari, 'Invalid Date's throw a range error. 'null' is returned in all other browsers.
+    return 'null';
+  }
 }
 
 

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1169,6 +1169,8 @@ function toJsonReplacer(key, value) {
     val = '$DOCUMENT';
   } else if (isScope(value)) {
     val = '$SCOPE';
+  } else if (isDate(value) && isNaN(value.getMilliseconds())) {
+    val = null;
   }
 
   return val;
@@ -1195,12 +1197,7 @@ function toJson(obj, pretty) {
   if (!isNumber(pretty)) {
     pretty = pretty ? 2 : null;
   }
-  try {
-    return JSON.stringify(obj, toJsonReplacer, pretty);
-  } catch (RangeError) {
-    // In Safari, 'Invalid Date's throw a range error. 'null' is returned in all other browsers.
-    return 'null';
-  }
+  return JSON.stringify(obj, toJsonReplacer, pretty);
 }
 
 

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -2060,7 +2060,7 @@ describe('angular', function() {
     });
 
     it('should serialize invalid dates to null', function() {
-      expect(toJson(new Date(1 / 0))).toEqual('null');
+      expect(toJson({when: new Date(1 / 0)})).toEqual('{"when":null}');
     });
   });
 

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -2060,7 +2060,7 @@ describe('angular', function() {
     });
 
     it('should serialize invalid dates to null', function() {
-      expect(toJson(new Date(1/0))).toEqual('null');
+      expect(toJson(new Date(1 / 0))).toEqual('null');
     });
   });
 

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -2058,6 +2058,10 @@ describe('angular', function() {
     it('should serialize undefined as undefined', function() {
       expect(toJson(undefined)).toEqual(undefined);
     });
+    
+    it('should serialize invalid dates to null', function() {
+      expect(toJson(new Date(1/0))).toEqual('null');
+    });
   });
 
   describe('isElement', function() {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -2058,7 +2058,7 @@ describe('angular', function() {
     it('should serialize undefined as undefined', function() {
       expect(toJson(undefined)).toEqual(undefined);
     });
-    
+
     it('should serialize invalid dates to null', function() {
       expect(toJson(new Date(1/0))).toEqual('null');
     });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix.

**What is the current behavior? (You can also link to an open issue here)**

Fixes #13415. Current behaviour is that Safari throws a render error instead of correctly handling Invalid Dates (such as `new Date(1/0)`).

**What is the new behavior (if this is a feature change)?**

New behaviour is that Safari performs the same as other browsers, by serializing the invalid date or any `RangeError`) to `'null'`.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [Yes] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [Yes] Tests for the changes have been added (for bug fixes / features)
- [Unnecessary] Docs have been added / updated (for bug fixes / features)

**Other information**:

Added test to prevent regression. No docs need updating since no behaviour changed and no new features were added.
