### PR TITLE
fix (date filter): added !isNaN check before creating new Date object

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -614,7 +614,7 @@ function dateFilter($locale) {
       date = NUMBER_STRING.test(date) ? toInt(date) : jsonStringToDate(date);
     }
 
-    if (isNumber(date)) {
+    if (isNumber(date) && !isNaN(date)) {
       date = new Date(date);
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
Please see: https://github.com/angular/angular.js/issues/13415#issuecomment-238309031

not solved by PR #14221 in release 1.4.12 or 1.5.8

**What is the new behavior (if this is a feature change)?**
Perform `!isNaN(date)` check in date filter before attempting to create `new Date(date)` object.

**Does this PR introduce a breaking change?**
Possibly.  If a user of the date filter expects it to throw the DateRange error if a `NaN` value is passed.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Workaround is simple enough to pass values through a normalization filter before passing to date filter.
