### PR TITLE
docs(guide/Providers): should line #220's literal read as 'unicornLauncherProvider'?

### DIFF
--- a/docs/content/guide/providers.ngdoc
+++ b/docs/content/guide/providers.ngdoc
@@ -217,7 +217,7 @@ that need it. We can make it configurable like so:
 
 
 ```javascript
-myApp.provider('unicornLauncher', function UnicornLauncherProvider() {
+myApp.provider('unicornLauncherProvider', function UnicornLauncherProvider() {
   var useTinfoilShielding = false;
 
   this.useTinfoilShielding = function(value) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs typo update

**What is the current behavior? (You can also link to an open issue here)**
just a typo

**What is the new behavior (if this is a feature change)?**
typo corrected

**Does this PR introduce a breaking change?**
no

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [n/a] Tests for the changes have been added (for bug fixes / features)
- [n/a] Docs have been added / updated (for bug fixes / features)

**Other information**:

**_Believe line #220's literal should read as 'unicornLauncherProvider' (currently it is 'unicornLauncher'), just so that line #240's dependency declaration to be valid._**
