### PR TITLE
chore(gitignore): exclude .log and .stackdump files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ npm-debug.log
 /tmp/
 /scripts/bower/bower-*
 .vscode
+*.log
+*.stackdump


### PR DESCRIPTION
Ignore those pesky .log files that are often generated by node and .stackdump, which is created by ConEmu.
