### PR TITLE
feat(input[range]): support step

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -576,7 +576,8 @@ var ALIASED_ATTR = {
   'ngMaxlength': 'maxlength',
   'ngMin': 'min',
   'ngMax': 'max',
-  'ngPattern': 'pattern'
+  'ngPattern': 'pattern',
+  'ngStep': 'step'
 };
 
 function getBooleanAttrName(element, name) {

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -679,7 +679,17 @@ var inputType = {
    * @param {string} ngModel Assignable angular expression to data-bind to.
    * @param {string=} name Property name of the form under which the control is published.
    * @param {string=} min Sets the `min` validation error key if the value entered is less than `min`.
+   *    Can be interpolated.
    * @param {string=} max Sets the `max` validation error key if the value entered is greater than `max`.
+   *    Can be interpolated.
+   * @param {string=} ngMin Like `min`, sets the `min` validation error key if the value entered is less than `ngMin`,
+   *    but does not trigger HTML5 native validation. Takes an expression.
+   * @param {string=} ngMax Like `max`, sets the `max` validation error key if the value entered is greater than `ngMax`,
+   *    but does not trigger HTML5 native validation. Takes an expression.
+   * @param {string=} step Sets the `step` validation error key if the value entered does not fit the `step` constraint.
+   *    Can be interpolated.
+   * @param {string=} ngStep Like `step`, sets the `max` validation error key if the value entered does not fit the `ngStep` constraint,
+   *    but does not trigger HTML5 native validation. Takes an expression.
    * @param {string=} required Sets `required` validation error key if the value is not entered.
    * @param {string=} ngRequired Adds `required` attribute and `required` validation constraint to
    *    the element when the ngRequired expression evaluates to true. Use `ngRequired` instead of
@@ -1545,6 +1555,19 @@ function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
 
     attr.$observe('max', function(val) {
       maxVal = parseNumberAttrVal(val);
+      // TODO(matsko): implement validateLater to reduce number of validations
+      ctrl.$validate();
+    });
+  }
+
+  if (isDefined(attr.step) || attr.ngStep) {
+    var stepVal;
+    ctrl.$validators.step = function(modelValue, viewValue) {
+      return ctrl.$isEmpty(viewValue) || isUndefined(stepVal) || viewValue % stepVal === 0;
+    };
+
+    attr.$observe('step', function(val) {
+      stepVal = parseNumberAttrVal(val);
       // TODO(matsko): implement validateLater to reduce number of validations
       ctrl.$validate();
     });

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2621,6 +2621,157 @@ describe('input', function() {
       });
     });
 
