### PR TITLE
fix($parse): allow arguments to contain filter chains

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -545,7 +545,7 @@ AST.prototype = {
     var args = [];
     if (this.peekToken().text !== ')') {
       do {
-        args.push(this.expression());
+        args.push(this.filterChain());
       } while (this.expect(','));
     }
     return args;

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -2139,6 +2139,15 @@ describe('parser', function() {
         expect(scope.$eval("add(1,2)")).toEqual(3);
       });
 
+      it('should allow filter chains as arguments', function() {
+        scope.concat = function(a, b) {
+          return a + b;
+        };
+        scope.begin = 1;
+        scope.limit = 2;
+        expect(scope.$eval("concat('abcd'|limitTo:limit:begin,'abcd'|limitTo:2:1|uppercase)")).toEqual("bcBC");
+      });
+
       it('should evaluate function call from a return value', function() {
         scope.getter = function() { return function() { return 33; }; };
         expect(scope.$eval("getter()()")).toBe(33);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

fix

**What is the current behavior? (You can also link to an open issue here)**

call expressions cannot take filter chains as parameters

**What is the new behavior (if this is a feature change)?**

call expressions can take filter chains as parameters

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
  ~~\- [ ] Docs have been added / updated (for bug fixes / features)~~

**Other information**:

Closes #4175
Closes #4168
