### PR TITLE
docs(ng.$log): show how log methods are bound to console

### DIFF
--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -10,6 +10,14 @@
  * into the browser's console (if present).
  *
  * The main purpose of this service is to simplify debugging and troubleshooting.
+ * Also, all `$log` methods are applied directly to `console`, streamlining using
+ * `$log` methods as handler functions (e.g. for {@link ng.$http $http}):
+ *
+ * ```js
+ *   $http.get('/api/widgets')
+ *   .then(function (response) { use(response); })
+ *   .catch($log.error) // replaces `console.error.bind(console)` or a wrapping function
+ * ```
  *
  * The default is to log `debug` messages. You can use
  * {@link ng.$logProvider ng.$logProvider#debugEnabled} to change this.


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs update

**What is the current behavior? (You can also link to an open issue here)**

The fact that `$log` methods are applied to the `console` regardless of invocation context is useful but not noted anywhere.

**What is the new behavior (if this is a feature change)?**

An example is provided of how this pre-binding streamlines the use of `$log` methods as handler functions, e.g. for `$http` promises.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format

**Other information**:

N/A.
