### PR TITLE
perf(ngOptions): don't render options before the first digest

### DIFF
--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -587,8 +587,14 @@ var ngOptionsDirective = ['$compile', '$document', '$parse', function($compile, 
       selectElement.empty();
 
       // We need to do this here to ensure that the options object is defined
-      // when we first hit it in writeNgOptionsValue
-      updateOptions();
+      // when we first hit it in writeNgOptionsValue updateOptions();
+      // The watchCollection will then initalize the actual options and render them
+      options = {
+        getViewValueFromOption: noop,
+        getOptionFromViewValue: noop,
+        selectValueMap: {},
+        items: []
+      };
 
       // We will re-render the option elements if the option values or labels change
       scope.$watchCollection(ngOptions.getWatchables, updateOptions);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
perf

**What is the current behavior? (You can also link to an open issue here)**
see commit message

**What is the new behavior (if this is a feature change)?**
see commit message

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- ~~[ ] Tests for the changes have been added (for bug fixes / features)~~
- ~~[ ] Docs have been added / updated (for bug fixes / features)~~

**Other information**:

Previously, ngOptions would collect and render the options during linking
and then again immediately after the next digest passed, in order to have
the options ready when the select directive tries to render ngModel.
Since we are completely removing the options when they are updated, this means
we are essentially creating each ngOptions select twice after it is compiled.

This fix changes it so that ngOptions creates a noop version of the internal API
so that select can correctly try to render ngModel
