### PR TITLE
Patch 14734 boolean sync validators

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -603,8 +603,7 @@ NgModelController.prototype = {
     function processSyncValidators() {
       var syncValidatorsValid = true;
       forEach(that.$validators, function(validator, name) {
-        var result = validator(modelValue, viewValue);
-        // var result = Boolean(validator(modelValue, viewValue));
+        var result = Boolean(validator(modelValue, viewValue));
         syncValidatorsValid = syncValidatorsValid && result;
         setValidity(name, result);
       });

--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -604,6 +604,7 @@ NgModelController.prototype = {
       var syncValidatorsValid = true;
       forEach(that.$validators, function(validator, name) {
         var result = validator(modelValue, viewValue);
+        // var result = Boolean(validator(modelValue, viewValue));
         syncValidatorsValid = syncValidatorsValid && result;
         setValidity(name, result);
       });

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -847,36 +847,36 @@ describe('ngModel', function() {
         expect(ctrl.$valid).toBe(true);
       });
 
-      it('should treat all responses as boolean for synchronous validators', function() {
-        var curry = function(v) {
-          return function() {
-            return v;
-          };
-        };
+      fit('should treat all responses as boolean for synchronous validators', function() {
+        // var curry = function(v) {
+        //   return function() {
+        //     return v;
+        //   };
+        // };
 
-        var tester = function(v, e) {
+        var expectValid = function(v, e) {
           ctrl.$modelValue = undefined;
-          ctrl.$validators.a = curry(v);
+          ctrl.$validators.a = valueFn(v);
 
           ctrl.$validate();
           expect(ctrl.$valid).toBe(e);
         };
 
         // False tests
-        tester(false, false);
-        tester(undefined, false);
-        tester(null, false);
-        tester(0, false);
-        tester(NaN, false);
-        tester('', false);
+        expectValid(false, false);
+        expectValid(undefined, false);
+        expectValid(null, false);
+        expectValid(0, false);
+        expectValid(NaN, false);
+        expectValid('', false);
 
         // True tests
-        tester(true, true);
-        tester(1, true);
-        tester('0', true);
-        tester('false', true);
-        tester([], true);
-        tester({}, true);
+        expectValid(true, true);
+        expectValid(1, true);
+        expectValid('0', true);
+        expectValid('false', true);
+        expectValid([], true);
+        expectValid({}, true);
       });
 
 

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -847,43 +847,7 @@ describe('ngModel', function() {
         expect(ctrl.$valid).toBe(true);
       });
 
-      // See also the test on L886.
-      fit('should demonstrate how synchronous validators work now', function() {
-        var curry = function(v) {
-          return function() {
-            return v;
-          };
-        };
-
-        var tester = function(v, e) {
-          ctrl.$modelValue = undefined;
-          ctrl.$validators.a = curry(v);
-
-          ctrl.$validate();
-          expect(ctrl.$valid).toBe(e);
-        };
-
-        // False tests
-        tester(false, false);
-        tester(undefined, undefined);
-        tester(null, true);
-        tester(0, true);
-        tester(NaN, true);
-        tester('', true);
-
-        // True tests
-        tester(true, true);
-        tester(1, true);
-        tester('0', true);
-        tester('false', true);
-        tester([], true);
-        tester({}, true);
-      });
-
-      // Flip this test with the one above (L851) as well as line L606 with L607 in `ngModel.js`
-      // The differences between the two would likely being a breaking change
-      // Though the feature it is breaking was undocumented.
-      xit('should demonstrate how synchronous validators will work after this change', function() {
+      it('should treat all responses as boolean for synchronous validators', function() {
         var curry = function(v) {
           return function() {
             return v;

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -848,18 +848,12 @@ describe('ngModel', function() {
       });
 
       it('should treat all responses as boolean for synchronous validators', function() {
-        // var curry = function(v) {
-        //   return function() {
-        //     return v;
-        //   };
-        // };
-
-        var expectValid = function(v, e) {
+        var expectValid = function(value, expected) {
           ctrl.$modelValue = undefined;
-          ctrl.$validators.a = valueFn(v);
+          ctrl.$validators.a = valueFn(value);
 
           ctrl.$validate();
-          expect(ctrl.$valid).toBe(e);
+          expect(ctrl.$valid).toBe(expected);
         };
 
         // False tests

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -847,7 +847,7 @@ describe('ngModel', function() {
         expect(ctrl.$valid).toBe(true);
       });
 
-      fit('should treat all responses as boolean for synchronous validators', function() {
+      it('should treat all responses as boolean for synchronous validators', function() {
         // var curry = function(v) {
         //   return function() {
         //     return v;

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -847,6 +847,74 @@ describe('ngModel', function() {
         expect(ctrl.$valid).toBe(true);
       });
 
+      // See also the test on L886.
+      fit('should demonstrate how synchronous validators work now', function() {
+        var curry = function(v) {
+          return function() {
+            return v;
+          };
+        };
+
+        var tester = function(v, e) {
+          ctrl.$modelValue = undefined;
+          ctrl.$validators.a = curry(v);
+
+          ctrl.$validate();
+          expect(ctrl.$valid).toBe(e);
+        };
+
+        // False tests
+        tester(false, false);
+        tester(undefined, undefined);
+        tester(null, true);
+        tester(0, true);
+        tester(NaN, true);
+        tester('', true);
+
+        // True tests
+        tester(true, true);
+        tester(1, true);
+        tester('0', true);
+        tester('false', true);
+        tester([], true);
+        tester({}, true);
+      });
+
+      // Flip this test with the one above (L851) as well as line L606 with L607 in `ngModel.js`
+      // The differences between the two would likely being a breaking change
+      // Though the feature it is breaking was undocumented.
+      xit('should demonstrate how synchronous validators will work after this change', function() {
+        var curry = function(v) {
+          return function() {
+            return v;
+          };
+        };
+
+        var tester = function(v, e) {
+          ctrl.$modelValue = undefined;
+          ctrl.$validators.a = curry(v);
+
+          ctrl.$validate();
+          expect(ctrl.$valid).toBe(e);
+        };
+
+        // False tests
+        tester(false, false);
+        tester(undefined, false);
+        tester(null, false);
+        tester(0, false);
+        tester(NaN, false);
+        tester('', false);
+
+        // True tests
+        tester(true, true);
+        tester(1, true);
+        tester('0', true);
+        tester('false', true);
+        tester([], true);
+        tester({}, true);
+      });
+
 
       it('should register invalid validations on the $error object', function() {
         var curry = function(v) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fix/clarification of how synchronous validators work.

**What is the current behavior? (You can also link to an open issue here)**
#14734 All values except `false` literal and `undefined` are treated as a pass. `undefined` is treated as pending, which makes no sense for synchronous operation.

**What is the new behavior (if this is a feature change)?**

All falsy value returns to a synchronous validator are treated as fails, including `undefined`.

**Does this PR introduce a breaking change?**

Yes, see commit message.

**Please check if the PR fulfills these requirements**
- [ x ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

I believe a change to docs in unnecessary. We still expect `true` and `false` to be the primary returns and don't want to encourage otherwise. This is mostly clarifying a niche, undocumented, edge-case to behave more intuitively.
