### PR TITLE
ngClass[Odd/Even] overhaul

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -15,14 +15,12 @@ function classDirective(name, selector) {
       link: function(scope, element, attr) {
         var oldVal;
 
-        scope.$watch(attr[name], ngClassWatchAction, true);
-
         if (name !== 'ngClass') {
           scope.$watch('$index', function($index, old$index) {
             /* eslint-disable no-bitwise */
             var mod = $index & 1;
             if (mod !== (old$index & 1)) {
-              var classes = arrayClasses(scope.$eval(attr[name]));
+              var classes = arrayClasses(oldVal);
               if (mod === selector) {
                 addClasses(classes);
               } else {
@@ -32,6 +30,8 @@ function classDirective(name, selector) {
             /* eslint-enable */
           });
         }
+
+        scope.$watch(attr[name], ngClassWatchAction, true);
 
         function addClasses(classes) {
           var newClasses = digestClassCounts(classes, 1);

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -97,41 +97,42 @@ function classDirective(name, selector) {
         }
       }
     };
-
-    function arrayDifference(tokens1, tokens2) {
-      var values = [];
-
-      outer:
-      for (var i = 0; i < tokens1.length; i++) {
-        var token = tokens1[i];
-        for (var j = 0; j < tokens2.length; j++) {
-          if (token === tokens2[j]) continue outer;
-        }
-        values.push(token);
-      }
-      return values;
-    }
-
-    function arrayClasses(classVal) {
-      var classes = [];
-      if (isArray(classVal)) {
-        forEach(classVal, function(v) {
-          classes = classes.concat(arrayClasses(v));
-        });
-        return classes;
-      } else if (isString(classVal)) {
-        return classVal.split(' ');
-      } else if (isObject(classVal)) {
-        forEach(classVal, function(v, k) {
-          if (v) {
-            classes = classes.concat(k.split(' '));
-          }
-        });
-        return classes;
-      }
-      return classVal;
-    }
   }];
+
+  // Helpers
+  function arrayDifference(tokens1, tokens2) {
+    var values = [];
+
+    outer:
+    for (var i = 0; i < tokens1.length; i++) {
+      var token = tokens1[i];
+      for (var j = 0; j < tokens2.length; j++) {
+        if (token === tokens2[j]) continue outer;
+      }
+      values.push(token);
+    }
+    return values;
+  }
+
+  function arrayClasses(classVal) {
+    var classes = [];
+    if (isArray(classVal)) {
+      forEach(classVal, function(v) {
+        classes = classes.concat(arrayClasses(v));
+      });
+      return classes;
+    } else if (isString(classVal)) {
+      return classVal.split(' ');
+    } else if (isObject(classVal)) {
+      forEach(classVal, function(v, k) {
+        if (v) {
+          classes = classes.concat(k.split(' '));
+        }
+      });
+      return classes;
+    }
+    return classVal;
+  }
 }
 
 /**

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -17,11 +17,6 @@ function classDirective(name, selector) {
 
         scope.$watch(attr[name], ngClassWatchAction, true);
 
-        attr.$observe('class', function(value) {
-          ngClassWatchAction(scope.$eval(attr[name]));
-        });
-
-
         if (name !== 'ngClass') {
           scope.$watch('$index', function($index, old$index) {
             /* eslint-disable no-bitwise */

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -14,6 +14,7 @@ function classDirective(name, selector) {
       restrict: 'AC',
       link: function(scope, element, attr) {
         var classCounts = element.data('$classCounts');
+        var oldModulo = true;
         var oldVal;
 
         if (!classCounts) {
@@ -24,18 +25,20 @@ function classDirective(name, selector) {
         }
 
         if (name !== 'ngClass') {
-          scope.$watch('$index', function($index, old$index) {
-            /* eslint-disable no-bitwise */
-            var mod = $index & 1;
-            if (mod !== (old$index & 1)) {
+          scope.$watch('$index', function($index) {
+            // eslint-disable-next-line no-bitwise
+            var newModulo = $index & 1;
+
+            if (newModulo !== oldModulo) {
               var classes = arrayClasses(oldVal);
-              if (mod === selector) {
+              if (newModulo === selector) {
                 addClasses(classes);
               } else {
                 removeClasses(classes);
               }
+
+              oldModulo = newModulo;
             }
-            /* eslint-enable */
           });
         }
 
@@ -77,8 +80,7 @@ function classDirective(name, selector) {
         }
 
         function ngClassWatchAction(newVal) {
-          // eslint-disable-next-line no-bitwise
-          if (selector === true || (scope.$index & 1) === selector) {
+          if (oldModulo === selector) {
             var newClasses = arrayClasses(newVal || []);
             if (!oldVal) {
               addClasses(newClasses);

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -8,7 +8,8 @@
 
 function classDirective(name, selector) {
   name = 'ngClass' + name;
-  return ['$animate', function($animate) {
+
+  return [function() {
     return {
       restrict: 'AC',
       link: function(scope, element, attr) {
@@ -69,12 +70,9 @@ function classDirective(name, selector) {
           var toRemove = arrayDifference(oldClasses, newClasses);
           toAdd = digestClassCounts(toAdd, 1);
           toRemove = digestClassCounts(toRemove, -1);
-          if (toAdd && toAdd.length) {
-            $animate.addClass(element, toAdd);
-          }
-          if (toRemove && toRemove.length) {
-            $animate.removeClass(element, toRemove);
-          }
+
+          attr.$addClass(toAdd);
+          attr.$removeClass(toRemove);
         }
 
         function ngClassWatchAction(newVal) {

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -9,13 +9,20 @@
 function classDirective(name, selector) {
   name = 'ngClass' + name;
 
-  return [function() {
+  return ['$parse', function($parse) {
     return {
       restrict: 'AC',
       link: function(scope, element, attr) {
+        var expression = attr[name].trim();
+        var isOneTime = (expression.charAt(0) === ':') && (expression.charAt(1) === ':');
+
+        var watchInterceptor = isOneTime ? toFlatValue : toClassString;
+        var watchExpression = $parse(expression, watchInterceptor);
+        var watchAction = isOneTime ? ngClassOneTimeWatchAction : ngClassWatchAction;
+
         var classCounts = element.data('$classCounts');
         var oldModulo = true;
-        var oldVal;
+        var oldClassString;
 
         if (!classCounts) {
           // Use createMap() to prevent class assumptions involving property
@@ -30,11 +37,10 @@ function classDirective(name, selector) {
             var newModulo = $index & 1;
 
             if (newModulo !== oldModulo) {
-              var classes = arrayClasses(oldVal);
               if (newModulo === selector) {
-                addClasses(classes);
+                addClasses(oldClassString);
               } else {
-                removeClasses(classes);
+                removeClasses(oldClassString);
               }
 
               oldModulo = newModulo;
@@ -42,22 +48,36 @@ function classDirective(name, selector) {
           });
         }
 
-        scope.$watch(attr[name], ngClassWatchAction, true);
+        scope.$watch(watchExpression, watchAction, isOneTime);
 
-        function addClasses(classes) {
-          var newClasses = digestClassCounts(classes, 1);
-          attr.$addClass(newClasses);
+        function addClasses(classString) {
+          classString = digestClassCounts(split(classString), 1);
+          attr.$addClass(classString);
         }
 
-        function removeClasses(classes) {
-          var newClasses = digestClassCounts(classes, -1);
-          attr.$removeClass(newClasses);
+        function removeClasses(classString) {
+          classString = digestClassCounts(split(classString), -1);
+          attr.$removeClass(classString);
         }
 
-        function digestClassCounts(classes, count) {
+        function updateClasses(oldClassString, newClassString) {
+          var oldClassArray = split(oldClassString);
+          var newClassArray = split(newClassString);
+
+          var toRemoveArray = arrayDifference(oldClassArray, newClassArray);
+          var toAddArray = arrayDifference(newClassArray, oldClassArray);
+
+          var toRemoveString = digestClassCounts(toRemoveArray, -1);
+          var toAddString = digestClassCounts(toAddArray, 1);
+
+          attr.$addClass(toAddString);
+          attr.$removeClass(toRemoveString);
+        }
+
+        function digestClassCounts(classArray, count) {
           var classesToUpdate = [];
 
-          forEach(classes, function(className) {
+          forEach(classArray, function(className) {
             if (count > 0 || classCounts[className]) {
               classCounts[className] = (classCounts[className] || 0) + count;
               if (classCounts[className] === +(count > 0)) {
@@ -69,31 +89,20 @@ function classDirective(name, selector) {
           return classesToUpdate.join(' ');
         }
 
-        function updateClasses(oldClasses, newClasses) {
-          var toAdd = arrayDifference(newClasses, oldClasses);
-          var toRemove = arrayDifference(oldClasses, newClasses);
-          toAdd = digestClassCounts(toAdd, 1);
-          toRemove = digestClassCounts(toRemove, -1);
+        function ngClassOneTimeWatchAction(newClassValue) {
+          var newClassString = toClassString(newClassValue);
 
-          attr.$addClass(toAdd);
-          attr.$removeClass(toRemove);
+          if (newClassString !== oldClassString) {
+            ngClassWatchAction(newClassString);
+          }
         }
 
-        function ngClassWatchAction(newVal) {
+        function ngClassWatchAction(newClassString) {
           if (oldModulo === selector) {
-            var newClasses = arrayClasses(newVal || []);
-            if (!oldVal) {
-              addClasses(newClasses);
-            } else if (!equals(newVal,oldVal)) {
-              var oldClasses = arrayClasses(oldVal);
-              updateClasses(oldClasses, newClasses);
-            }
+            updateClasses(oldClassString, newClassString);
           }
-          if (isArray(newVal)) {
-            oldVal = newVal.map(function(v) { return shallowCopy(v); });
-          } else {
-            oldVal = shallowCopy(newVal);
-          }
+
+          oldClassString = newClassString;
         }
       }
     };
@@ -118,24 +127,50 @@ function classDirective(name, selector) {
     return values;
   }
 
-  function arrayClasses(classVal) {
-    var classes = [];
-    if (isArray(classVal)) {
-      forEach(classVal, function(v) {
-        classes = classes.concat(arrayClasses(v));
-      });
-      return classes;
-    } else if (isString(classVal)) {
-      return classVal.split(' ');
-    } else if (isObject(classVal)) {
-      forEach(classVal, function(v, k) {
-        if (v) {
-          classes = classes.concat(k.split(' '));
-        }
-      });
-      return classes;
+  function split(classString) {
+    return classString && classString.split(' ');
+  }
+
+  function toClassString(classValue) {
+    var classString = classValue;
+
+    if (isArray(classValue)) {
+      classString = classValue.map(toClassString).join(' ');
+    } else if (isObject(classValue)) {
+      classString = Object.keys(classValue).
+        filter(function(key) { return classValue[key]; }).
+        join(' ');
     }
-    return classVal;
+
+    return classString;
+  }
+
+  function toFlatValue(classValue) {
+    var flatValue = classValue;
+
+    if (isArray(classValue)) {
+      flatValue = classValue.map(toFlatValue);
+    } else if (isObject(classValue)) {
+      var hasUndefined = false;
+
+      flatValue = Object.keys(classValue).filter(function(key) {
+        var value = classValue[key];
+
+        if (!hasUndefined && isUndefined(value)) {
+          hasUndefined = true;
+        }
+
+        return value;
+      });
+
+      if (hasUndefined) {
+        // Prevent the `oneTimeLiteralWatchInterceptor` from unregistering
+        // the watcher, by including at least one `undefined` value.
+        flatValue.push(undefined);
+      }
+    }
+
+    return flatValue;
   }
 }
 

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -101,6 +101,9 @@ function classDirective(name, selector) {
 
   // Helpers
   function arrayDifference(tokens1, tokens2) {
+    if (!tokens1 || !tokens1.length) return [];
+    if (!tokens2 || !tokens2.length) return tokens1;
+
     var values = [];
 
     outer:
@@ -111,6 +114,7 @@ function classDirective(name, selector) {
       }
       values.push(token);
     }
+
     return values;
   }
 

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -13,7 +13,15 @@ function classDirective(name, selector) {
     return {
       restrict: 'AC',
       link: function(scope, element, attr) {
+        var classCounts = element.data('$classCounts');
         var oldVal;
+
+        if (!classCounts) {
+          // Use createMap() to prevent class assumptions involving property
+          // names in Object.prototype
+          classCounts = createMap();
+          element.data('$classCounts', classCounts);
+        }
 
         if (name !== 'ngClass') {
           scope.$watch('$index', function($index, old$index) {
@@ -44,10 +52,8 @@ function classDirective(name, selector) {
         }
 
         function digestClassCounts(classes, count) {
-          // Use createMap() to prevent class assumptions involving property
-          // names in Object.prototype
-          var classCounts = element.data('$classCounts') || createMap();
           var classesToUpdate = [];
+
           forEach(classes, function(className) {
             if (count > 0 || classCounts[className]) {
               classCounts[className] = (classCounts[className] || 0) + count;
@@ -56,7 +62,7 @@ function classDirective(name, selector) {
               }
             }
           });
-          element.data('$classCounts', classCounts);
+
           return classesToUpdate.join(' ');
         }
 

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -32,20 +32,7 @@ function classDirective(name, selector) {
         }
 
         if (name !== 'ngClass') {
-          scope.$watch('$index', function($index) {
-            // eslint-disable-next-line no-bitwise
-            var newModulo = $index & 1;
-
-            if (newModulo !== oldModulo) {
-              if (newModulo === selector) {
-                addClasses(oldClassString);
-              } else {
-                removeClasses(oldClassString);
-              }
-
-              oldModulo = newModulo;
-            }
-          });
+          scope.$watch('$index', ngClassIndexWatchAction);
         }
 
         scope.$watch(watchExpression, watchAction, isOneTime);
@@ -87,6 +74,24 @@ function classDirective(name, selector) {
           });
 
           return classesToUpdate.join(' ');
+        }
+
+        function ngClassIndexWatchAction($index) {
+          // eslint-disable-next-line no-bitwise
+          var newModulo = $index & 1;
+
+          if (newModulo !== oldModulo) {
+            // This watch-action should run before the `ngClass[OneTime]WatchAction()`, thus it
+            // adds/removes `oldClassString`. If the `ngClass` expression has changed as well, the
+            // `ngClass[OneTime]WatchAction()` will update the classes.
+            if (newModulo === selector) {
+              addClasses(oldClassString);
+            } else {
+              removeClasses(oldClassString);
+            }
+
+            oldModulo = newModulo;
+          }
         }
 
         function ngClassOneTimeWatchAction(newClassValue) {

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -463,7 +463,7 @@ describe('ngClass', function() {
   }));
 
 
-  it('should keep track of old classes even if odd/even does not match `$index` atm',
+  it('should add/remove the correct classes when the expression and `$index` change simultaneously',
     inject(function($compile, $rootScope) {
       element = $compile(
           '<div>' +

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-fdescribe('ngClass', function() {
+describe('ngClass', function() {
   var element;
 
   beforeEach(module(function($compileProvider) {

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -574,6 +574,76 @@ fdescribe('ngClass', function() {
       expect(element).not.toHaveClass('orange');
     })
   );
+
+  describe('large objects', function() {
+    var getProp;
+    var veryLargeObj;
+
+    beforeEach(function() {
+      getProp = jasmine.createSpy('getProp');
+      veryLargeObj = {};
+
+      Object.defineProperty(veryLargeObj, 'prop', {
+        get: getProp,
+        enumerable: true
+      });
+    });
+
+    it('should not be copied when using an expression', inject(function($compile, $rootScope) {
+      element = $compile('<div ng-class="fooClass"></div>')($rootScope);
+      $rootScope.fooClass = {foo: veryLargeObj};
+      $rootScope.$digest();
+
+      expect(element).toHaveClass('foo');
+      expect(getProp).not.toHaveBeenCalled();
+    }));
+
+    it('should not be copied when using a literal', inject(function($compile, $rootScope) {
+      element = $compile('<div ng-class="{foo: veryLargeObj}"></div>')($rootScope);
+      $rootScope.veryLargeObj = veryLargeObj;
+      $rootScope.$digest();
+
+      expect(element).toHaveClass('foo');
+      expect(getProp).not.toHaveBeenCalled();
+    }));
+
+    it('should not be copied when inside an array', inject(function($compile, $rootScope) {
+      element = $compile('<div ng-class="[{foo: veryLargeObj}]"></div>')($rootScope);
+      $rootScope.veryLargeObj = veryLargeObj;
+      $rootScope.$digest();
+
+      expect(element).toHaveClass('foo');
+      expect(getProp).not.toHaveBeenCalled();
+    }));
+
+    it('should not be copied when using one-time binding', inject(function($compile, $rootScope) {
+      element = $compile('<div ng-class="::{foo: veryLargeObj, bar: bar}"></div>')($rootScope);
+      $rootScope.veryLargeObj = veryLargeObj;
+      $rootScope.$digest();
+
+      expect(element).toHaveClass('foo');
+      expect(element).not.toHaveClass('bar');
+      expect(getProp).not.toHaveBeenCalled();
+
+      $rootScope.$apply('veryLargeObj.bar = "bar"');
+
+      expect(element).toHaveClass('foo');
+      expect(element).not.toHaveClass('bar');
+      expect(getProp).not.toHaveBeenCalled();
+
+      $rootScope.$apply('bar = "bar"');
+
+      expect(element).toHaveClass('foo');
+      expect(element).toHaveClass('bar');
+      expect(getProp).not.toHaveBeenCalled();
+
+      $rootScope.$apply('veryLargeObj.bar = "qux"');
+
+      expect(element).toHaveClass('foo');
+      expect(element).toHaveClass('bar');
+      expect(getProp).not.toHaveBeenCalled();
+    }));
+  });
 });
 
 describe('ngClass animations', function() {

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -477,6 +477,62 @@ fdescribe('ngClass', function() {
     })
   );
 
+  it('should do value stabilization as expected when one-time binding',
+    inject(function($rootScope, $compile) {
+      element = $compile('<div ng-class="::className"></div>')($rootScope);
+      $rootScope.$digest();
+
+      $rootScope.className = 'foo';
+      $rootScope.$digest();
+      expect(element).toHaveClass('foo');
+
+      $rootScope.className = 'bar';
+      $rootScope.$digest();
+      expect(element).toHaveClass('foo');
+    })
+  );
+
+  it('should remove the watcher when static array one-time binding',
+    inject(function($rootScope, $compile) {
+      element = $compile('<div ng-class="::[className]"></div>')($rootScope);
+      $rootScope.$digest();
+
+      $rootScope.$apply('className = "foo"');
+      expect(element).toHaveClass('foo');
+
+      $rootScope.$apply('className = "bar"');
+      expect(element).toHaveClass('foo');
+      expect(element).not.toHaveClass('bar');
+    })
+  );
+
+  it('should do value remove the watcher when static map one-time binding',
+    inject(function($rootScope, $compile) {
+      element = $compile('<div ng-class="::{foo: fooPresent}"></div>')($rootScope);
+      $rootScope.$digest();
+
+      $rootScope.fooPresent = true;
+      $rootScope.$digest();
+      expect(element).toHaveClass('foo');
+
+      $rootScope.fooPresent = false;
+      $rootScope.$digest();
+      expect(element).toHaveClass('foo');
+    })
+  );
+
+  it('should track changes of mutating object inside an array',
+    inject(function($rootScope, $compile) {
+      $rootScope.classVar = [{orange: true}];
+      element = $compile('<div ng-class="classVar"></div>')($rootScope);
+      $rootScope.$digest();
+
+      $rootScope.classVar[0].orange = false;
+      $rootScope.$digest();
+
+      expect(element).not.toHaveClass('orange');
+    })
+  );
 });
 
 describe('ngClass animations', function() {

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -311,37 +311,79 @@ fdescribe('ngClass', function() {
   }));
 
 
-  it('should reapply ngClass when interpolated class attribute changes', inject(function($rootScope, $compile) {
-    element = $compile('<div class="one {{cls}} three" ng-class="{four: four}"></div>')($rootScope);
+  it('should reapply ngClass when interpolated class attribute changes',
+    inject(function($compile, $rootScope) {
+      element = $compile(
+        '<div>' +
+          '<div class="one {{two}} three" ng-class="{five: five}"></div>' +
+          '<div class="one {{two}} three {{four}}" ng-class="{five: five}"></div>' +
+        '</div>')($rootScope);
+      var e1 = element.children().eq(0);
+      var e2 = element.children().eq(1);
 
-    $rootScope.$apply(function() {
-      $rootScope.cls = 'two';
-      $rootScope.four = true;
-    });
-    expect(element).toHaveClass('one');
-    expect(element).toHaveClass('two'); // interpolated
-    expect(element).toHaveClass('three');
-    expect(element).toHaveClass('four');
+      $rootScope.$apply('two = "two"; five = true');
 
-    $rootScope.$apply(function() {
-      $rootScope.cls = 'too';
-    });
-    expect(element).toHaveClass('one');
-    expect(element).toHaveClass('too'); // interpolated
-    expect(element).toHaveClass('three');
-    expect(element).toHaveClass('four'); // should still be there
-    expect(element.hasClass('two')).toBeFalsy();
+      expect(e1).toHaveClass('one');
+      expect(e1).toHaveClass('two');
+      expect(e1).toHaveClass('three');
+      expect(e1).not.toHaveClass('four');
+      expect(e1).toHaveClass('five');
+      expect(e2).toHaveClass('one');
+      expect(e2).toHaveClass('two');
+      expect(e2).toHaveClass('three');
+      expect(e2).not.toHaveClass('four');
+      expect(e2).toHaveClass('five');
 
-    $rootScope.$apply(function() {
-      $rootScope.cls = 'to';
-    });
-    expect(element).toHaveClass('one');
-    expect(element).toHaveClass('to'); // interpolated
-    expect(element).toHaveClass('three');
-    expect(element).toHaveClass('four'); // should still be there
-    expect(element.hasClass('two')).toBeFalsy();
-    expect(element.hasClass('too')).toBeFalsy();
-  }));
+      $rootScope.$apply('two = "too"');
+
+      expect(e1).toHaveClass('one');
+      expect(e1).not.toHaveClass('two');
+      expect(e1).toHaveClass('too');
+      expect(e1).toHaveClass('three');
+      expect(e1).not.toHaveClass('four');
+      expect(e1).toHaveClass('five');
+      expect(e2).toHaveClass('one');
+      expect(e2).not.toHaveClass('two');
+      expect(e2).toHaveClass('too');
+      expect(e2).toHaveClass('three');
+      expect(e2).not.toHaveClass('four');
+      expect(e2).toHaveClass('five');
+
+      $rootScope.$apply('two = "to"; four = "four"');
+
+      expect(e1).toHaveClass('one');
+      expect(e1).not.toHaveClass('two');
+      expect(e1).not.toHaveClass('too');
+      expect(e1).toHaveClass('to');
+      expect(e1).toHaveClass('three');
+      expect(e1).not.toHaveClass('four');
+      expect(e1).toHaveClass('five');
+      expect(e2).toHaveClass('one');
+      expect(e2).not.toHaveClass('two');
+      expect(e2).not.toHaveClass('too');
+      expect(e2).toHaveClass('to');
+      expect(e2).toHaveClass('three');
+      expect(e2).toHaveClass('four');
+      expect(e2).toHaveClass('five');
+
+      $rootScope.$apply('five = false');
+
+      expect(e1).toHaveClass('one');
+      expect(e1).not.toHaveClass('two');
+      expect(e1).not.toHaveClass('too');
+      expect(e1).toHaveClass('to');
+      expect(e1).toHaveClass('three');
+      expect(e1).not.toHaveClass('four');
+      expect(e1).not.toHaveClass('five');
+      expect(e2).toHaveClass('one');
+      expect(e2).not.toHaveClass('two');
+      expect(e2).not.toHaveClass('too');
+      expect(e2).toHaveClass('to');
+      expect(e2).toHaveClass('three');
+      expect(e2).toHaveClass('four');
+      expect(e2).not.toHaveClass('five');
+    })
+  );
 
 
   it('should not mess up class value due to observing an interpolated class attribute', inject(function($rootScope, $compile) {

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -462,6 +462,47 @@ fdescribe('ngClass', function() {
     expect(e2.hasClass('odd')).toBeFalsy();
   }));
 
+
+  it('should keep track of old classes even if odd/even does not match `$index` atm',
+    inject(function($compile, $rootScope) {
+      element = $compile(
+          '<div>' +
+            '<div ng-class-odd="foo"></div>' +
+            '<div ng-class-even="foo"></div>' +
+          '</div>')($rootScope);
+      var odd = element.children().eq(0);
+      var even = element.children().eq(1);
+
+      $rootScope.$apply('$index = 0; foo = "class1"');
+
+      expect(odd).toHaveClass('class1');
+      expect(odd).not.toHaveClass('class2');
+      expect(even).not.toHaveClass('class1');
+      expect(even).not.toHaveClass('class2');
+
+      $rootScope.$apply('$index = 1; foo = "class2"');
+
+      expect(odd).not.toHaveClass('class1');
+      expect(odd).not.toHaveClass('class2');
+      expect(even).not.toHaveClass('class1');
+      expect(even).toHaveClass('class2');
+
+      $rootScope.$apply('foo = "class1"');
+
+      expect(odd).not.toHaveClass('class1');
+      expect(odd).not.toHaveClass('class2');
+      expect(even).toHaveClass('class1');
+      expect(even).not.toHaveClass('class2');
+
+      $rootScope.$apply('$index = 2');
+
+      expect(odd).toHaveClass('class1');
+      expect(odd).not.toHaveClass('class2');
+      expect(even).not.toHaveClass('class1');
+      expect(even).not.toHaveClass('class2');
+    })
+  );
+
   it('should support mixed array/object variable with a mutating object',
     inject(function($rootScope, $compile) {
       element = $compile('<div ng-class="classVar"></div>')($rootScope);

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -547,7 +547,7 @@ describe('ngClass', function() {
     })
   );
 
-  it('should do value remove the watcher when static map one-time binding',
+  it('should remove the watcher when static map one-time binding',
     inject(function($rootScope, $compile) {
       element = $compile('<div ng-class="::{foo: fooPresent}"></div>')($rootScope);
       $rootScope.$digest();
@@ -567,6 +567,8 @@ describe('ngClass', function() {
       $rootScope.classVar = [{orange: true}];
       element = $compile('<div ng-class="classVar"></div>')($rootScope);
       $rootScope.$digest();
+
+      expect(element).toHaveClass('orange');
 
       $rootScope.classVar[0].orange = false;
       $rootScope.$digest();

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('ngClass', function() {
+fdescribe('ngClass', function() {
   var element;
 
   beforeEach(module(function($compileProvider) {
@@ -244,21 +244,34 @@ describe('ngClass', function() {
   }));
 
 
-  it('should allow ngClassOdd/Even on the same element with overlapping classes', inject(function($rootScope, $compile, $animate) {
-      var className;
-
-      element = $compile('<ul><li ng-repeat="i in [0,1,2]" ng-class-odd="\'same odd\'" ng-class-even="\'same even\'"></li><ul>')($rootScope);
+  it('should allow ngClassOdd/Even on the same element with overlapping classes',
+    inject(function($compile, $rootScope) {
+      element = $compile(
+          '<ul>' +
+            '<li ng-repeat="i in [0,1,2]" ' +
+                'ng-class-odd="\'same odd\'" ' +
+                'ng-class-even="\'same even\'">' +
+            '</li>' +
+          '<ul>')($rootScope);
       $rootScope.$digest();
-      var e1 = jqLite(element[0].childNodes[1]);
-      var e2 = jqLite(element[0].childNodes[5]);
-      expect(e1.hasClass('same')).toBeTruthy();
-      expect(e1.hasClass('odd')).toBeTruthy();
-      expect(e2.hasClass('same')).toBeTruthy();
-      expect(e2.hasClass('odd')).toBeTruthy();
+
+      var e1 = element.children().eq(0);
+      var e2 = element.children().eq(1);
+      var e3 = element.children().eq(2);
+
+      expect(e1).toHaveClass('same');
+      expect(e1).toHaveClass('odd');
+      expect(e1).not.toHaveClass('even');
+      expect(e2).toHaveClass('same');
+      expect(e2).not.toHaveClass('odd');
+      expect(e2).toHaveClass('even');
+      expect(e3).toHaveClass('same');
+      expect(e3).toHaveClass('odd');
+      expect(e3).not.toHaveClass('even');
     })
   );
 
-  it('should allow ngClass with overlapping classes', inject(function($rootScope, $compile, $animate) {
+  it('should allow ngClass with overlapping classes', inject(function($rootScope, $compile) {
     element = $compile('<div ng-class="{\'same yes\': test, \'same no\': !test}"></div>')($rootScope);
     $rootScope.$digest();
 
@@ -266,9 +279,7 @@ describe('ngClass', function() {
     expect(element).not.toHaveClass('yes');
     expect(element).toHaveClass('no');
 
-    $rootScope.$apply(function() {
-      $rootScope.test = true;
-    });
+    $rootScope.$apply('test = true');
 
     expect(element).toHaveClass('same');
     expect(element).toHaveClass('yes');

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -334,34 +334,34 @@ describe('ngClass', function() {
       expect(e2).not.toHaveClass('four');
       expect(e2).toHaveClass('five');
 
-      $rootScope.$apply('two = "too"');
+      $rootScope.$apply('two = "another-two"');
 
       expect(e1).toHaveClass('one');
       expect(e1).not.toHaveClass('two');
-      expect(e1).toHaveClass('too');
+      expect(e1).toHaveClass('another-two');
       expect(e1).toHaveClass('three');
       expect(e1).not.toHaveClass('four');
       expect(e1).toHaveClass('five');
       expect(e2).toHaveClass('one');
       expect(e2).not.toHaveClass('two');
-      expect(e2).toHaveClass('too');
+      expect(e2).toHaveClass('another-two');
       expect(e2).toHaveClass('three');
       expect(e2).not.toHaveClass('four');
       expect(e2).toHaveClass('five');
 
-      $rootScope.$apply('two = "to"; four = "four"');
+      $rootScope.$apply('two = "two-more"; four = "four"');
 
       expect(e1).toHaveClass('one');
       expect(e1).not.toHaveClass('two');
-      expect(e1).not.toHaveClass('too');
-      expect(e1).toHaveClass('to');
+      expect(e1).not.toHaveClass('another-two');
+      expect(e1).toHaveClass('two-more');
       expect(e1).toHaveClass('three');
       expect(e1).not.toHaveClass('four');
       expect(e1).toHaveClass('five');
       expect(e2).toHaveClass('one');
       expect(e2).not.toHaveClass('two');
-      expect(e2).not.toHaveClass('too');
-      expect(e2).toHaveClass('to');
+      expect(e2).not.toHaveClass('another-two');
+      expect(e2).toHaveClass('two-more');
       expect(e2).toHaveClass('three');
       expect(e2).toHaveClass('four');
       expect(e2).toHaveClass('five');
@@ -370,15 +370,15 @@ describe('ngClass', function() {
 
       expect(e1).toHaveClass('one');
       expect(e1).not.toHaveClass('two');
-      expect(e1).not.toHaveClass('too');
-      expect(e1).toHaveClass('to');
+      expect(e1).not.toHaveClass('another-two');
+      expect(e1).toHaveClass('two-more');
       expect(e1).toHaveClass('three');
       expect(e1).not.toHaveClass('four');
       expect(e1).not.toHaveClass('five');
       expect(e2).toHaveClass('one');
       expect(e2).not.toHaveClass('two');
-      expect(e2).not.toHaveClass('too');
-      expect(e2).toHaveClass('to');
+      expect(e2).not.toHaveClass('another-two');
+      expect(e2).toHaveClass('two-more');
       expect(e2).toHaveClass('three');
       expect(e2).toHaveClass('four');
       expect(e2).not.toHaveClass('five');


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix, Test, Refactor, Perf

**What is the current behavior? (You can also link to an open issue here)**
Broken, inefficient.

**What is the new behavior (if this is a feature change)?**
Fixed, efficient.

**Does this PR introduce a breaking change?**
No (to the best of my knowledge).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Supercedes (and partly based on) #14404. Mad props to @drpicox for the initial idea and implementation.

This PR has been broken up in smaller, focused commits for easier reviewing. Better to review commit by commit (and probably in order). Most commits are (more or less) trivial - except for the last one.

Refactoring commits:
- 8822006: refactor(ngClass): remove unnecessary dependency on `$animate`
- 0409589: refactor(ngClass): remove redundant `$observe`r
- 2871a11: refactor(ngClass): simplify conditions
- a7e69f7: refactor(ngClass): move helper functions outside the closure
- 37cec7a: refactor(ngClass): exit `arrayDifference()` early if an input is empty

Test commits:
- 2705085: test(ngClass): add some tests about one-time bindings and objects inside arrays

Fix commits:
- 0ba4be6: fix(ngClassOdd/Even): keep track of classes even if odd/even do not match index

Perf commits:
- 89268af: perf(ngClass): only access the element's `data` once
- 5708424: perf(ngClass): avoid deep-watching (if possible) and unnecessary copies

Closes #14404
