### PR TITLE
chore(ng-closure-runner): upgrade to version 0.2.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,6 @@
     "jquery-2.2": "jquery#2.2.4",
     "jquery-2.1": "jquery#2.1.4",
     "closure-compiler": "https://dl.google.com/closure-compiler/compiler-20140814.zip",
-    "ng-closure-runner": "https://raw.github.com/angular/ng-closure-runner/v0.2.3/assets/ng-closure-runner.zip"
+    "ng-closure-runner": "https://raw.github.com/angular/ng-closure-runner/v0.2.4/assets/ng-closure-runner.zip"
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Chore.

**What is the current behavior? (You can also link to an open issue here)**
We are using `ngClosureRunner` version 0.2.3, which has an outdated implementation of `minErr`. Thus the minified versions have a slightly different imlementation of `minErr`.
See also #14971.

**What is the new behavior (if this is a feature change)?**
We will be using `ngClosureRunner` version 0.2.4, which has the updated implementation of `minErr`.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ]~~ Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Fixes #14971

Depends on angular/ng-closure-runner#11. 
**Do not merge** before v0.2.4 has been actually released :smiley:
