### PR TITLE
docs($http): Add explanation for error status

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -451,9 +451,11 @@ function $HttpProvider() {
      *   - **statusText** – `{string}` – HTTP status text of the response.
      *
      * A response status code between 200 and 299 is considered a success status and
-     * will result in the success callback being called. Note that if the response is a redirect,
-     * XMLHttpRequest will transparently follow it, meaning that the error callback will not be
-     * called for such responses.
+     * will result in the success callback being called. Response status code other than
+     * the mentioned ones is considered as error status. The error callback is called in such case.
+     * Also, any negative status code is normalized to zero. Other codes are returned as such.
+     * Note that if the response is a redirect, XMLHttpRequest will transparently follow it, meaning
+     * that the error callback will not be called for such responses.
      *
      *
      * ## Shortcut methods


### PR DESCRIPTION
Add explanation for error status codes in $http call and line about normalization to zero in case of negative status code.
This alleviates confusion about status codes for which error callback would be called and final values to be expected from an erroneous call.
