### PR TITLE
fix(ngMessagesInclude): do not compile template if scope is destroyed

### DIFF
--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -550,6 +550,8 @@ angular.module('ngMessages', [])
        link: function($scope, element, attrs) {
          var src = attrs.ngMessagesInclude || attrs.src;
          $templateRequest(src).then(function(html) {
+           if ($scope.$$destroyed) return;
+
            $compile(html)($scope, function(contents) {
              element.after(contents);
 

--- a/test/ngMessages/messagesSpec.js
+++ b/test/ngMessages/messagesSpec.js
@@ -842,6 +842,33 @@ describe('ngMessages', function() {
       })
     );
 
+    it('should not compile template if scope is destroyed', function() {
+      module(function($provide) {
+        $provide.decorator('$compile', ['$delegate', function($delegate) {
+          var result = jasmine.createSpy('$compile').and.callFake($delegate);
+          result.$$createComment = $delegate.$$createComment;
+          return result;
+        }]);
+      });
+      inject(function($rootScope, $httpBackend, $compile) {
+        $httpBackend.expectGET('messages.html').respond('<div ng-message="a">A</div>');
+        $rootScope.show = true;
+        var html =
+            '<div ng-if="show">' +
+              '<div ng-messages="items">' +
+                '<div ng-messages-include="messages.html"></div>' +
+              '</div>' +
+            '</div>';
+
+        element = $compile(html)($rootScope);
+        $rootScope.$digest();
+        $rootScope.show = false;
+        $rootScope.$digest();
+        $compile.calls.reset();
+        $httpBackend.flush();
+        expect($compile).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('when multiple', function() {

--- a/test/ngMessages/messagesSpec.js
+++ b/test/ngMessages/messagesSpec.js
@@ -842,14 +842,7 @@ describe('ngMessages', function() {
       })
     );
 
-    it('should not compile template if scope is destroyed', function() {
-      module(function($provide) {
-        $provide.decorator('$compile', ['$delegate', function($delegate) {
-          var result = jasmine.createSpy('$compile').and.callFake($delegate);
-          result.$$createComment = $delegate.$$createComment;
-          return result;
-        }]);
-      });
+    it('should not throw if scope has been destroyed when template request is ready',
       inject(function($rootScope, $httpBackend, $compile) {
         $httpBackend.expectGET('messages.html').respond('<div ng-message="a">A</div>');
         $rootScope.show = true;
@@ -864,11 +857,10 @@ describe('ngMessages', function() {
         $rootScope.$digest();
         $rootScope.show = false;
         $rootScope.$digest();
-        $compile.calls.reset();
-        $httpBackend.flush();
-        expect($compile).not.toHaveBeenCalled();
-      });
-    });
+        expect(function() {
+          $httpBackend.flush();
+        }).not.toThrow();
+    }));
   });
 
   describe('when multiple', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
https://github.com/angular/angular.js/issues/12695

**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change?**

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Messages imported with ngMessagesInclude are loaded asynchronously and they can arrive after the ngMessages element has already been removed from DOM. Previously such messages were still compiled and that caused a $compile:ctreq error. Now they are silently ignored if ngMessagesInclude's scope has already been destroyed.

Closes #12695
