### PR TITLE
perf(injector): cache the results of the native class detection check

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -837,13 +837,16 @@ function createInjector(modulesToLoad, strictDi) {
 
     function isClass(func) {
       // IE 9-11 do not support classes and IE9 leaks with the code below.
-      if (msie <= 11) {
+      if (msie <= 11 || typeof func !== 'function') {
         return false;
       }
-      // Workaround for MS Edge.
-      // Check https://connect.microsoft.com/IE/Feedback/Details/2211653
-      return typeof func === 'function'
-        && /^(?:class\s|constructor\()/.test(Function.prototype.toString.call(func));
+      var result = func.$$ngIsClass;
+      if (!isBoolean(result)) {
+        // Workaround for MS Edge.
+        // Check https://connect.microsoft.com/IE/Feedback/Details/2211653
+        result = func.$$ngIsClass = /^(?:class\s|constructor\()/.test(Function.prototype.toString.call(func));
+      }
+      return result;
     }
 
     function invoke(fn, self, locals, serviceName) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Performance improvement

**What is the current behavior? (You can also link to an open issue here)**

Relatively expensive `Function.prototype.toString` is called every time a function is checked for being a native class. See #14268.

**What is the new behavior (if this is a feature change)?**

The results of the check are cached in the `$$ngIsClass` property of the function.

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
