### PR TITLE
fix(input): update $viewValue when cleared

### DIFF
--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -73,7 +73,7 @@ function $SnifferProvider() {
         // when cut operation is performed.
         // IE10+ implements 'input' event but it erroneously fires under various situations,
         // e.g. when placeholder changes, or a form is focused.
-        if (event === 'input' && msie <= 11) return false;
+        if (event === 'input' && msie <= 9) return false;
 
         if (isUndefined(eventSupport[event])) {
           var divElm = document.createElement('div');

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -135,7 +135,7 @@ describe('$sniffer', function() {
       // IE10+ implementation is fubared when mixed with placeholders
       mockDivElement = {oninput: noop};
 
-      expect($sniffer.hasEvent('input')).toBe(!(msie && msie <= 11));
+      expect($sniffer.hasEvent('input')).toBe(!(msie && msie <= 9));
     });
   });
 


### PR DESCRIPTION
- Fix when user clicks clear button in an input element in IE, $viewValue not being correctly updated

This should fix #11193.
