### PR TITLE
ng-annotate to avoid to break app

### DIFF
--- a/docs/content/guide/di.ngdoc
+++ b/docs/content/guide/di.ngdoc
@@ -152,6 +152,9 @@ the parameters in the function declaration.
 <div class="alert alert-danger">
 **Careful:** If you plan to [minify](http://en.wikipedia.org/wiki/Minification_(programming&#41;)
 your code, your service names will get renamed and break your app.
+
+You will need to use a library such like [ng-annotate](https://github.com/olov/ng-annotate)
+to add on the fly dependencies names before minification.
 </div>
 
 The simplest way to get hold of the dependencies is to assume that the function parameter names


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Doc improve

**What is the current behavior? (You can also link to an open issue here)**

Following documentation, I can't use dependencies annotation without to break
my app when I minify it.

**What is the new behavior (if this is a feature change)?**

Doc says that I can use ng-minify, so I can plainly use dependencies annotation
and minify my javascript.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

Notice that we can use ng-annotate before minification to avoid to break app.
