### PR TITLE
docs(ngReadonly): added note about input type checkbox and radio

### DIFF
--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -234,6 +234,8 @@
  *
  * A special directive is necessary because we cannot use interpolation inside the `readOnly`
  * attribute. See the {@link guide/interpolation interpolation guide} for more info.
+ * 
+ * Please note that `ngReadonly` does not work with input `type="radio"` and `type="checkbox"`, text based inputs works fine.
  *
  * @example
     <example>

--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -232,10 +232,11 @@
  *
  * Sets the `readOnly` attribute on the element, if the expression inside `ngReadonly` is truthy.
  *
+ * Note that `ngReadonly` does not work with input `type="radio"` and `type="checkbox"`,
+ * text based inputs works fine.
+ *
  * A special directive is necessary because we cannot use interpolation inside the `readOnly`
  * attribute. See the {@link guide/interpolation interpolation guide} for more info.
- * 
- * Please note that `ngReadonly` does not work with input `type="radio"` and `type="checkbox"`, text based inputs works fine.
  *
  * @example
     <example>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

**What is the current behavior? (You can also link to an open issue here)**

Current docs does not mention, that ngReadonly does work with input type checkbox|radio.

**What is the new behavior (if this is a feature change)?**

Added note to docs string.

**Does this PR introduce a breaking change?**

No, text change in comment only.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
