### PR TITLE
Fix ngClass mixed array/object when object instance does not changes

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -78,7 +78,11 @@ function classDirective(name, selector) {
               updateClasses(oldClasses, newClasses);
             }
           }
-          oldVal = shallowCopy(newVal);
+          if (isArray(newVal)) {
+            oldVal = newVal.map(function(v) { return shallowCopy(v); });
+          } else {
+            oldVal = shallowCopy(newVal);
+          }
         }
       }
     };

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -410,16 +410,20 @@ describe('ngClass', function() {
     expect(e2.hasClass('odd')).toBeFalsy();
   }));
 
-  it('should support changing multiple classes via variable array mixed with conditionally via a map', inject(function($rootScope, $compile) {
-    $rootScope.classVar = ['', {orange: true}];
-    element = $compile('<div class="existing" ng-class="classVar"></div>')($rootScope);
-    $rootScope.$digest();
+  it('should support mixed array/object variable with a mutating object',
+    inject(function($rootScope, $compile) {
+      element = $compile('<div ng-class="classVar"></div>')($rootScope);
 
-    $rootScope.classVar[1].orange = false;
-    $rootScope.$digest();
+      $rootScope.classVar = [{orange: true}];
+      $rootScope.$digest();
+      expect(element).toHaveClass('orange');
 
-    expect(element.hasClass('orange')).toBeFalsy();
-  }));
+      $rootScope.classVar[0].orange = false;
+      $rootScope.$digest();
+
+      expect(element).not.toHaveClass('orange');
+    })
+  );
 
 });
 

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -409,6 +409,18 @@ describe('ngClass', function() {
     expect(e2.hasClass('even')).toBeTruthy();
     expect(e2.hasClass('odd')).toBeFalsy();
   }));
+
+  it('should support changing multiple classes via variable array mixed with conditionally via a map', inject(function($rootScope, $compile) {
+    $rootScope.classVar = ['', {orange: true}];
+    element = $compile('<div class="existing" ng-class="classVar"></div>')($rootScope);
+    $rootScope.$digest();
+
+    $rootScope.classVar[1].orange = false;
+    $rootScope.$digest();
+
+    expect(element.hasClass('orange')).toBeFalsy();
+  }));
+
 });
 
 describe('ngClass animations', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)** bugfix

**What is the current behavior? (You can also link to an open issue here)**: when the expression is [{}] it does not tracks changes inside the object

``` javascript
  it('should support changing multiple classes via variable array mixed with conditionally via a map', inject(function($rootScope, $compile) {
    $rootScope.classVar = ['', {orange: true}];
    element = $compile('<div class="existing" ng-class="classVar"></div>')($rootScope);
    $rootScope.$digest();

    $rootScope.classVar[1].orange = false;
    $rootScope.$digest();

    expect(element.hasClass('orange')).toBeFalsy(); /// <<--- this fails before this patch
  }));
```

**What is the new behavior (if this is a feature change)?**: now it tracks changes correctly

**Does this PR introduce a breaking change?**: nop

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:

In this plnkr you can see the failure:
- http://plnkr.co/edit/f0V9RVDGREetSW00TTRZ?p=preview 

https://github.com/angular/angular.js/pull/14404 also fixes this problem by doing a refactor. (it tries to be a performance optimization) 
This PR can be combined into https://github.com/angular/angular.js/pull/14394 if you ask.
