### PR TITLE
Removed not used 'use strict'

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -1134,9 +1134,6 @@ var ngModelDirective = ['$rootScope', function($rootScope) {
 }];
 
 
-
-'use strict';
-
 var DEFAULT_REGEXP = /(\s+|^)default(\s+|$)/;
 
 /**


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
code organization

**What is the current behavior? (You can also link to an open issue here)**
There are 2 instructions using 'use strict' on file. The first at the top of the document has been kept it

**What is the new behavior (if this is a feature change)?**
Removed duplicated line 

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
