### PR TITLE
fix($parse): correctly escape unsafe identifier characters 

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -398,8 +398,7 @@ AST.prototype = {
 
   filterChain: function() {
     var left = this.expression();
-    var token;
-    while ((token = this.expect('|'))) {
+    while (this.expect('|')) {
       left = this.filter(left);
     }
     return left;
@@ -695,6 +694,7 @@ function isStateless($filter, filterName) {
 function findConstantAndWatchExpressions(ast, $filter) {
   var allConstants;
   var argsToWatch;
+  var isStatelessFilter;
   switch (ast.type) {
   case AST.Program:
     allConstants = true;
@@ -745,7 +745,8 @@ function findConstantAndWatchExpressions(ast, $filter) {
     ast.toWatch = [ast];
     break;
   case AST.CallExpression:
-    allConstants = ast.filter ? isStateless($filter, ast.callee.name) : false;
+    isStatelessFilter = ast.filter ? isStateless($filter, ast.callee.name) : false;
+    allConstants = isStatelessFilter;
     argsToWatch = [];
     forEach(ast.arguments, function(expr) {
       findConstantAndWatchExpressions(expr, $filter);
@@ -755,7 +756,7 @@ function findConstantAndWatchExpressions(ast, $filter) {
       }
     });
     ast.constant = allConstants;
-    ast.toWatch = ast.filter && isStateless($filter, ast.callee.name) ? argsToWatch : [ast];
+    ast.toWatch = isStatelessFilter ? argsToWatch : [ast];
     break;
   case AST.AssignmentExpression:
     findConstantAndWatchExpressions(ast.left, $filter);

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1261,7 +1261,7 @@ ASTCompiler.prototype = {
   },
 
   nonComputedMember: function(left, right) {
-    var SAFE_IDENTIFIER = /[$_a-zA-Z][$_a-zA-Z0-9]*/;
+    var SAFE_IDENTIFIER = /^[$_a-zA-Z][$_a-zA-Z0-9]$/;
     var UNSAFE_CHARACTERS = /[^$_a-zA-Z0-9]/g;
     if (SAFE_IDENTIFIER.test(right)) {
       return left + '.' + right;

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1261,7 +1261,7 @@ ASTCompiler.prototype = {
   },
 
   nonComputedMember: function(left, right) {
-    var SAFE_IDENTIFIER = /^[$_a-zA-Z][$_a-zA-Z0-9]$/;
+    var SAFE_IDENTIFIER = /^[$_a-zA-Z][$_a-zA-Z0-9]*$/;
     var UNSAFE_CHARACTERS = /[^$_a-zA-Z0-9]/g;
     if (SAFE_IDENTIFIER.test(right)) {
       return left + '.' + right;

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -868,7 +868,6 @@ describe('parser', function() {
     });
 
 
-
     it('should understand logical operators', function() {
       forEach(['||', '&&'], function(operator) {
         expect(createAst('foo' + operator + 'bar')).toEqual(
@@ -916,7 +915,6 @@ describe('parser', function() {
         );
       });
     });
-
 
 
     it('should understand ternary operators', function() {
@@ -1081,7 +1079,6 @@ describe('parser', function() {
         }
       );
     });
-
 
 
     it('should give higher precedence to the logical `or` than to the conditional operator', function() {
@@ -1355,6 +1352,7 @@ describe('parser', function() {
       );
     });
 
+
     it('should understand ES6 object initializer', function() {
       // Shorthand properties definitions.
       expect(createAst('{x, y, z}')).toEqual(
@@ -1446,6 +1444,7 @@ describe('parser', function() {
         }
       );
     });
+
 
     it('should understand multiple expressions', function() {
       expect(createAst('foo = bar; man = shell')).toEqual(
@@ -1551,6 +1550,7 @@ describe('parser', function() {
       );
     });
 
+
     it('should give higher precedence to assignments over filters', function() {
       expect(createAst('foo=bar | man')).toEqual(
         {
@@ -1576,6 +1576,7 @@ describe('parser', function() {
         }
       );
     });
+
 
     it('should accept expression as filters parameters', function() {
       expect(createAst('foo | bar:baz=man')).toEqual(
@@ -1604,6 +1605,7 @@ describe('parser', function() {
       );
     });
 
+
     it('should accept expression as computer members', function() {
       expect(createAst('foo[a = 1]')).toEqual(
         {
@@ -1627,6 +1629,7 @@ describe('parser', function() {
         }
       );
     });
+
 
     it('should accept expression in function arguments', function() {
       expect(createAst('foo(a = 1)')).toEqual(
@@ -1652,6 +1655,7 @@ describe('parser', function() {
         }
       );
     });
+
 
     it('should accept expression as part of ternary operators', function() {
       expect(createAst('foo || bar ? man = 1 : shell = 1')).toEqual(
@@ -1687,6 +1691,7 @@ describe('parser', function() {
       );
     });
 
+
     it('should accept expression as part of array literals', function() {
       expect(createAst('[foo = 1]')).toEqual(
         {
@@ -1710,6 +1715,7 @@ describe('parser', function() {
         }
       );
     });
+
 
     it('should accept expression as part of object literals', function() {
       expect(createAst('{foo: bar = 1}')).toEqual(
@@ -1741,6 +1747,7 @@ describe('parser', function() {
       );
     });
 
+
     it('should be possible to use parenthesis to indicate precedence', function() {
       expect(createAst('(foo + bar).man')).toEqual(
         {
@@ -1764,6 +1771,7 @@ describe('parser', function() {
         }
       );
     });
+
 
     it('should skip empty expressions', function() {
       expect(createAst('foo;;;;bar')).toEqual(
@@ -1813,9 +1821,10 @@ describe('parser', function() {
   }]));
 
   forEach([true, false], function(cspEnabled) {
-    beforeEach(module(['$parseProvider', function(parseProvider) {
-      parseProvider.addLiteral('Infinity', Infinity);
-    }]));
+    beforeEach(module(function($parseProvider) {
+      $parseProvider.addLiteral('Infinity', Infinity);
+      csp().noUnsafeEval = cspEnabled;
+    }));
 
     it('should allow extending literals with csp ' + cspEnabled, inject(function($rootScope) {
       expect($rootScope.$eval("Infinity")).toEqual(Infinity);
@@ -2116,16 +2125,16 @@ describe('parser', function() {
         expect(scope.b).toEqual(234);
       });
 
-        it('should evaluate assignments in ternary operator', function() {
-          scope.$eval('a = 1 ? 2 : 3');
-          expect(scope.a).toBe(2);
+      it('should evaluate assignments in ternary operator', function() {
+        scope.$eval('a = 1 ? 2 : 3');
+        expect(scope.a).toBe(2);
 
-          scope.$eval('0 ? a = 2 : a = 3');
-          expect(scope.a).toBe(3);
+        scope.$eval('0 ? a = 2 : a = 3');
+        expect(scope.a).toBe(3);
 
-          scope.$eval('1 ? a = 2 : a = 3');
-          expect(scope.a).toBe(2);
-        });
+        scope.$eval('1 ? a = 2 : a = 3');
+        expect(scope.a).toBe(2);
+      });
 
       it('should evaluate function call without arguments', function() {
         scope['const'] =  function(a, b) {return 123;};
@@ -2417,7 +2426,6 @@ describe('parser', function() {
             }).toThrowMinErr(
                     '$parse', 'isecfn', 'Referencing Function in Angular expressions is disallowed! ' +
                     'Expression: {}.toString.constructor');
-
           });
 
           it('should not allow access to the Function prototype in the getter', function() {
@@ -2426,7 +2434,6 @@ describe('parser', function() {
             }).toThrowMinErr(
                     '$parse', 'isecfn', 'Referencing Function in Angular expressions is disallowed! ' +
                     'Expression: toString.constructor.prototype');
-
           });
 
           it('should NOT allow access to Function constructor in getter', function() {
@@ -2435,7 +2442,6 @@ describe('parser', function() {
             }).toThrowMinErr(
                     '$parse', 'isecfn', 'Referencing Function in Angular expressions is disallowed! ' +
                     'Expression: {}.toString.constructor("alert(1)")');
-
           });
 
           it('should NOT allow access to Function constructor in setter', function() {
@@ -2936,14 +2942,14 @@ describe('parser', function() {
           });
         });
 
-       it('should prevent the exploit', function() {
-          expect(function() {
-            scope.$eval('(1)[{0: "__proto__", 1: "__proto__", 2: "__proto__", 3: "safe", length: 4, toString: [].pop}].foo = 1');
-          }).toThrow();
-          if (!msie || msie > 10) {
-            expect((1)['__proto__'].foo).toBeUndefined();
-          }
-       });
+        it('should prevent the exploit', function() {
+           expect(function() {
+             scope.$eval('(1)[{0: "__proto__", 1: "__proto__", 2: "__proto__", 3: "safe", length: 4, toString: [].pop}].foo = 1');
+           }).toThrow();
+           if (!msie || msie > 10) {
+             expect((1)['__proto__'].foo).toBeUndefined();
+           }
+        });
 
         it('should prevent the exploit', function() {
           expect(function() {
@@ -3337,7 +3343,6 @@ describe('parser', function() {
             expect($rootScope.$$watchers.length).toBe(1);
             expect(log).toEqual([]);
           }));
-
         });
       });
 

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3897,4 +3897,92 @@ describe('parser', function() {
       });
     });
   });
+
+  forEach([true, false], function(cspEnabled) {
+    describe('custom identifiers (csp: ' + cspEnabled + ')', function() {
+      var isIdentifierStartRe = /[#a-z]/;
+      var isIdentifierContinueRe = /[\-a-z]/;
+      var isIdentifierStartFn;
+      var isIdentifierContinueFn;
+      var scope;
+
+      beforeEach(module(function($parseProvider) {
+        isIdentifierStartFn = jasmine.
+          createSpy('isIdentifierStart').
+          and.callFake(function (ch, cp) { return isIdentifierStartRe.test(ch); });
+        isIdentifierContinueFn = jasmine.
+          createSpy('isIdentifierContinue').
+          and.callFake(function (ch, cp) { return isIdentifierContinueRe.test(ch); });
+
+        $parseProvider.setIdentifierFns(isIdentifierStartFn, isIdentifierContinueFn);
+        csp().noUnsafeEval = cspEnabled;
+      }));
+
+      beforeEach(inject(function($rootScope) {
+        scope = $rootScope;
+      }));
+
+
+      it('should allow specifying a custom `isIdentifierStart/Continue` functions', function() {
+        scope.x = {};
+
+        scope['#foo'] = 'foo';
+        scope.x['#foo'] = 'foo';
+        expect(scope.$eval('#foo')).toBe('foo');
+        expect(scope.$eval('x.#foo')).toBe('foo');
+
+        scope['bar--'] = 42;
+        scope.x['bar--'] = 42;
+        expect(scope.$eval('bar--')).toBe(42);
+        expect(scope.$eval('x.bar--')).toBe(42);
+        expect(scope['bar--']).toBe(42);
+        expect(scope.x['bar--']).toBe(42);
+
+        scope['#-'] = 'baz';
+        scope.x['#-'] = 'baz';
+        expect(scope.$eval('#-')).toBe('baz');
+        expect(scope.$eval('x.#-')).toBe('baz');
+
+        expect(function() { scope.$eval('##'); }).toThrow();
+        expect(function() { scope.$eval('x.##'); }).toThrow();
+
+        expect(function() { scope.$eval('--'); }).toThrow();
+        expect(function() { scope.$eval('x.--'); }).toThrow();
+      });
+
+
+      it('should pass the character and codepoint to the custom functions', function() {
+        scope.$eval('#-');
+        expect(isIdentifierStartFn).toHaveBeenCalledOnceWith('#', '#'.charCodeAt(0));
+        expect(isIdentifierContinueFn).toHaveBeenCalledOnceWith('-', '-'.charCodeAt(0));
+
+        isIdentifierStartFn.calls.reset();
+        isIdentifierContinueFn.calls.reset();
+
+        scope.$eval('#.foo.#-.bar-');
+        expect(isIdentifierStartFn).toHaveBeenCalledTimes(7);
+        expect(isIdentifierStartFn.calls.allArgs()).toEqual([
+          ['#', '#'.charCodeAt(0)],
+          ['.', '.'.charCodeAt(0)],
+          ['f', 'f'.charCodeAt(0)],
+          ['.', '.'.charCodeAt(0)],
+          ['#', '#'.charCodeAt(0)],
+          ['.', '.'.charCodeAt(0)],
+          ['b', 'b'.charCodeAt(0)]
+        ]);
+        expect(isIdentifierContinueFn).toHaveBeenCalledTimes(9);
+        expect(isIdentifierContinueFn.calls.allArgs()).toEqual([
+          ['.', '.'.charCodeAt(0)],
+          ['o', 'o'.charCodeAt(0)],
+          ['o', 'o'.charCodeAt(0)],
+          ['.', '.'.charCodeAt(0)],
+          ['-', '-'.charCodeAt(0)],
+          ['.', '.'.charCodeAt(0)],
+          ['a', 'a'.charCodeAt(0)],
+          ['r', 'r'.charCodeAt(0)],
+          ['-', '-'.charCodeAt(0)]
+        ]);
+      });
+    });
+  });
 });

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3909,10 +3909,10 @@ describe('parser', function() {
       beforeEach(module(function($parseProvider) {
         isIdentifierStartFn = jasmine.
           createSpy('isIdentifierStart').
-          and.callFake(function (ch, cp) { return isIdentifierStartRe.test(ch); });
+          and.callFake(function(ch, cp) { return isIdentifierStartRe.test(ch); });
         isIdentifierContinueFn = jasmine.
           createSpy('isIdentifierContinue').
-          and.callFake(function (ch, cp) { return isIdentifierContinueRe.test(ch); });
+          and.callFake(function(ch, cp) { return isIdentifierContinueRe.test(ch); });
 
         $parseProvider.setIdentifierFns(isIdentifierStartFn, isIdentifierContinueFn);
         csp().noUnsafeEval = cspEnabled;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.

**What is the current behavior? (You can also link to an open issue here)**
While it is possible to use arbitrary identifier characters in Angular expressions, the RegExp that detect unsafe identifiers (in order to escape them in the generated JS code), was failing to detect them in some cases.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
This PR also includes some minor clean-up changes and fixes the `setLiteral()` tests to run in CSP mode too.
