### PR TITLE
docs(orderBy): Clarify behavior of default comparator

### DIFF
--- a/docs/content/guide/migration.ngdoc
+++ b/docs/content/guide/migration.ngdoc
@@ -1229,8 +1229,7 @@ or simply use:
 ### Filters (`orderBy`)
 
 - due to [a097aa95](https://github.com/angular/angular.js/commit/a097aa95b7c78beab6d1b7d521c25f7d9d7843d9),
-  the default orderBy comparator sorts null values (strings, objects, etc.) as if they were the string `'null'`:
-  a null string will be sorted as if it started with the letter N.
+  the default orderBy comparator now treats null values as the string 'null'
 
 
 

--- a/docs/content/guide/migration.ngdoc
+++ b/docs/content/guide/migration.ngdoc
@@ -1226,6 +1226,16 @@ or simply use:
   As communicated before, IE8 is no longer supported.
 
 
+### Filters (`orderBy`)
+
+- due to [a097aa95](https://github.com/angular/angular.js/commit/a097aa95b7c78beab6d1b7d521c25f7d9d7843d9),
+  the default orderBy comparator sorts null values (strings, objects, etc.) as if they were the string `'null'`:
+  a null string will be sorted as if it started with the letter N.  To sort nonexistent items to the last (or first,
+  if sort order is reversed) positions in the sort results, the sort predicate should use the empty string instead
+  of null. Similarly, predicate values that are `undefined` will be sorted as if they were strings starting with
+  the letter U.
+
+
 
 
 

--- a/docs/content/guide/migration.ngdoc
+++ b/docs/content/guide/migration.ngdoc
@@ -1230,10 +1230,7 @@ or simply use:
 
 - due to [a097aa95](https://github.com/angular/angular.js/commit/a097aa95b7c78beab6d1b7d521c25f7d9d7843d9),
   the default orderBy comparator sorts null values (strings, objects, etc.) as if they were the string `'null'`:
-  a null string will be sorted as if it started with the letter N.  To sort nonexistent items to the last (or first,
-  if sort order is reversed) positions in the sort results, the sort predicate should use the empty string instead
-  of null. Similarly, predicate values that are `undefined` will be sorted as if they were strings starting with
-  the letter U.
+  a null string will be sorted as if it started with the letter N.
 
 
 

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -86,6 +86,9 @@
  *
  * **Note:** If you notice numbers not being sorted as expected, make sure they are actually being
  *           saved as numbers and not strings.
+ * **Note:** If null or undefined values are not being sorted as expected, convert them to the empty
+ *           string before sorting. This is because of rule number 1 above which sorts `null` as `'null'`
+ *           and `undefined` as `'undefined'`.
  *
  * @param {Array|ArrayLike} collection - The collection (array or array-like object) to sort.
  * @param {(Function|string|Array.<Function|string>)=} expression - A predicate (or list of

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -86,9 +86,8 @@
  *
  * **Note:** If you notice numbers not being sorted as expected, make sure they are actually being
  *           saved as numbers and not strings.
- * **Note:** If null or undefined values are not being sorted as expected, convert them to the empty
- *           string before sorting. This is because of rule number 1 above which sorts `null` as `'null'`
- *           and `undefined` as `'undefined'`.
+ * **Note:** If null values are not being sorted as expected it may be due to rule number
+ *           1 above which sorts `null` as the string `'null'`.
  *
  * @param {Array|ArrayLike} collection - The collection (array or array-like object) to sort.
  * @param {(Function|string|Array.<Function|string>)=} expression - A predicate (or list of

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -86,8 +86,8 @@
  *
  * **Note:** If you notice numbers not being sorted as expected, make sure they are actually being
  *           saved as numbers and not strings.
- * **Note:** If null values are not being sorted as expected it may be due to rule number
- *           1 above which sorts `null` as the string `'null'`.
+ * **Note:** The above algorithm converts `null` values (normally of type `object`) to the string
+ *           `'null'` (so has type `string`). This may cause unexpected sort order.
  *
  * @param {Array|ArrayLike} collection - The collection (array or array-like object) to sort.
  * @param {(Function|string|Array.<Function|string>)=} expression - A predicate (or list of


### PR DESCRIPTION
Documentation updates to clarify default sort behavior. See
https://github.com/angular/angular.js/issues/15293 for more information

(These changes are slightly different than the ones in #15302, since I started from master rather than 1.3.x docs)
