### PR TITLE
fix(select): don't register options when select has no ngModel

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -519,11 +519,16 @@ var selectDirective = function() {
 
   function selectPreLink(scope, element, attr, ctrls) {
 
-      // if ngModel is not defined, we don't need to do anything
-      var ngModelCtrl = ctrls[1];
-      if (!ngModelCtrl) return;
-
       var selectCtrl = ctrls[0];
+      var ngModelCtrl = ctrls[1];
+
+      // if ngModel is not defined, we don't need to do anything but set the registerOption
+      // function to noop, so options don't get added internally
+      if (!ngModelCtrl) {
+        selectCtrl.registerOption = noop;
+        return;
+      }
+
 
       selectCtrl.ngModelCtrl = ngModelCtrl;
 

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -136,6 +136,30 @@ describe('select', function() {
 
   });
 
+  it('should not add options to the select if ngModel is not present', inject(function($rootScope) {
+    var scope = $rootScope;
+    scope.d = 'd';
+    scope.e = 'e';
+    scope.f = 'f';
+
+    compile('<select>' +
+      '<option ng-value="\'a\'">alabel</option>' +
+      '<option value="b">blabel</option>' +
+      '<option >c</option>' +
+      '<option ng-value="d">dlabel</option>' +
+      '<option value="{{e}}">elabel</option>' +
+      '<option>{{f}}</option>' +
+    '</select>');
+
+    var selectCtrl = element.controller('select');
+
+    expect(selectCtrl.hasOption('a')).toBe(false);
+    expect(selectCtrl.hasOption('b')).toBe(false);
+    expect(selectCtrl.hasOption('c')).toBe(false);
+    expect(selectCtrl.hasOption('d')).toBe(false);
+    expect(selectCtrl.hasOption('e')).toBe(false);
+    expect(selectCtrl.hasOption('f')).toBe(false);
+  }));
 
   describe('select-one', function() {
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bug fix

**What is the current behavior? (You can also link to an open issue here)**
Options are added even if select has no ngModel. ngValue replaces the value attribute of the element with a hashed value, and this might break tests (it does in angular material)

**What is the new behavior (if this is a feature change)?**
Options are not added to select

**Does this PR introduce a breaking change?**
?
I can't think of a valid use case where you'd want registerning options without ngModel integration. If you don't have model binding, then you don't need to store the options internally. You can actually use ngOptions without ngModel to render a list of options - but you don't need to register the options for that.

The registerOption function is also not documented, so this is an implementation detail from the perspective of the user

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)

**Other information**:

When option elements use ngValue, value or interpolated text simply to set
the option value, i.e. when the parent select doesn't have an ngModel,
there is no necessity in registering the options with the select controller.
This was previously no problem, as the ngModelController is set to a noop controller,
so that all further interactions are aborted ($render etc)

However, ngValue sets a hashed value inside the option value (to support arbitrary object types).
This can cause issues with tests that expect unhashed values.
