### PR TITLE
fix($compile): correctly denormalize templates that do not use standard interpolation symbols

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1292,6 +1292,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
   function createGlobalRegexMatcher(str) {
     return new RegExp(escapeRegExp(str), 'g');
   }
+  function escapeSymbol(str) {
+    return str.replace(/./g, '\\$&');
+  }
   var moduleSymbolMap = createMap();
   var defaultSymbols = {
     startSymbol: '{{',
@@ -1607,13 +1610,17 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
 
     var startSymbol = $interpolate.startSymbol(),
+        startSymbolRegex = createGlobalRegexMatcher(startSymbol),
         endSymbol = $interpolate.endSymbol(),
+        endSymbolRegex = createGlobalRegexMatcher(endSymbol),
         denormalizeTemplate = function(moduleName, template) {
           var moduleSymbols = moduleSymbolMap[moduleName] || defaultSymbols;
           if (moduleSymbols.startSymbol !== startSymbol) {
+            template = template.replace(startSymbolRegex, escapeSymbol);
             template = template.replace(moduleSymbols.startRegex, startSymbol);
           }
           if (moduleSymbols.endSymbol !== endSymbol) {
+            template = template.replace(endSymbolRegex, escapeSymbol);
             template = template.replace(moduleSymbols.endRegex, endSymbol);
           }
           return template;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3155,6 +3155,26 @@ describe('$compile', function() {
       });
     });
 
+    it('should allow modules to specify what interpolation symbol is used in templates', function() {
+      angular.module('symbol-test', [])
+        .directive('myDirective', function() {
+          return {
+            template: '<span foo=\'{"ctx":{"id":3}}\'></span>'
+          };
+        });
+
+      module('symbol-test', function($interpolateProvider, $compileProvider) {
+        $interpolateProvider.startSymbol('##');
+        $interpolateProvider.endSymbol(']]');
+        $compileProvider.moduleSymbols('symbol-test', '##', ']]');
+      });
+
+      inject(function($compile) {
+        element = $compile('<div><div my-directive></div></div>')($rootScope);
+        expect(element.children('div').children('span').attr('foo')).toBe('{"ctx":{"id":3}}');
+      });
+    });
+
 
     it('should support custom start interpolation symbol, even when `endSymbol` doesn\'t change',
       function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

FIX

**What is the current behavior? (You can also link to an open issue here)**

See #6493

**What is the new behavior (if this is a feature change)?**

Fixed

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

*\* STILL NEED TO ADD DOCS **

In order to support third party modules that do not use the same interpolation
symbols as the main app, we implemented denormalization (see dfe99836c).

This required that 3rd party modules always used the standad `{{` and `}}`
interpolation symbols, so that we could correctly denormalise them to the
current app's symbols.

The problem with this became apparent when an app template using new symbols
inadvertently contained one of the standard interpolation symbols.

E.g. `<div data-context='{"context":{"id":3,"type":"page"}}">`

The double closing curly braces were being incorrectly denormalised.

This commit fixes this by allowing the compiler to be configured to know
what symbols are being used in templates from a given module.

Now modules can specify that what interpolation symbols they use and the
compiler will denormalize appropriately.

Closes #6493
Closes #6453
