### PR TITLE
docs(guide/Component Router): describe your change...

### DIFF
--- a/docs/content/guide/component-router.ngdoc
+++ b/docs/content/guide/component-router.ngdoc
@@ -956,9 +956,9 @@ respectively.
 
 **How do I prevent navigation from occurring?**
 
-Each **Component** can provide the `$routerCanActivate` and `$routerCanDeactivate` **Lifecycle Hooks**. The
-`$routerCanDeactivate` hook is an instance method on the **Component**. The `$routerCanActivate` hook is a
-static method defined on either the **Component Definition Object** or the **Component's** constructor function.
+Each **Component** can provide the `$canActivate` and `$routerCanDeactivate` **Lifecycle Hooks**. The
+`$routerCanDeactivate` hook is an instance method on the **Component**. The `$canActivate` hook is used as a
+static method defined on the **Component Definition Object**.
 
 The **Router** will call these hooks to control navigation from one **Route** to another. Each of these hooks can
 return a `boolean` or a Promise that will resolve to a `boolean`.
@@ -966,7 +966,7 @@ return a `boolean` or a Promise that will resolve to a `boolean`.
 During a navigation, some **Components** will become inactive and some will become active. Before the navigation
 can complete, all the **Components** must agree that they can be deactivated or activated, respectively.
 
-The **Router** will call the `$routerCanDeactivate` and `$routerCanActivate` hooks, if they are provided. If any
+The **Router** will call the `$routerCanDeactivate` and `$canActivate` hooks, if they are provided. If any
 of the hooks resolve to `false` then the navigation is cancelled.
 
 ### Dialog Box Service


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs update

**What is the current behavior? (You can also link to an open issue here)**

Method $routerCanActivate lifecycle hook does not appear to exist for components in 1.x

**What is the new behavior (if this is a feature change)?**

The $canActivate hook on the CDO appears to be the only way to control route resolution for components in 1.x

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

NOTES:

From what I can tell, the only way of "resolving" for a component route is in the component's definition object and the method is $canActivate, not $routerCanActivate. Adding a $routerCanActivate alternative would be helpful as a method that can be called on the constructor.

I did find a helpful min-safe pattern that might be worth documenting. This is the ability to inject into the CDO's $canActivate method by putting to-be-injected module strings AFTER the default parameters ($nextInstruction and $prevInstruction), followed by the callback with the injected modules as the 3rd - xx arguments. This way I can reference a service to check authentication status (for example), returning a promise that will resolve to true or false and thereby either permit the route to proceed or kill it.

However, the best feature would be to add some way to reference a routeProvider, as with ngRoute, for global $canActivate patterns. A pattern I had successfully used with ngRoute was to extend the "when" method to do my authentication check and abort any route that had a configuration setting like "requiresAuth." To be able to do the same with component-based routes would be helpful, but I haven't figured out how. Thanks.
