### PR TITLE
feat($compile): improve filter system of directive

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2670,7 +2670,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
      */
     function addDirective(tDirectives, name, location, maxPriority, ignoreDirective, startAttrName,
                           endAttrName) {
-      if (name === ignoreDirective) return null;
+      if (typeof ignoreDirective === 'string' && name === ignoreDirective) return null;
+      if (typeof ignoreDirective === 'function' && !ignoreDirective.call(null, name)) return null;
+
       var match = null;
       if (hasDirectives.hasOwnProperty(name)) {
         for (var directive, directives = $injector.get(name + Suffix),


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
when you

```
$compile(element, undefined, undefined, 'ngController')($scope);
$scope.$apply();
```

only a single directive can be excluded

**What is the new behavior (if this is a feature change)?**
with this patch we could have more control on what directives we want to compile.
An example could be:

```
element.attr("ng-include", "template");
$compile(element, undefined, undefined, function(name){ return name == 'ngInclude'; })($scope);
$scope.$apply();
```

so we could compile just the directives we need. maybe just those attached runtime.
this way we can avoid re-attaching controllers or other ng-directives.

**Does this PR introduce a breaking change?**
No. the code provided is backward compatible

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
