### PR TITLE
fix($compile): correctly merge consecutive text nodes on IE11

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1845,33 +1845,15 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           // `nodeList` can be either an element's `.childNodes` (live NodeList)
           // or a jqLite/jQuery collection or an array
           notLiveList = isArray(nodeList) || (nodeList instanceof jqLite),
-          attrs, directives, node, nodeLinkFn, childNodes, childLinkFn, linkFnFound, nodeLinkFnFound;
+          attrs, directives, nodeLinkFn, childNodes, childLinkFn, linkFnFound, nodeLinkFnFound;
 
 
       for (var i = 0; i < nodeList.length; i++) {
         attrs = new Attributes();
-        node = nodeList[i];
 
         // Workaround for #11781 and #14924
-        if ((msie === 11) && (node.nodeType === NODE_TYPE_TEXT)) {
-          var parent = node.parentNode;
-          var sibling;
-
-          while (true) {
-            sibling = parent ? node.nextSibling : nodeList[i + 1];
-            if (!sibling || sibling.nodeType !== NODE_TYPE_TEXT) {
-              break;
-            }
-
-            node.nodeValue = node.nodeValue + sibling.nodeValue;
-
-            if (sibling.parentNode) {
-              sibling.parentNode.removeChild(sibling);
-            }
-            if (notLiveList && sibling === nodeList[i + 1]) {
-              nodeList.splice(i + 1, 1);
-            }
-          }
+        if (msie === 11) {
+          mergeConsecutiveTextNodes(nodeList, i, notLiveList);
         }
 
         // We must always refer to `nodeList[i]` hereafter,
@@ -1962,6 +1944,32 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           } else if (childLinkFn) {
             childLinkFn(scope, node.childNodes, undefined, parentBoundTranscludeFn);
           }
+        }
+      }
+    }
+
+    function mergeConsecutiveTextNodes(nodeList, idx, notLiveList) {
+      var node = nodeList[idx];
+      var parent = node.parentNode;
+      var sibling;
+
+      if (node.nodeType !== NODE_TYPE_TEXT) {
+        return;
+      }
+
+      while (true) {
+        sibling = parent ? node.nextSibling : nodeList[idx + 1];
+        if (!sibling || sibling.nodeType !== NODE_TYPE_TEXT) {
+          break;
+        }
+
+        node.nodeValue = node.nodeValue + sibling.nodeValue;
+
+        if (sibling.parentNode) {
+          sibling.parentNode.removeChild(sibling);
+        }
+        if (notLiveList && sibling === nodeList[idx + 1]) {
+          nodeList.splice(idx + 1, 1);
         }
       }
     }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -3260,6 +3260,26 @@ describe('$compile', function() {
     }));
 
 
+    it('should not process text nodes merged into their sibling', inject(function($compile, $rootScope) {
+      var div = document.createElement('div');
+      div.appendChild(document.createTextNode('1{{ value }}'));
+      div.appendChild(document.createTextNode('2{{ value }}'));
+      div.appendChild(document.createTextNode('3{{ value }}'));
+
+      element = jqLite(div.childNodes);
+
+      var initialWatcherCount = $rootScope.$countWatchers();
+      $compile(element)($rootScope);
+      $rootScope.$apply('value = 0');
+      var newWatcherCount = $rootScope.$countWatchers() - initialWatcherCount;
+
+      expect(element.text()).toBe('102030');
+      expect(newWatcherCount).toBe(3);
+
+      dealoc(div);
+    }));
+
+
     it('should support custom start/end interpolation symbols in template and directive template',
         function() {
       module(function($interpolateProvider, $compileProvider) {
@@ -8530,8 +8550,36 @@ describe('$compile', function() {
           element = $compile('<div transclude><div child></div></div>')($rootScope);
           expect(capturedChildCtrl).toBeTruthy();
         });
-
       });
+
+
+      // See issue https://github.com/angular/angular.js/issues/14924
+      it('should not process top-level transcluded text nodes merged into their sibling',
+        function() {
+          module(function() {
+            directive('transclude', valueFn({
+              template: '<ng-transclude></ng-transclude>',
+              transclude: true,
+              scope: {}
+            }));
+          });
+
+          inject(function($compile) {
+            element = jqLite('<div transclude></div>');
+            element[0].appendChild(document.createTextNode('1{{ value }}'));
+            element[0].appendChild(document.createTextNode('2{{ value }}'));
+            element[0].appendChild(document.createTextNode('3{{ value }}'));
+
+            var initialWatcherCount = $rootScope.$countWatchers();
+            $compile(element)($rootScope);
+            $rootScope.$apply('value = 0');
+            var newWatcherCount = $rootScope.$countWatchers() - initialWatcherCount;
+
+            expect(element.text()).toBe('102030');
+            expect(newWatcherCount).toBe(3);
+          });
+        }
+      );
 
 
       // see issue https://github.com/angular/angular.js/issues/9413
@@ -9996,6 +10044,39 @@ describe('$compile', function() {
         expect(element.children().eq(2).text()).toEqual('dorothy');
       });
     });
