### PR TITLE
fix(ngSrcset): ignore undefined ng-srcset directive

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1447,7 +1447,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             (nodeName === 'img' && key === 'src')) {
           // sanitize a[href] and img[src] values
           this[key] = value = $$sanitizeUri(value, key === 'src');
-        } else if (nodeName === 'img' && key === 'srcset') {
+        } else if (nodeName === 'img' && key === 'srcset' && isDefined(value)) {
           // sanitize img[srcset] values
           var result = "";
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -9394,6 +9394,21 @@ describe('$compile', function() {
 
   describe('img[srcset] sanitization', function() {
 
+    it('should not error if undefined', function() {
+      module(function() {
+        directive({
+          setter: valueFn(function(scope, element, attr) {
+            attr.$set('srcset', undefined);
+            expect(attr.srcset).toBeUndefined();
+          })
+        });
+      });
+      inject(function($rootScope, $compile) {
+        element = $compile('<img setter></img>')($rootScope);
+        expect(element.attr('srcset')).toBeUndefined();
+      });
+    });
+
     it('should NOT require trusted values for img srcset', inject(function($rootScope, $compile, $sce) {
       element = $compile('<img srcset="{{testUrl}}"></img>')($rootScope);
       $rootScope.testUrl = 'http://example.com/image.png';

--- a/test/ng/directive/ngSrcsetSpec.js
+++ b/test/ng/directive/ngSrcsetSpec.js
@@ -30,7 +30,7 @@ describe('ngSrcset', function() {
   }));
 
   it('should not throw an error if undefined', inject(function($rootScope, $compile) {
-    element = $compile('<img data-ng-attr-srcset="{{undefined}}">')($rootScope);
+    element = $compile('<img ng-attr-srcset="{{undefined}}">')($rootScope);
     $rootScope.$digest();
   }));
 });

--- a/test/ng/directive/ngSrcsetSpec.js
+++ b/test/ng/directive/ngSrcsetSpec.js
@@ -30,10 +30,8 @@ describe('ngSrcset', function() {
   }));
 
   it('should not throw an error if undefined', inject(function($rootScope, $compile) {
-    $rootScope.imageUrl = {};
-    element = $compile('<img ng-srcset="{{undefined}}">')($rootScope);
+    element = $compile('<img data-ng-attr-srcset="{{undefined}}">')($rootScope);
     $rootScope.$digest();
-    expect(element.attr('srcset')).toBe(undefined);
   }));
 });
 

--- a/test/ng/directive/ngSrcsetSpec.js
+++ b/test/ng/directive/ngSrcsetSpec.js
@@ -28,5 +28,12 @@ describe('ngSrcset', function() {
     $rootScope.$digest();
     expect(element.attr('srcset')).toBe('http://example.com/image1.png 1x,unsafe:javascript:doEvilStuff() 2x');
   }));
+
+  it('should not throw an error if undefined', inject(function($rootScope, $compile) {
+    $rootScope.imageUrl = {};
+    element = $compile('<img ng-srcset="{{undefined}}">')($rootScope);
+    $rootScope.$digest();
+    expect(element.attr('srcset')).toBe(undefined);
+  }));
 });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This is a bug fix.

**What is the current behavior? (You can also link to an open issue here)**
Currently, a TypeError is thrown when data-ng-attr-srcset is undefined.

**What is the new behavior (if this is a feature change)?**
Now, the attribute is ignored if it's undefined.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Closes #14470
