### PR TITLE
fix($compile): Cleanup attribute-binding observers

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3434,7 +3434,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             if (!optional && !hasOwnProperty.call(attrs, attrName)) {
               destination[scopeName] = attrs[attrName] = undefined;
             }
-            attrs.$observe(attrName, function(value) {
+            removeWatch = attrs.$observe(attrName, function(value) {
               if (isString(value) || isBoolean(value)) {
                 var oldValue = destination[scopeName];
                 recordChanges(scopeName, value, oldValue);
@@ -3453,6 +3453,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               destination[scopeName] = lastValue;
             }
             initialChanges[scopeName] = new SimpleChange(_UNINITIALIZED_VALUE, destination[scopeName]);
+            removeWatchCollection.push(removeWatch);
             break;
 
           case '=':

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4069,7 +4069,7 @@ describe('$compile', function() {
         });
 
         describe('$doCheck', function() {
-          it('should call `$doCheck`, if provided, for each digest cycle, after $onChanges and $onInit', function() {
+          it('should call `$doCheck`, if provided, for each digest cycle, after and $onInit', function() {
             var log = [];
 
             function TestController() { }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4069,7 +4069,7 @@ describe('$compile', function() {
         });
 
         describe('$doCheck', function() {
-          it('should call `$doCheck`, if provided, for each digest cycle, after and $onInit', function() {
+          it('should call `$doCheck`, if provided, for each digest cycle, after $onChanges and $onInit', function() {
             var log = [];
 
             function TestController() { }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
https://github.com/angular/angular.js/issues/15268

**What is the new behavior (if this is a feature change)?**
Cleans up attributes observer on change.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
