### PR TITLE
docs(tutorial): add deprecation notice to v1.4.x tutorial and point to the correct branch

### DIFF
--- a/docs/app/src/tutorials.js
+++ b/docs/app/src/tutorials.js
@@ -11,16 +11,16 @@ angular.module('tutorials', [])
     scope: {},
     template:
       '<a ng-href="tutorial/{{prev}}"><li class="btn btn-primary"><i class="glyphicon glyphicon-step-backward"></i> Previous</li></a>\n' +
-      '<a ng-href="http://angular.github.io/angular-phonecat/step-{{seq}}/app"><li class="btn btn-primary"><i class="glyphicon glyphicon-play"></i> Live Demo</li></a>\n' +
-      '<a ng-href="https://github.com/angular/angular-phonecat/compare/step-{{diffLo}}...step-{{diffHi}}"><li class="btn btn-primary"><i class="glyphicon glyphicon-search"></i> Code Diff</li></a>\n' +
+      // '<a ng-href="http://angular.github.io/angular-phonecat/step-{{seq}}/app"><li class="btn btn-primary"><i class="glyphicon glyphicon-play"></i> Live Demo</li></a>\n' +
+      '<a ng-href="https://github.com/angular/angular-phonecat/compare/pre-v1.5.0-snapshot~{{diffLo}}...pre-v1.5.0-snapshot~{{diffHi}}"><li class="btn btn-primary"><i class="glyphicon glyphicon-search"></i> Code Diff</li></a>\n' +
       '<a ng-href="tutorial/{{next}}"><li class="btn btn-primary">Next <i class="glyphicon glyphicon-step-forward"></i></li></a>',
     link: function(scope, element, attrs) {
       var seq = 1 * attrs.docTutorialNav;
       scope.seq = seq;
       scope.prev = pages[seq];
       scope.next = pages[2 + seq];
-      scope.diffLo = seq ? (seq - 1): '0~1';
-      scope.diffHi = seq;
+      scope.diffLo = 13 - seq;
+      scope.diffHi = 12 - seq;
 
       element.addClass('btn-group');
       element.addClass('tutorial-nav');
@@ -38,12 +38,13 @@ angular.module('tutorials', [])
       '<p><button class="btn" ng-click="show=!show">Workspace Reset Instructions  ➤</button></p>\n' +
       '<div class="alert alert-info" ng-show="show">\n' +
       '  <p>Reset the workspace to step {{step}}.</p>' +
-      '  <p><pre>git checkout -f step-{{step}}</pre></p>\n' +
-      '  <p>Refresh your browser or check out this step online: '+
-          '<a href="http://angular.github.io/angular-phonecat/step-{{step}}/app">Step {{step}} Live Demo</a>.</p>\n' +
+      '  <p><pre>git checkout -f old-step-{{step}}</pre></p>\n' +
+      // '  <p>Refresh your browser or check out this step online: '+
+      //     '<a href="http://angular.github.io/angular-phonecat/step-{{step}}/app">Step {{step}} Live Demo</a>.</p>\n' +
+      '  <p>Refresh your browser to see the changes.</p>\n' +
       '</div>\n' +
       '<p>The most important changes are listed below. You can see the full diff on ' +
-        '<a ng-href="https://github.com/angular/angular-phonecat/compare/step-{{step ? (step - 1): \'0~1\'}}...step-{{step}}" title="See diff on Github">GitHub</a>\n' +
+        '<a ng-href="https://github.com/angular/angular-phonecat/compare/pre-v1.5.0-snapshot~{{13 - step}}...pre-v1.5.0-snapshot~{{12 - step}}" title="See diff on Github">GitHub</a>.\n' +
       '</p>'
   };
 });

--- a/docs/app/src/tutorials.js
+++ b/docs/app/src/tutorials.js
@@ -11,16 +11,15 @@ angular.module('tutorials', [])
     scope: {},
     template:
       '<a ng-href="tutorial/{{prev}}"><li class="btn btn-primary"><i class="glyphicon glyphicon-step-backward"></i> Previous</li></a>\n' +
