### PR TITLE
feat($httpBackend): flush requests in desired order

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1788,29 +1788,30 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
    * @ngdoc method
    * @name $httpBackend#flush
    * @description
-   * Flushes pending requests using the trained responses in the order they arrived.
-   * If there are no pending requests when the flush method is called
+   * Flushes pending requests in the order they arrived beginning at specified request using the trained responses.
+   * If there are no pending requests to flush when the method is called
    * an exception is thrown (as this typically a sign of programming error).
    *
    * @param {number=} count Number of responses to flush. If undefined,
-   *   all pending requests will be flushed beginning at `start`.
-   * @param {number=} [start=0] Sequential request number at which to begin to flush.
+   *   all pending requests from `skip` will be flushed.
+   * @param {number=} [skip=0] Number of pending requests to skip before flushing.
+   *   So it specifies the first request to flush.
    */
-  $httpBackend.flush = function(count, start, digest) {
+  $httpBackend.flush = function(count, skip, digest) {
     if (digest !== false) $rootScope.$digest();
-    if (!responses.length) throw new Error('No pending request to flush !');
 
-    start = angular.isDefined(start) && start !== null ? start : 0;
+    skip = skip || 0;
+    if (skip >= responses.length) throw new Error('No pending request to flush !');
 
     if (angular.isDefined(count) && count !== null) {
       while (count--) {
-        var part = responses.splice(start, 1);
+        var part = responses.splice(skip, 1);
         if (!part.length) throw new Error('No more pending request to flush !');
         part[0]();
       }
     } else {
-      while (responses.length > start) {
-        responses.splice(start, 1)[0]();
+      while (responses.length > skip) {
+        responses.splice(skip, 1)[0]();
       }
     }
     $httpBackend.verifyNoOutstandingExpectation(digest);

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -2210,7 +2210,7 @@ describe('$http with $applyAsync', function() {
     // Ensure requests are sent
     $rootScope.$digest();
 
-    $httpBackend.flush(null, false);
+    $httpBackend.flush(null, null, false);
     expect($rootScope.$applyAsync).toHaveBeenCalledOnce();
     expect(handler).not.toHaveBeenCalled();
 
@@ -2228,7 +2228,7 @@ describe('$http with $applyAsync', function() {
     // Ensure requests are sent
     $rootScope.$digest();
 
-    $httpBackend.flush(null, false);
+    $httpBackend.flush(null, null, false);
     expect(log).toEqual([]);
 
     $browser.defer.flush();
@@ -2253,7 +2253,7 @@ describe('$http with $applyAsync', function() {
     expect(log).toEqual(['response 1', 'response 2']);
 
     // Finally, third response is received, and a second coalesced $apply is started
-    $httpBackend.flush(null, false);
+    $httpBackend.flush(null, null, false);
     $browser.defer.flush();
     expect(log).toEqual(['response 1', 'response 2', 'response 3']);
   });

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1543,7 +1543,6 @@ describe('ngMock', function() {
 
         hb.flush(2, 1);
         expect(dontCallMe).not.toHaveBeenCalled();
-        expect(callback).toHaveBeenCalled();
         expect(callback).toHaveBeenCalledTimes(2);
       });
 
@@ -1559,7 +1558,6 @@ describe('ngMock', function() {
 
         hb.flush(null, 2);
         expect(dontCallMe).not.toHaveBeenCalled();
-        expect(callback).toHaveBeenCalled();
         expect(callback).toHaveBeenCalledTimes(2);
       });
 
@@ -1578,8 +1576,9 @@ describe('ngMock', function() {
 
         hb.when('GET').respond(200, '');
         hb('GET', '/some', null, callback);
-        hb.flush();
+        expect(function() {hb.flush(null, 1);}).toThrowError('No pending request to flush !');
 
+        hb.flush();
         expect(function() {hb.flush();}).toThrowError('No pending request to flush !');
       });
 

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1532,6 +1532,38 @@ describe('ngMock', function() {
       });
 
 
+      it('should flush given number of pending requests beginning at specified request', function() {
+        var dontCallMe = jasmine.createSpy('dontCallMe');
+
+        hb.when('GET').respond(200, '');
+        hb('GET', '/some', null, dontCallMe);
+        hb('GET', '/some', null, callback);
+        hb('GET', '/some', null, callback);
+        hb('GET', '/some', null, dontCallMe);
+
+        hb.flush(2, 1);
+        expect(dontCallMe).not.toHaveBeenCalled();
+        expect(callback).toHaveBeenCalled();
+        expect(callback).toHaveBeenCalledTimes(2);
+      });
+
+
+      it('should flush all pending requests beginning at specified request', function() {
+        var dontCallMe = jasmine.createSpy('dontCallMe');
+
+        hb.when('GET').respond(200, '');
+        hb('GET', '/some', null, dontCallMe);
+        hb('GET', '/some', null, dontCallMe);
+        hb('GET', '/some', null, callback);
+        hb('GET', '/some', null, callback);
+
+        hb.flush(null, 2);
+        expect(dontCallMe).not.toHaveBeenCalled();
+        expect(callback).toHaveBeenCalled();
+        expect(callback).toHaveBeenCalledTimes(2);
+      });
+
+
       it('should throw exception when flushing more requests than pending', function() {
         hb.when('GET').respond(200, '');
         hb('GET', '/url', null, callback);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feature

**What is the current behavior? (You can also link to an open issue here)**
#13717 We are currently unable to test what happens if two HTTP requests complete in a different order with the current API.

**What is the new behavior (if this is a feature change)?**

Now `$httpBackend.flush` has the second parameter `start`. So you can flush any range of pending requests array. Hence you can flush requests in a different order.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

It was impossible to flush pending requests in desired order.
Now it is possible because you can specify a `start` number.
