### PR TITLE
perf($compile): use strict comparison for controller === '@'

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2484,7 +2484,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         };
 
         var controller = directive.controller;
-        if (controller == '@') {
+        if (controller === '@') {
           controller = attrs[directive.name];
         }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
perf improvement

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format

**Other information**:

In the DDO, controller can be '@', which means the controller name
is taken from the directive attribute. This is undocumented and internally
only used by ngController. There seems to be no case where converting the
controller function to a string would actually be necessary.

Related #14268
