### PR TITLE
fix($parse): allow watching object/array literals

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3522,7 +3522,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               }
               recordChanges(scopeName, newValue, oldValue);
               destination[scopeName] = newValue;
-            }, deepWatch);
+            });
 
             removeWatchCollection.push(removeWatch);
             break;

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1826,7 +1826,7 @@ function $ParseProvider() {
             oldInputValueOf = newInputValue && getValueOf(newInputValue);
           }
           return lastResult;
-        }, listener, objectEquality, prettyPrintExpression);
+        }, listener, objectEquality || parsedExpression.literal, prettyPrintExpression);
       }
 
       var oldInputValueOfValues = [];
@@ -1852,7 +1852,7 @@ function $ParseProvider() {
         }
 
         return lastResult;
-      }, listener, objectEquality, prettyPrintExpression);
+      }, listener, objectEquality || parsedExpression.literal, prettyPrintExpression);
     }
 
     function oneTimeWatchDelegate(scope, listener, objectEquality, parsedExpression, prettyPrintExpression) {

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3117,6 +3117,29 @@ describe('parser', function() {
           scope.$digest();
           expect(objB.value).toBe(scope.input);
         }));
+
+        it('should support watching literals', inject(function($parse) {
+          var lastVal = NaN;
+          var callCount = 0;
+          var listener = function(val) { callCount++; lastVal = val; };
+
+          scope.$watch('{val: val}', listener);
+
+          scope.$apply('val = 1');
+          expect(callCount).toBe(1);
+          expect(lastVal).toEqual({val: 1});
+
+          scope.$apply('val = []');
+          expect(callCount).toBe(2);
+          expect(lastVal).toEqual({val: []});
+
+          scope.$apply('val = []');
+          expect(callCount).toBe(2);
+
+          scope.$apply('val.push(1)');
+          expect(callCount).toBe(3);
+          expect(lastVal).toEqual({val: [1]});
+        }));
       });
 
       describe('locals', function() {


### PR DESCRIPTION
This moves the object/array-literal watching logic from $compile to $parse so it can by used by watchers anywhere (not only bindings).

By moving this to `$parse` we can potentially improve it more. Maybe pushing the `equals` check into `expressionInputDirtyCheck` for literals, then we can avoid creating the object and avoid calling `equals` on the full object each digest?

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bug fix

**What is the current behavior? (You can also link to an open issue here)**
watching object/array literals throws infdig if any inputs are non-simple values

**What is the new behavior (if this is a feature change)?**
watching object/array literals does what compile previously did to solve this

**Does this PR introduce a breaking change?**
no

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
