### PR TITLE
fix($parse): call once stable bind-once expressions with filter

### DIFF
--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3232,6 +3232,18 @@ describe('parser', function() {
           expect(fn()).toEqual(undefined);
         }));
 
+        it('should invoke a stateless filter once when the parsed expression has an interceptor',
+           inject(function($parse, $rootScope) {
+          var countFilter = jasmine.createSpy();
+          var interceptor = jasmine.createSpy();
+          countFilter.and.returnValue(1);
+          $filterProvider.register('count', valueFn(countFilter));
+          $rootScope.foo = function() { return 1; };
+          $rootScope.$watch($parse(':: foo() | count', interceptor));
+          $rootScope.$digest();
+          expect(countFilter.calls.count()).toBe(1);
+        }));
+
         describe('literal expressions', function() {
           it('should mark an empty expressions as literal', inject(function($parse) {
             expect($parse('').literal).toBe(true);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
fix, but given the nature I would submit this for 1.6 only

**What is the current behavior? (You can also link to an open issue here)**
stateless filters on bind-once expression are called multiple times.

**What is the new behavior (if this is a feature change)?**
stateless filters on bind-once expression are called once.

**Does this PR introduce a breaking change?**
No, but developers might expect the multiple calls (even when they should not)

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)

**Other information**:

When an expression has the following:
- Bind-once
- A stateless filter at the end
- Optionally an expression interceptor

Then call the filter in the expression once.

Closes: #14583
