### PR TITLE
fix($compile): don't allow constructor to overwrite input bindings

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2465,11 +2465,22 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           }
         }
 
-        // Bind the required controllers to the controller, if `require` is an object and `bindToController` is truthy
         forEach(controllerDirectives, function(controllerDirective, name) {
-          var require = controllerDirective.require;
-          if (controllerDirective.bindToController && !isArray(require) && isObject(require)) {
-            extend(elementControllers[name].instance, getControllers(name, require, $element, elementControllers));
+          if (controllerDirective.bindToController) {
+
+            var controllerInstance = elementControllers[name].instance;
+
+            // Bind the required controllers to the controller, if `require` is an object and `bindToController` is truthy
+            var require = controllerDirective.require;
+            if (!isArray(require) && isObject(require)) {
+              extend(controllerInstance, getControllers(name, require, $element, elementControllers));
+            }
+
+            // Re-assign the properties in case they were changed in the constructor
+            var initialChanges = controller.bindingInfo.initialChanges;
+            forEach(initialChanges, function(value, key) {
+              controllerInstance[key] = value.currentValue;
+            });
           }
         });
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4827,6 +4827,31 @@ describe('$compile', function() {
             });
         });
 
+
+        it('should reassign bindings to the controller before $onInit, in case the constructor has overwritten them', function() {
+          angular.module('owComponentTest', [])
+            .component('owComponent', {
+              bindings: { input: '<' },
+              controller: function() {
+                component = this;
+                this.input = 'constructor-changed';
+                this.$onInit = function() {
+                  log.push('$onInit: input=' + this.input);
+                };
+              }
+            });
+
+          module('owComponentTest');
+          inject(function() {
+            $rootScope.name = 'outer';
+            compile('<ow-component input="name"></ow-component>');
+            expect(component.input).toEqual('outer');
+            expect(log).toEqual([
+              '$onInit: input=outer'
+            ]);
+          });
+        });
+
         it('should not update isolate again after $onInit if outer has not changed', function() {
           module('owComponentTest');
           inject(function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

FIX

**What is the current behavior? (You can also link to an open issue here)**

Changes to input bound properties inside the controller constructor are overwriting the
initial value of the input binding.

**What is the new behavior (if this is a feature change)?**

We now reassign these properties after calling the constructor.

**Does this PR introduce a breaking change?**

No - previous releases of Angular 1.5.x over-wrote these properties both
after the constructor and after $onInit.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
  ~~\- [ ] Docs have been added / updated (for bug fixes / features)~~

**Other information**:

Previously any input bindings would be reassigned after the constructor
and the `$onInit` hook had been called because of an invalid extra update
in the input binding watch handler.

In 304796471292f9805b9cf77e51aacc9cfbb09921 we removed this extra update,
which resulted in changes to the controller properties in either the
constructor or the `$onInit` hook to be kept.

It turns out that the fact that we can overwrite the input bindings in the
constructor is invalid. Really the bindings should have been assigned
only after the constructor is called but due to a historical feature that
enabled developers to access the bindings from within the constructor this
was possible.

To prevent this we now assign the bindings before calling the constructor
and then reassign them after the constructor but before the call to `$onInit`.

This is the behaviour that we want in the long term, where we will remove
the feature of pre-binding properties before calling the constructor any
way.
