### PR TITLE
fix($compile): removing unnecessary white space

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1620,7 +1620,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
     compile.$$createComment = function(directiveName, comment) {
       var content = '';
-
       if (debugInfoEnabled) {
         content = ' ';
         content += (directiveName || '');
@@ -1628,7 +1627,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         content += comment ? ' ' + comment : '';
         content += ' ';
       }
-
       return window.document.createComment(content);
     };
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1620,9 +1620,15 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
     compile.$$createComment = function(directiveName, comment) {
       var content = '';
+
       if (debugInfoEnabled) {
-        content = ' ' + (directiveName || '') + ': ' + (comment || '') + ' ';
+        content = ' ';
+        content += (directiveName || '');
+        content += ':';
+        content += comment ? ' ' + comment : '';
+        content += ' ';
       }
+
       return window.document.createComment(content);
     };
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -8438,7 +8438,7 @@ describe('$compile', function() {
           expect(function() {
             $compile('<div first second></div>');
           }).toThrowMinErr('$compile', 'multidir', 'Multiple directives [first, second] asking for transclusion on: ' +
-                  '<!-- first:  -->');
+                  '<!-- first: -->');
         });
       });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
https://github.com/angular/angular.js/issues/14549

**What is the new behavior (if this is a feature change)?**
https://github.com/angular/angular.js/issues/14549

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

When creating DOM commentary for ng-switch-when theres an unecessary white space at the end.
