### PR TITLE
perf($compile): wrap try/catch of collect comment directives into a function to avoid V8 deopt

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2052,24 +2052,30 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           addTextInterpolateDirective(directives, node.nodeValue);
           break;
         case NODE_TYPE_COMMENT: /* Comment */
-          try {
-            match = COMMENT_DIRECTIVE_REGEXP.exec(node.nodeValue);
-            if (match) {
-              nName = directiveNormalize(match[1]);
-              if (addDirective(directives, nName, 'M', maxPriority, ignoreDirective)) {
-                attrs[nName] = trim(match[2]);
-              }
-            }
-          } catch (e) {
-            // turns out that under some circumstances IE9 throws errors when one attempts to read
-            // comment's node value.
-            // Just ignore it and continue. (Can't seem to reproduce in test case.)
-          }
+          collectCommentDirectives();
           break;
       }
 
       directives.sort(byPriority);
       return directives;
+
+      function collectCommentDirectives() {
+        // function created because of performance, try/catch disables
+        // the optimization of the whole function #14848
+        try {
+          match = COMMENT_DIRECTIVE_REGEXP.exec(node.nodeValue);
+          if (match) {
+            nName = directiveNormalize(match[1]);
+            if (addDirective(directives, nName, 'M', maxPriority, ignoreDirective)) {
+              attrs[nName] = trim(match[2]);
+            }
+          }
+        } catch (e) {
+          // turns out that under some circumstances IE9 throws errors when one attempts to read
+          // comment's node value.
+          // Just ignore it and continue. (Can't seem to reproduce in test case.)
+        }
+      }
     }
 
     /**

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2052,29 +2052,29 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           addTextInterpolateDirective(directives, node.nodeValue);
           break;
         case NODE_TYPE_COMMENT: /* Comment */
-          collectCommentDirectives();
+          collectCommentDirectives(node, directives, attrs, maxPriority, ignoreDirective);
           break;
       }
 
       directives.sort(byPriority);
       return directives;
+    }
 
-      function collectCommentDirectives() {
-        // function created because of performance, try/catch disables
-        // the optimization of the whole function #14848
-        try {
-          match = COMMENT_DIRECTIVE_REGEXP.exec(node.nodeValue);
-          if (match) {
-            nName = directiveNormalize(match[1]);
-            if (addDirective(directives, nName, 'M', maxPriority, ignoreDirective)) {
-              attrs[nName] = trim(match[2]);
-            }
+    function collectCommentDirectives(node, directives, attrs, maxPriority, ignoreDirective) {
+      // function created because of performance, try/catch disables
+      // the optimization of the whole function #14848
+      try {
+        var match = COMMENT_DIRECTIVE_REGEXP.exec(node.nodeValue);
+        if (match) {
+          var nName = directiveNormalize(match[1]);
+          if (addDirective(directives, nName, 'M', maxPriority, ignoreDirective)) {
+            attrs[nName] = trim(match[2]);
           }
-        } catch (e) {
-          // turns out that under some circumstances IE9 throws errors when one attempts to read
-          // comment's node value.
-          // Just ignore it and continue. (Can't seem to reproduce in test case.)
         }
+      } catch (e) {
+        // turns out that under some circumstances IE9 throws errors when one attempts to read
+        // comment's node value.
+        // Just ignore it and continue. (Can't seem to reproduce in test case.)
       }
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)** its a performance optimization. It turns out that try/catch statements prevents the optimization of the function collectDirectives, which has a great weight in the initial document parse.

**What is the current behavior? (You can also link to an open issue here)**
It should be around a 5% faster in the angular initial document parse, and also in directives compilation.

**What is the new behavior (if this is a feature change)?**
There is no change in the functionality.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
See: https://github.com/GoogleChrome/devtools-docs/issues/53

I did all performance checking over existing code from my customers, in their code this optimization makes it go a **5% faster in the initial parse time and compile time** in average (I just performed 200 evaluation comparison with execution times around 50 - 100ms of each evaluation). I did the performance test over chrome, safari and firefox, all of them with similar speedup results.
I am not sure which environment do you use to check performance (I think that it is probably related to benchpress). ¿Do you have a guide about how to set up and do testing?

I found the problem while doing performance optimization in a customer code. Just clicking around I found this message lots of times:
![screen shot 2016-06-29 at 21 44 27](https://cloud.githubusercontent.com/assets/2758345/16481148/f80ae36c-3ea9-11e6-89b4-3cdba113d681.png)

![screen shot 2016-06-29 at 21 46 24](https://cloud.githubusercontent.com/assets/2758345/16481156/fdda3216-3ea9-11e6-90a5-c8120aeb9dee.png)

It should solve it, because in production environments usually there are no comments, so, this function is likely to be never executed.

I did no new documentation neither new tests because nothing changes but performance.
