### PR TITLE
chore(version-info): use branchPattern to check tag

### DIFF
--- a/lib/versions/version-info.js
+++ b/lib/versions/version-info.js
@@ -73,6 +73,11 @@ function getBuild() {
   return 'sha.' + hash;
 }
 
+function checkBranchPattern(version, branchPattern) {
+  // check that the version starts with the branch pattern minus its asterisk
+  // e.g. branchPattern = '1.6.*'; version = '1.6.0-rc.0' => '1.6.' === '1.6.'
+  return version.slice(0, branchPattern.length - 1) === branchPattern.replace('*', '');
+}
 
 /**
  * If the current commit is tagged as a version get that version
@@ -85,7 +90,7 @@ var getTaggedVersion = function() {
     var tag = gitTagResult.output.trim();
     var version = semver.parse(tag);
 
-    if (version && semver.satisfies(version, currentPackage.branchVersion)) {
+    if (version && checkBranchPattern(version, currentPackage.branchPattern)) {
       version.codeName = getCodeName(tag);
       version.full = version.version;
       version.branch = 'v' + currentPackage.branchPattern.replace('*', 'x');


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change?**

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

We have two fields in package.json for checking the current version:
- branchVersion
- branchPattern

The `branchVersion` field is used to work out what version to use in the
docs application, so we should not update this to the most recent version
until that version is on the Google CDN. Otherwise the docs app will break.

The `branchPattern` is used to determine what branch we are currently
working from and is generally used as a gate-keeper to prevent invalid
releases from the wrong branch.

The `getTaggedVersion()` method was using the `branchVersion` to check
that the tagged commit was valid but this fails when we are moving to a
new minor version with release candidates.

This fix avoids the problem by doing a custom comparison against the
`branchPattern` instead.
