### PR TITLE
fix($http): properly increment/decrement `$browser.outstandingRequestCount`

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -978,7 +978,7 @@ function $HttpProvider() {
       promise = chainInterceptors(promise, requestInterceptors);
       promise = promise.then(serverRequest);
       promise = chainInterceptors(promise, responseInterceptors);
-      promise.finally(completeOutstandingRequest);
+      promise = promise.finally(completeOutstandingRequest);
 
       if (useLegacyPromise) {
         promise.success = function(fn) {

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -959,26 +959,25 @@ function $HttpProvider() {
       config.paramSerializer = isString(config.paramSerializer) ?
           $injector.get(config.paramSerializer) : config.paramSerializer;
 
-      var chain = [serverRequest, undefined];
-      var promise = initiateOutstandingRequest(config);
+      $browser.$$incOutstandingRequestCount();
+
+      var requestInterceptors = [];
+      var responseInterceptors = [];
+      var promise = $q.when(config);
 
       // apply interceptors
       forEach(reversedInterceptors, function(interceptor) {
         if (interceptor.request || interceptor.requestError) {
-          chain.unshift(interceptor.request, interceptor.requestError);
+          requestInterceptors.unshift(interceptor.request, interceptor.requestError);
         }
         if (interceptor.response || interceptor.responseError) {
-          chain.push(interceptor.response, interceptor.responseError);
+          responseInterceptors.push(interceptor.response, interceptor.responseError);
         }
       });
 
-      while (chain.length) {
-        var thenFn = chain.shift();
-        var rejectFn = chain.shift();
-
-        promise = promise.then(thenFn, rejectFn);
-      }
-
+      promise = chainInterceptors(promise, requestInterceptors);
+      promise = promise.then(serverRequest);
+      promise = chainInterceptors(promise, responseInterceptors);
       promise.finally(completeOutstandingRequest);
 
       if (useLegacyPromise) {
@@ -1006,9 +1005,18 @@ function $HttpProvider() {
 
       return promise;
 
-      function initiateOutstandingRequest(config) {
-        $browser.$$incOutstandingRequestCount();
-        return $q.when(config);
+
+      function chainInterceptors(promise, interceptors) {
+        for (var i = 0, ii = interceptors.length; i < ii;) {
+          var thenFn = interceptors[i++];
+          var rejectFn = interceptors[i++];
+
+          promise = promise.then(thenFn, rejectFn);
+        }
+
+        interceptors.length = 0;
+
+        return promise;
       }
 
       function completeOutstandingRequest() {

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -55,7 +55,6 @@ function $HttpBackendProvider() {
 function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDocument) {
   // TODO(vojta): fix the signature
   return function(method, url, post, callback, headers, timeout, withCredentials, responseType, eventHandlers, uploadEventHandlers) {
-    $browser.$$incOutstandingRequestCount();
     url = url || $browser.url();
 
     if (lowercase(method) === 'jsonp') {
@@ -162,7 +161,6 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
       jsonpDone = xhr = null;
 
       callback(status, response, headersString, statusText);
-      $browser.$$completeOutstandingRequest(noop);
     }
   };
 

--- a/test/e2e/fixtures/http/index.html
+++ b/test/e2e/fixtures/http/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html ng-app="test">
+  <body>
+    <div ng-controller="TestController">
+      <p>{{text}}</p>
+    </div>
+
+    <script src="angular.js"></script>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/test/e2e/fixtures/http/script.js
+++ b/test/e2e/fixtures/http/script.js
@@ -1,0 +1,28 @@
+angular.
+  module('test', []).
+  config(function($httpProvider) {
+    $httpProvider.interceptors.push(function($q) {
+      return {
+        request: function(config) {
+          return $q(function(resolve) {
+            setTimeout(resolve, 100, config);
+          });
+        },
+        response: function(response) {
+          return $q(function(resolve) {
+            setTimeout(resolve, 100, response);
+          });
+        }
+      };
+    });
+  }).
+  controller('TestController', function($cacheFactory, $http, $scope) {
+    var url = '/some/url';
+
+    var cache = $cacheFactory('test');
+    cache.put(url, 'Hello, world!');
+
+    $http.
+      get(url, {cache: cache}).
+      then(function(response) { $scope.text = response.data; });
+  });

--- a/test/e2e/tests/httpSpec.js
+++ b/test/e2e/tests/httpSpec.js
@@ -1,0 +1,9 @@
+describe('$http', function() {
+  beforeEach(function() {
+    loadFixture('http');
+  });
+
+  it('should correctly update the outstanding request count', function() {
+    expect(element(by.binding('text')).getText()).toBe('Hello, world!');
+  });
+});

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1896,6 +1896,37 @@ describe('$http', function() {
         expect(paramSerializer({foo: 'foo', bar: ['bar', 'baz']})).toEqual('bar=bar&bar=baz&foo=foo');
       });
     });
+
+    describe('$browser\'s outstandingRequestCount', function() {
+      var incOutstandingRequestCountSpy, completeOutstandingRequestSpy;
+
+      beforeEach(inject(function($browser) {
+        incOutstandingRequestCountSpy
+          = spyOn($browser, '$$incOutstandingRequestCount').andCallThrough();
+        completeOutstandingRequestSpy
+          = spyOn($browser, '$$completeOutstandingRequest').andCallThrough();
+      }));
+
+      it('should update $browser outstandingRequestCount on success', function() {
+        $httpBackend.when('GET').respond(200);
+
+        expect(incOutstandingRequestCountSpy).not.toHaveBeenCalled();
+        $http.get('');
+        expect(incOutstandingRequestCountSpy).toHaveBeenCalledOnce();
+        $httpBackend.flush();
+        expect(completeOutstandingRequestSpy).toHaveBeenCalledOnce();
+      });
+
+      it('should update $browser outstandingRequestCount on error', function() {
+        $httpBackend.when('GET').respond(500);
+
+        expect(incOutstandingRequestCountSpy).not.toHaveBeenCalled();
+        $http.get('');
+        expect(incOutstandingRequestCountSpy).toHaveBeenCalledOnce();
+        $httpBackend.flush();
+        expect(completeOutstandingRequestSpy).toHaveBeenCalledOnce();
+      });
+    });
   });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.

**What is the current behavior? (You can also link to an open issue here)**
Calling `$http` will not increment `$browser.outstandingRequestCount` until after all (potentially
asynchronous) request interceptors have been processed and will decrement it before any (potentially
asynchronous) response interceptors have been processed.
This can lead to `$browser.notifyWhenNoOutstandingRequests` firing prematurely, which can be
problematic in end-to-end tests.
See also #13782.

**What is the new behavior (if this is a feature change)?**
The increment/decrement operations are synchronized with `$http`'s internal interceptor promise chain.
The `outstandingRequestCount` will be incremented **as soon as** `$http()` is called and will be decremented **after** all response interceptors have been processed/fulfilled.

**Does this PR introduce a breaking change?**
No (I don't think so).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Fixes #13782.
Incorporates #13862 and #13869.

This PR is split up in several commits, so that it is easier to review and easier to selectively "lgtm".
It will be much easier to review commit-by-commit :smile:

It includes the following (in order of appearance):
- The original PR (#13862) by @wbyoko for fixing the issue (with some slight modifications).
- A couple of (optional) refactoring commits, that I believe make the `$http` code easier to follow.
- A fix for a `Possibly Unhandled Rejection` error and more thorough test coverage (mainly ported from #13869).
