### PR TITLE
docs(guide/Scopes): add comma for readability

### DIFF
--- a/docs/content/guide/scope.ngdoc
+++ b/docs/content/guide/scope.ngdoc
@@ -257,7 +257,7 @@ the `$digest` phase. This delay is desirable, since it coalesces multiple model 
 
   2. **Watcher registration**
 
-     During template linking directives register {@link
+     During template linking, directives register {@link
      ng.$rootScope.Scope#$watch watches} on the scope. These watches will be
      used to propagate model values to the DOM.
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs update

**What is the current behavior? (You can also link to an open issue here)**
During template linking directives register watches on the scope

**What is the new behavior (if this is a feature change)?**
During template linking, directives register watches on the scope

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

docs(guide/Scopes): add comma for readability

Previous: During template linking directives register watches on the scope
New: During template linking, directives register watches on the scope
