### PR TITLE
refactor(ngModelSpec): use valueFn over curry

### DIFF
--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -827,21 +827,15 @@ describe('ngModel', function() {
 
 
       it('should only validate to true if all validations are true', function() {
-        var curry = function(v) {
-          return function() {
-            return v;
-          };
-        };
-
         ctrl.$modelValue = undefined;
-        ctrl.$validators.a = curry(true);
-        ctrl.$validators.b = curry(true);
-        ctrl.$validators.c = curry(false);
+        ctrl.$validators.a = valueFn(true);
+        ctrl.$validators.b = valueFn(true);
+        ctrl.$validators.c = valueFn(false);
 
         ctrl.$validate();
         expect(ctrl.$valid).toBe(false);
 
-        ctrl.$validators.c = curry(true);
+        ctrl.$validators.c = valueFn(true);
 
         ctrl.$validate();
         expect(ctrl.$valid).toBe(true);
@@ -875,16 +869,10 @@ describe('ngModel', function() {
 
 
       it('should register invalid validations on the $error object', function() {
-        var curry = function(v) {
-          return function() {
-            return v;
-          };
-        };
-
         ctrl.$modelValue = undefined;
-        ctrl.$validators.unique = curry(false);
-        ctrl.$validators.tooLong = curry(false);
-        ctrl.$validators.notNumeric = curry(true);
+        ctrl.$validators.unique = valueFn(false);
+        ctrl.$validators.tooLong = valueFn(false);
+        ctrl.$validators.notNumeric = valueFn(true);
 
         ctrl.$validate();
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Refactor.

**What is the current behavior? (You can also link to an open issue here)**

Defines a `curry` function, which is not needed because the internal helper `valueFn` does the exact same thing. See also this comment chain: [PR 15208 Comment](https://github.com/angular/angular.js/pull/15208#discussion_r81514963)

**What is the new behavior (if this is a feature change)?**

Nothing changes.

**Does this PR introduce a breaking change?**

Nope.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Refactor ngModelSpec to use internal helper function `valueFn`.
Use instead of multiple-defining a function called `curry`.

Addresses a quick change mentioned in PR 15208 from Issue #14734
