### PR TITLE
 fix($compile): don't trim white-space in attributes

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2753,7 +2753,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       forEach(dst, function(value, key) {
         if (key.charAt(0) !== '$') {
           if (src[key] && src[key] !== value) {
-            value += (key === 'style' ? ';' : ' ') + src[key];
+            if (value.length) {
+              value += (key === 'style' ? ';' : ' ') + src[key];
+            } else {
+              value = src[key];
+            }
           }
           dst.$set(key, value, true, srcAttr[key]);
         }

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1893,7 +1893,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
             attr = nAttrs[j];
             name = attr.name;
-            value = trim(attr.value);
+            value = attr.value;
 
             // support ngAttr attribute binding
             ngAttrName = directiveNormalize(name);

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1461,14 +1461,20 @@ function emailInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 }
 
 function radioInputType(scope, element, attr, ctrl) {
+  var doTrim = !attr.ngTrim || trim(attr.ngTrim) !== 'false';
   // make the name unique, if not defined
   if (isUndefined(attr.name)) {
     element.attr('name', nextUid());
   }
 
   var listener = function(ev) {
+    var value;
     if (element[0].checked) {
-      ctrl.$setViewValue(attr.value, ev && ev.type);
+      value = attr.value;
+      if (doTrim) {
+        value = trim(value);
+      }
+      ctrl.$setViewValue(value, ev && ev.type);
     }
   };
 
@@ -1476,6 +1482,9 @@ function radioInputType(scope, element, attr, ctrl) {
 
   ctrl.$render = function() {
     var value = attr.value;
+    if (doTrim) {
+      value = trim(value);
+    }
     // Strict comparison would cause a BC
     /* jshint eqeqeq:false */
     element[0].checked = (value == ctrl.$viewValue);

--- a/src/ng/directive/ngList.js
+++ b/src/ng/directive/ngList.js
@@ -91,9 +91,7 @@ var ngListDirective = function() {
     priority: 100,
     require: 'ngModel',
     link: function(scope, element, attr, ctrl) {
-      // We want to control whitespace trimming so we use this convoluted approach
-      // to access the ngList attribute, which doesn't pre-trim the attribute
-      var ngList = element.attr(attr.$attr.ngList) || ', ';
+      var ngList = attr.ngList || ', ';
       var trimValues = attr.ngTrim !== 'false';
       var separator = trimValues ? trim(ngList) : ngList;
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -980,6 +980,17 @@ describe('$compile', function() {
         }));
 
 
+        it('should not add white-space when merging an attribute that is "" in the replaced element',
+          inject(function($compile, $rootScope) {
+            element = $compile(
+              '<div><div replace class=""></div><div>')($rootScope);
+            var div = element.find('div');
+            expect(div.hasClass('log')).toBe(true);
+            expect(div.attr('class')).toBe('log');
+          })
+        );
+
+
         it('should not set merged attributes twice in $attrs', function() {
           var attrs;
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4725,6 +4725,14 @@ describe('$compile', function() {
         expect(componentScope.attrAlias).toEqual(componentScope.attr);
       }));
 
+      it('should copy an attribute with spaces', inject(function() {
+        compile('<div><span my-component attr=" some text ">');
+
+        expect(componentScope.attr).toEqual(' some text ');
+        expect(componentScope.attrAlias).toEqual(' some text ');
+        expect(componentScope.attrAlias).toEqual(componentScope.attr);
+      }));
+
       it('should set up the interpolation before it reaches the link function', inject(function() {
         $rootScope.name = 'misko';
         compile('<div><span my-component attr="hello {{name}}">');

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2989,6 +2989,53 @@ describe('input', function() {
       expect(inputElm[0].checked).toBe(false);
       expect(inputElm[1].checked).toBe(false);
     });
+
+
+    it('should allow the use of ngTrim', function() {
+      $rootScope.some = 11;
+      var inputElm = helper.compileInput(
+          '<input type="radio" ng-model="value" value="opt1" />' +
+          '<input type="radio" ng-model="value" value="  opt2  " />' +
+          '<input type="radio" ng-model="value" ng-trim="false" value="  opt3  " />' +
+          '<input type="radio" ng-model="value" ng-trim="false" value="{{some}}" />' +
+          '<input type="radio" ng-model="value" ng-trim="false" value="  {{some}}  " />');
+
+      $rootScope.$apply(function() {
+        $rootScope.value = 'blue';
+        $rootScope.some = 'blue';
+      });
+
+      expect(inputElm[0].checked).toBe(false);
+      expect(inputElm[1].checked).toBe(false);
+      expect(inputElm[2].checked).toBe(false);
+      expect(inputElm[3].checked).toBe(true);
+      expect(inputElm[4].checked).toBe(false);
+
+      browserTrigger(inputElm[1], 'click');
+      expect($rootScope.value).toBe('opt2');
+      browserTrigger(inputElm[2], 'click');
+      expect($rootScope.value).toBe('  opt3  ');
+      browserTrigger(inputElm[3], 'click');
+      expect($rootScope.value).toBe('blue');
+      browserTrigger(inputElm[4], 'click');
+      expect($rootScope.value).toBe('  blue  ');
+
+      $rootScope.$apply("value = '  opt2  '");
+      expect(inputElm[1].checked).toBe(false);
+      $rootScope.$apply("value = 'opt2'");
+      expect(inputElm[1].checked).toBe(true);
+      $rootScope.$apply("value = '  opt3  '");
+      expect(inputElm[2].checked).toBe(true);
+      $rootScope.$apply("value = 'opt3'");
+      expect(inputElm[2].checked).toBe(false);
+
+      $rootScope.$apply("value = 'blue'");
+      expect(inputElm[3].checked).toBe(true);
+      expect(inputElm[4].checked).toBe(false);
+      $rootScope.$apply("value = '  blue  '");
+      expect(inputElm[3].checked).toBe(false);
+      expect(inputElm[4].checked).toBe(true);
+    });
   });
 
 

--- a/test/ng/directive/ngListSpec.js
+++ b/test/ng/directive/ngListSpec.js
@@ -130,6 +130,12 @@ describe('ngList', function() {
       helper.changeInputValueTo('a\nb');
       expect($rootScope.list).toEqual(['a','b']);
     });
+
+    it('should support splitting on whitespace', function() {
+      helper.compileInput('<textarea type="text" ng-model="list" ng-trim="false" ng-list=" "></textarea>');
+      helper.changeInputValueTo('a b');
+      expect($rootScope.list).toEqual(['a','b']);
+    })
   });
 });
 

--- a/test/ng/directive/ngListSpec.js
+++ b/test/ng/directive/ngListSpec.js
@@ -135,7 +135,7 @@ describe('ngList', function() {
       helper.compileInput('<textarea type="text" ng-model="list" ng-trim="false" ng-list=" "></textarea>');
       helper.changeInputValueTo('a b');
       expect($rootScope.list).toEqual(['a','b']);
-    })
+    });
   });
 });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
$compile trims white-space from attributes when making them available to directives.

**Does this PR introduce a breaking change?**
Yes. Previosuly stray white-space was trimmed, and therefore didn't impact application logic. I suspect this could have a moderate impact on existing apps - it depends on how common it is that attributes are read and used.
I think however that not trimming white-space lets Angular work more like it is expected from HTML (which allows almost anything as an attribute value)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
