### PR TITLE
fix($sanitize): blacklist the `usemap` attribute

### DIFF
--- a/karma-shared.conf.js
+++ b/karma-shared.conf.js
@@ -45,8 +45,8 @@ module.exports = function(config, specificOptions) {
       'SL_Safari': {
         base: 'SauceLabs',
         browserName: 'safari',
-        platform: 'OS X 10.9',
-        version: '7'
+        platform: 'OS X 10.10',
+        version: '8'
       },
       'SL_IE_8': {
         base: 'SauceLabs',

--- a/protractor-travis-conf.js
+++ b/protractor-travis-conf.js
@@ -20,8 +20,8 @@ config.multiCapabilities = [{
   'version': '28'
 }, {
   browserName: 'safari',
-  'platform': 'OS X 10.9',
-  'version': '7',
+  'platform': 'OS X 10.10',
+  'version': '8',
   'name': 'Angular E2E',
   'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
   'build': process.env.TRAVIS_BUILD_NUMBER

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -9,9 +9,9 @@ if [ $JOB = "ci-checks" ]; then
   grunt ci-checks
 elif [ $JOB = "unit" ]; then
   if [ "$BROWSER_PROVIDER" == "browserstack" ]; then
-    BROWSERS="BS_Chrome,BS_Safari,BS_Firefox,BS_IE_8,BS_IE_9,BS_IE_10,BS_IE_11"
+    BROWSERS="BS_Chrome,BS_Firefox,BS_Safari,BS_IE_8,BS_IE_9,BS_IE_10,BS_IE_11"
   else
-    BROWSERS="SL_Chrome,SL_Safari,SL_Firefox,SL_IE_8,SL_IE_9,SL_IE_10,SL_IE_11"
+    BROWSERS="SL_Chrome,SL_Firefox,SL_Safari,SL_IE_8,SL_IE_9,SL_IE_10,SL_IE_11"
   fi
 
   grunt test:promises-aplus

--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -204,7 +204,7 @@ var validElements = angular.extend({},
                                    optionalEndTagElements);
 
 //Attributes that have href and hence need to be sanitized
-var uriAttrs = makeMap("background,cite,href,longdesc,src,usemap");
+var uriAttrs = makeMap("background,cite,href,longdesc,src");
 var validAttrs = angular.extend({}, uriAttrs, makeMap(
     'abbr,align,alt,axis,bgcolor,border,cellpadding,cellspacing,class,clear,'+
     'color,cols,colspan,compact,coords,dir,face,headers,height,hreflang,hspace,'+

--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -174,6 +174,7 @@ describe('HTML', function() {
 
   it('should remove unsafe value', function() {
     expectHTML('<a href="javascript:alert()">').toEqual('<a></a>');
+    expectHTML('<img src="foo.gif" usemap="#foomap">').toEqual('<img src="foo.gif"/>');
   });
 
   it('should handle self closed elements', function() {


### PR DESCRIPTION
Backport of 234053f.

BREAKING CHANGE:

The `$sanitize` service will now remove instances of the `usemap` attribute from any elements passed to it.

This attribute is used to reference another element by `name` or `id`. Since the `name` and `id` attributes are already blacklisted, a sanitized `usemap` attribute could only reference unsanitized content, which is a security risk.
