### PR TITLE
chore(ci-checks): fix the `ddescribe-iit` task for Jasmine 2

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -266,12 +266,17 @@ module.exports = function(grunt) {
       ],
       options: {
         disallowed: [
+          'fit',
           'iit',
           'xit',
+          'fthey',
           'tthey',
           'xthey',
+          'fdescribe',
           'ddescribe',
-          'xdescribe'
+          'xdescribe',
+          'it.only',
+          'describe.only'
         ]
       }
     },


### PR DESCRIPTION
Without this fix, we are "vulnerable" to sneaky `fit`/`fthey`/`fdescribe`s.
