### PR TITLE
fix($parse): Handle sign of `-undefined` consistently

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1516,7 +1516,7 @@ ASTInterpreter.prototype = {
       if (isDefined(arg)) {
         arg = -arg;
       } else {
-        arg = 0;
+        arg = -0;
       }
       return context ? {value: arg} : arg;
     };

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1755,7 +1755,7 @@ describe('parser', function() {
         expect(scope.$eval("+'1'")).toEqual(+'1');
         expect(scope.$eval("-'1'")).toEqual(-'1');
         expect(scope.$eval("+undefined")).toEqual(0);
-        expect(scope.$eval("-undefined")).toBe(0);
+        expect(scope.$eval("-undefined")).toEqual(-0);
         expect(scope.$eval("+null")).toEqual(+null);
         expect(scope.$eval("-null")).toEqual(-null);
         expect(scope.$eval("+false")).toEqual(+false);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
fix

**What is the current behavior? (You can also link to an open issue here)**
When csp is enabled `$parse('-undefined')` is `0`

**What is the new behavior (if this is a feature change)?**
When csp is enabled `$parse('-undefined')` is `-0`

**Does this PR introduce a breaking change?**
No, this is the way it should work, and the way it works when csp is disabled.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)

**Other information**:

When csp is disabled, evaluating `-undefined` is `-0` and when csp is enabled
the evaluation is `0`. In most cases this is not an issue as `0 === -0`, but
there is an edge case as `1/0 === Infinity` and `1/-0 === -Infinity`
