### PR TITLE
docs(CONTRIBUTING.md): add note about scope wildcard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,6 +249,8 @@ Must be one of the following:
 The scope could be anything specifying place of the commit change. For example `$location`,
 `$browser`, `$compile`, `$rootScope`, `ngHref`, `ngClick`, `ngView`, etc...
 
+You can use `*` when the change affects more than a single scope.
+
 ### Subject
 The subject contains succinct description of the change:
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

docs update

**What is the current behavior? (You can also link to an open issue here)**

no hint that `*` is a valid scope -- it hints you could omit the `(...)` bit, but most commits of late don't

**What is the new behavior (if this is a feature change)?**

documentation of `*`

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format

**Other information**:
