### PR TITLE
fix($componentController): expressions passed to $componentController '&'-bindings are now parsed

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -484,9 +484,10 @@ describe('component: heroDetail', function() {
   });
 
   it('should call the onDelete binding when a hero is deleted', function() {
+    scope.deleteFn = jasmine.createSpy('deleteSpy');
     component = $componentController('heroDetail',
       {$scope: scope},
-      {hero: hero, onDelete: jasmine.createSpy('deleteSpy')}
+      {hero: hero, onDelete: 'deleteFn(hero)'}
     );
 
     component.onDelete({hero: component.hero});

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -2110,6 +2110,43 @@ describe('ngMock', function() {
         expect($rootScope.a).toEqual(17);
       });
     });
+
+    it('should parse \'&\'-bindings which are expressions', function() {
+      function TestController($scope) {
+        this.$scope = $scope;
+      }
+      module(function($compileProvider) {
+        $compileProvider.component('test', {
+          controller: TestController,
+          bindings: {
+            exprBinding: '&',
+            namedExprBinding: '&somethingElse',
+            fnBinding: '&'
+          }
+        });
+      });
+      inject(function($componentController) {
+        var exprBindingSpy = jasmine.createSpy('exprBindingSpy');
+        var namedExprBindingSpy = jasmine.createSpy('namedExprBindingSpy');
+        var fnBindingSpy = jasmine.createSpy('fnBindingSpy');
+        var $scope = { parentFn: exprBindingSpy, otherParentFn: namedExprBindingSpy };
+        var ctrl = $componentController(
+          'test',
+          { $scope: $scope },
+          {
+            exprBinding: 'parentFn(arg)',
+            namedExprBinding: 'otherParentFn(arg)',
+            fnBinding: fnBindingSpy
+          }
+        );
+        ctrl.fnBinding({ arg: 'test' });
+        expect(fnBindingSpy).toHaveBeenCalledWith({ arg: 'test' });
+        ctrl.exprBinding({ arg: 'test2'});
+        expect(exprBindingSpy).toHaveBeenCalledWith('test2');
+        ctrl.namedExprBinding({ arg: 'test3' });
+        expect(namedExprBindingSpy).toHaveBeenCalledWith('test3');
+      });
+    });
   });
 });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
Behavior is explained in issue #14426.

**What is the new behavior (if this is a feature change)?**
The new behavior is the ability to pass expressions to `$componentController` `&`-bindings. Example:

``` javascript
  it('should call the onDelete binding when a hero is deleted', function() {
    scope.deleteFn = jasmine.createSpy('deleteSpy');
    component = $componentController('heroDetail',
      {$scope: scope},
      {hero: hero, onDelete: 'deleteFn(hero)'}
    );

    component.onDelete({hero: component.hero});
    expect(spy('deleteSpy')).toHaveBeenCalledWith(component.hero);
  });
```

The expression is parsed in a way similar to the parsing of a binding during the compilation of a component element.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
