### PR TITLE
docs(guide/Component Router): fix npm typo

### DIFF
--- a/docs/content/guide/component-router.ngdoc
+++ b/docs/content/guide/component-router.ngdoc
@@ -467,7 +467,7 @@ AngularJS itself via npm:
 
 ```bash
 npm init
-npm install@1.5.x angular --save
+npm install angular@1.5.x --save
 npm install @angular/router --save
 ```
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fix a npm install typo in the component router guide https://docs.angularjs.org/guide/component-router

**What is the current behavior? (You can also link to an open issue here)**

There is a typo for installing angular via npm in the component router guide

**What is the new behavior (if this is a feature change)?**

The typo is fixed

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

Fix a typo in npm install instructions
