### PR TITLE
feat($componentController): provide isolated scope if none is passed

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2226,12 +2226,8 @@ angular.mock.$ComponentControllerProvider = ['$compileProvider', function($compi
       // get the info of the component
       var directiveInfo = candidateDirectives[0];
       // create a scope if needed
-      if (!locals) {
-        locals = {};
-      }
-      if (!locals.$scope) {
-        locals.$scope = locals.$scope || $rootScope.$new(true);
-      }
+      locals = locals || {};
+      locals.$scope = locals.$scope || $rootScope.$new(true);
       return $controller(directiveInfo.controller, locals, bindings, ident || directiveInfo.controllerAs);
     };
   }];

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2196,8 +2196,8 @@ angular.mock.$ControllerDecorator = ['$delegate', function($delegate) {
  * A service that can be used to create instances of component controllers.
  * <div class="alert alert-info">
  * Be aware that the controller will be instantiated and attached to the scope as specified in
- * the component definition object. That means that you must always provide a `$scope` object
- * in the `locals` param.
+ * the component definition object. If you do not provide a `$scope` object in the `locals` param
+ * then the helper will create a new isolated scope as a child of `$rootScope`.
  * </div>
  * @param {string} componentName the name of the component whose controller we want to instantiate
  * @param {Object} locals Injection locals for Controller.
@@ -2207,7 +2207,7 @@ angular.mock.$ControllerDecorator = ['$delegate', function($delegate) {
  * @return {Object} Instance of requested controller.
  */
 angular.mock.$ComponentControllerProvider = ['$compileProvider', function($compileProvider) {
-  this.$get = ['$controller','$injector', function($controller,$injector) {
+  this.$get = ['$controller','$injector', '$rootScope', function($controller, $injector, $rootScope) {
     return function $componentController(componentName, locals, bindings, ident) {
       // get all directives associated to the component name
       var directives = $injector.get(componentName + 'Directive');
@@ -2225,6 +2225,13 @@ angular.mock.$ComponentControllerProvider = ['$compileProvider', function($compi
       }
       // get the info of the component
       var directiveInfo = candidateDirectives[0];
+      // create a scope if needed
+      if (!locals) {
+        locals = {};
+      }
+      if (!locals.$scope) {
+        locals.$scope = locals.$scope || $rootScope.$new(true);
+      }
       return $controller(directiveInfo.controller, locals, bindings, ident || directiveInfo.controllerAs);
     };
   }];

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -2089,6 +2089,26 @@ describe('ngMock', function() {
         }).toThrowError('Too many components found');
       });
     });
+
+    it('should create an isolated child of $rootScope, if no `$scope` local is provided', function() {
+      function TestController($scope) {
+        this.$scope = $scope;
+      }
+      module(function($compileProvider) {
+        $compileProvider.component('test', {
+          controller: TestController
+        });
+      });
+      inject(function($componentController, $rootScope) {
+        var $ctrl = $componentController('test');
+        expect($ctrl.$scope).toBeDefined();
+        expect($ctrl.$scope.$parent).toBe($rootScope);
+        // check it is isolated
+        $rootScope.a = 17;
+        $ctrl.$scope.a = 42;
+        expect($rootScope.a).toEqual(17);
+      });
+    });
   });
 });
 

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -2105,6 +2105,7 @@ describe('ngMock', function() {
         expect($ctrl.$scope.$parent).toBe($rootScope);
         // check it is isolated
         $rootScope.a = 17;
+        expect($ctrl.$scope.a).toBeUndefined();
         $ctrl.$scope.a = 42;
         expect($rootScope.a).toEqual(17);
       });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feat

**What is the current behavior? (You can also link to an open issue here)**

one must always provide a scope for the $componentController helper, which is annoying

**What is the new behavior (if this is a feature change)?**

now an isolated child of rootScope is created and used if no scope is provided

**Does this PR introduce a breaking change?**

Nope

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
