### PR TITLE
fix($animate): improve detection and handling of invalid `classNameFilter` RegExp

### DIFF
--- a/docs/content/error/$animate/nongcls.ngdoc
+++ b/docs/content/error/$animate/nongcls.ngdoc
@@ -1,0 +1,8 @@
+@ngdoc error
+@name $animate:nongcls
+@fullName `ng-animate` class not allowed
+@description
+
+This error occurs, when trying to set `$animateProvider.classNameFilter()` to a RegExp containing
+the reserved `ng-animate` class. Since `.ng-animate` will be added/removed by `$animate` itself,
+using it as part of the `classNameFilter` RegExp is not allowed.

--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -179,6 +179,7 @@ var $$CoreAnimateQueueProvider = /** @this */ function() {
  */
 var $AnimateProvider = ['$provide', /** @this */ function($provide) {
   var provider = this;
+  var classNameFilter = null;
 
   this.$$registeredAnimations = Object.create(null);
 
@@ -247,15 +248,15 @@ var $AnimateProvider = ['$provide', /** @this */ function($provide) {
    */
   this.classNameFilter = function(expression) {
     if (arguments.length === 1) {
-      this.$$classNameFilter = (expression instanceof RegExp) ? expression : null;
-      if (this.$$classNameFilter) {
-        var reservedRegex = new RegExp('(\\s+|\\/)' + NG_ANIMATE_CLASSNAME + '(\\s+|\\/)');
-        if (reservedRegex.test(this.$$classNameFilter.toString())) {
-          throw $animateMinErr('nongcls','$animateProvider.classNameFilter(regex) prohibits accepting a regex value which matches/contains the "{0}" CSS class.', NG_ANIMATE_CLASSNAME);
+      classNameFilter = (expression instanceof RegExp) ? expression : null;
+      if (classNameFilter) {
+        var reservedRegex = new RegExp('[(\\s|\\/)]' + NG_ANIMATE_CLASSNAME + '[(\\s|\\/)]');
+        if (reservedRegex.test(classNameFilter.toString())) {
+          throw $animateMinErr('nongcls', '$animateProvider.classNameFilter(regex) prohibits accepting a regex value which matches/contains the "{0}" CSS class.', NG_ANIMATE_CLASSNAME);
         }
       }
     }
-    return this.$$classNameFilter;
+    return classNameFilter;
   };
 
   this.$get = ['$$animateQueue', function($$animateQueue) {

--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -252,6 +252,7 @@ var $AnimateProvider = ['$provide', /** @this */ function($provide) {
       if (classNameFilter) {
         var reservedRegex = new RegExp('[(\\s|\\/)]' + NG_ANIMATE_CLASSNAME + '[(\\s|\\/)]');
         if (reservedRegex.test(classNameFilter.toString())) {
+          classNameFilter = null;
           throw $animateMinErr('nongcls', '$animateProvider.classNameFilter(regex) prohibits accepting a regex value which matches/contains the "{0}" CSS class.', NG_ANIMATE_CLASSNAME);
         }
       }

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -255,29 +255,33 @@ describe('animations', function() {
       });
     });
 
-    it('should throw a minErr if a regex value is used which partially contains or fully matches the `ng-animate` CSS class', function() {
+    it('should throw a minErr if a regex value is used which partially contains or fully matches the `ng-animate` CSS class',
       module(function($animateProvider) {
+        var errorMessage = '$animateProvider.classNameFilter(regex) prohibits accepting a regex ' +
+                           'value which matches/contains the "ng-animate" CSS class.';
+
         assertError(/ng-animate/, true);
         assertError(/first ng-animate last/, true);
         assertError(/ng-animate-special/, false);
         assertError(/first ng-animate-special last/, false);
         assertError(/first ng-animate ng-animate-special last/, true);
+        assertError(/(ng-animate)/, true);
+        assertError(/(foo|ng-animate|bar)/, true);
+        assertError(/(foo|)ng-animate(|bar)/, true);
 
         function assertError(regex, bool) {
           var expectation = expect(function() {
             $animateProvider.classNameFilter(regex);
           });
 
-          var message = '$animateProvider.classNameFilter(regex) prohibits accepting a regex value which matches/contains the "ng-animate" CSS class.';
-
           if (bool) {
-            expectation.toThrowMinErr('$animate', 'nongcls', message);
+            expectation.toThrowMinErr('$animate', 'nongcls', errorMessage);
           } else {
-            expectation.not.toThrowMinErr('$animate', 'nongcls', message);
+            expectation.not.toThrow();
           }
         }
-      });
-    });
+      })
+    );
 
     it('should complete the leave DOM operation in case the classNameFilter fails', function() {
       module(function($animateProvider) {

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -283,6 +283,19 @@ describe('animations', function() {
       })
     );
 
+    it('should clear the `classNameFilter` if a disallowed RegExp is passed',
+      module(function($animateProvider) {
+        var validRegex = /no-ng-animate/;
+        var invalidRegex = /no ng-animate/;
+
+        $animateProvider.classNameFilter(validRegex);
+        expect($animateProvider.classNameFilter()).toEqual(validRegex);
+
+        try { $animateProvider.classNameFilter(invalidRegex); } catch (err) {}
+        expect($animateProvider.classNameFilter()).toBeNull();
+      })
+    );
+
     it('should complete the leave DOM operation in case the classNameFilter fails', function() {
       module(function($animateProvider) {
         $animateProvider.classNameFilter(/memorable-animation/);

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -285,6 +285,7 @@ describe('animations', function() {
         $animateProvider.classNameFilter(validRegex);
         expect($animateProvider.classNameFilter()).toEqual(validRegex);
 
+        // eslint-disable-next-line no-empty
         try { $animateProvider.classNameFilter(invalidRegex); } catch (err) {}
         expect($animateProvider.classNameFilter()).toBeNull();
       })

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -257,28 +257,22 @@ describe('animations', function() {
 
     it('should throw a minErr if a regex value is used which partially contains or fully matches the `ng-animate` CSS class',
       module(function($animateProvider) {
-        var errorMessage = '$animateProvider.classNameFilter(regex) prohibits accepting a regex ' +
-                           'value which matches/contains the "ng-animate" CSS class.';
+        expect(setFilter(/ng-animate/)).toThrowMinErr('$animate', 'nongcls');
+        expect(setFilter(/first ng-animate last/)).toThrowMinErr('$animate', 'nongcls');
+        expect(setFilter(/first ng-animate ng-animate-special last/)).toThrowMinErr('$animate', 'nongcls');
+        expect(setFilter(/(ng-animate)/)).toThrowMinErr('$animate', 'nongcls');
+        expect(setFilter(/(foo|ng-animate|bar)/)).toThrowMinErr('$animate', 'nongcls');
+        expect(setFilter(/(foo|)ng-animate(|bar)/)).toThrowMinErr('$animate', 'nongcls');
 
-        assertError(/ng-animate/, true);
-        assertError(/first ng-animate last/, true);
-        assertError(/ng-animate-special/, false);
-        assertError(/first ng-animate-special last/, false);
-        assertError(/first ng-animate ng-animate-special last/, true);
-        assertError(/(ng-animate)/, true);
-        assertError(/(foo|ng-animate|bar)/, true);
-        assertError(/(foo|)ng-animate(|bar)/, true);
+        expect(setFilter(/ng-animater/)).not.toThrow();
+        expect(setFilter(/my-ng-animate/)).not.toThrow();
+        expect(setFilter(/first ng-animater last/)).not.toThrow();
+        expect(setFilter(/first my-ng-animate last/)).not.toThrow();
 
-        function assertError(regex, bool) {
-          var expectation = expect(function() {
+        function setFilter(regex) {
+          return function() {
             $animateProvider.classNameFilter(regex);
-          });
-
-          if (bool) {
-            expectation.toThrowMinErr('$animate', 'nongcls', errorMessage);
-          } else {
-            expectation.not.toThrow();
-          }
+          };
         }
       })
     );


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.

**What is the current behavior? (You can also link to an open issue here)**
1. `$animateProvider` fails to detect several invalid `classNameFilter` RegExps.
2. Even if a `classNameFilter` RegExp is detected as invalid, `$animateProvider` will still use it (despite printing an error message saying that it _is prohibited_).

**What is the new behavior (if this is a feature change)?**
1. `$animateProvider` does a better job detecting invalid `classNameFilter` RegExps (it is still not perfect though).
2. If a `classNameFilter` RegExp is detected as invalid, `classNameFilter` will be reset to `null` (to avoid using an invalid RegExp).

**Does this PR introduce a breaking change?**
No (unless someone was hacking around the previous implementation in order to allow invalid RegExps - which they shouldn't do anyway).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
<sub>This PR contains two separate commits - which fix two different things - so that they can be liked/disliked independently.</sub>
