### PR TITLE
fix(formatNumber): handle small numbers correctly different gSize and…

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -323,7 +323,7 @@ function formatNumber(number, pattern, groupSep, decimalSep, fractionSize) {
 
     // format the integer digits with grouping separators
     var groups = [];
-    if (digits.length > pattern.lgSize) {
+    if (digits.length >= pattern.lgSize) {
       groups.unshift(digits.splice(-pattern.lgSize).join(''));
     }
     while (digits.length > pattern.gSize) {

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -35,7 +35,11 @@ describe('filters', function() {
 
     it('should format according to different patterns', function() {
       pattern.gSize = 2;
-      var num = formatNumber(1234567.89, pattern, ',', '.');
+      var num = formatNumber(99, pattern, ',', '.');
+      expect(num).toBe('99');
+      num = formatNumber(888, pattern, ',', '.');
+      expect(num).toBe('888');
+      num = formatNumber(1234567.89, pattern, ',', '.');
       expect(num).toBe('12,34,567.89');
       num = formatNumber(1234.56, pattern, ',', '.');
       expect(num).toBe('1,234.56');


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug Fix

**What is the current behavior? (You can also link to an open issue here)**
#14289

**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

… lgSize

By using >= when comparing the number length to the lgSize we'll provide
the correct value when formatting numbers with differing lgSize and gSize

Closes #14289
