### PR TITLE
feat($rootScope): allow $watch to be triggered by an event

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -94,6 +94,14 @@ function $RootScopeProvider() {
     return ChildScope;
   }
 
+  function watchEquals(value, last, objectEquality) {
+    return value !== last &&
+      !(objectEquality
+          ? equals(value, last)
+          : (typeof value === 'number' && typeof last === 'number'
+            && isNaN(value) && isNaN(last)))
+  }
+
   this.$get = ['$exceptionHandler', '$parse', '$browser',
       function($exceptionHandler, $parse, $browser) {
 
@@ -384,6 +392,29 @@ function $RootScopeProvider() {
        * @returns {function()} Returns a deregistration function for this listener.
        */
       $watch: function(watchExp, listener, objectEquality, prettyPrintExpression) {
+        if (!angular.isFunction(listener)) {
+          listener = angular.noop;
+        }
+
+        if (typeof watchExp === 'string' && watchExp.match(/^ *[a-zA-Z]+ *:/)) {
+          var statement = watchExp.split(':'),
+              eventName = statement[0].trim(),
+              get = $parse(statement.slice(1).join(':')),
+              last = initWatchVal,
+              scope = this;
+          function watchOnEvaluate() {
+            var reallyLast,
+                value = get(scope);
+            if (watchEquals(value, last, objectEquality)) {
+              reallyLast = last; // before setting new last
+              last = objectEquality ? copy(value, null) : value;
+              return listener(value, (reallyLast === initWatchVal ? value : reallyLast), scope);
+            }
+          }
+          watchOnEvaluate();
+          return this.$on(eventName, watchOnEvaluate);
+        }
+
         var get = $parse(watchExp);
 
         if (get.$$watchDelegate) {
@@ -400,10 +431,6 @@ function $RootScopeProvider() {
             };
 
         lastDirtyWatch = null;
-
-        if (!isFunction(listener)) {
-          watcher.fn = noop;
-        }
 
         if (!array) {
           array = scope.$$watchers = [];
@@ -795,11 +822,7 @@ function $RootScopeProvider() {
                   // circuit it with === operator, only when === fails do we use .equals
                   if (watch) {
                     get = watch.get;
-                    if ((value = get(current)) !== (last = watch.last) &&
-                        !(watch.eq
-                            ? equals(value, last)
-                            : (typeof value === 'number' && typeof last === 'number'
-                               && isNaN(value) && isNaN(last)))) {
+                    if (watchEquals((value = get(current)), (last = watch.last), watch.eq)) {
                       dirty = true;
                       lastDirtyWatch = watch;
                       watch.last = watch.eq ? copy(value, null) : value;


### PR DESCRIPTION
**Note:** I did not yet add documentation/tests because I first want to know if this actually makes sense to do this.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feat

**What is the current behavior? (You can also link to an open issue here)**
Watch expressions are always evaluated on every digest.

**What is the new behavior (if this is a feature change)?**
Allow `$watch` to be evaluated when an event is triggered (using `$on`), with a new syntax `"eventName: watchExpression"`.

Example:

_HTML:_

``` html
<div ng-if="sessionChanged: currentUser">
  <!-- Below doesn't really work yet since I don't know where that is -->
  Hi, {{sessionChanged: currentUser.username}}
</div>
```

_JavaScript:_

``` javascript
$rootScope.currentUser = { username: "..." };
$rootScope.$broadcast('sessionChanged');
```

**Does this PR introduce a breaking change?**
No.

**Other information**:
This is actually more of a suggestion/question: I read everywhere that watchers are bad, but there is no true solution for this apart from writing directives that basically destroy the templating concept. I understand that using events (`$on`) should be better, and so I figured it might be a good idea to patch into `$watch` (which is used everywhere, `ng-if` etc) the ability to be triggered by an event rather than adding it to the digest cycle.
