### PR TITLE
fix($compile): avoid calling `$onChanges()` twice for `NaN` initial values

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3500,7 +3500,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       });
 
       function recordChanges(key, currentValue, previousValue) {
-        if (isFunction(destination.$onChanges) && currentValue !== previousValue) {
+        if (isFunction(destination.$onChanges) && currentValue !== previousValue &&
+            // eslint-disable-next-line no-self-compare
+            (currentValue === currentValue || previousValue === previousValue)) {
           // If we have not already scheduled the top level onChangesQueue handler then do so now
           if (!onChangesQueue) {
             scope.$$postDigest(flushOnChangesQueue);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.

**What is the current behavior? (You can also link to an open issue here)**
When the initial value of a binding is `NaN`, `$onChanges()` will be called twice (because we fail to detect that `NaN` equals `NaN`. For all other values, `$onChanges()` is called once.

**What is the new behavior (if this is a feature change)?**
`$onChanges()` is always called once, even if the initial value of a binding is `NaN`.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Discussed in #15095.
