### PR TITLE
feat($compile): add `isFirstChange()` method to onChanges object

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -156,7 +156,7 @@ of the component. The following hook methods can be implemented:
     this element). This is a good place to put initialization code for your controller.
   * `$onChanges(changesObj)` - Called whenever one-way bindings are updated. The `changesObj` is a hash whose keys
     are the names of the bound properties that have changed, and the values are an object of the form
-    `{ currentValue: ..., previousValue: ... }`. Use this hook to trigger updates within a component such as
+    `{ currentValue, previousValue, isFirstChange() }`. Use this hook to trigger updates within a component such as
     cloning the bound value to prevent accidental mutation of the outer value.
   * `$onDestroy()` - Called on a controller when its containing scope is destroyed. Use this hook for releasing
     external resources, watches and event handlers.


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature

**What is the current behavior? (You can also link to an open issue here)**

Fixes #14318

**What is the new behavior (if this is a feature change)?**

Adds `isFirstChange()` method to changes objects

**Does this PR introduce a breaking change?**

No - although there is now an extra onChanges call if items are not updated during the first digest since the bindings were defined.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

Closes #14318
