### PR TITLE
chore(build): fix version placeholder matching

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -122,12 +122,12 @@ module.exports = {
 
   process: function(src, NG_VERSION, strict) {
     var processed = src
-      .replace(/"NG_VERSION_FULL"/g, NG_VERSION.full)
-      .replace(/"NG_VERSION_MAJOR"/, NG_VERSION.major)
-      .replace(/"NG_VERSION_MINOR"/, NG_VERSION.minor)
-      .replace(/"NG_VERSION_DOT"/, NG_VERSION.patch)
-      .replace(/"NG_VERSION_CDN"/, NG_VERSION.cdn)
-      .replace(/"NG_VERSION_CODENAME"/, NG_VERSION.codeName);
+      .replace(/(['"])NG_VERSION_FULL\1/g, NG_VERSION.full)
+      .replace(/(['"])NG_VERSION_MAJOR\1/, NG_VERSION.major)
+      .replace(/(['"])NG_VERSION_MINOR\1/, NG_VERSION.minor)
+      .replace(/(['"])NG_VERSION_DOT\1/, NG_VERSION.patch)
+      .replace(/(['"])NG_VERSION_CDN\1/, NG_VERSION.cdn)
+      .replace(/(['"])NG_VERSION_CODENAME\1/, NG_VERSION.codeName);
     if (strict !== false) processed = this.singleStrict(processed, '\n\n', true);
     return processed;
   },

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -115,14 +115,12 @@
  */
 var version = {
   // These placeholder strings will be replaced by grunt's `build` task.
-  // They need to be surrounded by double-quotes.
-  /* eslint-disable quotes */
+  // They need to be double- or single-quoted.
   full: '"NG_VERSION_FULL"',
-  major: "NG_VERSION_MAJOR",
-  minor: "NG_VERSION_MINOR",
-  dot: "NG_VERSION_DOT",
+  major: 'NG_VERSION_MAJOR',
+  minor: 'NG_VERSION_MINOR',
+  dot: 'NG_VERSION_DOT',
   codeName: '"NG_VERSION_CODENAME"'
-  /* eslint-enable quotes */
 };
 
 

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -114,11 +114,15 @@
  * - `codeName` – `{string}` – Code name of the release, such as "jiggling-armfat".
  */
 var version = {
-  full: '"NG_VERSION_FULL"',    // all of these placeholder strings will be replaced by grunt's
-  major: 'NG_VERSION_MAJOR',    // package task
-  minor: 'NG_VERSION_MINOR',
-  dot: 'NG_VERSION_DOT',
+  // These placeholder strings will be replaced by grunt's `build` task.
+  // They need to be surrounded by double-quotes.
+  /* eslint-disable quotes */
+  full: '"NG_VERSION_FULL"',
+  major: "NG_VERSION_MAJOR",
+  minor: "NG_VERSION_MINOR",
+  dot: "NG_VERSION_DOT",
   codeName: '"NG_VERSION_CODENAME"'
+  /* eslint-enable quotes */
 };
 
 

--- a/test/e2e/fixtures/version/index.html
+++ b/test/e2e/fixtures/version/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html ng-app>
+  <body>
+    <script src="angular.js"></script>
+  </body>
+</html>

--- a/test/e2e/tests/version.spec.js
+++ b/test/e2e/tests/version.spec.js
@@ -1,0 +1,51 @@
+'use strict';
+
+describe('angular.version', function() {
+  var version;
+
+  beforeEach(function() {
+    loadFixture('version');
+    version = browser.driver.executeScript('return angular.version');
+  });
+
+
+  it('should expose the current version as object', function() {
+    expect(version).toEqual(jasmine.any(Object));
+  });
+
+  it('should contain property `full` (string)', function() {
+    expect(version.then(get('full'))).toEqual(jasmine.any(String));
+  });
+
+  it('should contain property `major` (number)', function() {
+    expect(version.then(get('major'))).toEqual(jasmine.any(Number));
+  });
+
+  it('should contain property `minor` (number)', function() {
+    expect(version.then(get('minor'))).toEqual(jasmine.any(Number));
+  });
+
+  it('should contain property `dot` (number)', function() {
+    expect(version.then(get('dot'))).toEqual(jasmine.any(Number));
+  });
+
+  it('should contain property `codeName` (string)', function() {
+    expect(version.then(get('codeName'))).toEqual(jasmine.any(String));
+  });
+
+  it('should have `full` === `"major.minor.dot"`', function() {
+    expect(version.then(validate)).toBe(true);
+
+    function validate(ver) {
+      return ver.full.indexOf([ver.major, ver.minor, ver.dot].join('.')) === 0;
+    }
+  });
+
+
+  // Helpers
+  function get(prop) {
+    return function getter(obj) {
+      return obj[prop];
+    };
+  }
+});

--- a/test/e2e/tests/version.spec.js
+++ b/test/e2e/tests/version.spec.js
@@ -33,6 +33,10 @@ describe('angular.version', function() {
     expect(version.then(get('codeName'))).toEqual(jasmine.any(String));
   });
 
+  it('should not contain "NG_VERSION_" in `codeName`', function() {
+    expect(version.then(get('codeName'))).not.toMatch(/NG_VERSION_/);
+  });
+
   it('should have `full` === `"major.minor.dot"`', function() {
     expect(version.then(validate)).toBe(true);
 

--- a/test/e2e/tests/version.spec.js
+++ b/test/e2e/tests/version.spec.js
@@ -37,10 +37,12 @@ describe('angular.version', function() {
     expect(version.then(get('codeName'))).not.toMatch(/NG_VERSION_/);
   });
 
-  it('should have `full` === `"major.minor.dot"`', function() {
+  it('\'s `full` property should start with `"major.minor.dot"`', function() {
     expect(version.then(validate)).toBe(true);
 
     function validate(ver) {
+      // We test for "starts with", because `full` is not always equal to `"major.minor.dot"`.
+      // Possible formats: `1.5.8`, `1.5.0-rc.2`, `1.5.9-build.4949`, `1.5.9-local+sha.859348c`
       return ver.full.indexOf([ver.major, ver.minor, ver.dot].join('.')) === 0;
     }
   });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.

**What is the current behavior? (You can also link to an open issue here)**

``` js
angular.version === {
  ...
  major: 'NG_VERSION_MAJOR',
  minor: 'NG_VERSION_MINOR',
  dot: 'NG_VERSION_DOT',
  ...
}
```

**What is the new behavior (if this is a feature change)?**

``` js
angular.version === {
  ...
  major: 1,
  minor: 5,
  dot: 9,
  ...
}
```

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
During the `build` task, the version placeholders will be replaced with the actual values using a
RegExp, which expects the placeholders to be surrounded by double quotes. By replacing the quotes
from double to single in #15011, the RegExp was not able to match the placeholders.

Btw, this has broken `ngMaterial` (since they polyfill `$animateCss` based on the value of `angular.version.minor`).
