### PR TITLE
Align jqLite's attr method with jQuery

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -654,11 +654,13 @@ forEach({
         return element.getAttribute(name) != null ? lowercasedName : undefined;
       }
     } else if (isDefined(value)) {
-      element.setAttribute(name, value);
+      if (value === null) {
+        element.removeAttribute(name);
+      } else {
+        element.setAttribute(name, value);
+      }
     } else if (element.getAttribute) {
-      // the extra argument "2" is to get the right thing for a.href in IE, see jQuery code
-      // some elements (e.g. Document) don't have get attribute, so return undefined
-      var ret = element.getAttribute(name, 2);
+      var ret = element.getAttribute(name);
       // normalize non-existing attributes to undefined (as jQuery)
       return ret === null ? undefined : ret;
     }

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -645,7 +645,7 @@ forEach({
     var lowercasedName = lowercase(name);
     if (BOOLEAN_ATTR[lowercasedName]) {
       if (isDefined(value)) {
-        if (value) {
+        if (value !== false && value !== null) {
           element.setAttribute(name, name);
         } else {
           element.removeAttribute(name);

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -646,17 +646,12 @@ forEach({
     if (BOOLEAN_ATTR[lowercasedName]) {
       if (isDefined(value)) {
         if (value) {
-          element[name] = true;
-          element.setAttribute(name, lowercasedName);
+          element.setAttribute(name, name);
         } else {
-          element[name] = false;
-          element.removeAttribute(lowercasedName);
+          element.removeAttribute(name);
         }
       } else {
-        return (element[name] ||
-                 (element.attributes.getNamedItem(name) || noop).specified)
-               ? lowercasedName
-               : undefined;
+        return element.getAttribute(name) != null ? lowercasedName : undefined;
       }
     } else if (isDefined(value)) {
       element.setAttribute(name, value);

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -638,30 +638,32 @@ forEach({
   },
 
   attr: function(element, name, value) {
+    var ret;
     var nodeType = element.nodeType;
     if (nodeType === NODE_TYPE_TEXT || nodeType === NODE_TYPE_ATTRIBUTE || nodeType === NODE_TYPE_COMMENT) {
       return;
     }
+
     var lowercasedName = lowercase(name);
-    if (BOOLEAN_ATTR[lowercasedName]) {
-      if (isDefined(value)) {
-        if (value !== false && value !== null) {
-          element.setAttribute(name, name);
-        } else {
-          element.removeAttribute(name);
-        }
-      } else {
-        return element.getAttribute(name) != null ? lowercasedName : undefined;
-      }
-    } else if (isDefined(value)) {
-      if (value === null) {
+    var isBooleanAttr = BOOLEAN_ATTR[lowercasedName];
+
+    if (isDefined(value)) {
+      // setter
+
+      if (value === null || (value === false && isBooleanAttr)) {
         element.removeAttribute(name);
       } else {
-        element.setAttribute(name, value);
+        element.setAttribute(name, isBooleanAttr ? lowercasedName : value);
       }
     } else if (element.getAttribute) {
-      var ret = element.getAttribute(name);
-      // normalize non-existing attributes to undefined (as jQuery)
+      // getter
+
+      ret = element.getAttribute(name);
+
+      if (isBooleanAttr && ret !== null) {
+        ret = lowercasedName;
+      }
+      // Normalize non-existing attributes to undefined (as jQuery).
       return ret === null ? undefined : ret;
     }
   },

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -78,7 +78,7 @@
  * - [`prop()`](http://api.jquery.com/prop/)
  * - [`ready()`](http://api.jquery.com/ready/)
  * - [`remove()`](http://api.jquery.com/remove/)
- * - [`removeAttr()`](http://api.jquery.com/removeAttr/)
+ * - [`removeAttr()`](http://api.jquery.com/removeAttr/) - Does not support multiple attributes
  * - [`removeClass()`](http://api.jquery.com/removeClass/) - Does not support a function as first argument
  * - [`removeData()`](http://api.jquery.com/removeData/)
  * - [`replaceWith()`](http://api.jquery.com/replaceWith/)

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -1060,11 +1060,11 @@ forEach({
     }
     return isDefined(value) ? value : this;
   };
-
-  // bind legacy bind/unbind to on/off
-  JQLite.prototype.bind = JQLite.prototype.on;
-  JQLite.prototype.unbind = JQLite.prototype.off;
 });
+
+// bind legacy bind/unbind to on/off
+JQLite.prototype.bind = JQLite.prototype.on;
+JQLite.prototype.unbind = JQLite.prototype.off;
 
 
 // Provider for private $$jqLite service

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -640,7 +640,8 @@ forEach({
   attr: function(element, name, value) {
     var ret;
     var nodeType = element.nodeType;
-    if (nodeType === NODE_TYPE_TEXT || nodeType === NODE_TYPE_ATTRIBUTE || nodeType === NODE_TYPE_COMMENT) {
+    if (nodeType === NODE_TYPE_TEXT || nodeType === NODE_TYPE_ATTRIBUTE || nodeType === NODE_TYPE_COMMENT ||
+      !element.getAttribute) {
       return;
     }
 
@@ -655,7 +656,7 @@ forEach({
       } else {
         element.setAttribute(name, isBooleanAttr ? lowercasedName : value);
       }
-    } else if (element.getAttribute) {
+    } else {
       // getter
 
       ret = element.getAttribute(name);

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -56,7 +56,7 @@
  * - [`after()`](http://api.jquery.com/after/)
  * - [`append()`](http://api.jquery.com/append/)
  * - [`attr()`](http://api.jquery.com/attr/) - Does not support functions as parameters
- * - [`bind()`](http://api.jquery.com/bind/) - Does not support namespaces, selectors or eventData
+ * - [`bind()`](http://api.jquery.com/bind/) (_deprecated_ - to be removed in 1.7.0, use [`on()`](http://api.jquery.com/on/)) - Does not support namespaces, selectors or eventData
  * - [`children()`](http://api.jquery.com/children/) - Does not support selectors
  * - [`clone()`](http://api.jquery.com/clone/)
  * - [`contents()`](http://api.jquery.com/contents/)
@@ -85,7 +85,7 @@
  * - [`text()`](http://api.jquery.com/text/)
  * - [`toggleClass()`](http://api.jquery.com/toggleClass/) - Does not support a function as first argument
  * - [`triggerHandler()`](http://api.jquery.com/triggerHandler/) - Passes a dummy event object to handlers
- * - [`unbind()`](http://api.jquery.com/unbind/) - Does not support namespaces or event object as parameter
+ * - [`unbind()`](http://api.jquery.com/unbind/) (_deprecated_ - to be removed in 1.7.0, use [`off()`](http://api.jquery.com/off/)) - Does not support namespaces or event object as parameter
  * - [`val()`](http://api.jquery.com/val/)
  * - [`wrap()`](http://api.jquery.com/wrap/)
  *

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -598,7 +598,7 @@ describe('jqLite', function() {
 
 
   describe('attr', function() {
-    it('should read write and remove attr', function() {
+    it('should read, write and remove attr', function() {
       var selector = jqLite([a, b]);
 
       expect(selector.attr('prop', 'value')).toEqual(selector);

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -2323,4 +2323,19 @@ describe('jqLite', function() {
       expect(onLoadCallback).toHaveBeenCalledOnce();
     });
   });
+
+
+  describe('bind/unbind', function() {
+    if (!_jqLiteMode) return;
+
+    it('should alias bind() to on()', function() {
+      var element = jqLite(a);
+      expect(element.bind).toBe(element.on);
+    });
+
+    it('should alias unbind() to off()', function() {
+      var element = jqLite(a);
+      expect(element.unbind).toBe(element.off);
+    });
+  });
 });

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -635,6 +635,43 @@ describe('jqLite', function() {
       expect(select.attr('multiple')).toBe('multiple');
     });
 
+    it('should not take properties into account when getting respective boolean attributes', function() {
+      // Use a div and not a select as the latter would itself reflect the multiple attribute
+      // to a property.
+      var div = jqLite('<div>');
+
+      div[0].multiple = true;
+      expect(div.attr('multiple')).toBe(undefined);
+
+      div.attr('multiple', 'multiple');
+      div[0].multiple = false;
+      expect(div.attr('multiple')).toBe('multiple');
+    });
+
+    it('should not set properties when setting respective boolean attributes', function() {
+      // jQuery 2.x has different behavior; skip the test.
+      if (isJQuery2x()) return;
+
+      // Use a div and not a select as the latter would itself reflect the multiple attribute
+      // to a property.
+      var div = jqLite('<div>');
+
+      // Check the initial state.
+      expect(div[0].multiple).toBe(undefined);
+
+      div.attr('multiple', 'multiple');
+      expect(div[0].multiple).toBe(undefined);
+
+      div.attr('multiple', '');
+      expect(div[0].multiple).toBe(undefined);
+
+      div.attr('multiple', false);
+      expect(div[0].multiple).toBe(undefined);
+
+      div.attr('multiple', null);
+      expect(div[0].multiple).toBe(undefined);
+    });
+
     it('should normalize the case of boolean attributes', function() {
       var input = jqLite('<input readonly>');
       expect(input.attr('readonly')).toBe('readonly');

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -733,6 +733,24 @@ describe('jqLite', function() {
       elm.attr('attribute', '');
       expect(elm[0].getAttribute('attribute')).toBe('');
     });
+
+    it('should remove the boolean attribute for a false value', function() {
+      var elm = jqLite('<select multiple>');
+      elm.attr('multiple', false);
+      expect(elm[0].hasAttribute('multiple')).toBe(false);
+    });
+
+    it('should remove the boolean attribute for a null value', function() {
+      var elm = jqLite('<select multiple>');
+      elm.attr('multiple', null);
+      expect(elm[0].hasAttribute('multiple')).toBe(false);
+    });
+
+    it('should not remove the boolean attribute for an empty string as a value', function() {
+      var elm = jqLite('<select multiple>');
+      elm.attr('multiple', '');
+      expect(elm[0].getAttribute('multiple')).toBe('multiple');
+    });
   });
 
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -751,6 +751,17 @@ describe('jqLite', function() {
       elm.attr('multiple', '');
       expect(elm[0].getAttribute('multiple')).toBe('multiple');
     });
+
+    it('should not fail on elements without the getAttribute method', function() {
+      forEach([window, document], function(node) {
+        expect(function() {
+          var elem = jqLite(node);
+          elem.attr('foo');
+          elem.attr('bar', 'baz');
+          elem.attr('bar');
+        }).not.toThrow();
+      });
+    });
   });
 
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -721,6 +721,18 @@ describe('jqLite', function() {
       expect(comment.attr('some-attribute','somevalue')).toEqual(comment);
       expect(comment.attr('some-attribute')).toBeUndefined();
     });
+
+    it('should remove the attribute for a null value', function() {
+      var elm = jqLite('<div attribute="value">a</div>');
+      elm.attr('attribute', null);
+      expect(elm[0].hasAttribute('attribute')).toBe(false);
+    });
+
+    it('should not remove the attribute for an empty string as a value', function() {
+      var elm = jqLite('<div attribute="value">a</div>');
+      elm.attr('attribute', '');
+      expect(elm[0].getAttribute('attribute')).toBe('');
+    });
   });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Refactors & breaking API changes.

**What is the current behavior? (You can also link to an open issue here)**
Boolean attribute getters take properties into account and setters modify them. All falsy values for boolean attribute setters remove the attribute and set the property to false. The `null` value in a setter (for all attributes, not only boolean ones) sets the attribute value to the string `"null"` instead of removing it.

**What is the new behavior (if this is a feature change)?**
Boolean attribute getters/setters don't touch properties. The `null` value in a setter (for all attributes, not only boolean ones) removes the attribute. The `false` value removes it only for boolean attributes. Other defined values for boolean attributes set the value to the lowercased attribute name.

**Does this PR introduce a breaking change?**
Yes.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~ - only in a form of commit messages with their `BREAKING CHANGES` sections; is anything else needed?

**Other information**:
