### PR TITLE
fix($compile): do not use `noop()` as controller for multiple components

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1092,7 +1092,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    * See also {@link ng.$compileProvider#directive $compileProvider.directive()}.
    */
   this.component = function registerComponent(name, options) {
-    var controller = options.controller || noop;
+    var controller = options.controller || function() {};
 
     function factory($injector) {
       function makeInjectable(fn) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -10494,7 +10494,7 @@ describe('$compile', function() {
     });
 
     it('should expose additional annotations on the directive definition object', function() {
-      var myModule = angular.module('my', []).component('myComponent', {
+      angular.module('my', []).component('myComponent', {
         $canActivate: 'canActivate',
         $routeConfig: 'routeConfig',
         $customAnnotation: 'XXX'
@@ -10510,7 +10510,7 @@ describe('$compile', function() {
     });
 
     it('should support custom annotations if the controller is named', function() {
-      var myModule = angular.module('my', []).component('myComponent', {
+      angular.module('my', []).component('myComponent', {
         $customAnnotation: 'XXX',
         controller: 'SomeNamedController'
       });
@@ -10519,6 +10519,24 @@ describe('$compile', function() {
         expect(myComponentDirective[0]).toEqual(jasmine.objectContaining({
           $customAnnotation: 'XXX'
         }));
+      });
+    });
+
+    it('should provide a new empty controller if none is specified', function() {
+      angular.
+        module('my', []).
+        component('myComponent1', {$customAnnotation1: 'XXX'}).
+        component('myComponent2', {$customAnnotation2: 'YYY'});
+      module('my');
+      inject(function(myComponent1Directive, myComponent2Directive) {
+        var ctrl1 = myComponent1Directive[0].controller;
+        var ctrl2 = myComponent2Directive[0].controller;
+
+        expect(ctrl1).not.toBe(ctrl2);
+        expect(ctrl1.$customAnnotation1).toBe('XXX');
+        expect(ctrl1.$customAnnotation2).toBeUndefined();
+        expect(ctrl2.$customAnnotation1).toBeUndefined();
+        expect(ctrl2.$customAnnotation2).toBe('YYY');
       });
     });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
#14391

**What is the new behavior (if this is a feature change)?**
A new function is used as controller for each component that does not specify one.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Currently, custom annotations are copied from the CDO onto the controller constructor.
Using `noop()` when no controller has been specified, pollutes it with custom annotations and makes one component's annotations available to all other components that have `noop()` as their controller.

Fixes #14391
