### PR TITLE
docs(ngMock): add verifyNoOutstandingExpectation digest parameter

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1799,6 +1799,10 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
    * ```js
    *   afterEach($httpBackend.verifyNoOutstandingExpectation);
    * ```
+   *
+   * @param {boolean=} digest Whether to perform a `$rootScope.$digest()` (default is `true`).
+   *   If performing `verifyNoOutstandingExpectation` after a `flush` (which also performs
+   *   a digest), you can pass in `false` to prevent digest-in-progress errors.
    */
   $httpBackend.verifyNoOutstandingExpectation = function(digest) {
     if (digest !== false) $rootScope.$digest();


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs update.

**What is the current behavior? (You can also link to an open issue here)**

Undocumented yet public API — parameter `digest` of $httpBackend.verifyNoOutstandingExpectation was previously not listed.

**What is the new behavior (if this is a feature change)?**

Now explained along with motivating use case.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format

**Other information**:

add detailed documentation, with motivation, for the previously-undocumented
verifyNoOutstandingExpectation parameter `digest`.