-      // '<a ng-href="http://angular.github.io/angular-phonecat/step-{{seq}}/app"><li class="btn btn-primary"><i class="glyphicon glyphicon-play"></i> Live Demo</li></a>\n' +
-      '<a ng-href="https://github.com/angular/angular-phonecat/compare/pre-v1.5.0-snapshot~{{diffLo}}...pre-v1.5.0-snapshot~{{diffHi}}"><li class="btn btn-primary"><i class="glyphicon glyphicon-search"></i> Code Diff</li></a>\n' +
+      '<a ng-href="https://github.com/angular/angular-phonecat/compare/old-step-{{diffLo}}...old-step-{{diffHi}}"><li class="btn btn-primary"><i class="glyphicon glyphicon-search"></i> Code Diff</li></a>\n' +
       '<a ng-href="tutorial/{{next}}"><li class="btn btn-primary">Next <i class="glyphicon glyphicon-step-forward"></i></li></a>',
     link: function(scope, element, attrs) {
       var seq = 1 * attrs.docTutorialNav;
       scope.seq = seq;
       scope.prev = pages[seq];
       scope.next = pages[2 + seq];
-      scope.diffLo = 13 - seq;
-      scope.diffHi = 12 - seq;
+      scope.diffLo = seq ? (seq - 1): '0~1';
+      scope.diffHi = seq;
 
       element.addClass('btn-group');
       element.addClass('tutorial-nav');
@@ -39,12 +38,10 @@ angular.module('tutorials', [])
       '<div class="alert alert-info" ng-show="show">\n' +
       '  <p>Reset the workspace to step {{step}}.</p>' +
       '  <p><pre>git checkout -f old-step-{{step}}</pre></p>\n' +
-      // '  <p>Refresh your browser or check out this step online: '+
-      //     '<a href="http://angular.github.io/angular-phonecat/step-{{step}}/app">Step {{step}} Live Demo</a>.</p>\n' +
       '  <p>Refresh your browser to see the changes.</p>\n' +
       '</div>\n' +
       '<p>The most important changes are listed below. You can see the full diff on ' +
-        '<a ng-href="https://github.com/angular/angular-phonecat/compare/pre-v1.5.0-snapshot~{{13 - step}}...pre-v1.5.0-snapshot~{{12 - step}}" title="See diff on Github">GitHub</a>.\n' +
+        '<a ng-href="https://github.com/angular/angular-phonecat/compare/old-step-{{step ? (step - 1) : \'0~1\'}}...old-step-{{step}}" title="See diff on Github">GitHub</a>\n' +
       '</p>'
   };
 });

--- a/docs/app/src/tutorials.js
+++ b/docs/app/src/tutorials.js
@@ -11,7 +11,7 @@ angular.module('tutorials', [])
     scope: {},
     template:
       '<a ng-href="tutorial/{{prev}}"><li class="btn btn-primary"><i class="glyphicon glyphicon-step-backward"></i> Previous</li></a>\n' +
-      '<a ng-href="https://github.com/angular/angular-phonecat/compare/old-step-{{diffLo}}...old-step-{{diffHi}}"><li class="btn btn-primary"><i class="glyphicon glyphicon-search"></i> Code Diff</li></a>\n' +
+      '<a ng-href="https://github.com/angular/angular-phonecat/compare/1.4-step-{{diffLo}}...1.4-step-{{diffHi}}"><li class="btn btn-primary"><i class="glyphicon glyphicon-search"></i> Code Diff</li></a>\n' +
       '<a ng-href="tutorial/{{next}}"><li class="btn btn-primary">Next <i class="glyphicon glyphicon-step-forward"></i></li></a>',
     link: function(scope, element, attrs) {
       var seq = 1 * attrs.docTutorialNav;
@@ -37,11 +37,11 @@ angular.module('tutorials', [])
       '<p><button class="btn" ng-click="show=!show">Workspace Reset Instructions  ➤</button></p>\n' +
       '<div class="alert alert-info" ng-show="show">\n' +
       '  <p>Reset the workspace to step {{step}}.</p>' +
-      '  <p><pre>git checkout -f old-step-{{step}}</pre></p>\n' +
+      '  <p><pre>git checkout -f 1.4-step-{{step}}</pre></p>\n' +
       '  <p>Refresh your browser to see the changes.</p>\n' +
       '</div>\n' +
       '<p>The most important changes are listed below. You can see the full diff on ' +
-        '<a ng-href="https://github.com/angular/angular-phonecat/compare/old-step-{{step ? (step - 1) : \'0~1\'}}...old-step-{{step}}" title="See diff on Github">GitHub</a>\n' +
+        '<a ng-href="https://github.com/angular/angular-phonecat/compare/1.4-step-{{step ? (step - 1) : \'0~1\'}}...1.4-step-{{step}}" title="See diff on Github">GitHub</a>\n' +
       '</p>'
   };
 });

