### PR TITLE
fix($http): pass event object to `eventHandlers`/`uploadEventHandlers`

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -1276,13 +1276,17 @@ function $HttpProvider() {
         if (eventHandlers) {
           var applyHandlers = {};
           forEach(eventHandlers, function(eventHandler, key) {
-            applyHandlers[key] = function() {
+            applyHandlers[key] = function(event) {
               if (useApplyAsync) {
-                $rootScope.$applyAsync(eventHandler);
+                $rootScope.$applyAsync(callEventHandler);
               } else if ($rootScope.$$phase) {
-                eventHandler();
+                callEventHandler();
               } else {
-                $rootScope.$apply(eventHandler);
+                $rootScope.$apply(callEventHandler);
+              }
+
+              function callEventHandler() {
+                eventHandler(event);
               }
             };
           });

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1066,14 +1066,15 @@ describe('$http', function() {
         expect(mockXHR.$$events.progress).toEqual(jasmine.any(Function));
         expect(mockXHR.upload.$$events.progress).toEqual(jasmine.any(Function));
 
+        var eventObj = {};
         spyOn($rootScope, '$digest');
 
-        mockXHR.$$events.progress();
-        expect(progressFn).toHaveBeenCalledOnce();
+        mockXHR.$$events.progress(eventObj);
+        expect(progressFn).toHaveBeenCalledOnceWith(eventObj);
         expect($rootScope.$digest).toHaveBeenCalledTimes(1);
 
-        mockXHR.upload.$$events.progress();
-        expect(uploadProgressFn).toHaveBeenCalledOnce();
+        mockXHR.upload.$$events.progress(eventObj);
+        expect(uploadProgressFn).toHaveBeenCalledOnceWith(eventObj);
         expect($rootScope.$digest).toHaveBeenCalledTimes(2);
       });
     });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.

**What is the current behavior? (You can also link to an open issue here)**
The event object is not passed to the [upload]event handlers. Under cirtain circumstances, the `$rootScope` is passed as argument.
See #14436.

**What is the new behavior (if this is a feature change)?**
The event object is passed to the [upload]event handlers.

**Does this PR introduce a breaking change?**
(Depends on your point of view :stuck_out_tongue:)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Fixes #14436
