### PR TITLE
fix($httpBackend): complete the request on timeout

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -108,6 +108,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
 
       xhr.onerror = requestError;
       xhr.onabort = requestError;
+      xhr.ontimeout = requestError;
 
       forEach(eventHandlers, function(value, key) {
           xhr.addEventListener(key, value);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.

**What is the current behavior? (You can also link to an open issue here)**
`$httpBackend` fails to detect a request timeout, when `.timeout` has been specified on the XHR (or any timeout in Safari 9).
See #14969.

**What is the new behavior (if this is a feature change)?**
`$httpBackend` detects request timeouts.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- ~~[ ] Docs have been added / updated (for bug fixes / features)~~

**Other information**:
When using the [timeout attribute](https://xhr.spec.whatwg.org/#the-timeout-attribute) and an XHR request times out, browsers trigger the `timeout` event (and execute the XHR's `ontimeout` callback). Additionally, Safari 9 handles timed-out requests in the same way, even if no `timeout` has been explicitly set on the XHR.
In the above cases, `$httpBackend` would fail to capture the XHR's completing (with an error), so the corresponding `$http` promise would never get fulfilled.

Fixes #14969.
