### PR TITLE
docs(guide/Filters): adding a a clear link to angular built-in filters

### DIFF
--- a/docs/content/guide/filter.ngdoc
+++ b/docs/content/guide/filter.ngdoc
@@ -10,7 +10,9 @@ controllers or services and it is easy to define your own filter.
 
 The underlying API is the {@link ng.$filterProvider `filterProvider`}.
 
-## Using filters in view templates
+A list of {@link ng.filter `built in filters`} in Angular.
+
+## Using filters in view templatesa
 
 Filters can be applied to expressions in view templates using the following syntax:
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Documentation update for the online guide of angularjs

**What is the current behavior? (You can also link to an open issue here)**
In the Filter guide on the angularjs docs, there are a few examples of filters but no direct link to see a list of the supported built-in filters

**What is the new behavior (if this is a feature change)?**
Making it clear to the reader where to find a list of supported built-in filters: https://docs.angularjs.org/api/ng/filter

**Does this PR introduce a breaking change?**
No, it's a documentation update.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
