### PR TITLE
fix($injector): add workaround for class stringification in Chrome v50/51

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -70,12 +70,16 @@ var FN_ARG = /^\s*(_?)(\S+?)\1\s*$/;
 var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 var $injectorMinErr = minErr('$injector');
 
-function extractArgs(fn) {
+function stringifyFn(fn) {
   // Support: Chrome 50-51 only
   // Creating a new string by adding `' '` at the end, to hack around some bug in Chrome v50/51
   // (See https://github.com/angular/angular.js/issues/14487.)
   // TODO (gkalpak): Remove workaround when Chrome v52 is released
-  var fnText = Function.prototype.toString.call(fn).replace(STRIP_COMMENTS, '') + ' ',
+  return Function.prototype.toString.call(fn) + ' ';
+}
+
+function extractArgs(fn) {
+  var fnText = stringifyFn(fn).replace(STRIP_COMMENTS, ''),
       args = fnText.match(ARROW_ARG) || fnText.match(FN_ARGS);
   return args;
 }
@@ -849,7 +853,7 @@ function createInjector(modulesToLoad, strictDi) {
       if (!isBoolean(result)) {
         // Workaround for MS Edge.
         // Check https://connect.microsoft.com/IE/Feedback/Details/2211653
-        result = func.$$ngIsClass = /^(?:class\s|constructor\()/.test(Function.prototype.toString.call(func));
+        result = func.$$ngIsClass = /^(?:class\s|constructor\()/.test(stringifyFn(func));
       }
       return result;
     }

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -283,6 +283,14 @@ describe('injector', function() {
         it('should take args before first arrow', function() {
           expect(annotate(eval('a => b => b'))).toEqual(['a']);
         });
+
+        // Support: Chrome 50-51 only
+        // TODO (gkalpak): Remove when Chrome v52 is relased.
+        // it('should be able to inject fat-arrow function', function() {
+        //   inject(($injector) => {
+        //     expect($injector).toBeDefined();
+        //   });
+        // });
       }
 
       if (support.classes) {
@@ -293,6 +301,19 @@ describe('injector', function() {
           expect(instance).toEqual(new Clazz('a-value'));
           expect(instance.aVal()).toEqual('a-value');
         });
+
+        // Support: Chrome 50-51 only
+        // TODO (gkalpak): Remove when Chrome v52 is relased.
+        // it('should be able to invoke classes', function() {
+        //   class Test {
+        //     constructor($injector) {
+        //       this.$injector = $injector;
+        //     }
+        //   }
+        //   var instance = injector.invoke(Test, null, null, 'Test');
+
+        //   expect(instance.$injector).toBe(injector);
+        // });
       }
       /*jshint +W061 */
     });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.

**What is the current behavior? (You can also link to an open issue here)**
In Chrome v50, the `$injector` fails to properly detect classes and throws when trying to `invoke` a class.
See #14240 (especially https://github.com/angular/angular.js/issues/14240#issuecomment-197418167 and https://github.com/angular/angular.js/issues/14240#issuecomment-214039468).

**What is the new behavior (if this is a feature change)?**
Classes are detected and `$injetor.invoke`d correctly.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Everything works correctly on v52 without the fix. Not sure about v51.
We can't run the tests on CI, because the problem appears only when creating a class directly (not through `eval()`). I added a couple of commented out tests, so it is easy to test once Chrome v52 is released (as stable). (I left a TODO note to remove them.)

Partially fixes #14240.
