### PR TITLE
fix(currencyFilter): trim currency string

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -69,10 +69,11 @@ function currencyFilter($locale) {
     }
 
     // if null or undefined pass it through
-    return (amount == null)
+    var currencyString = (amount == null)
         ? amount
         : formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP, fractionSize).
             replace(/\u00A4/g, currencySymbol);
+	return currencyString.trim();
   };
 }
 

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -27,12 +27,6 @@ var ZERO_CHAR = '0';
            .controller('ExampleController', ['$scope', function($scope) {
              $scope.amount = 1234.56;
            }]);
-		 angular.module('otherLocaleExample', []) {
-			 .controller('otherLocaleController', ['$scope', function($scope) {
-				 $locale.NUMBERFORMATS.PATTERNS[1].posPre = ' ';
-				 $scope.amount = 1234.56;
-			 }]);
-		 }
        </script>
        <div ng-controller="ExampleController">
          <input type="number" ng-model="amount" aria-label="amount"> <br>
@@ -40,17 +34,12 @@ var ZERO_CHAR = '0';
          custom currency identifier (USD$): <span id="currency-custom">{{amount | currency:"USD$"}}</span>
          no fractions (0): <span id="currency-no-fractions">{{amount | currency:"USD$":0}}</span>
        </div>
-	   <div ng-controller="otherLocaleController">
-		 <input type="number" ng-model="amount" aria-label="amount"> <br>
-		 no currency symbol: <span id="currency-no-symbol-other-locale">{{amount | currency:''}}</span>
-	   </div>
      </file>
      <file name="protractor.js" type="protractor">
        it('should init with 1234.56', function() {
          expect(element(by.id('currency-default')).getText()).toBe('$1,234.56');
          expect(element(by.id('currency-custom')).getText()).toBe('USD$1,234.56');
          expect(element(by.id('currency-no-fractions')).getText()).toBe('USD$1,235');
-		 expect(element(by.id('currency-no-symbol-other-locale')).getText()).toBe('1,234.56');
        });
        it('should update', function() {
          if (browser.params.browser === 'safari') {
@@ -63,7 +52,6 @@ var ZERO_CHAR = '0';
          expect(element(by.id('currency-default')).getText()).toBe('-$1,234.00');
          expect(element(by.id('currency-custom')).getText()).toBe('-USD$1,234.00');
          expect(element(by.id('currency-no-fractions')).getText()).toBe('-USD$1,234');
-		 expect(element(by.id('currency-no-symbol-other-locale')).getText()).toBe('-1,234');
        });
      </file>
    </example>

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -69,11 +69,10 @@ function currencyFilter($locale) {
     }
 
     // if null or undefined pass it through
-    var currencyString = (amount == null)
+    return currencyString = (amount == null)
         ? amount
         : formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP, fractionSize).
-            replace(/\u00A4/g, currencySymbol);
-	return currencyString.trim();
+            replace(/\u00A4/g, currencySymbol).trim();
   };
 }
 

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -27,6 +27,12 @@ var ZERO_CHAR = '0';
            .controller('ExampleController', ['$scope', function($scope) {
              $scope.amount = 1234.56;
            }]);
+		 angular.module('otherLocaleExample', []) {
+			 .controller('otherLocaleController', ['$scope', function($scope) {
+				 $locale.NUMBERFORMATS.PATTERNS[1].posPre = ' ';
+				 $scope.amount = 1234.56;
+			 }]);
+		 }
        </script>
        <div ng-controller="ExampleController">
          <input type="number" ng-model="amount" aria-label="amount"> <br>
@@ -34,12 +40,17 @@ var ZERO_CHAR = '0';
          custom currency identifier (USD$): <span id="currency-custom">{{amount | currency:"USD$"}}</span>
          no fractions (0): <span id="currency-no-fractions">{{amount | currency:"USD$":0}}</span>
        </div>
+	   <div ng-controller="otherLocaleController">
+		 <input type="number" ng-model="amount" aria-label="amount"> <br>
+		 no currency symbol: <span id="currency-no-symbol-other-locale">{{amount | currency:''}}</span>
+	   </div>
      </file>
      <file name="protractor.js" type="protractor">
        it('should init with 1234.56', function() {
          expect(element(by.id('currency-default')).getText()).toBe('$1,234.56');
          expect(element(by.id('currency-custom')).getText()).toBe('USD$1,234.56');
          expect(element(by.id('currency-no-fractions')).getText()).toBe('USD$1,235');
+		 expect(element(by.id('currency-no-symbol-other-locale')).getText()).toBe('1,234.56');
        });
        it('should update', function() {
          if (browser.params.browser === 'safari') {
@@ -52,6 +63,7 @@ var ZERO_CHAR = '0';
          expect(element(by.id('currency-default')).getText()).toBe('-$1,234.00');
          expect(element(by.id('currency-custom')).getText()).toBe('-USD$1,234.00');
          expect(element(by.id('currency-no-fractions')).getText()).toBe('-USD$1,234');
+		 expect(element(by.id('currency-no-symbol-other-locale')).getText()).toBe('-1,234');
        });
      </file>
    </example>

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -69,7 +69,7 @@ function currencyFilter($locale) {
     }
 
     // if null or undefined pass it through
-    return currencyString = (amount == null)
+    return (amount == null)
         ? amount
         : formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP, fractionSize).
             replace(/\u00A4/g, currencySymbol).trim();

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -186,12 +186,12 @@ describe('filters', function() {
 
       expect(currency(1.07)).toBe('$1.1');
     }));
-	
-	it('should trim the currency string if there are spaces before or after the currency string', inject(function($locale){
-	  $locale.NUMBER_FORMATS.PATTERNS[1].posPre = ' ';
-	  
-	  expect(currency(1.07, '')).toBe('1.07');
-	}));
+
+    it('should trim the currency string if there are spaces before or after the currency string', inject(function($locale){
+      $locale.NUMBER_FORMATS.PATTERNS[1].posPre = ' ';
+
+      expect(currency(1.07, '')).toBe('1.07');
+    }));
   });
 
   describe('number', function() {

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -186,6 +186,12 @@ describe('filters', function() {
 
       expect(currency(1.07)).toBe('$1.1');
     }));
+	
+	it('should trim the currency string if there are spaces before or after the currency string', inject(function($locale){
+	  $locale.NUMBER_FORMATS.PATTERNS[1].posPre = ' ';
+	  
+	  expect(currency(1.07, '')).toBe('1.07');
+	}));
   });
 
   describe('number', function() {

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -187,7 +187,7 @@ describe('filters', function() {
       expect(currency(1.07)).toBe('$1.1');
     }));
 
-    it('should trim the currency string if there are spaces before or after the currency string', inject(function($locale){
+    it('should trim the currency string if there are spaces before or after the currency string', inject(function($locale) {
       $locale.NUMBER_FORMATS.PATTERNS[1].posPre = ' ';
 
       expect(currency(1.07, '')).toBe('1.07');


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

For certain locales, when the `currencySymbol` is set to an empty string, there is trailing white space. [See issue #15018 ](https://github.com/angular/angular.js/issues/15018)

**What is the new behavior (if this is a feature change)?**

Any currency string will be trimmed.

**Does this PR introduce a breaking change?**

yes

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

Trim any beginning or trailing white space in a currency string.
Motivation: global fix for issue 15018
