### PR TITLE
fix($compile): don't add replaced attributes twice to $attrs

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2761,19 +2761,19 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
       // copy the new attributes on the old attrs object
       forEach(src, function(value, key) {
-        // Check if we already set this attribute in the loop above
-        if (!dst[key]) {
+        // Check if we already set this attribute in the loop above.
+        // `dst` will never contain hasOwnProperty as DOM parser won't let it.
+        // You will get an "InvalidCharacterError: DOM Exception 5" error if you
+        // have an attribute like "has-own-property" or "data-has-own-property", etc.
+        if (!dst.hasOwnProperty(key)) {
 
           if (key === 'class') {
             safeAddClass($element, value);
-            dst['class'] = (dst['class']   ? dst['class'] + ' ' : '') + value;
+            dst['class'] = value;
           } else if (key === 'style') {
             $element.attr('style', $element.attr('style') + ';' + value);
-            dst['style'] = (dst['style'] ? dst['style'] + ';' : '') + value;
-            // `dst` will never contain hasOwnProperty as DOM parser won't let it.
-            // You will get an "InvalidCharacterError: DOM Exception 5" error if you
-            // have an attribute like "has-own-property" or "data-has-own-property", etc.
-          } else if (key.charAt(0) !== '$' && !dst.hasOwnProperty(key)) {
+            dst['style'] = value;
+          } else if (key.charAt(0) !== '$') {
             dst[key] = value;
             dstAttr[key] = srcAttr[key];
           }

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2765,18 +2765,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         // `dst` will never contain hasOwnProperty as DOM parser won't let it.
         // You will get an "InvalidCharacterError: DOM Exception 5" error if you
         // have an attribute like "has-own-property" or "data-has-own-property", etc.
-        if (!dst.hasOwnProperty(key)) {
-
-          if (key === 'class') {
-            safeAddClass($element, value);
-            dst['class'] = value;
-          } else if (key === 'style') {
-            $element.attr('style', $element.attr('style') + ';' + value);
-            dst['style'] = value;
-          } else if (key.charAt(0) !== '$') {
-            dst[key] = value;
-            dstAttr[key] = srcAttr[key];
-          }
+        if (!dst.hasOwnProperty(key) && key.charAt(0) !== '$') {
+          dst.$set(key, value, true, srcAttr[key]);
         }
       });
     }

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2766,7 +2766,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         // You will get an "InvalidCharacterError: DOM Exception 5" error if you
         // have an attribute like "has-own-property" or "data-has-own-property", etc.
         if (!dst.hasOwnProperty(key) && key.charAt(0) !== '$') {
-          dst.$set(key, value, true, srcAttr[key]);
+          dst[key] = value;
+
+          if (key !== 'class' && key !== 'style') {
+            dstAttr[key] = srcAttr[key];
+          }
         }
       });
     }

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2761,18 +2761,22 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
       // copy the new attributes on the old attrs object
       forEach(src, function(value, key) {
-        if (key === 'class') {
-          safeAddClass($element, value);
-          dst['class'] = (dst['class'] ? dst['class'] + ' ' : '') + value;
-        } else if (key === 'style') {
-          $element.attr('style', $element.attr('style') + ';' + value);
-          dst['style'] = (dst['style'] ? dst['style'] + ';' : '') + value;
-          // `dst` will never contain hasOwnProperty as DOM parser won't let it.
-          // You will get an "InvalidCharacterError: DOM Exception 5" error if you
-          // have an attribute like "has-own-property" or "data-has-own-property", etc.
-        } else if (key.charAt(0) !== '$' && !dst.hasOwnProperty(key)) {
-          dst[key] = value;
-          dstAttr[key] = srcAttr[key];
+        // Check if we already set this attribute in the loop above
+        if (!dst[key]) {
+
+          if (key === 'class') {
+            safeAddClass($element, value);
+            dst['class'] = (dst['class']   ? dst['class'] + ' ' : '') + value;
+          } else if (key === 'style') {
+            $element.attr('style', $element.attr('style') + ';' + value);
+            dst['style'] = (dst['style'] ? dst['style'] + ';' : '') + value;
+            // `dst` will never contain hasOwnProperty as DOM parser won't let it.
+            // You will get an "InvalidCharacterError: DOM Exception 5" error if you
+            // have an attribute like "has-own-property" or "data-has-own-property", etc.
+          } else if (key.charAt(0) !== '$' && !dst.hasOwnProperty(key)) {
+            dst[key] = value;
+            dstAttr[key] = srcAttr[key];
+          }
         }
       });
     }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -989,8 +989,8 @@ describe('$compile', function() {
                 link: function($scope, $element, $attrs) {
                   attrs = $attrs;
                 }
-              }
-            })
+              };
+            });
           });
 
           inject(function($compile, $rootScope) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -980,6 +980,29 @@ describe('$compile', function() {
         }));
 
 
+        it('should not set merged attributes twice in $attrs', function() {
+          var attrs;
+
+          module(function() {
+            directive('logAttrs', function() {
+              return {
+                link: function($scope, $element, $attrs) {
+                  attrs = $attrs;
+                }
+              }
+            })
+          });
+
+          inject(function($compile, $rootScope) {
+            element = $compile(
+              '<div><div log-attrs replace class="myLog"></div><div>')($rootScope);
+            var div = element.find('div');
+            expect(div.attr('class')).toBe('myLog log');
+            expect(attrs.class).toBe('myLog log');
+          });
+        });
+
+
         it('should prevent multiple templates per element', inject(function($compile) {
           try {
             $compile('<div><span replace class="replace"></span></div>');


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bugfix

**What is the current behavior? (You can also link to an open issue here)**
In replace directives, attribute values from the template are added twice to the replaced element when both the replaced element and the template element have the attribute. This does not affect the DOM, as it normalizes duplicate values. The values are however duplicated in the $attrs object that is available to directive link functions.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)

**Other information**:
@gkalpak I fixed this while working on another attribute-related PR.

Fixes #8159
Closes #5597
