### PR TITLE
style(angular.bootstrap): remove unnecessary capital letters

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1623,7 +1623,7 @@ function bootstrap(element, modules, config) {
       //Encode angle brackets to prevent input from being sanitized to empty string #8683
       throw ngMinErr(
           'btstrpd',
-          "App Already Bootstrapped with this Element '{0}'",
+          "App already bootstrapped with this element '{0}'",
           tag.replace(/</,'&lt;').replace(/>/,'&gt;'));
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Style.

**What is the current behavior? (You can also link to an open issue here)**
Error message in bootstrap function has awkward capital letters: "App Already Bootstrapped with this Element ..."

**What is the new behavior (if this is a feature change)?**
It now shows: "App already bootstrapped with this element ..."

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
