### PR TITLE
feat($compile): attach the containing controller to transcluded scope

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1840,6 +1840,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         if (!transcludedScope) {
           transcludedScope = scope.$new(false, containingScope);
           transcludedScope.$$transcluded = true;
+          transcludedScope.$container = containingScope && containingScope.$ctrl;
         }
 
         return transcludeFn(transcludedScope, cloneFn, {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -7915,6 +7915,24 @@ describe('$compile', function() {
       }
 
 
+      it('should add a $container property onto the transcluded scope, referencing the containing controller', function() {
+        module(function($compileProvider) {
+          $compileProvider.component('myComp', {
+            transclude: true,
+            controller: function() {
+              this.val = 'xxx';
+            },
+            template: '<div><span>I:{{$ctrl.val}}</span><span ng-transclude></span></div>'
+          });
+        });
+        inject(function($rootScope, $compile) {
+          element = $compile('<div><my-comp>T:{{$container.val}}</my-comp></div>')($rootScope);
+          $rootScope.$apply();
+          expect(jqLite(element.find('span')[0]).text()).toEqual('I:xxx');
+          expect(jqLite(element.find('span')[1]).text()).toEqual('T:xxx');
+        });
+      });
+
       it('should add a $$transcluded property onto the transcluded scope', function() {
         module(function() {
           directive('trans', function() {


### PR DESCRIPTION
This is a POC strawman...
- What are the memory-leak implications of this approach?
- Would it be sufficient to cover the kind of cases that people want to achieve with #14386?
