### PR TITLE
test(TzDate): fix test in Australia

### DIFF
--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -26,17 +26,19 @@ describe('ngMock', function() {
 
 
     it('should fake getLocalDateString method', function() {
-      //0 in -3h
-      var t0 = new angular.mock.TzDate(-3, 0);
-      expect(t0.toLocaleDateString()).toMatch('1970');
+      var millenium = new Date('2000').getTime();
 
-      //0 in +0h
-      var t1 = new angular.mock.TzDate(0, 0);
-      expect(t1.toLocaleDateString()).toMatch('1970');
+      // millenium in -3h
+      var t0 = new angular.mock.TzDate(-3, millenium);
+      expect(t0.toLocaleDateString()).toMatch('2000');
 
-      //0 in +3h
-      var t2 = new angular.mock.TzDate(3, 0);
-      expect(t2.toLocaleDateString()).toMatch('1969');
+      // millenium in +0h
+      var t1 = new angular.mock.TzDate(0, millenium);
+      expect(t1.toLocaleDateString()).toMatch('2000');
+
+      // millenium in +3h
+      var t2 = new angular.mock.TzDate(3, millenium);
+      expect(t2.toLocaleDateString()).toMatch('1999');
     });
 
 


### PR DESCRIPTION
Probably due to implementation differences in browsers for pre-DST periods (see https://github.com/angular/angular.js/issues/5017 and especially https://github.com/angular/angular.js/issues/5017#issuecomment-90775226 for context), some `TzDate` tests had different behavior on different Timezones/Regions (e.g. failed in Australia, which started to observe DST in 1971).
Since the used year (`1970`) didn't have any particular significance, this commit fixes the issue
by using a year that is more consistently handled by browsers (`2000`).

Fixes #14272
