### PR TITLE
Extend with customized reduce function

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -36,6 +36,7 @@
     "nextUid": false,
     "setHashKey": false,
     "extend": false,
+    "extendWith": false,
     "toInt": false,
     "inherit": false,
     "merge": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -27,6 +27,7 @@
   nextUid: true,
   setHashKey: true,
   extend: true,
+  extendWith: true,
   toInt: true,
   inherit: true,
   merge: true,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -324,7 +324,7 @@ function setHashKey(obj, h) {
 }
 
 
-function baseExtend(dst, objs, deep) {
+function baseExtend(dst, objs, deep, reducer) {
   var h = dst.$$hashKey;
 
   for (var i = 0, ii = objs.length; i < ii; ++i) {
@@ -349,7 +349,11 @@ function baseExtend(dst, objs, deep) {
           baseExtend(dst[key], [src], true);
         }
       } else {
-        dst[key] = src;
+        if (isDefined(dst[key]) && isFunction(reducer)) {
+          dst[key] = reducer(dst[key], src);
+        } else {
+          dst[key] = src;
+        }
       }
     }
   }
@@ -378,6 +382,33 @@ function baseExtend(dst, objs, deep) {
  */
 function extend(dst) {
   return baseExtend(dst, slice.call(arguments, 1), false);
+}
+
+
+/**
+ * @ngdoc function
+ * @name angular.extendWith
+ * @module ng
+ * @kind function
+ *
+ * @description
+ * Extends the destination object `dst` by copying own enumerable properties from the `src` object(s)
+ * to `dst`. You can specify multiple `src` objects. If you want to preserve original objects, you can do so
+ * by passing an empty object as the target: `var object = angular.extend({}, object1, object2)`.
+ *
+ * The difference between this method and '{@link angular.extend}' is that when a property is specified in
+ * both the destination object and source object, the assigned value will be calculated by reducer from
+ * the orginal values.
+ *
+ * **Note:** Keep in mind that `angular.extendWith` does not support recursive merge (deep copy).
+ *
+ * @param {Object} dst Destination object.
+ * @param {function(dstValue, srcValue)} reducer Function for producing assigned value.
+ * @param {...Object} src Source object(s).
+ * @returns {Object} Reference to `dst`.
+ */
+function extendWith(dst, reducer) {
+  return baseExtend(dst, slice.call(arguments, 2), false, reducer);
 }
 
 

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -128,6 +128,7 @@ function publishExternalAPI(angular) {
     'bootstrap': bootstrap,
     'copy': copy,
     'extend': extend,
+    'extendWith': extendWith,
     'merge': merge,
     'equals': equals,
     'element': jqLite,

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -30,6 +30,7 @@
     "nextUid": false,
     "setHashKey": false,
     "extend": false,
+    "extendWith": false,
     "merge": false,
     "toInt": false,
     "inherit": false,

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -659,6 +659,34 @@ describe('angular', function() {
     });
   });
 
+  fdescribe("extendWith", function() {
+
+    it('should extend with the customized reducer', function() {
+      var reducer = function(dstValue, srcValue) {
+        if (isArray(dstValue)) {
+          return dstValue.concat(srcValue);
+        }
+        return srcValue;
+      };
+      var src = {
+        x: [1, 2, 3],
+        y: 8,
+        z: 'src only'
+      };
+      var dst = {
+        x: [4, 5, 6],
+        y: 7,
+        w: 'dst only'
+      };
+      dst = extendWith(dst, reducer, src);
+      expect(dst).toEqual({
+        x: [4, 5, 6, 1, 2, 3],
+        y: 8,
+        z: 'src only',
+        w: 'dst only'
+      });
+    });
+  });
 
   describe('merge', function() {
     it('should recursively copy objects into dst from left to right', function() {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -659,7 +659,7 @@ describe('angular', function() {
     });
   });
 
-  fdescribe("extendWith", function() {
+  describe("extendWith", function() {
 
     it('should extend with the customized reducer', function() {
       var reducer = function(dstValue, srcValue) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feature

**What is the current behavior? (You can also link to an open issue here)**

'extend' will use new value to override original value

**What is the new behavior (if this is a feature change)?**

by using 'extendWith', user can specify the new value assigned with a customized function of both the destination value and source value.
The test case provides an example where concat is used as an customized function for array like properties. Without the if statement, extendWith will behave the same as extend.

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
