### PR TITLE
feat($compileProvider): use options as controller in .component if is function or class

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -73,7 +73,7 @@ It's also possible to add components via {@link $compileProvider#component} in a
 | bindings          | No                   | Yes (binds to controller)      |
 | bindToController  | Yes (default: false) | No (use bindings instead)       |
 | compile function  | Yes                  | No       |
-| controller        | Yes                  | Yes (default `function() {}`)     |
+| controller        | Yes                  | Yes (default `function() {}` or _the Component config object_ if it is a function or class )     |
 | controllerAs      | Yes (default: false) | Yes (default: `$ctrl`)       |
 | link functions    | Yes                  | No       |
 | multiElement      | Yes                  | No       |
@@ -450,6 +450,96 @@ angular.module('docsTabsExample', [])
 </example>
 
 
+## Creating Components with classes
+
+It is possible to use ES2015 classes as components.
+The method `.component` can take a class (or function) as second argument.
+If it is the case,
+it will use the class (or function) as controller of the component.
+Component configuration will appear statically defined in the object.
+
+```javascript
+class EditableFieldComponent {
+  static get templateUrl() {
+    return 'heroDetail.html';
+  }
+  static get bindings() {
+    return {
+      fieldValue: '<',
+      fieldType: '@?',
+      onUpdate: '&'
+    };
+  }
+
+  constructor() {
+    this.editMode = false;
+  }
+
+  handleModeChange() {
+    if (this.editMode) {
+      this.onUpdate({value: this.fieldValue});
+      this.fieldValueCopy = this.fieldValue;
+    }
+    this.editMode = !this.editMode;
+  }
+
+  reset() {
+    this.fieldValue = this.fieldValueCopy;
+  }
+
+  $onInit() {
+    this.fieldValueCopy = this.fieldValue;
+
+    if (!this.fieldType) {
+      this.fieldType = 'text';
+    }
+  }
+}
+```
+
+If you are using Typescript, Babel, or Traceur
+you can use class properties:
+
+```javascript
+class EditableFieldComponent {
+  static template = `
+    <span ng-switch="$ctrl.editMode">
+      <input ng-switch-when="true" type="{{$ctrl.fieldType}}" ng-model="$ctrl.fieldValue">
+      <span ng-switch-default>{{$ctrl.fieldValue}}</span>
+    </span>
+    <button ng-click="$ctrl.handleModeChange()">{{$ctrl.editMode ? 'Save' : 'Edit'}}</button>
+    <button ng-if="$ctrl.editMode" ng-click="$ctrl.reset()">Reset</button>
+  `;
+  static bindings = {
+    fieldValue: '<',
+    fieldType: '@?',
+    onUpdate: '&'
+  };
+
+  editMode = false;
+
+  handleModeChange() {
+    if (this.editMode) {
+      this.onUpdate({value: this.fieldValue});
+      this.fieldValueCopy = this.fieldValue;
+    }
+    this.editMode = !this.editMode;
+  }
+
+  reset() {
+    this.fieldValue = this.fieldValueCopy;
+  }
+
+  $onInit() {
+    this.fieldValueCopy = this.fieldValue;
+
+    if (!this.fieldType) {
+      this.fieldType = 'text';
+    }
+  }
+}
+```
+
 # Unit-testing Component Controllers
 
 The easiest way to unit-test a component controller is by using the
