### PR TITLE
perf(ngClass): optimize the case of static map of classes of large objects

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -80,7 +80,11 @@ function classDirective(name, selector) {
               updateClasses(oldClasses, newClasses);
             }
           }
-          oldVal = shallowCopy(newVal);
+          if (isArray(newVal)) {
+            oldVal = newVal.map(function(v) { return shallowCopy(v); });
+          } else {
+            oldVal = shallowCopy(newVal);
+          }
         }
       }
     };

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -1,6 +1,7 @@
 'use strict';
 
 function classDirective(name, selector) {
+  var staticMapClassRegEx = /^\s*(::)?\s*\{/;
   name = 'ngClass' + name;
   return ['$animate', function($animate) {
     return {
@@ -8,7 +9,8 @@ function classDirective(name, selector) {
       link: function(scope, element, attr) {
         var oldVal;
 
-        scope.$watch(attr[name], ngClassWatchAction, true);
+        // shortcut: if it is clearly a map of classes do not copy values, they are supposed to be boolean (truly/falsy)
+        scope[staticMapClassRegEx.test(attr[name]) ? '$watchCollection' : '$watch'](attr[name], ngClassWatchAction, true);
 
         attr.$observe('class', function(value) {
           ngClassWatchAction(scope.$eval(attr[name]));

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -409,6 +409,37 @@ describe('ngClass', function() {
     expect(e2.hasClass('even')).toBeTruthy();
     expect(e2.hasClass('odd')).toBeFalsy();
   }));
+
+  describe('large objects', function() {
+
+    var verylargeobject, getProp;
+    beforeEach(function() {
+      getProp = jasmine.createSpy('getProp');
+      verylargeobject = {};
+      Object.defineProperty(verylargeobject, 'prop', {
+        get: getProp,
+        enumerable: true
+      });
+    });
+
+    it('should not copy large objects via hard map of classes', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-class="{foo: verylargeobject}"></div>')($rootScope);
+      $rootScope.verylargeobject = verylargeobject;
+      $rootScope.$digest();
+
+      expect(getProp).not.toHaveBeenCalled();
+    }));
+
+    it('should not copy large objects via hard map of classes in one-time binding', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-class="::{foo: verylargeobject}"></div>')($rootScope);
+      $rootScope.verylargeobject = verylargeobject;
+      $rootScope.$digest();
+
+      expect(getProp).not.toHaveBeenCalled();
+    }));
+  });
+
+
 });
 
 describe('ngClass animations', function() {

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -410,6 +410,17 @@ describe('ngClass', function() {
     expect(e2.hasClass('odd')).toBeFalsy();
   }));
 
+  it('should support mixed array/object variable with a mutating object', inject(function($rootScope, $compile) {
+    $rootScope.classVar = ['', {orange: true}];
+    element = $compile('<div class="existing" ng-class="classVar"></div>')($rootScope);
+    $rootScope.$digest();
+
+    $rootScope.classVar[1].orange = false;
+    $rootScope.$digest();
+
+    expect(element.hasClass('orange')).toBeFalsy();
+  }));
+
   describe('large objects', function() {
 
     var verylargeobject, getProp;
@@ -438,7 +449,6 @@ describe('ngClass', function() {
       expect(getProp).not.toHaveBeenCalled();
     }));
   });
-
 
 });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**: performance optimization of the ngClass

**What is the current behavior? (You can also link to an open issue here)**: when there is an ngClass with an object, it makes a deep copy of all its values, although it only needs to check for truly or falsy. It is because it uses `$watch(,, true)`.

**What is the new behavior (if this is a feature change)?**: it tries to statically detect the case of `ng-class="{foo: bar, ...}"` case and then do a `$watchCollection(,)` instead of a `$watch(,, true)`. Its a mere and simple test against initial attribute value.

**Does this PR introduce a breaking change?**: nop

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)

**Other information**:

Time to time, working with my customers, they ask to me to make performance tasks: they give me access to angular projects and they ask me to optimize them. One of the mistakes that I found many times is to do the following:

``` html
<div ng-class="{friendly: user.friends}">
  ...
</div>
```

because `user.friends` is truly (it has a value) or falsy (it is undefined or null) it works, but some times with truly values, associated data can be big taking up to seconds perform some copy (imagine that friends are not ids but objects with more relationships, ...), in such cases,  always give _white papers_ asking for things like:

``` html
<div ng-class="{friendly: !!user.friends}">
  ...
</div>
```

which solves all performance problems, or if it is only one class do something like:

``` html
<div ng-class="user.friends && 'friendly'">
  ...
</div>
```

which gives a string easy to copy and compare (but not so recommendable because not all designers or programmers understand it easily and difficult to express more than one class)

The current solution that I give is simple, fast to compute, and it works in 99% of the cases. I can try to do a custom changeDetector (like the one in $watchCollection) but I believe that it is not worth (I didn't know that arrays could be used to add classes). So it will work well in the initial example:

``` html
<div ng-class="{friendly: user.friends}">
  <!-- new: starts with { so it becomes optimized through $watchCollection -->
  ...
</div>
```

but:

```
<div ng-init="classes = {friendly: user.friends}"></div>
<div ng-class="classes">
  <!-- new: does not starts with { so it is not optimized, not very common -->
  ...
</div>
```
