### PR TITLE
fix($location): prevent infinite digest with IDN urls in Edge

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -49,7 +49,7 @@ function parseAppUrl(relativeUrl, locationObj) {
 }
 
 function startsWith(haystack, needle) {
-  return haystack.lastIndexOf(needle, 0) === 0;
+  return haystack.indexOf(needle) === 0;
 }
 
 /**

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -48,8 +48,8 @@ function parseAppUrl(relativeUrl, locationObj) {
   }
 }
 
-function startsWith(haystack, needle) {
-  return haystack.indexOf(needle) === 0;
+function startsWith(str, search) {
+  return str.slice(0, search.length) === search;
 }
 
 /**

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -2450,10 +2450,11 @@ describe('$location', function() {
 
 
   describe('LocationHtml5Url', function() {
-    var locationUrl, locationIndexUrl;
+    var locationUrl, locationUmlautUrl, locationIndexUrl;
 
     beforeEach(function() {
       locationUrl = new LocationHtml5Url('http://server/pre/', 'http://server/pre/', 'http://server/pre/path');
+      locationUmlautUrl = new LocationHtml5Url('http://särver/pre/', 'http://särver/pre/', 'http://särver/pre/path');
       locationIndexUrl = new LocationHtml5Url('http://server/pre/index.html', 'http://server/pre/', 'http://server/pre/path');
     });
 
@@ -2464,6 +2465,13 @@ describe('$location', function() {
       expect(parseLinkAndReturn(locationUrl, 'http://server/pre/otherPath')).toEqual('http://server/pre/otherPath');
       // Note: relies on the previous state!
       expect(parseLinkAndReturn(locationUrl, 'someIgnoredAbsoluteHref', '#test')).toEqual('http://server/pre/otherPath#test');
+
+      expect(parseLinkAndReturn(locationUmlautUrl, 'http://other')).toEqual(undefined);
+      expect(parseLinkAndReturn(locationUmlautUrl, 'http://särver/pre')).toEqual('http://särver/pre/');
+      expect(parseLinkAndReturn(locationUmlautUrl, 'http://särver/pre/')).toEqual('http://särver/pre/');
+      expect(parseLinkAndReturn(locationUmlautUrl, 'http://särver/pre/otherPath')).toEqual('http://särver/pre/otherPath');
+      // Note: relies on the previous state!
+      expect(parseLinkAndReturn(locationUmlautUrl, 'someIgnoredAbsoluteHref', '#test')).toEqual('http://särver/pre/otherPath#test');
 
       expect(parseLinkAndReturn(locationIndexUrl, 'http://server/pre')).toEqual('http://server/pre/');
       expect(parseLinkAndReturn(locationIndexUrl, 'http://server/pre/')).toEqual('http://server/pre/');


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix

**What is the current behavior? (You can also link to an open issue here)**
Internationalized Domain Name Urls (IDN), e.g. with an Umlaut, in Edge lead to an infinite digest on page load.

**What is the new behavior (if this is a feature change)?**
No Infdig

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)

Fixes #15217

Note:
We don't test on Edge yet, but I've tested this locally with the https://github.com/nickmccurdy/karma-edge-launcher 
