### PR TITLE
fix(docsApp): show correct version number in api index

### DIFF
--- a/docs/app/src/docs.js
+++ b/docs/app/src/docs.js
@@ -8,8 +8,6 @@ angular.module('DocsController', [])
   function($scope, $rootScope, $location, $window, $cookies,
               NG_PAGES, NG_NAVIGATION, NG_VERSION) {
 
-  $scope.docsVersion = NG_VERSION.isSnapshot ? 'snapshot' : NG_VERSION.version;
-
   $scope.navClass = function(navItem) {
     return {
       active: navItem.href && this.currentPage && this.currentPage.path,
@@ -53,8 +51,8 @@ angular.module('DocsController', [])
    Initialize
    ***********************************/
 
-  $scope.versionNumber = angular.version.full;
-  $scope.version = angular.version.full + '  ' + angular.version.codeName;
+  $scope.versionNumber = NG_VERSION.full;
+  $scope.version = NG_VERSION.full + ' ' + NG_VERSION.codeName;
   $scope.loading = 0;
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
fix in the docs app

**What is the current behavior? (You can also link to an open issue here)**
On https://docs.angularjs.org/api, the text currently says 

> These pages contain the AngularJS reference materials for version 1.5.8 arbitrary-fallbacks.

but the default docs are for the master / snapshot version. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format

**Other information**:

Previously, the index would show the version of Angular that runs on
the page, not the version for which the docs are. This meant that in
that snapshot docs the stable version was displayed.

The `$scope.docsVersion` value was used in the plnkr opening code, but
has not been used since https://github.com/angular/angular.js/commit/bdec35cebc89e0d80a04eeffbd71ad999fc7e61a.
