### PR TITLE
fix+perf($parse): allow watching array/object literal values, disable deep watch for one-way bindings

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3508,14 +3508,14 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             if (optional && !attrs[attrName]) break;
 
             parentGet = $parse(attrs[attrName]);
-            var deepWatch = parentGet.literal;
+            var isLiteral = parentGet.literal;
 
             var initialValue = destination[scopeName] = parentGet(scope);
             initialChanges[scopeName] = new SimpleChange(_UNINITIALIZED_VALUE, destination[scopeName]);
 
             removeWatch = scope.$watch(parentGet, function parentValueWatchAction(newValue, oldValue) {
               if (oldValue === newValue) {
-                if (oldValue === initialValue || (deepWatch && equals(oldValue, initialValue))) {
+                if (oldValue === initialValue || (isLiteral && equals(oldValue, initialValue))) {
                   return;
                 }
                 oldValue = initialValue;

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3522,7 +3522,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               }
               recordChanges(scopeName, newValue, oldValue);
               destination[scopeName] = newValue;
-            }, deepWatch);
+            });
 
             removeWatchCollection.push(removeWatch);
             break;

--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1786,13 +1786,13 @@ function $ParseProvider() {
       }
     }
 
-    function expressionInputDirtyCheck(newValue, oldValueOfValue) {
+    function expressionInputDirtyCheck(newValue, oldValueOfValue, compareObjectIdentity) {
 
       if (newValue == null || oldValueOfValue == null) { // null/undefined
         return newValue === oldValueOfValue;
       }
 
-      if (typeof newValue === 'object') {
+      if (typeof newValue === 'object' && !compareObjectIdentity) {
 
         // attempt to convert the value to a primitive type
         // TODO(docs): add a note to docs that by implementing valueOf even objects and arrays can
@@ -1821,7 +1821,7 @@ function $ParseProvider() {
         inputExpressions = inputExpressions[0];
         return scope.$watch(function expressionInputWatch(scope) {
           var newInputValue = inputExpressions(scope);
-          if (!expressionInputDirtyCheck(newInputValue, oldInputValueOf)) {
+          if (!expressionInputDirtyCheck(newInputValue, oldInputValueOf, parsedExpression.literal)) {
             lastResult = parsedExpression(scope, undefined, undefined, [newInputValue]);
             oldInputValueOf = newInputValue && getValueOf(newInputValue);
           }
@@ -1841,7 +1841,7 @@ function $ParseProvider() {
 
         for (var i = 0, ii = inputExpressions.length; i < ii; i++) {
           var newInputValue = inputExpressions[i](scope);
-          if (changed || (changed = !expressionInputDirtyCheck(newInputValue, oldInputValueOfValues[i]))) {
+          if (changed || (changed = !expressionInputDirtyCheck(newInputValue, oldInputValueOfValues[i], parsedExpression.literal))) {
             oldInputValues[i] = newInputValue;
             oldInputValueOfValues[i] = newInputValue && getValueOf(newInputValue);
           }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -5676,7 +5676,7 @@ describe('$compile', function() {
             }));
 
 
-            it('should deep-watch array literals', inject(function() {
+            it('should watch input values to array literals', inject(function() {
               $rootScope.name = 'georgios';
               $rootScope.obj = {name: 'pete'};
               compile('<div><span my-component ow-ref="[{name: name}, obj]">');
@@ -5690,7 +5690,7 @@ describe('$compile', function() {
             }));
 
 
-            it('should deep-watch object literals', inject(function() {
+            it('should watch input values object literals', inject(function() {
               $rootScope.name = 'georgios';
               $rootScope.obj = {name: 'pete'};
               compile('<div><span my-component ow-ref="{name: name, item: obj}">');

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -4259,6 +4259,78 @@ describe('$compile', function() {
           });
 
 
+          it('should trigger `$onChanges` for literal expressions when expression input value changes (simple value)', function() {
+            var log = [];
+            function TestController() { }
+            TestController.prototype.$onChanges = function(change) { log.push(change); };
+
+            angular.module('my', [])
+              .component('c1', {
+                controller: TestController,
+                bindings: { 'prop1': '<' }
+              });
+
+            module('my');
+            inject(function($compile, $rootScope) {
+              element = $compile('<c1 prop1="[val]"></c1>')($rootScope);
+
+              $rootScope.$apply('val = 1');
+              expect(log.pop()).toEqual({prop1: jasmine.objectContaining({previousValue: [undefined], currentValue: [1]})});
+
+              $rootScope.$apply('val = 2');
+              expect(log.pop()).toEqual({prop1: jasmine.objectContaining({previousValue: [1], currentValue: [2]})});
+            });
+          });
+
+
+          it('should trigger `$onChanges` for literal expressions when expression input value changes (complex value)', function() {
+            var log = [];
+            function TestController() { }
+            TestController.prototype.$onChanges = function(change) { log.push(change); };
+
+            angular.module('my', [])
+              .component('c1', {
+                controller: TestController,
+                bindings: { 'prop1': '<' }
+              });
+
+            module('my');
+            inject(function($compile, $rootScope) {
+              element = $compile('<c1 prop1="[val]"></c1>')($rootScope);
+
+              $rootScope.$apply('val = [1]');
+              expect(log.pop()).toEqual({prop1: jasmine.objectContaining({previousValue: [undefined], currentValue: [[1]]})});
+
+              $rootScope.$apply('val = [2]');
+              expect(log.pop()).toEqual({prop1: jasmine.objectContaining({previousValue: [[1]], currentValue: [[2]]})});
+            });
+          });
+
+
+          it('should trigger `$onChanges` for literal expressions when expression input value changes instances, even when equal', function() {
+            var log = [];
+            function TestController() { }
+            TestController.prototype.$onChanges = function(change) { log.push(change); };
+
+            angular.module('my', [])
+              .component('c1', {
+                controller: TestController,
+                bindings: { 'prop1': '<' }
+              });
+
+            module('my');
+            inject(function($compile, $rootScope) {
+              element = $compile('<c1 prop1="[val]"></c1>')($rootScope);
+
+              $rootScope.$apply('val = [1]');
+              expect(log.pop()).toEqual({prop1: jasmine.objectContaining({previousValue: [undefined], currentValue: [[1]]})});
+
+              $rootScope.$apply('val = [1]');
+              expect(log.pop()).toEqual({prop1: jasmine.objectContaining({previousValue: [[1]], currentValue: [[1]]})});
+            });
+          });
+
+
           it('should pass the original value as `previousValue` even if there were multiple changes in a single digest', function() {
             var log = [];
             function TestController() { }

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3117,6 +3117,74 @@ describe('parser', function() {
           scope.$digest();
           expect(objB.value).toBe(scope.input);
         }));
+
+        it('should support watching literals', inject(function($parse) {
+          var lastVal = NaN;
+          var callCount = 0;
+          var listener = function(val) { callCount++; lastVal = val; };
+
+          scope.$watch('{val: val}', listener);
+
+          scope.$apply('val = 1');
+          expect(callCount).toBe(1);
+          expect(lastVal).toEqual({val: 1});
+
+          scope.$apply('val = []');
+          expect(callCount).toBe(2);
+          expect(lastVal).toEqual({val: []});
+
+          scope.$apply('val = []');
+          expect(callCount).toBe(3);
+          expect(lastVal).toEqual({val: []});
+
+          scope.$apply('val = {}');
+          expect(callCount).toBe(4);
+          expect(lastVal).toEqual({val: {}});
+        }));
+
+        it('should only watch the direct inputs to literals', inject(function($parse) {
+          var lastVal = NaN;
+          var callCount = 0;
+          var listener = function(val) { callCount++; lastVal = val; };
+
+          scope.$watch('{val: val}', listener);
+
+          scope.$apply('val = 1');
+          expect(callCount).toBe(1);
+          expect(lastVal).toEqual({val: 1});
+
+          scope.$apply('val = [2]');
+          expect(callCount).toBe(2);
+          expect(lastVal).toEqual({val: [2]});
+
+          scope.$apply('val.push(3)');
+          expect(callCount).toBe(2);
+
+          scope.$apply('val.length = 0');
+          expect(callCount).toBe(2);
+        }));
+
+        it('should only watch the direct inputs to nested literals', inject(function($parse) {
+          var lastVal = NaN;
+          var callCount = 0;
+          var listener = function(val) { callCount++; lastVal = val; };
+
+          scope.$watch('[{val: [val]}]', listener);
+
+          scope.$apply('val = 1');
+          expect(callCount).toBe(1);
+          expect(lastVal).toEqual([{val: [1]}]);
+
+          scope.$apply('val = [2]');
+          expect(callCount).toBe(2);
+          expect(lastVal).toEqual([{val: [[2]]}]);
+
+          scope.$apply('val.push(3)');
+          expect(callCount).toBe(2);
+
+          scope.$apply('val.length = 0');
+          expect(callCount).toBe(2);
+        }));
       });
 
       describe('locals', function() {


### PR DESCRIPTION
I think this is a better alternative to #15274, but has a breaking change (which didn't break any tests!).

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix, perf

**What is the current behavior? (You can also link to an open issue here)**
Watching literals doesn't always work, literals passed to components are deep watched to work around this.

**What is the new behavior (if this is a feature change)?**
Watching literals now does a watch of the inputs.

**Does this PR introduce a breaking change?**
YES - see below or second commit

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

BREAKING CHANGE (65ff861):
Previously when a literal value was passed into a directive/component via one-way binding it would be watched with a deep watcher.

For example, for `<my-component input="[a]">`, a new instance of the array would be passed into the directive/component (and trigger $onChanges) not only if `a` changed but also if any sub property of `a` changed such as `a.b` or `a.b.c.d.e` etc.

This also means a new but equal value for `a` would NOT trigger such a change.

Now literal values use a non-deep watch similar to other directive/component one-way bindings. Changes are only trigger when the value itself changes.

Avoiding deep watchers for array/object literals will improve watcher performance of all literals passed as one-way bindings, especially those containing references to large/complex objects.
