### PR TITLE
chore(version-info.js): ignore curl file write errors

### DIFF
--- a/lib/versions/version-info.js
+++ b/lib/versions/version-info.js
@@ -151,7 +151,9 @@ var getCdnVersion = function() {
           var cdnResult = shell.exec('curl http://ajax.googleapis.com/ajax/libs/angularjs/' + version + '/angular.min.js ' +
                     '--head --write-out "%{http_code}" -o /dev/null -silent',
                                       {silent: true});
-          if (cdnResult.code === 0) {
+          // Ignore if Curl can't write the file (code 23), e.g. on Windows, as we still get
+          // the needed output from --write-out
+          if (cdnResult.code === 0 || cdnResult.code === 23) {
             var statusCode = cdnResult.output.trim();
             if (statusCode === '200') {
               cdnVersion = version;
@@ -220,6 +222,8 @@ if (NO_REMOTE_REQUESTS) {
   console.log(' - this is due to the "NG1_BUILD_NO_REMOTE_VERSION_REQUESTS" environment variable being defined.');
   console.log(' - be aware that the generated docs may not have valid or the most recent version information.');
   console.log('==============================================================================================');
+  console.log('Current local version', exports.currentVersion.raw);
+}  else {
+  console.log('CDN version:', cdnVersion.raw);
+  console.log('Current version:', exports.currentVersion.raw);
 }
-console.log('CDN version:', cdnVersion.raw);
-console.log('Current version:', exports.currentVersion.raw);

--- a/lib/versions/version-info.js
+++ b/lib/versions/version-info.js
@@ -9,6 +9,7 @@ var _ = require('lodash');
 var process = require('process');
 // We are only interested in whether this environment variable exists, hence the !!
 var NO_REMOTE_REQUESTS = !!process.env['NG1_BUILD_NO_REMOTE_VERSION_REQUESTS'];
+var versionSource = NO_REMOTE_REQUESTS ? 'local' : 'remote';
 
 var currentPackage, previousVersions, cdnVersion, gitRepoInfo;
 
@@ -149,12 +150,11 @@ var getCdnVersion = function() {
           // Note: need to use shell.exec and curl here
           // as version-infos returns its result synchronously...
           var cdnResult = shell.exec('curl http://ajax.googleapis.com/ajax/libs/angularjs/' + version + '/angular.min.js ' +
-                    '--head --write-out "%{http_code}" -o /dev/null -silent',
+                    '--head --write-out "%{http_code}" -silent',
                                       {silent: true});
-          // Ignore if Curl can't write the file (code 23), e.g. on Windows, as we still get
-          // the needed output from --write-out
-          if (cdnResult.code === 0 || cdnResult.code === 23) {
-            var statusCode = cdnResult.output.trim();
+          if (cdnResult.code === 0) {
+            // --write-out appends its content to the general request response, so extract it
+            var statusCode = cdnResult.output.split('\n').pop().trim();
             if (statusCode === '200') {
               cdnVersion = version;
             }
@@ -222,8 +222,7 @@ if (NO_REMOTE_REQUESTS) {
   console.log(' - this is due to the "NG1_BUILD_NO_REMOTE_VERSION_REQUESTS" environment variable being defined.');
   console.log(' - be aware that the generated docs may not have valid or the most recent version information.');
   console.log('==============================================================================================');
-  console.log('Current local version', exports.currentVersion.raw);
-}  else {
-  console.log('CDN version:', cdnVersion.raw);
-  console.log('Current version:', exports.currentVersion.raw);
 }
+
+console.log('CDN version (' + versionSource + '):', cdnVersion ? cdnVersion.raw : 'No version found.');
+console.log('Current version (' + versionSource + '):', exports.currentVersion.raw);


### PR DESCRIPTION
On Windows, curl can obviously not write to `dev/null`, and throws code 23, which prevents us from checking that the CDN server responded. However, we don't need the file anyway, we just need the status code, so we can ignore the file write error.

This needs to be tested on Linux / Mac however!
