### PR TITLE
fix(input): fix `step` validation for `input[number]`/`input[range]`

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1529,13 +1529,62 @@ function parseNumberAttrVal(val) {
   return !isNumberNaN(val) ? val : undefined;
 }
 
+function isNumberInteger(num) {
+  // See http://stackoverflow.com/questions/14636536/how-to-check-if-a-variable-is-an-integer-in-javascript#14794066
+  // (minus the assumption that `num` is a number)
+
+  // eslint-disable-next-line no-bitwise
+  return (num | 0) === num;
+}
+
+function countDecimals(num) {
+  var numString = num.toString();
+  var decimalSymbolIndex = numString.indexOf('.');
+
+  if (decimalSymbolIndex === -1) {
+    if (-1 < num && num < 1) {
+      // It may be in the exponentional notation format (`1e-X`)
+      var match = /e-(\d+)$/.exec(numString);
+
+      if (match) {
+        return Number(match[1]);
+      }
+    }
+
+    return 0;
+  }
+
+  return numString.length - decimalSymbolIndex - 1;
+}
+
+function isValidForStep(viewValue, stepBase, step) {
+  // At this point `stepBase` and `step` are expected to be non-NaN values
+  // and `viewValue` is expected to be a valid stringified number.
+  var value = Number(viewValue);
+
+  // Due to limitations is Floating Point Arithmetic (e.g. `0.3 - 0.2 !== 0.1` or
+  // `0.5 % 0.1 !== 0`), we need to make sure all numbers are integers before proceeding.
+  if (!isNumberInteger(value) || !isNumberInteger(stepBase) || !isNumberInteger(step)) {
+    var decimalCount = Math.max(countDecimals(value), countDecimals(stepBase), countDecimals(step));
+    var multiplier = Math.pow(10, decimalCount);
+
+    value = value * multiplier;
+    stepBase = stepBase * multiplier;
+    step = step * multiplier;
+  }
+
+  return (value - stepBase) % step === 0;
+}
+
 function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   badInputChecker(scope, element, attr, ctrl);
   numberFormatterParser(ctrl);
   baseInputType(scope, element, attr, ctrl, $sniffer, $browser);
 
