### PR TITLE
fix($compile): still trigger `$onChanges` even if the inner value alr…

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3197,10 +3197,14 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             destination[scopeName] = parentGet(scope);
             initialChanges[scopeName] = new SimpleChange(_UNINITIALIZED_VALUE, destination[scopeName]);
 
-            removeWatch = scope.$watch(parentGet, function parentValueWatchAction(newParentValue) {
-              var oldValue = destination[scopeName];
-              recordChanges(scopeName, newParentValue, oldValue);
-              destination[scopeName] = newParentValue;
+            removeWatch = scope.$watch(parentGet, function parentValueWatchAction(newValue, oldValue) {
+              if (newValue === oldValue) {
+                // If the new and old values are identical then this is the first time the watch has been triggered
+                // So instead we use the current value on the destination as the old value
+                oldValue = destination[scopeName];
+              }
+              recordChanges(scopeName, newValue, oldValue);
+              destination[scopeName] = newValue;
             }, parentGet.literal);
 
             removeWatchCollection.push(removeWatch);
@@ -3233,7 +3237,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             onChangesQueue.push(triggerOnChangesHook);
           }
           // If the has been a change on this property already then we need to reuse the previous value
-          if (changes[key]) {
+          if (isDefined(changes[key])) {
             previousValue = changes[key].previousValue;
           }
           // Store this change

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3755,15 +3755,12 @@ describe('$compile', function() {
 
         module('my');
         inject(function($compile, $rootScope) {
-          $rootScope.getVal = function() { return $rootScope.val; };
           element = $compile('<c1 prop1="val"></c1>')($rootScope);
-          var isolateScope = element.isolateScope();
 
-          log = [];
           $rootScope.$apply('val = 1');
           expect(log.pop()).toEqual({prop1: jasmine.objectContaining({previousValue: undefined, currentValue: 1})});
 
-          isolateScope.$ctrl.prop1 = 2;
+          element.isolateScope().$ctrl.prop1 = 2;
           $rootScope.$apply('val = 2');
           expect(log.pop()).toEqual({prop1: jasmine.objectContaining({previousValue: 1, currentValue: 2})});
         });

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3742,6 +3742,34 @@ describe('$compile', function() {
       });
 
 
+      it('should trigger `$onChanges` even if the inner value already equals the new outer value', function() {
+        var log = [];
+        function TestController() { }
+        TestController.prototype.$onChanges = function(change) { log.push(change); };
+
+        angular.module('my', [])
+          .component('c1', {
+            controller: TestController,
+            bindings: { 'prop1': '<' }
+          });
+
+        module('my');
+        inject(function($compile, $rootScope) {
+          $rootScope.getVal = function() { return $rootScope.val; };
+          element = $compile('<c1 prop1="val"></c1>')($rootScope);
+          var isolateScope = element.isolateScope();
+
+          log = [];
+          $rootScope.$apply('val = 1');
+          expect(log.pop()).toEqual({prop1: jasmine.objectContaining({previousValue: undefined, currentValue: 1})});
+
+          isolateScope.$ctrl.prop1 = 2;
+          $rootScope.$apply('val = 2');
+          expect(log.pop()).toEqual({prop1: jasmine.objectContaining({previousValue: 1, currentValue: 2})});
+        });
+      });
+
+
       it('should pass the original value as `previousValue` even if there were multiple changes in a single digest', function() {
         var log = [];
         function TestController() { }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

fix

**What is the current behavior? (You can also link to an open issue here)**

the `$onChanges` hook is not getting called if the value on the controller is already set to the new value

A2 does trigger this value - see http://plnkr.co/edit/V15jwFA7e5zsWgLVLDKf?p=preview

**What is the new behavior (if this is a feature change)?**

now the hook is triggered

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

…eady matches the new value
