### PR TITLE
fix($sniffer): don't use history.pushState for sandboxed Chrome apps

### DIFF
--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -21,8 +21,13 @@ function $SnifferProvider() {
   this.$get = ['$window', '$document', function($window, $document) {
     var eventSupport = {},
         // Chrome Packaged Apps are not allowed to access `history.pushState`. They can be detected by
-        // the presence of `chrome.app.runtime` (see https://developer.chrome.com/apps/api_index)
-        isChromePackagedApp = $window.chrome && $window.chrome.app && $window.chrome.app.runtime,
+        // the presence of `chrome.app.runtime` (see https://developer.chrome.com/apps/api_index).
+        // For sandboxed apps, check for an extension runtime ID, but no access to other Chrome
+        // runtime APIs. See https://developer.chrome.com/apps/manifest/sandbox
+        isChromePackagedApp =
+            $window.chrome &&
+            ($window.chrome.app && $window.chrome.app.runtime ||
+                !$window.chrome.app && $window.chrome.runtime && $window.chrome.runtime.id),
         hasHistoryPushState = !isChromePackagedApp && $window.history && $window.history.pushState,
         android =
           toInt((/android (\d+)/.exec(lowercase(($window.navigator || {}).userAgent)) || [])[1]),

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -90,6 +90,26 @@ describe('$sniffer', function() {
 
       expect(pushStateAccessCount).toBe(0);
     });
+
+    it('should not try to access `history.pushState` in sandbox Chrome Packaged Apps', function() {
+      var pushStateAccessCount = 0;
+
+      var mockHistory = Object.create(Object.prototype, {
+        pushState: {get: function() { pushStateAccessCount++; return noop; }}
+      });
+      var mockWindow = {
+        chrome: {
+          runtime: {
+            id: 'x'
+          }
+        },
+        history: mockHistory
+      };
+
+      sniffer(mockWindow);
+
+      expect(pushStateAccessCount).toBe(0);
+    });
   });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

When using Angular in a [sandboxed Chrome app](https://developer.chrome.com/apps/manifest/sandbox), errors occur when attempting to call `history.pushState()`, which is not available.

**What is the new behavior (if this is a feature change)?**

Similar to #11932 and building on the code in #13945, check if inside a sandboxed app, and substitute `history.pushState()` with a no-op.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Check in $sniffer if operating in a sandboxed Chrome app, which does not
have access to chrome.app.runtime like other apps, but also does not
have access to history.pushState. If inside a sandboxed Chrome app, do
not try and use history.pushState, else an error will occur. See #11932
and #13945 for previous work.
