### PR TITLE
docs(guide/Filters): Fix incorrect wording

### DIFF
--- a/docs/content/guide/filter.ngdoc
+++ b/docs/content/guide/filter.ngdoc
@@ -109,8 +109,9 @@ as the first argument. Any filter arguments are passed in as additional argument
 function.
 
 The filter function should be a [pure function](http://en.wikipedia.org/wiki/Pure_function), which
-means that it should be stateless and idempotent, and not rely for example on other Angular services.
-Angular relies on this contract and will by default execute a filter only when the inputs to the function change.
+means that it should always return the same result given the same input arguments and should not affect
+external state, for example, other Angular services. Angular relies on this contract and will by default
+execute a filter only when the inputs to the function change.
 {@link guide/filter#stateful-filters Stateful filters} are possible, but less performant.
 
 <div class="alert alert-warning">


### PR DESCRIPTION
**What kind of change does this PR introduce?** Docs

**What is the current behavior?** Incorrect wording

**What is the new behavior (if this is a feature change)?** Correct wording

**Does this PR introduce a breaking change?** No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

I don't think "Idempotence" is a property that filters need to fulfill: https://en.wikipedia.org/wiki/Idempotence. Idempotence means that `f(f(x)) == f(x)`, i.e. that applying a filter to the result of itself gives the same value as only applying it once. Many common filters are not idempotent. For example, applying reverse twice is not the same as applying it once.
