### PR TITLE
revert: "fix(ngRoute): allow `ngView` to be included in an asynchronously loaded template"

### DIFF
--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -26,11 +26,12 @@ ngRouteModule.directive('ngView', ngViewFillContentFactory);
  *
  * The enter and leave animation occur concurrently.
  *
- * @knownIssue If `ngView` is contained in an asynchronously loaded templated (i.e. not directly
- *             inside your main HTML file, then you need to make sure that `$route` is instantiated
- *             in time to capture the initial `$locationChangeStart` event and load the appropriate
- *             view. One way to ensure `$route` will be instantiated in time, it to have it as a
- *             dependency in a `.run` block: `myModule.run(['$route', function() {}]);`
+ * @knownIssue If `ngView` is contained in an asynchronously loaded template (e.g. in another
+ *             directive's templateUrl or in a template loaded using `ngInclude`), then you need to
+ *             make sure that `$route` is instantiated in time to capture the initial
+ *             `$locationChangeStart` event and load the appropriate view. One way to achieve this
+ *             is to have it as a dependency in a `.run` block:
+ *             `myModule.run(['$route', function() {}]);`
  *
  * @scope
  * @priority 400

--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -26,6 +26,12 @@ ngRouteModule.directive('ngView', ngViewFillContentFactory);
  *
  * The enter and leave animation occur concurrently.
  *
+ * @knownIssue If `ngView` is contained in an asynchronously loaded templated (i.e. not directly
+ *             inside your main HTML file, then you need to make sure that `$route` is instantiated
+ *             in time to capture the initial `$locationChangeStart` event and load the appropriate
+ *             view. One way to ensure `$route` will be instantiated in time, it to have it as a
+ *             dependency in a `.run` block: `myModule.run(['$route', function() {}]);`
+ *
  * @scope
  * @priority 400
  * @param {string=} onload Expression to evaluate whenever the view updates.

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -17,11 +17,7 @@
  */
  /* global -ngRouteModule */
 var ngRouteModule = angular.module('ngRoute', ['ng']).
-                        provider('$route', $RouteProvider).
-                        // Ensure `$route` will be instantiated in time to capture the initial
-                        // `$locationChangeSuccess` event. This is necessary in case `ngView` is
-                        // included in an asynchronously loaded template.
-                        run(['$route', angular.noop]),
+                        provider('$route', $RouteProvider),
     $routeMinErr = angular.$$minErr('ngRoute');
 
 /**

--- a/test/ngRoute/directive/ngViewSpec.js
+++ b/test/ngRoute/directive/ngViewSpec.js
@@ -1027,34 +1027,3 @@ describe('ngView animations', function() {
     ));
   });
 });
-
-describe('ngView in async template', function() {
-  beforeEach(module('ngRoute'));
-  beforeEach(module(function($compileProvider, $provide, $routeProvider) {
-    $compileProvider.directive('asyncView', function() {
-      return {templateUrl: 'async-view.html'};
-    });
-
-    $provide.decorator('$templateRequest', function($timeout) {
-      return function() {
-        return $timeout(angular.identity, 500, false, '<ng-view></ng-view>');
-      };
-    });
-
-    $routeProvider.when('/', {template: 'Hello, world !'});
-  }));
-
-
-  it('should work correctly upon initial page load',
-    // Injecting `$location` here is necessary, so that it gets instantiated early
-    inject(function($compile, $location, $rootScope, $timeout) {
-      var elem = $compile('<async-view></async-view>')($rootScope);
-      $rootScope.$digest();
-      $timeout.flush(500);
-
-      expect(elem.text()).toBe('Hello, world !');
-
-      dealoc(elem);
-    })
-  );
-});

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -23,21 +23,6 @@ describe('$route', function() {
     dealoc(element);
   });
 
-  it('should be loaded upon initial load (even if `ngView` is loaded async)', function() {
-    module(function($routeProvider) {
-      $routeProvider.when('/', {template: 'Hello, world !'});
-    });
-
-    inject(function($location, $rootScope) {
-      $location.path('/');
-      $rootScope.$digest();
-    });
-
-    inject(function($route) {
-      expect($route.current).toBeDefined();
-    });
-  });
-
   it('should allow cancellation via $locationChangeStart via $routeChangeStart', function() {
     module(function($routeProvider) {
       $routeProvider.when('/Edit', {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix (regression).

**What is the current behavior? (You can also link to an open issue here)**
Eagerly loading `$route`, could break tests, because it might request the root or default route
template (something `$httpBackend` would know nothing about).
See #14337.

**What is the new behavior (if this is a feature change)?**
Tests don't break.
Also, this was added as a known issue in `ngView` docs.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
This reverts commit 5e37b2a.

It will be re-applied for `v1.6.x`, with a breaking change notice and possibly a way to disable
the feature is tests.

Fixes #14337
