### PR TITLE
docs(guide/Components): add note to output events

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -133,8 +133,13 @@ components should follow a few simple conventions:
     For a deletion, that means the component doesn't delete the `hero` itself, but sends it back to
     the owner component via the correct event.
     ```html
+        <editable-field on-update="$ctrl.update('location', value)"></editable-field><br>
         <button ng-click="$ctrl.onDelete({hero: $ctrl.hero})">Delete</button>
     ```
+    <div class="alert alert-warning">
+      Remember to convert from camelCase (onDelete, onUpdate) to snake-case (on-delete, on-update) for each bound event name 
+      in the parent component's template (ie.. onUpdate: '&' => on-update="expression").
+    </div>
   - That way, the parent component can decide what to do with the event (e.g. delete an item or update the properties)
     ```js
       ctrl.deleteHero(hero) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs clarification and additional line added to example

**What is the current behavior? (You can also link to an open issue here)**
Currently the example for using output events doesn't include an attribute binding example from a parent component/directive. Others are finding the lack of example confusing here:  http://stackoverflow.com/questions/35559354/the-in-angular-1-5-components/35560611

**What is the new behavior (if this is a feature change)?**
- Include line of code pulled from full example demonstrating Output event's use in parent component
- Add note clarifying camelCase to snake-case requirement to use the Output event callback feature on components

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
