### PR TITLE
chore(grunt): add SRI file to build output

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -311,6 +311,17 @@ module.exports = function(grunt) {
         createTag: false,
         push: false
       }
+    },
+
+    sri: {
+      modules: {
+        options: {
+          dest: 'build/sri.json'
+        },
+        src: [
+          'build/*.js'
+        ]
+      }
     }
   });
 
@@ -338,7 +349,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('minify', ['bower', 'clean', 'build', 'minall']);
   grunt.registerTask('webserver', ['connect:devserver']);
-  grunt.registerTask('package', ['bower', 'validate-angular-files', 'clean', 'buildall', 'minall', 'collect-errors', 'docs', 'copy', 'write', 'compress']);
+  grunt.registerTask('package', ['bower', 'validate-angular-files', 'clean', 'buildall', 'minall', 'collect-errors', 'docs', 'copy', 'write', 'compress', 'sri']);
   grunt.registerTask('ci-checks', ['ddescribe-iit', 'merge-conflict', 'eslint']);
   grunt.registerTask('default', ['package']);
 };

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "grunt-eslint": "^19.0.0",
     "grunt-merge-conflict": "~0.0.1",
     "grunt-shell": "^1.3.0",
+    "grunt-sri": "0.0.5",
     "gulp": "~3.8.0",
     "gulp-concat": "^2.4.1",
     "gulp-eslint": "^3.0.1",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

chore

**What is the current behavior? (You can also link to an open issue here)**

no SRI

**What is the new behavior (if this is a feature change)?**

SRI info stored in the `build/sri.json` file

**Does this PR introduce a breaking change?**

Nope

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Related to #13968
- needs some docs
- good to see if we could use the SRI info in the docs application
