### PR TITLE
feat($compile):make the required controllers available during the instantiation of the controller

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -376,11 +376,6 @@ between each other. This can be achieved in a component by providing an
 object mapping for the `require` property. The object keys specify the property names under which
 the required controllers (object values) will be bound to the requiring component's controller.
 
-<div class="alert alert-warning">
-Note that the required controllers will not be available during the instantiation of the controller,
-but they are guaranteed to be available just before the `$onInit` method is executed!
-</div>
-
 Here is a tab pane example built from components:
 
 <example module="docsTabsExample" name="component-tabs-pane">

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -6818,7 +6818,11 @@ describe('$compile', function() {
 
       function ParentController() { this.name = 'Parent'; }
       function SiblingController() { this.name = 'Sibling'; }
-      function MeController() { this.name = 'Me'; }
+      function MeController() {
+        this.name = 'Me';
+        expect(this.container).toEqual(jasmine.any(ParentController));
+        expect(this.friend).toEqual(jasmine.any(SiblingController));
+      }
       MeController.prototype.$onInit = function() {
         parentController = this.container;
         siblingController = this.friend;
@@ -6947,7 +6951,11 @@ describe('$compile', function() {
 
       function ParentController() { this.name = 'Parent'; }
       function SiblingController() { this.name = 'Sibling'; }
-      function MeController() { this.name = 'Me'; }
+      function MeController() {
+        this.name = 'Me';
+        expect(this.container).toBeUndefined();
+        expect(this.friend).toBeUndefined();
+      }
       MeController.prototype.$onInit = function() {
         parentController = this.container;
         siblingController = this.friend;
@@ -6998,6 +7006,8 @@ describe('$compile', function() {
             siblingController = this.friend;
           }
         };
+        expect(this.container).toEqual(jasmine.any(ParentController));
+        expect(this.friend).toEqual(jasmine.any(SiblingController));
         spyOn(meController, '$onInit').and.callThrough();
         return meController;
       }
@@ -7045,6 +7055,8 @@ describe('$compile', function() {
           containerController = this.container;
           friendController = this.friend;
         };
+        expect(this.container).toEqual(new ParentController());
+        expect(this.friend).toEqual(new SiblingController());
       }
       function ParentController() {
         parentController = { name: 'Parent' };
@@ -7078,11 +7090,16 @@ describe('$compile', function() {
           return {
             controller: SiblingController
           };
+        })
+        .directive('aSibling', function() {
+          return {
+            controller: SiblingController
+          };
         });
 
       module('my');
       inject(function($compile, $rootScope, meDirective) {
-        element = $compile('<parent><me sibling></me></parent>')($rootScope);
+        element = $compile('<parent><me a-sibling sibling></me></parent>')($rootScope);
         expect(containerController).toEqual(parentController);
         expect(friendController).toEqual(siblingController);
       });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature

**What is the current behavior? (You can also link to an open issue here)**
the required controllers will not be available during the instantiation of the controller when `bindToContrller` is truthy, but they are guaranteed to be available just before the $onInit method is executed

**What is the new behavior (if this is a feature change)?**
the required controllers is available during the instantiation of the controller now when `bindToContrller` is truthy

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/angular/angular.js/15055)

<!-- Reviewable:end -->
