### PR TITLE
fix($compile): turn link[href] into a RESOURCE_URL context.

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2953,6 +2953,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       // maction[xlink:href] can source SVG.  It's not limited to <maction>.
       if (attrNormalizedName === "xlinkHref" ||
           (tag === "form" && attrNormalizedName === "action") ||
+          // links can be stylesheets or imports, which can run script in the current origin
+          (tag === "link" && attrNormalizedName === "href") ||
           (tag !== "img" && (attrNormalizedName === "src" ||
                             attrNormalizedName === "ngSrc"))) {
         return $sce.RESOURCE_URL;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -10002,6 +10002,7 @@ describe('$compile', function() {
           "loading resource from url not allowed by $sceDelegate policy.  URL: javascript:doTrustedStuff()");
     }));
 
+
     it('should pass through $sce.trustAs() values in action attribute', inject(function($compile, $rootScope, $sce) {
       /* jshint scripturl:true */
       element = $compile('<form action="{{testUrl}}"></form>')($rootScope);
@@ -10009,6 +10010,36 @@ describe('$compile', function() {
       $rootScope.$apply();
 
       expect(element.attr('action')).toEqual('javascript:doTrustedStuff()');
+    }));
+  });
+
+  describe('link[href]', function() {
+    it('should reject invalid RESOURCE_URLs', inject(function($compile, $rootScope) {
+      element = $compile('<link href="{{testUrl}}" rel="stylesheet" />')($rootScope);
+      $rootScope.testUrl = "https://evil.example.org/css.css";
+      expect(function() { $rootScope.$apply(); }).toThrowMinErr(
+          "$interpolate", "interr", "Can't interpolate: {{testUrl}}\nError: [$sce:insecurl] Blocked " +
+          "loading resource from url not allowed by $sceDelegate policy.  URL: " +
+          "https://evil.example.org/css.css");
+    }));
+
+    it('should accept valid RESOURCE_URLs', inject(function($compile, $rootScope, $sce) {
+      element = $compile('<link href="{{testUrl}}" rel="stylesheet" />')($rootScope);
+
+      $rootScope.testUrl = "./css1.css";
+      $rootScope.$apply();
+      expect(element.attr('href')).toContain('css1.css');
+
+      $rootScope.testUrl = $sce.trustAsResourceUrl('https://elsewhere.example.org/css2.css');
+      $rootScope.$apply();
+      expect(element.attr('href')).toContain('https://elsewhere.example.org/css2.css');
+    }));
+
+    it('should accept valid constants', inject(function($compile, $rootScope) {
+      element = $compile('<link href="https://elsewhere.example.org/css2.css" rel="stylesheet" />')($rootScope);
+
+      $rootScope.$apply();
+      expect(element.attr('href')).toContain('https://elsewhere.example.org/css2.css');
     }));
   });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix.

**What is the current behavior? (You can also link to an open issue here)**

There's no $sce context for link[href], meaning a <link rel="foo" href="{{bar}}" /> tag will have no $sce protection (might have link sanitization though, I'm not sure of that). That's fine for several rel types, but at least stylesheet and import can run script in your origin, which corresponds to a RESOURCE_URL context.

**What is the new behavior (if this is a feature change)?**

Turn it into a RESOURCE_URL context. Note that this is an overcorrection, sadly, but the security level of this attribute depends on the rel attribute, and I don't know if we can make context-aware decisions in this type of situation. 

RESOURCE_URLs are allowed to be interpolated if the value is $sce-blessed, or for plain strings if they're from the same origin.

Angular2 is being fixed to do the same with https://github.com/angular/angular/pull/8869/files#diff-5ffbf51559339aaa2db503c37cc3a658R60.

**Does this PR introduce a breaking change?**

Most apps keep the default whitelist, so it will break apps with dynamically-set link[href]s pointing to other origins.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

No comprehensive list of contexts in the docs to update, they just say the $sce.RESOURCE_URL type is "For URLs that are not only safe to follow as links, but whose contents are also safe to include in your application. Examples include ... ".
