### PR TITLE
test(helpers): fix error message generation for `toHaveBeenCalledOnce[With]` matchers

### DIFF
--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -972,7 +972,7 @@ describe('jqLite', function() {
 
 
   describe('text', function() {
-    it('should return null on empty', function() {
+    it('should return `""` on empty', function() {
       expect(jqLite().length).toEqual(0);
       expect(jqLite().text()).toEqual('');
     });
@@ -1040,7 +1040,7 @@ describe('jqLite', function() {
 
 
   describe('html', function() {
-    it('should return null on empty', function() {
+    it('should return `undefined` on empty', function() {
       expect(jqLite().length).toEqual(0);
       expect(jqLite().html()).toEqual(undefined);
     });

--- a/test/modules/no_bootstrap.js
+++ b/test/modules/no_bootstrap.js
@@ -1,3 +1,3 @@
-// When runnint the modules test, then the page should not be bootstrapped.
+// When running the modules test, then the page should not be bootstrapped.
 window.name = "NG_DEFER_BOOTSTRAP!";
 

--- a/test/ng/anchorScrollSpec.js
+++ b/test/ng/anchorScrollSpec.js
@@ -88,6 +88,9 @@ describe('$anchorScroll', function() {
     return function($window) {
       forEach(elmSpy, function(spy, id) {
         var count = map[id] || 0;
+        // TODO(gkalpak): `toHaveBeenCalledTimes()` works correctly with 0 since
+        // https://github.com/jasmine/jasmine/commit/342f0eb9a38194ecb8559e7df872c72afc0fe52e
+        // Fix when we upgrade to a version that contains the fix.
         if (count > 0) {
           expect(spy).toHaveBeenCalledTimes(count);
         } else {
@@ -386,6 +389,9 @@ describe('$anchorScroll', function() {
 
       return function($rootScope, $window) {
         inject(expectScrollingTo(identifierCountMap));
+        // TODO(gkalpak): `toHaveBeenCalledTimes()` works correctly with 0 since
+        // https://github.com/jasmine/jasmine/commit/342f0eb9a38194ecb8559e7df872c72afc0fe52e
+        // Fix when we upgrade to a version that contains the fix.
         if (list.length > 0) {
           expect($window.scrollBy).toHaveBeenCalledTimes(list.length);
         } else {


### PR DESCRIPTION
This commit fixes the error messages for 2 of our internal matchers (`toHaveBeenCalledOnce()` and `toHaveBeenCalledOnceWith()`). The previous format (returning an array containing both the "normal" and the negative error messages), is not supported in Jasmine 2.4. It will always concatenate the messages.

Related to #14226.

<sub>There is also a 2nd commit (to be squashed when merging) with minor fixes (typos and testcase descriptions) and a couple of TODOs.</sub>
