### PR TITLE
fix($templateRequest): Handle empty templates in cache correctly.

### DIFF
--- a/src/ng/templateRequest.js
+++ b/src/ng/templateRequest.js
@@ -68,14 +68,8 @@ function $TemplateRequestProvider() {
       // are included in there. This also makes Angular accept any script
       // directive, no matter its name. However, we still need to unwrap trusted
       // types.
-      if (!isString(tpl)) { // Safe types need unwrapping.
+      if (!isString(tpl) || isUndefined($templateCache.get(tpl))) {
         tpl = $sce.getTrustedResourceUrl(tpl);
-      } else { // Strings can be tested against the cache.
-        var cacheAnswer = $templateCache.get(tpl);
-        if (typeof cacheAnswer === 'undefined') {
-          // It is not in the cache, hence we don't trust it and it has to go through the $sce.
-          tpl = $sce.getTrustedResourceUrl(tpl);
-        } // Anything else means the cache has a record of it, so no need to check.
       }
 
       var transformResponse = $http.defaults && $http.defaults.transformResponse;

--- a/src/ng/templateRequest.js
+++ b/src/ng/templateRequest.js
@@ -68,8 +68,14 @@ function $TemplateRequestProvider() {
       // are included in there. This also makes Angular accept any script
       // directive, no matter its name. However, we still need to unwrap trusted
       // types.
-      if (!isString(tpl) || !$templateCache.get(tpl)) {
+      if (!isString(tpl)) { // Safe types need unwrapping.
         tpl = $sce.getTrustedResourceUrl(tpl);
+      } else { // Strings can be tested against the cache.
+        var cacheAnswer = $templateCache.get(tpl);
+        if (typeof cacheAnswer === 'undefined') {
+          // It is not in the cache, hence we don't trust it and it has to go through the $sce.
+          tpl = $sce.getTrustedResourceUrl(tpl);
+        } // Anything else means the cache has a record of it, so no need to check.
       }
 
       var transformResponse = $http.defaults && $http.defaults.transformResponse;

--- a/test/ng/templateRequestSpec.js
+++ b/test/ng/templateRequestSpec.js
@@ -158,6 +158,37 @@ describe('$templateRequest', function() {
     }).not.toThrow();
   }));
 
+  it('should accept empty templates and refuse null or undefined templates in cache',
+    inject(function($rootScope, $templateRequest, $templateCache, $sce) {
+
+    // Will throw on any template not in cache.
+    spyOn($sce, 'getTrustedResourceUrl').and.returnValue(false);
+
+    expect(function() {
+      $templateRequest('tpl.html'); // should go through $sce
+      $rootScope.$digest();
+    }).toThrow();
+
+    $templateCache.put('tpl.html'); // is a no-op, so $sce check as well.
+    expect(function() {
+      $templateRequest('tpl.html');
+      $rootScope.$digest();
+    }).toThrow();
+
+    $templateCache.put('tpl.html', null); // makes no sense, but it's been added, so trust it.
+    expect(function() {
+      $templateRequest('tpl.html');
+      $rootScope.$digest();
+    }).not.toThrow();
+
+    $templateCache.put('tpl.html', ''); // should work (empty template)
+    expect(function() {
+      $templateRequest('tpl.html');
+      $rootScope.$digest();
+    }).not.toThrow();
+
+  }));
+
   it('should keep track of how many requests are going on',
     inject(function($rootScope, $templateRequest, $httpBackend) {
 

--- a/test/ng/templateRequestSpec.js
+++ b/test/ng/templateRequestSpec.js
@@ -174,19 +174,21 @@ describe('$templateRequest', function() {
       $templateRequest('tpl.html');
       $rootScope.$digest();
     }).toThrow();
+    $templateCache.removeAll();
 
     $templateCache.put('tpl.html', null); // makes no sense, but it's been added, so trust it.
     expect(function() {
       $templateRequest('tpl.html');
       $rootScope.$digest();
     }).not.toThrow();
+    $templateCache.removeAll();
 
     $templateCache.put('tpl.html', ''); // should work (empty template)
     expect(function() {
       $templateRequest('tpl.html');
       $rootScope.$digest();
     }).not.toThrow();
-
+    $templateCache.removeAll();
   }));
 
   it('should keep track of how many requests are going on',


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix.

**What is the current behavior? (You can also link to an open issue here)**

Empty templates in $templateCache are not considered as in cache for $templateRequest security purposes, so they trigger $sce checks. Specifically, $templateRequest calls $templateCache.get, but looks for the falsiness of the return value instead of it being defined. 

**What is the new behavior (if this is a feature change)?**

Empty templates in $templateCache are now considered as trusted as any other in $templateCache.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.--set-upstreamjs/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)

I'm not sure docs are necessary, as this bug wasn't documented.

**Other information**:

Fixes #14479.
