### PR TITLE
perf(ngOptions): avoid calls to element.value

### DIFF
--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -591,7 +591,7 @@ var ngOptionsDirective = ['$compile', '$document', '$parse', function($compile, 
           element.label = option.label;
           element.textContent = option.label;
         }
-        if (option.value !== element.value) element.value = option.selectValue;
+        element.value = option.selectValue;
       }
 
       function updateOptions() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Performance

**What is the current behavior? (You can also link to an open issue here)**

In some cases IE11/Edge calls to element.value are very slow when the element.value has not been set. Normally, these calls are usualy 0-3 ms but in these cases it can take 200-300 ms. This can easily add 3 or more seconds to the load time on a view that has 10 or more select tags using ngOptions.

The line this pull request is changing not only suffers from the performance issue described above but it also appears to be broken. The code is checking that option.value does not equal element.value but then sets element.value to option.selectValue. I don't believe option.value is actually defined anywhere and likely it was always intended to be option.selectValue. This means that check would always be true and since this code has been this way for quite a while and is causing a performance issue I've just removed the check. This way a call to element.value is never made prior to it's value being set.

**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
