### PR TITLE
fix($resource): append extra params even if `Object.prototype` has properties with the same name

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -535,7 +535,7 @@ angular.module('ngResource', ['ng']).
             encodedVal,
             protocolAndDomain = '';
 
-          var urlParams = self.urlParams = {};
+          var urlParams = self.urlParams = Object.create(null);
           forEach(url.split(/\W/), function(param) {
             if (param === 'hasOwnProperty') {
               throw $resourceMinErr('badname', "hasOwnProperty is not a valid parameter name.");
@@ -591,7 +591,7 @@ angular.module('ngResource', ['ng']).
 
           // set params - delegate param encoding to $http
           forEach(params, function(value, key) {
-            if (!self.urlParams.hasOwnProperty(key)) {
+            if (!self.urlParams[key]) {
               config.params = config.params || {};
               config.params[key] = value;
             }

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -591,7 +591,7 @@ angular.module('ngResource', ['ng']).
 
           // set params - delegate param encoding to $http
           forEach(params, function(value, key) {
-            if (!self.urlParams[key]) {
+            if (!self.urlParams.hasOwnProperty(key)) {
               config.params = config.params || {};
               config.params[key] = value;
             }

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1363,6 +1363,49 @@ describe("basic usage", function() {
   });
 });
 
+describe('extra params', function() {
+  var $http;
+  var $httpBackend;
+  var $resource;
+
+  beforeEach(module('ngResource'));
+
+  beforeEach(module(function($provide) {
+    $provide.decorator('$http', function($delegate) {
+      return jasmine.createSpy('$http').and.callFake($delegate);
+    });
+  }));
+
+  beforeEach(inject(function(_$http_, _$httpBackend_, _$resource_) {
+    $http = _$http_;
+    $httpBackend = _$httpBackend_;
+    $resource = _$resource_;
+  }));
+
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+  });
+
+
+  it('should pass extra params to `$http` as `config.params`', function() {
+    $httpBackend.expectGET('/bar?baz=qux').respond('{}');
+
+    var R = $resource('/:foo');
+    R.get({foo: 'bar', baz: 'qux'});
+
+    expect($http).toHaveBeenCalledWith(jasmine.objectContaining({params: {baz: 'qux'}}));
+  });
+
+  it('should pass extra params even if `Object.prototype` has properties with the same name',
+    function() {
+      $httpBackend.expectGET('/foo?toString=bar').respond('{}');
+
+      var R = $resource('/foo');
+      R.get({toString: 'bar'});
+    }
+  );
+});
+
 describe('errors', function() {
   var $httpBackend, $resource, $q;
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
If `Object.prototype` has a property named `xyz`, then an extra `xyz` param passed to a `$resource` action call, **does not** get passed to `$http` (in `config.params`).
See #14866.

**What is the new behavior (if this is a feature change)?**
If `Object.prototype` has a property named `xyz`, then an extra `xyz` param passed to a `$resource` action call, **does** get passed to `$http` (in `config.params`).

**Does this PR introduce a breaking change?**
Possibly. If someone relied on using a `params` object with own, enumerable properties that have the same names with properties on `Object.prototype` and not have these properties passed to `$http` (and included in the URL as query params), then this would break them. Highly unlikely though.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Fixes #14866
