### PR TITLE
fix(ngAria): Prevent aria-invalid from being added to hidden inputs

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -225,7 +225,7 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
 .directive('ngModel', ['$aria', function($aria) {
 
   function shouldAttachAttr(attr, normalizedAttr, elem, allowBlacklistEls) {
-    return $aria.config(normalizedAttr) && !elem.attr(attr) && (allowBlacklistEls || !isNodeOneOf(elem, nodeBlackList));
+    return $aria.config(normalizedAttr) && !elem.attr(attr) && (allowBlacklistEls || !isNodeOneOf(elem, nodeBlackList)) && elem.attr('type') !== 'hidden';
   }
 
   function shouldAttachRole(role, elem) {

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -421,7 +421,7 @@ describe('$aria', function() {
       expect(element.attr('aria-invalid')).toBe('userSetValue');
     });
 
-    it('should not attach if input is hidden', function() {
+    it('should not attach if input is type="hidden"', function() {
       compileElement('<input type="hidden" ng-model="txtInput">');
       expect(element.attr('aria-invalid')).toBeUndefined();
     });

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -420,6 +420,11 @@ describe('$aria', function() {
       scope.$apply('txtInput=\'LTten\'');
       expect(element.attr('aria-invalid')).toBe('userSetValue');
     });
+
+    it('should not attach if input is hidden', function() {
+      compileElement('<input type="hidden" ng-model="txtInput">');
+      expect(element.attr('aria-invalid')).toBeUndefined();
+    });
   });
 
   describe('aria-invalid when disabled', function() {


### PR DESCRIPTION
This fixes a error found using the Google Accessibility Developer Tools audit.
Input fields of type hidden shouldn't have aria attributes.
https://www.w3.org/TR/html-aria/#allowed-aria-roles-states-and-properties-1
