### PR TITLE
docs(guide/Unit Testing): change the incorrect parameter

### DIFF
--- a/docs/content/guide/unit-testing.ngdoc
+++ b/docs/content/guide/unit-testing.ngdoc
@@ -185,7 +185,7 @@ describe('PasswordController', function() {
   describe('$scope.grade', function() {
     it('sets the strength to "strong" if the password length is >8 chars', function() {
       var $scope = {};
-      var controller = $controller('PasswordController', { $scope: $scope });
+      var controller = $controller('PasswordController', { $scope: scope });
       $scope.password = 'longerthaneightchars';
       $scope.grade();
       expect($scope.strength).toEqual('strong');
@@ -193,7 +193,7 @@ describe('PasswordController', function() {
 
     it('sets the strength to "weak" if the password length <3 chars', function() {
       var $scope = {};
-      var controller = $controller('PasswordController', { $scope: $scope });
+      var controller = $controller('PasswordController', { $scope: scope });
       $scope.password = 'a';
       $scope.grade();
       expect($scope.strength).toEqual('weak');


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change?**

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

{ $scope: scope } is the right object to pass as second parameter, pass { $scope: $scope } makes the test fail.
