### PR TITLE
docs($filter): add link to built-in filters page

### DIFF
--- a/src/ng/filter.js
+++ b/src/ng/filter.js
@@ -73,7 +73,9 @@
  * @name $filter
  * @kind function
  * @description
- * Filters are used for formatting data displayed to the user.
+ * Filters are used for formatting data displayed to the user. They can be used in view
+ * templates, controllers or services. Angular comes with a collection of
+ * [built-in filters](api/ng/filter), but it is easy to define your own as well.
  *
  * The general syntax in templates is as follows:
  *


### PR DESCRIPTION
tired to seek page with built-in filters every time I go to filters
