### PR TITLE
fix(input[radio]): use strict comparison when evaluating checked-ness

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1761,9 +1761,7 @@ function radioInputType(scope, element, attr, ctrl) {
     if (doTrim) {
       value = trim(value);
     }
-    // Strict comparison would cause a BC
-    // eslint-disable-next-line eqeqeq
-    element[0].checked = (value == ctrl.$viewValue);
+    element[0].checked = (value === ctrl.$viewValue);
   };
 
   attr.$observe('value', ctrl.$render);

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -3867,9 +3867,7 @@ describe('input', function() {
       expect($rootScope.color).toBe('blue');
     });
 
-
-    // We generally use strict comparison. This tests behavior we cannot change without a BC
-    it('should use non-strict comparison the evaluate checked-ness', function() {
+    it('should treat the value as a string when evaluating checked-ness', function() {
       var inputElm = helper.compileInput(
           '<input type="radio" ng-model="model" value="0" />');
 
@@ -3877,7 +3875,7 @@ describe('input', function() {
       expect(inputElm[0].checked).toBe(true);
 
       $rootScope.$apply('model = 0');
-      expect(inputElm[0].checked).toBe(true);
+      expect(inputElm[0].checked).toBe(false);
     });
 
 
@@ -4128,6 +4126,18 @@ describe('input', function() {
 
       browserTrigger(inputElm[2], 'click');
       expect($rootScope.selected).toBe(1);
+    });
+
+
+    it('should use strict comparison between model and value', function() {
+      $rootScope.selected = false;
+      var inputElm = helper.compileInput('<input type="radio" ng-model="selected" ng-value="false">' +
+                   '<input type="radio" ng-model="selected" ng-value="\'\'">' +
+                   '<input type="radio" ng-model="selected" ng-value="0">');
+
+      expect(inputElm[0].checked).toBe(true);
+      expect(inputElm[1].checked).toBe(false);
+      expect(inputElm[2].checked).toBe(false);
     });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix

**What is the current behavior? (You can also link to an open issue here)**
When using input[radio], the checked status is determined by doing
a non-strict comparison between the value of the input and the ngModel.$viewValue. This can
lead to inconsistencies when using values such as 0 and false.

**Does this PR introduce a breaking change?**
Yes

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

Closes #15283

BREAKING CHANGE:

When using input[radio], the checked status is now determined by doing
a strict comparison between the value of the input and the ngModel.$viewValue.
Previously, this was a non-strict comparison (==).

This means in the following examples the radio is no longer checked:

```
  <!-- this.selected = 0 -->
  <input type="radio" ng-model="$ctrl.selected" value="0" >

  <!-- this.selected = 0; this.value = false; -->
  <input type="radio" ng-model="$ctrl.selected" ng-value="$ctrl.value" >
```

The migration strategy is to convert values that matched with non-strict
conversion so that they will match with strict conversion.