+  var minVal;
+  var maxVal;
+
   if (isDefined(attr.min) || attr.ngMin) {
-    var minVal;
     ctrl.$validators.min = function(value) {
       return ctrl.$isEmpty(value) || isUndefined(minVal) || value >= minVal;
     };
@@ -1548,7 +1597,6 @@ function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   }
 
   if (isDefined(attr.max) || attr.ngMax) {
-    var maxVal;
     ctrl.$validators.max = function(value) {
       return ctrl.$isEmpty(value) || isUndefined(maxVal) || value <= maxVal;
     };
@@ -1563,7 +1611,8 @@ function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   if (isDefined(attr.step) || attr.ngStep) {
     var stepVal;
     ctrl.$validators.step = function(modelValue, viewValue) {
-      return ctrl.$isEmpty(viewValue) || isUndefined(stepVal) || viewValue % stepVal === 0;
+      return ctrl.$isEmpty(viewValue) || isUndefined(stepVal) ||
+             isValidForStep(viewValue, minVal || 0, stepVal);
     };
 
     attr.$observe('step', function(val) {
@@ -1633,7 +1682,8 @@ function rangeInputType(scope, element, attr, ctrl, $sniffer, $browser) {
       } :
       // ngStep doesn't set the setp attr, so the browser doesn't adjust the input value as setting step would
       function stepValidator(modelValue, viewValue) {
-        return ctrl.$isEmpty(viewValue) || isUndefined(stepVal) || viewValue % stepVal === 0;
+        return ctrl.$isEmpty(viewValue) || isUndefined(stepVal) ||
+               isValidForStep(viewValue, minVal || 0, stepVal);
       };
 
     setInitialValueAndObserver('step', stepChange);

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1562,8 +1562,8 @@ function isValidForStep(viewValue, stepBase, step) {
   // and `viewValue` is expected to be a valid stringified number.
   var value = Number(viewValue);
 
-  // Due to limitations is Floating Point Arithmetic (e.g. `0.3 - 0.2 !== 0.1` or
-  // `0.5 % 0.1 !== 0`), we need to make sure all numbers are integers before proceeding.
+  // Due to limitations in Floating Point Arithmetic (e.g. `0.3 - 0.2 !== 0.1` or
+  // `0.5 % 0.1 !== 0`), we need to convert all numbers to integers.
   if (!isNumberInteger(value) || !isNumberInteger(stepBase) || !isNumberInteger(step)) {
     var decimalCount = Math.max(countDecimals(value), countDecimals(stepBase), countDecimals(step));
     var multiplier = Math.pow(10, decimalCount);

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1543,7 +1543,7 @@ function countDecimals(num) {
 
   if (decimalSymbolIndex === -1) {
     if (-1 < num && num < 1) {
-      // It may be in the exponentional notation format (`1e-X`)
+      // It may be in the exponential notation format (`1e-X`)
       var match = /e-(\d+)$/.exec(numString);
 
       if (match) {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2621,154 +2621,88 @@ describe('input', function() {
       });
     });
 
-    describe('step', function() {
-      it('should validate', function() {
-        $rootScope.step = 10;
-        $rootScope.value = 20;
-        var inputElm = helper.compileInput('<input type="number" ng-model="value" name="alias" step="{{step}}" />');
 
-        expect(inputElm.val()).toBe('20');
-        expect(inputElm).toBeValid();
-        expect($rootScope.value).toBe(20);
-        expect($rootScope.form.alias.$error.step).toBeFalsy();
+    forEach({
+      step: 'step="{{step}}"',
+      ngStep: 'ng-step="step"'
+    }, function(attrHtml, attrName) {
 
-        helper.changeInputValueTo('18');
-        expect(inputElm).toBeInvalid();
-        expect(inputElm.val()).toBe('18');
-        expect($rootScope.value).toBeUndefined();
-        expect($rootScope.form.alias.$error.step).toBeTruthy();
+      describe(attrName, function() {
 
-        helper.changeInputValueTo('10');
-        expect(inputElm).toBeValid();
-        expect(inputElm.val()).toBe('10');
-        expect($rootScope.value).toBe(10);
-        expect($rootScope.form.alias.$error.step).toBeFalsy();
+        it('should validate', function() {
+          $rootScope.step = 10;
+          $rootScope.value = 20;
+          var inputElm = helper.compileInput(
+              '<input type="number" ng-model="value" name="alias" ' + attrHtml + ' />');
 
-        $rootScope.$apply('value = 12');
-        expect(inputElm).toBeInvalid();
-        expect(inputElm.val()).toBe('12');
-        expect($rootScope.value).toBe(12);
-        expect($rootScope.form.alias.$error.step).toBeTruthy();
-      });
+          expect(inputElm.val()).toBe('20');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(20);
+          expect($rootScope.form.alias.$error.step).toBeFalsy();
 
-      it('should validate even if the step value changes on-the-fly', function() {
-        $rootScope.step = 10;
-        var inputElm = helper.compileInput('<input type="number" ng-model="value" name="alias" step="{{step}}" />');
+          helper.changeInputValueTo('18');
+          expect(inputElm).toBeInvalid();
+          expect(inputElm.val()).toBe('18');
+          expect($rootScope.value).toBeUndefined();
+          expect($rootScope.form.alias.$error.step).toBeTruthy();
 
-        helper.changeInputValueTo('10');
-        expect(inputElm).toBeValid();
-        expect($rootScope.value).toBe(10);
+          helper.changeInputValueTo('10');
+          expect(inputElm).toBeValid();
+          expect(inputElm.val()).toBe('10');
+          expect($rootScope.value).toBe(10);
+          expect($rootScope.form.alias.$error.step).toBeFalsy();
 
-        // Step changes, but value matches
-        $rootScope.$apply('step = 5');
-        expect(inputElm.val()).toBe('10');
-        expect(inputElm).toBeValid();
-        expect($rootScope.value).toBe(10);
-        expect($rootScope.form.alias.$error.step).toBeFalsy();
+          $rootScope.$apply('value = 12');
+          expect(inputElm).toBeInvalid();
+          expect(inputElm.val()).toBe('12');
+          expect($rootScope.value).toBe(12);
+          expect($rootScope.form.alias.$error.step).toBeTruthy();
+        });
 
-        // Step changes, value does not match
-        $rootScope.$apply('step = 6');
-        expect(inputElm).toBeInvalid();
-        expect($rootScope.value).toBeUndefined();
-        expect(inputElm.val()).toBe('10');
-        expect($rootScope.form.alias.$error.step).toBeTruthy();
+        it('should validate even if the step value changes on-the-fly', function() {
+          $rootScope.step = 10;
+          var inputElm = helper.compileInput(
+              '<input type="number" ng-model="value" name="alias" ' + attrHtml + ' />');
 
-        // null = valid
-        $rootScope.$apply('step = null');
-        expect(inputElm).toBeValid();
-        expect($rootScope.value).toBe(10);
-        expect(inputElm.val()).toBe('10');
-        expect($rootScope.form.alias.$error.step).toBeFalsy();
+          helper.changeInputValueTo('10');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(10);
 
-        // Step val as string
-        $rootScope.$apply('step = "7"');
-        expect(inputElm).toBeInvalid();
-        expect($rootScope.value).toBeUndefined();
-        expect(inputElm.val()).toBe('10');
-        expect($rootScope.form.alias.$error.step).toBeTruthy();
+          // Step changes, but value matches
+          $rootScope.$apply('step = 5');
+          expect(inputElm.val()).toBe('10');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(10);
+          expect($rootScope.form.alias.$error.step).toBeFalsy();
 
-        // unparsable string is ignored
-        $rootScope.$apply('step = "abc"');
-        expect(inputElm).toBeValid();
-        expect($rootScope.value).toBe(10);
-        expect(inputElm.val()).toBe('10');
-        expect($rootScope.form.alias.$error.step).toBeFalsy();
-      });
-    });
+          // Step changes, value does not match
+          $rootScope.$apply('step = 6');
+          expect(inputElm).toBeInvalid();
+          expect($rootScope.value).toBeUndefined();
+          expect(inputElm.val()).toBe('10');
+          expect($rootScope.form.alias.$error.step).toBeTruthy();
 
+          // null = valid
+          $rootScope.$apply('step = null');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(10);
+          expect(inputElm.val()).toBe('10');
+          expect($rootScope.form.alias.$error.step).toBeFalsy();
 
-    describe('ngStep', function() {
-      it('should validate', function() {
-        $rootScope.step = 10;
-        $rootScope.value = 20;
-        var inputElm = helper.compileInput('<input type="number" ng-model="value" name="alias" ng-step="step" />');
+          // Step val as string
+          $rootScope.$apply('step = "7"');
+          expect(inputElm).toBeInvalid();
+          expect($rootScope.value).toBeUndefined();
+          expect(inputElm.val()).toBe('10');
+          expect($rootScope.form.alias.$error.step).toBeTruthy();
 
-        expect(inputElm.val()).toBe('20');
-        expect(inputElm).toBeValid();
-        expect($rootScope.value).toBe(20);
-        expect($rootScope.form.alias.$error.step).toBeFalsy();
-
-        helper.changeInputValueTo('18');
-        expect(inputElm).toBeInvalid();
-        expect(inputElm.val()).toBe('18');
-        expect($rootScope.value).toBeUndefined();
-        expect($rootScope.form.alias.$error.step).toBeTruthy();
-
-        helper.changeInputValueTo('10');
-        expect(inputElm).toBeValid();
-        expect(inputElm.val()).toBe('10');
-        expect($rootScope.value).toBe(10);
-        expect($rootScope.form.alias.$error.step).toBeFalsy();
-
-        $rootScope.$apply('value = 12');
-        expect(inputElm).toBeInvalid();
-        expect(inputElm.val()).toBe('12');
-        expect($rootScope.value).toBe(12);
-        expect($rootScope.form.alias.$error.step).toBeTruthy();
-      });
-
-      it('should validate even if the step value changes on-the-fly', function() {
-        $rootScope.step = 10;
-        var inputElm = helper.compileInput('<input type="number" ng-model="value" name="alias" ng-step="step" />');
-
-        helper.changeInputValueTo('10');
-        expect(inputElm).toBeValid();
-        expect($rootScope.value).toBe(10);
-
-        // Step changes, but value matches
-        $rootScope.$apply('step = 5');
-        expect(inputElm.val()).toBe('10');
-        expect(inputElm).toBeValid();
-        expect($rootScope.value).toBe(10);
-        expect($rootScope.form.alias.$error.step).toBeFalsy();
-
-        // Step changes, value does not match
-        $rootScope.$apply('step = 6');
-        expect(inputElm).toBeInvalid();
-        expect($rootScope.value).toBeUndefined();
-        expect(inputElm.val()).toBe('10');
-        expect($rootScope.form.alias.$error.step).toBeTruthy();
-
-        // null = valid
-        $rootScope.$apply('step = null');
-        expect(inputElm).toBeValid();
-        expect($rootScope.value).toBe(10);
-        expect(inputElm.val()).toBe('10');
-        expect($rootScope.form.alias.$error.step).toBeFalsy();
-
-        // Step val as string
-        $rootScope.$apply('step = "7"');
-        expect(inputElm).toBeInvalid();
-        expect($rootScope.value).toBeUndefined();
-        expect(inputElm.val()).toBe('10');
-        expect($rootScope.form.alias.$error.step).toBeTruthy();
-
-        // unparsable string is ignored
-        $rootScope.$apply('step = "abc"');
-        expect(inputElm).toBeValid();
-        expect($rootScope.value).toBe(10);
-        expect(inputElm.val()).toBe('10');
-        expect($rootScope.form.alias.$error.step).toBeFalsy();
+          // unparsable string is ignored
+          $rootScope.$apply('step = "abc"');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(10);
+          expect(inputElm.val()).toBe('10');
+          expect($rootScope.form.alias.$error.step).toBeFalsy();
+        });
       });
     });
 
@@ -3001,7 +2935,6 @@ describe('input', function() {
   });
 
   describe('range', function() {
-
     var scope;
 
     var rangeTestEl = angular.element('<input type="range">');
@@ -3048,7 +2981,6 @@ describe('input', function() {
         expect(scope.age).toBe(50);
         expect(inputElm).toBeValid();
       });
-
     } else {
 
       it('should reset the model if view is invalid', function() {
@@ -3438,7 +3370,6 @@ describe('input', function() {
           expect(scope.value).toBe(40);
         });
       });
-
     }
 
 
@@ -3448,6 +3379,7 @@ describe('input', function() {
         // Browsers that implement range will never allow you to set a value that doesn't match the step value
         // However, currently only Firefox fully implements the spec when setting the value after the step value changes.
         // Other browsers fail in various edge cases, which is why they are not tested here.
+
         it('should round the input value to the nearest step on user input', function() {
           var inputElm = helper.compileInput('<input type="range" ng-model="value" name="alias" step="5" />');
 
@@ -3510,8 +3442,8 @@ describe('input', function() {
           expect(scope.value).toBe(10);
           expect(scope.form.alias.$error.step).toBeFalsy();
         });
-
       } else {
+
         it('should validate if "range" is not implemented', function() {
           scope.step = 10;
           scope.value = 20;

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2731,7 +2731,8 @@ describe('input', function() {
           expect(inputElm).toBeValid();
           expect($rootScope.value).toBe(8);
 
-          $rootScope.$apply('min = 10; step = 20; value = 30');
+          $rootScope.$apply('min = 10; step = 20');
+          helper.changeInputValueTo('30');
           expect(inputElm.val()).toBe('30');
           expect(inputElm).toBeValid();
           expect($rootScope.value).toBe(30);
@@ -2748,7 +2749,8 @@ describe('input', function() {
           expect($rootScope.value).toBe(30);
 
           // 0.3 - 0.2 === 0.09999999999999998
-          $rootScope.$apply('min = 0.2; step = 0.09999999999999998; value = 0.3');
+          $rootScope.$apply('min = 0.2; step = (0.3 - 0.2)');
+          helper.changeInputValueTo('0.3');
           expect(inputElm.val()).toBe('0.3');
           expect(inputElm).toBeInvalid();
           expect(ngModel.$error.step).toBe(true);

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2757,35 +2757,37 @@ describe('input', function() {
           expect($rootScope.value).toBeUndefined();
         });
 
-        it('should correctly validate even in cases where `(x*y % x !== 0)`', function() {
-          $rootScope.step = 0.1;
-          var inputElm = helper.compileInput(
-              '<input type="number" ng-model="value" ' + attrHtml + ' />');
-          var ngModel = inputElm.controller('ngModel');
+        it('should correctly validate even in cases where the JS floating point arithmetic fails',
+          function() {
+            $rootScope.step = 0.1;
+            var inputElm = helper.compileInput(
+                '<input type="number" ng-model="value" ' + attrHtml + ' />');
+            var ngModel = inputElm.controller('ngModel');
 
-          expect(inputElm.val()).toBe('');
-          expect(inputElm).toBeValid();
-          expect($rootScope.value).toBeUndefined();
+            expect(inputElm.val()).toBe('');
+            expect(inputElm).toBeValid();
+            expect($rootScope.value).toBeUndefined();
 
-          helper.changeInputValueTo('0.3');
-          expect(inputElm).toBeValid();
-          expect($rootScope.value).toBe(0.3);
+            helper.changeInputValueTo('0.3');
+            expect(inputElm).toBeValid();
+            expect($rootScope.value).toBe(0.3);
 
-          helper.changeInputValueTo('2.9999999999999996');
-          expect(inputElm).toBeInvalid();
-          expect(ngModel.$error.step).toBe(true);
-          expect($rootScope.value).toBeUndefined();
+            helper.changeInputValueTo('2.9999999999999996');
+            expect(inputElm).toBeInvalid();
+            expect(ngModel.$error.step).toBe(true);
+            expect($rootScope.value).toBeUndefined();
 
-          // 0.5 % 0.1 === 0.09999999999999998
-          helper.changeInputValueTo('0.5');
-          expect(inputElm).toBeValid();
-          expect($rootScope.value).toBe(0.5);
+            // 0.5 % 0.1 === 0.09999999999999998
+            helper.changeInputValueTo('0.5');
+            expect(inputElm).toBeValid();
+            expect($rootScope.value).toBe(0.5);
 
-          // 3.5 % 0.1 === 0.09999999999999981
-          helper.changeInputValueTo('3.5');
-          expect(inputElm).toBeValid();
-          expect($rootScope.value).toBe(3.5);
-        });
+            // 3.5 % 0.1 === 0.09999999999999981
+            helper.changeInputValueTo('3.5');
+            expect(inputElm).toBeValid();
+            expect($rootScope.value).toBe(3.5);
+          }
+        );
       });
     });
 
@@ -3651,33 +3653,35 @@ describe('input', function() {
           expect($rootScope.value).toBeUndefined();
         });
 
-        it('should correctly validate even in cases where `(x*y % x !== 0)`', function() {
-          var inputElm = helper.compileInput('<input type="range" ng-model="value" step="0.1" />');
-          var ngModel = inputElm.controller('ngModel');
+        it('should correctly validate even in cases where the JS floating point arithmetic fails',
+          function() {
+            var inputElm = helper.compileInput('<input type="range" ng-model="value" step="0.1" />');
+            var ngModel = inputElm.controller('ngModel');
 
-          expect(inputElm.val()).toBe('');
-          expect(inputElm).toBeValid();
-          expect($rootScope.value).toBeUndefined();
+            expect(inputElm.val()).toBe('');
+            expect(inputElm).toBeValid();
+            expect($rootScope.value).toBeUndefined();
 
-          helper.changeInputValueTo('0.3');
-          expect(inputElm).toBeValid();
-          expect($rootScope.value).toBe(0.3);
+            helper.changeInputValueTo('0.3');
+            expect(inputElm).toBeValid();
+            expect($rootScope.value).toBe(0.3);
 
-          helper.changeInputValueTo('2.9999999999999996');
-          expect(inputElm).toBeInvalid();
-          expect(ngModel.$error.step).toBe(true);
-          expect($rootScope.value).toBeUndefined();
+            helper.changeInputValueTo('2.9999999999999996');
+            expect(inputElm).toBeInvalid();
+            expect(ngModel.$error.step).toBe(true);
+            expect($rootScope.value).toBeUndefined();
 
-          // 0.5 % 0.1 === 0.09999999999999998
-          helper.changeInputValueTo('0.5');
-          expect(inputElm).toBeValid();
-          expect($rootScope.value).toBe(0.5);
+            // 0.5 % 0.1 === 0.09999999999999998
+            helper.changeInputValueTo('0.5');
+            expect(inputElm).toBeValid();
+            expect($rootScope.value).toBe(0.5);
 
-          // 3.5 % 0.1 === 0.09999999999999981
-          helper.changeInputValueTo('3.5');
-          expect(inputElm).toBeValid();
-          expect($rootScope.value).toBe(3.5);
-        });
+            // 3.5 % 0.1 === 0.09999999999999981
+            helper.changeInputValueTo('3.5');
+            expect(inputElm).toBeValid();
+            expect($rootScope.value).toBe(3.5);
+          }
+        );
       }
     });
   });

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2703,6 +2703,87 @@ describe('input', function() {
           expect(inputElm.val()).toBe('10');
           expect($rootScope.form.alias.$error.step).toBeFalsy();
         });
+
+        it('should use the correct "step base" when `[min]` is specified', function() {
+          $rootScope.min = 5;
+          $rootScope.step = 10;
+          $rootScope.value = 10;
+          var inputElm = helper.compileInput(
+              '<input type="number" ng-model="value" min="{{min}}" ' + attrHtml + ' />');
+          var ngModel = inputElm.controller('ngModel');
+
+          expect(inputElm.val()).toBe('10');
+          expect(inputElm).toBeInvalid();
+          expect(ngModel.$error.step).toBe(true);
+          expect($rootScope.value).toBeUndefined();
+
+          helper.changeInputValueTo('15');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(15);
+
+          $rootScope.$apply('step = 3');
+          expect(inputElm.val()).toBe('15');
+          expect(inputElm).toBeInvalid();
+          expect(ngModel.$error.step).toBe(true);
+          expect($rootScope.value).toBeUndefined();
+
+          helper.changeInputValueTo('8');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(8);
+
+          $rootScope.$apply('min = 10; step = 20; value = 30');
+          expect(inputElm.val()).toBe('30');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(30);
+
+          $rootScope.$apply('min = 5');
+          expect(inputElm.val()).toBe('30');
+          expect(inputElm).toBeInvalid();
+          expect(ngModel.$error.step).toBe(true);
+          expect($rootScope.value).toBeUndefined();
+
+          $rootScope.$apply('step = 0.00000001');
+          expect(inputElm.val()).toBe('30');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(30);
+
+          // 0.3 - 0.2 === 0.09999999999999998
+          $rootScope.$apply('min = 0.2; step = 0.09999999999999998; value = 0.3');
+          expect(inputElm.val()).toBe('0.3');
+          expect(inputElm).toBeInvalid();
+          expect(ngModel.$error.step).toBe(true);
+          expect($rootScope.value).toBeUndefined();
+        });
+
+        it('should correctly validate even in cases where `(x*y % x !== 0)`', function() {
+          $rootScope.step = 0.1;
+          var inputElm = helper.compileInput(
+              '<input type="number" ng-model="value" ' + attrHtml + ' />');
+          var ngModel = inputElm.controller('ngModel');
+
+          expect(inputElm.val()).toBe('');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBeUndefined();
+
+          helper.changeInputValueTo('0.3');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(0.3);
+
+          helper.changeInputValueTo('2.9999999999999996');
+          expect(inputElm).toBeInvalid();
+          expect(ngModel.$error.step).toBe(true);
+          expect($rootScope.value).toBeUndefined();
+
+          // 0.5 % 0.1 === 0.09999999999999998
+          helper.changeInputValueTo('0.5');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(0.5);
+
+          // 3.5 % 0.1 === 0.09999999999999981
+          helper.changeInputValueTo('3.5');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(3.5);
+        });
       });
     });
 
@@ -3515,6 +3596,85 @@ describe('input', function() {
           expect(scope.value).toBe(10);
           expect(inputElm.val()).toBe('10');
           expect(scope.form.alias.$error.step).toBeFalsy();
+        });
+
+        it('should use the correct "step base" when `[min]` is specified', function() {
+          $rootScope.min = 5;
+          $rootScope.step = 10;
+          $rootScope.value = 10;
+          var inputElm = helper.compileInput(
+              '<input type="range" ng-model="value" min="{{min}}" step="{{step}}"" />');
+          var ngModel = inputElm.controller('ngModel');
+
+          expect(inputElm.val()).toBe('10');
+          expect(inputElm).toBeInvalid();
+          expect(ngModel.$error.step).toBe(true);
+          expect($rootScope.value).toBeUndefined();
+
+          helper.changeInputValueTo('15');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(15);
+
+          $rootScope.$apply('step = 3');
+          expect(inputElm.val()).toBe('15');
+          expect(inputElm).toBeInvalid();
+          expect(ngModel.$error.step).toBe(true);
+          expect($rootScope.value).toBeUndefined();
+
+          helper.changeInputValueTo('8');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(8);
+
+          $rootScope.$apply('min = 10; step = 20; value = 30');
+          expect(inputElm.val()).toBe('30');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(30);
+
+          $rootScope.$apply('min = 5');
+          expect(inputElm.val()).toBe('30');
+          expect(inputElm).toBeInvalid();
+          expect(ngModel.$error.step).toBe(true);
+          expect($rootScope.value).toBeUndefined();
+
+          $rootScope.$apply('step = 0.00000001');
+          expect(inputElm.val()).toBe('30');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(30);
+
+          // 0.3 - 0.2 === 0.09999999999999998
+          $rootScope.$apply('min = 0.2; step = 0.09999999999999998; value = 0.3');
+          expect(inputElm.val()).toBe('0.3');
+          expect(inputElm).toBeInvalid();
+          expect(ngModel.$error.step).toBe(true);
+          expect($rootScope.value).toBeUndefined();
+        });
+
+        it('should correctly validate even in cases where `(x*y % x !== 0)`', function() {
+          var inputElm = helper.compileInput('<input type="range" ng-model="value" step="0.1" />');
+          var ngModel = inputElm.controller('ngModel');
+
+          expect(inputElm.val()).toBe('');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBeUndefined();
+
+          helper.changeInputValueTo('0.3');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(0.3);
+
+          helper.changeInputValueTo('2.9999999999999996');
+          expect(inputElm).toBeInvalid();
+          expect(ngModel.$error.step).toBe(true);
+          expect($rootScope.value).toBeUndefined();
+
+          // 0.5 % 0.1 === 0.09999999999999998
+          helper.changeInputValueTo('0.5');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(0.5);
+
+          // 3.5 % 0.1 === 0.09999999999999981
+          helper.changeInputValueTo('3.5');
+          expect(inputElm).toBeValid();
+          expect($rootScope.value).toBe(3.5);
         });
       }
     });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.

**What is the current behavior? (You can also link to an open issue here)**
`step` validation (for `input[number]`/`input[range]`) fails on some occasions due to limitations of Floating Point Arithmetic (as described in #15257) and does not fully account for a `stepBase` as descussed in https://github.com/angular/angular.js/commit/9a8b8aa#commitcomment-19108436. 

**What is the new behavior (if this is a feature change)?**
It works as expected!
BTW, according to [the spec](https://www.w3.org/TR/html5/forms.html#concept-input-min-zero), when there is no `min` attribute (to determine the step base), but there is a value attribute, then the step base is set to the value of that. In our case this doesn't apply very well, because the value attribute is not compatible with `ngModel` and is essentially ignored.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
- [ ] Needs to be backported to 1.5.x for `[ng-input-range]`.

Fixes https://github.com/angular/angular.js/commit/9a8b8aa#commitcomment-19108436
Fixes #15257
