### PR TITLE
chore(protractor): use `directConnect` locally to speed up tests

### DIFF
--- a/protractor-conf.js
+++ b/protractor-conf.js
@@ -12,4 +12,6 @@ config.capabilities = {
   browserName: 'chrome'
 };
 
+config.directConnect = true;
+
 exports.config = config;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Chore.

**What is the current behavior? (You can also link to an open issue here)**
Protractor tests use Selenium Server.

**What is the new behavior (if this is a feature change)?**
Protractor tests use the ChromeDriver to connect to Chrome directly.
_This does not affect e2e tests on Travis or Jenkins._

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
For me it reduced the execution time from ~130s to ~110s.
It is no big deal, but if it's for free, why not.
