### PR TITLE
fix(aria/ngModel): do not overwrite the default `$isEmpty()` method for checkboxes

### DIFF
--- a/docs/content/guide/accessibility.ngdoc
+++ b/docs/content/guide/accessibility.ngdoc
@@ -59,79 +59,133 @@ attributes (if they have not been explicitly specified by the developer):
  * aria-invalid
  * aria-required
  * aria-readonly
+ * aria-disabled
 
 ### Example
 
 <example module="ngAria_ngModelExample" deps="angular-aria.js" name="accessibility-ng-model">
   <file name="index.html">
-    <form ng-controller="formsController">
-      <some-checkbox role="checkbox" ng-model="checked" ng-class="{active: checked}"
-        ng-disabled="isDisabled" ng-click="toggleCheckbox()"
-        aria-label="Custom Checkbox" show-attrs>
-        <span class="icon" aria-hidden="true"></span>
-        Custom Checkbox
-      </some-checkbox>
+    <form>
+      <custom-checkbox role="checkbox" ng-model="checked" required
+          aria-label="Custom checkbox" show-attrs>
+        Custom checkbox
+      </custom-checkbox>
     </form>
+    <hr />
+    <b>Is checked:</b> {{ !!checked }}
   </file>
   <file name="script.js">
-    angular.module('ngAria_ngModelExample', ['ngAria'])
-    .controller('formsController', function($scope) {
-      $scope.checked = false;
-      $scope.toggleCheckbox = function() {
-        $scope.checked = !$scope.checked;
-      };
-    })
-    .directive('someCheckbox', function() {
+    angular.
+      module('ngAria_ngModelExample', ['ngAria']).
+      directive('customCheckbox', customCheckboxDirective).
+      directive('showAttrs', showAttrsDirective);
+
+    function customCheckboxDirective() {
       return {
         restrict: 'E',
-        link: function($scope, $el, $attrs) {
-          $el.on('keypress', function(event) {
+        require: 'ngModel',
+        transclude: true,
+        template:
+            '<span class="icon" aria-hidden="true"></span> ' +
+            '<ng-transclude></ng-transclude>',
+        link: function(scope, elem, attrs, ctrl) {
+          // Overwrite necessary `NgModelController` methods
+          ctrl.$isEmpty = isEmpty;
+          ctrl.$render = render;
+
+          // Bind to events
+          elem.on('click', function(event) {
+            event.preventDefault();
+            scope.$apply(toggleCheckbox);
+          });
+          elem.on('keypress', function(event) {
             event.preventDefault();
             if (event.keyCode === 32 || event.keyCode === 13) {
-              $scope.toggleCheckbox();
-              $scope.$apply();
+              scope.$apply(toggleCheckbox);
             }
           });
+
+          // Helpers
+          function isEmpty(value) {
+            return !value;
+          }
+          
+          function render() {
+            elem[ctrl.$viewValue ? 'addClass' : 'removeClass']('checked');
+          }
+     
+          function toggleCheckbox() {
+            ctrl.$setViewValue(!ctrl.$viewValue);
+            ctrl.$render();
+          }
         }
       };
-    })
-    .directive('showAttrs', function() {
-      return function($scope, $el, $attrs) {
+    }
+
+    function showAttrsDirective($timeout) {
+      return function(scope, elem, attrs) {
         var pre = document.createElement('pre');
-        $el.after(pre);
-        $scope.$watch(function() {
-          var $attrs = {};
-          Array.prototype.slice.call($el[0].attributes, 0).forEach(function(item) {
-            if (item.name !== 'show-$attrs') {
-              $attrs[item.name] = item.value;
-            }
+        elem.after(pre);
+
+        scope.$watchCollection(function() {
+          return Array.prototype.slice.call(elem[0].attributes).reduce(function(aggr, attr) {
+            if (attr.name !== attrs.$attr.showAttrs) aggr[attr.name] = attr.value;
+            return aggr;
+          }, {});
+        }, function(newValues) {
+          $timeout(function() {
+            pre.textContent = angular.toJson(newValues, 2);
           });
-          return $attrs;
-        }, function(newAttrs, oldAttrs) {
-          pre.textContent = JSON.stringify(newAttrs, null, 2);
-        }, true);
+        });
       };
-    });
+    }
   </file>
   <file name="style.css">
-    [role=checkbox] {
+    custom-checkbox {
       cursor: pointer;
       display: inline-block;
     }
-    [role=checkbox] .icon:before {
+
+    custom-checkbox .icon:before {
       content: '\2610';
       display: inline-block;
       font-size: 2em;
       line-height: 1;
-      vertical-align: middle;
       speak: none;
+      vertical-align: middle;
     }
-    [role=checkbox].active .icon:before {
+
+    custom-checkbox.checked .icon:before {
       content: '\2611';
     }
-    pre {
-      white-space: pre-wrap;
-    }
+  </file>
+  <file name="protractor.js" type="protractor">
+    var checkbox = element(by.css('custom-checkbox'));
+    var checkedCheckbox = element(by.css('custom-checkbox.checked'));
+
+    it('should have the `checked` class only when checked', function() {
+      expect(checkbox.isPresent()).toBe(true);
+      expect(checkedCheckbox.isPresent()).toBe(false);
+
+      checkbox.click();
+      expect(checkedCheckbox.isPresent()).toBe(true);
+
+      checkbox.click();
+      expect(checkedCheckbox.isPresent()).toBe(false);
+    });
+
+    it('should have the `aria-checked` attribute set to the appropriate value', function() {
+      expect(checkedCheckbox.isPresent()).toBe(false);
+      expect(checkbox.getAttribute('aria-checked')).toBe('false');
+
+      checkbox.click();
+      expect(checkedCheckbox.isPresent()).toBe(true);
+      expect(checkbox.getAttribute('aria-checked')).toBe('true');
+
+      checkbox.click();
+      expect(checkedCheckbox.isPresent()).toBe(false);
+      expect(checkbox.getAttribute('aria-checked')).toBe('false');
+    });
   </file>
 </example>
 

--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -252,14 +252,6 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
       var shape = getShape(attr, elem);
 
       return {
-        pre: function(scope, elem, attr, ngModel) {
-          if (shape === 'checkbox') {
-            //Use the input[checkbox] $isEmpty implementation for elements with checkbox roles
-            ngModel.$isEmpty = function(value) {
-              return value === false;
-            };
-          }
-        },
         post: function(scope, elem, attr, ngModel) {
           var needsTabIndex = shouldAttachAttr('tabindex', 'tabindex', elem, false);
 

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -123,29 +123,31 @@ describe('$aria', function() {
       expect(element.attr('aria-checked')).toBe('false');
     });
 
-    it('should rely on the `$isEmpty()` method', function() {
-      compileElement('<div role="checkbox" ng-model="val"></div>');
-      var ctrl = element.controller('ngModel');
-      ctrl.$isEmpty = function(value) {
-        return value === 'not-checked';
-      };
+    it('should use `$isEmpty()` to determine if the checkbox is checked',
+      function() {
+        compileElement('<div role="checkbox" ng-model="val"></div>');
+        var ctrl = element.controller('ngModel');
+        ctrl.$isEmpty = function(value) {
+          return value === 'not-checked';
+        };
 
-      scope.$apply('val = true');
-      expect(ctrl.$modelValue).toBe(true);
-      expect(element.attr('aria-checked')).toBe('true');
+        scope.$apply('val = true');
+        expect(ctrl.$modelValue).toBe(true);
+        expect(element.attr('aria-checked')).toBe('true');
 
-      scope.$apply('val = false');
-      expect(ctrl.$modelValue).toBe(false);
-      expect(element.attr('aria-checked')).toBe('true');
+        scope.$apply('val = false');
+        expect(ctrl.$modelValue).toBe(false);
+        expect(element.attr('aria-checked')).toBe('true');
 
-      scope.$apply('val = "not-checked"');
-      expect(ctrl.$modelValue).toBe('not-checked');
-      expect(element.attr('aria-checked')).toBe('false');
+        scope.$apply('val = "not-checked"');
+        expect(ctrl.$modelValue).toBe('not-checked');
+        expect(element.attr('aria-checked')).toBe('false');
 
-      scope.$apply('val = "checked"');
-      expect(ctrl.$modelValue).toBe('checked');
-      expect(element.attr('aria-checked')).toBe('true');
-    });
+        scope.$apply('val = "checked"');
+        expect(ctrl.$modelValue).toBe('checked');
+        expect(element.attr('aria-checked')).toBe('true');
+      }
+    );
 
     it('should not handle native checkbox with ngChecked', function() {
       var element = $compile('<input type="checkbox" ng-checked="val">')(scope);

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -84,7 +84,6 @@ describe('$aria', function() {
     });
   });
 
-
   describe('aria-hidden when disabled', function() {
     beforeEach(configAriaProvider({
       ariaHidden: false
@@ -115,13 +114,37 @@ describe('$aria', function() {
     });
 
     it('should attach itself to custom checkbox', function() {
-      compileElement('<div role="checkbox" ng-model="val">');
+      compileElement('<div role="checkbox" ng-model="val"></div>');
+
+      scope.$apply('val = "checked"');
+      expect(element.attr('aria-checked')).toBe('true');
+
+      scope.$apply('val = null');
+      expect(element.attr('aria-checked')).toBe('false');
+    });
+
+    it('should rely on the `$isEmpty()` method', function() {
+      compileElement('<div role="checkbox" ng-model="val"></div>');
+      var ctrl = element.controller('ngModel');
+      ctrl.$isEmpty = function(value) {
+        return value === 'not-checked';
+      };
 
       scope.$apply('val = true');
+      expect(ctrl.$modelValue).toBe(true);
       expect(element.attr('aria-checked')).toBe('true');
 
       scope.$apply('val = false');
+      expect(ctrl.$modelValue).toBe(false);
+      expect(element.attr('aria-checked')).toBe('true');
+
+      scope.$apply('val = "not-checked"');
+      expect(ctrl.$modelValue).toBe('not-checked');
       expect(element.attr('aria-checked')).toBe('false');
+
+      scope.$apply('val = "checked"');
+      expect(ctrl.$modelValue).toBe('checked');
+      expect(element.attr('aria-checked')).toBe('true');
     });
 
     it('should not handle native checkbox with ngChecked', function() {
@@ -210,11 +233,12 @@ describe('$aria', function() {
     });
 
     it('should attach itself to role="menuitemcheckbox"', function() {
-      scope.val = true;
       compileElement('<div role="menuitemcheckbox" ng-model="val"></div>');
+
+      scope.$apply('val = "checked"');
       expect(element.attr('aria-checked')).toBe('true');
 
-      scope.$apply('val = false');
+      scope.$apply('val = null');
       expect(element.attr('aria-checked')).toBe('false');
     });
 
@@ -830,6 +854,28 @@ describe('$aria', function() {
 
       compileElement('<div ng-dblclick="someAction()"></div>');
       expect(element.attr('tabindex')).toBeUndefined();
+    });
+  });
+
+  describe('ngModel', function() {
+    it('should not break when manually compiling', function() {
+      module(function($compileProvider) {
+        $compileProvider.directive('foo', function() {
+          return {
+            priority: 10,
+            terminal: true,
+            link: function(scope, elem) {
+              $compile(elem, null, 10)(scope);
+            }
+          };
+        });
+      });
+
+      injectScopeAndCompiler();
+      compileElement('<div role="checkbox" ng-model="value" foo />');
+
+      // Just check an arbitrary feature to make sure it worked
+      expect(element.attr('tabindex')).toBe('0');
     });
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix(es)

**What is the current behavior? (You can also link to an open issue here)**
`ngAria` overwrites `NgModelController.$isEmpty()` for custom checkboxes (only considering `false` as empty), despite the fact that custom checkboxes don't necessarily have custom parsers setting falsy values to `false`. (E.g. the checkbox is considered "checked" even if value is `undefined` (because `undefined !== false`.)
Also, `ngModel` breaks when manually compiling from a terminal directive with lower priorty (see #14621).

**Does this PR introduce a breaking change?**
Yes!

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Previously, `ngAria` would overwrite the default `ngModelController.$isEmpty()` method for custom
`checkbox`-shaped controls (e.g. `role="checkbox"` or `role="menuitemcheckbox"`), using the same
implementation as `input[checkbox]` (i.e. `value === false`). While this makes sense for
`input[checkbox]` which also defines a custom parser, it doesn't make sense for a custom `checkbox`
out-of-the-box. For example, an unintialized value (`undefined`) would make the checkbox appear as
"checked".

If the user wants to provide a custom parser (e.g. setting falsy values to `false`), then they
should also provide a custom `$isEmpty()` method.

As a side effect, this commit solves issue #14621. (We could have solved it in different ways.)

Fixes #14621

BREAKING CHANGE:

Custom `checkbox`-shaped controls (e.g. checkboxes, menuitemcheckboxes), no longer have a custom
`$isEmpty()` method on their `NgModelController` that checks for `value === false`. Unless
overwritten, the default `$isEmpty()` method will be used, which treats `undefined`, `null`, `NaN`
and `''` as "empty".

**Note:** The `$isEmpty()` method is used to determine if the checkbox is checked ("not empty" means
          "checked") and thus it can indirectly affect other things, such as the control's validity
          with respect to the `required` validator (e.g. "empty" + "required" --> "invalid").

Before:

``` js
var template = '<my-checkbox role="checkbox" ng-model="value"></my-checkbox>';
var customCheckbox = $compile(template)(scope);
var ctrl = customCheckbox.controller('ngModel');

scope.$apply('value = false');
console.log(ctrl.$isEmpty());   //--> true

scope.$apply('value = true');
console.log(ctrl.$isEmpty());   //--> false

scope.$apply('value = undefined'/* or null or NaN or '' */);
console.log(ctrl.$isEmpty());   //--> false
```

After:

``` js
var template = '<my-checkbox role="checkbox" ng-model="value"></my-checkbox>';
var customCheckbox = $compile(template)(scope);
var ctrl = customCheckbox.controller('ngModel');

scope.$apply('value = false');
console.log(ctrl.$isEmpty());   //--> false

scope.$apply('value = true');
console.log(ctrl.$isEmpty());   //--> false

scope.$apply('value = undefined'/* or null or NaN or '' */);
console.log(ctrl.$isEmpty());   //--> true
```
## 

If you want to have a custom `$isEmpty()` method, you need to overwrite the default. For example:

``` js
.directive('myCheckbox', function myCheckboxDirective() {
  return {
    require: 'ngModel',
    link: function myCheckboxPostLink(scope, elem, attrs, ngModelCtrl) {
      ngModelCtrl.$isEmpty = function myCheckboxIsEmpty(value) {
        return !value;   // Any falsy value means "empty"

        // Or to restore the previous behavior:
        // return value === false;
      };
    }
  };
})
```
