### PR TITLE
fix($brower): set the url even if the browser transforms it

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -153,7 +153,7 @@ function Browser(window, document, $log, $sniffer) {
         // Do the assignment again so that those two variables are referentially identical.
         lastHistoryState = cachedState;
       } else {
-        if (!sameBase || pendingLocation) {
+        if (!sameBase) {
           pendingLocation = url;
         }
         if (replace) {
@@ -166,6 +166,9 @@ function Browser(window, document, $log, $sniffer) {
         if (location.href !== url) {
           pendingLocation = url;
         }
+      }
+      if (pendingLocation) {
+        pendingLocation = url;
       }
       return self;
     // getter

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -452,7 +452,7 @@ describe('browser', function() {
 
     sniffer.history = true;
     var originalReplace = fakeWindow.location.replace;
-    fakeWindow.location.replace = function (url) {
+    fakeWindow.location.replace = function(url) {
       url = url.replace('&not', '¬');
       // I really don't know why IE 11 (sometimes) does this, but I am not the only one to notice:
       // https://connect.microsoft.com/IE/feedback/details/1040980/bug-in-ie-which-interprets-document-location-href-as-html

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -457,7 +457,7 @@ describe('browser', function() {
       // I really don't know why IE 11 (sometimes) does this, but I am not the only one to notice:
       // https://connect.microsoft.com/IE/feedback/details/1040980/bug-in-ie-which-interprets-document-location-href-as-html
       originalReplace.call(this, url);
-    }
+    };
 
     // the initial URL contains a lengthy oauth token in the hash
     var initialUrl = 'http://test.com/oauthcallback#state=xxx%3D&not-before-policy=0';


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fixes #14427

**What is the current behavior? (You can also link to an open issue here)**

See #14427

**What is the new behavior (if this is a feature change)?**

Features should not be affected - unless you consider inifinite digest a feature ;-)

**Does this PR introduce a breaking change?**

No as far as I know. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

While $location expects that $browser stores the URL unchanged, some browsers transform the URL
when setting or defer the acutal update. To work around this, $browser.url() kept the unchanged
URL in pendingLocation. However, it failed to update pendingLocation in all code paths, causing
$browser.url() to sometimes incorrectly report previous URLs, which horribly confused $location.
This fix ensures that pendingLocation is always updated if set, causing url() to report the
current url.

Fixes #14427
