### PR TITLE
feat($resource): pass `status`/`statusText` to success callbacks

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -238,9 +238,9 @@ function shallowClearAndCopy(src, dst) {
  *   - non-GET instance actions:  `instance.$action([parameters], [success], [error])`
  *
  *
- *   Success callback is called with (value, responseHeaders) arguments, where the value is
- *   the populated resource instance or collection object. The error callback is called
- *   with (httpResponse) argument.
+ *   Success callback is called with (value (Object|Array), responseHeaders (Function),
+ *   status (number), statusText (string)) arguments, where the value is the populated resource
+ *   instance or collection object. The error callback is called with (httpResponse) argument.
  *
  *   Class actions return empty instance (with additional properties below).
  *   Instance actions return promise of the action.
@@ -773,7 +773,7 @@ angular.module('ngResource', ['ng']).
             promise = promise.then(
               function(response) {
                 var value = responseInterceptor(response);
-                (success || noop)(value, response.headers);
+                (success || noop)(value, response.headers, response.status, response.statusText);
                 return value;
               },
               responseErrorInterceptor || error ?

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1024,6 +1024,7 @@ describe("basic usage", function() {
       });
     });
 
+
     it('should allow per action response interceptor that gets full response', function() {
       CreditCard = $resource('/CreditCard', {}, {
         query: {
@@ -1081,6 +1082,65 @@ describe("basic usage", function() {
     });
   });
 
+
+  describe('success mode', function() {
+    it('should call the success callback (as 1st argument) on 2xx responses', function() {
+      var instance, headers, status, statusText;
+      var successCb = jasmine.createSpy('successCb').and.callFake(function(d, h, s, t) {
+        expect(d).toBe(instance);
+        expect(h()).toEqual(jasmine.objectContaining(headers));
+        expect(s).toBe(status);
+        expect(t).toBe(statusText);
+      });
+
+      instance = CreditCard.get(successCb);
+      headers = {foo: 'bar'};
+      status = 200;
+      statusText = 'OK';
+      $httpBackend.expect('GET', '/CreditCard').respond(status, {}, headers, statusText);
+      $httpBackend.flush();
+
+      expect(successCb).toHaveBeenCalledOnce();
+
+      instance = CreditCard.get(successCb);
+      headers = {baz: 'qux'};
+      status = 299;
+      statusText = 'KO';
+      $httpBackend.expect('GET', '/CreditCard').respond(status, {}, headers, statusText);
+      $httpBackend.flush();
+
+      expect(successCb).toHaveBeenCalledTimes(2);
+    });
+
+
+    it('should call the success callback (as 2nd argument) on 2xx responses', function() {
+      var instance, headers, status, statusText;
+      var successCb = jasmine.createSpy('successCb').and.callFake(function(d, h, s, t) {
+        expect(d).toBe(instance);
+        expect(h()).toEqual(jasmine.objectContaining(headers));
+        expect(s).toBe(status);
+        expect(t).toBe(statusText);
+      });
+
+      instance = CreditCard.get({id: 123}, successCb);
+      headers = {foo: 'bar'};
+      status = 200;
+      statusText = 'OK';
+      $httpBackend.expect('GET', '/CreditCard/123').respond(status, {}, headers, statusText);
+      $httpBackend.flush();
+
+      expect(successCb).toHaveBeenCalledOnce();
+
+      instance = CreditCard.get({id: 456}, successCb);
+      headers = {baz: 'qux'};
+      status = 299;
+      statusText = 'KO';
+      $httpBackend.expect('GET', '/CreditCard/456').respond(status, {}, headers, statusText);
+      $httpBackend.flush();
+
+      expect(successCb).toHaveBeenCalledTimes(2);
+    });
+  });
 
   describe('failure mode', function() {
     var ERROR_CODE = 500,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature.

**What is the current behavior? (You can also link to an open issue here)**
Only the data/instance and the headers function are passed to success callbacks.

**What is the new behavior (if this is a feature change)?**
The `status` and `statusText` are also passed to the success callbacks.

**Does this PR introduce a breaking change?**
No. Yes. I don't know. Could be...in tests...if someone verifies what arguments their callbacks are called with...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
Fixes #8341
Closes #8841