+    describe('step', function() {
+      it('should validate', function() {
+        $rootScope.step = 10;
+        $rootScope.value = 20;
+        var inputElm = helper.compileInput('<input type="number" ng-model="value" name="alias" step="{{step}}" />');
+
+        expect(inputElm.val()).toBe('20');
+        expect(inputElm).toBeValid();
+        expect($rootScope.value).toBe(20);
+        expect($rootScope.form.alias.$error.step).toBeFalsy();
+
+        helper.changeInputValueTo('18');
+        expect(inputElm).toBeInvalid();
+        expect(inputElm.val()).toBe('18');
+        expect($rootScope.value).toBeUndefined();
+        expect($rootScope.form.alias.$error.step).toBeTruthy();
+
+        helper.changeInputValueTo('10');
+        expect(inputElm).toBeValid();
+        expect(inputElm.val()).toBe('10');
+        expect($rootScope.value).toBe(10);
+        expect($rootScope.form.alias.$error.step).toBeFalsy();
+
+        $rootScope.$apply('value = 12');
+        expect(inputElm).toBeInvalid();
+        expect(inputElm.val()).toBe('12');
+        expect($rootScope.value).toBe(12);
+        expect($rootScope.form.alias.$error.step).toBeTruthy();
+      });
+
+      it('should validate even if the step value changes on-the-fly', function() {
+        $rootScope.step = 10;
+        var inputElm = helper.compileInput('<input type="number" ng-model="value" name="alias" step="{{step}}" />');
+
+        helper.changeInputValueTo('10');
+        expect(inputElm).toBeValid();
+        expect($rootScope.value).toBe(10);
+
+        // Step changes, but value matches
+        $rootScope.$apply('step = 5');
+        expect(inputElm.val()).toBe('10');
+        expect(inputElm).toBeValid();
+        expect($rootScope.value).toBe(10);
+        expect($rootScope.form.alias.$error.step).toBeFalsy();
+
+        // Step changes, value does not match
+        $rootScope.$apply('step = 6');
+        expect(inputElm).toBeInvalid();
+        expect($rootScope.value).toBeUndefined();
+        expect(inputElm.val()).toBe('10');
+        expect($rootScope.form.alias.$error.step).toBeTruthy();
+
+        // null = valid
+        $rootScope.$apply('step = null');
+        expect(inputElm).toBeValid();
+        expect($rootScope.value).toBe(10);
+        expect(inputElm.val()).toBe('10');
+        expect($rootScope.form.alias.$error.step).toBeFalsy();
+
+        // Step val as string
+        $rootScope.$apply('step = "7"');
+        expect(inputElm).toBeInvalid();
+        expect($rootScope.value).toBeUndefined();
+        expect(inputElm.val()).toBe('10');
+        expect($rootScope.form.alias.$error.step).toBeTruthy();
+
+        // unparsable string is ignored
+        $rootScope.$apply('step = "abc"');
+        expect(inputElm).toBeValid();
+        expect($rootScope.value).toBe(10);
+        expect(inputElm.val()).toBe('10');
+        expect($rootScope.form.alias.$error.step).toBeFalsy();
+      });
+    });
+
+
+    describe('ngStep', function() {
+      it('should validate', function() {
+        $rootScope.step = 10;
+        $rootScope.value = 20;
+        var inputElm = helper.compileInput('<input type="number" ng-model="value" name="alias" ng-step="step" />');
+
+        expect(inputElm.val()).toBe('20');
+        expect(inputElm).toBeValid();
+        expect($rootScope.value).toBe(20);
+        expect($rootScope.form.alias.$error.step).toBeFalsy();
+
+        helper.changeInputValueTo('18');
+        expect(inputElm).toBeInvalid();
+        expect(inputElm.val()).toBe('18');
+        expect($rootScope.value).toBeUndefined();
+        expect($rootScope.form.alias.$error.step).toBeTruthy();
+
+        helper.changeInputValueTo('10');
+        expect(inputElm).toBeValid();
+        expect(inputElm.val()).toBe('10');
+        expect($rootScope.value).toBe(10);
+        expect($rootScope.form.alias.$error.step).toBeFalsy();
+
+        $rootScope.$apply('value = 12');
+        expect(inputElm).toBeInvalid();
+        expect(inputElm.val()).toBe('12');
+        expect($rootScope.value).toBe(12);
+        expect($rootScope.form.alias.$error.step).toBeTruthy();
+      });
+
+      it('should validate even if the step value changes on-the-fly', function() {
+        $rootScope.step = 10;
+        var inputElm = helper.compileInput('<input type="number" ng-model="value" name="alias" ng-step="step" />');
+
+        helper.changeInputValueTo('10');
+        expect(inputElm).toBeValid();
+        expect($rootScope.value).toBe(10);
+
+        // Step changes, but value matches
+        $rootScope.$apply('step = 5');
+        expect(inputElm.val()).toBe('10');
+        expect(inputElm).toBeValid();
+        expect($rootScope.value).toBe(10);
+        expect($rootScope.form.alias.$error.step).toBeFalsy();
+
+        // Step changes, value does not match
+        $rootScope.$apply('step = 6');
+        expect(inputElm).toBeInvalid();
+        expect($rootScope.value).toBeUndefined();
+        expect(inputElm.val()).toBe('10');
+        expect($rootScope.form.alias.$error.step).toBeTruthy();
+
+        // null = valid
+        $rootScope.$apply('step = null');
+        expect(inputElm).toBeValid();
+        expect($rootScope.value).toBe(10);
+        expect(inputElm.val()).toBe('10');
+        expect($rootScope.form.alias.$error.step).toBeFalsy();
+
+        // Step val as string
+        $rootScope.$apply('step = "7"');
+        expect(inputElm).toBeInvalid();
+        expect($rootScope.value).toBeUndefined();
+        expect(inputElm.val()).toBe('10');
+        expect($rootScope.form.alias.$error.step).toBeTruthy();
+
+        // unparsable string is ignored
+        $rootScope.$apply('step = "abc"');
+        expect(inputElm).toBeValid();
+        expect($rootScope.value).toBe(10);
+        expect(inputElm.val()).toBe('10');
+        expect($rootScope.form.alias.$error.step).toBeFalsy();
+      });
+    });
+
 
     describe('required', function() {
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -3290,6 +3290,151 @@ describe('input', function() {
 
     }
 
+
+    describe('step', function() {
+
+      if (supportsRange) {
+        // Browsers that implement range will never allow you to set a value that doesn't match the step value
+        // However, currently only Firefox fully inplements the spec when setting the value after the step value changes.
+        // Other browsers fail in various edge cases, which is why they are not tested here.
+        it('should round the input value to the nearest step on user input', function() {
+          var inputElm = helper.compileInput('<input type="range" ng-model="value" name="alias" step="5" />');
+
+          helper.changeInputValueTo('5');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(5);
+          expect(scope.form.alias.$error.step).toBeFalsy();
+
+          helper.changeInputValueTo('10');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(10);
+          expect(scope.form.alias.$error.step).toBeFalsy();
+
+          helper.changeInputValueTo('9');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(10);
+          expect(scope.form.alias.$error.step).toBeFalsy();
+
+          helper.changeInputValueTo('7');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(5);
+          expect(scope.form.alias.$error.step).toBeFalsy();
+
+          helper.changeInputValueTo('7.5');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(10);
+          expect(scope.form.alias.$error.step).toBeFalsy();
+        });
+
+        it('should round the input value to the nearest step when setting the model', function() {
+          var inputElm = helper.compileInput('<input type="range" ng-model="value" name="alias" step="5" />');
+
+          scope.$apply('value = 10');
+          expect(inputElm.val()).toBe('10');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(10);
+          expect(scope.form.alias.$error.step).toBeFalsy();
+
+          scope.$apply('value = 5');
+          expect(inputElm.val()).toBe('5');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(5);
+          expect(scope.form.alias.$error.step).toBeFalsy();
+
+          scope.$apply('value = 7.5');
+          expect(inputElm.val()).toBe('10');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(10);
+          expect(scope.form.alias.$error.step).toBeFalsy();
+
+          scope.$apply('value = 7');
+          expect(inputElm.val()).toBe('5');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(5);
+          expect(scope.form.alias.$error.step).toBeFalsy();
+
+          scope.$apply('value = 9');
+          expect(inputElm.val()).toBe('10');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(10);
+          expect(scope.form.alias.$error.step).toBeFalsy();
+        });
+
+      } else {
+        it('should validate if "range" is not implemented', function() {
+          scope.step = 10;
+          scope.value = 20;
+          var inputElm = helper.compileInput('<input type="range" ng-model="value" name="alias" step="{{step}}" />');
+
+          expect(inputElm.val()).toBe('20');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(20);
+          expect(scope.form.alias.$error.step).toBeFalsy();
+
+          helper.changeInputValueTo('18');
+          expect(inputElm).toBeInvalid();
+          expect(inputElm.val()).toBe('18');
+          expect(scope.value).toBeUndefined();
+          expect(scope.form.alias.$error.step).toBeTruthy();
+
+          helper.changeInputValueTo('10');
+          expect(inputElm).toBeValid();
+          expect(inputElm.val()).toBe('10');
+          expect(scope.value).toBe(10);
+          expect(scope.form.alias.$error.step).toBeFalsy();
+
+          scope.$apply('value = 12');
+          expect(inputElm).toBeInvalid();
+          expect(inputElm.val()).toBe('12');
+          expect(scope.value).toBe(12);
+          expect(scope.form.alias.$error.step).toBeTruthy();
+        });
+
+        it('should validate even if the step value changes on-the-fly', function() {
+          scope.step = 10;
+          var inputElm = helper.compileInput('<input type="range" ng-model="value" name="alias" step="{{step}}" />');
+
+          helper.changeInputValueTo('10');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(10);
+
+          // Step changes, but value matches
+          scope.$apply('step = 5');
+          expect(inputElm.val()).toBe('10');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(10);
+          expect(scope.form.alias.$error.step).toBeFalsy();
+
+          // Step changes, value does not match
+          scope.$apply('step = 6');
+          expect(inputElm).toBeInvalid();
+          expect(scope.value).toBeUndefined();
+          expect(inputElm.val()).toBe('10');
+          expect(scope.form.alias.$error.step).toBeTruthy();
+
+          // null = valid
+          scope.$apply('step = null');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(10);
+          expect(inputElm.val()).toBe('10');
+          expect(scope.form.alias.$error.step).toBeFalsy();
+
+          // Step val as string
+          scope.$apply('step = "7"');
+          expect(inputElm).toBeInvalid();
+          expect(scope.value).toBeUndefined();
+          expect(inputElm.val()).toBe('10');
+          expect(scope.form.alias.$error.step).toBeTruthy();
+
+          // unparsable string is ignored
+          scope.$apply('step = "abc"');
+          expect(inputElm).toBeValid();
+          expect(scope.value).toBe(10);
+          expect(inputElm.val()).toBe('10');
+          expect(scope.form.alias.$error.step).toBeFalsy();
+        });
+      }
+    });
   });
 
   describe('email', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feat

**What is the current behavior? (You can also link to an open issue here)**
Input range doesn't handle the step attribute wrt to validation and model updates

**Does this PR introduce a breaking change?**
No

**TODO**
- [ ] Add tests for step + min + max
- [x] Add docs
- [x] Find out exactly what is broken in Chrome

**Other information**:

Wrt the Chrome bug mentioned in https://github.com/angular/angular.js/pull/14870#issuecomment-235829620, it looks like setting a number isn't the problem, but that Chrome has a bug when you change the step value multiple times. Not sure yet, though.
