### PR TITLE
fix(ngLocale): set correct first day of week for french people

### DIFF
--- a/src/ngLocale/angular-locale_fr-fr.js
+++ b/src/ngLocale/angular-locale_fr-fr.js
@@ -24,7 +24,7 @@ $provide.value("$locale", {
       "av. J.-C.",
       "ap. J.-C."
     ],
-    "FIRSTDAYOFWEEK": 0,
+    "FIRSTDAYOFWEEK": 1,
     "MONTH": [
       "janvier",
       "f\u00e9vrier",

--- a/src/ngLocale/angular-locale_fr.js
+++ b/src/ngLocale/angular-locale_fr.js
@@ -24,7 +24,7 @@ $provide.value("$locale", {
       "av. J.-C.",
       "ap. J.-C."
     ],
-    "FIRSTDAYOFWEEK": 0,
+    "FIRSTDAYOFWEEK": 1,
     "MONTH": [
       "janvier",
       "f\u00e9vrier",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Update locale file

**Other information**:

For french people, first day of week is monday
