### PR TITLE
fix(ngRoute): Don't deep-copy the route object, just plain copy it instead.

### DIFF
--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -160,7 +160,7 @@ function $RouteProvider() {
    */
   this.when = function(path, route) {
     //copy original route object to preserve params inherited from proto chain
-    var routeCopy = angular.copy(route);
+    var routeCopy = route;
     if (angular.isUndefined(routeCopy.reloadOnSearch)) {
       routeCopy.reloadOnSearch = true;
     }

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -1297,6 +1297,39 @@ describe('$route', function() {
       });
     });
 
+
+    it('should not deep-copy or alter route fields', function() {
+      // Object.seal is used to block future modifications of the object: we do not want
+      // to alter the objects passed as parameters.
+      var canaryObject = Object.seal({});
+
+       // No point faking a full template, use the syntax from above
+      var canaryTemplate = function() {
+        return "<p>hi</p>";
+      };
+      canaryTemplate.someField = canaryObject;
+      Object.seal(canaryTemplate);  // sealed as well, just in case
+
+      module(function($routeProvider) {
+        $routeProvider.when('/foo',
+            {
+              template: canaryTemplate,
+              myObject: canaryObject,
+            });
+      });
+
+      inject(function($route, $location, $rootScope) {
+        $location.path('/foo');
+        $rootScope.$digest();
+
+        // Copies of the canaries won't be their originals.
+        expect($route.current.myObject).toBe(canaryObject);
+        expect($route.current.template).toBe(canaryTemplate);
+        expect($route.current.template.someField).toBe(canaryObject);
+      });
+    });
+
+
     describe('reload', function() {
       var $location;
       var $log;

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -1314,7 +1314,7 @@ describe('$route', function() {
         $routeProvider.when('/foo',
             {
               template: canaryTemplate,
-              myObject: canaryObject,
+              myObject: canaryObject
             });
       });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix for #14478

**What is the current behavior? (You can also link to an open issue here)**
Angular runs angular.copy on its routes, which isn't necessary and breaks some things

**What is the new behavior (if this is a feature change)?**
No more angular.copy on these, which appears to not break anything.

**Does this PR introduce a breaking change?**
No, it shouldn't. 

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

That's Angular's guts, the previous behavior wasn't documented, and the new one seems obvious enough. 

**Other information**:

This seems to fix #14478. No need for a deep copy, just a plain one is enough as ngRoute does not modify the fields in the route object. 

I'm not that familiar with ngRoute, and the fix seems too easy: if something's wrong, I'll be glad to add tests for that :) As mentionned in the issue, #8181 and #9731 seems to be relevant, but this PR shouldn't reopen the issues.
