### PR TITLE
chore(doc-gen, docs-app): create plnkr examples with correct Angular …

### DIFF
--- a/docs/app/src/examples.js
+++ b/docs/app/src/examples.js
@@ -181,9 +181,8 @@ angular.module('examples', [])
           filePromises.push($http.get(exampleFolder + '/' + filename, { transformResponse: [] })
             .then(function(response) {
 
-              // The manifests provide the production index file but Plunkr wants
-              // a straight index.html
-              if (filename === 'index-production.html') {
+              // Plunkr needs an index file that's simply named index.html
+              if (filename === 'index-plnkr.html') {
                 filename = 'index.html';
               }
 

--- a/docs/config/index.js
+++ b/docs/config/index.js
@@ -23,6 +23,7 @@ module.exports = new Package('angularjs', [
 .factory(require('./services/deployments/default'))
 .factory(require('./services/deployments/jquery'))
 .factory(require('./services/deployments/production'))
+.factory(require('./services/deployments/plnkr'))
 
 .factory(require('./inline-tag-defs/type'))
 
@@ -150,7 +151,8 @@ module.exports = new Package('angularjs', [
   generateProtractorTestsProcessor,
   generateExamplesProcessor,
   debugDeployment, defaultDeployment,
-  jqueryDeployment, productionDeployment) {
+  jqueryDeployment, productionDeployment,
+  plnkrDeployment) {
 
   generateIndexPagesProcessor.deployments = [
     debugDeployment,
@@ -170,7 +172,8 @@ module.exports = new Package('angularjs', [
     debugDeployment,
     defaultDeployment,
     jqueryDeployment,
-    productionDeployment
+    productionDeployment,
+    plnkrDeployment
   ];
 })
 

--- a/docs/config/services/deployments/plnkr.js
+++ b/docs/config/services/deployments/plnkr.js
@@ -1,0 +1,49 @@
+'use strict';
+// Special deployment that is only used for the examples on plnkr.
+// While the embedded examples use the Angular files relative the docs folder,
+// plnkr uses the CDN urls, and needs to switch between Google CDN for tagged versions
+// and the code.angularjs.org server for the snapshot (master) version.
+
+var versionInfo = require('../../../../lib/versions/version-info');
+var isSnapshot = versionInfo.currentVersion.isSnapshot;
+
+var cdnUrl = isSnapshot ?
+  '//code.angularjs.org/snapshot' :
+  '//ajax.googleapis.com/ajax/libs/angularjs/' + versionInfo.cdnVersion;
+
+module.exports = function plnkrDeployment(getVersion) {
+  return {
+    name: 'plnkr',
+    examples: {
+      commonFiles: {
+        scripts: [cdnUrl + '/angular.min.js']
+      },
+      dependencyPath: cdnUrl + '/'
+    },
+    scripts: [
+      cdnUrl + '/angular.min.js',
+      cdnUrl + '/angular-resource.min.js',
+      cdnUrl + '/angular-route.min.js',
+      cdnUrl + '/angular-cookies.min.js',
+      cdnUrl + '/angular-sanitize.min.js',
+      cdnUrl + '/angular-touch.min.js',
+      cdnUrl + '/angular-animate.min.js',
+      'components/marked-' + getVersion('marked', 'node_modules', 'package.json') + '/lib/marked.js',
+      'js/angular-bootstrap/dropdown-toggle.min.js',
+      'components/lunr.js-' + getVersion('lunr.js') + '/lunr.min.js',
+      'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/prettify.js',
+      'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/lang-css.js',
+      'js/versions-data.js',
+      'js/pages-data.js',
+      'js/nav-data.js',
+      'js/docs.min.js'
+    ],
+    stylesheets: [
+      'components/bootstrap-' + getVersion('bootstrap') + '/css/bootstrap.min.css',
+      'components/open-sans-fontface-' + getVersion('open-sans-fontface') + '/open-sans.css',
+      'css/prettify-theme.css',
+      'css/docs.css',
+      'css/animations.css'
+    ]
+  };
+};


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs-gen / app fix

**What is the current behavior? (You can also link to an open issue here)**
The plnkr examples include the latest stable Angular version instead of the snapshot version when opened from snapshot docs.

**What is the new behavior (if this is a feature change)?**
Fixes the plnkr examples generated from snapshot docs

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- ~[ ] Tests for the changes have been added (for bug fixes / features)~
- ~[ ] Docs have been added / updated (for bug fixes / features)~

**Other information**:

…version

When the docs are based on the snapshot, the plnkr examples must use the snapshot files
from code.angularjs.org

Fixes https://github.com/angular/angular.js/issues/15267
