### PR TITLE
Japan Yen do never use fractions

### DIFF
--- a/src/ngLocale/angular-locale_ja-jp.js
+++ b/src/ngLocale/angular-locale_ja-jp.js
@@ -97,7 +97,7 @@ $provide.value("$locale", {
       {
         "gSize": 3,
         "lgSize": 3,
-        "maxFrac": 3,
+        "maxFrac": 0,
         "minFrac": 0,
         "minInt": 1,
         "negPre": "-",
@@ -108,8 +108,8 @@ $provide.value("$locale", {
       {
         "gSize": 3,
         "lgSize": 3,
-        "maxFrac": 2,
-        "minFrac": 2,
+        "maxFrac": 0,
+        "minFrac": 0,
         "minInt": 1,
         "negPre": "-\u00a4",
         "negSuf": "",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change?**

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

As seen in hundreds of threads in Internet, this issue is kind of universal when working in a website having the JP locale and currency. Japanese currency never use Fractions and they are really picky about it.
