### PR TITLE
feat($compile): throw error when directive name or factory fn is invalid

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1087,6 +1087,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    * @returns {ng.$compileProvider} Self for chaining.
    */
   this.directive = function registerDirective(name, directiveFactory) {
+    assertArg(name, 'name');
     assertNotHasOwnProperty(name, 'directive');
     if (isString(name)) {
       assertValidDirectiveName(name);

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -214,6 +214,7 @@ describe('$compile', function() {
       });
       inject(function($compile) {});
     });
+
     it('should throw an exception if a directive name has leading or trailing whitespace', function() {
       module(function() {
         function assertLeadingOrTrailingWhitespaceInDirectiveName(name) {
@@ -226,6 +227,24 @@ describe('$compile', function() {
         assertLeadingOrTrailingWhitespaceInDirectiveName(' leadingWhitespaceDirectiveName');
         assertLeadingOrTrailingWhitespaceInDirectiveName('trailingWhitespaceDirectiveName ');
         assertLeadingOrTrailingWhitespaceInDirectiveName(' leadingAndTrailingWhitespaceDirectiveName ');
+      });
+      inject(function($compile) {});
+    });
+
+    it('should throw an exception if the directive name is not defined', function() {
+      module(function() {
+        expect(function() {
+          directive();
+        }).toThrowMinErr('ng','areq');
+      });
+      inject(function($compile) {});
+    });
+
+    it('should throw an exception if the directive factory is not defined', function() {
+      module(function() {
+        expect(function() {
+          directive('myDir');
+        }).toThrowMinErr('ng','areq');
       });
       inject(function($compile) {});
     });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feat

**What is the current behavior? (You can also link to an open issue here)**
when the directive name or factory fn is undefined, no error is thrown

**What is the new behavior (if this is a feature change)?**
better errors are thrown

**Does this PR introduce a breaking change?**
No. Although I'm not sure if isFunction will catch all exotic ways to define a function.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)

**Other information**:

Closes: #15056
