### PR TITLE
fix($scope): fixes multiple root element error when there is a whites…

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3679,8 +3679,9 @@ function removeComments(jqNodes) {
 
   while (i--) {
     var node = jqNodes[i];
-    if (node.nodeType === NODE_TYPE_COMMENT) {
-      splice.call(jqNodes, i, 1);
+    if (node.nodeType === NODE_TYPE_COMMENT ||
+       (node.nodeType === NODE_TYPE_TEXT && node.nodeValue.trim() === '')) {
+         splice.call(jqNodes, i, 1);
     }
   }
   return jqNodes;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1364,6 +1364,22 @@ describe('$compile', function() {
           });
         });
 
+        it('should ignore whitespace betwee comment and root node when replacing with a template', function() {
+          module(function() {
+            directive('replaceWithWhitespace', valueFn({
+              replace: true,
+              template: '<!-- ignored comment --> <p>Hello, world!</p> <!-- ignored comment-->'
+            }));
+          });
+          inject(function($compile, $rootScope) {
+            expect(function() {
+              element = $compile('<div><div replace-with-whitespace></div></div>')($rootScope);
+            }).not.toThrow();
+            expect(element.find('p').length).toBe(1);
+            expect(element.find('p').text()).toBe('Hello, world!');
+          });
+        });
+
         it('should keep prototype properties on directive', function() {
           module(function() {
             function DirectiveClass() {
@@ -2092,6 +2108,18 @@ describe('$compile', function() {
             $compile('<p template></p>');
             $rootScope.$apply();
             expect($exceptionHandler.errors).toEqual([]);
+
+            // comments are ok
+            $templateCache.put('template.html', '<!-- oh hi --><div></div> \n');
+            $compile('<p template></p>');
+            $rootScope.$apply();
+            expect($exceptionHandler.errors).toEqual([]);
+
+            // white space around comments is ok
+            $templateCache.put('template.html', '  <!-- oh hi -->  <div></div>  <!-- oh hi -->\n');
+            $compile('<p template></p>');
+            $rootScope.$apply();
+            expect($exceptionHandler.errors).toEqual([]);
           });
         });
 
@@ -2302,6 +2330,26 @@ describe('$compile', function() {
             expect(element.find('p').text()).toBe('Hello, world!');
           });
         });
+
+        it('should ignore whitespace between comment and root node when replacing with a templateUrl', function() {
+          module(function() {
+            directive('replaceWithWhitespace', valueFn({
+              replace: true,
+              templateUrl: 'templateWithWhitespace.html'
+            }));
+          });
+          inject(function($compile, $rootScope, $httpBackend) {
+            $httpBackend.whenGET('templateWithWhitespace.html').
+              respond('<!-- ignored comment --> <p>Hello, world!</p> <!-- ignored comment-->');
+            expect(function() {
+              element = $compile('<div><div replace-with-whitespace></div></div>')($rootScope);
+            }).not.toThrow();
+            $httpBackend.flush();
+            expect(element.find('p').length).toBe(1);
+            expect(element.find('p').text()).toBe('Hello, world!');
+          });
+        });
+
 
         it('should keep prototype properties on sync version of async directive', function() {
           module(function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
If one tries to load a directive with a top-level comment angular throws an error 
Error: [$compile:tplrt] Template for directive 'myDirective' must have exactly one root element
https://github.com/angular/angular.js/issues/15108

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

fixes multiple root element error when there is a whitespace after a comment

Added new conditional for NODE_TYPE_TEXT inside removeComments method of $compile
Added corresponding unit tests.

Closes #15108
