### PR TITLE
docs(guide/Components): small single letter typo

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -133,7 +133,7 @@ components should follow a few simple conventions:
     For a deletion, that means the component doesn't delete the `hero` itself, but sends it back to
     the owner component via the correct event.
     ```html
-        <!-- not that we use snake case for bindings in the template as usual -->
+        <!-- note that we use snake case for bindings in the template as usual -->
         <editable-field on-update="$ctrl.update('location', value)"></editable-field><br>
         <button ng-click="$ctrl.onDelete({hero: $ctrl.hero})">Delete</button>
     ```


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update: typo

**What is the current behavior? (You can also link to an open issue here)**
Word 'note' is misspelled 'not': introduced in another PR I just worked on that was just merged: https://github.com/angular/angular.js/commit/a1e63c8d4a67d1f720bbdbe157432053e27b7a71

**What is the new behavior (if this is a feature change)?**
'not' => 'note'

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

line 136: 'not' should be 'note'
