### PR TITLE
feat(location): add configurable attr to force html5mode link rewriting

### DIFF
--- a/docs/content/guide/$location.ngdoc
+++ b/docs/content/guide/$location.ngdoc
@@ -95,6 +95,8 @@ To configure the `$location` service, retrieve the
   `true` or `enabled:true` - see HTML5 mode<br />
   `false` or `enabled:false` - see Hashbang mode<br />
   `requireBase:true` - see Relative links<br />
+  `rewriteLinks:true` - see Html link rewriting<br />
+  `rewriteLinks:'string'` - see Html link rewriting<br />
   default: `enabled:false`
 
 - **hashPrefix(prefix)**: {string}<br />
@@ -325,6 +327,18 @@ reload to the original link.
   Example: `<a href="http://angularjs.org/">link</a>`
 - Links starting with '/' that lead to a different base path<br>
   Example: `<a href="/not-my-base/link">link</a>`
+
+If `html5Mode.rewriteLinks` is set to `false` in the html5Mode definition object passed to
+`$locationProvider.html5Mode()`, the browser will perform a full page reload for every link.
+`html5Mode.rewriteLinks` can also be set to a string, which will enable link re-writing only on
+links that have the given attribute.
+
+For example, if `html5Mode.rewriteLinks` is set to "internal-link":
+- `<a href="/some/path" internal-link>link</a>` will be rewritten
+- `<a href="/some/path">link</a>` will perform a full page reload
+
+Note that attribute name (de)normalization does not apply here, so "internalLink" is different from
+"internal-link".
 
 
 ### Relative links
@@ -853,6 +867,3 @@ angular.module('locationExample', [])
 # Related API
 
 * {@link ng.$location `$location` API}
