### PR TITLE
docs(input[range]): Fix erroneous examples

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1116,7 +1116,7 @@ var inputType = {
             <hr>
             Model as number: <input type="number" ng-model="value"><br>
             Min: <input type="number" ng-model="min"><br>
-            Max: <input type="number" ng-model="min"><br>
+            Max: <input type="number" ng-model="max"><br>
             value = <code>{{value}}</code><br/>
             myForm.range.$valid = <code>{{myForm.range.$valid}}</code><br/>
             myForm.range.$error = <code>{{myForm.range.$error}}</code>
@@ -1142,7 +1142,7 @@ var inputType = {
             <hr>
             Model as number: <input type="number" ng-model="value"><br>
             Min: <input type="number" ng-model="min"><br>
-            Max: <input type="number" ng-model="min"><br>
+            Max: <input type="number" ng-model="max"><br>
             value = <code>{{value}}</code><br/>
             myForm.range.$valid = <code>{{myForm.range.$valid}}</code><br/>
             myForm.range.$error = <code>{{myForm.range.$error}}</code>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Documentation update. 

**What is the current behavior? (You can also link to an open issue here)**

Examples of input[range] doesn't works well because it use only the `scope.min` value instead of `scope.max`

**What is the new behavior (if this is a feature change)?**
- When updating min value, it update the min only.
- When updating max value, it update the max only.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
