### PR TITLE
chore(docs-app): allow switching to newer versions

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,6 +20,8 @@ module.exports = function(grunt) {
   NG_VERSION.cdn = versionInfo.cdnVersion;
   var dist = 'angular-' + NG_VERSION.full;
 
+  var NG_VERSIONS = versionInfo.previousVersions;
+
   if (versionInfo.cdnVersion == null) {
     throw new Error('Unable to read CDN version, are you offline or has the CDN not been properly pushed?');
   }
@@ -301,7 +303,8 @@ module.exports = function(grunt) {
 
     write: {
       versionTXT: {file: 'build/version.txt', val: NG_VERSION.full},
-      versionJSON: {file: 'build/version.json', val: JSON.stringify(NG_VERSION)}
+      versionJSON: {file: 'build/version.json', val: JSON.stringify(NG_VERSION)},
+      versionsJSON: {file: 'build/versions.json', val: JSON.stringify(NG_VERSIONS.concat([NG_VERSION]))}
     },
 
     bump: {

--- a/docs/app/src/versions.js
+++ b/docs/app/src/versions.js
@@ -2,23 +2,35 @@
 
 angular.module('versions', [])
 
-.controller('DocsVersionsCtrl', ['$scope', '$location', '$window', 'NG_VERSIONS', function($scope, $location, $window, NG_VERSIONS) {
+.controller('DocsVersionsCtrl', [
+  '$scope',
+  '$location',
+  '$window',
+  '$http',
+  '$q',
+  'NG_VERSIONS', function($scope, $location, $window, $http, $q, NG_VERSIONS) {
+
   $scope.docs_version  = NG_VERSIONS[0];
   $scope.docs_versions = NG_VERSIONS;
 
-  for (var i = 0, minor = NaN; i < NG_VERSIONS.length; i++) {
-    var version = NG_VERSIONS[i];
-    if (version.isSnapshot) {
-      version.isLatest = true;
-      continue;
+  // If this is not the snapshot version, request the snapshot's versions data
+  // to fill the version list with current data
+  $q(function(resolve, reject) {
+    if ($scope.docs_version.isSnapshot) {
+      reject();
+    } else {
+      resolve();
     }
-    // NaN will give false here
-    if (minor <= version.minor) {
-      continue;
-    }
-    version.isLatest = true;
-    minor = version.minor;
-  }
+  }).then(function() {
+    return $http.get('../snapshot/versions_data.json');
+  }).then(function(response) {
+    $scope.docs_versions = response.data;
+  }).catch(function() {
+    // Ignore error. This either means this is already the snapshot version or that
+    // the requested versions-data file could not be found
+  }).finally(function() {
+    setLatestVersion($scope.docs_versions);
+  });
 
   $scope.getGroupName = function(v) {
     return v.isLatest ? 'Latest' : ('v' + v.major + '.' + v.minor + '.x');
@@ -26,12 +38,34 @@ angular.module('versions', [])
 
   $scope.jumpToDocsVersion = function(version) {
     var currentPagePath = $location.path().replace(/\/$/, ''),
-        url = '';
-    if (version.isOldDocsUrl) {
-      url = version.docsUrl;
-    } else {
-      url = version.docsUrl + currentPagePath;
+        url = version.docsUrl;
+
+    //Workaround for an ngOptions quirk that can cause ngChange to be called
+    //with the same version
+    if (url === window.location + '') {
+      return;
     }
+
+    if (!version.isOldDocsUrl) {
+      url += currentPagePath;
+    }
+
     $window.location = url;
   };
+
+  function setLatestVersion(ng_versions) {
+    for (var i = 0, minor = NaN; i < ng_versions.length; i++) {
+      var version = ng_versions[i];
+      if (version.isSnapshot) {
+        version.isLatest = true;
+        continue;
+      }
+      // NaN will give false here
+      if (minor <= version.minor) {
+        continue;
+      }
+      version.isLatest = true;
+      minor = version.minor;
+    }
+  }
 }]);

--- a/docs/config/templates/indexPage.template.html
+++ b/docs/config/templates/indexPage.template.html
@@ -166,7 +166,7 @@
         <div class="container main-grid main-header-grid">
           <div class="grid-left">
             <div ng-controller="DocsVersionsCtrl" class="picker version-picker">
-              <select ng-options="v as (v.isSnapshot ? v.branch : ('v' + v.version)) group by getGroupName(v) for v in docs_versions"
+              <select ng-options="v as (v.isSnapshot ? v.branch : ('v' + v.version)) group by getGroupName(v) for v in docs_versions track by v.version"
                       ng-model="docs_version"
                       ng-change="jumpToDocsVersion(docs_version)"
                       class="docs-version-jump">


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature for the docs app

**What is the current behavior? (You can also link to an open issue here)**
You cannot switch to a newer version from an older version in the docs app.

**What is the new behavior (if this is a feature change)?**
For docs app versions that contain this commit, switchting is possible. The docs app
will request the new versions-data.json file from the snapshot folder and fill the version switcher with
this data.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- ~[] Tests for the changes have been added (for bug fixes / features)~
- ~[ ] Docs have been added / updated (for bug fixes / features)~

**Other information**:

With this patch, the docs app will request available versions data from the snapshot,
which are now stored in a separate versions-data.json file.

This only affects docs apps that contain this commit, so older doc apps
will still only display the versions up to their own version.
