### PR TITLE
docs(indexPage.template.html): change bad punctuation in documentatio…

### DIFF
--- a/docs/config/templates/indexPage.template.html
+++ b/docs/config/templates/indexPage.template.html
@@ -220,12 +220,11 @@
         <p class="pull-right"><a back-to-top>Back to top</a></p>
 
         <p>
-          Super-powered by Google  ©2010-2016
-          ( <a id="version"
+          Super-powered by Google ©2010-2016
+          (<a id="version"
                ng-href="https://github.com/angular/angular.js/blob/master/CHANGELOG.md#{{versionNumber}}"
                ng-bind-template="v{{version}}" title="Changelog of this version of Angular JS">
-            </a>
-          )
+           </a>)
         </p>
         <p>
           Code licensed under


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update to fix punctuation typo in footer

**What is the current behavior? (You can also link to an open issue here)**
See the footer of the Angular official [documentation](https://docs.angularjs.org/) page

**What is the new behavior (if this is a feature change)?**
There are no more punctuation typos in the footer

**Does this PR introduce a breaking change?**
No, it doesn't. Only affects to the footer.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)

**Other information**:
N/A
