### PR TITLE
docs($exceptionHandler): code snippet syntax is incorrect

### DIFF
--- a/src/ng/exceptionHandler.js
+++ b/src/ng/exceptionHandler.js
@@ -27,7 +27,7 @@
  *         logErrorsToBackend(exception, cause);
  *         $log.warn(exception, cause);
  *       };
- *     });
+ *     }]);
  * ```
  *
  * <hr />


### PR DESCRIPTION
Updated the documentation on exception handler, there was an end bracket missing.

Supposedly not a breaking change, it's only documentation update.