@@ -502,3 +592,4 @@ describe('component: heroDetail', function() {
 
 });
 ```
+

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1225,7 +1225,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    * See also {@link ng.$compileProvider#directive $compileProvider.directive()}.
    */
   this.component = function registerComponent(name, options) {
-    var controller = options.controller || function() {};
+    var controller = options.controller || isFunction(options) && options || function() {};
 
     function factory($injector) {
       function makeInjectable(fn) {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -12021,6 +12021,64 @@ describe('$compile', function() {
         }));
       });
     });
+
+    it('should register as controller options if options is a function', function() {
+      function Controller(log) {
+        log('OK');
+      }
+      Controller.template = '<div>SUCCESS</div>';
+      angular.module('my', []).component('myComponent', Controller);
+      module('my');
+
+      inject(function($compile, $rootScope, log) {
+        element = $compile('<my-component></my-component>')($rootScope);
+        expect(element.find('div').text()).toEqual('SUCCESS');
+        expect(log).toEqual('OK');
+      });
+    });
+
+    it('should register as controller options if options is a class', function() {
+      if (!/chrome/i.test(window.navigator.userAgent)) return;
+      // eslint-disable-next-line no-eval
+      var Controller = eval('' +
+        'class Foo {\n' +
+        '  static get template() {\n' +
+        '    return "<div>SUCCESS</div>";\n' +
+        '  }\n' +
+        '  constructor(log) {\n' +
+        '    log("OK")\n' +
+        '  }\n' +
+        '}\n' +
+      '');
+      Controller.$inject = ['log'];
+      angular.module('my', []).component('myComponent', Controller);
+      module('my');
+
+      inject(function($compile, $rootScope, log) {
+        element = $compile('<my-component></my-component>')($rootScope);
+        expect(element.find('div').text()).toEqual('SUCCESS');
+        expect(log).toEqual('OK');
+      });
+    });
+
+    it('should not register as controller options if controller is specified', function() {
+      function Controller(log) {
+        log('OK');
+      }
+      function Options(log) {
+        log('KO');
+      }
+      Options.template = '<div>SUCCESS</div>';
+      Options.controller = Controller;
+      angular.module('my', []).component('myComponent', Options);
+      module('my');
+
+      inject(function($compile, $rootScope, log) {
+        element = $compile('<my-component></my-component>')($rootScope);
+        expect(element.find('div').text()).toEqual('SUCCESS');
+        expect(log).toEqual('OK');
+      });
+    });
   });
 
   describe('$$createComment', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
New feature.

**What is the current behavior? (You can also link to an open issue here)**
When creating a component you must specify the controller unless you are ok using an empty controller.

**What is the new behavior (if this is a feature change)?**
If you use a class or function as Component config object it becomes the controller unless it specifies a controller.

**Does this PR introduce a breaking change?**
Yes.

Small breaking change with probably low affectation (if any): 
if the config object is a function or class and no controller is defined,
now it will execute it and use its instance as controller instead of `function() {}`

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:

The reason of this  feature is to enable to use classes as components with the little effort possible and closer to Angular 2.

> #### Without this PR:

Now if you want to create a component with a controller instantiated from a class you need to do something like:

``` javascript
class EditableFieldController {
  constructor() {
    this.editMode = false;
  }

  handleModeChange() {
    if (this.editMode) {
      this.onUpdate({value: this.fieldValue});
      this.fieldValueCopy = this.fieldValue;
    }
    this.editMode = !this.editMode;
  }

  reset() {
    this.fieldValue = this.fieldValueCopy;
  }

  $onInit() {
    this.fieldValueCopy = this.fieldValue;

    if (!this.fieldType) {
      this.fieldType = 'text';
    }
  }
}

export const EditableFieldComponent = {
  templateUrl: 'heroDetail.html',
  bindings: {
    fieldValue: '<',
    fieldType: '@?',
    onUpdate: '&'
  },
  controller: EditableFieldController,
};
```

Currently, there is a **trick** (at least if you are using Typescript) that allows you to do the following:

``` javascript
export class EditableFieldComponent {
  static controller = EditableFieldComponent; // *** this is the trick
  static templateUrl = 'heroDetail.html';
  static bindings = {
    fieldValue: '<',
    fieldType: '@?',
    onUpdate: '&'
  };

  editMode = false;

  handleModeChange() {
    if (this.editMode) {
      this.onUpdate({value: this.fieldValue});
      this.fieldValueCopy = this.fieldValue;
    }
    this.editMode = !this.editMode;
  }

  reset() {
    this.fieldValue = this.fieldValueCopy;
  }

  $onInit() {
    this.fieldValueCopy = this.fieldValue;

    if (!this.fieldType) {
      this.fieldType = 'text';
    }
  }
}
```

> #### With this PR:

This PR sets as default the Component config object as controller
if it is a function or class. So you do not need to use _the trick_.

So in ES2015 you can do:

``` javascript
export class EditableFieldComponent {
  static get templateUrl() {
    return 'heroDetail.html';
  }
  static get bindings() {
    return {
      fieldValue: '<',
      fieldType: '@?',
      onUpdate: '&'
    };
  }

  constructor() {
    this.editMode = false;
  }

  handleModeChange() {
    if (this.editMode) {
      this.onUpdate({value: this.fieldValue});
      this.fieldValueCopy = this.fieldValue;
    }
    this.editMode = !this.editMode;
  }

  reset() {
    this.fieldValue = this.fieldValueCopy;
  }

  $onInit() {
    this.fieldValueCopy = this.fieldValue;

    if (!this.fieldType) {
      this.fieldType = 'text';
    }
  }
}
```

And in esnext, babel, traceur and typescript you can do:

``` javascript
export class EditableFieldComponent {
  static templateUrl = 'heroDetail.html';
  static bindings = {
    fieldValue: '<',
    fieldType: '@?',
    onUpdate: '&'
  };

  editMode = false;

  handleModeChange() {
    if (this.editMode) {
      this.onUpdate({value: this.fieldValue});
      this.fieldValueCopy = this.fieldValue;
    }
    this.editMode = !this.editMode;
  }

  reset() {
    this.fieldValue = this.fieldValueCopy;
  }

  $onInit() {
    this.fieldValueCopy = this.fieldValue;

    if (!this.fieldType) {
      this.fieldType = 'text';
    }
  }
}
```
