### PR TITLE
docs(orderBy): clarify behavior of default comparator

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -8,7 +8,8 @@
  * @description
  * Orders a specified `array` by the `expression` predicate. It is ordered alphabetically
  * for strings and numerically for numbers. Note: if you notice numbers are not being sorted
- * correctly, make sure they are actually being saved as numbers and not strings.
+ * correctly, make sure they are actually being saved as numbers and not strings and are not
+ * null or undefined.
  *
  * @param {Array} array The array to sort.
  * @param {function(*)|string|Array.<(function(*)|string)>=} expression A predicate to be


### PR DESCRIPTION
Doc update to clarify behavior of the default comparator starting in v1.3.7. See https://github.com/angular/angular.js/issues/15293
