### PR TITLE
docs(ngMock): use master installation template

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2251,49 +2251,6 @@ angular.mock.$ComponentControllerProvider = ['$compileProvider', function($compi
  *
  *
  * <div doc-module-components="ngMock"></div>
- *
- * @installation
- *
- *  <p>First, download the file:</p>
- *  <ul>
-      <li>
-        <a href="https://developers.google.com/speed/libraries/devguide#angularjs">Google CDN</a> e.g.
-        {% code %}"//ajax.googleapis.com/ajax/libs/angularjs/X.Y.Z/"{% endcode %}
-      </li>
-      <li>
-        <a href="https://www.npmjs.com/">NPM</a> e.g.
-        {% code %}npm install {$ doc.packageName $}@X.Y.Z{% endcode %}
-      </li>
-      <li>
-        <a href="http://bower.io">Bower</a><br> e.g.
-        {% code %}bower install {$ doc.packageName $}@X.Y.Z{% endcode %}
-      </li>
-      <li>
-        <a href="https://code.angularjs.org/">code.angularjs.org</a> (discouraged for
-        production use)  e.g.
-        {% code %}"//code.angularjs.org/X.Y.Z/{$ doc.packageFile $}"{% endcode %}
-      </li>
-    </ul>
-    <p>where X.Y.Z is the AngularJS version you are running.</p>
-
-    <p>Then, configure your test runner to load `angular-mocks.js` after `angular.js`.
-    This example uses <a href="http://karma-runner.github.io/">Karma</a>:</p>
-
-    {% code %}
-        config.set({
-          files: [
-            'build/angular.js', // and other module files you need
-            'build/angular-mocks.js',
-            '<path/to/application/files>',
-            '<path/to/spec/files>'
-          ]
-        });
-    {% endcode %}
-
-    <p>Including the `angular-mocks.js` file automatically adds the `ngMock` module, so your tests
-    are ready to go!</p>
- *
- *
  */
 angular.module('ngMock', ['ng']).provider({
   $browser: angular.mock.$BrowserProvider,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

docs update

**What is the current behavior? (You can also link to an open issue here)**

```
Google CDN e.g. {% code %}"//ajax.googleapis.com/ajax/libs/angularjs/X.Y.Z/"{% endcode %}
```

**What is the new behavior (if this is a feature change)?**

```
Google CDN e.g.
"//ajax.googleapis.com/ajax/libs/angularjs/X.Y.Z/angular-mock.js"
```

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

The inline installation can't display the proper context. On the website, it shows something like

```
Google CDN e.g. {% code %}"//ajax.googleapis.com/ajax/libs/angularjs/X.Y.Z/"{% endcode %}
```
