### PR TITLE
docs(plnkrOpener): open plnkr.co with HTTPS

### DIFF
--- a/docs/app/src/examples.js
+++ b/docs/app/src/examples.js
@@ -153,7 +153,7 @@ angular.module('examples', [])
 
             postData.description = ctrl.example.name;
 
-            formPostData('http://plnkr.co/edit/?p=preview', newWindow, postData);
+            formPostData('https://plnkr.co/edit/?p=preview', newWindow, postData);
           });
 
       };


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs update

**What is the current behavior? (You can also link to an open issue here)**
Currently, plnkr gets opened with an unencrypted HTTP-connection. As the AngularJS-website redirects all users from HTTP to HTTPS, Firefox complains about the redirection (and the sending of data from an encrypted to an unencrytped site) to plnkr with a warning pop-up.

**What is the new behavior (if this is a feature change)?**
Examples are no getting opened using a HTTPS connection.

**Does this PR introduce a breaking change?**
no

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
