### PR TITLE
feat($compile): backport $doCheck

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -300,6 +300,12 @@
  *   `changesObj` is a hash whose keys are the names of the bound properties that have changed, and the values are an
  *   object of the form `{ currentValue, previousValue, isFirstChange() }`. Use this hook to trigger updates within a
  *   component such as cloning the bound value to prevent accidental mutation of the outer value.
+ * * `$doCheck()` - Called on each turn of the digest cycle. Provides an opportunity to detect and act on
+ *   changes. Any actions that you wish to take in response to the changes that you detect must be
+ *   invoked from this hook; implementing this has no effect on when `$onChanges` is called. For example, this hook
+ *   could be useful if you wish to perform a deep equality check, or to check a Date object, changes to which would not
+ *   be detected by Angular's change detector and thus not trigger `$onChanges`. This hook is invoked with no arguments;
+ *   if detecting changes, you must store the previous value(s) for comparison to the current values.
  * * `$onDestroy()` - Called on a controller when its containing scope is destroyed. Use this hook for releasing
  *   external resources, watches and event handlers. Note that components have their `$onDestroy()` hooks called in
  *   the same order as the `$scope.$broadcast` events are triggered, which is top down. This means that parent
@@ -2483,6 +2489,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           if (isFunction(controllerInstance.$onInit)) {
             controllerInstance.$onInit();
           }
+          if (isFunction(controllerInstance.$doCheck)) {
+            controllerInstance.$doCheck();
+          }
           if (isFunction(controllerInstance.$onDestroy)) {
             controllerScope.$on('$destroy', function callOnDestroyHook() {
               controllerInstance.$onDestroy();
@@ -3131,7 +3140,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       forEach(bindings, function initializeBinding(definition, scopeName) {
         var attrName = definition.attrName,
         optional = definition.optional,
-        mode = definition.mode, // @, =, or &
+        mode = definition.mode, // @, =, <, or &
         lastValue,
         parentGet, parentSet, compare, removeWatch;
 
@@ -3243,6 +3252,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         }
       });
 
+      if (isFunction(destination.$doCheck)) {
+        var doCheckWatch = scope.$watch(triggerDoCheckHook);
+        removeWatchCollection.push(doCheckWatch);
+      }
+
       function recordChanges(key, currentValue, previousValue) {
         if (isFunction(destination.$onChanges) && currentValue !== previousValue) {
           // If we have not already scheduled the top level onChangesQueue handler then do so now
@@ -3268,6 +3282,10 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         destination.$onChanges(changes);
         // Now clear the changes so that we schedule onChanges when more changes arrive
         changes = undefined;
+      }
+
+      function triggerDoCheckHook() {
+        destination.$doCheck();
       }
 
       return {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3754,6 +3754,51 @@ describe('$compile', function() {
       });
     });
 
+    describe('$doCheck', function() {
+      it('should call `$doCheck`, if provided, for each digest cycle, after $onChanges and $onInit', function() {
+        var log = [];
+
+        function TestController() { }
+        TestController.prototype.$doCheck = function() { log.push('$doCheck'); };
+        TestController.prototype.$onChanges = function() { log.push('$onChanges'); };
+        TestController.prototype.$onInit = function() { log.push('$onInit'); };
+
+        angular.module('my', [])
+          .component('dcc', {
+            controller: TestController,
+            bindings: { 'prop1': '<' }
+          });
+
+        module('my');
+        inject(function($compile, $rootScope) {
+          element = $compile('<dcc prop1="val"></dcc>')($rootScope);
+          expect(log).toEqual([
+            '$onChanges',
+            '$onInit',
+            '$doCheck'
+          ]);
+
+          // Clear log
+          log = [];
+
+          $rootScope.$apply()
+          expect(log).toEqual([
+            '$doCheck',
+            '$doCheck'
+          ]);
+
+          // Clear log
+          log = [];
+
+          $rootScope.$apply('val = 2');
+          expect(log).toEqual([
+            '$doCheck',
+            '$onChanges',
+            '$doCheck'
+          ]);
+        });
+      });
+    });
 
     describe('$onChanges', function() {
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
If implemented, $doCheck will not be invoked

**What is the new behavior (if this is a feature change)?**
$doCheck will be invoked on every digest cycle.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

This mirrors the current actual behavior of Angular 2:
- During the initial compile, the sequence is `$onChanges`, `$onInit`, `$doCheck`.
- During subsequent digests, the sequence is `$doCheck`, `$onChanges`, `$doCheck`.
  (See the [live peekaboo demo from the docs](https://angular.io/resources/live-examples/lifecycle-hooks/ts/plnkr.html) to see the sequence.)
- Per my comments [here](https://github.com/angular/angular/issues/6810#issuecomment-220889605), `ngDoCheck` in Angular 2 just seems to be a hook into the digest cycle that supplements, but does not replace/override, the default change detector. The Angular 2 [docs](https://angular.io/docs/ts/latest/api/core/DoCheck-interface.html) are incorrect ([issue](https://github.com/angular/angular/issues/7307)): `$onChanges` is indeed called, and the code in `doCheck` does not override the default CD.

/cc @gkalpak
