### PR TITLE
feat(currencyFilter): trim whitespace around an empty currency symbol

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -68,11 +68,14 @@ function currencyFilter($locale) {
       fractionSize = formats.PATTERNS[1].maxFrac;
     }
 
+    // If the currency symbol is empty, trim whitespace around the symbol
+    var currencySymbolRe = !currencySymbol ? /\s*\u00A4\s*/g : /\u00A4/g;
+
     // if null or undefined pass it through
     return (amount == null)
         ? amount
         : formatNumber(amount, formats.PATTERNS[1], formats.GROUP_SEP, formats.DECIMAL_SEP, fractionSize).
-            replace(/\u00A4/g, currencySymbol);
+            replace(currencySymbolRe, currencySymbol);
   };
 }
 

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -186,6 +186,19 @@ describe('filters', function() {
 
       expect(currency(1.07)).toBe('$1.1');
     }));
+
+    it('should trim whitespace around the currency symbol if it is empty',
+      inject(function($locale) {
+        var pattern = $locale.NUMBER_FORMATS.PATTERNS[1];
+        pattern.posPre = pattern.posSuf = '     \u00A4     ';
+        pattern.negPre = pattern.negSuf = '  -  \u00A4  -  ';
+
+        expect(currency(+1.07, '$')).toBe('     $     1.07     $     ');
+        expect(currency(-1.07, '$')).toBe('  -  $  -  1.07  -  $  -  ');
+        expect(currency(+1.07, '')).toBe('1.07');
+        expect(currency(-1.07, '')).toBe('  --  1.07  --  ');
+      })
+    );
   });
 
   describe('number', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
See #15018.

**What is the new behavior (if this is a feature change)?**
Whitespace around the currency symbol is trimmed, when the currency symbol is empty.

**Does this PR introduce a breaking change?**
Who knows... If someone relied on the whitespave being there, I guess it does :disappointed: 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
In most locales, this won't make a difference (since they do not have whotespace around their currency symbols). In locales where there is a whitespace separating the currency symbol from the number, it makes sense to also remove such whitespace if the user specified an empty currency symbol (indicating they just want the number).

Fixes #15018
Closes #15085
