### PR TITLE
fix($q): treat thrown errors as regular rejections

### DIFF
--- a/lib/promises-aplus/promises-aplus-test-adapter.js
+++ b/lib/promises-aplus/promises-aplus-test-adapter.js
@@ -9,21 +9,21 @@
  minErr,
  extend
 */
+
 /* eslint-disable no-unused-vars */
+function isFunction(value) { return typeof value === 'function'; }
+function isPromiseLike(obj) { return obj && isFunction(obj.then); }
+function isObject(value) { return value !== null && typeof value === 'object'; }
+function isUndefined(value) { return typeof value === 'undefined'; }
 
-var isFunction = function isFunction(value) {return typeof value === 'function';};
-var isPromiseLike = function isPromiseLike(obj) {return obj && isFunction(obj.then);};
-var isObject = function isObject(value) {return value != null && typeof value === 'object';};
-var isUndefined = function isUndefined(value) {return typeof value === 'undefined';};
-
-var minErr = function minErr(module, constructor) {
+function minErr(module, constructor) {
   return function() {
     var ErrorConstructor = constructor || Error;
     throw new ErrorConstructor(module + arguments[0] + arguments[1]);
   };
-};
+}
 
-var extend = function extend(dst) {
+function extend(dst) {
   for (var i = 1, ii = arguments.length; i < ii; i++) {
     var obj = arguments[i];
     if (obj) {
@@ -35,18 +35,11 @@ var extend = function extend(dst) {
     }
   }
   return dst;
-};
+}
+/* eslint-enable */
 
 var $q = qFactory(process.nextTick, function noopExceptionHandler() {});
 
 exports.resolved = $q.resolve;
 exports.rejected = $q.reject;
-exports.deferred = function() {
-    var deferred = $q.defer();
-
-    return {
-        promise: deferred.promise,
-        resolve: deferred.resolve,
-        reject: deferred.reject
-    };
-};
+exports.deferred = $q.defer;

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3052,8 +3052,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
       $compileNode.empty();
 
-      $templateRequest(templateUrl).
-        then(function(content) {
+      $templateRequest(templateUrl)
+        .then(function(content) {
           var compileNode, tempTemplateAttrs, $template, childBoundTranscludeFn;
 
           content = denormalizeTemplate(content);
@@ -3131,13 +3131,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               childBoundTranscludeFn);
           }
           linkQueue = null;
-        }).
-        catch(function(error) {
+        }).catch(function(error) {
           if (error instanceof Error) {
             $exceptionHandler(error);
           }
-        }).
-        catch(noop);
+        }).catch(noop);
 
       return function delayedNodeLinkFn(ignoreChildLinkFn, scope, node, rootElement, boundTranscludeFn) {
         var childBoundTranscludeFn = boundTranscludeFn;

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3052,8 +3052,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
       $compileNode.empty();
 
-      $templateRequest(templateUrl)
-        .then(function(content) {
+      $templateRequest(templateUrl).
+        then(function(content) {
           var compileNode, tempTemplateAttrs, $template, childBoundTranscludeFn;
 
           content = denormalizeTemplate(content);
@@ -3131,7 +3131,13 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               childBoundTranscludeFn);
           }
           linkQueue = null;
-        }).catch(noop);
+        }).
+        catch(function(error) {
+          if (error instanceof Error) {
+            $exceptionHandler(error);
+          }
+        }).
+        catch(noop);
 
       return function delayedNodeLinkFn(ignoreChildLinkFn, scope, node, rootElement, boundTranscludeFn) {
         var childBoundTranscludeFn = boundTranscludeFn;

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -9,8 +9,8 @@
  * A service that helps you run functions asynchronously, and use their return values (or exceptions)
  * when they are done processing.
  *
- * This is an implementation of promises/deferred objects inspired by
- * [Kris Kowal's Q](https://github.com/kriskowal/q).
+ * This is a [Promises/A+](https://promisesaplus.com/)-compliant implementation of promises/deferred
+ * objects inspired by [Kris Kowal's Q](https://github.com/kriskowal/q).
  *
  * $q can be used in two fashions --- one which is more similar to Kris Kowal's Q or jQuery's Deferred
  * implementations, and the other which resembles ES6 (ES2015) promises to some degree.
@@ -366,7 +366,6 @@ function qFactory(nextTick, exceptionHandler, errorOnUnhandledRejections) {
           }
         } catch (e) {
           deferred.reject(e);
-          exceptionHandler(e);
         }
       }
     } finally {
@@ -417,18 +416,15 @@ function qFactory(nextTick, exceptionHandler, errorOnUnhandledRejections) {
       } else {
         this.$$resolve(val);
       }
-
     },
 
     $$resolve: function(val) {
-      var then;
       var that = this;
       var done = false;
       try {
-        if ((isObject(val) || isFunction(val))) then = val && val.then;
-        if (isFunction(then)) {
+        if ((isObject(val) || isFunction(val)) && isFunction(val.then)) {
           this.promise.$$state.status = -1;
-          then.call(val, resolvePromise, rejectPromise, simpleBind(this, this.notify));
+          val.then(resolvePromise, rejectPromise, simpleBind(this, this.notify));
         } else {
           this.promise.$$state.value = val;
           this.promise.$$state.status = 1;
@@ -436,7 +432,6 @@ function qFactory(nextTick, exceptionHandler, errorOnUnhandledRejections) {
         }
       } catch (e) {
         rejectPromise(e);
-        exceptionHandler(e);
       }
 
       function resolvePromise(val) {

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -419,12 +419,14 @@ function qFactory(nextTick, exceptionHandler, errorOnUnhandledRejections) {
     },
 
     $$resolve: function(val) {
+      var then;
       var that = this;
       var done = false;
       try {
-        if ((isObject(val) || isFunction(val)) && isFunction(val.then)) {
+        if (isObject(val) || isFunction(val)) then = val.then;
+        if (isFunction(then)) {
           this.promise.$$state.status = -1;
-          val.then(resolvePromise, rejectPromise, simpleBind(this, this.notify));
+          then.call(val, resolvePromise, rejectPromise, simpleBind(this, this.notify));
         } else {
           this.promise.$$state.value = val;
           this.promise.$$state.status = 1;

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1941,7 +1941,7 @@ describe('$http', function() {
 
 
       it('should increment/decrement `outstandingRequestCount` on error in `transformRequest`',
-        inject(function($exceptionHandler) {
+        function() {
           expect(incOutstandingRequestCountSpy).not.toHaveBeenCalled();
           expect(completeOutstandingRequestSpy).not.toHaveBeenCalled();
 
@@ -1954,15 +1954,12 @@ describe('$http', function() {
 
           expect(incOutstandingRequestCountSpy).toHaveBeenCalledOnce();
           expect(completeOutstandingRequestSpy).toHaveBeenCalledOnce();
-
-          expect($exceptionHandler.errors).toEqual([jasmine.any(Error)]);
-          $exceptionHandler.errors = [];
-        })
+        }
       );
 
 
       it('should increment/decrement `outstandingRequestCount` on error in `transformResponse`',
-        inject(function($exceptionHandler) {
+        function() {
           expect(incOutstandingRequestCountSpy).not.toHaveBeenCalled();
           expect(completeOutstandingRequestSpy).not.toHaveBeenCalled();
 
@@ -1976,10 +1973,7 @@ describe('$http', function() {
 
           expect(incOutstandingRequestCountSpy).toHaveBeenCalledOnce();
           expect(completeOutstandingRequestSpy).toHaveBeenCalledOnce();
-
-          expect($exceptionHandler.errors).toEqual([jasmine.any(Error)]);
-          $exceptionHandler.errors = [];
-        })
+        }
       );
     });
 

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -2077,13 +2077,13 @@ describe('q', function() {
 
 
     describe('in then', function() {
-      it('should log exceptions thrown in a success callback and reject the derived promise',
+      it('should NOT log exceptions thrown in a success callback but reject the derived promise',
           function() {
         var success1 = success(1, 'oops', true);
         promise.then(success1).then(success(2), error(2)).catch(noop);
         syncResolve(deferred, 'done');
         expect(logStr()).toBe('success1(done)->throw(oops); error2(oops)->reject(oops)');
-        expect(mockExceptionLogger.log).toEqual(['oops']);
+        expect(mockExceptionLogger.log).toEqual([]);
       });
 
 
@@ -2095,12 +2095,13 @@ describe('q', function() {
       });
 
 
-      it('should log exceptions thrown in a errback and reject the derived promise', function() {
+      it('should NOT log exceptions thrown in an errback but reject the derived promise',
+          function() {
         var error1 = error(1, 'oops', true);
         promise.then(null, error1).then(success(2), error(2)).catch(noop);
         syncReject(deferred, 'nope');
         expect(logStr()).toBe('error1(nope)->throw(oops); error2(oops)->reject(oops)');
-        expect(mockExceptionLogger.log).toEqual(['oops']);
+        expect(mockExceptionLogger.log).toEqual([]);
       });
 
 
@@ -2127,13 +2128,13 @@ describe('q', function() {
 
 
     describe('in when', function() {
-      it('should log exceptions thrown in a success callback and reject the derived promise',
+      it('should NOT log exceptions thrown in a success callback but reject the derived promise',
           function() {
         var success1 = success(1, 'oops', true);
         q.when('hi', success1, error()).then(success(), error(2)).catch(noop);
         mockNextTick.flush();
         expect(logStr()).toBe('success1(hi)->throw(oops); error2(oops)->reject(oops)');
-        expect(mockExceptionLogger.log).toEqual(['oops']);
+        expect(mockExceptionLogger.log).toEqual([]);
       });
 
 
@@ -2145,12 +2146,12 @@ describe('q', function() {
       });
 
 
-      it('should log exceptions thrown in a errback and reject the derived promise', function() {
+      it('should NOT log exceptions thrown in a errback but reject the derived promise', function() {
         var error1 = error(1, 'oops', true);
         q.when(q.reject('sorry'), success(), error1).then(success(), error(2)).catch(noop);
         mockNextTick.flush();
         expect(logStr()).toBe('error1(sorry)->throw(oops); error2(oops)->reject(oops)');
-        expect(mockExceptionLogger.log).toEqual(['oops']);
+        expect(mockExceptionLogger.log).toEqual([]);
       });
 
 
@@ -2205,52 +2206,6 @@ describe('q', function() {
       defer.resolve(q.reject('foo'));
       mockNextTick.flush();
       expect(exceptionHandlerStr()).toBe('');
-    });
-  });
-
-
-  describe('when exceptionHandler rethrows exceptions, ', function() {
-    var originalLogExceptions, deferred, errorSpy, exceptionExceptionSpy;
-
-    beforeEach(function() {
-      // Turn off exception logging for these particular tests
-      originalLogExceptions = mockNextTick.logExceptions;
-      mockNextTick.logExceptions = false;
-
-      // Set up spies
-      exceptionExceptionSpy = jasmine.createSpy('rethrowExceptionHandler')
-      .and.callFake(function rethrowExceptionHandler(e) {
-        throw e;
-      });
-      errorSpy = jasmine.createSpy('errorSpy');
-
-
-      q = qFactory(mockNextTick.nextTick, exceptionExceptionSpy);
-      deferred = q.defer();
-    });
-
-
-    afterEach(function() {
-      // Restore the original exception logging mode
-      mockNextTick.logExceptions = originalLogExceptions;
-    });
-
-
-    it('should still reject the promise, when exception is thrown in success handler, even if exceptionHandler rethrows', function() {
-      deferred.promise.then(function() { throw new Error('reject'); }).then(null, errorSpy);
-      deferred.resolve('resolve');
-      mockNextTick.flush();
-      expect(exceptionExceptionSpy).toHaveBeenCalled();
-      expect(errorSpy).toHaveBeenCalled();
-    });
-
-
-    it('should still reject the promise, when exception is thrown in error handler, even if exceptionHandler rethrows', function() {
-      deferred.promise.then(null, function() { throw new Error('reject again'); }).then(null, errorSpy);
-      deferred.reject('reject');
-      mockNextTick.flush();
-      expect(exceptionExceptionSpy).toHaveBeenCalled();
-      expect(errorSpy).toHaveBeenCalled();
     });
   });
 });

--- a/test/ng/templateRequestSpec.js
+++ b/test/ng/templateRequestSpec.js
@@ -114,47 +114,59 @@ describe('$templateRequest', function() {
     expect($templateCache.get('tpl.html')).toBe('matias');
   }));
 
-  it('should throw an error when the template is not found',
-    inject(function($exceptionHandler, $httpBackend, $rootScope, $templateRequest) {
-      $httpBackend.expectGET('tpl.html').respond(404, '', {}, 'Not found');
+  it('should call `$exceptionHandler` on request error', function() {
+    module(function($exceptionHandlerProvider) {
+      $exceptionHandlerProvider.mode('log');
+    });
 
-      $templateRequest('tpl.html').catch(noop);
-      $httpBackend.flush();
-
-      expect($exceptionHandler.errors[0].message).toMatch(new RegExp(
-          '^\\[\\$compile:tpload] Failed to load template: tpl\\.html ' +
-          '\\(HTTP status: 404 Not found\\)'));
-    })
-  );
-
-  it('should not throw when the template is not found and ignoreRequestError is true',
-    inject(function($rootScope, $templateRequest, $httpBackend) {
-
-      $httpBackend.expectGET('tpl.html').respond(404);
+    inject(function($exceptionHandler, $httpBackend, $templateRequest) {
+      $httpBackend.expectGET('tpl.html').respond(404, '', {}, 'Not Found');
 
       var err;
-      $templateRequest('tpl.html', true).catch(function(reason) { err = reason; });
+      $templateRequest('tpl.html').catch(function(reason) { err = reason; });
+      $httpBackend.flush();
 
+      expect(err.message).toMatch(new RegExp(
+          '^\\[\\$compile:tpload] Failed to load template: tpl\\.html ' +
+          '\\(HTTP status: 404 Not Found\\)'));
+      expect($exceptionHandler.errors[0].message).toMatch(new RegExp(
+          '^\\[\\$compile:tpload] Failed to load template: tpl\\.html ' +
+          '\\(HTTP status: 404 Not Found\\)'));
+    });
+  });
+
+  it('should not call `$exceptionHandler` on request error when `ignoreRequestError` is true',
+    function() {
+      module(function($exceptionHandlerProvider) {
+        $exceptionHandlerProvider.mode('log');
+      });
+
+      inject(function($exceptionHandler, $httpBackend, $templateRequest) {
+        $httpBackend.expectGET('tpl.html').respond(404);
+
+        var err;
+        $templateRequest('tpl.html', true).catch(function(reason) { err = reason; });
+        $httpBackend.flush();
+
+        expect(err.status).toBe(404);
+        expect($exceptionHandler.errors).toEqual([]);
+      });
+    }
+  );
+
+  it('should not call `$exceptionHandler` when the template is empty',
+    inject(function($exceptionHandler, $httpBackend, $rootScope, $templateRequest) {
+      $httpBackend.expectGET('tpl.html').respond('');
+
+      var onError = jasmine.createSpy('onError');
+      $templateRequest('tpl.html').catch(onError);
       $rootScope.$digest();
       $httpBackend.flush();
 
-      expect(err.status).toBe(404);
-  }));
-
-  it('should not throw an error when the template is empty',
-    inject(function($rootScope, $templateRequest, $httpBackend) {
-
-    $httpBackend.expectGET('tpl.html').respond('');
-
-    $templateRequest('tpl.html');
-
-    $rootScope.$digest();
-
-    expect(function() {
-      $rootScope.$digest();
-      $httpBackend.flush();
-    }).not.toThrow();
-  }));
+      expect(onError).not.toHaveBeenCalled();
+      expect($exceptionHandler.errors).toEqual([]);
+    })
+  );
 
   it('should accept empty templates and refuse null or undefined templates in cache',
     inject(function($rootScope, $templateRequest, $templateCache, $sce) {

--- a/test/ng/templateRequestSpec.js
+++ b/test/ng/templateRequestSpec.js
@@ -115,19 +115,17 @@ describe('$templateRequest', function() {
   }));
 
   it('should throw an error when the template is not found',
-    inject(function($rootScope, $templateRequest, $httpBackend) {
+    inject(function($exceptionHandler, $httpBackend, $rootScope, $templateRequest) {
+      $httpBackend.expectGET('tpl.html').respond(404, '', {}, 'Not found');
 
-    $httpBackend.expectGET('tpl.html').respond(404, '', {}, 'Not found');
-
-    $templateRequest('tpl.html');
-
-    $rootScope.$digest();
-
-    expect(function() {
-      $rootScope.$digest();
+      $templateRequest('tpl.html').catch(noop);
       $httpBackend.flush();
-    }).toThrowMinErr('$compile', 'tpload', 'Failed to load template: tpl.html (HTTP status: 404 Not found)');
-  }));
+
+      expect($exceptionHandler.errors[0].message).toMatch(new RegExp(
+          '^\\[\\$compile:tpload] Failed to load template: tpl\\.html ' +
+          '\\(HTTP status: 404 Not found\\)'));
+    })
+  );
 
   it('should not throw when the template is not found and ignoreRequestError is true',
     inject(function($rootScope, $templateRequest, $httpBackend) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Refactor/Fix (depending on your point of view).

**What is the current behavior? (You can also link to an open issue here)**
Errors thrown in a promise's `onFulfilled` or `onRejected` handlers are treated in a
slightly different manner than regular rejections:  
They are passed to the `$exceptionHandler()` (in addition to being converted to rejections).
See also #3174 and #14745.

**What is the new behavior (if this is a feature change)?**
The distinction is removed, by skipping the call to `$exceptionHandler()`, thus treating
thrown errors as regular rejections.

**Does this PR introduce a breaking change?**
Yes.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Previously, errors thrown in a promise's `onFulfilled` or `onRejected` handlers were treated in a
slightly different manner than regular rejections:
They were passed to the `$exceptionHandler()` (in addition to being converted to rejections).

The reasoning for this behavior was that an uncaught error is different than a regular rejection, as
it can be caused by a programming error, for example. In practice, this turned out to be confusing
or undesirable for users, since neither native promises nor any other popular promise library
distinguishes thrown errors from regular rejections.
(Note: While this behavior does not go against the Promises/A+ spec, it is not prescribed either.)

This commit removes the distinction, by skipping the call to `$exceptionHandler()`, thus treating
thrown errors as regular rejections.

**Note:**
Unless explicitly turned off, possibly unhandled rejections will still be caught and passed to the
`$exceptionHandler()`, so errors thrown due to programming errors and not otherwise handled (with a
subsequent `onRejected` handler) will not go unnoticed.

BREAKING CHANGE:

Previously, throwing an error from a promise's `onFulfilled` or `onRejection` handlers, would result
in passing the error to the `$exceptionHandler()` (in addition to rejecting the promise with the
error as reason).

Now, a thrown error is treated exactly the same as a regular rejection. This applies to all
services/controllers/filters etc that rely on `$q` (including built-in services, such as `$http` and
`$route`). For example, `$http`'s `transformRequest/Response` functions or a route's `redirectTo`
function as well as functions specified in a route's `resolve` object, will no longer result in a
call to `$exceptionHandler()` if they throw an error. Other than that, everything will continue to
behave in the same way; i.e. the promises will be rejected, route transition will be cancelled,
`$routeChangeError` events will be broadcasted etc.

Fixes #3174
Fixes #14745
