### PR TITLE
docs(form.FormController): fix doc typo

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -84,7 +84,7 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
    * @description
    * Rollback all form controls pending updates to the `$modelValue`.
    *
-   * Updates may be pending by a debounced event or because the input is waiting for a some future
+   * Updates may be pending by a debounced event or because the input is waiting for a future
    * event defined in `ng-model-options`. This method is typically needed by the reset button of
    * a form that uses `ng-model-options` to pend updates.
    */
@@ -101,7 +101,7 @@ function FormController(element, attrs, $scope, $animate, $interpolate) {
    * @description
    * Commit all form controls pending updates to the `$modelValue`.
    *
-   * Updates may be pending by a debounced event or because the input is waiting for a some future
+   * Updates may be pending by a debounced event or because the input is waiting for a future
    * event defined in `ng-model-options`. This method is rarely needed as `NgModelController`
    * usually handles calling this in response to input events.
    */


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

docs update

**What is the current behavior? (You can also link to an open issue here)**

The documentation contains the apparent typo, "for a some future event".

**What is the new behavior (if this is a feature change)?**

The typo is changed to, "for a future event".

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
