### PR TITLE
docs($httpBackend): updated response data api

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1420,7 +1420,7 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
    *      `{function([status,] data[, headers, statusText])
    *      | function(function(method, url, data, headers, params)}`
    *    – The respond method takes a set of static data to be returned or a function that can
-   *    return an array containing response status (number), response data (string), response
+   *    return an array containing response status (number), response data (Object | string), response
    *    headers (Object), and the text for the status (string). The respond method returns the
    *    `requestHandler` object for possible overrides.
    */
@@ -1610,7 +1610,7 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
    *    `{function([status,] data[, headers, statusText])
    *    | function(function(method, url, data, headers, params)}`
    *    – The respond method takes a set of static data to be returned or a function that can
-   *    return an array containing response status (number), response data (string), response
+   *    return an array containing response status (number), response data (Object | string), response
    *    headers (Object), and the text for the status (string). The respond method returns the
    *    `requestHandler` object for possible overrides.
    */
@@ -2330,7 +2330,7 @@ angular.module('ngMockE2E', ['ng']).config(['$provide', function($provide) {
  *    `{function([status,] data[, headers, statusText])
  *    | function(function(method, url, data, headers, params)}`
  *    – The respond method takes a set of static data to be returned or a function that can return
- *    an array containing response status (number), response data (string), response headers
+ *    an array containing response status (number), response data (Object | string), response headers
  *    (Object), and the text for the status (string).
  *  - passThrough – `{function()}` – Any request matching a backend definition with
  *    `passThrough` handler will be passed through to the real backend (an XHR request will be made


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update

**What is the current behavior? (You can also link to an open issue here)**
Missing return type in documentation for httpBackend requestHandler function

**What is the new behavior (if this is a feature change)?**
Added missing return type in documentation

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

Updated docs to reflect that response data can either be an object _or_ a string
