### PR TITLE
fix(ngEventDirs): check for $rootScope.$$phase in event handler and d…

### DIFF
--- a/src/ng/directive/ngEventDirs.js
+++ b/src/ng/directive/ngEventDirs.js
@@ -63,10 +63,12 @@ forEach(
               var callback = function() {
                 fn(scope, {$event:event});
               };
-              if (forceAsyncEvents[eventName] && $rootScope.$$phase) {
+              if (!$rootScope.$$phase) {
+                scope.$apply(callback);
+              } else if (forceAsyncEvents[eventName]) {
                 scope.$evalAsync(callback);
               } else {
-                scope.$apply(callback);
+                callback();
               }
             });
           };

--- a/test/ng/directive/ngEventDirsSpec.js
+++ b/test/ng/directive/ngEventDirsSpec.js
@@ -150,4 +150,46 @@ describe('event directives', function() {
     }));
 
   });
+
+  describe('click', function() {
+
+    it('should call the listener synchronously if inside of $apply',
+        inject(function($rootScope, $compile) {
+      var watchedVal;
+
+      element = $compile('<button type="button" ng-click="click()">Button</button>')($rootScope);
+      $rootScope.$watch('value', function(newValue) {
+        watchedVal = newValue;
+      });
+      $rootScope.click = jasmine.createSpy('click').and.callFake(function() {
+        $rootScope.value = 'newValue';
+      });
+
+      $rootScope.$apply(function() {
+        element.triggerHandler('click');
+      });
+
+      expect($rootScope.click).toHaveBeenCalledOnce();
+      expect(watchedVal).toEqual('newValue');
+    }));
+
+    it('should call the listener synchronously if outside of $apply',
+        inject(function($rootScope, $compile) {
+      var watchedVal;
+
+      element = $compile('<button type="button" ng-click="click()">Button</button>')($rootScope);
+      $rootScope.$watch('value', function(newValue) {
+        watchedVal = newValue;
+      });
+      $rootScope.click = jasmine.createSpy('click').and.callFake(function() {
+        $rootScope.value = 'newValue';
+      });
+
+      element.triggerHandler('click');
+
+      expect($rootScope.click).toHaveBeenCalledOnce();
+      expect(watchedVal).toEqual('newValue');
+    }));
+
+  });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
#14673

Digest cycle already in progress error can inadvertently be caused when triggering an
element's click event while within an active digest cycle. This is due to the ngEventsDirs
event handler always calling $rootScope.$apply regardless of the status of $rootScope.$$phase.
Checking the phase and calling the function immediately if within an active digest cycle
will prevent the problem without reducing current functionality.

**What is the new behavior (if this is a feature change)?**
This will change ngClick and the like to check for $rootScope.$$phase to determine if it should call the callback function without entering a new $apply.

**Does this PR introduce a breaking change?**
Nope

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
