### PR TITLE
Fix input range init

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1640,7 +1640,8 @@ function rangeInputType(scope, element, attr, ctrl, $sniffer, $browser) {
       // IE11 doesn't set the el val correctly if the maxVal is less than the element value
       if (maxVal < elVal) {
         element.val(maxVal);
-        elVal = minVal;
+        // IE11 and Chrome don't set the value to the minVal when max < min
+        elVal = maxVal < minVal ? minVal : maxVal;
       }
       ctrl.$setViewValue(elVal);
     } else {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -3105,49 +3105,6 @@ describe('input', function() {
       }
     });
 
-    describe('ngMin', function() {
-
-      it('should validate', function() {
-        var inputElm = helper.compileInput('<input type="range" ng-model="value" name="alias" ng-min="50" />');
-
-        helper.changeInputValueTo('1');
-        expect(inputElm).toBeInvalid();
-        expect(scope.value).toBeFalsy();
-        expect(scope.form.alias.$error.min).toBeTruthy();
-
-        helper.changeInputValueTo('100');
-        expect(inputElm).toBeValid();
-        expect(scope.value).toBe(100);
-        expect(scope.form.alias.$error.min).toBeFalsy();
-      });
-
-      it('should validate even if the ngMin value changes on-the-fly', function() {
-        scope.min = 10;
-        var inputElm = helper.compileInput('<input type="range" ng-model="value" name="alias" ng-min="min" />');
-
-        helper.changeInputValueTo('15');
-        expect(inputElm).toBeValid();
-
-        scope.min = 20;
-        scope.$digest();
-        expect(inputElm).toBeInvalid();
-        expect(inputElm.val()).toBe('15');
-
-        scope.min = null;
-        scope.$digest();
-        expect(inputElm).toBeValid();
-
-        scope.min = '20';
-        scope.$digest();
-        expect(inputElm).toBeInvalid();
-
-        scope.min = 'abc';
-        scope.$digest();
-        expect(inputElm).toBeValid();
-      });
-    });
-
-
     describe('max', function() {
 
       if (supportsRange) {
@@ -3301,48 +3258,6 @@ describe('input', function() {
           expect(inputElm.val()).toBe('5');
         });
       }
-    });
-
-    describe('ngMax', function() {
-
-      it('should validate', function() {
-        var inputElm = helper.compileInput('<input type="range" ng-model="value" name="alias" ng-max="5" />');
-
-        helper.changeInputValueTo('20');
-        expect(inputElm).toBeInvalid();
-        expect(scope.value).toBeUndefined();
-        expect(scope.form.alias.$error.max).toBeTruthy();
-
-        helper.changeInputValueTo('0');
-        expect(inputElm).toBeValid();
-        expect(scope.value).toBe(0);
-        expect(scope.form.alias.$error.max).toBeFalsy();
-      });
-
-      it('should validate even if the ngMax value changes on-the-fly', function() {
-        scope.max = 10;
-        var inputElm = helper.compileInput('<input type="range" ng-model="value" name="alias" ng-max="max" />');
-
-        helper.changeInputValueTo('5');
-        expect(inputElm).toBeValid();
-
-        scope.max = 0;
-        scope.$digest();
-        expect(inputElm).toBeInvalid();
-
-        scope.max = null;
-        scope.$digest();
-        expect(inputElm).toBeValid();
-
-        scope.max = '4';
-        scope.$digest();
-        expect(inputElm).toBeInvalid();
-
-        scope.max = 'abc';
-        scope.$digest();
-        expect(inputElm).toBeValid();
-      });
-
     });
 
     if (supportsRange) {

--- a/test/ng/directive/validatorsSpec.js
+++ b/test/ng/directive/validatorsSpec.js
@@ -351,7 +351,7 @@ describe('validators', function() {
 
 
     it('should accept values of any length when maxlength is non-numeric', function() {
-      var inputElm = helper.compileInput('<input type="text" ng-model="value" ng-maxlength="{{maxlength}}" />');
+      var inputElm = helper.compileInput('<input type="text" ng-model="value" ng-maxlength="maxlength" />');
       helper.changeInputValueTo('aaaaaaaaaa');
 
       $rootScope.$apply('maxlength = "5"');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- ~~[ ] Docs have been added / updated (for bug fixes / features)~~

**Other information**:

This PR fixes 1 bigger and 2 smaller issues:
- correctly initialize with interpolated min / max values

The interpolation directive only sets the actual element attribute value after
a digest passed. That means previously the min/max values on input range were
not set when the first $render happened, so the browser would not adjust
the input value according to min/max. This meant the range input and model would
not be initialzed as expected.

With this change, input range will set the actual element attribute value during its own
linking phase, as it is already available on the attrs argument passed to the link fn.

Fixes #14982
- correctly sets the range value when min > max. Chrome and IE don't set this correctly in all cases.
- removes interpolation from an ng-maxlength attribute in a test (interpolation in an attribute that expects an expression is discouraged)
