### PR TITLE
fix(input[radio]): use non-strict comparison for checkedness

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1753,7 +1753,9 @@ function radioInputType(scope, element, attr, ctrl) {
 
   ctrl.$render = function() {
     var value = attr.value;
-    element[0].checked = (value === ctrl.$viewValue);
+    // We generally use strict comparison. This is behavior we cannot change without a BC.
+    // eslint-disable-next-line eqeqeq
+    element[0].checked = (value == ctrl.$viewValue);
   };
 
   attr.$observe('value', ctrl.$render);

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -3871,6 +3871,17 @@ describe('input', function() {
     });
 
 
+    it('should use non-strict comparison between model and value', function() {
+      $rootScope.selected = false;
+      var inputElm = helper.compileInput('<input type="radio" ng-model="selected" ng-value="false">' +
+                   '<input type="radio" ng-model="selected" ng-value="\'\'">' +
+                   '<input type="radio" ng-model="selected" ng-value="0">');
+
+      expect(inputElm[0].checked).toBe(true);
+      expect(inputElm[1].checked).toBe(true);
+      expect(inputElm[2].checked).toBe(true);
+    });
+
     it('should watch the expression', function() {
       var inputElm = helper.compileInput('<input type="radio" ng-model="selected" ng-value="value">');
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Reverting a Breaking Change

**What is the current behavior? (You can also link to an open issue here)**
Checkedness is determined by comparing $viewValue and value strictly.

**What is the new behavior (if this is a feature change)?**
Checkedness is determined by comparing $viewValue and value non-strictly.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- ~[ ] Docs have been added / updated (for bug fixes / features)~

**Other information**:

This was introduced during the switch to ESLint, but it is a breaking change.
