### PR TITLE
fix(ngAnimate): safe-guard against missing document

### DIFF
--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -103,6 +103,9 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
     var activeAnimationsLookup = new $$HashMap();
     var disabledElementsLookup = new $$HashMap();
     var animationsEnabled = null;
+    // $document might be mocked and won't include a real document.
+    // Providing an empty object will prevent property read errors
+    var rawDocument = $document[0] || {};
 
     function postDigestTaskFactory() {
       var postDigestCalled = false;
@@ -331,7 +334,7 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
 
       var isStructural = ['enter', 'move', 'leave'].indexOf(event) >= 0;
 
-      var documentHidden = animationsEnabled && $document[0].hidden;
+      var documentHidden = rawDocument.hidden;
 
       // this is a hard disable of all animations for the application or on
       // the element itself, therefore  there is no need to continue further
@@ -583,7 +586,7 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
      * d) the element is not a child of the $rootElement
      */
     function areAnimationsAllowed(element, parentElement, event) {
-      var bodyElement = jqLite($document[0].body);
+      var bodyElement = jqLite(rawDocument.body);
       var bodyElementDetected = isMatchingElement(element, bodyElement) || element[0].nodeName === 'HTML';
       var rootElementDetected = isMatchingElement(element, $rootElement);
       var parentAnimationDetected = false;

--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -103,9 +103,9 @@ var $$AnimateQueueProvider = ['$animateProvider', function($animateProvider) {
     var activeAnimationsLookup = new $$HashMap();
     var disabledElementsLookup = new $$HashMap();
     var animationsEnabled = null;
-    // $document might be mocked and won't include a real document.
-    // Providing an empty object will prevent property read errors
-    var rawDocument = $document[0] || {};
+    // $document might be mocked out in tests and won't include a real document.
+    // Providing an empty object with hidden = true will prevent animations from running
+    var rawDocument = $document[0] || {hidden: true};
 
     function postDigestTaskFactory() {
       var postDigestCalled = false;

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -1404,6 +1404,36 @@ describe("animations", function() {
     });
   });
 
+
+  it('should not run animations if the document is unavailable', function() {
+    var capturedAnimation;
+
+    module(function($provide) {
+      $provide.value('$document', {});
+
+      $provide.factory('$$animation', function($$AnimateRunner) {
+        return function(element, method, options) {
+          capturedAnimation = arguments;
+          return new $$AnimateRunner();
+        };
+      });
+    });
+
+    inject(function($animate, $rootScope, $rootElement, $document) {
+      $animate.enabled(true);
+
+      var spy = jasmine.createSpy();
+
+      element = jqLite('<div></div>');
+      var runner = $animate.enter(element, $rootElement);
+      $rootScope.$digest();
+
+      $animate.flush();
+
+      expect(capturedAnimation).toBeUndefined();
+    });
+  });
+
   describe('[ng-animate-children]', function() {
     var parent, element, child, capturedAnimation, captureLog;
     beforeEach(module(function($provide) {


### PR DESCRIPTION
A different fix for the mocked document problem (in 1.4.x) that also fixes another possibly breaking access to the document.

One caveat: since we are now failing gracefully, and a missing document means no animations fire, tests that test animations and mock out document will not run animations, and this will be opaque to developers. However, I assume that most tests that mock document are actually very basic, as lots of other things should break when $document is mocked

Please check if the PR fulfills these requirements

```
The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
```
