### PR TITLE
fix($compile): Cleanup attribute-binding observers

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3434,7 +3434,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             if (!optional && !hasOwnProperty.call(attrs, attrName)) {
               destination[scopeName] = attrs[attrName] = undefined;
             }
-            attrs.$observe(attrName, function(value) {
+            removeWatch = attrs.$observe(attrName, function(value) {
               if (isString(value) || isBoolean(value)) {
                 var oldValue = destination[scopeName];
                 recordChanges(scopeName, value, oldValue);
@@ -3453,6 +3453,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               destination[scopeName] = lastValue;
             }
             initialChanges[scopeName] = new SimpleChange(_UNINITIALIZED_VALUE, destination[scopeName]);
+            removeWatchCollection.push(removeWatch);
             break;
 
           case '=':

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4380,39 +4380,34 @@ describe('$compile', function() {
 
           it('should reinitialize watchers on attribute change', function() {
             var constructorSpy = jasmine.createSpy('constructor');
+            var prototypeSpy = jasmine.createSpy('prototype');
 
             function TestDirective() {
-              this.constructorProp = true;
-              this.constructorSpy = constructorSpy;
+              return {$onChanges: constructorSpy};
             }
 
-            TestDirective.prototype.$onChanges = function(changes) {
-              this.constructorSpy(this.constructorProp);
-            };
+            TestDirective.prototype.$onChanges = prototypeSpy;
 
             module(function($compileProvider) {
               $compileProvider.component('test', {
-                bindings: {prop: '<', attr: '@'},
+                bindings: {attr: '@'},
                 controller: TestDirective
               });
             });
 
             inject(function($compile, $rootScope) {
-              var template = '<test prop="a" attr="{{b}}"></test>';
+              var template = '<test attr="{{a}}"></test>';
               $rootScope.a = 'foo';
-              $rootScope.b = NaN;
 
               element = $compile(template)($rootScope);
               $rootScope.$digest();
-              expect(constructorSpy).toHaveBeenCalledWith(true);
+              expect(constructorSpy).toHaveBeenCalled();
+              expect(prototypeSpy).not.toHaveBeenCalled();
 
               constructorSpy.calls.reset();
               $rootScope.$apply('a = "bar"');
-              expect(constructorSpy).toHaveBeenCalledWith(true);
-
-              constructorSpy.calls.reset();
-              $rootScope.$apply('b = 42');
-              expect(constructorSpy).toHaveBeenCalledWith(true);
+              expect(constructorSpy).toHaveBeenCalled();
+              expect(prototypeSpy).not.toHaveBeenCalled();
             });
           });
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4381,16 +4381,14 @@ describe('$compile', function() {
           it('should reinitialize watchers on attribute change', function() {
             var constructorSpy = jasmine.createSpy('constructor');
 
-            class TestDirective {
-              constructor() {
-                this.constructorProp = true;
-                this.constructorSpy = constructorSpy;
-              }
-
-              $onChanges(changes) {
-                this.constructorSpy(this.constructorProp);
-              }
+            function TestDirective() {
+              this.constructorProp = true;
+              this.constructorSpy = constructorSpy;
             }
+            
+            TestDirective.prototype.$onChanges = function(changes) {
+              this.constructorSpy(this.constructorProp);
+            };
 
             module(function($compileProvider) {
               $compileProvider.component('test', {

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4416,7 +4416,6 @@ describe('$compile', function() {
             });
           });
 
-
           it('should not call `$onChanges` twice even when the initial value is `NaN`', function() {
             var onChangesSpy = jasmine.createSpy('$onChanges');
 

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4385,7 +4385,7 @@ describe('$compile', function() {
               this.constructorProp = true;
               this.constructorSpy = constructorSpy;
             }
-            
+
             TestDirective.prototype.$onChanges = function(changes) {
               this.constructorSpy(this.constructorProp);
             };


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
https://github.com/angular/angular.js/issues/15268

**What is the new behavior (if this is a feature change)?**
Cleans up attributes observer on change.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