--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -5,6 +5,22 @@
 
 # PhoneCat Tutorial App
 
+<div class="alert alert-danger">
+  <p>
+    This version of the tutorial is deprecated and no longer maintained. You can find the most
+    recent version of the tutorial at https://docs.angularjs.org/tutorial/.
+  </p>
+  <p>
+    It is recommended to use the latest tutorial version for the following reasons:
+    <ul>
+      <li>It showcases features introduced in AngularJS v1.5+</li>
+      <li>It follows modern best practices in terms of architecture and code organization</li>
+      <li>It has more up-to-date dependencies and tools</li>
+      <li>It is actively maintained</li>
+    </ul>
+  </p>
+</div>
+
 A great way to get introduced to AngularJS is to work through this tutorial, which walks you through
 the construction of an AngularJS web app. The app you will build is a catalog that displays a list
 of Android devices, lets you filter the list to see only devices that interest you, and then view
@@ -73,13 +89,18 @@ Clone the [angular-phonecat repository][angular-phonecat] located at GitHub by r
 command:
 
 ```
-git clone --depth=14 https://github.com/angular/angular-phonecat.git
+git clone --depth=14 --branch=pre-v1.5.0-snapshot https://github.com/angular/angular-phonecat.git
 ```
 
 This command creates the `angular-phonecat` directory in your current directory.
 
 <div class="alert alert-info">The `--depth=14` option just tells Git to pull down only the last 14 commits.  This makes the
 download much smaller and faster.
+</div>
+
+<div class="alert alert-info">
+  The `--branch=pre-v1.5.0-snapshot` option tells Git to pull down the `pre-v1.5.0-snapshot` branch.
+  The code for this older version of the tutorial is on that branch.
 </div>
 
 Change your current directory to `angular-phonecat`.

--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -89,7 +89,7 @@ Clone the [angular-phonecat repository][angular-phonecat] located at GitHub by r
 command:
 
 ```
-git clone --depth=14 --branch=pre-v1.5.0-snapshot https://github.com/angular/angular-phonecat.git
+git clone --depth=14 --branch=1.4-snapshot https://github.com/angular/angular-phonecat.git
 ```
 
 This command creates the `angular-phonecat` directory in your current directory.
@@ -99,7 +99,7 @@ download much smaller and faster.
 </div>
 
 <div class="alert alert-info">
-  The `--branch=pre-v1.5.0-snapshot` option tells Git to pull down the `pre-v1.5.0-snapshot` branch.
+  The `--branch=1.4-snapshot` option tells Git to pull down the `1.4-snapshot` branch.
   The code for this older version of the tutorial is on that branch.
 </div>
 

--- a/docs/content/tutorial/step_00.ngdoc
+++ b/docs/content/tutorial/step_00.ngdoc
@@ -16,7 +16,7 @@ dependencies, as described in {@link index#get-started Get Started}.
 In the `angular-phonecat` directory, run this command:
 
 ```
-git checkout -f old-step-0
+git checkout -f 1.4-step-0
 ```
 
 

--- a/docs/content/tutorial/step_00.ngdoc
+++ b/docs/content/tutorial/step_00.ngdoc
@@ -16,7 +16,7 @@ dependencies, as described in {@link index#get-started Get Started}.
 In the `angular-phonecat` directory, run this command:
 
 ```
-git checkout -f step-0
+git checkout -f old-step-0
 ```
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
- Add a deprecation notice on the 'index' page.
- Hide the "Live Demo" buttons (since we don't have a live demo).
- Update the GitHub diff links to point to the ~~`pre-v1.5.0-snapshot`~~ `1.4-snapshot` angular-phonecat branch.
- Modify all git commangs to use the appropriate branch and tags.

Related to #14416.
