### PR TITLE
feat(ngAria[ngClick]): preventDefault on pressing Space so the page doesn't scroll

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -377,6 +377,7 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
             elem.on('keypress', function(event) {
               var keyCode = event.which || event.keyCode;
               if (keyCode === 32 || keyCode === 13) {
+                event.preventDefault();
                 scope.$apply(callback);
               }
 


### PR DESCRIPTION
This is a bug fix for the ngAria ngClick directive.

When a user presses space on a "normal" `button`, the page should not scroll. However, with a "fake", `[role="button"]`, pressing space doesn't `preventDefault()`, so it scrolls the page.

You can see the bad behavior here: https://plnkr.co/edit/SPxQ0X2RQvvfvAmDVTNA?p=preview 

This PR adds `event.preventDefault();` so that pressing Space doesn't activate the native browser function.
