### PR TITLE
docs(guide/Component Router): changed path to match diagram

### DIFF
--- a/docs/content/guide/component-router.ngdoc
+++ b/docs/content/guide/component-router.ngdoc
@@ -124,9 +124,9 @@ This process continues until we run out of **Routing Components** or consume the
 
 ![Routed Components](img/guide/component-routes.svg)
 
-In the previous diagram can see that the URL `/heros/2` has been matched against the `App`, `Heroes` and
+In the previous diagram can see that the URL `/heros/4` has been matched against the `App`, `Heroes` and
 `HeroDetail` **Routing Components**. The **Routers** for each of the **Routing Components** consumed a part
-of the URL: "/", "/heroes" and "/2" respectively.
+of the URL: "/", "/heroes" and "/4" respectively.
 
 The result is that we end up with a hierarchy of **Routing Components** rendered in **Outlets**, via the
 {@link ngOutlet} directive, in each **Routing Component's** template, as you can see in the following diagram.


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update

**What is the current behavior? (You can also link to an open issue here)**
Currently the path in the docs does not match the path in the diagram for the Route Matching section.

**What is the new behavior (if this is a feature change)?**
N/A

**Does this PR introduce a breaking change?**
N/A

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
