### PR TITLE
chore(package): fix some warnings/errors

### DIFF
--- a/docs/app/src/search.js
+++ b/docs/app/src/search.js
@@ -95,7 +95,7 @@ angular.module('search', [])
     }
 
     // Create the lunr index
-    var index = lunr(/* @this */ function() {
+    var index = lunr(/** @this */ function() {
       this.ref('path');
       this.field('titleWords', {boost: 50});
       this.field('members', { boost: 40});

--- a/docs/config/index.js
+++ b/docs/config/index.js
@@ -55,6 +55,7 @@ module.exports = new Package('angularjs', [
   parseTagsProcessor.tagDefinitions.push(require('./tag-defs/tutorial-step'));
   parseTagsProcessor.tagDefinitions.push(require('./tag-defs/sortOrder'));
   parseTagsProcessor.tagDefinitions.push(require('./tag-defs/installation'));
+  parseTagsProcessor.tagDefinitions.push(require('./tag-defs/this'));
 })
 
 

--- a/docs/config/tag-defs/this.js
+++ b/docs/config/tag-defs/this.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  name: 'this'
+};

--- a/docs/gulpfile.js
+++ b/docs/gulpfile.js
@@ -126,8 +126,12 @@ gulp.task('eslint', ['doc-gen'], function() {
   // compatible with non-browser window implementations like jsdom, it's not necessary
   // in examples and may look weird to casual readers.
   examplesConfig.envs = ['browser'];
+  // Dgeni-generated files use the system's default linebreak style (i.e. CRLF on Windows)
+  examplesConfig.rules['linebreak-style'] = 'off';
 
   var protractorConfig = getMergedEslintConfig('../docs/app/e2e/.eslintrc.json');
+  // Dgeni-generated files use the system's default linebreak style (i.e. CRLF on Windows)
+  protractorConfig.rules['linebreak-style'] = 'off';
   protractorConfig.rules['no-unused-vars'] = ['error', {
     vars: 'local',
     args: 'none',

--- a/docs/gulpfile.js
+++ b/docs/gulpfile.js
@@ -34,6 +34,8 @@ var getMergedEslintConfig = function(filepath) {
       strict: 'off',
       // Generated examples may miss the final EOL; ignore that.
       'eol-last': 'off',
+      // Generated files use the system's default linebreak style (i.e. CRLF on Windows)
+      'linebreak-style': 'off',
       // While alerts would be bad to have in the library or test code,
       // they're perfectly fine in examples.
       'no-alert': 'off',
@@ -126,12 +128,8 @@ gulp.task('eslint', ['doc-gen'], function() {
   // compatible with non-browser window implementations like jsdom, it's not necessary
   // in examples and may look weird to casual readers.
   examplesConfig.envs = ['browser'];
-  // Dgeni-generated files use the system's default linebreak style (i.e. CRLF on Windows)
-  examplesConfig.rules['linebreak-style'] = 'off';
 
   var protractorConfig = getMergedEslintConfig('../docs/app/e2e/.eslintrc.json');
-  // Dgeni-generated files use the system's default linebreak style (i.e. CRLF on Windows)
-  protractorConfig.rules['linebreak-style'] = 'off';
   protractorConfig.rules['no-unused-vars'] = ['error', {
     vars: 'local',
     args: 'none',

--- a/src/apis.js
+++ b/src/apis.js
@@ -74,7 +74,7 @@ HashMap.prototype = {
   }
 };
 
-var $$HashMapProvider = [/* @this */function() {
+var $$HashMapProvider = [/** @this */function() {
   this.$get = [function() {
     return HashMap;
   }];

--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -710,7 +710,7 @@ function createInjector(modulesToLoad, strictDi) {
   }
 
   function enforceReturnValue(name, factory) {
-    return /* @this */ function enforcedReturnValue() {
+    return /** @this */ function enforcedReturnValue() {
       var result = instanceInjector.invoke(factory, this);
       if (isUndefined(result)) {
         throw $injectorMinErr('undef', "Provider '{0}' must return a value from $get factory method.", name);

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -262,7 +262,7 @@ function jqLiteWrapNode(node, wrapper) {
 
 
 // IE9-11 has no method "contains" in SVG element and in Node.prototype. Bug #10259.
-var jqLiteContains = window.Node.prototype.contains || /* @this */ function(arg) {
+var jqLiteContains = window.Node.prototype.contains || /** @this */ function(arg) {
   // eslint-disable-next-line no-bitwise
   return !!(this.compareDocumentPosition(arg) & 16);
 };
@@ -1068,7 +1068,7 @@ forEach({
 
 
 // Provider for private $$jqLite service
-/* @this */
+/** @this */
 function $$jqLiteProvider() {
   this.$get = function $$jqLite() {
     return extend(JQLite, {

--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -53,13 +53,13 @@ function prepareAnimateOptions(options) {
       : {};
 }
 
-var $$CoreAnimateJsProvider = /* @this */ function() {
+var $$CoreAnimateJsProvider = /** @this */ function() {
   this.$get = noop;
 };
 
 // this is prefixed with Core since it conflicts with
 // the animateQueueProvider defined in ngAnimate/animateQueue.js
-var $$CoreAnimateQueueProvider = /* @this */ function() {
+var $$CoreAnimateQueueProvider = /** @this */ function() {
   var postDigestQueue = new HashMap();
   var postDigestElements = [];
 
@@ -177,7 +177,7 @@ var $$CoreAnimateQueueProvider = /* @this */ function() {
  *
  * To see the functional implementation check out `src/ngAnimate/animate.js`.
  */
-var $AnimateProvider = ['$provide', /* @this */ function($provide) {
+var $AnimateProvider = ['$provide', /** @this */ function($provide) {
   var provider = this;
 
   this.$$registeredAnimations = Object.create(null);

--- a/src/ng/animateRunner.js
+++ b/src/ng/animateRunner.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var $$AnimateAsyncRunFactoryProvider = /* @this */ function() {
+var $$AnimateAsyncRunFactoryProvider = /** @this */ function() {
   this.$get = ['$$rAF', function($$rAF) {
     var waitQueue = [];
 
@@ -31,7 +31,7 @@ var $$AnimateAsyncRunFactoryProvider = /* @this */ function() {
   }];
 };
 
-var $$AnimateRunnerFactoryProvider = /* @this */ function() {
+var $$AnimateRunnerFactoryProvider = /** @this */ function() {
   this.$get = ['$q', '$sniffer', '$$animateAsyncRun', '$$isDocumentHidden', '$timeout',
        function($q,   $sniffer,   $$animateAsyncRun,   $$isDocumentHidden,   $timeout) {
 

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -353,7 +353,7 @@ function Browser(window, document, $log, $sniffer) {
 
 }
 
-/* @this */
+/** @this */
 function $BrowserProvider() {
   this.$get = ['$window', '$log', '$sniffer', '$document',
       function($window, $log, $sniffer, $document) {

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -958,7 +958,7 @@ var _UNINITIALIZED_VALUE = new UNINITIALIZED_VALUE();
  * @description
  */
 $CompileProvider.$inject = ['$provide', '$$sanitizeUriProvider'];
-/* @this */
+/** @this */
 function $CompileProvider($provide, $$sanitizeUriProvider) {
   var hasDirectives = {},
       Suffix = 'Directive',
@@ -1217,7 +1217,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
     function factory($injector) {
       function makeInjectable(fn) {
         if (isFunction(fn) || isArray(fn)) {
-          return /* @this */ function(tElement, tAttrs) {
+          return /** @this */ function(tElement, tAttrs) {
             return $injector.invoke(fn, this, {$element: tElement, $attrs: tAttrs});
           };
         } else {
@@ -2146,7 +2146,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       if (eager) {
         return compile($compileNodes, transcludeFn, maxPriority, ignoreDirective, previousCompileContext);
       }
-      return /* @this */ function lazyCompilation() {
+      return /** @this */ function lazyCompilation() {
         if (!compiled) {
           compiled = compile($compileNodes, transcludeFn, maxPriority, ignoreDirective, previousCompileContext);
 

--- a/src/ng/cookieReader.js
+++ b/src/ng/cookieReader.js
@@ -51,7 +51,7 @@ function $$CookieReader($document) {
 
 $$CookieReader.$inject = ['$document'];
 
-/* @this */
+/** @this */
 function $$CookieReaderProvider() {
   this.$get = $$CookieReader;
 }

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1271,7 +1271,7 @@ function baseInputType(scope, element, attr, ctrl, $sniffer, $browser) {
       }
     };
 
-    element.on('keydown', /* @this */ function(event) {
+    element.on('keydown', /** @this */ function(event) {
       var key = event.keyCode;
 
       // ignore
@@ -1296,7 +1296,7 @@ function baseInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   // For these event types, when native validators are present and the browser supports the type,
   // check for validity changes on various DOM events.
   if (PARTIAL_VALIDATION_TYPES[type] && ctrl.$$hasNativeValidators && type === attr.type) {
-    element.on(PARTIAL_VALIDATION_EVENTS, /* @this */ function(ev) {
+    element.on(PARTIAL_VALIDATION_EVENTS, /** @this */ function(ev) {
       if (!timeout) {
         var validity = this[VALIDITY_STATE_PROPERTY];
         var origBadInput = validity.badInput;

--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -221,7 +221,7 @@ is set to `true`. The parse error is stored in `ngModel.$error.parse`.
  *
  */
 var NgModelController = ['$scope', '$exceptionHandler', '$attrs', '$element', '$parse', '$animate', '$timeout', '$rootScope', '$q', '$interpolate',
-    /* @this */ function($scope, $exceptionHandler, $attr, $element, $parse, $animate, $timeout, $rootScope, $q, $interpolate) {
+    /** @this */ function($scope, $exceptionHandler, $attr, $element, $parse, $animate, $timeout, $rootScope, $q, $interpolate) {
   this.$viewValue = Number.NaN;
   this.$modelValue = Number.NaN;
   this.$$rawModelValue = undefined; // stores the parsed modelValue / model set from scope regardless of validity.

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -13,7 +13,7 @@ var noopNgModelController = { $setViewValue: noop, $render: noop };
  * added `<option>` elements, perhaps by an `ngRepeat` directive.
  */
 var SelectController =
-        ['$element', '$scope', /* @this */ function($element, $scope) {
+        ['$element', '$scope', /** @this */ function($element, $scope) {
 
   var self = this,
       optionsMap = new HashMap();

--- a/src/ng/filter.js
+++ b/src/ng/filter.js
@@ -106,7 +106,7 @@
    </example>
   */
 $FilterProvider.$inject = ['$provide'];
-/* @this */
+/** @this */
 function $FilterProvider($provide) {
   var suffix = 'Filter';
 

--- a/src/ng/forceReflow.js
+++ b/src/ng/forceReflow.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var $$ForceReflowProvider = /* @this */ function() {
+var $$ForceReflowProvider = /** @this */ function() {
   this.$get = ['$document', function($document) {
     return function(domNode) {
       //the line below will force the browser to perform a repaint so

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -23,7 +23,7 @@ function serializeValue(v) {
 }
 
 
-/* @this */
+/** @this */
 function $HttpParamSerializerProvider() {
   /**
    * @ngdoc service
@@ -61,7 +61,7 @@ function $HttpParamSerializerProvider() {
   };
 }
 
-/* @this */
+/** @this */
 function $HttpParamSerializerJQLikeProvider() {
   /**
    * @ngdoc service

--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -331,7 +331,7 @@ function $InterpolateProvider() {
           expressions: expressions,
           $$watchDelegate: function(scope, listener) {
             var lastValue;
-            return scope.$watchGroup(parseFns, /* @this */ function interpolateFnWatcher(values, oldValues) {
+            return scope.$watchGroup(parseFns, /** @this */ function interpolateFnWatcher(values, oldValues) {
               var currValue = compute(values);
               if (isFunction(listener)) {
                 listener.call(this, currValue, values !== oldValues ? lastValue : currValue, scope);

--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* @this */
+/** @this */
 function $IntervalProvider() {
   this.$get = ['$rootScope', '$window', '$q', '$$q', '$browser',
        function($rootScope,   $window,   $q,   $$q,   $browser) {

--- a/src/ng/jsonpCallbacks.js
+++ b/src/ng/jsonpCallbacks.js
@@ -9,7 +9,7 @@
  * Override this service if you wish to customise where the callbacks are stored and
  * how they vary compared to the requested url.
  */
-var $jsonpCallbacksProvider = /* @this */ function() {
+var $jsonpCallbacksProvider = /** @this */ function() {
   this.$get = ['$window', function($window) {
     var callbacks = $window.angular.callbacks;
     var callbackMap = {};

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -657,14 +657,14 @@ forEach([LocationHashbangInHtml5Url, LocationHashbangUrl, LocationHtml5Url], fun
 
 
 function locationGetter(property) {
-  return /* @this */ function() {
+  return /** @this */ function() {
     return this[property];
   };
 }
 
 
 function locationGetterSetter(property, preprocess) {
-  return /* @this */ function(value) {
+  return /** @this */ function(value) {
     if (isUndefined(value)) {
       return this[property];
     }

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -254,7 +254,7 @@ function $QProvider() {
   };
 }
 
-/* @this */
+/** @this */
 function $$QProvider() {
   var errorOnUnhandledRejections = true;
   this.$get = ['$browser', '$exceptionHandler', function($browser, $exceptionHandler) {

--- a/src/ng/raf.js
+++ b/src/ng/raf.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* @this */
+/** @this */
 function $$RAFProvider() { //rAF
   this.$get = ['$window', '$timeout', function($window, $timeout) {
     var requestAnimationFrame = $window.requestAnimationFrame ||

--- a/src/ng/testability.js
+++ b/src/ng/testability.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* @this */
+/** @this */
 function $$TestabilityProvider() {
   this.$get = ['$rootScope', '$browser', '$location',
        function($rootScope,   $browser,   $location) {

--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* @this */
+/** @this */
 function $TimeoutProvider() {
   this.$get = ['$rootScope', '$browser', '$q', '$$q', '$exceptionHandler',
        function($rootScope,   $browser,   $q,   $$q,   $exceptionHandler) {

--- a/src/ngAnimate/animateCss.js
+++ b/src/ngAnimate/animateCss.js
@@ -348,7 +348,7 @@ function registerRestorableStyles(backup, node, properties) {
   });
 }
 
-var $AnimateCssProvider = ['$animateProvider', /* @this */ function($animateProvider) {
+var $AnimateCssProvider = ['$animateProvider', /** @this */ function($animateProvider) {
   var gcsLookup = createLocalCacheLookup();
   var gcsStaggerLookup = createLocalCacheLookup();
 

--- a/src/ngAnimate/animateCssDriver.js
+++ b/src/ngAnimate/animateCssDriver.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var $$AnimateCssDriverProvider = ['$$animationProvider', /* @this */ function($$animationProvider) {
+var $$AnimateCssDriverProvider = ['$$animationProvider', /** @this */ function($$animationProvider) {
   $$animationProvider.drivers.push('$$animateCssDriver');
 
   var NG_ANIMATE_SHIM_CLASS_NAME = 'ng-animate-shim';

--- a/src/ngAnimate/animateJs.js
+++ b/src/ngAnimate/animateJs.js
@@ -4,7 +4,7 @@
 // TODO(matsko): add documentation
 //  by the time...
 
-var $$AnimateJsProvider = ['$animateProvider', /* @this */ function($animateProvider) {
+var $$AnimateJsProvider = ['$animateProvider', /** @this */ function($animateProvider) {
   this.$get = ['$injector', '$$AnimateRunner', '$$jqLite',
        function($injector,   $$AnimateRunner,   $$jqLite) {
 

--- a/src/ngAnimate/animateJsDriver.js
+++ b/src/ngAnimate/animateJsDriver.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var $$AnimateJsDriverProvider = ['$$animationProvider', /* @this */ function($$animationProvider) {
+var $$AnimateJsDriverProvider = ['$$animationProvider', /** @this */ function($$animationProvider) {
   $$animationProvider.drivers.push('$$animateJsDriver');
   this.$get = ['$$animateJs', '$$AnimateRunner', function($$animateJs, $$AnimateRunner) {
     return function initDriverFn(animationDetails) {

--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -2,7 +2,7 @@
 
 var NG_ANIMATE_ATTR_NAME = 'data-ng-animate';
 var NG_ANIMATE_PIN_DATA = '$ngAnimatePin';
-var $$AnimateQueueProvider = ['$animateProvider', /* @this */ function($animateProvider) {
+var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animateProvider) {
   var PRE_DIGEST_STATE = 1;
   var RUNNING_STATE = 2;
   var ONE_SPACE = ' ';
@@ -176,7 +176,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /* @this */ function($animateP
     }
 
     // IE9-11 has no method "contains" in SVG element and in Node.prototype. Bug #10259.
-    var contains = window.Node.prototype.contains || /* @this */ function(arg) {
+    var contains = window.Node.prototype.contains || /** @this */ function(arg) {
       // eslint-disable-next-line no-bitwise
       return this === arg || !!(this.compareDocumentPosition(arg) & 16);
     };

--- a/src/ngAnimate/animation.js
+++ b/src/ngAnimate/animation.js
@@ -2,7 +2,7 @@
 
 /* exported $$AnimationProvider */
 
-var $$AnimationProvider = ['$animateProvider', /* @this */ function($animateProvider) {
+var $$AnimationProvider = ['$animateProvider', /** @this */ function($animateProvider) {
   var NG_ANIMATE_REF_ATTR = 'ng-animate-ref';
 
   var drivers = this.drivers = [];

--- a/src/ngCookies/cookieWriter.js
+++ b/src/ngCookies/cookieWriter.js
@@ -55,6 +55,6 @@ function $$CookieWriter($document, $log, $browser) {
 
 $$CookieWriter.$inject = ['$document', '$log', '$browser'];
 
-angular.module('ngCookies').provider('$$cookieWriter', /* @this */ function $$CookieWriterProvider() {
+angular.module('ngCookies').provider('$$cookieWriter', /** @this */ function $$CookieWriterProvider() {
   this.$get = $$CookieWriter;
 });

--- a/src/ngCookies/cookies.js
+++ b/src/ngCookies/cookies.js
@@ -23,7 +23,7 @@ angular.module('ngCookies', ['ng']).
    * @description
    * Use `$cookiesProvider` to change the default behavior of the {@link ngCookies.$cookies $cookies} service.
    * */
-   provider('$cookies', [/* @this */function $CookiesProvider() {
+   provider('$cookies', [/** @this */function $CookiesProvider() {
     /**
      * @ngdoc property
      * @name $cookiesProvider#defaults

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2874,7 +2874,7 @@ angular.mock.$RootScopeDecorator = ['$delegate', function($delegate) {
 
     var initialized = false;
 
-    module.$$beforeAllHook(/* @this */ function() {
+    module.$$beforeAllHook(/** @this */ function() {
       if (injectorState.shared) {
         injectorState.sharedError = Error("sharedInjector() cannot be called inside a context that has already called sharedInjector()");
         throw injectorState.sharedError;

--- a/src/ngScenario/Describe.js
+++ b/src/ngScenario/Describe.js
@@ -23,7 +23,7 @@ angular.scenario.Describe = function(descName, parent) {
   var beforeEachFns = this.beforeEachFns;
   this.setupBefore = function() {
     if (parent) parent.setupBefore.call(this);
-    angular.forEach(beforeEachFns, /* @this */ function(fn) { fn.call(this); }, this);
+    angular.forEach(beforeEachFns, /** @this */ function(fn) { fn.call(this); }, this);
   };
 
   /**
@@ -31,7 +31,7 @@ angular.scenario.Describe = function(descName, parent) {
    */
   var afterEachFns = this.afterEachFns;
   this.setupAfter  = function() {
-    angular.forEach(afterEachFns, /* @this */ function(fn) { fn.call(this); }, this);
+    angular.forEach(afterEachFns, /** @this */ function(fn) { fn.call(this); }, this);
     if (parent) parent.setupAfter.call(this);
   };
 };

--- a/src/ngScenario/Runner.js
+++ b/src/ngScenario/Runner.js
@@ -21,7 +21,7 @@ angular.scenario.Runner = function($window) {
     beforeEach: this.beforeEach,
     afterEach: this.afterEach
   };
-  angular.forEach(this.api, angular.bind(this, /* @this */ function(fn, key) {
+  angular.forEach(this.api, angular.bind(this, /** @this */ function(fn, key) {
     this.$window[key] = angular.bind(this, fn);
   }));
 };
@@ -66,7 +66,7 @@ angular.scenario.Runner.prototype.on = function(eventName, listener) {
  */
 angular.scenario.Runner.prototype.describe = function(name, body) {
   var self = this;
-  this.currentDescribe.describe(name, /* @this */ function() {
+  this.currentDescribe.describe(name, /** @this */ function() {
     var parentDescribe = self.currentDescribe;
     self.currentDescribe = this;
     try {
@@ -87,7 +87,7 @@ angular.scenario.Runner.prototype.describe = function(name, body) {
  */
 angular.scenario.Runner.prototype.ddescribe = function(name, body) {
   var self = this;
-  this.currentDescribe.ddescribe(name, /* @this */ function() {
+  this.currentDescribe.ddescribe(name, /** @this */ function() {
     var parentDescribe = self.currentDescribe;
     self.currentDescribe = this;
     try {
@@ -215,7 +215,7 @@ angular.scenario.Runner.prototype.run = function(application) {
         return scope.dsl[key].apply(scope, arguments);
       };
     });
-    runner.run(spec, /* @this */ function() {
+    runner.run(spec, /** @this */ function() {
       runner.$destroy();
       specDone.apply(this, arguments);
     });

--- a/src/ngScenario/Scenario.js
+++ b/src/ngScenario/Scenario.js
@@ -40,7 +40,7 @@ angular.scenario.output = angular.scenario.output || function(name, fn) {
 angular.scenario.dsl = angular.scenario.dsl || function(name, fn) {
   angular.scenario.dsl[name] = function() {
     // The dsl binds `this` for us when calling chained functions
-    /* @this */
+    /** @this */
     function executeStatement(statement, args) {
       var result = statement.apply(this, args);
       if (angular.isFunction(result) || result instanceof angular.scenario.Future) {
@@ -60,7 +60,7 @@ angular.scenario.dsl = angular.scenario.dsl || function(name, fn) {
       return chain;
     }
     var statement = fn.apply(this, arguments);
-    return /* @this */ function() {
+    return /** @this */ function() {
       return executeStatement.call(this, statement, arguments);
     };
   };

--- a/src/ngScenario/SpecRunner.js
+++ b/src/ngScenario/SpecRunner.js
@@ -107,7 +107,7 @@ angular.scenario.SpecRunner.prototype.addFuture = function(name, behavior, line)
 angular.scenario.SpecRunner.prototype.addFutureAction = function(name, behavior, line) {
   var self = this;
   var NG = /\[ng\\:/;
-  return this.addFuture(name, /* @this */ function(done) {
+  return this.addFuture(name, /** @this */ function(done) {
     this.application.executeAction(function($window, $document) {
 
       //TODO(esprehn): Refactor this so it doesn't need to be in here.

--- a/src/ngScenario/matchers.js
+++ b/src/ngScenario/matchers.js
@@ -4,42 +4,42 @@
  * Matchers for implementing specs. Follows the Jasmine spec conventions.
  */
 
-angular.scenario.matcher('toEqual', /* @this */ function(expected) {
+angular.scenario.matcher('toEqual', /** @this */ function(expected) {
   return angular.equals(this.actual, expected);
 });
 
-angular.scenario.matcher('toBe', /* @this */ function(expected) {
+angular.scenario.matcher('toBe', /** @this */ function(expected) {
   return this.actual === expected;
 });
 
-angular.scenario.matcher('toBeDefined', /* @this */ function() {
+angular.scenario.matcher('toBeDefined', /** @this */ function() {
   return angular.isDefined(this.actual);
 });
 
-angular.scenario.matcher('toBeTruthy', /* @this */ function() {
+angular.scenario.matcher('toBeTruthy', /** @this */ function() {
   return this.actual;
 });
 
-angular.scenario.matcher('toBeFalsy', /* @this */ function() {
+angular.scenario.matcher('toBeFalsy', /** @this */ function() {
   return !this.actual;
 });
 
-angular.scenario.matcher('toMatch', /* @this */ function(expected) {
+angular.scenario.matcher('toMatch', /** @this */ function(expected) {
   return new RegExp(expected).test(this.actual);
 });
 
-angular.scenario.matcher('toBeNull', /* @this */ function() {
+angular.scenario.matcher('toBeNull', /** @this */ function() {
   return this.actual === null;
 });
 
-angular.scenario.matcher('toContain', /* @this */ function(expected) {
+angular.scenario.matcher('toContain', /** @this */ function(expected) {
   return includes(this.actual, expected);
 });
 
-angular.scenario.matcher('toBeLessThan', /* @this */ function(expected) {
+angular.scenario.matcher('toBeLessThan', /** @this */ function(expected) {
   return this.actual < expected;
 });
 
-angular.scenario.matcher('toBeGreaterThan', /* @this */ function(expected) {
+angular.scenario.matcher('toBeGreaterThan', /** @this */ function(expected) {
   return this.actual > expected;
 });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Chore.

**What is the current behavior? (You can also link to an open issue here)**
Warnings (or even errors), when running some build commands (e.g. `grunt package`).

**What is the new behavior (if this is a feature change)?**
No warnings or errors, when running build commands.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
chore(package): fix some warnings/errors

Related to #14952. Fixed the following warnings/errors:
1. **Warning**: Closure Compiler complained about `/* @this */` (annotations in non-JSDoc cooments).
   Fixed by changing `/* @this */` to `/** @this */`.
2. **Warning**: Dgeni complaines about `/** @this */` (invalid tags found).
   Fixed by adding an empty `this` tag definition in `docs/config/tag-defs/`.
3. **Error**: ESLint complained about CRLF linebreaks in `build/docs/examples/`. These are generated by dgeni and (apparently) use the system's default linebreak (i.e. CRLF on Windows).
   Fixed by disabling the `linebreak-style` rule for `build/docs/examples/`.
