### PR TITLE
docs(guide/Developer Guide): Fixed formatting with subtitles

### DIFF
--- a/docs/content/guide/index.ngdoc
+++ b/docs/content/guide/index.ngdoc
@@ -101,7 +101,7 @@ This is a short list of libraries with specific support and documentation for wo
 
 ## Learning Resources
 
-###Books
+### Books
 * [AngularJS: Up and Running](http://www.amazon.com/AngularJS-Running-Enhanced-Productivity-Structured/dp/1491901942) by Brad Green and Shyam Seshadri
 * [Mastering Web App Development](http://www.amazon.com/Mastering-Web-Application-Development-AngularJS/dp/1782161821) by Pawel Kozlowski and Pete Bacon Darwin
 * [AngularJS Directives](http://www.amazon.com/AngularJS-Directives-Alex-Vanston/dp/1783280336) by Alex Vanston
@@ -113,7 +113,7 @@ This is a short list of libraries with specific support and documentation for wo
 * [Responsive Web Design with AngularJS](http://www.amazon.com/Responsive-Design-AngularJS-Sandeep-Kumar/dp/178439842X) by Sandeep Kumar Patel
 * [Professional AngularJS](http://www.amazon.com/Professional-AngularJS-Valeri-Karpov/dp/1118832078/)
 
-###Videos:
+### Videos:
 * [egghead.io](http://egghead.io/)
 * [Angular on YouTube](http://youtube.com/angularjs)
 * [Firebase Foundations for AngularJS](http://blog.watchandcode.com/firebase-foundations/)


### PR DESCRIPTION
On the [main page](https://docs.angularjs.org/guide) of the developer guide:

The "Books" and "Videos" subtitles had no space between text and the '#' so it didn't render as a subtitle in the web page.

It should be:
### Videos

Instead of:
### Videos
