### PR TITLE
docs(misc/Getting Started): Add spaces after markup headers

### DIFF
--- a/docs/content/misc/started.ngdoc
+++ b/docs/content/misc/started.ngdoc
@@ -16,9 +16,9 @@ becoming an Angular expert.
    starter app with a directory layout, test harness, and scripts to begin building your application.
 
 
-#Further Steps
+# Further Steps
 
-##Watch Videos
+## Watch Videos
 
 If you haven’t had a chance to watch the videos from the homepage, please check out:
 
@@ -29,13 +29,13 @@ If you haven’t had a chance to watch the videos from the homepage, please chec
 And visit our [YouTube channel](http://www.youtube.com/user/angularjs) for more AngularJS video presentations and
 tutorials.
 
-##Subscribe
+## Subscribe
 
 * Subscribe to the [mailing list](http://groups.google.com/forum/?fromgroups#!forum/angular).  Ask questions here!
 * Follow us on [Twitter](https://twitter.com/intent/follow?original_referer=http%3A%2F%2Fangularjs.org%2F&region=follow_link&screen_name=angularjs&source=followbutton&variant=2.0)
 * Add us to your circles on [Google+](https://plus.google.com/110323587230527980117/posts)
 
-##Read more
+## Read more
 
 The AngularJS documentation includes the {@link guide/index Developer Guide} covering concepts and the
 {@link ./api API Reference} for syntax and usage.


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Quick fix to the markdown.

**What is the current behavior? (You can also link to an open issue here)**
Markdown headers are not rendered correctly.

**What is the new behavior (if this is a feature change)?**
Markdown headers are rendered as such.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
