### PR TITLE
refactor(jshint): don't assume browser-only globals

### DIFF
--- a/.jshintrc-base
+++ b/.jshintrc-base
@@ -1,19 +1,24 @@
 {
   "bitwise": true,
+  "esversion": 6,
   "immed": true,
   "newcap": true,
   "noarg": true,
   "noempty": true,
   "nonew": true,
-  "trailing": true,
   "maxlen": 200,
   "boss": true,
   "eqnull": true,
   "expr": true,
-  "globalstrict": true,
   "laxbreak": true,
   "loopfunc": true,
+  "strict": "global",
   "sub": true,
   "undef": true,
-  "indent": 2
+  "indent": 2,
+
+  "globals": {
+    "ArrayBuffer": false,
+    "Uint8Array": false
+  }
 }

--- a/docs/app/e2e/.jshintrc
+++ b/docs/app/e2e/.jshintrc
@@ -19,9 +19,12 @@
     "dump": false,
 
     /* e2e */
+    "protractor": false,
     "browser": false,
     "element": false,
     "by": false,
+    "$": false,
+    "$$": false,
 
     /* testabilityPatch / matchers */
     "inject": false,

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -2733,373 +2733,6 @@
             "any-shell-escape": {
               "version": "0.1.1"
             },
-            "gulp-util": {
-              "version": "3.0.7",
-              "dependencies": {
-                "array-differ": {
-                  "version": "1.0.0"
-                },
-                "array-uniq": {
-                  "version": "1.0.2"
-                },
-                "beeper": {
-                  "version": "1.1.0"
-                },
-                "dateformat": {
-                  "version": "1.0.12",
-                  "dependencies": {
-                    "get-stdin": {
-                      "version": "4.0.1"
-                    },
-                    "meow": {
-                      "version": "3.7.0",
-                      "dependencies": {
-                        "camelcase-keys": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "camelcase": {
-                              "version": "2.1.0"
-                            }
-                          }
-                        },
-                        "decamelize": {
-                          "version": "1.2.0"
-                        },
-                        "loud-rejection": {
-                          "version": "1.3.0",
-                          "dependencies": {
-                            "array-find-index": {
-                              "version": "1.0.1"
-                            },
-                            "signal-exit": {
-                              "version": "2.1.2"
-                            }
-                          }
-                        },
-                        "map-obj": {
-                          "version": "1.0.1"
-                        },
-                        "normalize-package-data": {
-                          "version": "2.3.5",
-                          "dependencies": {
-                            "hosted-git-info": {
-                              "version": "2.1.4"
-                            },
-                            "is-builtin-module": {
-                              "version": "1.0.0",
-                              "dependencies": {
-                                "builtin-modules": {
-                                  "version": "1.1.1"
-                                }
-                              }
-                            },
-                            "validate-npm-package-license": {
-                              "version": "3.0.1",
-                              "dependencies": {
-                                "spdx-correct": {
-                                  "version": "1.0.2",
-                                  "dependencies": {
-                                    "spdx-license-ids": {
-                                      "version": "1.2.0"
-                                    }
-                                  }
-                                },
-                                "spdx-expression-parse": {
-                                  "version": "1.0.2",
-                                  "dependencies": {
-                                    "spdx-exceptions": {
-                                      "version": "1.0.4"
-                                    },
-                                    "spdx-license-ids": {
-                                      "version": "1.2.0"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "object-assign": {
-                          "version": "4.0.1"
-                        },
-                        "read-pkg-up": {
-                          "version": "1.0.1",
-                          "dependencies": {
-                            "find-up": {
-                              "version": "1.1.2",
-                              "dependencies": {
-                                "path-exists": {
-                                  "version": "2.1.0"
-                                },
-                                "pinkie-promise": {
-                                  "version": "2.0.0",
-                                  "dependencies": {
-                                    "pinkie": {
-                                      "version": "2.0.4"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "read-pkg": {
-                              "version": "1.1.0",
-                              "dependencies": {
-                                "load-json-file": {
-                                  "version": "1.1.0",
-                                  "dependencies": {
-                                    "graceful-fs": {
-                                      "version": "4.1.3"
-                                    },
-                                    "parse-json": {
-                                      "version": "2.2.0",
-                                      "dependencies": {
-                                        "error-ex": {
-                                          "version": "1.3.0",
-                                          "dependencies": {
-                                            "is-arrayish": {
-                                              "version": "0.2.1"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "pify": {
-                                      "version": "2.3.0"
-                                    },
-                                    "pinkie-promise": {
-                                      "version": "2.0.0",
-                                      "dependencies": {
-                                        "pinkie": {
-                                          "version": "2.0.4"
-                                        }
-                                      }
-                                    },
-                                    "strip-bom": {
-                                      "version": "2.0.0",
-                                      "dependencies": {
-                                        "is-utf8": {
-                                          "version": "0.2.1"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "path-type": {
-                                  "version": "1.1.0",
-                                  "dependencies": {
-                                    "graceful-fs": {
-                                      "version": "4.1.3"
-                                    },
-                                    "pify": {
-                                      "version": "2.3.0"
-                                    },
-                                    "pinkie-promise": {
-                                      "version": "2.0.0",
-                                      "dependencies": {
-                                        "pinkie": {
-                                          "version": "2.0.4"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "redent": {
-                          "version": "1.0.0",
-                          "dependencies": {
-                            "indent-string": {
-                              "version": "2.1.0",
-                              "dependencies": {
-                                "repeating": {
-                                  "version": "2.0.0",
-                                  "dependencies": {
-                                    "is-finite": {
-                                      "version": "1.0.1",
-                                      "dependencies": {
-                                        "number-is-nan": {
-                                          "version": "1.0.0"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "strip-indent": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "trim-newlines": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "fancy-log": {
-                  "version": "1.2.0",
-                  "dependencies": {
-                    "time-stamp": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "gulplog": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "glogg": {
-                      "version": "1.0.0",
-                      "dependencies": {
-                        "sparkles": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "has-gulplog": {
-                  "version": "0.1.0",
-                  "dependencies": {
-                    "sparkles": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "lodash._reescape": {
-                  "version": "3.0.0"
-                },
-                "lodash._reevaluate": {
-                  "version": "3.0.0"
-                },
-                "lodash._reinterpolate": {
-                  "version": "3.0.0"
-                },
-                "lodash.template": {
-                  "version": "3.6.2",
-                  "dependencies": {
-                    "lodash._basecopy": {
-                      "version": "3.0.1"
-                    },
-                    "lodash._basetostring": {
-                      "version": "3.0.1"
-                    },
-                    "lodash._basevalues": {
-                      "version": "3.0.0"
-                    },
-                    "lodash._isiterateecall": {
-                      "version": "3.0.9"
-                    },
-                    "lodash.escape": {
-                      "version": "3.2.0",
-                      "dependencies": {
-                        "lodash._root": {
-                          "version": "3.0.1"
-                        }
-                      }
-                    },
-                    "lodash.keys": {
-                      "version": "3.1.2",
-                      "dependencies": {
-                        "lodash._getnative": {
-                          "version": "3.9.1"
-                        },
-                        "lodash.isarguments": {
-                          "version": "3.0.8"
-                        },
-                        "lodash.isarray": {
-                          "version": "3.0.4"
-                        }
-                      }
-                    },
-                    "lodash.restparam": {
-                      "version": "3.6.1"
-                    },
-                    "lodash.templatesettings": {
-                      "version": "3.1.1"
-                    }
-                  }
-                },
-                "multipipe": {
-                  "version": "0.1.2",
-                  "dependencies": {
-                    "duplexer2": {
-                      "version": "0.0.2",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "1.1.13",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2"
-                            },
-                            "isarray": {
-                              "version": "0.0.1"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31"
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "3.0.0"
-                },
-                "replace-ext": {
-                  "version": "0.0.1"
-                },
-                "through2": {
-                  "version": "2.0.1",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "2.0.5",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
-                        },
-                        "isarray": {
-                          "version": "0.0.1"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    },
-                    "xtend": {
-                      "version": "4.0.1"
-                    }
-                  }
-                },
-                "vinyl": {
-                  "version": "0.5.3",
-                  "dependencies": {
-                    "clone": {
-                      "version": "1.0.2"
-                    },
-                    "clone-stats": {
-                      "version": "0.0.1"
-                    }
-                  }
-                }
-              }
-            },
             "require-dir": {
               "version": "0.1.0"
             },
@@ -4280,109 +3913,35 @@
       }
     },
     "grunt-contrib-jshint": {
-      "version": "0.10.0",
+      "version": "1.0.0",
       "dependencies": {
-        "jshint": {
-          "version": "2.5.11",
+        "chalk": {
+          "version": "1.1.3",
           "dependencies": {
-            "cli": {
-              "version": "0.6.6",
+            "ansi-styles": {
+              "version": "2.2.1"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
               "dependencies": {
-                "glob": {
-                  "version": "3.2.11",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1"
-                    },
-                    "minimatch": {
-                      "version": "0.3.0",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    }
-                  }
+                "ansi-regex": {
+                  "version": "2.0.0"
                 }
               }
             },
-            "console-browserify": {
-              "version": "1.1.0",
+            "strip-ansi": {
+              "version": "3.0.1",
               "dependencies": {
-                "date-now": {
-                  "version": "0.1.4"
+                "ansi-regex": {
+                  "version": "2.0.0"
                 }
               }
             },
-            "exit": {
-              "version": "0.1.2"
-            },
-            "htmlparser2": {
-              "version": "3.8.2",
-              "dependencies": {
-                "domhandler": {
-                  "version": "2.3.0"
-                },
-                "domutils": {
-                  "version": "1.5.1",
-                  "dependencies": {
-                    "dom-serializer": {
-                      "version": "0.1.0",
-                      "dependencies": {
-                        "domelementtype": {
-                          "version": "1.1.3"
-                        },
-                        "entities": {
-                          "version": "1.1.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "domelementtype": {
-                  "version": "1.3.0"
-                },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    }
-                  }
-                },
-                "entities": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "1.0.0",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0"
-                },
-                "sigmund": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "strip-json-comments": {
-              "version": "1.0.2"
-            },
-            "underscore": {
-              "version": "1.6.0"
+            "supports-color": {
+              "version": "2.0.0"
             }
           }
         },
@@ -5991,503 +5550,60 @@
       }
     },
     "gulp-jshint": {
-      "version": "1.4.2",
+      "version": "2.0.0",
       "dependencies": {
-        "map-stream": {
-          "version": "0.1.0"
+        "lodash": {
+          "version": "3.10.1"
         },
-        "jshint": {
-          "version": "2.4.4",
+        "minimatch": {
+          "version": "2.0.10",
           "dependencies": {
-            "shelljs": {
-              "version": "0.1.4"
-            },
-            "underscore": {
-              "version": "1.4.4"
-            },
-            "cli": {
-              "version": "0.4.5",
+            "brace-expansion": {
+              "version": "1.1.3",
               "dependencies": {
-                "glob": {
-                  "version": "5.0.3",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    },
-                    "minimatch": {
-                      "version": "2.0.4",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.0",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.2.0"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.1",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "minimatch": {
-              "version": "0.4.0",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0"
+                "balanced-match": {
+                  "version": "0.3.0"
                 },
-                "sigmund": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "htmlparser2": {
-              "version": "3.3.0",
-              "dependencies": {
-                "domhandler": {
-                  "version": "2.1.0"
-                },
-                "domutils": {
-                  "version": "1.1.6"
-                },
-                "domelementtype": {
-                  "version": "1.3.0"
-                },
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "console-browserify": {
-              "version": "0.1.6"
-            },
-            "exit": {
-              "version": "0.1.2"
-            }
-          }
-        },
-        "gulp-util": {
-          "version": "2.2.20",
-          "dependencies": {
-            "chalk": {
-              "version": "0.5.1",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "1.1.0"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3"
-                },
-                "has-ansi": {
-                  "version": "0.1.0",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "0.2.1"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "0.3.0",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "0.2.1"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "0.2.0"
-                }
-              }
-            },
-            "dateformat": {
-              "version": "1.0.11",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1"
-                },
-                "meow": {
-                  "version": "3.1.0",
-                  "dependencies": {
-                    "camelcase-keys": {
-                      "version": "1.0.0",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.0.2"
-                        },
-                        "map-obj": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "indent-string": {
-                      "version": "1.2.1",
-                      "dependencies": {
-                        "repeating": {
-                          "version": "1.1.2",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "minimist": {
-                      "version": "1.1.1"
-                    },
-                    "object-assign": {
-                      "version": "2.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._reinterpolate": {
-              "version": "2.4.1"
-            },
-            "lodash.template": {
-              "version": "2.4.1",
-              "dependencies": {
-                "lodash.defaults": {
-                  "version": "2.4.1",
-                  "dependencies": {
-                    "lodash._objecttypes": {
-                      "version": "2.4.1"
-                    }
-                  }
-                },
-                "lodash.escape": {
-                  "version": "2.4.1",
-                  "dependencies": {
-                    "lodash._escapehtmlchar": {
-                      "version": "2.4.1",
-                      "dependencies": {
-                        "lodash._htmlescapes": {
-                          "version": "2.4.1"
-                        }
-                      }
-                    },
-                    "lodash._reunescapedhtml": {
-                      "version": "2.4.1",
-                      "dependencies": {
-                        "lodash._htmlescapes": {
-                          "version": "2.4.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash._escapestringchar": {
-                  "version": "2.4.1"
-                },
-                "lodash.keys": {
-                  "version": "2.4.1",
-                  "dependencies": {
-                    "lodash._isnative": {
-                      "version": "2.4.1"
-                    },
-                    "lodash.isobject": {
-                      "version": "2.4.1",
-                      "dependencies": {
-                        "lodash._objecttypes": {
-                          "version": "2.4.1"
-                        }
-                      }
-                    },
-                    "lodash._shimkeys": {
-                      "version": "2.4.1",
-                      "dependencies": {
-                        "lodash._objecttypes": {
-                          "version": "2.4.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash.templatesettings": {
-                  "version": "2.4.1"
-                },
-                "lodash.values": {
-                  "version": "2.4.1"
-                }
-              }
-            },
-            "minimist": {
-              "version": "0.2.0"
-            },
-            "multipipe": {
-              "version": "0.1.2",
-              "dependencies": {
-                "duplexer2": {
-                  "version": "0.0.2",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1"
-                        },
-                        "isarray": {
-                          "version": "0.0.1"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "through2": {
-              "version": "0.5.1",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "3.0.0"
-                }
-              }
-            },
-            "vinyl": {
-              "version": "0.2.3",
-              "dependencies": {
-                "clone-stats": {
+                "concat-map": {
                   "version": "0.0.1"
                 }
               }
             }
           }
         },
-        "lodash.clone": {
-          "version": "2.4.1",
+        "rcloader": {
+          "version": "0.1.2",
           "dependencies": {
-            "lodash._baseclone": {
-              "version": "2.4.1",
+            "rcfinder": {
+              "version": "0.1.8"
+            },
+            "lodash": {
+              "version": "2.4.2"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
               "dependencies": {
-                "lodash.assign": {
-                  "version": "2.4.1",
-                  "dependencies": {
-                    "lodash.keys": {
-                      "version": "2.4.1",
-                      "dependencies": {
-                        "lodash._isnative": {
-                          "version": "2.4.1"
-                        },
-                        "lodash._shimkeys": {
-                          "version": "2.4.1"
-                        }
-                      }
-                    },
-                    "lodash._objecttypes": {
-                      "version": "2.4.1"
-                    }
-                  }
+                "core-util-is": {
+                  "version": "1.0.2"
                 },
-                "lodash.foreach": {
-                  "version": "2.4.1"
+                "isarray": {
+                  "version": "0.0.1"
                 },
-                "lodash.forown": {
-                  "version": "2.4.1",
-                  "dependencies": {
-                    "lodash.keys": {
-                      "version": "2.4.1",
-                      "dependencies": {
-                        "lodash._isnative": {
-                          "version": "2.4.1"
-                        },
-                        "lodash._shimkeys": {
-                          "version": "2.4.1"
-                        }
-                      }
-                    },
-                    "lodash._objecttypes": {
-                      "version": "2.4.1"
-                    }
-                  }
+                "string_decoder": {
+                  "version": "0.10.31"
                 },
-                "lodash._getarray": {
-                  "version": "2.4.1",
-                  "dependencies": {
-                    "lodash._arraypool": {
-                      "version": "2.4.1"
-                    }
-                  }
-                },
-                "lodash.isarray": {
-                  "version": "2.4.1",
-                  "dependencies": {
-                    "lodash._isnative": {
-                      "version": "2.4.1"
-                    }
-                  }
-                },
-                "lodash.isobject": {
-                  "version": "2.4.1",
-                  "dependencies": {
-                    "lodash._objecttypes": {
-                      "version": "2.4.1"
-                    }
-                  }
-                },
-                "lodash._releasearray": {
-                  "version": "2.4.1",
-                  "dependencies": {
-                    "lodash._arraypool": {
-                      "version": "2.4.1"
-                    },
-                    "lodash._maxpoolsize": {
-                      "version": "2.4.1"
-                    }
-                  }
-                },
-                "lodash._slice": {
-                  "version": "2.4.1"
+                "inherits": {
+                  "version": "2.0.1"
                 }
               }
             },
-            "lodash._basecreatecallback": {
-              "version": "2.4.1",
-              "dependencies": {
-                "lodash.bind": {
-                  "version": "2.4.1",
-                  "dependencies": {
-                    "lodash._createwrapper": {
-                      "version": "2.4.1",
-                      "dependencies": {
-                        "lodash._basebind": {
-                          "version": "2.4.1",
-                          "dependencies": {
-                            "lodash._basecreate": {
-                              "version": "2.4.1",
-                              "dependencies": {
-                                "lodash._isnative": {
-                                  "version": "2.4.1"
-                                },
-                                "lodash.noop": {
-                                  "version": "2.4.1"
-                                }
-                              }
-                            },
-                            "lodash.isobject": {
-                              "version": "2.4.1",
-                              "dependencies": {
-                                "lodash._objecttypes": {
-                                  "version": "2.4.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash._basecreatewrapper": {
-                          "version": "2.4.1",
-                          "dependencies": {
-                            "lodash._basecreate": {
-                              "version": "2.4.1",
-                              "dependencies": {
-                                "lodash._isnative": {
-                                  "version": "2.4.1"
-                                },
-                                "lodash.noop": {
-                                  "version": "2.4.1"
-                                }
-                              }
-                            },
-                            "lodash.isobject": {
-                              "version": "2.4.1",
-                              "dependencies": {
-                                "lodash._objecttypes": {
-                                  "version": "2.4.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash.isfunction": {
-                          "version": "2.4.1"
-                        }
-                      }
-                    },
-                    "lodash._slice": {
-                      "version": "2.4.1"
-                    }
-                  }
-                },
-                "lodash.identity": {
-                  "version": "2.4.1"
-                },
-                "lodash._setbinddata": {
-                  "version": "2.4.1",
-                  "dependencies": {
-                    "lodash._isnative": {
-                      "version": "2.4.1"
-                    },
-                    "lodash.noop": {
-                      "version": "2.4.1"
-                    }
-                  }
-                },
-                "lodash.support": {
-                  "version": "2.4.1",
-                  "dependencies": {
-                    "lodash._isnative": {
-                      "version": "2.4.1"
-                    }
-                  }
-                }
-              }
+            "xtend": {
+              "version": "4.0.1"
             }
           }
         }
@@ -7227,19 +6343,123 @@
         }
       }
     },
-    "jshint-stylish": {
-      "version": "1.0.2",
+    "jshint": {
+      "version": "2.9.1",
       "dependencies": {
-        "chalk": {
-          "version": "1.1.1",
+        "cli": {
+          "version": "0.6.6",
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.0",
+            "glob": {
+              "version": "3.2.11",
               "dependencies": {
-                "color-convert": {
-                  "version": "1.0.0"
+                "inherits": {
+                  "version": "2.0.1"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1"
+                    }
+                  }
                 }
               }
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2"
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "dependencies": {
+            "domhandler": {
+              "version": "2.3.0"
+            },
+            "domutils": {
+              "version": "1.5.1",
+              "dependencies": {
+                "dom-serializer": {
+                  "version": "0.1.0",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.1.3"
+                    },
+                    "entities": {
+                      "version": "1.1.1"
+                    }
+                  }
+                }
+              }
+            },
+            "domelementtype": {
+              "version": "1.3.0"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2"
+                },
+                "isarray": {
+                  "version": "0.0.1"
+                },
+                "string_decoder": {
+                  "version": "0.10.31"
+                },
+                "inherits": {
+                  "version": "2.0.1"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.3",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.3.0"
+                },
+                "concat-map": {
+                  "version": "0.0.1"
+                }
+              }
+            }
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.4"
+        },
+        "lodash": {
+          "version": "3.7.0"
+        }
+      }
+    },
+    "jshint-stylish": {
+      "version": "2.1.0",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1"
             },
             "escape-string-regexp": {
               "version": "1.0.5"
@@ -7267,6 +6487,14 @@
         },
         "log-symbols": {
           "version": "1.0.2"
+        },
+        "plur": {
+          "version": "2.1.2",
+          "dependencies": {
+            "irregular-plurals": {
+              "version": "1.1.0"
+            }
+          }
         },
         "string-length": {
           "version": "1.0.1",
@@ -7625,11 +6853,11 @@
                 "combined-stream": {
                   "version": "1.0.5"
                 },
-                "core-util-is": {
-                  "version": "1.0.2"
-                },
                 "commander": {
                   "version": "2.9.0"
+                },
+                "core-util-is": {
+                  "version": "1.0.2"
                 },
                 "cryptiles": {
                   "version": "2.0.5"
@@ -7646,20 +6874,20 @@
                 "delayed-stream": {
                   "version": "1.0.0"
                 },
-                "ecc-jsbn": {
-                  "version": "0.1.1"
-                },
                 "delegates": {
                   "version": "1.0.0"
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.4"
                 },
-                "extsprintf": {
-                  "version": "1.0.2"
-                },
                 "extend": {
                   "version": "3.0.0"
+                },
+                "extsprintf": {
+                  "version": "1.0.2"
                 },
                 "forever-agent": {
                   "version": "0.6.1"
@@ -7829,11 +7057,11 @@
                 "strip-json-comments": {
                   "version": "1.0.4"
                 },
-                "supports-color": {
-                  "version": "2.0.0"
-                },
                 "tar": {
                   "version": "2.2.1"
+                },
+                "supports-color": {
+                  "version": "2.0.0"
                 },
                 "tar-pack": {
                   "version": "3.1.3"
@@ -9620,6 +8848,9 @@
     "rewire": {
       "version": "2.1.5"
     },
+    "sax": {
+      "version": "1.2.1"
+    },
     "semver": {
       "version": "4.0.3"
     },
@@ -9631,6 +8862,9 @@
     },
     "stringmap": {
       "version": "0.2.2"
+    },
+    "strip-json-comments": {
+      "version": "2.0.1"
     }
   },
   "name": "angularjs"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3482,97 +3482,97 @@
     },
     "commitizen": {
       "version": "2.7.2",
-      "from": "commitizen@2.7.2",
+      "from": "https://registry.npmjs.org/commitizen/-/commitizen-2.7.2.tgz",
       "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-2.7.2.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@1.1.1",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
               "dependencies": {
                 "color-convert": {
                   "version": "1.0.0",
-                  "from": "color-convert@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
                 }
               }
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "cz-conventional-changelog": {
           "version": "1.1.5",
-          "from": "cz-conventional-changelog@1.1.5",
+          "from": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-1.1.5.tgz",
           "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-1.1.5.tgz",
           "dependencies": {
             "word-wrap": {
               "version": "1.1.0",
-              "from": "word-wrap@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.1.0.tgz"
             }
           }
         },
         "dedent": {
           "version": "0.6.0",
-          "from": "dedent@0.6.0",
+          "from": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz"
         },
         "detect-indent": {
           "version": "4.0.0",
-          "from": "detect-indent@4.0.0",
+          "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
           "dependencies": {
             "repeating": {
               "version": "2.0.0",
-              "from": "repeating@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -3583,54 +3583,54 @@
         },
         "find-node-modules": {
           "version": "1.0.1",
-          "from": "find-node-modules@1.0.1",
+          "from": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-1.0.1.tgz",
           "dependencies": {
             "findup-sync": {
               "version": "0.2.1",
-              "from": "findup-sync@>=0.2.1 <0.3.0",
+              "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.3.5",
-                  "from": "glob@>=4.3.0 <4.4.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -3639,12 +3639,12 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -3655,56 +3655,56 @@
             },
             "merge": {
               "version": "1.2.0",
-              "from": "merge@>=1.2.0 <2.0.0",
+              "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
             }
           }
         },
         "find-root": {
           "version": "1.0.0",
-          "from": "find-root@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz"
         },
         "glob": {
           "version": "7.0.3",
-          "from": "glob@7.0.3",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.3",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -3713,98 +3713,98 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         },
         "gulp": {
           "version": "3.9.1",
-          "from": "gulp@3.9.1",
+          "from": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
           "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
           "dependencies": {
             "archy": {
               "version": "1.0.0",
-              "from": "archy@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
             },
             "deprecated": {
               "version": "0.0.1",
-              "from": "deprecated@>=0.0.1 <0.0.2",
+              "from": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
             },
             "interpret": {
               "version": "1.0.0",
-              "from": "interpret@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/interpret/-/interpret-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.0.tgz"
             },
             "liftoff": {
               "version": "2.2.0",
-              "from": "liftoff@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
               "dependencies": {
                 "extend": {
                   "version": "2.0.1",
-                  "from": "extend@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
                 },
                 "findup-sync": {
                   "version": "0.3.0",
-                  "from": "findup-sync@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
                   "dependencies": {
                     "glob": {
                       "version": "5.0.15",
-                      "from": "glob@>=5.0.0 <5.1.0",
+                      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
-                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "minimatch": {
                           "version": "3.0.0",
-                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.3",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.3.0",
-                                  "from": "balanced-match@>=0.3.0 <0.4.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
@@ -3813,19 +3813,19 @@
                         },
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@>=1.3.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
                         },
                         "path-is-absolute": {
                           "version": "1.0.0",
-                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                         }
                       }
@@ -3834,39 +3834,39 @@
                 },
                 "flagged-respawn": {
                   "version": "0.3.1",
-                  "from": "flagged-respawn@>=0.3.1 <0.4.0",
+                  "from": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
                 },
                 "rechoir": {
                   "version": "0.6.2",
-                  "from": "rechoir@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
                 },
                 "resolve": {
                   "version": "1.1.7",
-                  "from": "resolve@>=1.1.6 <2.0.0",
+                  "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
                   "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
                 }
               }
             },
             "orchestrator": {
               "version": "0.3.7",
-              "from": "orchestrator@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
               "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
               "dependencies": {
                 "end-of-stream": {
                   "version": "0.1.5",
-                  "from": "end-of-stream@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -3875,102 +3875,102 @@
                 },
                 "sequencify": {
                   "version": "0.0.7",
-                  "from": "sequencify@>=0.0.7 <0.1.0",
+                  "from": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
                 },
                 "stream-consume": {
                   "version": "0.1.0",
-                  "from": "stream-consume@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
                 }
               }
             },
             "pretty-hrtime": {
               "version": "1.0.2",
-              "from": "pretty-hrtime@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz"
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=4.1.0 <5.0.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "tildify": {
               "version": "1.1.2",
-              "from": "tildify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz",
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                 }
               }
             },
             "v8flags": {
               "version": "2.0.11",
-              "from": "v8flags@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
               "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
               "dependencies": {
                 "user-home": {
                   "version": "1.1.1",
-                  "from": "user-home@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
                 }
               }
             },
             "vinyl-fs": {
               "version": "0.3.14",
-              "from": "vinyl-fs@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
               "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
-                  "from": "defaults@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "from": "clone@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
                     }
                   }
                 },
                 "glob-stream": {
                   "version": "3.1.18",
-                  "from": "glob-stream@>=3.1.5 <4.0.0",
+                  "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
                   "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
                   "dependencies": {
                     "glob": {
                       "version": "4.5.3",
-                      "from": "glob@>=4.3.1 <5.0.0",
+                      "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
-                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@>=1.3.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
@@ -3979,22 +3979,22 @@
                     },
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -4003,78 +4003,78 @@
                     },
                     "ordered-read-streams": {
                       "version": "0.1.0",
-                      "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
                     },
                     "glob2base": {
                       "version": "0.0.12",
-                      "from": "glob2base@>=0.0.12 <0.0.13",
+                      "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
                       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
                       "dependencies": {
                         "find-index": {
                           "version": "0.1.1",
-                          "from": "find-index@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
                         }
                       }
                     },
                     "unique-stream": {
                       "version": "1.0.0",
-                      "from": "unique-stream@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
                     }
                   }
                 },
                 "glob-watcher": {
                   "version": "0.0.6",
-                  "from": "glob-watcher@>=0.0.6 <0.0.7",
+                  "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
                   "dependencies": {
                     "gaze": {
                       "version": "0.5.2",
-                      "from": "gaze@>=0.5.1 <0.6.0",
+                      "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
                       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
                       "dependencies": {
                         "globule": {
                           "version": "0.1.0",
-                          "from": "globule@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                           "dependencies": {
                             "lodash": {
                               "version": "1.0.2",
-                              "from": "lodash@>=1.0.1 <1.1.0",
+                              "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                             },
                             "glob": {
                               "version": "3.1.21",
-                              "from": "glob@>=3.1.21 <3.2.0",
+                              "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                               "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                               "dependencies": {
                                 "graceful-fs": {
                                   "version": "1.2.3",
-                                  "from": "graceful-fs@>=1.2.0 <1.3.0",
+                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
                                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                                 },
                                 "inherits": {
                                   "version": "1.0.2",
-                                  "from": "inherits@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
                                 }
                               }
                             },
                             "minimatch": {
                               "version": "0.2.14",
-                              "from": "minimatch@>=0.2.11 <0.3.0",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                               "dependencies": {
                                 "lru-cache": {
                                   "version": "2.7.3",
-                                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                                 },
                                 "sigmund": {
                                   "version": "1.0.1",
-                                  "from": "sigmund@>=1.0.0 <1.1.0",
+                                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                                 }
                               }
@@ -4087,90 +4087,90 @@
                 },
                 "graceful-fs": {
                   "version": "3.0.8",
-                  "from": "graceful-fs@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "strip-bom": {
                   "version": "1.0.0",
-                  "from": "strip-bom@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
                   "dependencies": {
                     "first-chunk-stream": {
                       "version": "1.0.0",
-                      "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
                     },
                     "is-utf8": {
                       "version": "0.2.1",
-                      "from": "is-utf8@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                     }
                   }
                 },
                 "through2": {
                   "version": "0.6.5",
-                  "from": "through2@>=0.6.1 <0.7.0",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "vinyl": {
                   "version": "0.4.6",
-                  "from": "vinyl@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                   "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                   "dependencies": {
                     "clone": {
                       "version": "0.2.0",
-                      "from": "clone@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
                     },
                     "clone-stats": {
                       "version": "0.0.1",
-                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                      "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
                     }
                   }
@@ -4181,615 +4181,54 @@
         },
         "gulp-git": {
           "version": "1.7.0",
-          "from": "gulp-git@1.7.0",
+          "from": "https://registry.npmjs.org/gulp-git/-/gulp-git-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/gulp-git/-/gulp-git-1.7.0.tgz",
           "dependencies": {
             "any-shell-escape": {
               "version": "0.1.1",
-              "from": "any-shell-escape@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/any-shell-escape/-/any-shell-escape-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/any-shell-escape/-/any-shell-escape-0.1.1.tgz"
-            },
-            "gulp-util": {
-              "version": "3.0.7",
-              "from": "gulp-util@>=3.0.6 <4.0.0",
-              "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-              "dependencies": {
-                "array-differ": {
-                  "version": "1.0.0",
-                  "from": "array-differ@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-                },
-                "array-uniq": {
-                  "version": "1.0.2",
-                  "from": "array-uniq@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                },
-                "beeper": {
-                  "version": "1.1.0",
-                  "from": "beeper@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
-                },
-                "dateformat": {
-                  "version": "1.0.12",
-                  "from": "dateformat@>=1.0.11 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-                  "dependencies": {
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "from": "get-stdin@>=4.0.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                    },
-                    "meow": {
-                      "version": "3.7.0",
-                      "from": "meow@>=3.3.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-                      "dependencies": {
-                        "camelcase-keys": {
-                          "version": "2.0.0",
-                          "from": "camelcase-keys@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
-                          "dependencies": {
-                            "camelcase": {
-                              "version": "2.1.0",
-                              "from": "camelcase@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
-                            }
-                          }
-                        },
-                        "decamelize": {
-                          "version": "1.2.0",
-                          "from": "decamelize@>=1.1.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-                        },
-                        "loud-rejection": {
-                          "version": "1.3.0",
-                          "from": "loud-rejection@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
-                          "dependencies": {
-                            "array-find-index": {
-                              "version": "1.0.1",
-                              "from": "array-find-index@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
-                            },
-                            "signal-exit": {
-                              "version": "2.1.2",
-                              "from": "signal-exit@>=2.1.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
-                            }
-                          }
-                        },
-                        "map-obj": {
-                          "version": "1.0.1",
-                          "from": "map-obj@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                        },
-                        "normalize-package-data": {
-                          "version": "2.3.5",
-                          "from": "normalize-package-data@>=2.3.4 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-                          "dependencies": {
-                            "hosted-git-info": {
-                              "version": "2.1.4",
-                              "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
-                            },
-                            "is-builtin-module": {
-                              "version": "1.0.0",
-                              "from": "is-builtin-module@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                              "dependencies": {
-                                "builtin-modules": {
-                                  "version": "1.1.1",
-                                  "from": "builtin-modules@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-                                }
-                              }
-                            },
-                            "validate-npm-package-license": {
-                              "version": "3.0.1",
-                              "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                              "dependencies": {
-                                "spdx-correct": {
-                                  "version": "1.0.2",
-                                  "from": "spdx-correct@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                                  "dependencies": {
-                                    "spdx-license-ids": {
-                                      "version": "1.2.0",
-                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
-                                    }
-                                  }
-                                },
-                                "spdx-expression-parse": {
-                                  "version": "1.0.2",
-                                  "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                                  "dependencies": {
-                                    "spdx-exceptions": {
-                                      "version": "1.0.4",
-                                      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
-                                    },
-                                    "spdx-license-ids": {
-                                      "version": "1.2.0",
-                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "object-assign": {
-                          "version": "4.0.1",
-                          "from": "object-assign@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                        },
-                        "read-pkg-up": {
-                          "version": "1.0.1",
-                          "from": "read-pkg-up@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                          "dependencies": {
-                            "find-up": {
-                              "version": "1.1.2",
-                              "from": "find-up@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                              "dependencies": {
-                                "path-exists": {
-                                  "version": "2.1.0",
-                                  "from": "path-exists@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-                                },
-                                "pinkie-promise": {
-                                  "version": "2.0.0",
-                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                                  "dependencies": {
-                                    "pinkie": {
-                                      "version": "2.0.4",
-                                      "from": "pinkie@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "read-pkg": {
-                              "version": "1.1.0",
-                              "from": "read-pkg@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                              "dependencies": {
-                                "load-json-file": {
-                                  "version": "1.1.0",
-                                  "from": "load-json-file@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                                  "dependencies": {
-                                    "graceful-fs": {
-                                      "version": "4.1.3",
-                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
-                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-                                    },
-                                    "parse-json": {
-                                      "version": "2.2.0",
-                                      "from": "parse-json@>=2.2.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                                      "dependencies": {
-                                        "error-ex": {
-                                          "version": "1.3.0",
-                                          "from": "error-ex@>=1.2.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                                          "dependencies": {
-                                            "is-arrayish": {
-                                              "version": "0.2.1",
-                                              "from": "is-arrayish@>=0.2.1 <0.3.0",
-                                              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "pify": {
-                                      "version": "2.3.0",
-                                      "from": "pify@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                                    },
-                                    "pinkie-promise": {
-                                      "version": "2.0.0",
-                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                                      "dependencies": {
-                                        "pinkie": {
-                                          "version": "2.0.4",
-                                          "from": "pinkie@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                                        }
-                                      }
-                                    },
-                                    "strip-bom": {
-                                      "version": "2.0.0",
-                                      "from": "strip-bom@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                                      "dependencies": {
-                                        "is-utf8": {
-                                          "version": "0.2.1",
-                                          "from": "is-utf8@>=0.2.0 <0.3.0",
-                                          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "path-type": {
-                                  "version": "1.1.0",
-                                  "from": "path-type@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                                  "dependencies": {
-                                    "graceful-fs": {
-                                      "version": "4.1.3",
-                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
-                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-                                    },
-                                    "pify": {
-                                      "version": "2.3.0",
-                                      "from": "pify@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                                    },
-                                    "pinkie-promise": {
-                                      "version": "2.0.0",
-                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                                      "dependencies": {
-                                        "pinkie": {
-                                          "version": "2.0.4",
-                                          "from": "pinkie@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "redent": {
-                          "version": "1.0.0",
-                          "from": "redent@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                          "dependencies": {
-                            "indent-string": {
-                              "version": "2.1.0",
-                              "from": "indent-string@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                              "dependencies": {
-                                "repeating": {
-                                  "version": "2.0.0",
-                                  "from": "repeating@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-                                  "dependencies": {
-                                    "is-finite": {
-                                      "version": "1.0.1",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                      "dependencies": {
-                                        "number-is-nan": {
-                                          "version": "1.0.0",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "strip-indent": {
-                              "version": "1.0.1",
-                              "from": "strip-indent@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "trim-newlines": {
-                          "version": "1.0.0",
-                          "from": "trim-newlines@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "fancy-log": {
-                  "version": "1.2.0",
-                  "from": "fancy-log@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-                  "dependencies": {
-                    "time-stamp": {
-                      "version": "1.0.0",
-                      "from": "time-stamp@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.0.tgz"
-                    }
-                  }
-                },
-                "gulplog": {
-                  "version": "1.0.0",
-                  "from": "gulplog@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-                  "dependencies": {
-                    "glogg": {
-                      "version": "1.0.0",
-                      "from": "glogg@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-                      "dependencies": {
-                        "sparkles": {
-                          "version": "1.0.0",
-                          "from": "sparkles@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "has-gulplog": {
-                  "version": "0.1.0",
-                  "from": "has-gulplog@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-                  "dependencies": {
-                    "sparkles": {
-                      "version": "1.0.0",
-                      "from": "sparkles@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
-                    }
-                  }
-                },
-                "lodash._reescape": {
-                  "version": "3.0.0",
-                  "from": "lodash._reescape@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
-                },
-                "lodash._reevaluate": {
-                  "version": "3.0.0",
-                  "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
-                },
-                "lodash._reinterpolate": {
-                  "version": "3.0.0",
-                  "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
-                },
-                "lodash.template": {
-                  "version": "3.6.2",
-                  "from": "lodash.template@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-                  "dependencies": {
-                    "lodash._basecopy": {
-                      "version": "3.0.1",
-                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-                    },
-                    "lodash._basetostring": {
-                      "version": "3.0.1",
-                      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-                    },
-                    "lodash._basevalues": {
-                      "version": "3.0.0",
-                      "from": "lodash._basevalues@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
-                    },
-                    "lodash._isiterateecall": {
-                      "version": "3.0.9",
-                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-                    },
-                    "lodash.escape": {
-                      "version": "3.2.0",
-                      "from": "lodash.escape@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-                      "dependencies": {
-                        "lodash._root": {
-                          "version": "3.0.1",
-                          "from": "lodash._root@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash.keys": {
-                      "version": "3.1.2",
-                      "from": "lodash.keys@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                      "dependencies": {
-                        "lodash._getnative": {
-                          "version": "3.9.1",
-                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                        },
-                        "lodash.isarguments": {
-                          "version": "3.0.8",
-                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
-                        },
-                        "lodash.isarray": {
-                          "version": "3.0.4",
-                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                        }
-                      }
-                    },
-                    "lodash.restparam": {
-                      "version": "3.6.1",
-                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-                    },
-                    "lodash.templatesettings": {
-                      "version": "3.1.1",
-                      "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
-                    }
-                  }
-                },
-                "multipipe": {
-                  "version": "0.1.2",
-                  "from": "multipipe@>=0.1.2 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-                  "dependencies": {
-                    "duplexer2": {
-                      "version": "0.0.2",
-                      "from": "duplexer2@0.0.2",
-                      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "1.1.13",
-                          "from": "readable-stream@>=1.1.9 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "3.0.0",
-                  "from": "object-assign@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-                },
-                "replace-ext": {
-                  "version": "0.0.1",
-                  "from": "replace-ext@0.0.1",
-                  "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-                },
-                "through2": {
-                  "version": "2.0.1",
-                  "from": "through2@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "2.0.5",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <4.1.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                    }
-                  }
-                },
-                "vinyl": {
-                  "version": "0.5.3",
-                  "from": "vinyl@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-                  "dependencies": {
-                    "clone": {
-                      "version": "1.0.2",
-                      "from": "clone@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-                    },
-                    "clone-stats": {
-                      "version": "0.0.1",
-                      "from": "clone-stats@>=0.0.1 <0.0.2",
-                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
             },
             "require-dir": {
               "version": "0.1.0",
-              "from": "require-dir@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/require-dir/-/require-dir-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.1.0.tgz"
             },
             "through2": {
               "version": "0.6.5",
-              "from": "through2@>=0.6.5 <0.7.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
@@ -4798,54 +4237,54 @@
         },
         "home-or-tmp": {
           "version": "2.0.0",
-          "from": "home-or-tmp@2.0.0",
+          "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
           "dependencies": {
             "os-homedir": {
               "version": "1.0.1",
-              "from": "os-homedir@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
             },
             "os-tmpdir": {
               "version": "1.0.1",
-              "from": "os-tmpdir@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
             }
           }
         },
         "inquirer": {
           "version": "0.12.0",
-          "from": "inquirer@0.12.0",
+          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "dependencies": {
             "ansi-escapes": {
               "version": "1.3.0",
-              "from": "ansi-escapes@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.3.0.tgz"
             },
             "ansi-regex": {
               "version": "2.0.0",
-              "from": "ansi-regex@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             },
             "cli-cursor": {
               "version": "1.0.2",
-              "from": "cli-cursor@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
               "dependencies": {
                 "restore-cursor": {
                   "version": "1.0.1",
-                  "from": "restore-cursor@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
                   "dependencies": {
                     "exit-hook": {
                       "version": "1.1.1",
-                      "from": "exit-hook@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
                     },
                     "onetime": {
                       "version": "1.1.0",
-                      "from": "onetime@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
                     }
                   }
@@ -4854,63 +4293,63 @@
             },
             "cli-width": {
               "version": "2.1.0",
-              "from": "cli-width@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
             },
             "figures": {
               "version": "1.4.0",
-              "from": "figures@>=1.3.5 <2.0.0",
+              "from": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
             },
             "readline2": {
               "version": "1.0.1",
-              "from": "readline2@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
-                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 },
                 "mute-stream": {
                   "version": "0.0.5",
-                  "from": "mute-stream@0.0.5",
+                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
                 }
               }
             },
             "run-async": {
               "version": "0.1.0",
-              "from": "run-async@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
               "dependencies": {
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -4919,34 +4358,34 @@
             },
             "rx-lite": {
               "version": "3.1.2",
-              "from": "rx-lite@>=3.1.2 <4.0.0",
+              "from": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
             },
             "string-width": {
               "version": "1.0.1",
-              "from": "string-width@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
-                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -4955,34 +4394,34 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
             },
             "through": {
               "version": "2.3.8",
-              "from": "through@>=2.3.6 <3.0.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
         "lodash": {
           "version": "4.6.1",
-          "from": "lodash@4.6.1",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz"
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@1.2.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "shelljs": {
           "version": "0.5.3",
-          "from": "shelljs@0.5.3",
+          "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz"
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "from": "strip-json-comments@2.0.1",
+          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
         }
       }
@@ -5001,89 +4440,89 @@
     },
     "dgeni": {
       "version": "0.4.2",
-      "from": "dgeni@0.4.2",
+      "from": "https://registry.npmjs.org/dgeni/-/dgeni-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/dgeni/-/dgeni-0.4.2.tgz",
       "dependencies": {
         "dependency-graph": {
           "version": "0.4.1",
-          "from": "dependency-graph@>=0.4.1 <0.5.0",
+          "from": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.4.1.tgz",
           "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.4.1.tgz"
         },
         "di": {
           "version": "0.0.1",
-          "from": "di@0.0.1",
+          "from": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.10.1 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "q": {
           "version": "1.4.1",
-          "from": "q@>=1.4.1 <1.5.0",
+          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
         },
         "validate.js": {
           "version": "0.9.0",
-          "from": "validate.js@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/validate.js/-/validate.js-0.9.0.tgz",
           "resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.9.0.tgz"
         },
         "winston": {
           "version": "2.2.0",
-          "from": "winston@>=2.1.1 <3.0.0",
+          "from": "https://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
           "dependencies": {
             "async": {
               "version": "1.0.0",
-              "from": "async@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
             },
             "colors": {
               "version": "1.0.3",
-              "from": "colors@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
             },
             "cycle": {
               "version": "1.0.3",
-              "from": "cycle@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
             },
             "eyes": {
               "version": "0.1.8",
-              "from": "eyes@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "pkginfo": {
               "version": "0.3.1",
-              "from": "pkginfo@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             }
           }
@@ -5092,22 +4531,22 @@
     },
     "dgeni-packages": {
       "version": "0.11.1",
-      "from": "dgeni-packages@0.11.1",
+      "from": "https://registry.npmjs.org/dgeni-packages/-/dgeni-packages-0.11.1.tgz",
       "resolved": "https://registry.npmjs.org/dgeni-packages/-/dgeni-packages-0.11.1.tgz",
       "dependencies": {
         "catharsis": {
           "version": "0.8.7",
-          "from": "catharsis@>=0.8.1 <0.9.0",
+          "from": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.7.tgz",
           "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.7.tgz",
           "dependencies": {
             "underscore-contrib": {
               "version": "0.3.0",
-              "from": "underscore-contrib@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.6.0",
-                  "from": "underscore@1.6.0",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                 }
               }
@@ -5116,141 +4555,141 @@
         },
         "change-case": {
           "version": "2.3.1",
-          "from": "change-case@>=2.1.0 <3.0.0",
+          "from": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
           "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
           "dependencies": {
             "camel-case": {
               "version": "1.2.2",
-              "from": "camel-case@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz",
               "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz"
             },
             "constant-case": {
               "version": "1.1.2",
-              "from": "constant-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz"
             },
             "dot-case": {
               "version": "1.1.2",
-              "from": "dot-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz"
             },
             "is-lower-case": {
               "version": "1.1.3",
-              "from": "is-lower-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
             },
             "is-upper-case": {
               "version": "1.1.2",
-              "from": "is-upper-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
             },
             "lower-case": {
               "version": "1.1.3",
-              "from": "lower-case@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
             },
             "lower-case-first": {
               "version": "1.0.2",
-              "from": "lower-case-first@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
             },
             "param-case": {
               "version": "1.1.2",
-              "from": "param-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz"
             },
             "pascal-case": {
               "version": "1.1.2",
-              "from": "pascal-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz"
             },
             "path-case": {
               "version": "1.1.2",
-              "from": "path-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz"
             },
             "sentence-case": {
               "version": "1.1.3",
-              "from": "sentence-case@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz"
             },
             "snake-case": {
               "version": "1.1.2",
-              "from": "snake-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz"
             },
             "swap-case": {
               "version": "1.1.2",
-              "from": "swap-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
             },
             "title-case": {
               "version": "1.1.2",
-              "from": "title-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz"
             },
             "upper-case": {
               "version": "1.1.3",
-              "from": "upper-case@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
             },
             "upper-case-first": {
               "version": "1.1.2",
-              "from": "upper-case-first@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
             }
           }
         },
         "espree": {
           "version": "2.2.5",
-          "from": "espree@>=2.2.3 <3.0.0",
+          "from": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
           "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
         },
         "estraverse": {
           "version": "4.2.0",
-          "from": "estraverse@>=4.1.0 <5.0.0",
+          "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.8 <3.3.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "htmlparser2": {
           "version": "3.9.0",
-          "from": "htmlparser2@>=3.7.3 <4.0.0",
+          "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.0.tgz",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.0.tgz",
           "dependencies": {
             "domelementtype": {
               "version": "1.3.0",
-              "from": "domelementtype@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
             },
             "domhandler": {
               "version": "2.3.0",
-              "from": "domhandler@>=2.3.0 <3.0.0",
+              "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.1",
-              "from": "domutils@>=1.5.1 <2.0.0",
+              "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "dependencies": {
                 "dom-serializer": {
                   "version": "0.1.0",
-                  "from": "dom-serializer@>=0.0.0 <1.0.0",
+                  "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.3",
-                      "from": "domelementtype@>=1.1.1 <1.2.0",
+                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     }
                   }
@@ -5259,42 +4698,42 @@
             },
             "entities": {
               "version": "1.1.1",
-              "from": "entities@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
             },
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -5303,98 +4742,98 @@
         },
         "minimatch": {
           "version": "0.3.0",
-          "from": "minimatch@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.7.3",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "sigmund@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "nunjucks": {
           "version": "1.3.4",
-          "from": "nunjucks@>=1.2.0 <2.0.0",
+          "from": "https://registry.npmjs.org/nunjucks/-/nunjucks-1.3.4.tgz",
           "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-1.3.4.tgz",
           "dependencies": {
             "optimist": {
               "version": "0.6.1",
-              "from": "optimist@*",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "chokidar": {
               "version": "0.12.6",
-              "from": "chokidar@>=0.12.5 <0.13.0",
+              "from": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
               "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
               "dependencies": {
                 "readdirp": {
                   "version": "1.3.0",
-                  "from": "readdirp@>=1.3.0 <1.4.0",
+                  "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "2.0.3",
-                      "from": "graceful-fs@>=2.0.0 <2.1.0",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                     },
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@>=0.2.12 <0.3.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.7.3",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
                     },
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -5403,17 +4842,17 @@
                 },
                 "async-each": {
                   "version": "0.1.6",
-                  "from": "async-each@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
                 },
                 "fsevents": {
                   "version": "0.3.8",
-                  "from": "fsevents@>=0.3.1 <0.4.0",
+                  "from": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
                   "dependencies": {
                     "nan": {
                       "version": "2.2.0",
-                      "from": "nan@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
                     }
                   }
@@ -5424,42 +4863,42 @@
         },
         "q-io": {
           "version": "1.10.9",
-          "from": "q-io@>=1.10.9 <1.11.0",
+          "from": "https://registry.npmjs.org/q-io/-/q-io-1.10.9.tgz",
           "resolved": "https://registry.npmjs.org/q-io/-/q-io-1.10.9.tgz",
           "dependencies": {
             "q": {
               "version": "0.9.7",
-              "from": "q@>=0.9.7 <0.10.0",
+              "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
               "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
             },
             "qs": {
               "version": "0.1.0",
-              "from": "qs@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-0.1.0.tgz"
             },
             "url2": {
               "version": "0.0.0",
-              "from": "url2@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz"
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@>=1.2.11 <1.3.0",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "mimeparse": {
               "version": "0.1.4",
-              "from": "mimeparse@>=0.1.4 <0.2.0",
+              "from": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz"
             },
             "collections": {
               "version": "0.2.2",
-              "from": "collections@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
               "resolved": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
               "dependencies": {
                 "weak-map": {
                   "version": "1.0.0",
-                  "from": "weak-map@1.0.0",
+                  "from": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz"
                 }
               }
@@ -5468,67 +4907,67 @@
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.3.4 <5.0.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         },
         "shelljs": {
           "version": "0.5.3",
-          "from": "shelljs@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz"
         },
         "spdx-license-list": {
           "version": "2.1.0",
-          "from": "spdx-license-list@>=2.1.0 <3.0.0",
+          "from": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-2.1.0.tgz"
         },
         "winston": {
           "version": "0.7.3",
-          "from": "winston@>=0.7.2 <0.8.0",
+          "from": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
           "resolved": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "colors": {
               "version": "0.6.2",
-              "from": "colors@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
               "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
             },
             "cycle": {
               "version": "1.0.3",
-              "from": "cycle@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
             },
             "eyes": {
               "version": "0.1.8",
-              "from": "eyes@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             },
             "pkginfo": {
               "version": "0.3.1",
-              "from": "pkginfo@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
             },
             "request": {
               "version": "2.16.6",
-              "from": "request@>=2.16.0 <2.17.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
               "dependencies": {
                 "form-data": {
                   "version": "0.0.10",
-                  "from": "form-data@>=0.0.3 <0.1.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
+                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
@@ -5537,81 +4976,81 @@
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@>=1.2.7 <1.3.0",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "hawk": {
                   "version": "0.10.2",
-                  "from": "hawk@>=0.10.2 <0.11.0",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.7.6",
-                      "from": "hoek@>=0.7.0 <0.8.0",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz"
                     },
                     "boom": {
                       "version": "0.3.8",
-                      "from": "boom@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz"
                     },
                     "cryptiles": {
                       "version": "0.1.3",
-                      "from": "cryptiles@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz"
                     },
                     "sntp": {
                       "version": "0.1.4",
-                      "from": "sntp@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.7",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "cookie-jar": {
                   "version": "0.2.0",
-                  "from": "cookie-jar@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz"
                 },
                 "aws-sign": {
                   "version": "0.2.0",
-                  "from": "aws-sign@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.2.0",
-                  "from": "oauth-sign@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.2.0",
-                  "from": "forever-agent@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.2.0",
-                  "from": "tunnel-agent@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "3.0.0",
-                  "from": "json-stringify-safe@>=3.0.0 <3.1.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz"
                 },
                 "qs": {
                   "version": "0.5.6",
-                  "from": "qs@>=0.5.4 <0.6.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
                 }
               }
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             }
           }
@@ -5662,44 +5101,44 @@
     },
     "glob": {
       "version": "6.0.4",
-      "from": "glob@6.0.4",
+      "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
       "dependencies": {
         "inflight": {
           "version": "1.0.4",
-          "from": "inflight@>=1.0.4 <2.0.0",
+          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
           "dependencies": {
             "wrappy": {
               "version": "1.0.1",
-              "from": "wrappy@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
             }
           }
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "minimatch": {
           "version": "3.0.0",
-          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.3",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.3.0",
-                  "from": "balanced-match@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
@@ -5708,19 +5147,19 @@
         },
         "once": {
           "version": "1.3.3",
-          "from": "once@>=1.3.0 <2.0.0",
+          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "dependencies": {
             "wrappy": {
               "version": "1.0.1",
-              "from": "wrappy@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
             }
           }
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         }
       }
@@ -6584,44 +6023,815 @@
       }
     },
     "grunt-contrib-jshint": {
-      "version": "0.10.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.0.0.tgz",
       "dependencies": {
-        "jshint": {
-          "version": "2.5.11",
-          "from": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
-          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
+        "chalk": {
+          "version": "1.1.3",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
-            "cli": {
-              "version": "0.6.6",
-              "from": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+            "ansi-styles": {
+              "version": "2.2.1",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
-                "glob": {
-                  "version": "3.2.11",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        }
+      }
+    },
+    "grunt-ddescribe-iit": {
+      "version": "0.0.6",
+      "from": "https://registry.npmjs.org/grunt-ddescribe-iit/-/grunt-ddescribe-iit-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-ddescribe-iit/-/grunt-ddescribe-iit-0.0.6.tgz",
+      "dependencies": {
+        "bluebird": {
+          "version": "2.9.24",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz"
+        },
+        "win-spawn": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
+        }
+      }
+    },
+    "grunt-jasmine-node": {
+      "version": "0.1.0",
+      "from": "git://github.com/vojtajina/grunt-jasmine-node.git#ced17cbe52c1412b2ada53160432a5b681f37cd7",
+      "resolved": "git://github.com/vojtajina/grunt-jasmine-node.git#ced17cbe52c1412b2ada53160432a5b681f37cd7"
+    },
+    "grunt-jscs": {
+      "version": "2.8.0",
+      "from": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-2.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-2.8.0.tgz",
+      "dependencies": {
+        "hooker": {
+          "version": "0.2.3",
+          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        },
+        "jscs": {
+          "version": "2.11.0",
+          "from": "https://registry.npmjs.org/jscs/-/jscs-2.11.0.tgz",
+          "resolved": "https://registry.npmjs.org/jscs/-/jscs-2.11.0.tgz",
+          "dependencies": {
+            "babel-jscs": {
+              "version": "2.0.5",
+              "from": "https://registry.npmjs.org/babel-jscs/-/babel-jscs-2.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/babel-jscs/-/babel-jscs-2.0.5.tgz",
+              "dependencies": {
+                "babel-core": {
+                  "version": "5.8.35",
+                  "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.35.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.35.tgz",
                   "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    "babel-plugin-constant-folding": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+                    },
+                    "babel-plugin-dead-code-elimination": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+                    },
+                    "babel-plugin-eval": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+                    },
+                    "babel-plugin-inline-environment-variables": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+                    },
+                    "babel-plugin-jscript": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+                    },
+                    "babel-plugin-member-expression-literals": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+                    },
+                    "babel-plugin-property-literals": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+                    },
+                    "babel-plugin-proto-to-assign": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+                    },
+                    "babel-plugin-react-constant-elements": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+                    },
+                    "babel-plugin-react-display-name": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+                    },
+                    "babel-plugin-remove-console": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+                    },
+                    "babel-plugin-remove-debugger": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+                    },
+                    "babel-plugin-runtime": {
+                      "version": "1.0.7",
+                      "from": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+                    },
+                    "babel-plugin-undeclared-variables-check": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                      "dependencies": {
+                        "leven": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "babel-plugin-undefined-to-void": {
+                      "version": "1.1.6",
+                      "from": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+                    },
+                    "babylon": {
+                      "version": "5.8.35",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-5.8.35.tgz",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.35.tgz"
+                    },
+                    "bluebird": {
+                      "version": "2.10.2",
+                      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+                    },
+                    "convert-source-map": {
+                      "version": "1.2.0",
+                      "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
+                    },
+                    "core-js": {
+                      "version": "1.2.6",
+                      "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "detect-indent": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                      "dependencies": {
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "fs-readdir-recursive": {
+                      "version": "0.1.2",
+                      "from": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+                    },
+                    "globals": {
+                      "version": "6.4.1",
+                      "from": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+                    },
+                    "home-or-tmp": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                      "dependencies": {
+                        "os-tmpdir": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                        },
+                        "user-home": {
+                          "version": "1.1.1",
+                          "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "is-integer": {
+                      "version": "1.0.6",
+                      "from": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "js-tokens": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+                    },
+                    "json5": {
+                      "version": "0.4.0",
+                      "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+                      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+                    },
+                    "line-numbers": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                      "dependencies": {
+                        "left-pad": {
+                          "version": "0.0.3",
+                          "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                        }
+                      }
                     },
                     "minimatch": {
-                      "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "version": "2.0.10",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "output-file-sync": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+                      "dependencies": {
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
                         },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        "xtend": {
+                          "version": "4.0.1",
+                          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-exists": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    },
+                    "private": {
+                      "version": "0.1.6",
+                      "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+                      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                    },
+                    "regenerator": {
+                      "version": "0.8.40",
+                      "from": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+                      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+                      "dependencies": {
+                        "commoner": {
+                          "version": "0.10.4",
+                          "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
+                          "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
+                          "dependencies": {
+                            "detective": {
+                              "version": "4.3.1",
+                              "from": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                              "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                              "dependencies": {
+                                "acorn": {
+                                  "version": "1.2.2",
+                                  "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                                },
+                                "defined": {
+                                  "version": "1.0.0",
+                                  "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "graceful-fs": {
+                              "version": "4.1.3",
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                            },
+                            "iconv-lite": {
+                              "version": "0.4.13",
+                              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                            },
+                            "mkdirp": {
+                              "version": "0.5.1",
+                              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                              "dependencies": {
+                                "minimist": {
+                                  "version": "0.0.8",
+                                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                }
+                              }
+                            },
+                            "q": {
+                              "version": "1.4.1",
+                              "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                              "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+                            }
+                          }
+                        },
+                        "defs": {
+                          "version": "1.1.1",
+                          "from": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+                          "dependencies": {
+                            "alter": {
+                              "version": "0.2.0",
+                              "from": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                              "dependencies": {
+                                "stable": {
+                                  "version": "0.1.5",
+                                  "from": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
+                                  "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+                                }
+                              }
+                            },
+                            "ast-traverse": {
+                              "version": "0.1.1",
+                              "from": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
+                            },
+                            "breakable": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+                            },
+                            "simple-fmt": {
+                              "version": "0.1.0",
+                              "from": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
+                              "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+                            },
+                            "simple-is": {
+                              "version": "0.2.0",
+                              "from": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
+                            },
+                            "stringset": {
+                              "version": "0.2.1",
+                              "from": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
+                              "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+                            },
+                            "tryor": {
+                              "version": "0.1.2",
+                              "from": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
+                              "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+                            },
+                            "yargs": {
+                              "version": "3.27.0",
+                              "from": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                              "dependencies": {
+                                "camelcase": {
+                                  "version": "1.2.1",
+                                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                                },
+                                "cliui": {
+                                  "version": "2.1.0",
+                                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                                  "dependencies": {
+                                    "center-align": {
+                                      "version": "0.1.3",
+                                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                      "dependencies": {
+                                        "align-text": {
+                                          "version": "0.1.4",
+                                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                          "dependencies": {
+                                            "kind-of": {
+                                              "version": "3.0.2",
+                                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                              "dependencies": {
+                                                "is-buffer": {
+                                                  "version": "1.1.3",
+                                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                                                }
+                                              }
+                                            },
+                                            "longest": {
+                                              "version": "1.0.1",
+                                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                            },
+                                            "repeat-string": {
+                                              "version": "1.5.4",
+                                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                            }
+                                          }
+                                        },
+                                        "lazy-cache": {
+                                          "version": "1.0.3",
+                                          "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+                                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                                        }
+                                      }
+                                    },
+                                    "right-align": {
+                                      "version": "0.1.3",
+                                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                      "dependencies": {
+                                        "align-text": {
+                                          "version": "0.1.4",
+                                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                          "dependencies": {
+                                            "kind-of": {
+                                              "version": "3.0.2",
+                                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                              "dependencies": {
+                                                "is-buffer": {
+                                                  "version": "1.1.3",
+                                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                                                }
+                                              }
+                                            },
+                                            "longest": {
+                                              "version": "1.0.1",
+                                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                            },
+                                            "repeat-string": {
+                                              "version": "1.5.4",
+                                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "wordwrap": {
+                                      "version": "0.0.2",
+                                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "decamelize": {
+                                  "version": "1.2.0",
+                                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                                },
+                                "os-locale": {
+                                  "version": "1.4.0",
+                                  "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                                  "dependencies": {
+                                    "lcid": {
+                                      "version": "1.0.0",
+                                      "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                                      "dependencies": {
+                                        "invert-kv": {
+                                          "version": "1.0.0",
+                                          "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                                          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "window-size": {
+                                  "version": "0.1.4",
+                                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+                                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+                                },
+                                "y18n": {
+                                  "version": "3.2.0",
+                                  "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "esprima-fb": {
+                          "version": "15001.1001.0-dev-harmony-fb",
+                          "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                        },
+                        "recast": {
+                          "version": "0.10.33",
+                          "from": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                          "dependencies": {
+                            "ast-types": {
+                              "version": "0.8.12",
+                              "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
+                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                            }
+                          }
+                        },
+                        "through": {
+                          "version": "2.3.8",
+                          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                        }
+                      }
+                    },
+                    "regexpu": {
+                      "version": "1.3.0",
+                      "from": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                      "dependencies": {
+                        "recast": {
+                          "version": "0.10.43",
+                          "from": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+                          "dependencies": {
+                            "esprima-fb": {
+                              "version": "15001.1001.0-dev-harmony-fb",
+                              "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                            },
+                            "ast-types": {
+                              "version": "0.8.15",
+                              "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
+                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
+                            }
+                          }
+                        },
+                        "regenerate": {
+                          "version": "1.2.1",
+                          "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                        },
+                        "regjsgen": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                        },
+                        "regjsparser": {
+                          "version": "0.1.5",
+                          "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                          "dependencies": {
+                            "jsesc": {
+                              "version": "0.5.0",
+                              "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "shebang-regex": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                    },
+                    "slash": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.5.3",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                    },
+                    "source-map-support": {
+                      "version": "0.2.10",
+                      "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                      "dependencies": {
+                        "source-map": {
+                          "version": "0.1.32",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                    },
+                    "trim-right": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+                    },
+                    "try-resolve": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+                    }
+                  }
+                },
+                "lodash.assign": {
+                  "version": "3.2.0",
+                  "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._baseassign": {
+                      "version": "3.2.0",
+                      "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                      "dependencies": {
+                        "lodash._basecopy": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._createassigner": {
+                      "version": "3.1.1",
+                      "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                      "dependencies": {
+                        "lodash._bindcallback": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                        },
+                        "lodash._isiterateecall": {
+                          "version": "3.0.9",
+                          "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                        },
+                        "lodash.restparam": {
+                          "version": "3.6.1",
+                          "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash.keys": {
+                      "version": "3.1.2",
+                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "dependencies": {
+                        "lodash._getnative": {
+                          "version": "3.9.1",
+                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                        },
+                        "lodash.isarguments": {
+                          "version": "3.0.8",
+                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
+                        },
+                        "lodash.isarray": {
+                          "version": "3.0.4",
+                          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                         }
                       }
                     }
@@ -6629,27 +6839,231 @@
                 }
               }
             },
-            "console-browserify": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+            "chalk": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
-                "date-now": {
-                  "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                "ansi-styles": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+                  "dependencies": {
+                    "color-convert": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                    }
+                  }
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
+            },
+            "cli-table": {
+              "version": "0.3.1",
+              "from": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+              "dependencies": {
+                "colors": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+                }
+              }
+            },
+            "commander": {
+              "version": "2.9.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                }
+              }
+            },
+            "escope": {
+              "version": "3.6.0",
+              "from": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+              "dependencies": {
+                "es6-map": {
+                  "version": "0.1.3",
+                  "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.11",
+                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+                    },
+                    "es6-iterator": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                    },
+                    "es6-set": {
+                      "version": "0.1.4",
+                      "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "3.0.2",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+                    },
+                    "event-emitter": {
+                      "version": "0.3.4",
+                      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+                    }
+                  }
+                },
+                "es6-weak-map": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.11",
+                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+                    },
+                    "es6-iterator": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "3.0.2",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+                    }
+                  }
+                },
+                "esrecurse": {
+                  "version": "4.1.0",
+                  "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+                  "dependencies": {
+                    "estraverse": {
+                      "version": "4.1.1",
+                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
+                    },
+                    "object-assign": {
+                      "version": "4.0.1",
+                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.7.2",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+            },
+            "estraverse": {
+              "version": "4.2.0",
+              "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
             },
             "exit": {
               "version": "0.1.2",
               "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
+            "glob": {
+              "version": "5.0.15",
+              "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                }
+              }
+            },
             "htmlparser2": {
-              "version": "3.8.2",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+              "version": "3.8.3",
+              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.3.0",
@@ -6691,9 +7105,9 @@
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
@@ -6719,1162 +7133,73 @@
                 }
               }
             },
-            "minimatch": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                }
-              }
-            },
-            "strip-json-comments": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
-            },
-            "underscore": {
-              "version": "1.6.0",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-            }
-          }
-        },
-        "hooker": {
-          "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-        }
-      }
-    },
-    "grunt-ddescribe-iit": {
-      "version": "0.0.6",
-      "from": "https://registry.npmjs.org/grunt-ddescribe-iit/-/grunt-ddescribe-iit-0.0.6.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-ddescribe-iit/-/grunt-ddescribe-iit-0.0.6.tgz",
-      "dependencies": {
-        "bluebird": {
-          "version": "2.9.24",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz"
-        },
-        "win-spawn": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
-        }
-      }
-    },
-    "grunt-jasmine-node": {
-      "version": "0.1.0",
-      "from": "git://github.com/vojtajina/grunt-jasmine-node.git#fix-grunt-exit-code",
-      "resolved": "git://github.com/vojtajina/grunt-jasmine-node.git#ced17cbe52c1412b2ada53160432a5b681f37cd7"
-    },
-    "grunt-jscs": {
-      "version": "2.8.0",
-      "from": "grunt-jscs@2.8.0",
-      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-2.8.0.tgz",
-      "dependencies": {
-        "hooker": {
-          "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-        },
-        "jscs": {
-          "version": "2.11.0",
-          "from": "jscs@>=2.11.0 <2.12.0",
-          "resolved": "https://registry.npmjs.org/jscs/-/jscs-2.11.0.tgz",
-          "dependencies": {
-            "babel-jscs": {
-              "version": "2.0.5",
-              "from": "babel-jscs@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/babel-jscs/-/babel-jscs-2.0.5.tgz",
-              "dependencies": {
-                "babel-core": {
-                  "version": "5.8.35",
-                  "from": "babel-core@>=5.8.3 <5.9.0",
-                  "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.35.tgz",
-                  "dependencies": {
-                    "babel-plugin-constant-folding": {
-                      "version": "1.0.1",
-                      "from": "babel-plugin-constant-folding@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
-                    },
-                    "babel-plugin-dead-code-elimination": {
-                      "version": "1.0.2",
-                      "from": "babel-plugin-dead-code-elimination@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
-                    },
-                    "babel-plugin-eval": {
-                      "version": "1.0.1",
-                      "from": "babel-plugin-eval@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
-                    },
-                    "babel-plugin-inline-environment-variables": {
-                      "version": "1.0.1",
-                      "from": "babel-plugin-inline-environment-variables@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
-                    },
-                    "babel-plugin-jscript": {
-                      "version": "1.0.4",
-                      "from": "babel-plugin-jscript@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
-                    },
-                    "babel-plugin-member-expression-literals": {
-                      "version": "1.0.1",
-                      "from": "babel-plugin-member-expression-literals@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
-                    },
-                    "babel-plugin-property-literals": {
-                      "version": "1.0.1",
-                      "from": "babel-plugin-property-literals@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
-                    },
-                    "babel-plugin-proto-to-assign": {
-                      "version": "1.0.4",
-                      "from": "babel-plugin-proto-to-assign@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
-                    },
-                    "babel-plugin-react-constant-elements": {
-                      "version": "1.0.3",
-                      "from": "babel-plugin-react-constant-elements@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
-                    },
-                    "babel-plugin-react-display-name": {
-                      "version": "1.0.3",
-                      "from": "babel-plugin-react-display-name@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
-                    },
-                    "babel-plugin-remove-console": {
-                      "version": "1.0.1",
-                      "from": "babel-plugin-remove-console@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
-                    },
-                    "babel-plugin-remove-debugger": {
-                      "version": "1.0.1",
-                      "from": "babel-plugin-remove-debugger@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
-                    },
-                    "babel-plugin-runtime": {
-                      "version": "1.0.7",
-                      "from": "babel-plugin-runtime@>=1.0.7 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
-                    },
-                    "babel-plugin-undeclared-variables-check": {
-                      "version": "1.0.2",
-                      "from": "babel-plugin-undeclared-variables-check@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
-                      "dependencies": {
-                        "leven": {
-                          "version": "1.0.2",
-                          "from": "leven@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "babel-plugin-undefined-to-void": {
-                      "version": "1.1.6",
-                      "from": "babel-plugin-undefined-to-void@>=1.1.6 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
-                    },
-                    "babylon": {
-                      "version": "5.8.35",
-                      "from": "babylon@>=5.8.35 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.35.tgz"
-                    },
-                    "bluebird": {
-                      "version": "2.10.2",
-                      "from": "bluebird@>=2.9.33 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
-                    },
-                    "convert-source-map": {
-                      "version": "1.2.0",
-                      "from": "convert-source-map@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
-                    },
-                    "core-js": {
-                      "version": "1.2.6",
-                      "from": "core-js@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "from": "debug@>=2.1.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "from": "ms@0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                        }
-                      }
-                    },
-                    "detect-indent": {
-                      "version": "3.0.1",
-                      "from": "detect-indent@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-                      "dependencies": {
-                        "get-stdin": {
-                          "version": "4.0.1",
-                          "from": "get-stdin@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                        },
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "fs-readdir-recursive": {
-                      "version": "0.1.2",
-                      "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
-                    },
-                    "globals": {
-                      "version": "6.4.1",
-                      "from": "globals@>=6.4.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
-                    },
-                    "home-or-tmp": {
-                      "version": "1.0.0",
-                      "from": "home-or-tmp@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-                      "dependencies": {
-                        "os-tmpdir": {
-                          "version": "1.0.1",
-                          "from": "os-tmpdir@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                        },
-                        "user-home": {
-                          "version": "1.1.1",
-                          "from": "user-home@>=1.1.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-                        }
-                      }
-                    },
-                    "is-integer": {
-                      "version": "1.0.6",
-                      "from": "is-integer@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "js-tokens": {
-                      "version": "1.0.1",
-                      "from": "js-tokens@1.0.1",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
-                    },
-                    "json5": {
-                      "version": "0.4.0",
-                      "from": "json5@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-                    },
-                    "line-numbers": {
-                      "version": "0.2.0",
-                      "from": "line-numbers@0.2.0",
-                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                      "dependencies": {
-                        "left-pad": {
-                          "version": "0.0.3",
-                          "from": "left-pad@0.0.3",
-                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                        }
-                      }
-                    },
-                    "minimatch": {
-                      "version": "2.0.10",
-                      "from": "minimatch@>=2.0.3 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "output-file-sync": {
-                      "version": "1.1.1",
-                      "from": "output-file-sync@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
-                      "dependencies": {
-                        "mkdirp": {
-                          "version": "0.5.1",
-                          "from": "mkdirp@>=0.5.1 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                          "dependencies": {
-                            "minimist": {
-                              "version": "0.0.8",
-                              "from": "minimist@0.0.8",
-                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                            }
-                          }
-                        },
-                        "xtend": {
-                          "version": "4.0.1",
-                          "from": "xtend@>=4.0.0 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                        }
-                      }
-                    },
-                    "path-exists": {
-                      "version": "1.0.0",
-                      "from": "path-exists@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                    },
-                    "private": {
-                      "version": "0.1.6",
-                      "from": "private@>=0.1.6 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
-                    },
-                    "regenerator": {
-                      "version": "0.8.40",
-                      "from": "regenerator@0.8.40",
-                      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
-                      "dependencies": {
-                        "commoner": {
-                          "version": "0.10.4",
-                          "from": "commoner@>=0.10.3 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
-                          "dependencies": {
-                            "detective": {
-                              "version": "4.3.1",
-                              "from": "detective@>=4.3.1 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
-                              "dependencies": {
-                                "acorn": {
-                                  "version": "1.2.2",
-                                  "from": "acorn@>=1.0.3 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
-                                },
-                                "defined": {
-                                  "version": "1.0.0",
-                                  "from": "defined@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "graceful-fs": {
-                              "version": "4.1.3",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-                            },
-                            "iconv-lite": {
-                              "version": "0.4.13",
-                              "from": "iconv-lite@>=0.4.5 <0.5.0",
-                              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
-                            },
-                            "mkdirp": {
-                              "version": "0.5.1",
-                              "from": "mkdirp@>=0.5.0 <0.6.0",
-                              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                              "dependencies": {
-                                "minimist": {
-                                  "version": "0.0.8",
-                                  "from": "minimist@0.0.8",
-                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                                }
-                              }
-                            },
-                            "q": {
-                              "version": "1.4.1",
-                              "from": "q@>=1.1.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
-                            }
-                          }
-                        },
-                        "defs": {
-                          "version": "1.1.1",
-                          "from": "defs@>=1.1.0 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-                          "dependencies": {
-                            "alter": {
-                              "version": "0.2.0",
-                              "from": "alter@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-                              "dependencies": {
-                                "stable": {
-                                  "version": "0.1.5",
-                                  "from": "stable@>=0.1.3 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
-                                }
-                              }
-                            },
-                            "ast-traverse": {
-                              "version": "0.1.1",
-                              "from": "ast-traverse@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
-                            },
-                            "breakable": {
-                              "version": "1.0.0",
-                              "from": "breakable@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
-                            },
-                            "simple-fmt": {
-                              "version": "0.1.0",
-                              "from": "simple-fmt@>=0.1.0 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
-                            },
-                            "simple-is": {
-                              "version": "0.2.0",
-                              "from": "simple-is@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
-                            },
-                            "stringset": {
-                              "version": "0.2.1",
-                              "from": "stringset@>=0.2.1 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
-                            },
-                            "tryor": {
-                              "version": "0.1.2",
-                              "from": "tryor@>=0.1.2 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
-                            },
-                            "yargs": {
-                              "version": "3.27.0",
-                              "from": "yargs@>=3.27.0 <3.28.0",
-                              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-                              "dependencies": {
-                                "camelcase": {
-                                  "version": "1.2.1",
-                                  "from": "camelcase@>=1.2.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                                },
-                                "cliui": {
-                                  "version": "2.1.0",
-                                  "from": "cliui@>=2.1.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                                  "dependencies": {
-                                    "center-align": {
-                                      "version": "0.1.3",
-                                      "from": "center-align@>=0.1.1 <0.2.0",
-                                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                                      "dependencies": {
-                                        "align-text": {
-                                          "version": "0.1.4",
-                                          "from": "align-text@>=0.1.1 <0.2.0",
-                                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                                          "dependencies": {
-                                            "kind-of": {
-                                              "version": "3.0.2",
-                                              "from": "kind-of@>=3.0.2 <4.0.0",
-                                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                              "dependencies": {
-                                                "is-buffer": {
-                                                  "version": "1.1.3",
-                                                  "from": "is-buffer@>=1.0.2 <2.0.0",
-                                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
-                                                }
-                                              }
-                                            },
-                                            "longest": {
-                                              "version": "1.0.1",
-                                              "from": "longest@>=1.0.1 <2.0.0",
-                                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                            },
-                                            "repeat-string": {
-                                              "version": "1.5.4",
-                                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
-                                            }
-                                          }
-                                        },
-                                        "lazy-cache": {
-                                          "version": "1.0.3",
-                                          "from": "lazy-cache@>=1.0.3 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
-                                        }
-                                      }
-                                    },
-                                    "right-align": {
-                                      "version": "0.1.3",
-                                      "from": "right-align@>=0.1.1 <0.2.0",
-                                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                                      "dependencies": {
-                                        "align-text": {
-                                          "version": "0.1.4",
-                                          "from": "align-text@>=0.1.1 <0.2.0",
-                                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                                          "dependencies": {
-                                            "kind-of": {
-                                              "version": "3.0.2",
-                                              "from": "kind-of@>=3.0.2 <4.0.0",
-                                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                              "dependencies": {
-                                                "is-buffer": {
-                                                  "version": "1.1.3",
-                                                  "from": "is-buffer@>=1.0.2 <2.0.0",
-                                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
-                                                }
-                                              }
-                                            },
-                                            "longest": {
-                                              "version": "1.0.1",
-                                              "from": "longest@>=1.0.1 <2.0.0",
-                                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                            },
-                                            "repeat-string": {
-                                              "version": "1.5.4",
-                                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "wordwrap": {
-                                      "version": "0.0.2",
-                                      "from": "wordwrap@0.0.2",
-                                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                                    }
-                                  }
-                                },
-                                "decamelize": {
-                                  "version": "1.2.0",
-                                  "from": "decamelize@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-                                },
-                                "os-locale": {
-                                  "version": "1.4.0",
-                                  "from": "os-locale@>=1.4.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-                                  "dependencies": {
-                                    "lcid": {
-                                      "version": "1.0.0",
-                                      "from": "lcid@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                                      "dependencies": {
-                                        "invert-kv": {
-                                          "version": "1.0.0",
-                                          "from": "invert-kv@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "window-size": {
-                                  "version": "0.1.4",
-                                  "from": "window-size@>=0.1.2 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
-                                },
-                                "y18n": {
-                                  "version": "3.2.0",
-                                  "from": "y18n@>=3.2.0 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "esprima-fb": {
-                          "version": "15001.1001.0-dev-harmony-fb",
-                          "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
-                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
-                        },
-                        "recast": {
-                          "version": "0.10.33",
-                          "from": "recast@0.10.33",
-                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
-                          "dependencies": {
-                            "ast-types": {
-                              "version": "0.8.12",
-                              "from": "ast-types@0.8.12",
-                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
-                            }
-                          }
-                        },
-                        "through": {
-                          "version": "2.3.8",
-                          "from": "through@>=2.3.8 <2.4.0",
-                          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                        }
-                      }
-                    },
-                    "regexpu": {
-                      "version": "1.3.0",
-                      "from": "regexpu@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
-                      "dependencies": {
-                        "recast": {
-                          "version": "0.10.43",
-                          "from": "recast@>=0.10.10 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
-                          "dependencies": {
-                            "esprima-fb": {
-                              "version": "15001.1001.0-dev-harmony-fb",
-                              "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
-                              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
-                            },
-                            "ast-types": {
-                              "version": "0.8.15",
-                              "from": "ast-types@0.8.15",
-                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
-                            }
-                          }
-                        },
-                        "regenerate": {
-                          "version": "1.2.1",
-                          "from": "regenerate@>=1.2.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
-                        },
-                        "regjsgen": {
-                          "version": "0.2.0",
-                          "from": "regjsgen@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
-                        },
-                        "regjsparser": {
-                          "version": "0.1.5",
-                          "from": "regjsparser@>=0.1.4 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                          "dependencies": {
-                            "jsesc": {
-                              "version": "0.5.0",
-                              "from": "jsesc@>=0.5.0 <0.6.0",
-                              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "repeating": {
-                      "version": "1.1.3",
-                      "from": "repeating@>=1.1.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "shebang-regex": {
-                      "version": "1.0.0",
-                      "from": "shebang-regex@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
-                    },
-                    "slash": {
-                      "version": "1.0.0",
-                      "from": "slash@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
-                    },
-                    "source-map": {
-                      "version": "0.5.3",
-                      "from": "source-map@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-                    },
-                    "source-map-support": {
-                      "version": "0.2.10",
-                      "from": "source-map-support@>=0.2.10 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-                      "dependencies": {
-                        "source-map": {
-                          "version": "0.1.32",
-                          "from": "source-map@0.1.32",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-                          "dependencies": {
-                            "amdefine": {
-                              "version": "1.0.0",
-                              "from": "amdefine@>=0.0.4",
-                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.1",
-                      "from": "to-fast-properties@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                    },
-                    "trim-right": {
-                      "version": "1.0.1",
-                      "from": "trim-right@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
-                    },
-                    "try-resolve": {
-                      "version": "1.0.1",
-                      "from": "try-resolve@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
-                    }
-                  }
-                },
-                "lodash.assign": {
-                  "version": "3.2.0",
-                  "from": "lodash.assign@>=3.2.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-                  "dependencies": {
-                    "lodash._baseassign": {
-                      "version": "3.2.0",
-                      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-                      "dependencies": {
-                        "lodash._basecopy": {
-                          "version": "3.0.1",
-                          "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash._createassigner": {
-                      "version": "3.1.1",
-                      "from": "lodash._createassigner@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-                      "dependencies": {
-                        "lodash._bindcallback": {
-                          "version": "3.0.1",
-                          "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
-                        },
-                        "lodash._isiterateecall": {
-                          "version": "3.0.9",
-                          "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-                        },
-                        "lodash.restparam": {
-                          "version": "3.6.1",
-                          "from": "lodash.restparam@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash.keys": {
-                      "version": "3.1.2",
-                      "from": "lodash.keys@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                      "dependencies": {
-                        "lodash._getnative": {
-                          "version": "3.9.1",
-                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                        },
-                        "lodash.isarguments": {
-                          "version": "3.0.8",
-                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
-                        },
-                        "lodash.isarray": {
-                          "version": "3.0.4",
-                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "chalk": {
-              "version": "1.1.1",
-              "from": "chalk@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.0",
-                  "from": "ansi-styles@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-                  "dependencies": {
-                    "color-convert": {
-                      "version": "1.0.0",
-                      "from": "color-convert@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
-                    }
-                  }
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                }
-              }
-            },
-            "cli-table": {
-              "version": "0.3.1",
-              "from": "cli-table@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-              "dependencies": {
-                "colors": {
-                  "version": "1.0.3",
-                  "from": "colors@1.0.3",
-                  "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-                }
-              }
-            },
-            "commander": {
-              "version": "2.9.0",
-              "from": "commander@>=2.9.0 <2.10.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-              "dependencies": {
-                "graceful-readlink": {
-                  "version": "1.0.1",
-                  "from": "graceful-readlink@>=1.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                }
-              }
-            },
-            "escope": {
-              "version": "3.6.0",
-              "from": "escope@>=3.2.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-              "dependencies": {
-                "es6-map": {
-                  "version": "0.1.3",
-                  "from": "es6-map@>=0.1.3 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
-                  "dependencies": {
-                    "d": {
-                      "version": "0.1.1",
-                      "from": "d@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                    },
-                    "es5-ext": {
-                      "version": "0.10.11",
-                      "from": "es5-ext@>=0.10.8 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
-                    },
-                    "es6-iterator": {
-                      "version": "2.0.0",
-                      "from": "es6-iterator@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
-                    },
-                    "es6-set": {
-                      "version": "0.1.4",
-                      "from": "es6-set@>=0.1.3 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
-                    },
-                    "es6-symbol": {
-                      "version": "3.0.2",
-                      "from": "es6-symbol@>=3.0.1 <3.1.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
-                    },
-                    "event-emitter": {
-                      "version": "0.3.4",
-                      "from": "event-emitter@>=0.3.4 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
-                    }
-                  }
-                },
-                "es6-weak-map": {
-                  "version": "2.0.1",
-                  "from": "es6-weak-map@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
-                  "dependencies": {
-                    "d": {
-                      "version": "0.1.1",
-                      "from": "d@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                    },
-                    "es5-ext": {
-                      "version": "0.10.11",
-                      "from": "es5-ext@>=0.10.8 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
-                    },
-                    "es6-iterator": {
-                      "version": "2.0.0",
-                      "from": "es6-iterator@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
-                    },
-                    "es6-symbol": {
-                      "version": "3.0.2",
-                      "from": "es6-symbol@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
-                    }
-                  }
-                },
-                "esrecurse": {
-                  "version": "4.1.0",
-                  "from": "esrecurse@>=4.1.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-                  "dependencies": {
-                    "estraverse": {
-                      "version": "4.1.1",
-                      "from": "estraverse@>=4.1.0 <4.2.0",
-                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
-                    },
-                    "object-assign": {
-                      "version": "4.0.1",
-                      "from": "object-assign@>=4.0.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "esprima": {
-              "version": "2.7.2",
-              "from": "esprima@>=2.7.0 <2.8.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "from": "estraverse@>=4.1.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
-            },
-            "exit": {
-              "version": "0.1.2",
-              "from": "exit@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-            },
-            "glob": {
-              "version": "5.0.15",
-              "from": "glob@>=5.0.1 <6.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            },
-            "htmlparser2": {
-              "version": "3.8.3",
-              "from": "htmlparser2@3.8.3",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-              "dependencies": {
-                "domhandler": {
-                  "version": "2.3.0",
-                  "from": "domhandler@>=2.3.0 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
-                },
-                "domutils": {
-                  "version": "1.5.1",
-                  "from": "domutils@>=1.5.0 <1.6.0",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-                  "dependencies": {
-                    "dom-serializer": {
-                      "version": "0.1.0",
-                      "from": "dom-serializer@>=0.0.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                      "dependencies": {
-                        "domelementtype": {
-                          "version": "1.1.3",
-                          "from": "domelementtype@>=1.1.1 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-                        },
-                        "entities": {
-                          "version": "1.1.1",
-                          "from": "entities@>=1.1.1 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "domelementtype": {
-                  "version": "1.3.0",
-                  "from": "domelementtype@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-                },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "entities": {
-                  "version": "1.0.0",
-                  "from": "entities@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
-                }
-              }
-            },
             "js-yaml": {
               "version": "3.4.6",
-              "from": "js-yaml@>=3.4.0 <3.5.0",
+              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.6",
-                  "from": "argparse@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.6.tgz",
                   "dependencies": {
                     "sprintf-js": {
                       "version": "1.0.3",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                     }
                   }
                 },
                 "inherit": {
                   "version": "2.2.3",
-                  "from": "inherit@>=2.2.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz"
                 }
               }
             },
             "jscs-jsdoc": {
               "version": "1.3.1",
-              "from": "jscs-jsdoc@>=1.3.1 <2.0.0",
+              "from": "https://registry.npmjs.org/jscs-jsdoc/-/jscs-jsdoc-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/jscs-jsdoc/-/jscs-jsdoc-1.3.1.tgz",
               "dependencies": {
                 "comment-parser": {
                   "version": "0.3.1",
-                  "from": "comment-parser@>=0.3.1 <0.4.0",
+                  "from": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.3.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.5",
-                      "from": "readable-stream@>=2.0.4 <3.0.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
@@ -7883,49 +7208,49 @@
                 },
                 "jsdoctypeparser": {
                   "version": "1.2.0",
-                  "from": "jsdoctypeparser@>=1.2.0 <1.3.0",
+                  "from": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz"
                 }
               }
             },
             "jscs-preset-wikimedia": {
               "version": "1.0.0",
-              "from": "jscs-preset-wikimedia@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/jscs-preset-wikimedia/-/jscs-preset-wikimedia-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/jscs-preset-wikimedia/-/jscs-preset-wikimedia-1.0.0.tgz"
             },
             "jsonlint": {
               "version": "1.6.2",
-              "from": "jsonlint@>=1.6.2 <1.7.0",
+              "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.2.tgz",
               "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.2.tgz",
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "nomnom@>=1.5.0",
+                  "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "underscore@>=1.6.0 <1.7.0",
+                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "chalk@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "has-color@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "ansi-styles@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "strip-ansi@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -7934,34 +7259,34 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@>=4.0.0",
+                  "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
             },
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@>=3.10.0 <3.11.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "minimatch@>=3.0.0 <3.1.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.3",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -7970,120 +7295,120 @@
             },
             "natural-compare": {
               "version": "1.2.2",
-              "from": "natural-compare@>=1.2.2 <1.3.0",
+              "from": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.2.2.tgz",
               "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.2.2.tgz"
             },
             "pathval": {
               "version": "0.1.1",
-              "from": "pathval@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz"
             },
             "prompt": {
               "version": "0.2.14",
-              "from": "prompt@>=0.2.14 <0.3.0",
+              "from": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
               "dependencies": {
                 "pkginfo": {
                   "version": "0.4.0",
-                  "from": "pkginfo@>=0.0.0 <1.0.0",
+                  "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz"
                 },
                 "read": {
                   "version": "1.0.7",
-                  "from": "read@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
                   "dependencies": {
                     "mute-stream": {
                       "version": "0.0.6",
-                      "from": "mute-stream@>=0.0.4 <0.1.0",
+                      "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
                     }
                   }
                 },
                 "revalidator": {
                   "version": "0.1.8",
-                  "from": "revalidator@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
                   "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
                 },
                 "utile": {
                   "version": "0.2.1",
-                  "from": "utile@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@>=0.2.9 <0.3.0",
+                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "deep-equal": {
                       "version": "1.0.1",
-                      "from": "deep-equal@*",
+                      "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
                     },
                     "i": {
                       "version": "0.3.4",
-                      "from": "i@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/i/-/i-0.3.4.tgz",
                       "resolved": "https://registry.npmjs.org/i/-/i-0.3.4.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.0.0 <1.0.0",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "minimist@0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "ncp": {
                       "version": "0.4.2",
-                      "from": "ncp@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                     },
                     "rimraf": {
                       "version": "2.5.2",
-                      "from": "rimraf@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
                       "dependencies": {
                         "glob": {
                           "version": "7.0.3",
-                          "from": "glob@>=7.0.0 <8.0.0",
+                          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                           "dependencies": {
                             "inflight": {
                               "version": "1.0.4",
-                              "from": "inflight@>=1.0.4 <2.0.0",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                 }
                               }
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             },
                             "once": {
                               "version": "1.3.3",
-                              "from": "once@>=1.3.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                 }
                               }
                             },
                             "path-is-absolute": {
                               "version": "1.0.0",
-                              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                             }
                           }
@@ -8094,42 +7419,42 @@
                 },
                 "winston": {
                   "version": "0.8.3",
-                  "from": "winston@>=0.8.0 <0.9.0",
+                  "from": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
                   "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "colors": {
                       "version": "0.6.2",
-                      "from": "colors@>=0.6.0 <0.7.0",
+                      "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
                     },
                     "cycle": {
                       "version": "1.0.3",
-                      "from": "cycle@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
                     },
                     "eyes": {
                       "version": "0.1.8",
-                      "from": "eyes@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
                       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
                     },
                     "isstream": {
                       "version": "0.1.2",
-                      "from": "isstream@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                     },
                     "pkginfo": {
                       "version": "0.3.1",
-                      "from": "pkginfo@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
                     },
                     "stack-trace": {
                       "version": "0.0.9",
-                      "from": "stack-trace@>=0.0.0 <0.1.0",
+                      "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                     }
                   }
@@ -8138,96 +7463,96 @@
             },
             "reserved-words": {
               "version": "0.1.1",
-              "from": "reserved-words@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.1.tgz"
             },
             "resolve": {
               "version": "1.1.7",
-              "from": "resolve@>=1.1.6 <2.0.0",
+              "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
             },
             "strip-bom": {
               "version": "2.0.0",
-              "from": "strip-bom@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
               "dependencies": {
                 "is-utf8": {
                   "version": "0.2.1",
-                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                 }
               }
             },
             "strip-json-comments": {
               "version": "1.0.4",
-              "from": "strip-json-comments@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "to-double-quotes": {
               "version": "2.0.0",
-              "from": "to-double-quotes@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-2.0.0.tgz"
             },
             "to-single-quotes": {
               "version": "2.0.0",
-              "from": "to-single-quotes@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.0.tgz"
             },
             "vow-fs": {
               "version": "0.3.4",
-              "from": "vow-fs@>=0.3.4 <0.4.0",
+              "from": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
               "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
               "dependencies": {
                 "node-uuid": {
                   "version": "1.4.7",
-                  "from": "node-uuid@>=1.4.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "vow-queue": {
                   "version": "0.4.2",
-                  "from": "vow-queue@>=0.4.1 <0.5.0",
+                  "from": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz"
                 },
                 "glob": {
                   "version": "4.5.3",
-                  "from": "glob@>=4.3.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -8236,12 +7561,12 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -8252,19 +7577,19 @@
             },
             "xmlbuilder": {
               "version": "3.1.0",
-              "from": "xmlbuilder@>=3.1.0 <4.0.0",
+              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-3.1.0.tgz",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-3.1.0.tgz"
             }
           }
         },
         "lodash": {
           "version": "4.6.1",
-          "from": "lodash@>=4.6.1 <4.7.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz"
         },
         "vow": {
           "version": "0.4.12",
-          "from": "vow@>=0.4.1 <0.5.0",
+          "from": "https://registry.npmjs.org/vow/-/vow-0.4.12.tgz",
           "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.12.tgz"
         }
       }
@@ -8824,56 +8149,56 @@
     },
     "gulp-concat": {
       "version": "2.6.0",
-      "from": "gulp-concat@2.6.0",
+      "from": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.0.tgz",
       "dependencies": {
         "concat-with-sourcemaps": {
           "version": "1.0.4",
-          "from": "concat-with-sourcemaps@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             }
           }
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -9214,765 +8539,92 @@
       }
     },
     "gulp-jshint": {
-      "version": "1.4.2",
-      "from": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-1.4.2.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-1.4.2.tgz",
+      "version": "2.0.0",
+      "from": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-2.0.0.tgz",
       "dependencies": {
-        "map-stream": {
-          "version": "0.1.0",
-          "from": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+        "lodash": {
+          "version": "3.10.1",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
-        "jshint": {
-          "version": "2.4.4",
-          "from": "https://registry.npmjs.org/jshint/-/jshint-2.4.4.tgz",
-          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.4.4.tgz",
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
-            "shelljs": {
-              "version": "0.1.4",
-              "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz"
-            },
-            "underscore": {
-              "version": "1.4.4",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
-            },
-            "cli": {
-              "version": "0.4.5",
-              "from": "https://registry.npmjs.org/cli/-/cli-0.4.5.tgz",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.5.tgz",
+            "brace-expansion": {
+              "version": "1.1.3",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
               "dependencies": {
-                "glob": {
-                  "version": "5.0.3",
-                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.3.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "2.0.4",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.2.0",
-                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.1",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "minimatch": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                }
-              }
-            },
-            "htmlparser2": {
-              "version": "3.3.0",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
-              "dependencies": {
-                "domhandler": {
-                  "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz"
-                },
-                "domutils": {
-                  "version": "1.1.6",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz"
-                },
-                "domelementtype": {
-                  "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-                },
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "console-browserify": {
-              "version": "0.1.6",
-              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz"
-            },
-            "exit": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-            }
-          }
-        },
-        "gulp-util": {
-          "version": "2.2.20",
-          "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
-          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
-          "dependencies": {
-            "chalk": {
-              "version": "0.5.1",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                },
-                "has-ansi": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
+                "balanced-match": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                    }
-                  }
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                 },
-                "supports-color": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-                }
-              }
-            },
-            "dateformat": {
-              "version": "1.0.11",
-              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
-              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                },
-                "meow": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
-                  "dependencies": {
-                    "camelcase-keys": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
-                        },
-                        "map-obj": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "indent-string": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
-                      "dependencies": {
-                        "repeating": {
-                          "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "minimist": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
-                    },
-                    "object-assign": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._reinterpolate": {
-              "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
-            },
-            "lodash.template": {
-              "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-              "dependencies": {
-                "lodash.defaults": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._objecttypes": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                    }
-                  }
-                },
-                "lodash.escape": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._escapehtmlchar": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._htmlescapes": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash._reunescapedhtml": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._htmlescapes": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash._escapestringchar": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
-                },
-                "lodash.keys": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._isnative": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                    },
-                    "lodash.isobject": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._objecttypes": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash._shimkeys": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._objecttypes": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash.templatesettings": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
-                },
-                "lodash.values": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
-                }
-              }
-            },
-            "minimist": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
-            },
-            "multipipe": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-              "dependencies": {
-                "duplexer2": {
-                  "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "through2": {
-              "version": "0.5.1",
-              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-                }
-              }
-            },
-            "vinyl": {
-              "version": "0.2.3",
-              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
-              "dependencies": {
-                "clone-stats": {
+                "concat-map": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
             }
           }
         },
-        "lodash.clone": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-2.4.1.tgz",
+        "rcloader": {
+          "version": "0.1.2",
+          "from": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
           "dependencies": {
-            "lodash._baseclone": {
-              "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-2.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-2.4.1.tgz",
+            "rcfinder": {
+              "version": "0.1.8",
+              "from": "https://registry.npmjs.org/rcfinder/-/rcfinder-0.1.8.tgz",
+              "resolved": "https://registry.npmjs.org/rcfinder/-/rcfinder-0.1.8.tgz"
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
-                "lodash.assign": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash.keys": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._isnative": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                        },
-                        "lodash._shimkeys": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash._objecttypes": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                    }
-                  }
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
-                "lodash.foreach": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz"
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
-                "lodash.forown": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash.keys": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._isnative": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                        },
-                        "lodash._shimkeys": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash._objecttypes": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                    }
-                  }
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
-                "lodash._getarray": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash._getarray/-/lodash._getarray-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._getarray/-/lodash._getarray-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._arraypool": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz"
-                    }
-                  }
-                },
-                "lodash.isarray": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._isnative": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                    }
-                  }
-                },
-                "lodash.isobject": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._objecttypes": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                    }
-                  }
-                },
-                "lodash._releasearray": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash._releasearray/-/lodash._releasearray-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._releasearray/-/lodash._releasearray-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._arraypool": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz"
-                    },
-                    "lodash._maxpoolsize": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz"
-                    }
-                  }
-                },
-                "lodash._slice": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
-            "lodash._basecreatecallback": {
-              "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
-              "dependencies": {
-                "lodash.bind": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._createwrapper": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._basebind": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
-                          "dependencies": {
-                            "lodash._basecreate": {
-                              "version": "2.4.1",
-                              "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-                              "dependencies": {
-                                "lodash._isnative": {
-                                  "version": "2.4.1",
-                                  "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                                },
-                                "lodash.noop": {
-                                  "version": "2.4.1",
-                                  "from": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-                                }
-                              }
-                            },
-                            "lodash.isobject": {
-                              "version": "2.4.1",
-                              "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                              "dependencies": {
-                                "lodash._objecttypes": {
-                                  "version": "2.4.1",
-                                  "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash._basecreatewrapper": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
-                          "dependencies": {
-                            "lodash._basecreate": {
-                              "version": "2.4.1",
-                              "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-                              "dependencies": {
-                                "lodash._isnative": {
-                                  "version": "2.4.1",
-                                  "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                                },
-                                "lodash.noop": {
-                                  "version": "2.4.1",
-                                  "from": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-                                }
-                              }
-                            },
-                            "lodash.isobject": {
-                              "version": "2.4.1",
-                              "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                              "dependencies": {
-                                "lodash._objecttypes": {
-                                  "version": "2.4.1",
-                                  "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash.isfunction": {
-                          "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash._slice": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
-                    }
-                  }
-                },
-                "lodash.identity": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
-                },
-                "lodash._setbinddata": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._isnative": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                    },
-                    "lodash.noop": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-                    }
-                  }
-                },
-                "lodash.support": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._isnative": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                    }
-                  }
-                }
-              }
+            "xtend": {
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         }
@@ -9985,98 +8637,98 @@
     },
     "gulp-sourcemaps": {
       "version": "1.6.0",
-      "from": "gulp-sourcemaps@1.6.0",
+      "from": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "dependencies": {
         "convert-source-map": {
           "version": "1.2.0",
-          "from": "convert-source-map@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
         },
         "graceful-fs": {
           "version": "4.1.3",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
         },
         "strip-bom": {
           "version": "2.0.0",
-          "from": "strip-bom@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "dependencies": {
             "is-utf8": {
               "version": "0.2.1",
-              "from": "is-utf8@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
             }
           }
         },
         "through2": {
           "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "vinyl": {
           "version": "1.1.1",
-          "from": "vinyl@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz",
           "dependencies": {
             "clone": {
               "version": "1.0.2",
-              "from": "clone@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
             },
             "clone-stats": {
               "version": "0.0.1",
-              "from": "clone-stats@>=0.0.1 <0.0.2",
+              "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
             },
             "replace-ext": {
               "version": "0.0.1",
-              "from": "replace-ext@0.0.1",
+              "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             }
           }
@@ -10085,246 +8737,246 @@
     },
     "gulp-uglify": {
       "version": "1.5.3",
-      "from": "gulp-uglify@1.5.3",
+      "from": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.5.3.tgz",
       "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.5.3.tgz",
       "dependencies": {
         "deap": {
           "version": "1.0.0",
-          "from": "deap@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz"
         },
         "fancy-log": {
           "version": "1.2.0",
-          "from": "fancy-log@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.0",
-                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
                   "dependencies": {
                     "color-convert": {
                       "version": "1.0.0",
-                      "from": "color-convert@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
                     }
                   }
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "time-stamp": {
               "version": "1.0.0",
-              "from": "time-stamp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.0.tgz"
             }
           }
         },
         "isobject": {
           "version": "2.0.0",
-          "from": "isobject@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
           "dependencies": {
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             }
           }
         },
         "through2": {
           "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.6.2",
-          "from": "uglify-js@2.6.2",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
               "version": "3.10.0",
-              "from": "yargs@>=3.10.0 <3.11.0",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "cliui": {
                   "version": "2.1.0",
-                  "from": "cliui@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.3",
-                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "align-text@>=0.1.3 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "3.0.2",
-                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.3",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.4",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                             }
                           }
                         },
                         "lazy-cache": {
                           "version": "1.0.3",
-                          "from": "lazy-cache@>=1.0.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
                         }
                       }
                     },
                     "right-align": {
                       "version": "0.1.3",
-                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "align-text@>=0.1.3 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "3.0.2",
-                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.3",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.4",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                             }
                           }
@@ -10333,19 +8985,19 @@
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.2.0",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "window-size": {
                   "version": "0.1.0",
-                  "from": "window-size@0.1.0",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                 }
               }
@@ -10354,17 +9006,17 @@
         },
         "uglify-save-license": {
           "version": "0.4.1",
-          "from": "uglify-save-license@>=0.4.1 <0.5.0",
+          "from": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz",
           "resolved": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz"
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.2.1",
-          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             }
           }
@@ -10373,183 +9025,183 @@
     },
     "gulp-util": {
       "version": "3.0.7",
-      "from": "gulp-util@3.0.7",
+      "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "dependencies": {
         "array-differ": {
           "version": "1.0.0",
-          "from": "array-differ@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
         },
         "array-uniq": {
           "version": "1.0.2",
-          "from": "array-uniq@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
         },
         "beeper": {
           "version": "1.1.0",
-          "from": "beeper@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
               "dependencies": {
                 "color-convert": {
                   "version": "1.0.0",
-                  "from": "color-convert@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
                 }
               }
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "dateformat": {
           "version": "1.0.12",
-          "from": "dateformat@>=1.0.11 <2.0.0",
+          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "meow": {
               "version": "3.7.0",
-              "from": "meow@>=3.3.0 <4.0.0",
+              "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "2.0.0",
-                  "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "2.1.0",
-                      "from": "camelcase@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.2.0",
-                  "from": "decamelize@>=1.1.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "loud-rejection": {
                   "version": "1.3.0",
-                  "from": "loud-rejection@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                   "dependencies": {
                     "array-find-index": {
                       "version": "1.0.1",
-                      "from": "array-find-index@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
                     },
                     "signal-exit": {
                       "version": "2.1.2",
-                      "from": "signal-exit@>=2.1.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
                     }
                   }
                 },
                 "map-obj": {
                   "version": "1.0.1",
-                  "from": "map-obj@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.4",
-                      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.1",
-                          "from": "builtin-modules@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                         }
                       }
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.2.0",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.2",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.4",
-                              "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                             },
                             "spdx-license-ids": {
                               "version": "1.2.0",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                             }
                           }
@@ -10560,32 +9212,32 @@
                 },
                 "object-assign": {
                   "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                 },
                 "read-pkg-up": {
                   "version": "1.0.1",
-                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "dependencies": {
                     "find-up": {
                       "version": "1.1.2",
-                      "from": "find-up@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",
-                          "from": "path-exists@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.0",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                             }
                           }
@@ -10594,32 +9246,32 @@
                     },
                     "read-pkg": {
                       "version": "1.1.0",
-                      "from": "read-pkg@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "dependencies": {
                         "load-json-file": {
                           "version": "1.1.0",
-                          "from": "load-json-file@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.3",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                             },
                             "parse-json": {
                               "version": "2.2.0",
-                              "from": "parse-json@>=2.2.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.3.0",
-                                  "from": "error-ex@>=1.2.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                   "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                   "dependencies": {
                                     "is-arrayish": {
                                       "version": "0.2.1",
-                                      "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                      "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
                                       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                     }
                                   }
@@ -10628,29 +9280,29 @@
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.0",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
                             },
                             "strip-bom": {
                               "version": "2.0.0",
-                              "from": "strip-bom@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "dependencies": {
                                 "is-utf8": {
                                   "version": "0.2.1",
-                                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
                                   "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                                 }
                               }
@@ -10659,27 +9311,27 @@
                         },
                         "path-type": {
                           "version": "1.1.0",
-                          "from": "path-type@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.3",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.0",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
@@ -10692,27 +9344,27 @@
                 },
                 "redent": {
                   "version": "1.0.0",
-                  "from": "redent@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "dependencies": {
                     "indent-string": {
                       "version": "2.1.0",
-                      "from": "indent-string@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "2.0.0",
-                          "from": "repeating@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -10723,14 +9375,14 @@
                     },
                     "strip-indent": {
                       "version": "1.0.1",
-                      "from": "strip-indent@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                     }
                   }
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
-                  "from": "trim-newlines@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                 }
               }
@@ -10739,29 +9391,29 @@
         },
         "fancy-log": {
           "version": "1.2.0",
-          "from": "fancy-log@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
           "dependencies": {
             "time-stamp": {
               "version": "1.0.0",
-              "from": "time-stamp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.0.tgz"
             }
           }
         },
         "gulplog": {
           "version": "1.0.0",
-          "from": "gulplog@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
           "dependencies": {
             "glogg": {
               "version": "1.0.0",
-              "from": "glogg@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
               "dependencies": {
                 "sparkles": {
                   "version": "1.0.0",
-                  "from": "sparkles@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
                 }
               }
@@ -10770,140 +9422,140 @@
         },
         "has-gulplog": {
           "version": "0.1.0",
-          "from": "has-gulplog@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
           "dependencies": {
             "sparkles": {
               "version": "1.0.0",
-              "from": "sparkles@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
             }
           }
         },
         "lodash._reescape": {
           "version": "3.0.0",
-          "from": "lodash._reescape@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
         },
         "lodash._reevaluate": {
           "version": "3.0.0",
-          "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
         },
         "lodash._reinterpolate": {
           "version": "3.0.0",
-          "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
         },
         "lodash.template": {
           "version": "3.6.2",
-          "from": "lodash.template@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
           "dependencies": {
             "lodash._basecopy": {
               "version": "3.0.1",
-              "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
             },
             "lodash._basetostring": {
               "version": "3.0.1",
-              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
             },
             "lodash._basevalues": {
               "version": "3.0.0",
-              "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
             },
             "lodash._isiterateecall": {
               "version": "3.0.9",
-              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
               "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
             },
             "lodash.escape": {
               "version": "3.2.0",
-              "from": "lodash.escape@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
               "dependencies": {
                 "lodash._root": {
                   "version": "3.0.1",
-                  "from": "lodash._root@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
                 }
               }
             },
             "lodash.keys": {
               "version": "3.1.2",
-              "from": "lodash.keys@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
               "dependencies": {
                 "lodash._getnative": {
                   "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                 },
                 "lodash.isarguments": {
                   "version": "3.0.8",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 }
               }
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "from": "lodash.restparam@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
             },
             "lodash.templatesettings": {
               "version": "3.1.1",
-              "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
             }
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "multipipe": {
           "version": "0.1.2",
-          "from": "multipipe@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
           "dependencies": {
             "duplexer2": {
               "version": "0.0.2",
-              "from": "duplexer2@0.0.2",
+              "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -10914,76 +9566,76 @@
         },
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
         },
         "replace-ext": {
           "version": "0.0.1",
-          "from": "replace-ext@0.0.1",
+          "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
         },
         "through2": {
           "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "vinyl": {
           "version": "0.5.3",
-          "from": "vinyl@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "dependencies": {
             "clone": {
               "version": "1.0.2",
-              "from": "clone@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
             },
             "clone-stats": {
               "version": "0.0.1",
-              "from": "clone-stats@>=0.0.1 <0.0.2",
+              "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
             }
           }
@@ -10992,7 +9644,7 @@
     },
     "jasmine-core": {
       "version": "2.4.1",
-      "from": "jasmine-core@2.4.1",
+      "from": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz"
     },
     "jasmine-node": {
@@ -11094,92 +9746,264 @@
     },
     "jasmine-reporters": {
       "version": "1.0.2",
-      "from": "jasmine-reporters@1.0.2",
+      "from": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-1.0.2.tgz",
       "dependencies": {
         "mkdirp": {
           "version": "0.3.5",
-          "from": "mkdirp@>=0.3.5 <0.4.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
         }
       }
     },
-    "jshint-stylish": {
-      "version": "1.0.2",
-      "from": "jshint-stylish@1.0.2",
-      "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-1.0.2.tgz",
+    "jshint": {
+      "version": "2.9.1",
+      "from": "https://registry.npmjs.org/jshint/-/jshint-2.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.1.tgz",
       "dependencies": {
-        "chalk": {
-          "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+        "cli": {
+          "version": "0.6.6",
+          "from": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+            "glob": {
+              "version": "3.2.11",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
-                "color-convert": {
-                  "version": "1.0.0",
-                  "from": "color-convert@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4",
+              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "dependencies": {
+            "domhandler": {
+              "version": "2.3.0",
+              "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+            },
+            "domutils": {
+              "version": "1.5.1",
+              "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+              "dependencies": {
+                "dom-serializer": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.1.3",
+                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                    },
+                    "entities": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                    }
+                  }
                 }
               }
             },
+            "domelementtype": {
+              "version": "1.3.0",
+              "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.3",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+        },
+        "lodash": {
+          "version": "3.7.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
+        }
+      }
+    },
+    "jshint-stylish": {
+      "version": "2.1.0",
+      "from": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-2.1.0.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+            },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "log-symbols": {
           "version": "1.0.2",
-          "from": "log-symbols@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
+        },
+        "plur": {
+          "version": "2.1.2",
+          "from": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+          "dependencies": {
+            "irregular-plurals": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.1.0.tgz"
+            }
+          }
         },
         "string-length": {
           "version": "1.0.1",
-          "from": "string-length@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
@@ -11188,132 +10012,132 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "karma": {
       "version": "0.13.22",
-      "from": "karma@0.13.22",
+      "from": "https://registry.npmjs.org/karma/-/karma-0.13.22.tgz",
       "resolved": "https://registry.npmjs.org/karma/-/karma-0.13.22.tgz",
       "dependencies": {
         "batch": {
           "version": "0.5.3",
-          "from": "batch@>=0.5.3 <0.6.0",
+          "from": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
         },
         "bluebird": {
           "version": "2.10.2",
-          "from": "bluebird@>=2.9.27 <3.0.0",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
         },
         "body-parser": {
           "version": "1.15.0",
-          "from": "body-parser@>=1.12.4 <2.0.0",
+          "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz",
           "dependencies": {
             "bytes": {
               "version": "2.2.0",
-              "from": "bytes@2.2.0",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
             },
             "content-type": {
               "version": "1.0.1",
-              "from": "content-type@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "depd": {
               "version": "1.1.0",
-              "from": "depd@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
             },
             "http-errors": {
               "version": "1.4.0",
-              "from": "http-errors@>=1.4.0 <1.5.0",
+              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "statuses": {
                   "version": "1.2.1",
-                  "from": "statuses@>=1.2.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                 }
               }
             },
             "iconv-lite": {
               "version": "0.4.13",
-              "from": "iconv-lite@0.4.13",
+              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
             },
             "on-finished": {
               "version": "2.3.0",
-              "from": "on-finished@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "dependencies": {
                 "ee-first": {
                   "version": "1.1.1",
-                  "from": "ee-first@1.1.1",
+                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                 }
               }
             },
             "qs": {
               "version": "6.1.0",
-              "from": "qs@6.1.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
             },
             "raw-body": {
               "version": "2.1.6",
-              "from": "raw-body@>=2.1.5 <2.2.0",
+              "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
               "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
               "dependencies": {
                 "bytes": {
                   "version": "2.3.0",
-                  "from": "bytes@2.3.0",
+                  "from": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
                 },
                 "unpipe": {
                   "version": "1.0.0",
-                  "from": "unpipe@1.0.0",
+                  "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
             },
             "type-is": {
               "version": "1.6.12",
-              "from": "type-is@>=1.6.11 <1.7.0",
+              "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
               "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
-                  "from": "media-typer@0.3.0",
+                  "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
                   "version": "2.1.10",
-                  "from": "mime-types@>=2.1.10 <2.2.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.22.0",
-                      "from": "mime-db@>=1.22.0 <1.23.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                     }
                   }
@@ -11324,81 +10148,81 @@
         },
         "chokidar": {
           "version": "1.4.3",
-          "from": "chokidar@>=1.4.1 <2.0.0",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "anymatch@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "arrify": {
                   "version": "1.0.1",
-                  "from": "arrify@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
                 },
                 "micromatch": {
                   "version": "2.3.7",
-                  "from": "micromatch@>=2.1.5 <3.0.0",
+                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
                   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "2.0.0",
-                      "from": "arr-diff@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                       "dependencies": {
                         "arr-flatten": {
                           "version": "1.0.1",
-                          "from": "arr-flatten@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
                         }
                       }
                     },
                     "array-unique": {
                       "version": "0.2.1",
-                      "from": "array-unique@>=0.2.1 <0.3.0",
+                      "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                     },
                     "braces": {
                       "version": "1.8.3",
-                      "from": "braces@>=1.8.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@>=1.8.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.3",
-                              "from": "fill-range@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "2.1.0",
-                                  "from": "is-number@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
                                 },
                                 "isobject": {
                                   "version": "2.0.0",
-                                  "from": "isobject@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
                                   "dependencies": {
                                     "isarray": {
                                       "version": "0.0.1",
-                                      "from": "isarray@0.0.1",
+                                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                     }
                                   }
                                 },
                                 "randomatic": {
                                   "version": "1.1.5",
-                                  "from": "randomatic@>=1.1.3 <2.0.0",
+                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.4",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
@@ -11407,107 +10231,107 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
-                          "from": "repeat-element@>=1.1.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.4",
-                      "from": "expand-brackets@>=0.1.4 <0.2.0",
+                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
                     },
                     "extglob": {
                       "version": "0.3.2",
-                      "from": "extglob@>=0.3.1 <0.4.0",
+                      "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "is-extglob": {
                       "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "3.0.2",
-                      "from": "kind-of@>=3.0.2 <4.0.0",
+                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                       "dependencies": {
                         "is-buffer": {
                           "version": "1.1.3",
-                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                         }
                       }
                     },
                     "normalize-path": {
                       "version": "2.0.1",
-                      "from": "normalize-path@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                     },
                     "object.omit": {
                       "version": "2.0.0",
-                      "from": "object.omit@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "for-own@>=0.1.3 <0.2.0",
+                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "for-in@>=0.1.4 <0.2.0",
+                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "is-extendable": {
                           "version": "0.1.1",
-                          "from": "is-extendable@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.4",
-                      "from": "parse-glob@>=3.0.4 <4.0.0",
+                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.3.0",
-                          "from": "glob-base@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.2",
-                          "from": "is-dotfile@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.2",
-                      "from": "regex-cache@>=0.4.2 <0.5.0",
+                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.3",
-                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
                         "is-primitive": {
                           "version": "2.0.0",
-                          "from": "is-primitive@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
@@ -11518,71 +10342,71 @@
             },
             "async-each": {
               "version": "1.0.0",
-              "from": "async-each@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz"
             },
             "glob-parent": {
               "version": "2.0.0",
-              "from": "glob-parent@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.4.0",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "2.0.1",
-              "from": "is-glob@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "dependencies": {
                 "is-extglob": {
                   "version": "1.0.0",
-                  "from": "is-extglob@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "readdirp": {
               "version": "2.0.0",
-              "from": "readdirp@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.10 <3.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.3",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -11591,32 +10415,32 @@
                 },
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -11625,12 +10449,12 @@
             },
             "fsevents": {
               "version": "1.0.8",
-              "from": "fsevents@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.8.tgz",
               "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.8.tgz",
               "dependencies": {
                 "nan": {
                   "version": "2.2.0",
-                  "from": "nan@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
                 },
                 "node-pre-gyp": {
@@ -11722,15 +10546,15 @@
                   "from": "combined-stream@~1.0.5",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
                 },
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
                 "commander": {
                   "version": "2.9.0",
                   "from": "commander@^2.9.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
@@ -11757,30 +10581,30 @@
                   "from": "delayed-stream@~1.0.0",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 },
-                "ecc-jsbn": {
-                  "version": "0.1.1",
-                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                },
                 "delegates": {
                   "version": "1.0.0",
                   "from": "delegates@^1.0.0",
                   "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.4",
                   "from": "escape-string-regexp@^1.0.2",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                 },
-                "extsprintf": {
-                  "version": "1.0.2",
-                  "from": "extsprintf@1.0.2",
-                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                },
                 "extend": {
                   "version": "3.0.0",
                   "from": "extend@~3.0.0",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                },
+                "extsprintf": {
+                  "version": "1.0.2",
+                  "from": "extsprintf@1.0.2",
+                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                 },
                 "forever-agent": {
                   "version": "0.6.1",
@@ -12062,15 +10886,15 @@
                   "from": "strip-json-comments@~1.0.4",
                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                 },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                },
                 "tar": {
                   "version": "2.2.1",
                   "from": "tar@~2.2.0",
                   "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 },
                 "tar-pack": {
                   "version": "3.1.3",
@@ -12250,137 +11074,137 @@
         },
         "colors": {
           "version": "1.1.2",
-          "from": "colors@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
         },
         "connect": {
           "version": "3.4.1",
-          "from": "connect@>=3.3.5 <4.0.0",
+          "from": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz",
           "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "finalhandler": {
               "version": "0.4.1",
-              "from": "finalhandler@0.4.1",
+              "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
               "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
               "dependencies": {
                 "escape-html": {
                   "version": "1.0.3",
-                  "from": "escape-html@>=1.0.3 <1.1.0",
+                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
                 },
                 "on-finished": {
                   "version": "2.3.0",
-                  "from": "on-finished@>=2.3.0 <2.4.0",
+                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.1",
-                      "from": "ee-first@1.1.1",
+                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                     }
                   }
                 },
                 "unpipe": {
                   "version": "1.0.0",
-                  "from": "unpipe@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
             },
             "parseurl": {
               "version": "1.3.1",
-              "from": "parseurl@>=1.3.1 <1.4.0",
+              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
             },
             "utils-merge": {
               "version": "1.0.0",
-              "from": "utils-merge@1.0.0",
+              "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
             }
           }
         },
         "core-js": {
           "version": "2.1.5",
-          "from": "core-js@>=2.1.0 <3.0.0",
+          "from": "https://registry.npmjs.org/core-js/-/core-js-2.1.5.tgz",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.1.5.tgz"
         },
         "di": {
           "version": "0.0.1",
-          "from": "di@>=0.0.1 <0.0.2",
+          "from": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
         },
         "dom-serialize": {
           "version": "2.2.1",
-          "from": "dom-serialize@>=2.2.0 <3.0.0",
+          "from": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
           "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
           "dependencies": {
             "custom-event": {
               "version": "1.0.0",
-              "from": "custom-event@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz"
             },
             "ent": {
               "version": "2.2.0",
-              "from": "ent@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz"
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "void-elements": {
               "version": "2.0.1",
-              "from": "void-elements@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
             }
           }
         },
         "expand-braces": {
           "version": "0.1.2",
-          "from": "expand-braces@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
           "dependencies": {
             "array-slice": {
               "version": "0.2.3",
-              "from": "array-slice@>=0.2.3 <0.3.0",
+              "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
               "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
             },
             "array-unique": {
               "version": "0.2.1",
-              "from": "array-unique@>=0.2.1 <0.3.0",
+              "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
             },
             "braces": {
               "version": "0.1.5",
-              "from": "braces@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
               "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
               "dependencies": {
                 "expand-range": {
                   "version": "0.1.1",
-                  "from": "expand-range@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
                   "dependencies": {
                     "is-number": {
                       "version": "0.1.1",
-                      "from": "is-number@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz"
                     },
                     "repeat-string": {
                       "version": "0.2.2",
-                      "from": "repeat-string@>=0.2.2 <0.3.0",
+                      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz"
                     }
                   }
@@ -12391,139 +11215,139 @@
         },
         "glob": {
           "version": "7.0.3",
-          "from": "glob@>=7.0.0 <8.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.3",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
         },
         "http-proxy": {
           "version": "1.13.2",
-          "from": "http-proxy@>=1.13.0 <2.0.0",
+          "from": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.2.tgz",
           "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.2.tgz",
           "dependencies": {
             "eventemitter3": {
               "version": "1.1.1",
-              "from": "eventemitter3@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz"
             },
             "requires-port": {
               "version": "1.0.0",
-              "from": "requires-port@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
             }
           }
         },
         "isbinaryfile": {
           "version": "3.0.0",
-          "from": "isbinaryfile@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.0.tgz"
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.8.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "log4js": {
           "version": "0.6.33",
-          "from": "log4js@>=0.6.31 <0.7.0",
+          "from": "https://registry.npmjs.org/log4js/-/log4js-0.6.33.tgz",
           "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.33.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=4.3.3 <4.4.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             }
           }
         },
         "mime": {
           "version": "1.3.4",
-          "from": "mime@>=1.3.4 <2.0.0",
+          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "minimatch": {
           "version": "3.0.0",
-          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.3",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.3.0",
-                  "from": "balanced-match@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
@@ -12532,122 +11356,122 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.5.2",
-          "from": "rimraf@>=2.3.3 <3.0.0",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
         },
         "socket.io": {
           "version": "1.4.5",
-          "from": "socket.io@>=1.4.5 <2.0.0",
+          "from": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.5.tgz",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.5.tgz",
           "dependencies": {
             "engine.io": {
               "version": "1.6.8",
-              "from": "engine.io@1.6.8",
+              "from": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.8.tgz",
               "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.8.tgz",
               "dependencies": {
                 "base64id": {
                   "version": "0.1.0",
-                  "from": "base64id@0.1.0",
+                  "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
                 },
                 "ws": {
                   "version": "1.0.1",
-                  "from": "ws@1.0.1",
+                  "from": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
                   "dependencies": {
                     "options": {
                       "version": "0.0.6",
-                      "from": "options@>=0.0.5",
+                      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     },
                     "ultron": {
                       "version": "1.0.2",
-                      "from": "ultron@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                     }
                   }
                 },
                 "engine.io-parser": {
                   "version": "1.2.4",
-                  "from": "engine.io-parser@1.2.4",
+                  "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
                   "dependencies": {
                     "after": {
                       "version": "0.8.1",
-                      "from": "after@0.8.1",
+                      "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
                       "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
                     },
                     "arraybuffer.slice": {
                       "version": "0.0.6",
-                      "from": "arraybuffer.slice@0.0.6",
+                      "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
                     },
                     "base64-arraybuffer": {
                       "version": "0.1.2",
-                      "from": "base64-arraybuffer@0.1.2",
+                      "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
                     },
                     "blob": {
                       "version": "0.0.4",
-                      "from": "blob@0.0.4",
+                      "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
                     },
                     "has-binary": {
                       "version": "0.1.6",
-                      "from": "has-binary@0.1.6",
+                      "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                       "dependencies": {
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         }
                       }
                     },
                     "utf8": {
                       "version": "2.1.0",
-                      "from": "utf8@2.1.0",
+                      "from": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
                     }
                   }
                 },
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@1.1.4",
+                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "mime-db@>=1.12.0 <1.13.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.4.9",
-                      "from": "negotiator@0.4.9",
+                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                     }
                   }
@@ -12656,125 +11480,125 @@
             },
             "socket.io-parser": {
               "version": "2.2.6",
-              "from": "socket.io-parser@2.2.6",
+              "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
               "dependencies": {
                 "json3": {
                   "version": "3.3.2",
-                  "from": "json3@3.3.2",
+                  "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
                 },
                 "component-emitter": {
                   "version": "1.1.2",
-                  "from": "component-emitter@1.1.2",
+                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 }
               }
             },
             "socket.io-client": {
               "version": "1.4.5",
-              "from": "socket.io-client@1.4.5",
+              "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.5.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.5.tgz",
               "dependencies": {
                 "engine.io-client": {
                   "version": "1.6.8",
-                  "from": "engine.io-client@1.6.8",
+                  "from": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.8.tgz",
                   "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.8.tgz",
                   "dependencies": {
                     "has-cors": {
                       "version": "1.1.0",
-                      "from": "has-cors@1.1.0",
+                      "from": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
                     },
                     "ws": {
                       "version": "1.0.1",
-                      "from": "ws@1.0.1",
+                      "from": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
                       "dependencies": {
                         "options": {
                           "version": "0.0.6",
-                          "from": "options@>=0.0.5",
+                          "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                         },
                         "ultron": {
                           "version": "1.0.2",
-                          "from": "ultron@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                         }
                       }
                     },
                     "xmlhttprequest-ssl": {
                       "version": "1.5.1",
-                      "from": "xmlhttprequest-ssl@1.5.1",
+                      "from": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
                     },
                     "component-emitter": {
                       "version": "1.1.2",
-                      "from": "component-emitter@1.1.2",
+                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                     },
                     "engine.io-parser": {
                       "version": "1.2.4",
-                      "from": "engine.io-parser@1.2.4",
+                      "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
                       "dependencies": {
                         "after": {
                           "version": "0.8.1",
-                          "from": "after@0.8.1",
+                          "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
                           "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
                         },
                         "arraybuffer.slice": {
                           "version": "0.0.6",
-                          "from": "arraybuffer.slice@0.0.6",
+                          "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
                         },
                         "base64-arraybuffer": {
                           "version": "0.1.2",
-                          "from": "base64-arraybuffer@0.1.2",
+                          "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
                         },
                         "blob": {
                           "version": "0.0.4",
-                          "from": "blob@0.0.4",
+                          "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
                         },
                         "has-binary": {
                           "version": "0.1.6",
-                          "from": "has-binary@0.1.6",
+                          "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                           "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                           "dependencies": {
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             }
                           }
                         },
                         "utf8": {
                           "version": "2.1.0",
-                          "from": "utf8@2.1.0",
+                          "from": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
                         }
                       }
                     },
                     "parsejson": {
                       "version": "0.0.1",
-                      "from": "parsejson@0.0.1",
+                      "from": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
                               "version": "1.0.0",
-                              "from": "callsite@1.0.0",
+                              "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                             }
                           }
@@ -12783,17 +11607,17 @@
                     },
                     "parseqs": {
                       "version": "0.0.2",
-                      "from": "parseqs@0.0.2",
+                      "from": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
                               "version": "1.0.0",
-                              "from": "callsite@1.0.0",
+                              "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                             }
                           }
@@ -12802,49 +11626,49 @@
                     },
                     "component-inherit": {
                       "version": "0.0.3",
-                      "from": "component-inherit@0.0.3",
+                      "from": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
                     },
                     "yeast": {
                       "version": "0.1.2",
-                      "from": "yeast@0.1.2",
+                      "from": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
                     }
                   }
                 },
                 "component-bind": {
                   "version": "1.0.0",
-                  "from": "component-bind@1.0.0",
+                  "from": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
                 },
                 "component-emitter": {
                   "version": "1.2.0",
-                  "from": "component-emitter@1.2.0",
+                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
                 },
                 "object-component": {
                   "version": "0.0.3",
-                  "from": "object-component@0.0.3",
+                  "from": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
                 },
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "indexof@0.0.1",
+                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 },
                 "parseuri": {
                   "version": "0.0.4",
-                  "from": "parseuri@0.0.4",
+                  "from": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
                   "dependencies": {
                     "better-assert": {
                       "version": "1.0.2",
-                      "from": "better-assert@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                       "dependencies": {
                         "callsite": {
                           "version": "1.0.0",
-                          "from": "callsite@1.0.0",
+                          "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                         }
                       }
@@ -12853,44 +11677,44 @@
                 },
                 "to-array": {
                   "version": "0.1.4",
-                  "from": "to-array@0.1.4",
+                  "from": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
                 },
                 "backo2": {
                   "version": "1.0.2",
-                  "from": "backo2@1.0.2",
+                  "from": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
                 }
               }
             },
             "socket.io-adapter": {
               "version": "0.4.0",
-              "from": "socket.io-adapter@0.4.0",
+              "from": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
               "dependencies": {
                 "socket.io-parser": {
                   "version": "2.2.2",
-                  "from": "socket.io-parser@2.2.2",
+                  "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
                   "dependencies": {
                     "debug": {
                       "version": "0.7.4",
-                      "from": "debug@0.7.4",
+                      "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                     },
                     "json3": {
                       "version": "3.2.6",
-                      "from": "json3@3.2.6",
+                      "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
                       "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
                     },
                     "component-emitter": {
                       "version": "1.1.2",
-                      "from": "component-emitter@1.1.2",
+                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     }
                   }
@@ -12899,24 +11723,24 @@
             },
             "has-binary": {
               "version": "0.1.7",
-              "from": "has-binary@0.1.7",
+              "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
               "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
               "dependencies": {
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 }
               }
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
@@ -12925,17 +11749,17 @@
         },
         "source-map": {
           "version": "0.5.3",
-          "from": "source-map@>=0.5.3 <0.6.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
         },
         "useragent": {
           "version": "2.1.8",
-          "from": "useragent@>=2.1.6 <3.0.0",
+          "from": "https://registry.npmjs.org/useragent/-/useragent-2.1.8.tgz",
           "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.8.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.2.4",
-              "from": "lru-cache@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
             }
           }
@@ -12944,91 +11768,91 @@
     },
     "karma-browserstack-launcher": {
       "version": "0.1.10",
-      "from": "karma-browserstack-launcher@0.1.10",
+      "from": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-0.1.10.tgz",
       "resolved": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-0.1.10.tgz",
       "dependencies": {
         "browserstack": {
           "version": "1.3.1",
-          "from": "browserstack@1.3.1",
+          "from": "https://registry.npmjs.org/browserstack/-/browserstack-1.3.1.tgz",
           "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.3.1.tgz"
         },
         "browserstacktunnel-wrapper": {
           "version": "1.4.2",
-          "from": "browserstacktunnel-wrapper@>=1.4.2 <1.5.0",
+          "from": "https://registry.npmjs.org/browserstacktunnel-wrapper/-/browserstacktunnel-wrapper-1.4.2.tgz",
           "resolved": "https://registry.npmjs.org/browserstacktunnel-wrapper/-/browserstacktunnel-wrapper-1.4.2.tgz",
           "dependencies": {
             "unzip": {
               "version": "0.1.11",
-              "from": "unzip@>=0.1.9 <0.2.0",
+              "from": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
               "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
               "dependencies": {
                 "fstream": {
                   "version": "0.1.31",
-                  "from": "fstream@>=0.1.30 <1.0.0",
+                  "from": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "3.0.8",
-                      "from": "graceful-fs@>=3.0.2 <3.1.0",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "minimist@0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "rimraf": {
                       "version": "2.5.2",
-                      "from": "rimraf@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
                       "dependencies": {
                         "glob": {
                           "version": "7.0.3",
-                          "from": "glob@>=7.0.0 <8.0.0",
+                          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                           "dependencies": {
                             "inflight": {
                               "version": "1.0.4",
-                              "from": "inflight@>=1.0.4 <2.0.0",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                 }
                               }
                             },
                             "minimatch": {
                               "version": "3.0.0",
-                              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.3",
-                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.3.0",
-                                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                                     },
                                     "concat-map": {
                                       "version": "0.0.1",
-                                      "from": "concat-map@0.0.1",
+                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                     }
                                   }
@@ -13037,19 +11861,19 @@
                             },
                             "once": {
                               "version": "1.3.3",
-                              "from": "once@>=1.3.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                 }
                               }
                             },
                             "path-is-absolute": {
                               "version": "1.0.0",
-                              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                             }
                           }
@@ -13060,85 +11884,85 @@
                 },
                 "pullstream": {
                   "version": "0.4.1",
-                  "from": "pullstream@>=0.4.1 <1.0.0",
+                  "from": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
                   "dependencies": {
                     "over": {
                       "version": "0.0.5",
-                      "from": "over@>=0.0.5 <1.0.0",
+                      "from": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz"
                     },
                     "slice-stream": {
                       "version": "1.0.0",
-                      "from": "slice-stream@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz"
                     }
                   }
                 },
                 "binary": {
                   "version": "0.3.0",
-                  "from": "binary@>=0.3.0 <1.0.0",
+                  "from": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
                   "dependencies": {
                     "chainsaw": {
                       "version": "0.1.0",
-                      "from": "chainsaw@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                       "dependencies": {
                         "traverse": {
                           "version": "0.3.9",
-                          "from": "traverse@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
                           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                         }
                       }
                     },
                     "buffers": {
                       "version": "0.1.1",
-                      "from": "buffers@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.31 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "setimmediate": {
                   "version": "1.0.4",
-                  "from": "setimmediate@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz"
                 },
                 "match-stream": {
                   "version": "0.0.2",
-                  "from": "match-stream@>=0.0.2 <1.0.0",
+                  "from": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
                   "dependencies": {
                     "buffers": {
                       "version": "0.1.1",
-                      "from": "buffers@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                     }
                   }
@@ -13149,7 +11973,7 @@
         },
         "q": {
           "version": "1.4.1",
-          "from": "q@>=1.4.1 <1.5.0",
+          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
         }
       }
@@ -13199,7 +12023,7 @@
     },
     "karma-jasmine": {
       "version": "0.3.7",
-      "from": "karma-jasmine@0.3.7",
+      "from": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.7.tgz",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.7.tgz"
     },
     "karma-junit-reporter": {
@@ -13228,79 +12052,79 @@
     },
     "karma-sauce-launcher": {
       "version": "0.3.1",
-      "from": "karma-sauce-launcher@0.3.1",
+      "from": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.3.1.tgz",
       "dependencies": {
         "q": {
           "version": "1.4.1",
-          "from": "q@>=1.4.1 <2.0.0",
+          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
         },
         "sauce-connect-launcher": {
           "version": "0.13.0",
-          "from": "sauce-connect-launcher@>=0.13.0 <0.14.0",
+          "from": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.13.0.tgz",
           "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.13.0.tgz",
           "dependencies": {
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@3.10.1",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "async": {
               "version": "1.4.0",
-              "from": "async@1.4.0",
+              "from": "https://registry.npmjs.org/async/-/async-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
             },
             "adm-zip": {
               "version": "0.4.7",
-              "from": "adm-zip@>=0.4.3 <0.5.0",
+              "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
               "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
             },
             "rimraf": {
               "version": "2.4.3",
-              "from": "rimraf@2.4.3",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
               "dependencies": {
                 "glob": {
                   "version": "5.0.15",
-                  "from": "glob@>=5.0.14 <6.0.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -13309,19 +12133,19 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
@@ -13332,41 +12156,41 @@
         },
         "saucelabs": {
           "version": "1.2.0",
-          "from": "saucelabs@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.2.0.tgz",
           "dependencies": {
             "https-proxy-agent": {
               "version": "1.0.0",
-              "from": "https-proxy-agent@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
               "dependencies": {
                 "agent-base": {
                   "version": "2.0.1",
-                  "from": "agent-base@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
                   "dependencies": {
                     "semver": {
                       "version": "5.0.3",
-                      "from": "semver@>=5.0.1 <5.1.0",
+                      "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
                     }
                   }
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "extend": {
                   "version": "3.0.0",
-                  "from": "extend@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 }
               }
@@ -13375,64 +12199,64 @@
         },
         "wd": {
           "version": "0.3.12",
-          "from": "wd@>=0.3.4 <0.4.0",
+          "from": "https://registry.npmjs.org/wd/-/wd-0.3.12.tgz",
           "resolved": "https://registry.npmjs.org/wd/-/wd-0.3.12.tgz",
           "dependencies": {
             "archiver": {
               "version": "0.14.4",
-              "from": "archiver@>=0.14.0 <0.15.0",
+              "from": "https://registry.npmjs.org/archiver/-/archiver-0.14.4.tgz",
               "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.14.4.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 },
                 "buffer-crc32": {
                   "version": "0.2.5",
-                  "from": "buffer-crc32@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz",
                   "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
                 },
                 "glob": {
                   "version": "4.3.5",
-                  "from": "glob@>=4.3.0 <4.4.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -13441,12 +12265,12 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -13455,64 +12279,64 @@
                 },
                 "lazystream": {
                   "version": "0.1.0",
-                  "from": "lazystream@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz"
                 },
                 "lodash": {
                   "version": "3.2.0",
-                  "from": "lodash@>=3.2.0 <3.3.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "tar-stream": {
                   "version": "1.1.5",
-                  "from": "tar-stream@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
                   "dependencies": {
                     "bl": {
                       "version": "0.9.5",
-                      "from": "bl@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz"
                     },
                     "end-of-stream": {
                       "version": "1.1.0",
-                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@>=1.3.0 <1.4.0",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
@@ -13521,29 +12345,29 @@
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <4.1.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "zip-stream": {
                   "version": "0.5.2",
-                  "from": "zip-stream@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.2.tgz",
                   "dependencies": {
                     "compress-commons": {
                       "version": "0.2.9",
-                      "from": "compress-commons@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.9.tgz",
                       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.9.tgz",
                       "dependencies": {
                         "crc32-stream": {
                           "version": "0.3.4",
-                          "from": "crc32-stream@>=0.3.1 <0.4.0",
+                          "from": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
                           "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz"
                         },
                         "node-int64": {
                           "version": "0.3.3",
-                          "from": "node-int64@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz",
                           "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz"
                         }
                       }
@@ -13554,47 +12378,47 @@
             },
             "async": {
               "version": "1.0.0",
-              "from": "async@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
             },
             "lodash": {
               "version": "3.9.3",
-              "from": "lodash@>=3.9.3 <3.10.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
             },
             "request": {
               "version": "2.55.0",
-              "from": "request@>=2.55.0 <2.56.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.5",
-                  "from": "bl@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -13603,249 +12427,249 @@
                 },
                 "caseless": {
                   "version": "0.9.0",
-                  "from": "caseless@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "from": "forever-agent@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "async@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     }
                   }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.12.0",
-                      "from": "mime-db@>=1.12.0 <1.13.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.7",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "qs": {
                   "version": "2.4.2",
-                  "from": "qs@>=2.4.0 <2.5.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.2",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.2.2",
-                  "from": "tough-cookie@>=0.12.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "asn1@0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "ctype@0.5.3",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.6.0",
-                  "from": "oauth-sign@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
                 },
                 "hawk": {
                   "version": "2.3.1",
-                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.16.3",
-                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
                     "boom": {
                       "version": "2.10.1",
-                      "from": "boom@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "isstream@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "har-validator": {
                   "version": "1.8.0",
-                  "from": "har-validator@>=1.4.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                   "dependencies": {
                     "bluebird": {
                       "version": "2.10.2",
-                      "from": "bluebird@>=2.9.30 <3.0.0",
+                      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
                       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
                     },
                     "chalk": {
                       "version": "1.1.1",
-                      "from": "chalk@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.0",
-                          "from": "ansi-styles@>=2.1.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
                           "dependencies": {
                             "color-convert": {
                               "version": "1.0.0",
-                              "from": "color-convert@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
                             }
                           }
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "commander": {
                       "version": "2.9.0",
-                      "from": "commander@>=2.8.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "from": "graceful-readlink@>=1.0.0",
+                          "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.13.1",
-                      "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
-                          "from": "generate-function@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "from": "generate-object-property@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
-                              "from": "is-property@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "2.0.0",
-                          "from": "jsonpointer@2.0.0",
+                          "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                         },
                         "xtend": {
                           "version": "4.0.1",
-                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                         }
                       }
@@ -13856,12 +12680,12 @@
             },
             "underscore.string": {
               "version": "3.0.3",
-              "from": "underscore.string@>=3.0.3 <3.1.0",
+              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz"
             },
             "vargs": {
               "version": "0.1.0",
-              "from": "vargs@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz"
             }
           }
@@ -13959,12 +12783,12 @@
     },
     "lodash": {
       "version": "2.4.2",
-      "from": "lodash@2.4.2",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
     },
     "marked": {
       "version": "0.3.5",
-      "from": "marked@0.3.5",
+      "from": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
     },
     "node-html-encoder": {
@@ -13974,105 +12798,105 @@
     },
     "promises-aplus-tests": {
       "version": "2.1.1",
-      "from": "promises-aplus-tests@2.1.1",
+      "from": "https://registry.npmjs.org/promises-aplus-tests/-/promises-aplus-tests-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/promises-aplus-tests/-/promises-aplus-tests-2.1.1.tgz",
       "dependencies": {
         "mocha": {
           "version": "1.21.5",
-          "from": "mocha@>=1.21.4 <1.22.0",
+          "from": "https://registry.npmjs.org/mocha/-/mocha-1.21.5.tgz",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.21.5.tgz",
           "dependencies": {
             "commander": {
               "version": "2.3.0",
-              "from": "commander@2.3.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
             },
             "debug": {
               "version": "2.0.0",
-              "from": "debug@2.0.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2",
-                  "from": "ms@0.6.2",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "diff": {
               "version": "1.0.8",
-              "from": "diff@1.0.8",
+              "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
               "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@1.0.2",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "glob": {
               "version": "3.2.3",
-              "from": "glob@3.2.3",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.11 <0.3.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "growl": {
               "version": "1.8.1",
-              "from": "growl@1.8.1",
+              "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
               "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
             },
             "jade": {
               "version": "0.26.3",
-              "from": "jade@0.26.3",
+              "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
               "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
               "dependencies": {
                 "commander": {
                   "version": "0.6.1",
-                  "from": "commander@0.6.1",
+                  "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
                 },
                 "mkdirp": {
                   "version": "0.3.0",
-                  "from": "mkdirp@0.3.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
                 }
               }
             },
             "mkdirp": {
               "version": "0.5.0",
-              "from": "mkdirp@0.5.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
@@ -14081,83 +12905,83 @@
         },
         "sinon": {
           "version": "1.17.3",
-          "from": "sinon@>=1.10.3 <2.0.0",
+          "from": "https://registry.npmjs.org/sinon/-/sinon-1.17.3.tgz",
           "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.3.tgz",
           "dependencies": {
             "formatio": {
               "version": "1.1.1",
-              "from": "formatio@1.1.1",
+              "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
             },
             "util": {
               "version": "0.10.3",
-              "from": "util@>=0.10.3 <1.0.0",
+              "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "lolex": {
               "version": "1.3.2",
-              "from": "lolex@1.3.2",
+              "from": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz"
             },
             "samsam": {
               "version": "1.1.2",
-              "from": "samsam@1.1.2",
+              "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
             }
           }
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@>=1.6.0 <1.7.0",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
     },
     "protractor": {
       "version": "2.5.1",
-      "from": "protractor@2.5.1",
+      "from": "https://registry.npmjs.org/protractor/-/protractor-2.5.1.tgz",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-2.5.1.tgz",
       "dependencies": {
         "request": {
           "version": "2.57.0",
-          "from": "request@>=2.57.0 <2.58.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.57.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.57.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.5",
-              "from": "bl@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -14166,32 +12990,32 @@
             },
             "caseless": {
               "version": "0.10.0",
-              "from": "caseless@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "0.2.0",
-              "from": "form-data@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
@@ -14200,227 +13024,227 @@
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.0.14",
-              "from": "mime-types@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.12.0",
-                  "from": "mime-db@>=1.12.0 <1.13.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "qs": {
               "version": "3.1.0",
-              "from": "qs@>=3.1.0 <3.2.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.2",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             },
             "tough-cookie": {
               "version": "2.2.2",
-              "from": "tough-cookie@>=0.12.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
             },
             "http-signature": {
               "version": "0.11.0",
-              "from": "http-signature@>=0.11.0 <0.12.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "asn1@0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "ctype@0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "oauth-sign": {
               "version": "0.8.1",
-              "from": "oauth-sign@>=0.8.0 <0.9.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
             },
             "hawk": {
               "version": "2.3.1",
-              "from": "hawk@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "boom": {
                   "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
               "version": "1.8.0",
-              "from": "har-validator@>=1.6.1 <2.0.0",
+              "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
               "dependencies": {
                 "bluebird": {
                   "version": "2.10.2",
-                  "from": "bluebird@>=2.9.30 <3.0.0",
+                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
                   "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
                 },
                 "chalk": {
                   "version": "1.1.1",
-                  "from": "chalk@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.0",
-                      "from": "ansi-styles@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
                       "dependencies": {
                         "color-convert": {
                           "version": "1.0.0",
-                          "from": "color-convert@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
                         }
                       }
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "from": "supports-color@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.8.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.13.1",
-                  "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
+                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
@@ -14431,54 +13255,54 @@
         },
         "selenium-webdriver": {
           "version": "2.47.0",
-          "from": "selenium-webdriver@2.47.0",
+          "from": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.47.0.tgz",
           "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.47.0.tgz",
           "dependencies": {
             "rimraf": {
               "version": "2.5.2",
-              "from": "rimraf@>=2.2.8 <3.0.0",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
               "dependencies": {
                 "glob": {
                   "version": "7.0.3",
-                  "from": "glob@>=7.0.0 <8.0.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -14487,19 +13311,19 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
@@ -14508,54 +13332,54 @@
             },
             "tmp": {
               "version": "0.0.24",
-              "from": "tmp@0.0.24",
+              "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
               "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
             },
             "ws": {
               "version": "0.8.1",
-              "from": "ws@>=0.8.0 <0.9.0",
+              "from": "https://registry.npmjs.org/ws/-/ws-0.8.1.tgz",
               "resolved": "https://registry.npmjs.org/ws/-/ws-0.8.1.tgz",
               "dependencies": {
                 "options": {
                   "version": "0.0.6",
-                  "from": "options@>=0.0.5",
+                  "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                 },
                 "ultron": {
                   "version": "1.0.2",
-                  "from": "ultron@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                 },
                 "bufferutil": {
                   "version": "1.2.1",
-                  "from": "bufferutil@>=1.2.0 <1.3.0",
+                  "from": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.2.1.tgz",
                   "dependencies": {
                     "bindings": {
                       "version": "1.2.1",
-                      "from": "bindings@>=1.2.0 <1.3.0",
+                      "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                     },
                     "nan": {
                       "version": "2.2.0",
-                      "from": "nan@>=2.0.5 <3.0.0",
+                      "from": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
                     }
                   }
                 },
                 "utf-8-validate": {
                   "version": "1.2.1",
-                  "from": "utf-8-validate@>=1.2.0 <1.3.0",
+                  "from": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.2.1.tgz",
                   "dependencies": {
                     "bindings": {
                       "version": "1.2.1",
-                      "from": "bindings@>=1.2.0 <1.3.0",
+                      "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                     },
                     "nan": {
                       "version": "2.2.0",
-                      "from": "nan@>=2.0.5 <3.0.0",
+                      "from": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
                     }
                   }
@@ -14564,22 +13388,22 @@
             },
             "xml2js": {
               "version": "0.4.4",
-              "from": "xml2js@0.4.4",
+              "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
               "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
               "dependencies": {
                 "sax": {
                   "version": "0.6.1",
-                  "from": "sax@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
                 },
                 "xmlbuilder": {
                   "version": "5.0.1",
-                  "from": "xmlbuilder@>=1.0.0",
+                  "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-5.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-5.0.1.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "4.6.1",
-                      "from": "lodash@>=4.0.0 <5.0.0",
+                      "from": "https://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz"
                     }
                   }
@@ -14590,73 +13414,73 @@
         },
         "minijasminenode": {
           "version": "1.1.1",
-          "from": "minijasminenode@1.1.1",
+          "from": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-1.1.1.tgz"
         },
         "jasminewd": {
           "version": "1.1.0",
-          "from": "jasminewd@1.1.0",
+          "from": "https://registry.npmjs.org/jasminewd/-/jasminewd-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/jasminewd/-/jasminewd-1.1.0.tgz"
         },
         "jasminewd2": {
           "version": "0.0.6",
-          "from": "jasminewd2@0.0.6",
+          "from": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.6.tgz",
           "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.6.tgz"
         },
         "jasmine": {
           "version": "2.3.2",
-          "from": "jasmine@2.3.2",
+          "from": "https://registry.npmjs.org/jasmine/-/jasmine-2.3.2.tgz",
           "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.3.2.tgz",
           "dependencies": {
             "exit": {
               "version": "0.1.2",
-              "from": "exit@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "jasmine-core": {
               "version": "2.3.4",
-              "from": "jasmine-core@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz",
               "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz"
             }
           }
         },
         "saucelabs": {
           "version": "1.0.1",
-          "from": "saucelabs@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.0.1.tgz",
           "dependencies": {
             "https-proxy-agent": {
               "version": "1.0.0",
-              "from": "https-proxy-agent@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
               "dependencies": {
                 "agent-base": {
                   "version": "2.0.1",
-                  "from": "agent-base@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
                   "dependencies": {
                     "semver": {
                       "version": "5.0.3",
-                      "from": "semver@>=5.0.1 <5.1.0",
+                      "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
                     }
                   }
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "extend": {
                   "version": "3.0.0",
-                  "from": "extend@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 }
               }
@@ -14665,27 +13489,27 @@
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.0 <3.3.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -14694,44 +13518,44 @@
         },
         "adm-zip": {
           "version": "0.4.4",
-          "from": "adm-zip@0.4.4",
+          "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "q": {
           "version": "1.0.0",
-          "from": "q@1.0.0",
+          "from": "https://registry.npmjs.org/q/-/q-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/q/-/q-1.0.0.tgz"
         },
         "source-map-support": {
           "version": "0.2.10",
-          "from": "source-map-support@>=0.2.6 <0.3.0",
+          "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
-              "from": "source-map@0.1.32",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
@@ -14740,12 +13564,12 @@
         },
         "html-entities": {
           "version": "1.1.3",
-          "from": "html-entities@>=1.1.1 <1.2.0",
+          "from": "https://registry.npmjs.org/html-entities/-/html-entities-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.1.3.tgz"
         },
         "accessibility-developer-tools": {
           "version": "2.6.0",
-          "from": "accessibility-developer-tools@>=2.6.0 <2.7.0",
+          "from": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.6.0.tgz",
           "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.6.0.tgz"
         }
       }
@@ -14757,37 +13581,37 @@
     },
     "q-io": {
       "version": "1.13.2",
-      "from": "q-io@1.13.2",
+      "from": "https://registry.npmjs.org/q-io/-/q-io-1.13.2.tgz",
       "resolved": "https://registry.npmjs.org/q-io/-/q-io-1.13.2.tgz",
       "dependencies": {
         "qs": {
           "version": "1.2.2",
-          "from": "qs@>=1.2.1 <2.0.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
         },
         "url2": {
           "version": "0.0.0",
-          "from": "url2@>=0.0.0 <0.0.1",
+          "from": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz"
         },
         "mime": {
           "version": "1.3.4",
-          "from": "mime@>=1.2.11 <2.0.0",
+          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "mimeparse": {
           "version": "0.1.4",
-          "from": "mimeparse@>=0.1.4 <0.2.0",
+          "from": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz"
         },
         "collections": {
           "version": "0.2.2",
-          "from": "collections@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
           "resolved": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
           "dependencies": {
             "weak-map": {
               "version": "1.0.0",
-              "from": "weak-map@1.0.0",
+              "from": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz"
             }
           }
@@ -14811,6 +13635,11 @@
       "from": "https://registry.npmjs.org/rewire/-/rewire-2.1.5.tgz",
       "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.1.5.tgz"
     },
+    "sax": {
+      "version": "1.2.1",
+      "from": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
+    },
     "semver": {
       "version": "4.0.3",
       "from": "https://registry.npmjs.org/semver/-/semver-4.0.3.tgz",
@@ -14830,6 +13659,11 @@
       "version": "0.2.2",
       "from": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "from": "strip-json-comments@latest",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt-contrib-compress": "~0.12.0",
     "grunt-contrib-connect": "~0.8.0",
     "grunt-contrib-copy": "~0.6.0",
-    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-jshint": "^1.0.0",
     "grunt-ddescribe-iit": "~0.0.1",
     "grunt-jasmine-node": "git://github.com/vojtajina/grunt-jasmine-node.git#fix-grunt-exit-code",
     "grunt-jscs": "^2.1.0",
@@ -48,7 +48,7 @@
     "gulp": "~3.8.0",
     "gulp-concat": "^2.4.1",
     "gulp-foreach": "0.0.1",
-    "gulp-jshint": "~1.4.2",
+    "gulp-jshint": "^2.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-sourcemaps": "^1.2.2",
     "gulp-uglify": "^1.0.1",
@@ -56,7 +56,8 @@
     "jasmine-core": "^2.4.0",
     "jasmine-node": "^2.0.0",
     "jasmine-reporters": "~1.0.1",
-    "jshint-stylish": "~1.0.0",
+    "jshint": "^2.9.1",
+    "jshint-stylish": "^2.1.0",
     "karma": "^0.13.19",
     "karma-browserstack-launcher": "^0.1.8",
     "karma-chrome-launcher": "^0.2.2",
@@ -80,7 +81,8 @@
     "semver": "~4.0.3",
     "shelljs": "~0.3.0",
     "sorted-object": "^1.0.0",
-    "stringmap": "^0.2.2"
+    "stringmap": "^0.2.2",
+    "strip-json-comments": "^2.0.1"
   },
   "licenses": [
     {

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -1,9 +1,10 @@
 {
   "extends": "../.jshintrc-base",
-  "browser": true,
   "eqeqeq": true,
   "eqnull": true,
   "globals": {
+    "window": false,
+
     /* auto/injector.js */
     "createInjector": false,
 

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -169,7 +169,7 @@ var
  * documentMode is an IE-only property
  * http://msdn.microsoft.com/en-us/library/ie/cc196988(v=vs.85).aspx
  */
-msie = document.documentMode;
+msie = window.document.documentMode;
 
 
 /**
@@ -1027,8 +1027,8 @@ var csp = function() {
   if (!isDefined(csp.rules)) {
 
 
-    var ngCspElement = (document.querySelector('[ng-csp]') ||
-                    document.querySelector('[data-ng-csp]'));
+    var ngCspElement = (window.document.querySelector('[ng-csp]') ||
+                    window.document.querySelector('[data-ng-csp]'));
 
     if (ngCspElement) {
       var ngCspAttribute = ngCspElement.getAttribute('ng-csp') ||
@@ -1103,7 +1103,7 @@ var jq = function() {
   var i, ii = ngAttrPrefixes.length, prefix, name;
   for (i = 0; i < ii; ++i) {
     prefix = ngAttrPrefixes[i];
-    if (el = document.querySelector('[' + prefix.replace(':', '\\:') + 'jq]')) {
+    if (el = window.document.querySelector('[' + prefix.replace(':', '\\:') + 'jq]')) {
       name = el.getAttribute(prefix + 'jq');
       break;
     }
@@ -1168,7 +1168,7 @@ function toJsonReplacer(key, value) {
     val = undefined;
   } else if (isWindow(value)) {
     val = '$WINDOW';
-  } else if (value &&  document === value) {
+  } else if (value &&  window.document === value) {
     val = '$DOCUMENT';
   } else if (isScope(value)) {
     val = '$SCOPE';
@@ -1620,7 +1620,7 @@ function bootstrap(element, modules, config) {
     element = jqLite(element);
 
     if (element.injector()) {
-      var tag = (element[0] === document) ? 'document' : startingTag(element);
+      var tag = (element[0] === window.document) ? 'document' : startingTag(element);
       //Encode angle brackets to prevent input from being sanitized to empty string #8683
       throw ngMinErr(
           'btstrpd',

--- a/src/angular.prefix
+++ b/src/angular.prefix
@@ -3,4 +3,4 @@
  * (c) 2010-2016 Google, Inc. http://angularjs.org
  * License: MIT
  */
-(function(window, document, undefined) {
+(function(window) {

--- a/src/angular.suffix
+++ b/src/angular.suffix
@@ -1,5 +1,5 @@
-  jqLite(document).ready(function() {
-    angularInit(document, bootstrap);
+  jqLite(window.document).ready(function() {
+    angularInit(window.document, bootstrap);
   });
 
-})(window, document);
+})(window);

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -232,7 +232,7 @@ function jqLiteBuildFragment(html, context) {
 }
 
 function jqLiteParseHTML(html, context) {
-  context = context || document;
+  context = context || window.document;
   var parsed;
 
   if ((parsed = SINGLE_TAG_REGEXP.exec(html))) {
@@ -258,7 +258,7 @@ function jqLiteWrapNode(node, wrapper) {
 
 
 // IE9-11 has no method "contains" in SVG element and in Node.prototype. Bug #10259.
-var jqLiteContains = Node.prototype.contains || function(arg) {
+var jqLiteContains = window.Node.prototype.contains || function(arg) {
   // jshint bitwise: false
   return !!(this.compareDocumentPosition(arg) & 16);
   // jshint bitwise: true
@@ -530,8 +530,8 @@ var JQLitePrototype = JQLite.prototype = {
     }
 
     // check if document is already loaded
-    if (document.readyState === 'complete') {
-      setTimeout(trigger);
+    if (window.document.readyState === 'complete') {
+      window.setTimeout(trigger);
     } else {
       this.on('DOMContentLoaded', trigger); // works for modern browsers and IE9
       // we can not use jqLite since we are not done loading and jQuery could be loaded later.

--- a/src/module.prefix
+++ b/src/module.prefix
@@ -3,4 +3,4 @@
  * (c) 2010-2016 Google, Inc. http://angularjs.org
  * License: MIT
  */
-(function(window, angular, undefined) {
+(function(window, angular) {

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1274,7 +1274,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
              $controller,   $rootScope,   $sce,   $animate,   $$sanitizeUri) {
 
     var SIMPLE_ATTR_NAME = /^\w/;
-    var specialAttrHolder = document.createElement('div');
+    var specialAttrHolder = window.document.createElement('div');
 
 
 
@@ -1605,7 +1605,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       if (debugInfoEnabled) {
         content = ' ' + (directiveName || '') + ': ' + (comment || '') + ' ';
       }
-      return document.createComment(content);
+      return window.document.createComment(content);
     };
 
     return compile;
@@ -2308,7 +2308,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             replaceDirective = directive;
           }
 
+          /* jshint -W021 */
           nodeLinkFn = compileTemplateUrl(directives.splice(i, directives.length - i), $compileNode,
+          /* jshint +W021 */
               templateAttrs, jqCollection, hasTranscludeDirective && childTranscludeFn, preLinkFns, postLinkFns, {
                 controllerDirectives: controllerDirectives,
                 newScopeDirective: (newScopeDirective !== directive) && newScopeDirective,
@@ -2914,7 +2916,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       switch (type) {
       case 'svg':
       case 'math':
-        var wrapper = document.createElement('div');
+        var wrapper = window.document.createElement('div');
         wrapper.innerHTML = '<' + type + '>' + template + '</' + type + '>';
         return wrapper.childNodes[0].childNodes;
       default:
@@ -3058,7 +3060,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       // - remove them from the DOM
       // - allow them to still be traversed with .nextSibling
       // - allow a single fragment.qSA to fetch all elements being removed
-      var fragment = document.createDocumentFragment();
+      var fragment = window.document.createDocumentFragment();
       for (i = 0; i < removeCount; i++) {
         fragment.appendChild(elementsToRemove[i]);
       }

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -292,7 +292,7 @@ var ngIncludeFillContentDirective = ['$compile',
           // support innerHTML, so detect this here and try to generate the contents
           // specially.
           $element.empty();
-          $compile(jqLiteBuildFragment(ctrl.template, document).childNodes)(scope,
+          $compile(jqLiteBuildFragment(ctrl.template, window.document).childNodes)(scope,
               function namespaceAdaptedClone(clone) {
             $element.append(clone);
           }, {futureParentElement: $element});

--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -406,8 +406,8 @@ var ngOptionsDirective = ['$compile', '$parse', function($compile, $parse) {
 
   // we can't just jqLite('<option>') since jqLite is not smart enough
   // to create it in <select> and IE barfs otherwise.
-  var optionTemplate = document.createElement('option'),
-      optGroupTemplate = document.createElement('optgroup');
+  var optionTemplate = window.document.createElement('option'),
+      optGroupTemplate = window.document.createElement('optgroup');
 
     function ngOptionsPostLink(scope, selectElement, attr, ctrls) {
 

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -34,7 +34,7 @@ var SelectController =
   //
   // We can't just jqLite('<option>') since jqLite is not smart enough
   // to create it in <select> and IE barfs otherwise.
-  self.unknownOption = jqLite(document.createElement('option'));
+  self.unknownOption = jqLite(window.document.createElement('option'));
   self.renderUnknownOption = function(val) {
     var unknownVal = '? ' + hashKey(val) + ' ?';
     self.unknownOption.val(unknownVal);

--- a/src/ng/urlUtils.js
+++ b/src/ng/urlUtils.js
@@ -6,7 +6,7 @@
 // doesn't know about mocked locations and resolves URLs to the real document - which is
 // exactly the behavior needed here.  There is little value is mocking these out for this
 // service.
-var urlParsingNode = document.createElement("a");
+var urlParsingNode = window.document.createElement("a");
 var originUrl = urlResolve(window.location.href);
 
 

--- a/src/ngAnimate/.jshintrc
+++ b/src/ngAnimate/.jshintrc
@@ -2,8 +2,9 @@
   "extends": "../../.jshintrc-base",
   "maxlen": false, /* ngAnimate docs contain wide tables */
   "newcap": false,
-  "browser": true,
   "globals": {
+    "window": false,
+
     "angular": false,
     "noop": false,
 

--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -174,7 +174,7 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
     }
 
     // IE9-11 has no method "contains" in SVG element and in Node.prototype. Bug #10259.
-    var contains = Node.prototype.contains || function(arg) {
+    var contains = window.Node.prototype.contains || function(arg) {
       // jshint bitwise: false
       return this === arg || !!(this.compareDocumentPosition(arg) & 16);
       // jshint bitwise: true

--- a/src/ngCookies/.jshintrc
+++ b/src/ngCookies/.jshintrc
@@ -1,7 +1,8 @@
 {
   "extends": "../../.jshintrc-base",
-  "browser": true,
   "globals": {
+    "window": false,
+
     "angular": false
   }
 }

--- a/src/ngLocale/.jshintrc
+++ b/src/ngLocale/.jshintrc
@@ -3,8 +3,9 @@
   "bitwise": false, /* locale files use bitwise operators */
   "maxlen": false, /* locale files are generated from a 3rd party library that has long lines */
   "eqeqeq": false,
-  "browser": true,
   "globals": {
+    "window": false,
+
     "angular": false
   },
   "-W041": false

--- a/src/ngMessageFormat/.jshintrc
+++ b/src/ngMessageFormat/.jshintrc
@@ -1,7 +1,8 @@
 {
   "extends": "../../.jshintrc-base",
-  "browser": true,
   "globals": {
+    "window": false,
+
     "angular": false,
     "goog": false // see src/module_closure.prefix
   }

--- a/src/ngMock/.jshintrc
+++ b/src/ngMock/.jshintrc
@@ -1,7 +1,8 @@
 {
   "extends": "../../.jshintrc-base",
-  "browser": true,
   "globals": {
+    "window": false,
+
     "angular": false,
     "expect": false,
     "jQuery": false

--- a/src/ngResource/.jshintrc
+++ b/src/ngResource/.jshintrc
@@ -1,7 +1,8 @@
 {
   "extends": "../../.jshintrc-base",
-  "browser": true,
   "globals": {
+    "window": false,
+
     "angular": false
   }
 }

--- a/src/ngRoute/.jshintrc
+++ b/src/ngRoute/.jshintrc
@@ -1,7 +1,8 @@
 {
   "extends": "../../.jshintrc-base",
-  "browser": true,
   "globals": {
+    "window": false,
+
     "angular": false,
     "ngRouteModule": false
   }

--- a/src/ngSanitize/.jshintrc
+++ b/src/ngSanitize/.jshintrc
@@ -1,7 +1,8 @@
 {
   "extends": "../../.jshintrc-base",
-  "browser": true,
   "globals": {
+    "window": false,
+
     "angular": false,
     "htmlSanitizeWriter": false
   }

--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -344,7 +344,7 @@ function htmlParser(html, handler) {
     mXSSAttempts--;
 
     // strip custom-namespaced attributes on IE<=11
-    if (document.documentMode <= 11) {
+    if (window.document.documentMode) {
       stripCustomNsAttrs(inertBodyElement);
     }
     html = inertBodyElement.innerHTML; //trigger mXSS
@@ -484,7 +484,7 @@ function htmlSanitizeWriter(buf, uriValidator) {
  * @param node Root element to process
  */
 function stripCustomNsAttrs(node) {
-  if (node.nodeType === Node.ELEMENT_NODE) {
+  if (node.nodeType === window.Node.ELEMENT_NODE) {
     var attrs = node.attributes;
     for (var i = 0, l = attrs.length; i < l; i++) {
       var attrNode = attrs[i];

--- a/src/ngScenario/.jshintrc
+++ b/src/ngScenario/.jshintrc
@@ -1,7 +1,8 @@
 {
   "extends": "../../.jshintrc-base",
-  "browser": true,
   "globals": {
+    "window": false,
+
     "angular": false,
     "includes": false,
     "asyncForEach": false,

--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -104,7 +104,7 @@ angular.scenario.matcher = angular.scenario.matcher || function(name, fn) {
  */
 angular.scenario.setUpAndRun = function(config) {
   var href = window.location.href;
-  var body = _jQuery(document.body);
+  var body = _jQuery(window.document.body);
   var output = [];
   var objModel = new angular.scenario.ObjectModel($runner);
 

--- a/src/ngScenario/angular-bootstrap.js
+++ b/src/ngScenario/angular-bootstrap.js
@@ -5,7 +5,7 @@
 (function(previousOnLoad) {
   var prefix = (function() {
     var filename = /(.*\/)angular-bootstrap.js(#(.*))?/;
-    var scripts = document.getElementsByTagName("script");
+    var scripts = window.document.getElementsByTagName("script");
     for (var j = 0; j < scripts.length; j++) {
       var src = scripts[j].src;
       if (src && src.match(filename)) {
@@ -16,11 +16,11 @@
   })();
 
   function addScript(path) {
-    document.write('<script type="text/javascript" src="' + prefix + path + '"></script>');
+    window.document.write('<script type="text/javascript" src="' + prefix + path + '"></script>');
   }
 
   function addCSS(path) {
-    document.write('<link rel="stylesheet" type="text/css" href="' + prefix + path + '"/>');
+    window.document.write('<link rel="stylesheet" type="text/css" href="' + prefix + path + '"/>');
   }
 
   window.onload = function() {
@@ -32,7 +32,7 @@
 
   addCSS("../../css/angular-scenario.css");
   addScript("../../lib/jquery/jquery.js");
-  document.write(
+  window.document.write(
     '<script type="text/javascript">' +
     'var _jQuery = jQuery.noConflict(true);' +
     '</script>'
@@ -54,7 +54,7 @@
   addScript("output/Xml.js");
 
   // Create the runner (which also sets up the global API)
-  document.write(
+  window.document.write(
     '<script type="text/javascript">' +
     '  var $runner = new angular.scenario.Runner(window);' +
     '</script>');

--- a/src/ngScenario/angular.prefix
+++ b/src/ngScenario/angular.prefix
@@ -3,5 +3,5 @@
  * (c) 2010-2016 Google, Inc. http://angularjs.org
  * License: MIT
  */
-(function(window, document){
+(function(window){
   var _jQuery = window.jQuery.noConflict(true);

--- a/src/ngScenario/angular.suffix
+++ b/src/ngScenario/angular.suffix
@@ -2,7 +2,7 @@ bindJQuery();
 publishExternalAPI(angular);
 
 var $runner = new angular.scenario.Runner(window),
-    scripts = document.getElementsByTagName('script'),
+    scripts = window.document.getElementsByTagName('script'),
     script = scripts[scripts.length - 1],
     config = {};
 
@@ -14,9 +14,9 @@ angular.forEach(script.attributes, function(attr) {
 });
 
 if (config.autotest) {
-  JQLite(document).ready(function() {
+  JQLite(window.document).ready(function() {
     angular.scenario.setUpAndRun(config);
   });
 }
-})(window, document);
+})(window);
 

--- a/src/ngScenario/browserTrigger.js
+++ b/src/ngScenario/browserTrigger.js
@@ -61,7 +61,7 @@
           evnt = new TransitionEvent(eventType, eventData);
         }
         catch (e) {
-          evnt = document.createEvent('TransitionEvent');
+          evnt = window.document.createEvent('TransitionEvent');
           evnt.initTransitionEvent(eventType, null, null, null, eventData.elapsedTime || 0);
         }
       }
@@ -74,14 +74,14 @@
           evnt = new AnimationEvent(eventType, eventData);
         }
         catch (e) {
-          evnt = document.createEvent('AnimationEvent');
+          evnt = window.document.createEvent('AnimationEvent');
           evnt.initAnimationEvent(eventType, null, null, null, eventData.elapsedTime || 0);
         }
       }
     } else if (/touch/.test(eventType) && supportsTouchEvents()) {
       evnt = createTouchEvent(element, eventType, x, y);
     } else {
-      evnt = document.createEvent('MouseEvents');
+      evnt = window.document.createEvent('MouseEvents');
       x = x || 0;
       y = y || 0;
       evnt.initMouseEvent(eventType, true, true, window, 0, x, y, x, y, pressed('ctrl'),
@@ -120,12 +120,12 @@
     if ('_cached' in supportsTouchEvents) {
       return supportsTouchEvents._cached;
     }
-    if (!document.createTouch || !document.createTouchList) {
+    if (!window.document.createTouch || !window.document.createTouchList) {
       supportsTouchEvents._cached = false;
       return false;
     }
     try {
-      document.createEvent('TouchEvent');
+      window.document.createEvent('TouchEvent');
     } catch (e) {
       supportsTouchEvents._cached = false;
       return false;
@@ -135,12 +135,12 @@
   }
 
   function createTouchEvent(element, eventType, x, y) {
-    var evnt = new Event(eventType);
+    var evnt = new window.Event(eventType);
     x = x || 0;
     y = y || 0;
 
-    var touch = document.createTouch(window, element, Date.now(), x, y, x, y);
-    var touches = document.createTouchList(touch);
+    var touch = window.document.createTouch(window, element, Date.now(), x, y, x, y);
+    var touches = window.document.createTouchList(touch);
 
     evnt.touches = touches;
 

--- a/src/ngScenario/dsl.js
+++ b/src/ngScenario/dsl.js
@@ -199,7 +199,7 @@ angular.scenario.dsl('binding', function() {
  */
 angular.scenario.dsl('input', function() {
   var chain = {};
-  var supportInputEvent = 'oninput' in document.createElement('div') && !(msie && msie <= 11);
+  var supportInputEvent = 'oninput' in window.document.createElement('div') && !msie;
 
   chain.enter = function(value, event) {
     return this.addFutureAction("input '" + this.name + "' enter '" + value + "'",

--- a/src/ngTouch/.jshintrc
+++ b/src/ngTouch/.jshintrc
@@ -1,7 +1,8 @@
 {
   "extends": "../../.jshintrc-base",
-  "browser": true,
   "globals": {
+    "window": false,
+
     "angular": false,
     "ngTouch": false
   }

--- a/test/modules/no_bootstrap.js
+++ b/test/modules/no_bootstrap.js
@@ -1,3 +1,4 @@
-// When runnint the modules test, then the page should not be bootstrapped.
-window.name = "NG_DEFER_BOOTSTRAP!";
+'use strict';
 
+// When running the modules test, then the page should not be bootstrapped.
+window.name = "NG_DEFER_BOOTSTRAP!";


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature: We're no longer assuming browser globals in `src/**/*.js` which will prevent issues like #13442 from happening in the future.

**What is the current behavior? (You can also link to an open issue here)**

Currently browser globals are assumed. This sometimes breaks tools like jsdom that make them available under `window` but not as globals; see e.g. #13442.

**What is the new behavior (if this is a feature change)?**

For the browser these changes shouldn't matter. In other environments browser globals are now taken from the `window` variable instead of the global.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:

Fixes #13442
