### PR TITLE
docs(guide/Components): typo in method name

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -32,7 +32,7 @@ Components can be registered using the `.component()` method of an Angular modul
 
 <example name="heroComponentSimple" module="heroApp">
 <file name="index.js">
-  angular.module('heroApp', []).controller('MainCtrl', function MainCtrl() {
+  angular.module('heroApp', []).component('MainCtrl', function MainCtrl() {
     this.hero = {
       name: 'Spawn'
     };


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fix typo in docs on components

**What is the current behavior? (You can also link to an open issue here)**

Docs say to use `component()` but sample code uses `controller()`

**What is the new behavior (if this is a feature change)?**

Sample code matches documentation.

**Does this PR introduce a breaking change?**

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
