### PR TITLE
Update component-router.ngdoc

### DIFF
--- a/docs/content/guide/component-router.ngdoc
+++ b/docs/content/guide/component-router.ngdoc
@@ -376,7 +376,6 @@ You can see the complete application running below.
       };
 
       this.cancel = function() {
-        ctrl.editName = ctrl.crisis.name;
         ctrl.gotoCrises();
       };
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

docs update

**What is the current behavior? (You can also link to an open issue here)**

The current example in the docs is broken. The user is never prompted to discard changes.

**What is the new behavior (if this is a feature change)?**

The new behavior fixes this

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

this.cancel should not reassign ctrl.editName. The reassignment causes this.$routerCanDeactivate to always return true, and the user is never prompted to Discard changes. 

Should the user press "Cancel" and not discard changes, the editName is preserved. Should the user press "Yes" and discard the changes, the ctrl.crisis.name will remain the same, which is exactly the behavior that we want.
