### PR TITLE
The Angular Docs do not show the restrictions

### DIFF
--- a/src/ng/directive/validators.js
+++ b/src/ng/directive/validators.js
@@ -2,7 +2,6 @@
 /**
  * @ngdoc directive
  * @name ngRequired
- *
  * @restrict A
  * 
  * @description

--- a/src/ng/directive/validators.js
+++ b/src/ng/directive/validators.js
@@ -3,6 +3,8 @@
  * @ngdoc directive
  * @name ngRequired
  *
+ * @restrict A
+ * 
  * @description
  *
  * ngRequired adds the required {@link ngModel.NgModelController#$validators `validator`} to {@link ngModel `ngModel`}.


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs

**What is the current behavior? (You can also link to an open issue here)**

The Directive ng-require does not show the correct restrictions in the USAGE section.

**What is the new behavior (if this is a feature change)?**

In the USAGE section it will show up as an attribute.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:

Added  \* @restrict A so it will show the correct restrictions in the docs
