### PR TITLE
refactor(jqLite): wrap the jqueryVersion binding in a span

### DIFF
--- a/test/e2e/fixtures/ng-jq-jquery/index.html
+++ b/test/e2e/fixtures/ng-jq-jquery/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html ng-app="test" ng-jq="jQuery_2_1_0">
   <body>
-    {{jqueryVersion}}
+    <span>{{jqueryVersion}}</span>
 
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
     <script>

--- a/test/e2e/fixtures/ng-jq/index.html
+++ b/test/e2e/fixtures/ng-jq/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html ng-app="test" ng-jq>
   <body>
-    {{jqueryVersion}}
+    <span>{{jqueryVersion}}</span>
 
     <script src="../../../../bower_components/jquery/dist/jquery.js"></script>
     <script type="text/javascript">


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Refactor

**What is the current behavior? (You can also link to an open issue here)**
Bindings are not wrapped in `<span>`s in some e2e tests.

**What is the new behavior (if this is a feature change)?**
Bindings are now wrapped in `<span>`s.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Protractor's by.binding selector selects the whole element in which the binding
is contained as otherwise it can't know which bit of text has been interpolated.

It's safer to wrap the binding in a span so that we're sure what the e2e tests
are exactly testing.
