### PR TITLE
fix($injector): fix class detection RegExp

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -851,9 +851,9 @@ function createInjector(modulesToLoad, strictDi) {
       }
       var result = func.$$ngIsClass;
       if (!isBoolean(result)) {
-        // Workaround for MS Edge.
-        // Check https://connect.microsoft.com/IE/Feedback/Details/2211653
-        result = func.$$ngIsClass = /^(?:class\s|constructor\()/.test(stringifyFn(func));
+        // Support: Edge 12-13 only
+        // See: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/6156135/
+        result = func.$$ngIsClass = /^(?:class\b|constructor\()/.test(stringifyFn(func));
       }
       return result;
     }

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -302,6 +302,26 @@ describe('injector', function() {
           expect(instance.aVal()).toEqual('a-value');
         });
 
+        if (/chrome/.test(navigator.userAgent)) {
+          they('should detect ES6 classes regardless of whitespace/comments ($prop)', [
+            'class Test {}',
+            'class Test{}',
+            'class //<--ES6 stuff\nTest {}',
+            'class//<--ES6 stuff\nTest {}',
+            'class {}',
+            'class{}',
+            'class //<--ES6 stuff\n {}',
+            'class//<--ES6 stuff\n {}',
+            'class/* Test */{}',
+            'class /* Test */ {}'
+          ], function(classDefinition) {
+            var Clazz = eval('(' + classDefinition + ')');
+            var instance = injector.invoke(Clazz);
+
+            expect(instance).toEqual(jasmine.any(Clazz));
+          });
+        }
+
         // Support: Chrome 50-51 only
         // TODO (gkalpak): Remove when Chrome v52 is relased.
         // it('should be able to invoke classes', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
ES6 classes are not properly detected unless `class` is followed by a whitespace character.

**What is the new behavior (if this is a feature change)?**
ES6 classes are properly detected, even if class is **not** followed by a whitespace character.
E.g. `class{}` or `class/* ... */ {}`.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Mentioned in https://github.com/angular/angular.js/pull/14531#discussion_r61410683.
