### PR TITLE
Fix unnecessary capital letters in error message

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1623,7 +1623,7 @@ function bootstrap(element, modules, config) {
       //Encode angle brackets to prevent input from being sanitized to empty string #8683
       throw ngMinErr(
           'btstrpd',
-          "App Already Bootstrapped with this Element '{0}'",
+          "App already bootstrapped with this element '{0}'",
           tag.replace(/</,'&lt;').replace(/>/,'&gt;'));
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Style. It improves the error message thrown by the bootstrap function.

**What is the current behavior? (You can also link to an open issue here)**
Currently, it throws this message: "App Already Bootstrapped with this Element"  
It's awkward because of the capitalized letters.          

**What is the new behavior (if this is a feature change)?**
It now shows:  "App already bootstrapped with this element"            

**Does this PR introduce a breaking change?**
No it does not.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
