### PR TITLE
feat($anchorScroll) Allow $anchorScroll to take a numeric input

### DIFF
--- a/src/ng/anchorScroll.js
+++ b/src/ng/anchorScroll.js
@@ -238,6 +238,9 @@ function $AnchorScrollProvider() {
     }
 
     function scroll(hash) {
+      //Allow hash to be a number
+      if(isNumber(hash)) hash = hash.toString();
+        
       hash = isString(hash) ? hash : $location.hash();
       var elm;
 

--- a/src/ng/anchorScroll.js
+++ b/src/ng/anchorScroll.js
@@ -239,8 +239,8 @@ function $AnchorScrollProvider() {
 
     function scroll(hash) {
       //Allow hash to be a number
-      if(isNumber(hash)) hash = hash.toString();
-        
+      if (isNumber(hash)) hash = hash.toString();
+
       hash = isString(hash) ? hash : $location.hash();
       var elm;
 

--- a/test/ng/anchorScrollSpec.js
+++ b/test/ng/anchorScrollSpec.js
@@ -260,6 +260,18 @@ describe('$anchorScroll', function() {
         addElements('id=top'),
         callAnchorScroll('top'),
         expectScrollingTo('id=top')));
+
+
+      it('should scroll to element with id "7" if present, with a given hash of type number', inject(
+        addElements('id=7'),
+        callAnchorScroll(7),
+        expectScrollingTo('id=7')));
+
+
+      it('should scroll to element with id "7" if present, with a given hash of type string', inject(
+        addElements('id=7'),
+        callAnchorScroll('7'),
+        expectScrollingTo('id=7')));
     });
   });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature

**What is the current behavior? (You can also link to an open issue here)**

Allow $anchorScroll to take a numeric input
Ref #14680

**What is the new behavior (if this is a feature change)?**

$anchorScroll can now take a numeric input :

<div id="7">
$anchorScroll(7);

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Ref #14680

Before the change :

<div id="7">
$anchorScroll(7); Does not work

After the change :

<div id="7">
$anchorScroll(7); works
