### PR TITLE
fix(injector): make sure we call Function.prototype.toString not an override

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -70,7 +70,7 @@ var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 var $injectorMinErr = minErr('$injector');
 
 function extractArgs(fn) {
-  var fnText = fn.toString().replace(STRIP_COMMENTS, ''),
+  var fnText = Function.prototype.toString.call(fn).replace(STRIP_COMMENTS, ''),
       args = fnText.match(ARROW_ARG) || fnText.match(FN_ARGS);
   return args;
 }

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -240,10 +240,10 @@ describe('injector', function() {
       expect(annotate($f_n0)).toEqual(['$a_']);
       expect($f_n0.$inject).toEqual(['$a_']);
     });
-    
+
     it('should handle functions with overridden toString', function() {
       function fn(a) {}
-      fn.toString = function () { return 'fn'; };
+      fn.toString = function() { return 'fn'; };
       expect(annotate(fn)).toEqual(['a']);
       expect(fn.$inject).toEqual(['a']);
     });

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -240,7 +240,13 @@ describe('injector', function() {
       expect(annotate($f_n0)).toEqual(['$a_']);
       expect($f_n0.$inject).toEqual(['$a_']);
     });
-
+    
+    it('should handle functions with overridden toString', function() {
+      function fn(a) {}
+      fn.toString = function () { return 'fn'; };
+      expect(annotate(fn)).toEqual(['a']);
+      expect(fn.$inject).toEqual(['a']);
+    });
 
     it('should throw on non function arg', function() {
       expect(function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

the injector uses fn.toString to extract function arguments

**What is the new behavior (if this is a feature change)?**

the injector uses Function.prototype.toString.call to avoid calling an override

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

use Function.prototype.toString.call instead of fn.toString, because the user might override the toString function of the "fn" instance, without knowing it's being used by the injector.
