### PR TITLE
feat(jqLite): return [] for .val() on <select multiple> with no selection

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -699,7 +699,7 @@ forEach({
             result.push(option.value || option.text);
           }
         });
-        return result.length === 0 ? null : result;
+        return result;
       }
       return element.value;
     }

--- a/test/helpers/matchers.js
+++ b/test/helpers/matchers.js
@@ -32,6 +32,12 @@ beforeEach(function() {
     };
   }
 
+  function DOMTester(a, b) {
+    if (a && b && a.nodeType > 0 && b.nodeType > 0) {
+      return a === b;
+    }
+  }
+
   function isNgElementHidden(element) {
     // we need to check element.getAttribute for SVG nodes
     var hidden = true;
@@ -111,12 +117,19 @@ beforeEach(function() {
           };
         }
       };
+    },
 
-      function DOMTester(a, b) {
-        if (a && b && a.nodeType > 0 && b.nodeType > 0) {
-          return a === b;
+    toEqualOneOf: function(util) {
+      return {
+        compare: function(actual) {
+          var expectedArgs = Array.prototype.slice.call(arguments, 1);
+          return {
+            pass: expectedArgs.some(function(expected) {
+              return util.equals(actual, expected, [DOMTester]);
+            })
+          };
         }
-      }
+      };
     },
 
     toEqualData: function() {

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1026,22 +1026,13 @@ describe('jqLite', function() {
           '<option>test 2</option>' +
         '</select>').val()).toEqual(['test 1']);
 
-      // In jQuery >= 3.0 .val() on select[multiple] with no selected options returns an
-      // empty array, not null.
-      // See https://github.com/jquery/jquery/issues/2562 for more details.
-      // jqLite will align with jQuery 3.0 behavior in Angular 1.6.
-      var val;
-      if (_jqLiteMode || isJQuery2x()) {
-        val = null;
-      } else {
-        val = [];
-      }
-
+      // In jQuery < 3.0 .val() on select[multiple] with no selected options returns an
+      // null instead of an empty array.
       expect(jqLite(
         '<select multiple>' +
           '<option>test 1</option>' +
           '<option>test 2</option>' +
-        '</select>').val()).toEqual(val);
+        '</select>').val()).toEqualOneOf(null, []);
     });
   });
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1034,6 +1034,31 @@ describe('jqLite', function() {
           '<option>test 2</option>' +
         '</select>').val()).toEqualOneOf(null, []);
     });
+
+    it('should get an empty array from a multi select if no elements are chosen', function() {
+      // In jQuery < 3.0 .val() on select[multiple] with no selected options returns an
+      // null instead of an empty array.
+      // See https://github.com/jquery/jquery/issues/2562 for more details.
+      if (isJQuery2x()) return;
+
+      expect(jqLite(
+        '<select multiple>' +
+          '<optgroup>' +
+            '<option>test 1</option>' +
+            '<option>test 2</option>' +
+          '</optgroup>' +
+          '<option>test 3</option>' +
+        '</select>').val()).toEqual([]);
+
+      expect(jqLite(
+        '<select multiple>' +
+          '<optgroup disabled>' +
+            '<option>test 1</option>' +
+            '<option>test 2</option>' +
+          '</optgroup>' +
+          '<option disabled>test 3</option>' +
+        '</select>').val()).toEqual([]);
+    });
   });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature (an API change).

**What is the current behavior? (You can also link to an open issue here)**
The `.val()` getter on `<select multiple>...</select>` returns `null` if no options are selected.

**What is the new behavior (if this is a feature change)?**
The `.val()` getter on `<select multiple>...</select>` returns an empty array if no options are selected.

**Does this PR introduce a breaking change?**
Yes.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) -- what should I do here?

**Other information**:

Fixes #14370
