### PR TITLE
fix($location) : initialize locationPrototype.$$absUrl to empty string

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -326,6 +326,12 @@ function LocationHashbangInHtml5Url(appBase, appBaseNoFile, hashPrefix) {
 var locationPrototype = {
 
   /**
+   * Ensure absolute url is initialized.
+   * @private
+   */
+  $$absUrl:'',
+
+  /**
    * Are we in html5 mode?
    * @private
    */

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -2537,6 +2537,18 @@ describe('$location', function() {
     it('should throw on url(urlString, stateObject)', function() {
       expectThrowOnStateChange(locationUrl);
     });
+
+    it('should not throw when base path is another domain', function() {
+      initService({html5Mode:true,hashPrefix: '!',supportHistory: true});
+      inject(
+        initBrowser({url:'http://domain.com/base/',basePath: 'http://otherdomain.com/base/'}),
+        function($location) {
+          expect(function() {
+            $location.absUrl();
+          }).not.toThrow();
+        }
+      );
+    });
   });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Initialize locationPrototype.$$absUrl to avoid a crash when base href and current location have different domains.

**What is the current behavior? (You can also link to an open issue here)**
#11091

**What is the new behavior (if this is a feature change)?**
Does not crash anymore.

**Does this PR introduce a breaking change?**
I don't think so...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Closes #11091
