### PR TITLE
fix($jsonpCallbacks): do not overwrite callbacks added by other apps

### DIFF
--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -150,7 +150,7 @@ function publishExternalAPI(angular) {
     'isDate': isDate,
     'lowercase': lowercase,
     'uppercase': uppercase,
-    'callbacks': {counter: 0},
+    'callbacks': {$$counter: 0},
     'getTestability': getTestability,
     '$$minErr': minErr,
     '$$csp': csp,

--- a/src/ng/jsonpCallbacks.js
+++ b/src/ng/jsonpCallbacks.js
@@ -11,9 +11,9 @@
  */
 var $jsonpCallbacksProvider = function() {
   this.$get = ['$window', function($window) {
-    var counter = 0;
-    $window.angular.callbacks = {};
     var callbackMap = {};
+    var callbacks = $window.angular.callbacks = $window.angular.callbacks || {};
+    callbacks.$$counter = callbacks.$$counter || 0;
 
     function createCallback(callbackId) {
       var callback = function(data) {
@@ -35,10 +35,10 @@ var $jsonpCallbacksProvider = function() {
        * to pass to the server, which will be used to call the callback with its payload in the JSONP response.
        */
       createCallback: function(url) {
-        var callbackId = '_' + (counter++).toString(36);
+        var callbackId = '_' + (callbacks.$$counter++).toString(36);
         var callbackPath = 'angular.callbacks.' + callbackId;
         var callback = createCallback(callbackId);
-        callbackMap[callbackPath] = $window.angular.callbacks[callbackId] = callback;
+        callbackMap[callbackPath] = callbacks[callbackId] = callback;
         return callbackPath;
       },
       /**
@@ -75,7 +75,7 @@ var $jsonpCallbacksProvider = function() {
        */
       removeCallback: function(callbackPath) {
         var callback = callbackMap[callbackPath];
-        delete $window.angular.callbacks[callback.id];
+        delete callbacks[callback.id];
         delete callbackMap[callbackPath];
       }
     };

--- a/src/ng/jsonpCallbacks.js
+++ b/src/ng/jsonpCallbacks.js
@@ -11,9 +11,8 @@
  */
 var $jsonpCallbacksProvider = function() {
   this.$get = ['$window', function($window) {
+    var callbacks = $window.angular.callbacks;
     var callbackMap = {};
-    var callbacks = $window.angular.callbacks = $window.angular.callbacks || {};
-    callbacks.$$counter = callbacks.$$counter || 0;
 
     function createCallback(callbackId) {
       var callback = function(data) {

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2954,7 +2954,7 @@ angular.mock.$RootScopeDecorator = ['$delegate', function($delegate) {
     angular.forEach(angular.callbacks, function(val, key) {
       delete angular.callbacks[key];
     });
-    angular.callbacks.counter = 0;
+    angular.callbacks.$$counter = 0;
   };
 
   (window.beforeEach || window.setup)(module.$$beforeEach);

--- a/test/ng/jsonpCallbacksSpec.js
+++ b/test/ng/jsonpCallbacksSpec.js
@@ -36,6 +36,19 @@ describe('$jsonpCallbacks', function() {
       $jsonpCallbacks.createCallback('http://some.dummy.com/jsonp/request');
       expect($window.angular.callbacks._3).toEqual(jasmine.any(Function));
     }));
+
+    it('should produce unique callback paths across multiple instances', function() {
+      var $jsonpCallbacks1 = angular.injector(['ng', 'ngMock']).get('$jsonpCallbacks');
+      var $jsonpCallbacks2 = angular.injector(['ng', 'ngMock']).get('$jsonpCallbacks');
+
+      var path1 = $jsonpCallbacks1.createCallback('http://some.dummy.com/jsonp/request');
+      var path2 = $jsonpCallbacks2.createCallback('http://some.dummy.com/jsonp/request');
+
+      expect(path1).toBe('angular.callbacks._0');
+      expect(path2).toBe('angular.callbacks._1');
+      expect(angular.callbacks._0).toBeDefined();
+      expect(angular.callbacks._1).toBeDefined();
+    });
   });
 
 

--- a/test/ng/jsonpCallbacksSpec.js
+++ b/test/ng/jsonpCallbacksSpec.js
@@ -2,11 +2,6 @@
 
 describe('$jsonpCallbacks', function() {
 
-  beforeEach(module(function($provide) {
-    // mock out the $window object
-    $provide.value('$window', { angular: {} });
-  }));
-
   describe('createCallback(url)', function() {
 
     it('should return a new unique path to a callback function on each call', inject(function($jsonpCallbacks) {
@@ -74,6 +69,7 @@ describe('$jsonpCallbacks', function() {
       expect(result).toBe(response);
     }));
   });
+
 
   describe('removeCallback(calbackPath)', function() {
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.

**What is the current behavior? (You can also link to an open issue here)**
When bootstrapping multiple apps on the same page, one could overwrite JSONP callbacks defined by others.

**What is the new behavior (if this is a feature change)?**
The callback paths are usnique across apps.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
/cc @petebacondarwin 
