### PR TITLE
fix($animate): don't break on anchored animations without duration

### DIFF
--- a/src/ngAnimate/animation.js
+++ b/src/ngAnimate/animation.js
@@ -378,7 +378,8 @@ var $$AnimationProvider = ['$animateProvider', function($animateProvider) {
         }
 
         function update(element) {
-          getRunner(element).setHost(newRunner);
+          var runner = getRunner(element);
+          if (runner) runner.setHost(newRunner);
         }
       }
 

--- a/test/ngAnimate/animateCssSpec.js
+++ b/test/ngAnimate/animateCssSpec.js
@@ -1880,6 +1880,24 @@ describe("ngAnimate $animateCss", function() {
         expect(element).not.toHaveClass('ng-leave-active');
         expect(element).not.toHaveClass('ng-move-active');
       }));
+
+      it('should not break when running anchored animations without duration',
+        inject(function($animate, $document, $rootElement) {
+          var element1 = jqLite('<div class="item" ng-animate-ref="test">Item 1</div>');
+          var element2 = jqLite('<div class="item" ng-animate-ref="test">Item 2</div>');
+
+          jqLite($document[0].body).append($rootElement);
+          $rootElement.append(element1);
+
+          expect($rootElement.text()).toBe('Item 1');
+
+          $animate.leave(element1);
+          $animate.enter(element2, $rootElement);
+          $animate.flush();
+
+          expect($rootElement.text()).toBe('Item 2');
+        })
+      );
     });
 
     describe("class-based animations", function() {

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -13,7 +13,7 @@ describe("animations", function() {
     };
   }));
 
-  afterEach(inject(function($$jqLite) {
+  afterEach(inject(function() {
     dealoc(element);
   }));
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
#14641

**What is the new behavior (if this is a feature change)?**
Anchored animations (via `[ng-animate-ref]`) without duration, don't break.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Fixes #14641
