### PR TITLE
feat(http): JSONP requests now require trusted resource URLs

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -881,6 +881,12 @@ function $HttpProvider() {
 </file>
 <file name="script.js">
   angular.module('httpExample', [])
+    .config(['$sceDelegateProvider', function($sceDelegateProvider) {
+      $sceDelegateProvider.resourceUrlWhitelist([
+        'self',
+        'https://angularjs.org/**'
+      ]);
+    }])
     .controller('FetchController', ['$scope', '$http', '$templateCache',
       function($scope, $http, $templateCache) {
         $scope.method = 'GET';

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1296,7 +1296,7 @@ angular.mock.dump = function(object) {
   ```
  */
 angular.mock.$HttpBackendProvider = function() {
-  this.$get = ['$rootScope', '$timeout', createHttpBackendMock];
+  this.$get = ['$sce', '$rootScope', '$timeout', createHttpBackendMock];
 };
 
 /**
@@ -1313,7 +1313,7 @@ angular.mock.$HttpBackendProvider = function() {
  * @param {Object=} $browser Auto-flushing enabled if specified
  * @return {Object} Instance of $httpBackend mock
  */
-function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
+function createHttpBackendMock($sce, $rootScope, $timeout, $delegate, $browser) {
   var definitions = [],
       expectations = [],
       responses = [],
@@ -1337,6 +1337,7 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
         expectation = expectations[0],
         wasExpected = false;
 
+    url = $sce.valueOf(url);
     xhr.$$events = eventHandlers;
     xhr.upload.$$events = uploadEventHandlers;
 
@@ -2666,7 +2667,7 @@ angular.module('ngMockE2E', ['ng']).config(['$provide', function($provide) {
  */
 angular.mock.e2e = {};
 angular.mock.e2e.$httpBackendDecorator =
-  ['$rootScope', '$timeout', '$delegate', '$browser', createHttpBackendMock];
+  ['$sce', '$rootScope', '$timeout', '$delegate', '$browser', createHttpBackendMock];
 
 
 /**

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1018,6 +1018,14 @@ describe('$http', function() {
         $httpBackend.expect('JSONP', '/url', undefined, checkHeader('Custom', 'Header')).respond('');
         $http.jsonp('/url', {headers: {'Custom': 'Header'}});
       });
+
+      it('jsonp() should allow trusted url', inject(['$sce', function($sce) {
+        $httpBackend.expect('JSONP', '/url').respond('');
+        $http.jsonp($sce.trustAsResourceUrl('/url'));
+
+        $httpBackend.expect('JSONP', '/url?a=b').respond('');
+        $http.jsonp($sce.trustAsResourceUrl('/url'), {params: {a: 'b'}});
+      }]));
     });
 
 

--- a/test/ngRoute/routeSpec.js
+++ b/test/ngRoute/routeSpec.js
@@ -1016,9 +1016,10 @@ describe('$route', function() {
       $routeProvider = _$routeProvider_;
 
       $provide.decorator('$sce', function($delegate) {
+        function getVal(v) { return v.getVal ? v.getVal() : v; }
         $delegate.trustAsResourceUrl = function(url) { return new MySafeResourceUrl(url); };
-        $delegate.getTrustedResourceUrl = function(v) { return v.getVal(); };
-        $delegate.valueOf = function(v) { return v.getVal(); };
+        $delegate.getTrustedResourceUrl = function(v) { return getVal(v); };
+        $delegate.valueOf = function(v) { return getVal(v); };
         return $delegate;
       });
     });


### PR DESCRIPTION
JSONP requests allow full access to the browser and the JavaScript context. So allowing a malicious attacker to make a JSONP request to an evil server could have bad results.

By requiring that JSONP urls are trusted we make it easier for developers to see that their app is only able to make JSONP requests to urls that they have audited.

There are two ways to trust:
- whitelisting the url
- explicitly marking a url as trusted by calling `$sce.trustAs`

The first commit in this PR ensures that all JSONP requests use a URL that is validated against the `$sce` ResourceUrl whitelist/blacklist checking. This commit creates a Breaking Change for app developers as they must now add all of their JSONP endpoints to the whitelist before their app will work. Although as significant breaking change, it is fairly simple to fix: just search for all calls to `$http.jsonp` and identify the url. Of course if the url is being generated dynamically then this is harder to fix but also indicates that perhaps there is a security vulnerability.

The second commit allows developers to provide explicitly trusted urls as a result of calling `$sce.trustAsResourceUrl`. This second approach has a few quirks:
- the `$http` service needs to append parameters to the url, which means that the trusted url must be unwrapped, modified and then re-wrapped as trusted before passing it to `$httpBackend`.
- it may be possible (??) that there might be an attack vector if an attacker is able to access a different endpoint by changing the parameters. But perhaps since the domain and path cannot be modified by the param serializer this is not an issue?

_Is it acceptable (from a security point of view) to allow parameters to be added to a trusted url? If so then we could refactor the checks to happen in the `$http` service instead of `$httpBackend` which would remove the need for the re-wrapping of the built url._

Closes #11352
Closes #11328
