### PR TITLE
docs(tutorial/2 - Angular Templates): fix wrong file path

### DIFF
--- a/docs/content/tutorial/step_02.ngdoc
+++ b/docs/content/tutorial/step_02.ngdoc
@@ -132,7 +132,7 @@ The "Angular way" of separating controller from the view, makes it easy to test 
 developed. If our controller is available on the global namespace then we could simply instantiate it
 with a mock `scope` object:
 
-__`test/e2e/scenarios.js`:__
+__`test/unit/controllersSpec.js`:__
 
 ```js
 describe('PhoneListCtrl', function(){


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs update.

**What is the current behavior? (You can also link to an open issue here)**

Wrong file path is given

**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change?**

Nope.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format

**Other information**:
