### PR TITLE
docs(Module): fix parameter names for `decorate`

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -197,9 +197,9 @@ function setupModuleLoader(window) {
            * @ngdoc method
            * @name angular.Module#decorator
            * @module ng
-           * @param {string} The name of the service to decorate.
-           * @param {Function} This function will be invoked when the service needs to be
-           *                                    instantiated and should return the decorated service instance.
+           * @param {string} name The name of the service to decorate.
+           * @param {Function} decorFn This function will be invoked when the service needs to be
+           *                           instantiated and should return the decorated service instance.
            * @description
            * See {@link auto.$provide#decorator $provide.decorator()}.
            */


### PR DESCRIPTION
That's how the docs are rendered without this change:

> ![image](https://cloud.githubusercontent.com/assets/94334/14444320/5faad374-004d-11e6-86d3-25634346e5b9.png)
