### PR TITLE
fix(ngAnimate): ensure animations are not attempted on empty jqLite c…

### DIFF
--- a/src/ngAnimate/shared.js
+++ b/src/ngAnimate/shared.js
@@ -127,7 +127,7 @@ function stripCommentsFromElement(element) {
   if (element instanceof jqLite) {
     switch (element.length) {
       case 0:
-        return [];
+        return element;
         break;
 
       case 1:

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -394,6 +394,18 @@ describe("animations", function() {
       expect(capturedAnimation).toBeFalsy();
     }));
 
+    it('should not attempt to perform an animation on an empty jqLite collection',
+      inject(function($rootScope, $animate) {
+
+        element.html('');
+        var emptyNode = jqLite(element[0].firstChild);
+
+        $animate.addClass(emptyNode, 'some-class');
+        $rootScope.$digest();
+
+        expect(capturedAnimation).toBeFalsy();
+      }));
+
     it('should perform the leave domOperation if a text node is used',
       inject(function($rootScope, $animate) {
 


### PR DESCRIPTION
Without this fix animation throw a javascript exception
`element.parent not a function` when we pass empty jqLite collection.

Closes #14558
