### PR TITLE
style (ngLocale): update en-US AMPMS values

### DIFF
--- a/src/ngLocale/angular-locale_en-us.js
+++ b/src/ngLocale/angular-locale_en-us.js
@@ -22,8 +22,8 @@ function getVF(n, opt_precision) {
 $provide.value("$locale", {
   "DATETIME_FORMATS": {
     "AMPMS": [
-      "AM",
-      "PM"
+      "a.m.",
+      "p.m."
     ],
     "DAY": [
       "Sunday",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Localized string

**What is the current behavior? (You can also link to an open issue here)**
Values are all uppercase

**What is the new behavior (if this is a feature change)?**
Values are lowercase, separated with periods

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [X ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ X] Tests for the changes have been added (for bug fixes / features)
- [ X] Docs have been added / updated (for bug fixes / features)

**Other information**:

The Chicago Manual of Style, AP Stylebook, MLA Style Manual, and Merriam-Webster’s Collegiate Dictionary all recommend "a.m." and "p.m." as the desired formatting of "ante meridiem" and "post meridiem" which is also consistent with other two-word Latin abbreviations like "i.e." and "e.g."