+
+
+    // See issue https://github.com/angular/angular.js/issues/14924
+    it('should not process top-level transcluded text nodes merged into their sibling',
+      function() {
+        module(function() {
+          directive('transclude', valueFn({
+            template: '<ng-transclude></ng-transclude>',
+            transclude: {},
+            scope: {}
+          }));
+        });
+
+        inject(function($compile) {
+          element = jqLite('<div transclude></div>');
+          element[0].appendChild(document.createTextNode('1{{ value }}'));
+          element[0].appendChild(document.createTextNode('2{{ value }}'));
+          element[0].appendChild(document.createTextNode('3{{ value }}'));
+
+          var initialWatcherCount = $rootScope.$countWatchers();
+          $compile(element)($rootScope);
+          $rootScope.$apply('value = 0');
+          var newWatcherCount = $rootScope.$countWatchers() - initialWatcherCount;
+
+          expect(element.text()).toBe('102030');
+          expect(newWatcherCount).toBe(3);
+
+          if (msie === 11) {
+            expect(element.find('ng-transclude').contents().length).toBe(1);
+          }
+        });
+      }
+    );
   });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix. (Actually, IE11 bug work-around.)

**What is the current behavior? (You can also link to an open issue here)**
Under certain circumstances, IE11 will break up text nodes, thus breaking interpolation. In some cases Angular fails to fix this (by merging consecutive text nodes) or compiles the merged nodes twice.
See also #14924.

**What is the new behavior (if this is a feature change)?**
Angular does a better job merging consecutive text nodes and doesn't compile merged nodes twice.

**Does this PR introduce a breaking change?**
Yes.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
As explained in #11781 and #14924, IE11 can (under certain circumstances) break up a text node into multiple consecutive ones, breaking interpolated expressions (e.g. `{{'foo'}}` would become `{{` + `'foo'}}`). To work-around this IE11 bug, #11796 introduced extra logic to merge consecutive text nodes (on IE11 only), which relies on the text nodes' having the same `parentNode`.

This approach works fine in the common case, where `compileNodes` is called with a live NodeList object, because removing a text node from its parent will automatically update the latter's `.childNodes` NodeList. It falls short though, when calling `compileNodes` with either a jqLite/jQuery collection or an Array. In fails in two ways:
1. If the text nodes do not have a parent at the moment of compiling, there will be no merging.
   (This happens for example on directives with `transclude: {...}`.)
2. If the text nodes do have a parent, just removing a text node from its parent does **not** remove it from the collection/array, which means that the merged text nodes will still get compiled and linked (and possibly be displayed in the view). E.g. `['{{text1}}', '{{text2}}', '{{text3}}']` will become `['{{text1}}{{text2}}{{text3}}', '{{text2}}', '{{text3}}']`.
## 

This commit works around the above problems by:
1. Merging consecutive text nodes in the provided list, even if they have no parent.
2. When merging a text node, explicitly remove it from the list (unless it is a live, auto-updating list).

This can nonetheless have undesirable (albeit rare) side effects by overzealously merging text nodes that are not meant to be merged (see the "BREAKING CHANGE" section below).

Fixes #14924

BREAKING CHANGE:

**Note:** Everything described below affects **IE11 only**.

Previously, consecutive text nodes would not get merged if they had no parent. They will now, which might have unexpectd side effects in the following cases:
1. Passing an array or jqLite/jQuery collection of parent-less text nodes to `$compile` directly:
   
   ``` js
   // Assuming:
   var textNodes = [
     document.createTextNode('{{'),
     document.createTextNode('"foo"'),
     document.createTextNode('}}')
   ];
   var compiledNodes = $compile(textNodes)($rootScope);
   
   // Before:
   console.log(compiledNodes.length);   // 3
   console.log(compiledNodes.text());   // {{'foo'}}
   
   // After:
   console.log(compiledNodes.length);   // 1
   console.log(compiledNodes.text());   // foo
   
   // To get the old behavior, compile each node separately:
   var textNodes = [
     document.createTextNode('{{'),
     document.createTextNode('"foo"'),
     document.createTextNode('}}')
   ];
   var compiledNodes = angular.element(textNodes.map(function (node) {
     return $compile(node)($rootScope)[0];
   }));
   ```
2. Using multi-slot transclusion with non-consecutive, default-content text nodes (that form interpolated expressions when merged):
   
   ``` js
   // Assuming the following component:
   .compoent('someThing', {
    template: '<ng-transclude><!-- Default content goes here --></ng-transclude>'
    transclude: {
      ignored: 'veryImportantContent'
    }
   })
   ```
   
   ``` html
   <!-- And assuming the following view: -->
   <some-thing>
    {{
    <very-important-content>Nooot</very-important-content>
    'foo'}}
   </some-thing>
   
   <!-- Before: -->
   <some-thing>
    <ng-transclude>
      {{       <-- Two separate
      'foo'}}  <-- text nodes
    </ng-transclude>
   </some-thing>
   
   <!-- After: -->
   <some-thing>
    <ng-transclude>
      foo  <-- The text nodes were merged into `{{'foo'}}`, which was then interpolated
    </ng-transclude>
   </some-thing>
   
   <!-- To (visually) get the old behavior, wrap top-level text nodes on -->
   <!-- multi-slot transclusion directives into `<span>` elements; e.g.: -->
   <some-thing>
    <span>{{</span>
    <very-important-content>Nooot</very-important-content>
    <span>'foo'}}</span>
   </some-thing>
   
   <!-- Result: -->
   <some-thing>
    <ng-transclude>
      <span>{{</span>       <-- Two separate
      <span>'foo'}}</span>  <-- nodes
    </ng-transclude>
   </some-thing>
   ```
