### PR TITLE
fix(copy): fix typed subarrays handling

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -901,7 +901,7 @@ function copy(source, destination) {
       case '[object Uint8ClampedArray]':
       case '[object Uint16Array]':
       case '[object Uint32Array]':
-        return new source.constructor(copyElement(source.buffer));
+        return new source.constructor(copyElement(source.buffer), source.byteOffset, source.length);
 
       case '[object ArrayBuffer]':
         //Support: IE10

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -240,13 +240,13 @@ describe('angular', function() {
       }
     });
 
-    it("should handle Uint8Array subarray", function() {
-      if (typeof Uint8Array !== 'undefined') {
-        var arr = new Uint8Array(4);
+    it("should handle Uint16Array subarray", function() {
+      if (typeof Uint16Array !== 'undefined') {
+        var arr = new Uint16Array(4);
         arr[1] = 1;
         var src = arr.subarray(1, 2);
         var dst = copy(src);
-        expect(dst instanceof Uint8Array).toBeTruthy();
+        expect(dst instanceof Uint16Array).toBeTruthy();
         expect(dst.length).toEqual(1);
         expect(dst[0]).toEqual(1);
         expect(dst).not.toBe(src);

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -240,6 +240,20 @@ describe('angular', function() {
       }
     });
 
+    it("should handle Uint8Array subarray", function() {
+      if (typeof Uint8Array !== 'undefined') {
+        var arr = new Uint8Array(4);
+        arr[1] = 1;
+        var src = arr.subarray(1, 2);
+        var dst = copy(src);
+        expect(dst instanceof Uint8Array).toBeTruthy();
+        expect(dst.length).toEqual(1);
+        expect(dst[0]).toEqual(1);
+        expect(dst).not.toBe(src);
+        expect(dst.buffer).not.toBe(src.buffer);
+      }
+    });
+
     it("should throw an exception if a Uint8Array is the destination", function() {
       if (typeof Uint8Array !== 'undefined') {
         var src = new Uint8Array();


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

It copies the whole buffer, not a slice.
Here is the demo: http://plnkr.co/edit/nU76OITTchFc48jFab2a?p=preview
#14842

**What is the new behavior (if this is a feature change)?**

When copying typed subarray the new value has the same length as the initial typed array.
This is not a feature change.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Previously, it would return copy of the whole original typed array, not its slice.
Now buffer offset and length are also saved.

Closes #14842
