### PR TITLE
fix(ngAnimate): allow animations when $rootElement is a comment (ng-v…

### DIFF
--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -614,6 +614,18 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       return getDomNode(nodeOrElmA) === getDomNode(nodeOrElmB);
     }
 
+    function getRootElement() {
+      var rootElement;
+      var rootElementNode = getDomNode($rootElement);
+      // if the root is a comment, like in ng-view case, we want its sibling and not the comment itself
+      if (rootElementNode.nodeType === COMMENT_NODE && rootElementNode.nextSibling) {
+          rootElement = jqLite(rootElementNode.nextSibling);
+      } else {
+        rootElement = $rootElement;
+      }
+      return rootElement;
+    }
+
     /**
      * This fn returns false if any of the following is true:
      * a) animations on any parent element are disabled, and animations on the element aren't explicitly allowed
@@ -623,8 +635,9 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
      */
     function areAnimationsAllowed(element, parentElement, event) {
       var bodyElement = jqLite($document[0].body);
+      var rootElement = getRootElement();
       var bodyElementDetected = isMatchingElement(element, bodyElement) || element[0].nodeName === 'HTML';
-      var rootElementDetected = isMatchingElement(element, $rootElement);
+      var rootElementDetected = isMatchingElement(element, rootElement);
       var parentAnimationDetected = false;
       var animateChildren;
       var elementDisabled = disabledElementsLookup.get(getDomNode(element));
@@ -640,7 +653,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
         if (!rootElementDetected) {
           // angular doesn't want to attempt to animate elements outside of the application
           // therefore we need to ensure that the rootElement is an ancestor of the current element
-          rootElementDetected = isMatchingElement(parentElement, $rootElement);
+          rootElementDetected = isMatchingElement(parentElement, rootElement);
         }
 
         if (parentElement.nodeType !== ELEMENT_NODE) {

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -841,6 +841,34 @@ describe('animations', function() {
         expect(capturedAnimation).toBeFalsy();
       }));
 
+      it('should not skip animations if the $rootElement is a comment', function() {
+
+        module(function($provide) {
+          $provide.factory('$rootElement', function() {
+            var commentElement = jqLite('<!-- A Comment -->');
+            return commentElement;
+          });
+        });
+
+        inject(function($compile, $rootScope, $document, $animate, $rootElement) {
+
+          $animate.enabled(true);
+
+          var elm1 = $compile('<div class="animated"></div>')($rootScope);
+          var rootSibling = $compile('<div class="sibling"></div>')($rootScope);
+
+          jqLite($document[0].body).append($rootElement);
+
+          $rootElement.after(rootSibling);
+          rootSibling.append(elm1);
+
+          expect(capturedAnimation).toBeFalsy();
+          $animate.addClass(elm1, 'red');
+          $rootScope.$digest();
+          expect(capturedAnimation).toBeTruthy();
+        });
+      });
+
       it('should skip the animation if the element is removed from the DOM before the post digest kicks in',
         inject(function($animate, $rootScope) {
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.

**What is the current behavior? (You can also link to an open issue here)**
Animations don't work when the root element of the app has ng-view on it.

**What is the new behavior (if this is a feature change)?**
Animations work now.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
https://jsbin.com/napenerajo/1/edit?html,js,output
See the jsbin to better understand the issue.

If the root of the app has ng-view, the $rootElement is then becoming its comment, and this lets ngAnimate think that animations should be skipped.
