### PR TITLE
fix($parse): validate assignment lval in parser phase

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -338,6 +338,10 @@ AST.prototype = {
   assignment: function() {
     var result = this.ternary();
     if (this.expect('=')) {
+      if (!isAssignable(result)) {
+        throw $parseMinErr('lval', 'Trying to assign a value to a non l-value');
+      }
+
       result = { type: AST.AssignmentExpression, left: result, right: this.assignment(), operator: '='};
     }
     return result;
@@ -1024,9 +1028,6 @@ ASTCompiler.prototype = {
     case AST.AssignmentExpression:
       right = this.nextId();
       left = {};
-      if (!isAssignable(ast.left)) {
-        throw $parseMinErr('lval', 'Trying to assign a value to a non l-value');
-      }
       this.recurse(ast.left, undefined, left, function() {
         self.if_(self.notNull(left.context), function() {
           self.recurse(ast.right, right);

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -2129,6 +2129,20 @@ describe('parser', function() {
         expect(scope.b).toEqual(234);
       });
 
+      it('should throw with invalid left-val in assignments', function() {
+        expect(function() { scope.$eval("1 = 1"); }).toThrowMinErr('$parse', 'lval');
+        expect(function() { scope.$eval("{} = 1"); }).toThrowMinErr('$parse', 'lval');
+        expect(function() { scope.$eval("[] = 1"); }).toThrowMinErr('$parse', 'lval');
+        expect(function() { scope.$eval("true = 1"); }).toThrowMinErr('$parse', 'lval');
+        expect(function() { scope.$eval("(a=b) = 1"); }).toThrowMinErr('$parse', 'lval');
+        expect(function() { scope.$eval("(1<2) = 1"); }).toThrowMinErr('$parse', 'lval');
+        expect(function() { scope.$eval("(1+2) = 1"); }).toThrowMinErr('$parse', 'lval');
+        expect(function() { scope.$eval("!v = 1"); }).toThrowMinErr('$parse', 'lval');
+        expect(function() { scope.$eval("this = 1"); }).toThrowMinErr('$parse', 'lval');
+        expect(function() { scope.$eval("+v = 1"); }).toThrowMinErr('$parse', 'lval');
+        expect(function() { scope.$eval("(1?v1:v2) = 1"); }).toThrowMinErr('$parse', 'lval');
+      });
+
       it('should evaluate assignments in ternary operator', function() {
         scope.$eval('a = 1 ? 2 : 3');
         expect(scope.a).toBe(2);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
fix

**What is the current behavior? (You can also link to an open issue here)**
csp and non-csp are different when parsing an invalid lval

**What is the new behavior (if this is a feature change)?**
csp and non-csp are the same when parsing an invalid lval

**Does this PR introduce a breaking change?**
no

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
