### PR TITLE
docs(tutorial/Tutorial): --depth=14 should be --depth=16

### DIFF
--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -73,12 +73,12 @@ Clone the [angular-phonecat repository][angular-phonecat] located at GitHub by r
 command:
 
 ```
-git clone --depth=14 https://github.com/angular/angular-phonecat.git
+git clone --depth=16 https://github.com/angular/angular-phonecat.git
 ```
 
 This command creates the `angular-phonecat` directory in your current directory.
 
-<div class="alert alert-info">The `--depth=14` option just tells Git to pull down only the last 14 commits.  This makes the
+<div class="alert alert-info">The `--depth=16` option just tells Git to pull down only the last 16 commits.  This makes the
 download much smaller and faster.
 </div>
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Doc update

**What is the current behavior? (You can also link to an open issue here)**
With '--depth=14' people cannot checkout step-0 as described here:
https://github.com/angular/angular-phonecat/issues/336

**What is the new behavior (if this is a feature change)?**
Just like it shows now on https://docs.angularjs.org/tutorial.

**Does this PR introduce a breaking change?**

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Just like it shows now on https://docs.angularjs.org/tutorial. 

With '--depth=14' people cannot checkout step-0 as described here:
https://github.com/angular/angular-phonecat/issues/336