-
-
-

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -750,8 +750,12 @@ function $LocationProvider() {
    *     whether or not a <base> tag is required to be present. If `enabled` and `requireBase` are
    *     true, and a base tag is not present, an error will be thrown when `$location` is injected.
    *     See the {@link guide/$location $location guide for more information}
-   *   - **rewriteLinks** - `{boolean}` - (default: `true`) When html5Mode is enabled,
-   *     enables/disables url rewriting for relative links.
+   *   - **rewriteLinks** - `{boolean|String}` - (default: `true`) When html5Mode is enabled,
+   *     enables/disables url rewriting for relative links. If set to a string, url rewriting will
+   *     only happen on links with an attribute that matches the given string. For example, if set
+   *     to "internal-link", then the URL will only be rewritten for `<a internal-link>` links. Note
+   *     that attribute name (de)normalization is not happening here. So "internal-link" is
+   *     different from "internalLink".
    *
    * @returns {Object} html5Mode object if used as getter or itself (chaining) if used as setter
    */
@@ -769,7 +773,7 @@ function $LocationProvider() {
         html5Mode.requireBase = mode.requireBase;
       }
 
-      if (isBoolean(mode.rewriteLinks)) {
+      if (isBoolean(mode.rewriteLinks) || isString(mode.rewriteLinks)) {
         html5Mode.rewriteLinks = mode.rewriteLinks;
       }
 
@@ -866,10 +870,11 @@ function $LocationProvider() {
     }
 
     $rootElement.on('click', function(event) {
+      var rewriteLinks = html5Mode.rewriteLinks;
       // TODO(vojta): rewrite link when opening in new tab/window (in legacy browser)
       // currently we open nice url link and redirect then
 
-      if (!html5Mode.rewriteLinks || event.ctrlKey || event.metaKey || event.shiftKey || event.which === 2 || event.button === 2) return;
+      if (!rewriteLinks || event.ctrlKey || event.metaKey || event.shiftKey || event.which === 2 || event.button === 2) return;
 
       var elm = jqLite(event.target);
 
@@ -878,6 +883,8 @@ function $LocationProvider() {
         // ignore rewriting if no A tag (reached root element, or no parent - removed from document)
         if (elm[0] === $rootElement[0] || !(elm = elm.parent())[0]) return;
       }
+
+      if (isString(rewriteLinks) && isUndefined(elm.attr(rewriteLinks))) return;
 
       var absHref = elm.prop('href');
       // get the actual href attribute - see

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1588,8 +1588,36 @@ describe('$location', function() {
 
 
     it('should not rewrite links when rewriting links is disabled', function() {
-      configureTestLink({linkHref: 'link?a#b', html5Mode: {enabled: true, rewriteLinks:false}, supportHist: true});
+      configureTestLink({linkHref: 'link?a#b'});
       initService({html5Mode:{enabled: true, rewriteLinks:false},supportHistory:true});
+      inject(
+        initBrowser({ url: 'http://host.com/base/index.html', basePath: '/base/index.html' }),
+        setupRewriteChecks(),
+        function($browser) {
+          browserTrigger(link, 'click');
+          expectNoRewrite($browser);
+        }
+      );
+    });
+
+
+    it('should rewrite links when the specified rewriteLinks attr is detected', function() {
+      configureTestLink({linkHref: 'link?a#b', attrs: 'force-rewrite'});
+      initService({html5Mode:{enabled: true, rewriteLinks:'force-rewrite'},supportHistory:true});
+      inject(
+        initBrowser({ url: 'http://host.com/base/index.html', basePath: '/base/index.html' }),
+        setupRewriteChecks(),
+        function($browser) {
+          browserTrigger(link, 'click');
+          expectRewriteTo($browser, 'http://host.com/base/link?a#b');
+        }
+      );
+    });
+
+
+    it('should not rewrite links when the specified rewriteLinks attr is not detected', function() {
+      configureTestLink({linkHref: 'link?a#b'});
+      initService({html5Mode:{enabled: true, rewriteLinks:'yes-rewrite'},supportHistory:true});
       inject(
         initBrowser({ url: 'http://host.com/base/index.html', basePath: '/base/index.html' }),
         setupRewriteChecks(),
@@ -1692,7 +1720,7 @@ describe('$location', function() {
 
     it('should not rewrite when full link to different base path when history enabled on old browser',
         function() {
-      configureTestLink({linkHref: 'http://host.com/other_base/link', html5Mode: true, supportHist: false});
+      configureTestLink({linkHref: 'http://host.com/other_base/link'});
       inject(
         initBrowser({ url: 'http://host.com/base/index.html', basePath: '/base/index.html' }),
         setupRewriteChecks(),
@@ -2357,12 +2385,12 @@ describe('$location', function() {
       });
 
 
-      it('should only overwrite existing properties if values are boolean', function() {
+      it('should only overwrite existing properties if values are the correct type', function() {
         module(function($locationProvider) {
           $locationProvider.html5Mode({
             enabled: 'duh',
             requireBase: 'probably',
-            rewriteLinks: 'nope'
+            rewriteLinks: 500
           });
 
           expect($locationProvider.html5Mode()).toEqual({
@@ -2370,6 +2398,19 @@ describe('$location', function() {
             requireBase: true,
             rewriteLinks: true
           });
+        });
+
+        inject(function() {});
+      });
+
+
+      it('should allow rewriteLinks config to be set to a string', function() {
+        module(function($locationProvider) {
+          $locationProvider.html5Mode({
+            rewriteLinks: 'yes-rewrite'
+          });
+
+          expect($locationProvider.html5Mode().rewriteLinks).toEqual('yes-rewrite');
         });
 
         inject(function() {});


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
When `rewriteLinks` is disabled in Location's `html5mode`, all links are treated as if they should reload from the server.

Also see this discussion: https://github.com/angular/angular.js/issues/14959

**What is the new behavior (if this is a feature change)?**
This allows the user to add an `ng-noserver` attribute to the `<a>` tag, like this:
`<a href="somewhere" ng-noserver>click me</a>` to explicitly mark this link as one that should **not** reload from server, i.e. to use angular javascript routing instead.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

See this discussion: https://github.com/angular/angular.js/issues/14959

When using html5mode, sometimes it is necessary to not use the <base> tag
in order to support SVG icons. An example of this is in the discussion
linked above.

When we do this, sometimes we also want to disable "rewriteLinks" so that
we can still leave the Angular application via navigation.

This feature allows the user to explicitly mark an <a> tag as a link that
should not refresh from server, even if rewriteLinks is disabled.
