### PR TITLE
feat($controller): throw error when requested controller is not regis…

### DIFF
--- a/docs/content/error/$controller/ctrlreg.ngdoc
+++ b/docs/content/error/$controller/ctrlreg.ngdoc
@@ -1,0 +1,24 @@
+@ngdoc error
+@name $controller:ctrlreg
+@fullName A controller with this name is not registered.
+@description
+
+This error occurs when the {@link ng.$controller `$controller()`} service is called
+with a string that does not match any of the registered controllers. The controller service may have
+been invoked directly, or indirectly through the {@link ng.ngController `ngController`} directive,
+or when inside a {@link angular.Module#component component} / {@link angular.Module#directive directive}
+definition (when using string notation for the controller property).
+
+Sources for this error can be:
+
+1. You have a typo in the {@link ng.ngController `ngController`} directive,
+in a {@link angular.Module#component component} / {@link angular.Module#directive directive}
+definition's controller property, or in the call to {@link ng.$controller `$controller()`}.
+2. You have not registered the controller (neither via {@link angular.Module#controller `Module.controller`}
+nor {@link ng.$controllerProvider#register `$controllerProvider.register()`}.
+3. You have a typo in the *registered* controller name.
+4. You want to use controllers defined on the `window`, but have turned off
+{@link ng.$controllerProvider#allowGlobals `allowGlobals()`}.
+
+
+Please consult the {@link ng.$controller $controller} service api docs to learn more.

--- a/docs/content/error/$controller/ctrlreg.ngdoc
+++ b/docs/content/error/$controller/ctrlreg.ngdoc
@@ -5,20 +5,19 @@
 
 This error occurs when the {@link ng.$controller `$controller()`} service is called
 with a string that does not match any of the registered controllers. The controller service may have
-been invoked directly, or indirectly through the {@link ng.ngController `ngController`} directive,
-or when inside a {@link angular.Module#component component} / {@link angular.Module#directive directive}
-definition (when using string notation for the controller property).
+been invoked directly, or indirectly, for example through the {@link ng.ngController `ngController`} directive,
+or inside a {@link angular.Module#component component} / {@link angular.Module#directive directive} /
+{@link ngRoute.$routeProvider#when route} definition (when using a string for the controller property).
+Third-party modules can also instantiate controllers with the {@link ng.$controller `$controller()`} service.
 
-Sources for this error can be:
+Causes for this error can be:
 
-1. You have a typo in the {@link ng.ngController `ngController`} directive,
-in a {@link angular.Module#component component} / {@link angular.Module#directive directive}
+1. Your reference to the controller has a typo. For example, in
+the {@link ng.ngController `ngController`} directive attribute, in a {@link angular.Module#component component}
 definition's controller property, or in the call to {@link ng.$controller `$controller()`}.
 2. You have not registered the controller (neither via {@link angular.Module#controller `Module.controller`}
 nor {@link ng.$controllerProvider#register `$controllerProvider.register()`}.
 3. You have a typo in the *registered* controller name.
-4. You want to use controllers defined on the `window`, but have turned off
-{@link ng.$controllerProvider#allowGlobals `allowGlobals()`}.
 
 
 Please consult the {@link ng.$controller $controller} service api docs to learn more.

--- a/docs/content/error/ng/areq.ngdoc
+++ b/docs/content/error/ng/areq.ngdoc
@@ -5,4 +5,5 @@
 
 AngularJS often asserts that certain values will be present and truthy using a
 helper function. If the assertion fails, this error is thrown. To fix this problem,
-make sure that the value the assertion expects is defined and truthy.
+make sure that the value the assertion expects is defined and matches the type mentioned in the
+error.

--- a/karma-shared.conf.js
+++ b/karma-shared.conf.js
@@ -135,7 +135,7 @@ module.exports = function(config, specificOptions) {
 
     config.logLevel = config.LOG_DEBUG;
     // Karma (with socket.io 1.x) buffers by 50 and 50 tests can take a long time on IEs;-)
-    config.browserNoActivityTimeout = 140000;
+    config.browserNoActivityTimeout = 120000;
 
     config.browserStack.build = buildLabel;
     config.browserStack.startTunnel = false;

--- a/karma-shared.conf.js
+++ b/karma-shared.conf.js
@@ -135,7 +135,7 @@ module.exports = function(config, specificOptions) {
 
     config.logLevel = config.LOG_DEBUG;
     // Karma (with socket.io 1.x) buffers by 50 and 50 tests can take a long time on IEs;-)
-    config.browserNoActivityTimeout = 120000;
+    config.browserNoActivityTimeout = 140000;
 
     config.browserStack.build = buildLabel;
     config.browserStack.startTunnel = false;

--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -122,6 +122,11 @@ function $ControllerProvider() {
             : getter(locals.$scope, constructor, true) ||
                 (globals ? getter($window, constructor, true) : undefined);
 
+        if (!expression) {
+          throw $controllerMinErr('ctrlreg',
+            'The controller with the name \'{0}\' is not registered.', constructor);
+        }
+
         assertArgFn(expression, constructor, true);
       }
 

--- a/test/ng/controllerSpec.js
+++ b/test/ng/controllerSpec.js
@@ -161,11 +161,11 @@ describe('$controller', function() {
     }).toThrow();
   }));
 
-  it('should throw ctrlreg when the controller name does not match a registered controller', inject(function($compile, $rootScope) {
+  it('should throw ctrlreg when the controller name does not match a registered controller', function() {
     expect(function() {
       $controller('IDoNotExist', {$scope: {}});
     }).toThrowMinErr('$controller', 'ctrlreg', 'The controller with the name \'IDoNotExist\' is not registered.');
-  }));
+  });
 
 
   describe('ctrl as syntax', function() {

--- a/test/ng/controllerSpec.js
+++ b/test/ng/controllerSpec.js
@@ -161,6 +161,12 @@ describe('$controller', function() {
     }).toThrow();
   }));
 
+  it('should throw ctrlreg when the controller name does not match a registered controller', inject(function($compile, $rootScope) {
+    expect(function() {
+      $controller('IDoNotExist', {$scope: {}});
+    }).toThrowMinErr('$controller', 'ctrlreg', 'The controller with the name \'IDoNotExist\' is not registered.');
+  }));
+
 
   describe('ctrl as syntax', function() {
 
@@ -226,7 +232,6 @@ describe('$controller', function() {
                        'Badly formed controller string \'ctrl as\'. ' +
                        'Must match `__name__ as __id__` or `__name__`.');
     });
-
 
     it('should allow identifiers containing `$`', function() {
       var scope = {};

--- a/test/ng/directive/ngControllerSpec.js
+++ b/test/ng/directive/ngControllerSpec.js
@@ -150,4 +150,13 @@ describe('ngController', function() {
     $httpBackend.flush();
     expect(controllerScope.name).toBeUndefined();
   }));
+
+  it('should throw ctrlreg when the controller name does not match a registered controller', inject(function($compile, $rootScope) {
+    element = jqLite('<div ng-controller="IDoNotExist"></div>');
+
+   expect(function() {
+      element = $compile(element)($rootScope);
+    }).toThrowMinErr('$controller', 'ctrlreg', 'The controller with the name \'IDoNotExist\' is not registered.');
+  }));
+
 });

--- a/test/ng/directive/ngControllerSpec.js
+++ b/test/ng/directive/ngControllerSpec.js
@@ -151,12 +151,4 @@ describe('ngController', function() {
     expect(controllerScope.name).toBeUndefined();
   }));
 
-  it('should throw ctrlreg when the controller name does not match a registered controller', inject(function($compile, $rootScope) {
-    element = jqLite('<div ng-controller="IDoNotExist"></div>');
-
-   expect(function() {
-      element = $compile(element)($rootScope);
-    }).toThrowMinErr('$controller', 'ctrlreg', 'The controller with the name \'IDoNotExist\' is not registered.');
-  }));
-
 });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs

**What is the current behavior? (You can also link to an open issue here)**
when a requested controller is not found (not registered), then a pretty non-descriptive ng:areq error is thrown

**What is the new behavior (if this is a feature change)?**
a new error is thrown

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

…tered

Previously, it would throw the ng:areq error, which is less
specific and just informs that the requested controller did
not yield a function. Given how commonly controllers are used
in Angular, it makes sense to have a specific error.

The ng:areq error is still thrown when the registered controller
is not a function.

Closes #14980
