### PR TITLE
docs(guide/Directives): remove confusing definition object message

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -162,10 +162,6 @@ initialization work here. The function is invoked using
 {@link auto.$injector#invoke $injector.invoke} which makes it injectable just like a
 controller.
 
-<div class="alert alert-success">
-**Best Practice:** Prefer using the definition object over returning a function.
-</div>
-
 
 We'll go over a few common examples of directives, then dive deep into the different options
 and compilation process.


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs update

**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Prior to this point, the doc does not mention returning a postLink function, and all the examples use the definition object form. New readers could misinterpret "returning a function" as returning the factory function mentioned in the previous section.

Since this page is only a "gentle introduction" to directives, using the definition object is a best practice, and the message is already echoed in the docs for [$compile](https://docs.angularjs.org/api/ng/service/$compile), I think we should just remove the message altogether.
