### PR TITLE
feat($q): Add notify functionality to ES6-style constructor

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -679,7 +679,7 @@ function qFactory(nextTick, exceptionHandler, errorOnUnhandledRejections) {
     function rejectFn(reason) {
       deferred.reject(reason);
     }
-    
+
     function notifyFn(value) {
       deferred.notify(value);
     }

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -32,7 +32,8 @@
  *
  *   function asyncGreet(name) {
  *     // perform some asynchronous operation, resolve or reject the promise when appropriate.
- *     return $q(function(resolve, reject) {
+ *     return $q(function(resolve, reject, notify) {
+ *       notify('Determining whether it\'s ok to greet.');
  *       setTimeout(function() {
  *         if (okToGreet(name)) {
  *           resolve('Hello, ' + name + '!');
@@ -48,10 +49,10 @@
  *     alert('Success: ' + greeting);
  *   }, function(reason) {
  *     alert('Failed: ' + reason);
+ *   }, function(progress) {
+ *     alert('Notification: ' + progress);
  *   });
  * ```
- *
- * Note: progress/notify callbacks are not currently supported via the ES6-style interface.
  *
  * Note: unlike ES6 behavior, an exception thrown in the constructor function will NOT implicitly reject the promise.
  *
@@ -89,8 +90,8 @@
  *     alert('Success: ' + greeting);
  *   }, function(reason) {
  *     alert('Failed: ' + reason);
- *   }, function(update) {
- *     alert('Got notification: ' + update);
+ *   }, function(value) {
+ *     alert('Got notification: ' + value);
  *   });
  * ```
  *
@@ -678,8 +679,12 @@ function qFactory(nextTick, exceptionHandler, errorOnUnhandledRejections) {
     function rejectFn(reason) {
       deferred.reject(reason);
     }
+    
+    function notifyFn(value) {
+      deferred.notify(value);
+    }
 
-    resolver(resolveFn, rejectFn);
+    resolver(resolveFn, rejectFn, notifyFn);
 
     return deferred.promise;
   };

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -467,7 +467,7 @@ describe('q', function() {
 
         log = [];
         notify('bar');
-        expect(mockTickNext.queue.length).toBe(0);
+        expect(mockNextTick.queue.length).toBe(0);
         expect(logStr()).toBe('');
 
         promise.then(success(2), error(), progress(2));
@@ -483,10 +483,10 @@ describe('q', function() {
         reject('foo');
         mockNextTick.flush();
         expect(logStr()).toBe('error1(foo)->reject(foo)');
-        
+
         log = [];
         notify('bar');
-        expect(mockTickNext.queue.length).toBe(0);
+        expect(mockNextTick.queue.length).toBe(0);
         expect(logStr()).toBe('');
 
         promise.then(success(), error(2), progress(2));

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -209,15 +209,17 @@ describe('q', function() {
 
 
   describe('$Q', function() {
-    var resolve, reject, resolve2, reject2;
+    var resolve, reject, notify, resolve2, reject2, notify2;
     var createPromise = function() {
-      return q(function(resolveFn, rejectFn) {
+      return q(function(resolveFn, rejectFn, notifyFn) {
         if (resolve === null) {
           resolve = resolveFn;
           reject = rejectFn;
+          notify = notifyFn;
         } else if (resolve2 === null) {
           resolve2 = resolveFn;
           reject2 = rejectFn;
+          notify2 = notifyFn;
         }
       });
     };
@@ -442,6 +444,86 @@ describe('q', function() {
       });
     });
 
+    describe('notify', function() {
+      it('should notify the promise and execute all progress callbacks in the registration order', function() {
+        var promise = createPromise();
+        promise.then(success(), error(), progress(1));
+        promise.then(success(), error(), progress(2));
+        expect(logStr()).toBe('');
+
+        notify('foo');
+        mockNextTick.flush();
+        expect(logStr()).toBe('progress1(foo)->foo; progress2(foo)->foo');
+      });
+
+      it('should do nothing if the promise was previously resolved', function() {
+        var promise = createPromise();
+        promise.then(success(1), error(), progress(1));
+        expect(logStr()).toBe('');
+
+        resolve('foo');
+        mockNextTick.flush();
+        expect(logStr()).toBe('success1(foo)->foo');
+
+        log = [];
+        notify('bar');
+        expect(mockTickNext.queue.length).toBe(0);
+        expect(logStr()).toBe('');
+
+        promise.then(success(2), error(), progress(2));
+        mockNextTick.flush();
+        expect(logStr()).toBe('success2(foo)->foo');
+      });
+
+      it('should do nothing if the promise was previously rejected', function() {
+        var promise = createPromise();
+        promise.then(success(), error(1), progress(1));
+        expect(logStr()).toBe('');
+
+        reject('foo');
+        mockNextTick.flush();
+        expect(logStr()).toBe('error1(foo)->reject(foo)');
+        
+        log = [];
+        notify('bar');
+        expect(mockTickNext.queue.length).toBe(0);
+        expect(logStr()).toBe('');
+
+        promise.then(success(), error(2), progress(2));
+        mockNextTick.flush();
+        expect(logStr()).toBe('error2(foo)->reject(foo)');
+      });
+
+      it('should not resolve the promise', function() {
+        var promise = createPromise();
+        promise.then(success(), error(), progress());
+        expect(logStr()).toBe('');
+
+        notify('50%');
+        mockNextTick.flush();
+        expect(logStr()).toBe('progress(50%)->50%');
+        log = [];
+
+        resolve('done');
+        mockNextTick.flush();
+        expect(logStr()).toBe('success(done)->done');
+      });
+
+      it('should not reject the promise', function() {
+        var promise = createPromise();
+        promise.then(success(), error(), progress());
+        expect(logStr()).toBe('');
+
+        notify('50%');
+        mockNextTick.flush();
+        expect(logStr()).toBe('progress(50%)->50%');
+        log = [];
+
+        reject('foo');
+        mockNextTick.flush();
+        expect(logStr()).toBe('error(foo)->reject(foo)');
+      });
+    });
 
     describe('promise', function() {
       describe('then', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature

**What is the current behavior? (You can also link to an open issue here)**
The ES6-style constructor $q() doesn't support the notify() function.

**What is the new behavior (if this is a feature change)?**
The resolver function passed to the ES6-style constructor $q() now takes three parameters: resolve, reject and notify.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

The resolver function passed to $q() may now take a third argument: notify, which wraps the deferred.notify() function.
