### PR TITLE
fix($LogProvider) : Allow console methods overriding

### DIFF
--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -150,7 +150,8 @@ function $LogProvider() {
           forEach(arguments, function(arg) {
             args.push(formatError(arg));
           });
-          return logFn.apply(console, args);
+          // Using logFn here prevents custom console methods overriding
+          return console[type].apply(console, args);
         };
       }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

If a user override a console method on its personal code, such as `console.error`

```
console.error = (function(cerror) {
  return function() {
    const args = Array.from(arguments);
    args.unshift('[my custom prefix] ');
    cerror.apply(console, args);
  };
})(console.error);
```

And then Angular logs something, such as an error:

```
scope.$apply(function() { throw new Error('boom'); })
// logs "boom"
```

We don't see the `[my custom prefix]` appended to the error message. The original `console.error` is being used.

**What is the new behavior (if this is a feature change)?**

This tiny change will make Angular use the overriden console methods.

```
scope.$apply(function() { throw new Error('boom'); })
// logs "[my custom prefix]  boom"
```

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

If a user overrides the methods console.log, console.error, etc, this
change will use them rather than the default ones.
