### PR TITLE
fix($injector): add workaround for fat-arrow stringification in Chrome v50

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -71,7 +71,11 @@ var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 var $injectorMinErr = minErr('$injector');
 
 function extractArgs(fn) {
-  var fnText = Function.prototype.toString.call(fn).replace(STRIP_COMMENTS, ''),
+  // Support: Chrome 50-51 only
+  // Creating a new string by adding `' '` at the end, to hack around some bug in Chrome v50/51
+  // (See https://github.com/angular/angular.js/issues/14487.)
+  // TODO (gkalpak): Remove workaround when Chrome v52 is released
+  var fnText = Function.prototype.toString.call(fn).replace(STRIP_COMMENTS, '') + ' ',
       args = fnText.match(ARROW_ARG) || fnText.match(FN_ARGS);
   return args;
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.

**What is the current behavior? (You can also link to an open issue here)**
Chrome v50 throws when trying to annotate fat-arrow functions.
See #14487.

**What is the new behavior (if this is a feature change)?**
Fat-arrow functions get annotated correctly.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Everything works correctly on v52 without the fix. Not sure about v51.
I couldn't write a test, because the problem appears only when creating a fat-arrow function directly (not through `eval()`).

Closes #14487
