### PR TITLE
fix(loader): module.decorator order of operations is now irrelevant

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -203,7 +203,7 @@ function setupModuleLoader(window) {
            * @description
            * See {@link auto.$provide#decorator $provide.decorator()}.
            */
-          decorator: invokeLaterAndSetModuleName('$provide', 'decorator'),
+          decorator: invokeLaterAndSetModuleName('$provide', 'decorator', configBlocks),
 
           /**
            * @ngdoc method
@@ -349,10 +349,11 @@ function setupModuleLoader(window) {
          * @param {string} method
          * @returns {angular.Module}
          */
-        function invokeLaterAndSetModuleName(provider, method) {
+        function invokeLaterAndSetModuleName(provider, method, queue) {
+          if (!queue) queue = invokeQueue;
           return function(recipeName, factoryFunction) {
             if (factoryFunction && isFunction(factoryFunction)) factoryFunction.$$moduleName = name;
-            invokeQueue.push([provider, method, arguments]);
+            queue.push([provider, method, arguments]);
             return moduleInstance;
           };
         }

--- a/test/loaderSpec.js
+++ b/test/loaderSpec.js
@@ -48,7 +48,6 @@ describe('module loader', function() {
     expect(myModule.requires).toEqual(['other']);
     expect(myModule._invokeQueue).toEqual([
       ['$provide', 'constant', jasmine.objectContaining(['abc', 123])],
-      ['$provide', 'decorator', jasmine.objectContaining(['dk', 'dv'])],
       ['$provide', 'provider', jasmine.objectContaining(['sk', 'sv'])],
       ['$provide', 'factory', jasmine.objectContaining(['fk', 'fv'])],
       ['$provide', 'service', jasmine.objectContaining(['a', 'aa'])],
@@ -60,9 +59,21 @@ describe('module loader', function() {
     ]);
     expect(myModule._configBlocks).toEqual([
       ['$injector', 'invoke', jasmine.objectContaining(['config'])],
+      ['$provide', 'decorator', jasmine.objectContaining(['dk', 'dv'])],
       ['$injector', 'invoke', jasmine.objectContaining(['init2'])]
     ]);
     expect(myModule._runBlocks).toEqual(['runBlock']);
+  });
+
+
+  it("should not throw error when `module.decorator` is declared before provider that it decorates", function() {
+    angular.module('theModule', []).
+      decorator('theProvider', function($delegate) { return $delegate; }).
+      factory('theProvider', function() { return {}; });
+
+    expect(function() {
+      createInjector(['theModule']);
+    }).not.toThrow();
   });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
See #12382 

**What is the new behavior (if this is a feature change)?**
module.decorator declarations are now invoked via the configBlocks queue to ensure that the provider being decorated has been declared regardless of the order in which module.decorator is declared.

**Does this PR introduce a breaking change?**
Possibly.  If the same provider is decorated multiple times via a combination of module.decorator and $provide.decorator (via module.config), the decoration order may change now depending on declaration order of the module methods.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)

**Other information**:

I didn't ngdoc the added `queue` param of `invokeLaterAndSetModuleName` because this fn isn't publically exposed and `queue` wasn't doc'd for `invokeLater`.

module.decorator() is now processed via the configBlocks order of operations and:
- no longer throws if declared before the provider being decorated
- guarantees the correct provider will be decorated when multiple,
  same-name providers are defined

Closes: #12382
