### PR TITLE
fix($compile): don't run unnecessary update to one-way bindings

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3213,14 +3213,13 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
             parentGet = $parse(attrs[attrName]);
 
-            destination[scopeName] = parentGet(scope);
+            var initialValue = destination[scopeName] = parentGet(scope);
             initialChanges[scopeName] = new SimpleChange(_UNINITIALIZED_VALUE, destination[scopeName]);
 
             removeWatch = scope.$watch(parentGet, function parentValueWatchAction(newValue, oldValue) {
-              if (newValue === oldValue) {
-                // If the new and old values are identical then this is the first time the watch has been triggered
-                // So instead we use the current value on the destination as the old value
-                oldValue = destination[scopeName];
+              if (oldValue === newValue) {
+                if (oldValue === initialValue) return;
+                oldValue = initialValue;
               }
               recordChanges(scopeName, newValue, oldValue);
               destination[scopeName] = newValue;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug Fix

**What is the current behavior? (You can also link to an open issue here)**

The watch handler was triggering on its first invocation, even though
its change had already been dealt with when setting up the binding.

**What is the new behavior (if this is a feature change)?**

The handler does not trigger an update on its first invocation

**Does this PR introduce a breaking change?**

Nope - I don't think so. Although I had to modify a bunch of tests to ensure that a digest occurred between compilation and the first checks.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
  ~~\- [ ] Docs have been added / updated (for bug fixes / features)~~

**Other information**:

Closes #14546
