### PR TITLE
fix($resource): Delete $cancelRequest from toJSON()

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -636,6 +636,7 @@ angular.module('ngResource', ['ng']).
           var data = extend({}, this);
           delete data.$promise;
           delete data.$resolved;
+          delete data.$cancelRequest;
           return data;
         };
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -29,9 +29,6 @@ describe('basic usage', function() {
         }
       }
 
-    },
-    {
-      cancellable: true
     });
     callback = jasmine.createSpy('callback');
   }));
@@ -740,7 +737,7 @@ describe('basic usage', function() {
     expect(person2).toEqual(jasmine.any(Person));
   });
 
-  it('should not include $promise, $resolved when resource is toJson\'ed', function() {
+  it('should not include $promise and $resolved when resource is toJson\'ed', function() {
     $httpBackend.expect('GET', '/CreditCard/123').respond({id: 123, number: '9876'});
     var cc = CreditCard.get({id: 123});
     $httpBackend.flush();
@@ -757,14 +754,22 @@ describe('basic usage', function() {
   });
 
   it('should not include $cancelRequest when resource is toJson\'ed', function() {
-    $httpBackend.expect('GET', '/CreditCard/123').respond({id: 123, number: '9876'});
-    var cc = CreditCard.get({id: 123});
+    $httpBackend.whenGET('/CreditCard').respond({});
+
+    var CreditCard = $resource('/CreditCard', {}, {
+      get: {
+        method: 'GET',
+        cancellable: true
+      }
+    });
+
+    var creditCard = CreditCard.get();
+
+    expect(creditCard.$cancelRequest).toBeDefined();
+
     $httpBackend.flush();
 
-    expect(cc.$cancelRequest).toBeDefined();
-
-    var json = cc.toJSON();
-
+    var json = creditCard.toJSON();
     expect(json.$cancelRequest).not.toBeDefined();
   });
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -737,7 +737,7 @@ describe('basic usage', function() {
     expect(person2).toEqual(jasmine.any(Person));
   });
 
-  it('should not include $promise and $resolved when resource is toJson\'ed', function() {
+  it('should not include $promise, $resolved and $cancelRequest when resource is toJson\'ed', function() {
     $httpBackend.expect('GET', '/CreditCard/123').respond({id: 123, number: '9876'});
     var cc = CreditCard.get({id: 123});
     $httpBackend.flush();
@@ -750,6 +750,7 @@ describe('basic usage', function() {
     var json = JSON.parse(angular.toJson(cc));
     expect(json.$promise).not.toBeDefined();
     expect(json.$resolved).not.toBeDefined();
+    expect(json.$cancelRequest).not.toBeDefined();
     expect(json).toEqual({id: 123, number: '9876', $myProp: 'still here'});
   });
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -29,6 +29,9 @@ describe('basic usage', function() {
         }
       }
 
+    },
+    {
+      cancellable: true
     });
     callback = jasmine.createSpy('callback');
   }));
@@ -746,6 +749,7 @@ describe('basic usage', function() {
 
     expect(cc.$promise).toBeDefined();
     expect(cc.$resolved).toBe(true);
+    expect(cc.$cancelRequest).toBeDefined();
 
     var json = JSON.parse(angular.toJson(cc));
     expect(json.$promise).not.toBeDefined();

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -740,7 +740,7 @@ describe('basic usage', function() {
     expect(person2).toEqual(jasmine.any(Person));
   });
 
-  it('should not include $promise, $resolved and $cancelRequest when resource is toJson\'ed', function() {
+  it('should not include $promise, $resolved when resource is toJson\'ed', function() {
     $httpBackend.expect('GET', '/CreditCard/123').respond({id: 123, number: '9876'});
     var cc = CreditCard.get({id: 123});
     $httpBackend.flush();
@@ -749,13 +749,23 @@ describe('basic usage', function() {
 
     expect(cc.$promise).toBeDefined();
     expect(cc.$resolved).toBe(true);
-    expect(cc.$cancelRequest).toBeDefined();
 
     var json = JSON.parse(angular.toJson(cc));
     expect(json.$promise).not.toBeDefined();
     expect(json.$resolved).not.toBeDefined();
-    expect(json.$cancelRequest).not.toBeDefined();
     expect(json).toEqual({id: 123, number: '9876', $myProp: 'still here'});
+  });
+
+  it('should not include $cancelRequest when resource is toJson\'ed', function() {
+    $httpBackend.expect('GET', '/CreditCard/123').respond({id: 123, number: '9876'});
+    var cc = CreditCard.get({id: 123});
+    $httpBackend.flush();
+
+    expect(cc.$cancelRequest).toBeDefined();
+
+    var json = cc.toJSON();
+
+    expect(json.$cancelRequest).not.toBeDefined();
   });
 
   describe('promise api', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
result of ngResource.toJSON still include $cancelRequest

**What is the new behavior (if this is a feature change)?**
remove delete $cancelRequest from ngResource.toJSON's result.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [ Y ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ N ] Tests for the changes have been added (for bug fixes / features)
- [ N ] Docs have been added / updated (for bug fixes / features)

**Other information**:
