### PR TITLE
docs(readme): Add link to Angular2 repo on ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 AngularJS [![Build Status](https://travis-ci.org/angular/angular.js.svg?branch=master)](https://travis-ci.org/angular/angular.js)
 =========
+##### Looking for Angular 2* (beta)? Go here: [https://github.com/angular/angular](https://github.com/angular/angular)
 
 AngularJS lets you write client-side web applications as if you had a smarter browser.  It lets you
 use good old HTML (or HAML, Jade and friends!) as your template language and lets you extend HTML’s


### PR DESCRIPTION
**Doc update**

**Other information**:
Might be a good idea include a link to point them to the Angular2 version if that's what they were looking for. Those completely new to Angular might not know this is the older 1.\* Repo.

Related to Issue #14524 
