### PR TITLE
Fix couple of typos in comments and docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ to make the fixes available to people that still need IE8 support._
   - secure `link[href]` as a `RESOURCE_URL`s in `$sce`
   ([f35f334b](https://github.com/angular/angular.js/commit/f35f334bd3197585bdf034f4b6d9ffa3122dac62),
    [#14687](https://github.com/angular/angular.js/issues/14687))
-  - properly sanitize `xlink:href` attribute interoplation
+  - properly sanitize `xlink:href` attribute interpolation
   ([f2fa1ed8](https://github.com/angular/angular.js/commit/f2fa1ed83d18d4e79a36f8c0db1c2524d762e513),
    [2687c261](https://github.com/angular/angular.js/commit/2687c26140585d9e3716f9f559390f5d8d598fdf))
 - **ngSanitize:** blacklist the attribute `usemap` as it can be used as a security exploit
@@ -569,7 +569,7 @@ for more info.
   - prevent assignment on constructor properties
   ([f47e2180](https://github.com/angular/angular.js/commit/f47e218006029f39b4785d820b430de3a0eebcb0),
    [#13417](https://github.com/angular/angular.js/issues/13417))
-  - preserve expensive checks when runnning `$eval` inside an expression
+  - preserve expensive checks when running `$eval` inside an expression
   ([96d62cc0](https://github.com/angular/angular.js/commit/96d62cc0fc77248d7e3ec4aa458bac0d3e072629))
   - copy `inputs` for expressions with expensive checks
   ([0b7fff30](https://github.com/angular/angular.js/commit/0b7fff303f46202bbae1ff3ca9d0e5fa76e0fc9a))
@@ -691,7 +691,7 @@ changes section for more information
   - handle boolean attributes in `@` bindings
   ([db5e0ffe](https://github.com/angular/angular.js/commit/db5e0ffe124ac588f01ef0fe79efebfa72f5eec7),
    [#13767](https://github.com/angular/angular.js/issues/13767), [#13769](https://github.com/angular/angular.js/issues/13769))
-- **$parse:** Preserve expensive checks when runnning $eval inside an expression
+- **$parse:** Preserve expensive checks when running $eval inside an expression
   ([acfda102](https://github.com/angular/angular.js/commit/acfda1022d23ecaea34bbc8931588a0715b3ab03))
 - **dateFilter:** follow the CLDR on pattern escape sequences
   ([1ab4e444](https://github.com/angular/angular.js/commit/1ab4e44443716c33cd857dcb1098d20580dbb0cc),

--- a/i18n/closure/numberSymbolsExt.js
+++ b/i18n/closure/numberSymbolsExt.js
@@ -20,7 +20,7 @@
  * using the --for_closure flag.
  * File generated from CLDR ver. 29
  *
- * This file coveres those locales that are not covered in
+ * This file covers those locales that are not covered in
  * "numberformatsymbols.js".
  *
  * Before checkin, this file could have been manually edited. This is
@@ -11836,4 +11836,3 @@ if (goog.LOCALE == 'zh_Hant_MO' || goog.LOCALE == 'zh-Hant-MO') {
 if (goog.LOCALE == 'zh_Hant_TW' || goog.LOCALE == 'zh-Hant-TW') {
   goog.i18n.NumberFormatSymbols = goog.i18n.NumberFormatSymbols_zh_Hant;
 }
-

--- a/src/ng/animate.js
+++ b/src/ng/animate.js
@@ -610,7 +610,7 @@ var $AnimateProvider = ['$provide', /** @this */ function($provide) {
        *
        * @description Performs an inline animation on the element which applies the provided to and from CSS styles to the element.
        * If any detected CSS transition, keyframe or JavaScript matches the provided className value, then the animation will take
-       * on the provided styles. For example, if a transition animation is set for the given classNamem, then the provided `from` and
+       * on the provided styles. For example, if a transition animation is set for the given className, then the provided `from` and
        * `to` styles will be applied alongside the given transition. If the CSS style provided in `from` does not have a corresponding
        * style in `to`, the style in `from` is applied immediately, and no animation is run.
        * If a JavaScript animation is detected then the provided styles will be given in as function parameters into the `animate`

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -407,7 +407,7 @@
  *          usual containers (e.g. like `<svg>`).
  *        * See also the `directive.templateNamespace` property.
  *    * `slotName`: (optional) the name of the slot to transclude. If falsy (e.g. `null`, `undefined` or `''`)
- *      then the default translusion is provided.
+ *      then the default transclusion is provided.
  *    The `$transclude` function also has a method on it, `$transclude.isSlotFilled(slotName)`, which returns
  *    `true` if the specified slot contains content (i.e. one or more DOM nodes).
  *

--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -50,7 +50,7 @@
  *
  * * `ngSwitchWhen`: the case statement to match against. If match then this
  *   case will be displayed. If the same match appears multiple times, all the
- *   elements will be displayed. It is possible to associate mutiple values to
+ *   elements will be displayed. It is possible to associate multiple values to
  *   the same `ngSwitchWhen` by defining the optional attribute
  *   `ngSwitchWhenSeparator`. The separator will be used to split the value of
  *   the `ngSwitchWhen` attribute into multiple tokens, and the element will show

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -16,7 +16,7 @@
  * String, etc).
  *
  * The `expression` can be a single predicate, or a list of predicates each serving as a tie-breaker
- * for the preceeding one. The `expression` is evaluated against each item and the output is used
+ * for the preceding one. The `expression` is evaluated against each item and the output is used
  * for comparing with other items.
  *
  * You can change the sorting order by setting `reverse` to `true`. By default, items are sorted in

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -1146,7 +1146,7 @@ function $HttpProvider() {
      *
      * @description
      * Shortcut method to perform `JSONP` request.
-     * If you would like to customise where and how the callbacks are stored then try overriding
+     * If you would like to customize where and how the callbacks are stored then try overriding
      * or decorating the {@link $jsonpCallbacks} service.
      *
      * @param {string} url Relative or absolute URL specifying the destination of the request.

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -17,14 +17,14 @@ var objectValueOf = {}.constructor.prototype.valueOf;
 
 // Sandboxing Angular Expressions
 // ------------------------------
-// Angular expressions are no longer sandboxed. So it is now even easier to access arbitary JS code by
+// Angular expressions are no longer sandboxed. So it is now even easier to access arbitrary JS code by
 // various means such as obtaining a reference to native JS functions like the Function constructor.
 //
 // As an example, consider the following Angular expression:
 //
 //   {}.toString.constructor('alert("evil JS code")')
 //
-// It is important to realise that if you create an expression from a string that contains user provided
+// It is important to realize that if you create an expression from a string that contains user provided
 // content then it is possible that your application contains a security vulnerability to an XSS style attack.
 //
 // See https://docs.angularjs.org/guide/security
@@ -1719,7 +1719,7 @@ function $ParseProvider() {
   * representation. It is expected for the function to return `true` or `false`, whether that
   * character is allowed or not.
   *
-  * Since this function will be called extensivelly, keep the implementation of these functions fast,
+  * Since this function will be called extensively, keep the implementation of these functions fast,
   * as the performance of these functions have a direct impact on the expressions parsing speed.
   *
   * @param {function=} identifierStart The function that will decide whether the given character is

--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -64,7 +64,7 @@ var jqLite;
  * By default, `ngMessages` will only display one message for a particular key/value collection at any time. If more
  * than one message (or error) key is currently true, then which message is shown is determined by the order of messages
  * in the HTML template code (messages declared first are prioritised). This mechanism means the developer does not have
- * to prioritise messages using custom JavaScript code.
+ * to prioritize messages using custom JavaScript code.
  *
  * Given the following error object for our example (which informs us that the field `myField` currently has both the
  * `required` and `email` errors):

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4331,7 +4331,7 @@ describe('$compile', function() {
               element = $compile('<c1 prop="a + b"></c1>')($rootScope);
 
               // We add this watch after the compilation to ensure that it will run after the binding watchers
-              // therefore triggering the thing that this test is hoping to enfore
+              // therefore triggering the thing that this test is hoping to enforce
               $rootScope.$watch('a', function(val) { $rootScope.b = val * 2; });
 
               expect(log).toEqual([{prop: jasmine.objectContaining({currentValue: undefined})}]);

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -3446,7 +3446,7 @@ describe('input', function() {
 
       if (supportsRange) {
         // Browsers that implement range will never allow you to set a value that doesn't match the step value
-        // However, currently only Firefox fully inplements the spec when setting the value after the step value changes.
+        // However, currently only Firefox fully implements the spec when setting the value after the step value changes.
         // Other browsers fail in various edge cases, which is why they are not tested here.
         it('should round the input value to the nearest step on user input', function() {
           var inputElm = helper.compileInput('<input type="range" ng-model="value" name="alias" step="5" />');
@@ -3750,7 +3750,7 @@ describe('input', function() {
         ['scheme-://example.com', true],
         ['scheme_://example.com', false],
 
-        // Vaidating `:` and `/` after `scheme`
+        // Validating `:` and `/` after `scheme`
         ['scheme//example.com', false],
         ['scheme:example.com', true],
         ['scheme:/example.com', true],

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -451,7 +451,7 @@ describe('Filter: orderBy', function() {
             return (isNerd1 && isNerd2) ? 0 : (isNerd1) ? -1 : 1;
           }
 
-          // No "nerd"; alpabetical order
+          // No "nerd"; alphabetical order
           return (v1 === v2) ? 0 : (v1 < v2) ? -1 : 1;
         };
 

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -26,18 +26,18 @@ describe('ngMock', function() {
 
 
     it('should fake getLocalDateString method', function() {
-      var millenium = new Date('2000').getTime();
+      var millennium = new Date('2000').getTime();
 
-      // millenium in -3h
-      var t0 = new angular.mock.TzDate(-3, millenium);
+      // millennium in -3h
+      var t0 = new angular.mock.TzDate(-3, millennium);
       expect(t0.toLocaleDateString()).toMatch('2000');
 
-      // millenium in +0h
-      var t1 = new angular.mock.TzDate(0, millenium);
+      // millennium in +0h
+      var t1 = new angular.mock.TzDate(0, millennium);
       expect(t1.toLocaleDateString()).toMatch('2000');
 
-      // millenium in +3h
-      var t2 = new angular.mock.TzDate(3, millenium);
+      // millennium in +3h
+      var t2 = new angular.mock.TzDate(3, millennium);
       expect(t2.toLocaleDateString()).toMatch('1999');
     });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This fixes couple of typos I found in the source and this mostly only affects docs and comments. There is just a single instance where a JS variable name was also updated to fix typo.

**What is the current behavior? (You can also link to an open issue here)**
No behavior changes.

**What is the new behavior (if this is a feature change)?**
No behavior changes.

**Does this PR introduce a breaking change?**
Nope.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
