### PR TITLE
docs(guide/Components): document $doCheck in the component guide

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -160,6 +160,12 @@ of the component. The following hook methods can be implemented:
     are the names of the bound properties that have changed, and the values are an object of the form
     `{ currentValue, previousValue, isFirstChange() }`. Use this hook to trigger updates within a component such as
     cloning the bound value to prevent accidental mutation of the outer value.
+  * `$doCheck()` - Called on each turn of the digest cycle. Provides an opportunity to detect and act on
+    changes. Any actions that you wish to take in response to the changes that you detect must be
+    invoked from this hook; implementing this has no effect on when `$onChanges` is called. For example, this hook
+    could be useful if you wish to perform a deep equality check, or to check a Date object, changes to which would not
+    be detected by Angular's change detector and thus not trigger `$onChanges`. This hook is invoked with no arguments;
+    if detecting changes, you must store the previous value(s) for comparison to the current values.
   * `$onDestroy()` - Called on a controller when its containing scope is destroyed. Use this hook for releasing
     external resources, watches and event handlers.
   * `$postLink()` - Called after this controller's element and its children have been linked. Similar to the post-link


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

docs update

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

The docs for `$compile` were [recently updated](https://github.com/angular/angular.js/commit/e235f20cc1621e389a938dfb74caa17ce87b41c7) to add information about the recently implemented `$doCheck` lifecycle hook for component controllers. The lifecycle hook documentation is mirrored in the Component guide, and this change mirrors the update made to the `$compile` docs, to the component guide docs.
