### PR TITLE
perf(*): don't trigger digests after enter/leave of structural directives

### DIFF
--- a/src/ng/directive/ngIf.js
+++ b/src/ng/directive/ngIf.js
@@ -115,8 +115,8 @@ var ngIfDirective = ['$animate', '$compile', function($animate, $compile) {
             }
             if (block) {
               previousElements = getBlockNodes(block.clone);
-              $animate.leave(previousElements).then(function() {
-                previousElements = null;
+              $animate.leave(previousElements).done(function(response) {
+                if (response !== false) previousElements = null;
               });
               block = null;
             }

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -214,8 +214,8 @@ var ngIncludeDirective = ['$templateRequest', '$anchorScroll', '$animate',
             currentScope = null;
           }
           if (currentElement) {
-            $animate.leave(currentElement).then(function() {
-              previousElement = null;
+            $animate.leave(currentElement).done(function(response) {
+              if (response !== false) previousElement = null;
             });
             previousElement = currentElement;
             currentElement = null;
@@ -223,9 +223,10 @@ var ngIncludeDirective = ['$templateRequest', '$anchorScroll', '$animate',
         };
 
         scope.$watch(srcExp, function ngIncludeWatchAction(src) {
-          var afterAnimation = function() {
-            if (isDefined(autoScrollExp) && (!autoScrollExp || scope.$eval(autoScrollExp))) {
-              $anchorScroll();
+          var afterAnimation = function(response) {
+            if (response !== false && isDefined(autoScrollExp) &&
+              (!autoScrollExp || scope.$eval(autoScrollExp))) {
+                $anchorScroll();
             }
           };
           var thisChangeId = ++changeCounter;
@@ -248,7 +249,7 @@ var ngIncludeDirective = ['$templateRequest', '$anchorScroll', '$animate',
               // directives to non existing elements.
               var clone = $transclude(newScope, function(clone) {
                 cleanupLastIncludeContent();
-                $animate.enter(clone, null, $element).then(afterAnimation);
+                $animate.enter(clone, null, $element).done(afterAnimation);
               });
 
               currentScope = newScope;

--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -153,21 +153,24 @@ var ngSwitchDirective = ['$animate', '$compile', function($animate, $compile) {
           selectedScopes = [];
 
       var spliceFactory = function(array, index) {
-          return function() { array.splice(index, 1); };
+          return function(response) {
+            if (response !== false) array.splice(index, 1);
+          };
       };
 
       scope.$watch(watchExpr, function ngSwitchWatchAction(value) {
         var i, ii;
-        for (i = 0, ii = previousLeaveAnimations.length; i < ii; ++i) {
-          $animate.cancel(previousLeaveAnimations[i]);
+
+        // Start with the last, in case the array is modified during the loop
+        while (previousLeaveAnimations.length) {
+          $animate.cancel(previousLeaveAnimations.pop());
         }
-        previousLeaveAnimations.length = 0;
 
         for (i = 0, ii = selectedScopes.length; i < ii; ++i) {
           var selected = getBlockNodes(selectedElements[i].clone);
           selectedScopes[i].$destroy();
-          var promise = previousLeaveAnimations[i] = $animate.leave(selected);
-          promise.then(spliceFactory(previousLeaveAnimations, i));
+          var runner = previousLeaveAnimations[i] = $animate.leave(selected);
+          runner.done(spliceFactory(previousLeaveAnimations, i));
         }
 
         selectedElements.length = 0;

--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -207,8 +207,8 @@ function ngViewFactory($route, $anchorScroll, $animate) {
           }
           if (currentElement) {
             previousLeaveAnimation = $animate.leave(currentElement);
-            previousLeaveAnimation.then(function() {
-              previousLeaveAnimation = null;
+            previousLeaveAnimation.done(function(response) {
+              if (response !== false) previousLeaveAnimation = null;
             });
             currentElement = null;
           }
@@ -229,8 +229,8 @@ function ngViewFactory($route, $anchorScroll, $animate) {
             // function is called before linking the content, which would apply child
             // directives to non existing elements.
             var clone = $transclude(newScope, function(clone) {
-              $animate.enter(clone, null, currentElement || $element).then(function onNgViewEnter() {
-                if (angular.isDefined(autoScrollExp)
+              $animate.enter(clone, null, currentElement || $element).done(function onNgViewEnter(response) {
+                if (response !== false && angular.isDefined(autoScrollExp)
                   && (!autoScrollExp || scope.$eval(autoScrollExp))) {
                   $anchorScroll();
                 }

--- a/test/ng/directive/ngIfSpec.js
+++ b/test/ng/directive/ngIfSpec.js
@@ -1,371 +1,375 @@
 'use strict';
 
 describe('ngIf', function() {
-  var $scope, $compile, element, $compileProvider;
 
-  beforeEach(module(function(_$compileProvider_) {
-    $compileProvider = _$compileProvider_;
-  }));
-  beforeEach(inject(function($rootScope, _$compile_) {
-    $scope = $rootScope.$new();
-    $compile = _$compile_;
-    element = $compile('<div></div>')($scope);
-  }));
+  describe('basic', function() {
+    var $scope, $compile, element, $compileProvider;
 
-  afterEach(function() {
-    dealoc(element);
-  });
+    beforeEach(module(function(_$compileProvider_) {
+      $compileProvider = _$compileProvider_;
+    }));
+    beforeEach(inject(function($rootScope, _$compile_) {
+      $scope = $rootScope.$new();
+      $compile = _$compile_;
+      element = $compile('<div></div>')($scope);
+    }));
 
-  function makeIf() {
-    forEach(arguments, function(expr) {
-      element.append($compile('<div class="my-class" ng-if="' + expr + '"><div>Hi</div></div>')($scope));
-    });
-    $scope.$apply();
-  }
-
-  it('should immediately remove the element if condition is falsy', function() {
-    makeIf('false', 'undefined', 'null', 'NaN', '\'\'', '0');
-    expect(element.children().length).toBe(0);
-  });
-
-  it('should leave the element if condition is true', function() {
-    makeIf('true');
-    expect(element.children().length).toBe(1);
-  });
-
-  it('should leave the element if the condition is a non-empty string', function() {
-    makeIf('\'f\'', '\'0\'', '\'false\'', '\'no\'', '\'n\'', '\'[]\'');
-    expect(element.children().length).toBe(6);
-  });
-
-  it('should leave the element if the condition is an object', function() {
-    makeIf('[]', '{}');
-    expect(element.children().length).toBe(2);
-  });
-
-  it('should not add the element twice if the condition goes from true to true', function() {
-    $scope.hello = 'true1';
-    makeIf('hello');
-    expect(element.children().length).toBe(1);
-    $scope.$apply('hello = "true2"');
-    expect(element.children().length).toBe(1);
-  });
-
-  it('should not recreate the element if the condition goes from true to true', function() {
-    $scope.hello = 'true1';
-    makeIf('hello');
-    element.children().data('flag', true);
-    $scope.$apply('hello = "true2"');
-    expect(element.children().data('flag')).toBe(true);
-  });
-
-  it('should create then remove the element if condition changes', function() {
-    $scope.hello = true;
-    makeIf('hello');
-    expect(element.children().length).toBe(1);
-    $scope.$apply('hello = false');
-    expect(element.children().length).toBe(0);
-  });
-
-  it('should create a new scope every time the expression evaluates to true', function() {
-    $scope.$apply('value = true');
-    element.append($compile(
-      '<div ng-if="value"><span ng-init="value=false"></span></div>'
-    )($scope));
-    $scope.$apply();
-    expect(element.children('div').length).toBe(1);
-  });
-
-  it('should destroy the child scope every time the expression evaluates to false', function() {
-    $scope.value = true;
-    element.append($compile(
-        '<div ng-if="value"></div>'
-    )($scope));
-    $scope.$apply();
-
-    var childScope = element.children().scope();
-    var destroyed = false;
-
-    childScope.$on('$destroy', function() {
-      destroyed = true;
-    });
-
-    $scope.value = false;
-    $scope.$apply();
-
-    expect(destroyed).toBe(true);
-  });
-
-  it('should play nice with other elements beside it', function() {
-    $scope.values = [1, 2, 3, 4];
-    element.append($compile(
-      '<div ng-repeat="i in values"></div>' +
-        '<div ng-if="values.length==4"></div>' +
-        '<div ng-repeat="i in values"></div>'
-    )($scope));
-    $scope.$apply();
-    expect(element.children().length).toBe(9);
-    $scope.$apply('values.splice(0,1)');
-    expect(element.children().length).toBe(6);
-    $scope.$apply('values.push(1)');
-    expect(element.children().length).toBe(9);
-  });
-
-  it('should play nice with ngInclude on the same element', inject(function($templateCache) {
-    $templateCache.put('test.html', [200, '{{value}}', {}]);
-
-    $scope.value = 'first';
-    element.append($compile(
-      '<div ng-if="value==\'first\'" ng-include="\'test.html\'"></div>'
-    )($scope));
-    $scope.$apply();
-    expect(element.text()).toBe('first');
-
-    $scope.value = 'later';
-    $scope.$apply();
-    expect(element.text()).toBe('');
-  }));
-
-  it('should work with multiple elements', function() {
-    $scope.show = true;
-    $scope.things = [1, 2, 3];
-    element.append($compile(
-      '<div>before;</div>' +
-        '<div ng-if-start="show">start;</div>' +
-        '<div ng-repeat="thing in things">{{thing}};</div>' +
-        '<div ng-if-end>end;</div>' +
-        '<div>after;</div>'
-    )($scope));
-    $scope.$apply();
-    expect(element.text()).toBe('before;start;1;2;3;end;after;');
-
-    $scope.things.push(4);
-    $scope.$apply();
-    expect(element.text()).toBe('before;start;1;2;3;4;end;after;');
-
-    $scope.show = false;
-    $scope.$apply();
-    expect(element.text()).toBe('before;after;');
-  });
-
-  it('should restore the element to its compiled state', function() {
-    $scope.value = true;
-    makeIf('value');
-    expect(element.children().length).toBe(1);
-    jqLite(element.children()[0]).removeClass('my-class');
-    expect(element.children()[0].className).not.toContain('my-class');
-    $scope.$apply('value = false');
-    expect(element.children().length).toBe(0);
-    $scope.$apply('value = true');
-    expect(element.children().length).toBe(1);
-    expect(element.children()[0].className).toContain('my-class');
-  });
-
-  it('should work when combined with an ASYNC template that loads after the first digest', inject(function($httpBackend, $compile, $rootScope) {
-    $compileProvider.directive('test', function() {
-      return {
-        templateUrl: 'test.html'
-      };
-    });
-    $httpBackend.whenGET('test.html').respond('hello');
-    element.append('<div ng-if="show" test></div>');
-    $compile(element)($rootScope);
-    $rootScope.show = true;
-    $rootScope.$apply();
-    expect(element.text()).toBe('');
-
-    $httpBackend.flush();
-    expect(element.text()).toBe('hello');
-
-    $rootScope.show = false;
-    $rootScope.$apply();
-    // Note: there are still comments in element!
-    expect(element.children().length).toBe(0);
-    expect(element.text()).toBe('');
-  }));
-});
-
-describe('ngIf and transcludes', function() {
-  it('should allow access to directive controller from children when used in a replace template', function() {
-    var controller;
-    module(function($compileProvider) {
-      var directive = $compileProvider.directive;
-      directive('template', valueFn({
-        template: '<div ng-if="true"><span test></span></div>',
-        replace: true,
-        controller: function() {
-          this.flag = true;
-        }
-      }));
-      directive('test', valueFn({
-        require: '^template',
-        link: function(scope, el, attr, ctrl) {
-          controller = ctrl;
-        }
-      }));
-    });
-    inject(function($compile, $rootScope) {
-      var element = $compile('<div><div template></div></div>')($rootScope);
-      $rootScope.$apply();
-      expect(controller.flag).toBe(true);
+    afterEach(function() {
       dealoc(element);
     });
-  });
 
-
-  it('should use the correct transcluded scope', function() {
-    module(function($compileProvider) {
-      $compileProvider.directive('iso', valueFn({
-        link: function(scope) {
-          scope.val = 'value in iso scope';
-        },
-        restrict: 'E',
-        transclude: true,
-        template: '<div ng-if="true">val={{val}}-<div ng-transclude></div></div>',
-        scope: {}
-      }));
-    });
-    inject(function($compile, $rootScope) {
-      $rootScope.val = 'transcluded content';
-      var element = $compile('<iso><span ng-bind="val"></span></iso>')($rootScope);
-      $rootScope.$digest();
-      expect(trim(element.text())).toEqual('val=value in iso scope-transcluded content');
-      dealoc(element);
-    });
-  });
-});
-
-describe('ngIf animations', function() {
-  var body, element, $rootElement;
-
-  function html(content) {
-    $rootElement.html(content);
-    element = $rootElement.children().eq(0);
-    return element;
-  }
-
-  beforeEach(module('ngAnimateMock'));
-
-  beforeEach(module(function() {
-    // we need to run animation on attached elements;
-    return function(_$rootElement_) {
-      $rootElement = _$rootElement_;
-      body = jqLite(window.document.body);
-      body.append($rootElement);
-    };
-  }));
-
-  afterEach(function() {
-    dealoc(body);
-    dealoc(element);
-  });
-
-  beforeEach(module(function($animateProvider, $provide) {
-    return function($animate) {
-      $animate.enabled(true);
-    };
-  }));
-
-  it('should fire off the enter animation',
-    inject(function($compile, $rootScope, $animate) {
-      var item;
-      var $scope = $rootScope.$new();
-      element = $compile(html(
-        '<div>' +
-          '<div ng-if="value"><div>Hi</div></div>' +
-        '</div>'
-      ))($scope);
-
-      $rootScope.$digest();
-      $scope.$apply('value = true');
-
-      item = $animate.queue.shift();
-      expect(item.event).toBe('enter');
-      expect(item.element.text()).toBe('Hi');
-
-      expect(element.children().length).toBe(1);
-    })
-  );
-
-  it('should fire off the leave animation',
-    inject(function($compile, $rootScope, $animate) {
-      var item;
-      var $scope = $rootScope.$new();
-      element = $compile(html(
-        '<div>' +
-          '<div ng-if="value"><div>Hi</div></div>' +
-        '</div>'
-      ))($scope);
-      $scope.$apply('value = true');
-
-      item = $animate.queue.shift();
-      expect(item.event).toBe('enter');
-      expect(item.element.text()).toBe('Hi');
-
-      expect(element.children().length).toBe(1);
-      $scope.$apply('value = false');
-
-      item = $animate.queue.shift();
-      expect(item.event).toBe('leave');
-      expect(item.element.text()).toBe('Hi');
-
-      expect(element.children().length).toBe(0);
-    })
-  );
-
-  it('should destroy the previous leave animation if a new one takes place', function() {
-    module(function($provide) {
-      $provide.decorator('$animate', function($delegate, $$q) {
-        var emptyPromise = $$q.defer().promise;
-        $delegate.leave = function() {
-          return emptyPromise;
-        };
-        return $delegate;
+    function makeIf() {
+      forEach(arguments, function(expr) {
+        element.append($compile('<div class="my-class" ng-if="' + expr + '"><div>Hi</div></div>')($scope));
       });
+      $scope.$apply();
+    }
+
+    it('should immediately remove the element if condition is falsy', function() {
+      makeIf('false', 'undefined', 'null', 'NaN', '\'\'', '0');
+      expect(element.children().length).toBe(0);
     });
-    inject(function($compile, $rootScope, $animate) {
-      var item;
-      var $scope = $rootScope.$new();
-      element = $compile(html(
-        '<div>' +
-          '<div ng-if="value">Yo</div>' +
-        '</div>'
-      ))($scope);
 
+    it('should leave the element if condition is true', function() {
+      makeIf('true');
+      expect(element.children().length).toBe(1);
+    });
+
+    it('should leave the element if the condition is a non-empty string', function() {
+      makeIf('\'f\'', '\'0\'', '\'false\'', '\'no\'', '\'n\'', '\'[]\'');
+      expect(element.children().length).toBe(6);
+    });
+
+    it('should leave the element if the condition is an object', function() {
+      makeIf('[]', '{}');
+      expect(element.children().length).toBe(2);
+    });
+
+    it('should not add the element twice if the condition goes from true to true', function() {
+      $scope.hello = 'true1';
+      makeIf('hello');
+      expect(element.children().length).toBe(1);
+      $scope.$apply('hello = "true2"');
+      expect(element.children().length).toBe(1);
+    });
+
+    it('should not recreate the element if the condition goes from true to true', function() {
+      $scope.hello = 'true1';
+      makeIf('hello');
+      element.children().data('flag', true);
+      $scope.$apply('hello = "true2"');
+      expect(element.children().data('flag')).toBe(true);
+    });
+
+    it('should create then remove the element if condition changes', function() {
+      $scope.hello = true;
+      makeIf('hello');
+      expect(element.children().length).toBe(1);
+      $scope.$apply('hello = false');
+      expect(element.children().length).toBe(0);
+    });
+
+    it('should create a new scope every time the expression evaluates to true', function() {
       $scope.$apply('value = true');
+      element.append($compile(
+        '<div ng-if="value"><span ng-init="value=false"></span></div>'
+      )($scope));
+      $scope.$apply();
+      expect(element.children('div').length).toBe(1);
+    });
 
-      var destroyed, inner = element.children(0);
-      inner.on('$destroy', function() {
+    it('should destroy the child scope every time the expression evaluates to false', function() {
+      $scope.value = true;
+      element.append($compile(
+          '<div ng-if="value"></div>'
+      )($scope));
+      $scope.$apply();
+
+      var childScope = element.children().scope();
+      var destroyed = false;
+
+      childScope.$on('$destroy', function() {
         destroyed = true;
       });
 
-      $scope.$apply('value = false');
-
-      $scope.$apply('value = true');
-
-      $scope.$apply('value = false');
+      $scope.value = false;
+      $scope.$apply();
 
       expect(destroyed).toBe(true);
     });
-  });
 
-  it('should work with svg elements when the svg container is transcluded', function() {
-    module(function($compileProvider) {
-      $compileProvider.directive('svgContainer', function() {
+    it('should play nice with other elements beside it', function() {
+      $scope.values = [1, 2, 3, 4];
+      element.append($compile(
+        '<div ng-repeat="i in values"></div>' +
+          '<div ng-if="values.length==4"></div>' +
+          '<div ng-repeat="i in values"></div>'
+      )($scope));
+      $scope.$apply();
+      expect(element.children().length).toBe(9);
+      $scope.$apply('values.splice(0,1)');
+      expect(element.children().length).toBe(6);
+      $scope.$apply('values.push(1)');
+      expect(element.children().length).toBe(9);
+    });
+
+    it('should play nice with ngInclude on the same element', inject(function($templateCache) {
+      $templateCache.put('test.html', [200, '{{value}}', {}]);
+
+      $scope.value = 'first';
+      element.append($compile(
+        '<div ng-if="value==\'first\'" ng-include="\'test.html\'"></div>'
+      )($scope));
+      $scope.$apply();
+      expect(element.text()).toBe('first');
+
+      $scope.value = 'later';
+      $scope.$apply();
+      expect(element.text()).toBe('');
+    }));
+
+    it('should work with multiple elements', function() {
+      $scope.show = true;
+      $scope.things = [1, 2, 3];
+      element.append($compile(
+        '<div>before;</div>' +
+          '<div ng-if-start="show">start;</div>' +
+          '<div ng-repeat="thing in things">{{thing}};</div>' +
+          '<div ng-if-end>end;</div>' +
+          '<div>after;</div>'
+      )($scope));
+      $scope.$apply();
+      expect(element.text()).toBe('before;start;1;2;3;end;after;');
+
+      $scope.things.push(4);
+      $scope.$apply();
+      expect(element.text()).toBe('before;start;1;2;3;4;end;after;');
+
+      $scope.show = false;
+      $scope.$apply();
+      expect(element.text()).toBe('before;after;');
+    });
+
+    it('should restore the element to its compiled state', function() {
+      $scope.value = true;
+      makeIf('value');
+      expect(element.children().length).toBe(1);
+      jqLite(element.children()[0]).removeClass('my-class');
+      expect(element.children()[0].className).not.toContain('my-class');
+      $scope.$apply('value = false');
+      expect(element.children().length).toBe(0);
+      $scope.$apply('value = true');
+      expect(element.children().length).toBe(1);
+      expect(element.children()[0].className).toContain('my-class');
+    });
+
+    it('should work when combined with an ASYNC template that loads after the first digest', inject(function($httpBackend, $compile, $rootScope) {
+      $compileProvider.directive('test', function() {
         return {
-          template: '<svg ng-transclude></svg>',
-          replace: true,
-          transclude: true
+          templateUrl: 'test.html'
         };
       });
-    });
-    inject(function($compile, $rootScope) {
-      element = $compile('<svg-container><circle ng-if="flag"></circle></svg-container>')($rootScope);
-      $rootScope.flag = true;
+      $httpBackend.whenGET('test.html').respond('hello');
+      element.append('<div ng-if="show" test></div>');
+      $compile(element)($rootScope);
+      $rootScope.show = true;
       $rootScope.$apply();
+      expect(element.text()).toBe('');
 
-      var circle = element.find('circle');
-      expect(circle[0].toString()).toMatch(/SVG/);
+      $httpBackend.flush();
+      expect(element.text()).toBe('hello');
+
+      $rootScope.show = false;
+      $rootScope.$apply();
+      // Note: there are still comments in element!
+      expect(element.children().length).toBe(0);
+      expect(element.text()).toBe('');
+    }));
+  });
+
+  describe('and transcludes', function() {
+    it('should allow access to directive controller from children when used in a replace template', function() {
+      var controller;
+      module(function($compileProvider) {
+        var directive = $compileProvider.directive;
+        directive('template', valueFn({
+          template: '<div ng-if="true"><span test></span></div>',
+          replace: true,
+          controller: function() {
+            this.flag = true;
+          }
+        }));
+        directive('test', valueFn({
+          require: '^template',
+          link: function(scope, el, attr, ctrl) {
+            controller = ctrl;
+          }
+        }));
+      });
+      inject(function($compile, $rootScope) {
+        var element = $compile('<div><div template></div></div>')($rootScope);
+        $rootScope.$apply();
+        expect(controller.flag).toBe(true);
+        dealoc(element);
+      });
+    });
+
+
+    it('should use the correct transcluded scope', function() {
+      module(function($compileProvider) {
+        $compileProvider.directive('iso', valueFn({
+          link: function(scope) {
+            scope.val = 'value in iso scope';
+          },
+          restrict: 'E',
+          transclude: true,
+          template: '<div ng-if="true">val={{val}}-<div ng-transclude></div></div>',
+          scope: {}
+        }));
+      });
+      inject(function($compile, $rootScope) {
+        $rootScope.val = 'transcluded content';
+        var element = $compile('<iso><span ng-bind="val"></span></iso>')($rootScope);
+        $rootScope.$digest();
+        expect(trim(element.text())).toEqual('val=value in iso scope-transcluded content');
+        dealoc(element);
+      });
+    });
+  });
+
+  describe('and animations', function() {
+    var body, element, $rootElement;
+
+    function html(content) {
+      $rootElement.html(content);
+      element = $rootElement.children().eq(0);
+      return element;
+    }
+
+    beforeEach(module('ngAnimateMock'));
+
+    beforeEach(module(function() {
+      // we need to run animation on attached elements;
+      return function(_$rootElement_) {
+        $rootElement = _$rootElement_;
+        body = jqLite(window.document.body);
+        body.append($rootElement);
+      };
+    }));
+
+    afterEach(function() {
+      dealoc(body);
+      dealoc(element);
+    });
+
+    beforeEach(module(function($animateProvider, $provide) {
+      return function($animate) {
+        $animate.enabled(true);
+      };
+    }));
+
+    it('should fire off the enter animation',
+      inject(function($compile, $rootScope, $animate) {
+        var item;
+        var $scope = $rootScope.$new();
+        element = $compile(html(
+          '<div>' +
+            '<div ng-if="value"><div>Hi</div></div>' +
+          '</div>'
+        ))($scope);
+
+        $rootScope.$digest();
+        $scope.$apply('value = true');
+
+        item = $animate.queue.shift();
+        expect(item.event).toBe('enter');
+        expect(item.element.text()).toBe('Hi');
+
+        expect(element.children().length).toBe(1);
+      })
+    );
+
+    it('should fire off the leave animation',
+      inject(function($compile, $rootScope, $animate) {
+        var item;
+        var $scope = $rootScope.$new();
+        element = $compile(html(
+          '<div>' +
+            '<div ng-if="value"><div>Hi</div></div>' +
+          '</div>'
+        ))($scope);
+        $scope.$apply('value = true');
+
+        item = $animate.queue.shift();
+        expect(item.event).toBe('enter');
+        expect(item.element.text()).toBe('Hi');
+
+        expect(element.children().length).toBe(1);
+        $scope.$apply('value = false');
+
+        item = $animate.queue.shift();
+        expect(item.event).toBe('leave');
+        expect(item.element.text()).toBe('Hi');
+
+        expect(element.children().length).toBe(0);
+      })
+    );
+
+    it('should destroy the previous leave animation if a new one takes place', function() {
+      module(function($provide) {
+        $provide.decorator('$animate', function($delegate, $$q) {
+          var emptyPromise = $$q.defer().promise;
+
+          $delegate.leave = function() {
+            return emptyPromise;
+          };
+          return $delegate;
+        });
+      });
+      inject(function($compile, $rootScope, $animate) {
+        var item;
+        var $scope = $rootScope.$new();
+        element = $compile(html(
+          '<div>' +
+            '<div ng-if="value">Yo</div>' +
+          '</div>'
+        ))($scope);
+
+        $scope.$apply('value = true');
+
+        var destroyed, inner = element.children(0);
+        inner.on('$destroy', function() {
+          destroyed = true;
+        });
+
+        $scope.$apply('value = false');
+
+        $scope.$apply('value = true');
+
+        $scope.$apply('value = false');
+
+        expect(destroyed).toBe(true);
+      });
+    });
+
+    it('should work with svg elements when the svg container is transcluded', function() {
+      module(function($compileProvider) {
+        $compileProvider.directive('svgContainer', function() {
+          return {
+            template: '<svg ng-transclude></svg>',
+            replace: true,
+            transclude: true
+          };
+        });
+      });
+      inject(function($compile, $rootScope) {
+        element = $compile('<svg-container><circle ng-if="flag"></circle></svg-container>')($rootScope);
+        $rootScope.flag = true;
+        $rootScope.$apply();
+
+        var circle = element.find('circle');
+        expect(circle[0].toString()).toMatch(/SVG/);
+      });
     });
   });
 });

--- a/test/ng/directive/ngIncludeSpec.js
+++ b/test/ng/directive/ngIncludeSpec.js
@@ -1,794 +1,798 @@
 'use strict';
 
 describe('ngInclude', function() {
-  var element;
 
-  afterEach(function() {
-    dealoc(element);
-  });
+  describe('basic', function() {
+    var element;
 
-
-  function putIntoCache(url, content) {
-    return function($templateCache) {
-      $templateCache.put(url, [200, content, {}]);
-    };
-  }
+    afterEach(function() {
+      dealoc(element);
+    });
 
 
-  it('should trust and use literal urls', inject(function(
-      $rootScope, $httpBackend, $compile) {
-    element = $compile('<div><div ng-include="\'url\'"></div></div>')($rootScope);
-    $httpBackend.expect('GET', 'url').respond('template text');
-    $rootScope.$digest();
-    $httpBackend.flush();
-    expect(element.text()).toEqual('template text');
-    dealoc($rootScope);
-  }));
+    function putIntoCache(url, content) {
+      return function($templateCache) {
+        $templateCache.put(url, [200, content, {}]);
+      };
+    }
 
 
-  it('should trust and use trusted urls', inject(function($rootScope, $httpBackend, $compile, $sce) {
-    element = $compile('<div><div ng-include="fooUrl"></div></div>')($rootScope);
-    $httpBackend.expect('GET', 'http://foo.bar/url').respond('template text');
-    $rootScope.fooUrl = $sce.trustAsResourceUrl('http://foo.bar/url');
-    $rootScope.$digest();
-    $httpBackend.flush();
-    expect(element.text()).toEqual('template text');
-    dealoc($rootScope);
-  }));
+    it('should trust and use literal urls', inject(function(
+        $rootScope, $httpBackend, $compile) {
+      element = $compile('<div><div ng-include="\'url\'"></div></div>')($rootScope);
+      $httpBackend.expect('GET', 'url').respond('template text');
+      $rootScope.$digest();
+      $httpBackend.flush();
+      expect(element.text()).toEqual('template text');
+      dealoc($rootScope);
+    }));
 
 
-  it('should include an external file', inject(putIntoCache('myUrl', '{{name}}'),
-      function($rootScope, $compile) {
-    element = jqLite('<div><ng:include src="url"></ng:include></div>');
-    var body = jqLite(window.document.body);
-    body.append(element);
-    element = $compile(element)($rootScope);
-    $rootScope.name = 'misko';
-    $rootScope.url = 'myUrl';
-    $rootScope.$digest();
-    expect(body.text()).toEqual('misko');
-    body.empty();
-  }));
+    it('should trust and use trusted urls', inject(function($rootScope, $httpBackend, $compile, $sce) {
+      element = $compile('<div><div ng-include="fooUrl"></div></div>')($rootScope);
+      $httpBackend.expect('GET', 'http://foo.bar/url').respond('template text');
+      $rootScope.fooUrl = $sce.trustAsResourceUrl('http://foo.bar/url');
+      $rootScope.$digest();
+      $httpBackend.flush();
+      expect(element.text()).toEqual('template text');
+      dealoc($rootScope);
+    }));
 
 
-  it('should support ng-include="src" syntax', inject(putIntoCache('myUrl', '{{name}}'),
-      function($rootScope, $compile) {
-    element = jqLite('<div><div ng-include="url"></div></div>');
-    jqLite(window.document.body).append(element);
-    element = $compile(element)($rootScope);
-    $rootScope.name = 'Alibaba';
-    $rootScope.url = 'myUrl';
-    $rootScope.$digest();
-    expect(element.text()).toEqual('Alibaba');
-    jqLite(window.document.body).empty();
-  }));
-
-
-  it('should NOT use untrusted URL expressions ', inject(putIntoCache('myUrl', '{{name}} text'),
-      function($rootScope, $compile, $sce) {
-    element = jqLite('<ng:include src="url"></ng:include>');
-    jqLite(window.document.body).append(element);
-    element = $compile(element)($rootScope);
-    $rootScope.name = 'chirayu';
-    $rootScope.url = 'http://example.com/myUrl';
-    expect(function() { $rootScope.$digest(); }).toThrowMinErr(
-        '$sce', 'insecurl',
-        /Blocked loading resource from url not allowed by \$sceDelegate policy. {2}URL: http:\/\/example.com\/myUrl.*/);
-    jqLite(window.document.body).empty();
-  }));
-
-
-  it('should NOT use mistyped expressions ', inject(putIntoCache('myUrl', '{{name}} text'),
-      function($rootScope, $compile, $sce) {
-    element = jqLite('<ng:include src="url"></ng:include>');
-    jqLite(window.document.body).append(element);
-    element = $compile(element)($rootScope);
-    $rootScope.name = 'chirayu';
-    $rootScope.url = $sce.trustAsUrl('http://example.com/myUrl');
-    expect(function() { $rootScope.$digest(); }).toThrowMinErr(
-        '$sce', 'insecurl',
-        /Blocked loading resource from url not allowed by \$sceDelegate policy. {2}URL: http:\/\/example.com\/myUrl.*/);
-    jqLite(window.document.body).empty();
-  }));
-
-
-  it('should remove previously included text if a falsy value is bound to src', inject(
-        putIntoCache('myUrl', '{{name}}'),
+    it('should include an external file', inject(putIntoCache('myUrl', '{{name}}'),
         function($rootScope, $compile) {
-    element = jqLite('<div><ng:include src="url"></ng:include></div>');
-    element = $compile(element)($rootScope);
-    $rootScope.name = 'igor';
-    $rootScope.url = 'myUrl';
-    $rootScope.$digest();
-
-    expect(element.text()).toEqual('igor');
-
-    $rootScope.url = undefined;
-    $rootScope.$digest();
-
-    expect(element.text()).toEqual('');
-  }));
-
-  it('should fire $includeContentRequested event on scope after making the xhr call', inject(
-      function($rootScope, $compile, $httpBackend) {
-    var contentRequestedSpy = jasmine.createSpy('content requested').and.callFake(function(event) {
-      expect(event.targetScope).toBe($rootScope);
-    });
-
-    $httpBackend.whenGET('url').respond('my partial');
-    $rootScope.$on('$includeContentRequested', contentRequestedSpy);
-
-    element = $compile('<div><div><ng:include src="\'url\'"></ng:include></div></div>')($rootScope);
-    $rootScope.$digest();
-
-    expect(contentRequestedSpy).toHaveBeenCalledOnceWith(jasmine.any(Object), 'url');
-
-    $httpBackend.flush();
-  }));
-
-  it('should fire $includeContentLoaded event on child scope after linking the content', inject(
-      function($rootScope, $compile, $templateCache) {
-    var contentLoadedSpy = jasmine.createSpy('content loaded').and.callFake(function(event) {
-      expect(event.targetScope.$parent).toBe($rootScope);
-      expect(element.text()).toBe('partial content');
-    });
-
-    $templateCache.put('url', [200, 'partial content', {}]);
-    $rootScope.$on('$includeContentLoaded', contentLoadedSpy);
-
-    element = $compile('<div><div><ng:include src="\'url\'"></ng:include></div></div>')($rootScope);
-    $rootScope.$digest();
-
-    expect(contentLoadedSpy).toHaveBeenCalledOnceWith(jasmine.any(Object), 'url');
-  }));
+      element = jqLite('<div><ng:include src="url"></ng:include></div>');
+      var body = jqLite(window.document.body);
+      body.append(element);
+      element = $compile(element)($rootScope);
+      $rootScope.name = 'misko';
+      $rootScope.url = 'myUrl';
+      $rootScope.$digest();
+      expect(body.text()).toEqual('misko');
+      body.empty();
+    }));
 
 
-  it('should fire $includeContentError event when content request fails', inject(
-      function($rootScope, $compile, $httpBackend, $templateCache) {
-    var contentLoadedSpy = jasmine.createSpy('content loaded'),
-        contentErrorSpy = jasmine.createSpy('content error');
-
-    $rootScope.$on('$includeContentLoaded', contentLoadedSpy);
-    $rootScope.$on('$includeContentError', contentErrorSpy);
-
-    $httpBackend.expect('GET', 'tpl.html').respond(400, 'nope');
-
-    element = $compile('<div><div ng-include="template"></div></div>')($rootScope);
-
-    $rootScope.$apply(function() {
-      $rootScope.template = 'tpl.html';
-    });
-    $httpBackend.flush();
-
-    expect(contentLoadedSpy).not.toHaveBeenCalled();
-    expect(contentErrorSpy).toHaveBeenCalledOnceWith(jasmine.any(Object), 'tpl.html');
-    expect(element.children('div').contents().length).toBe(0);
-  }));
+    it('should support ng-include="src" syntax', inject(putIntoCache('myUrl', '{{name}}'),
+        function($rootScope, $compile) {
+      element = jqLite('<div><div ng-include="url"></div></div>');
+      jqLite(window.document.body).append(element);
+      element = $compile(element)($rootScope);
+      $rootScope.name = 'Alibaba';
+      $rootScope.url = 'myUrl';
+      $rootScope.$digest();
+      expect(element.text()).toEqual('Alibaba');
+      jqLite(window.document.body).empty();
+    }));
 
 
-  it('should evaluate onload expression when a partial is loaded', inject(
-      putIntoCache('myUrl', 'my partial'),
-      function($rootScope, $compile) {
-    element = jqLite('<div><div><ng:include src="url" onload="loaded = true"></ng:include></div></div>');
-    element = $compile(element)($rootScope);
-
-    expect($rootScope.loaded).not.toBeDefined();
-
-    $rootScope.url = 'myUrl';
-    $rootScope.$digest();
-
-    expect(element.text()).toEqual('my partial');
-    expect($rootScope.loaded).toBe(true);
-  }));
+    it('should NOT use untrusted URL expressions ', inject(putIntoCache('myUrl', '{{name}} text'),
+        function($rootScope, $compile, $sce) {
+      element = jqLite('<ng:include src="url"></ng:include>');
+      jqLite(window.document.body).append(element);
+      element = $compile(element)($rootScope);
+      $rootScope.name = 'chirayu';
+      $rootScope.url = 'http://example.com/myUrl';
+      expect(function() { $rootScope.$digest(); }).toThrowMinErr(
+          '$sce', 'insecurl',
+          /Blocked loading resource from url not allowed by \$sceDelegate policy. {2}URL: http:\/\/example.com\/myUrl.*/);
+      jqLite(window.document.body).empty();
+    }));
 
 
-  it('should create child scope and destroy old one', inject(
+    it('should NOT use mistyped expressions ', inject(putIntoCache('myUrl', '{{name}} text'),
+        function($rootScope, $compile, $sce) {
+      element = jqLite('<ng:include src="url"></ng:include>');
+      jqLite(window.document.body).append(element);
+      element = $compile(element)($rootScope);
+      $rootScope.name = 'chirayu';
+      $rootScope.url = $sce.trustAsUrl('http://example.com/myUrl');
+      expect(function() { $rootScope.$digest(); }).toThrowMinErr(
+          '$sce', 'insecurl',
+          /Blocked loading resource from url not allowed by \$sceDelegate policy. {2}URL: http:\/\/example.com\/myUrl.*/);
+      jqLite(window.document.body).empty();
+    }));
+
+
+    it('should remove previously included text if a falsy value is bound to src', inject(
+          putIntoCache('myUrl', '{{name}}'),
+          function($rootScope, $compile) {
+      element = jqLite('<div><ng:include src="url"></ng:include></div>');
+      element = $compile(element)($rootScope);
+      $rootScope.name = 'igor';
+      $rootScope.url = 'myUrl';
+      $rootScope.$digest();
+
+      expect(element.text()).toEqual('igor');
+
+      $rootScope.url = undefined;
+      $rootScope.$digest();
+
+      expect(element.text()).toEqual('');
+    }));
+
+    it('should fire $includeContentRequested event on scope after making the xhr call', inject(
         function($rootScope, $compile, $httpBackend) {
-    $httpBackend.whenGET('url1').respond('partial {{$parent.url}}');
-    $httpBackend.whenGET('url2').respond(404);
+      var contentRequestedSpy = jasmine.createSpy('content requested').and.callFake(function(event) {
+        expect(event.targetScope).toBe($rootScope);
+      });
 
-    element = $compile('<div><ng:include src="url"></ng:include></div>')($rootScope);
-    expect(element.children().scope()).toBeFalsy();
+      $httpBackend.whenGET('url').respond('my partial');
+      $rootScope.$on('$includeContentRequested', contentRequestedSpy);
 
-    $rootScope.url = 'url1';
-    $rootScope.$digest();
-    $httpBackend.flush();
-    expect(element.children().scope().$parent).toBe($rootScope);
-    expect(element.text()).toBe('partial url1');
+      element = $compile('<div><div><ng:include src="\'url\'"></ng:include></div></div>')($rootScope);
+      $rootScope.$digest();
 
-    $rootScope.url = 'url2';
-    $rootScope.$digest();
-    $httpBackend.flush();
+      expect(contentRequestedSpy).toHaveBeenCalledOnceWith(jasmine.any(Object), 'url');
 
-    expect($rootScope.$$childHead).toBeFalsy();
-    expect(element.text()).toBe('');
+      $httpBackend.flush();
+    }));
 
-    $rootScope.url = 'url1';
-    $rootScope.$digest();
-    expect(element.children().scope().$parent).toBe($rootScope);
+    it('should fire $includeContentLoaded event on child scope after linking the content', inject(
+        function($rootScope, $compile, $templateCache) {
+      var contentLoadedSpy = jasmine.createSpy('content loaded').and.callFake(function(event) {
+        expect(event.targetScope.$parent).toBe($rootScope);
+        expect(element.text()).toBe('partial content');
+      });
 
-    $rootScope.url = null;
-    $rootScope.$digest();
-    expect($rootScope.$$childHead).toBeFalsy();
-  }));
+      $templateCache.put('url', [200, 'partial content', {}]);
+      $rootScope.$on('$includeContentLoaded', contentLoadedSpy);
 
+      element = $compile('<div><div><ng:include src="\'url\'"></ng:include></div></div>')($rootScope);
+      $rootScope.$digest();
 
-  it('should do xhr request and cache it',
-      inject(function($rootScope, $httpBackend, $compile) {
-    element = $compile('<div><ng:include src="url"></ng:include></div>')($rootScope);
-    $httpBackend.expect('GET', 'myUrl').respond('my partial');
-
-    $rootScope.url = 'myUrl';
-    $rootScope.$digest();
-    $httpBackend.flush();
-    expect(element.text()).toEqual('my partial');
-
-    $rootScope.url = null;
-    $rootScope.$digest();
-    expect(element.text()).toEqual('');
-
-    $rootScope.url = 'myUrl';
-    $rootScope.$digest();
-    expect(element.text()).toEqual('my partial');
-    dealoc($rootScope);
-  }));
+      expect(contentLoadedSpy).toHaveBeenCalledOnceWith(jasmine.any(Object), 'url');
+    }));
 
 
-  it('should clear content when error during xhr request',
-      inject(function($httpBackend, $compile, $rootScope) {
-    element = $compile('<div><ng:include src="url">content</ng:include></div>')($rootScope);
-    $httpBackend.expect('GET', 'myUrl').respond(404, '');
+    it('should fire $includeContentError event when content request fails', inject(
+        function($rootScope, $compile, $httpBackend, $templateCache) {
+      var contentLoadedSpy = jasmine.createSpy('content loaded'),
+          contentErrorSpy = jasmine.createSpy('content error');
 
-    $rootScope.url = 'myUrl';
-    $rootScope.$digest();
-    $httpBackend.flush();
+      $rootScope.$on('$includeContentLoaded', contentLoadedSpy);
+      $rootScope.$on('$includeContentError', contentErrorSpy);
 
-    expect(element.text()).toBe('');
-  }));
+      $httpBackend.expect('GET', 'tpl.html').respond(400, 'nope');
+
+      element = $compile('<div><div ng-include="template"></div></div>')($rootScope);
+
+      $rootScope.$apply(function() {
+        $rootScope.template = 'tpl.html';
+      });
+      $httpBackend.flush();
+
+      expect(contentLoadedSpy).not.toHaveBeenCalled();
+      expect(contentErrorSpy).toHaveBeenCalledOnceWith(jasmine.any(Object), 'tpl.html');
+      expect(element.children('div').contents().length).toBe(0);
+    }));
 
 
-  it('should be async even if served from cache', inject(
+    it('should evaluate onload expression when a partial is loaded', inject(
         putIntoCache('myUrl', 'my partial'),
         function($rootScope, $compile) {
-    element = $compile('<div><ng:include src="url"></ng:include></div>')($rootScope);
+      element = jqLite('<div><div><ng:include src="url" onload="loaded = true"></ng:include></div></div>');
+      element = $compile(element)($rootScope);
 
-    $rootScope.url = 'myUrl';
+      expect($rootScope.loaded).not.toBeDefined();
 
-    var called = 0;
-    // we want to assert only during first watch
-    $rootScope.$watch(function() {
-      if (!called) expect(element.text()).toBe('');
-      called++;
-    });
+      $rootScope.url = 'myUrl';
+      $rootScope.$digest();
 
-    $rootScope.$digest();
-    expect(element.text()).toBe('my partial');
-  }));
+      expect(element.text()).toEqual('my partial');
+      expect($rootScope.loaded).toBe(true);
+    }));
 
 
-  it('should discard pending xhr callbacks if a new template is requested before the current ' +
-      'finished loading', inject(function($rootScope, $compile, $httpBackend) {
-    element = jqLite('<div><ng:include src=\'templateUrl\'></ng:include></div>');
-    var log = {};
+    it('should create child scope and destroy old one', inject(
+          function($rootScope, $compile, $httpBackend) {
+      $httpBackend.whenGET('url1').respond('partial {{$parent.url}}');
+      $httpBackend.whenGET('url2').respond(404);
 
-    $rootScope.templateUrl = 'myUrl1';
-    $rootScope.logger = function(msg) {
-      log[msg] = true;
-    };
-    $compile(element)($rootScope);
-    expect(log).toEqual({});
+      element = $compile('<div><ng:include src="url"></ng:include></div>')($rootScope);
+      expect(element.children().scope()).toBeFalsy();
 
-    $httpBackend.expect('GET', 'myUrl1').respond('<div>{{logger("url1")}}</div>');
-    $rootScope.$digest();
-    expect(log).toEqual({});
-    $rootScope.templateUrl = 'myUrl2';
-    $httpBackend.expect('GET', 'myUrl2').respond('<div>{{logger("url2")}}</div>');
-    $httpBackend.flush(); // now that we have two requests pending, flush!
-
-    expect(log).toEqual({ url2: true });
-  }));
-
-
-  it('should compile only the content', inject(function($compile, $rootScope, $templateCache) {
-    // regression
-
-    var onload = jasmine.createSpy('$includeContentLoaded');
-    $rootScope.$on('$includeContentLoaded', onload);
-    $templateCache.put('tpl.html', [200, 'partial {{tpl}}', {}]);
-
-    element = $compile('<div><div ng-repeat="i in [1]">' +
-        '<ng:include src="tpl"></ng:include></div></div>')($rootScope);
-    expect(onload).not.toHaveBeenCalled();
-
-    $rootScope.$apply(function() {
-      $rootScope.tpl = 'tpl.html';
-    });
-    expect(onload).toHaveBeenCalledOnce();
-
-    $rootScope.tpl = '';
-    $rootScope.$digest();
-    dealoc(element);
-  }));
-
-
-  it('should not break attribute bindings on the same element', inject(function($compile, $rootScope, $httpBackend) {
-    // regression #3793
-
-    element = $compile('<div><span foo="#/{{hrefUrl}}" ng:include="includeUrl"></span></div>')($rootScope);
-    $httpBackend.expect('GET', 'url1').respond('template text 1');
-    $rootScope.hrefUrl = 'fooUrl1';
-    $rootScope.includeUrl = 'url1';
-    $rootScope.$digest();
-    $httpBackend.flush();
-    expect(element.text()).toBe('template text 1');
-    expect(element.find('span').attr('foo')).toBe('#/fooUrl1');
-
-    $httpBackend.expect('GET', 'url2').respond('template text 2');
-    $rootScope.includeUrl = 'url2';
-    $rootScope.$digest();
-    $httpBackend.flush();
-    expect(element.text()).toBe('template text 2');
-    expect(element.find('span').attr('foo')).toBe('#/fooUrl1');
-
-    $rootScope.hrefUrl = 'fooUrl2';
-    $rootScope.$digest();
-    expect(element.text()).toBe('template text 2');
-    expect(element.find('span').attr('foo')).toBe('#/fooUrl2');
-  }));
-
-
-  it('should exec scripts when jQuery is included', inject(function($compile, $rootScope, $httpBackend) {
-    if (!jQuery) {
-      return;
-    }
-
-    element = $compile('<div><span ng-include="includeUrl"></span></div>')($rootScope);
-
-    // the element needs to be appended for the script to run
-    element.appendTo(window.document.body);
-    window._ngIncludeCausesScriptToRun = false;
-    $httpBackend.expect('GET', 'url1').respond('<script>window._ngIncludeCausesScriptToRun = true;</script>');
-    $rootScope.includeUrl = 'url1';
-    $rootScope.$digest();
-    $httpBackend.flush();
-
-    expect(window._ngIncludeCausesScriptToRun).toBe(true);
-
-    delete window._ngIncludeCausesScriptToRun;
-  }));
-
-
-  it('should construct SVG template elements with correct namespace', function() {
-    if (!window.SVGRectElement) return;
-    module(function($compileProvider) {
-      $compileProvider.directive('test', valueFn({
-        templateNamespace: 'svg',
-        templateUrl: 'my-rect.html',
-        replace: true
-      }));
-    });
-    inject(function($compile, $rootScope, $httpBackend) {
-      $httpBackend.expectGET('my-rect.html').respond('<g ng-include="\'include.svg\'"></g>');
-      $httpBackend.expectGET('include.svg').respond('<rect></rect><rect></rect>');
-      element = $compile('<svg><test></test></svg>')($rootScope);
+      $rootScope.url = 'url1';
+      $rootScope.$digest();
       $httpBackend.flush();
-      var child = element.find('rect');
-      expect(child.length).toBe(2);
-      // eslint-disable-next-line no-undef
-      expect(child[0] instanceof SVGRectElement).toBe(true);
-    });
-  });
+      expect(element.children().scope().$parent).toBe($rootScope);
+      expect(element.text()).toBe('partial url1');
 
-
-  it('should compile only the template content of an SVG template', function() {
-    if (!window.SVGRectElement) return;
-    module(function($compileProvider) {
-      $compileProvider.directive('test', valueFn({
-        templateNamespace: 'svg',
-        templateUrl: 'my-rect.html',
-        replace: true
-      }));
-    });
-    inject(function($compile, $rootScope, $httpBackend) {
-      $httpBackend.expectGET('my-rect.html').respond('<g ng-include="\'include.svg\'"><a></a></g>');
-      $httpBackend.expectGET('include.svg').respond('<rect></rect><rect></rect>');
-      element = $compile('<svg><test></test></svg>')($rootScope);
+      $rootScope.url = 'url2';
+      $rootScope.$digest();
       $httpBackend.flush();
-      expect(element.find('a').length).toBe(0);
-    });
-  });
+
+      expect($rootScope.$$childHead).toBeFalsy();
+      expect(element.text()).toBe('');
+
+      $rootScope.url = 'url1';
+      $rootScope.$digest();
+      expect(element.children().scope().$parent).toBe($rootScope);
+
+      $rootScope.url = null;
+      $rootScope.$digest();
+      expect($rootScope.$$childHead).toBeFalsy();
+    }));
 
 
-  it('should not compile template if original scope is destroyed', function() {
-    module(function($provide) {
-      $provide.decorator('$compile', function($delegate) {
-        var result = jasmine.createSpy('$compile').and.callFake($delegate);
-        result.$$createComment = $delegate.$$createComment;
-        return result;
+    it('should do xhr request and cache it',
+        inject(function($rootScope, $httpBackend, $compile) {
+      element = $compile('<div><ng:include src="url"></ng:include></div>')($rootScope);
+      $httpBackend.expect('GET', 'myUrl').respond('my partial');
+
+      $rootScope.url = 'myUrl';
+      $rootScope.$digest();
+      $httpBackend.flush();
+      expect(element.text()).toEqual('my partial');
+
+      $rootScope.url = null;
+      $rootScope.$digest();
+      expect(element.text()).toEqual('');
+
+      $rootScope.url = 'myUrl';
+      $rootScope.$digest();
+      expect(element.text()).toEqual('my partial');
+      dealoc($rootScope);
+    }));
+
+
+    it('should clear content when error during xhr request',
+        inject(function($httpBackend, $compile, $rootScope) {
+      element = $compile('<div><ng:include src="url">content</ng:include></div>')($rootScope);
+      $httpBackend.expect('GET', 'myUrl').respond(404, '');
+
+      $rootScope.url = 'myUrl';
+      $rootScope.$digest();
+      $httpBackend.flush();
+
+      expect(element.text()).toBe('');
+    }));
+
+
+    it('should be async even if served from cache', inject(
+          putIntoCache('myUrl', 'my partial'),
+          function($rootScope, $compile) {
+      element = $compile('<div><ng:include src="url"></ng:include></div>')($rootScope);
+
+      $rootScope.url = 'myUrl';
+
+      var called = 0;
+      // we want to assert only during first watch
+      $rootScope.$watch(function() {
+        if (!called) expect(element.text()).toBe('');
+        called++;
       });
-    });
-    inject(function($rootScope, $httpBackend, $compile) {
-      $httpBackend.when('GET', 'url').respond('template text');
-      $rootScope.show = true;
-      element = $compile('<div ng-if="show"><div ng-include="\'url\'"></div></div>')($rootScope);
+
       $rootScope.$digest();
-      $rootScope.show = false;
-      $rootScope.$digest();
-      $compile.calls.reset();
-      $httpBackend.flush();
-      expect($compile).not.toHaveBeenCalled();
-    });
-  });
+      expect(element.text()).toBe('my partial');
+    }));
 
 
-  describe('autoscroll', function() {
-    var autoScrollSpy;
+    it('should discard pending xhr callbacks if a new template is requested before the current ' +
+        'finished loading', inject(function($rootScope, $compile, $httpBackend) {
+      element = jqLite('<div><ng:include src=\'templateUrl\'></ng:include></div>');
+      var log = {};
 
-    function spyOnAnchorScroll() {
-      return function($provide) {
-        autoScrollSpy = jasmine.createSpy('$anchorScroll');
-        $provide.value('$anchorScroll', autoScrollSpy);
+      $rootScope.templateUrl = 'myUrl1';
+      $rootScope.logger = function(msg) {
+        log[msg] = true;
       };
-    }
+      $compile(element)($rootScope);
+      expect(log).toEqual({});
 
-    function compileAndLink(tpl) {
-      return function($compile, $rootScope) {
-        element = $compile(tpl)($rootScope);
-      };
-    }
-
-    beforeEach(module(spyOnAnchorScroll(), 'ngAnimateMock'));
-    beforeEach(inject(
-        putIntoCache('template.html', 'CONTENT'),
-        putIntoCache('another.html', 'CONTENT')));
-
-    it('should call $anchorScroll if autoscroll attribute is present', inject(
-        compileAndLink('<div><ng:include src="tpl" autoscroll></ng:include></div>'),
-        function($rootScope, $animate, $timeout) {
-
-      $rootScope.$apply(function() {
-        $rootScope.tpl = 'template.html';
-      });
-
-      expect(autoScrollSpy).not.toHaveBeenCalled();
-
-      $animate.flush();
+      $httpBackend.expect('GET', 'myUrl1').respond('<div>{{logger("url1")}}</div>');
       $rootScope.$digest();
+      expect(log).toEqual({});
+      $rootScope.templateUrl = 'myUrl2';
+      $httpBackend.expect('GET', 'myUrl2').respond('<div>{{logger("url2")}}</div>');
+      $httpBackend.flush(); // now that we have two requests pending, flush!
 
-      expect($animate.queue.shift().event).toBe('enter');
-      expect(autoScrollSpy).toHaveBeenCalledOnce();
+      expect(log).toEqual({ url2: true });
     }));
 
 
-    it('should call $anchorScroll if autoscroll evaluates to true',
-      inject(function($rootScope, $compile, $animate, $timeout) {
+    it('should compile only the content', inject(function($compile, $rootScope, $templateCache) {
+      // regression
 
-      element = $compile('<div><ng:include src="tpl" autoscroll="value"></ng:include></div>')($rootScope);
+      var onload = jasmine.createSpy('$includeContentLoaded');
+      $rootScope.$on('$includeContentLoaded', onload);
+      $templateCache.put('tpl.html', [200, 'partial {{tpl}}', {}]);
 
-      $rootScope.$apply(function() {
-        $rootScope.tpl = 'template.html';
-        $rootScope.value = true;
-      });
-
-      expect($animate.queue.shift().event).toBe('enter');
-
-      $rootScope.$apply(function() {
-        $rootScope.tpl = 'another.html';
-        $rootScope.value = 'some-string';
-      });
-
-      expect($animate.queue.shift().event).toBe('leave');
-      expect($animate.queue.shift().event).toBe('enter');
+      element = $compile('<div><div ng-repeat="i in [1]">' +
+          '<ng:include src="tpl"></ng:include></div></div>')($rootScope);
+      expect(onload).not.toHaveBeenCalled();
 
       $rootScope.$apply(function() {
-        $rootScope.tpl = 'template.html';
-        $rootScope.value = 100;
+        $rootScope.tpl = 'tpl.html';
       });
-
-      expect($animate.queue.shift().event).toBe('leave');
-      expect($animate.queue.shift().event).toBe('enter');
-
-      $animate.flush();
-      $rootScope.$digest();
-
-      expect(autoScrollSpy).toHaveBeenCalled();
-      expect(autoScrollSpy).toHaveBeenCalledTimes(3);
-    }));
-
-
-    it('should not call $anchorScroll if autoscroll attribute is not present', inject(
-        compileAndLink('<div><ng:include src="tpl"></ng:include></div>'),
-        function($rootScope, $animate, $timeout) {
-
-      $rootScope.$apply(function() {
-        $rootScope.tpl = 'template.html';
-      });
-
-      expect($animate.queue.shift().event).toBe('enter');
-      expect(autoScrollSpy).not.toHaveBeenCalled();
-    }));
-
-
-    it('should not call $anchorScroll if autoscroll evaluates to false',
-      inject(function($rootScope, $compile, $animate, $timeout) {
-
-      element = $compile('<div><ng:include src="tpl" autoscroll="value"></ng:include></div>')($rootScope);
-
-      $rootScope.$apply(function() {
-        $rootScope.tpl = 'template.html';
-        $rootScope.value = false;
-      });
-
-      expect($animate.queue.shift().event).toBe('enter');
-
-      $rootScope.$apply(function() {
-        $rootScope.tpl = 'template.html';
-        $rootScope.value = undefined;
-      });
-
-      $rootScope.$apply(function() {
-        $rootScope.tpl = 'template.html';
-        $rootScope.value = null;
-      });
-
-      expect(autoScrollSpy).not.toHaveBeenCalled();
-    }));
-
-    it('should only call $anchorScroll after the "enter" animation completes', inject(
-        compileAndLink('<div><ng:include src="tpl" autoscroll></ng:include></div>'),
-        function($rootScope, $animate, $timeout) {
-          expect(autoScrollSpy).not.toHaveBeenCalled();
-
-          $rootScope.$apply('tpl = \'template.html\'');
-          expect($animate.queue.shift().event).toBe('enter');
-
-          $animate.flush();
-          $rootScope.$digest();
-
-          expect(autoScrollSpy).toHaveBeenCalledOnce();
-        }
-    ));
-  });
-});
-
-describe('ngInclude and transcludes', function() {
-  var element, directive;
-
-  beforeEach(module(function($compileProvider) {
-    element = null;
-    directive = $compileProvider.directive;
-  }));
-
-  afterEach(function() {
-    if (element) {
-      dealoc(element);
-    }
-  });
-
-  it('should allow access to directive controller from children when used in a replace template', function() {
-    var controller;
-    module(function() {
-      directive('template', valueFn({
-        template: '<div ng-include="\'include.html\'"></div>',
-        replace: true,
-        controller: function() {
-          this.flag = true;
-        }
-      }));
-      directive('test', valueFn({
-        require: '^template',
-        link: function(scope, el, attr, ctrl) {
-          controller = ctrl;
-        }
-      }));
-    });
-    inject(function($compile, $rootScope, $httpBackend) {
-      $httpBackend.expectGET('include.html').respond('<div><div test></div></div>');
-      element = $compile('<div><div template></div></div>')($rootScope);
-      $rootScope.$apply();
-      $httpBackend.flush();
-      expect(controller.flag).toBe(true);
-    });
-  });
-
-  it('should compile its content correctly (although we remove it later)', function() {
-    var testElement;
-    module(function() {
-      directive('test', function() {
-        return {
-          link: function(scope, element) {
-            testElement = element;
-          }
-        };
-      });
-    });
-    inject(function($compile, $rootScope, $httpBackend) {
-      $httpBackend.expectGET('include.html').respond(' ');
-      element = $compile('<div><div ng-include="\'include.html\'"><div test></div></div></div>')($rootScope);
-      $rootScope.$apply();
-      $httpBackend.flush();
-      expect(testElement[0].nodeName).toBe('DIV');
-    });
-
-  });
-
-  it('should link directives on the same element after the content has been loaded', function() {
-    var contentOnLink;
-    module(function() {
-      directive('test', function() {
-        return {
-          link: function(scope, element) {
-            contentOnLink = element.text();
-          }
-        };
-      });
-    });
-    inject(function($compile, $rootScope, $httpBackend) {
-      $httpBackend.expectGET('include.html').respond('someContent');
-      element = $compile('<div><div ng-include="\'include.html\'" test></div>')($rootScope);
-      $rootScope.$apply();
-      $httpBackend.flush();
-      expect(contentOnLink).toBe('someContent');
-    });
-  });
-
-  it('should add the content to the element before compiling it', function() {
-    var root;
-    module(function() {
-      directive('test', function() {
-        return {
-          link: function(scope, element) {
-            root = element.parent().parent();
-          }
-        };
-      });
-    });
-    inject(function($compile, $rootScope, $httpBackend) {
-      $httpBackend.expectGET('include.html').respond('<span test></span>');
-      element = $compile('<div><div ng-include="\'include.html\'"></div>')($rootScope);
-      $rootScope.$apply();
-      $httpBackend.flush();
-      expect(root[0]).toBe(element[0]);
-    });
-  });
-});
-
-describe('ngInclude animations', function() {
-  var body, element, $rootElement;
-
-  function html(content) {
-    $rootElement.html(content);
-    element = $rootElement.children().eq(0);
-    return element;
-  }
-
-  beforeEach(module(function() {
-    // we need to run animation on attached elements;
-    return function(_$rootElement_) {
-      $rootElement = _$rootElement_;
-      body = jqLite(window.document.body);
-      body.append($rootElement);
-    };
-  }));
-
-  afterEach(function() {
-    dealoc(body);
-    dealoc(element);
-  });
-
-  beforeEach(module('ngAnimateMock'));
-
-  afterEach(function() {
-    dealoc(element);
-  });
-
-  it('should fire off the enter animation',
-    inject(function($compile, $rootScope, $templateCache, $animate) {
-      var item;
-
-      $templateCache.put('enter', [200, '<div>data</div>', {}]);
-      $rootScope.tpl = 'enter';
-      element = $compile(html(
-        '<div><div ' +
-          'ng-include="tpl">' +
-        '</div></div>'
-      ))($rootScope);
-      $rootScope.$digest();
-
-      var animation = $animate.queue.pop();
-      expect(animation.event).toBe('enter');
-      expect(animation.element.text()).toBe('data');
-    })
-  );
-
-  it('should fire off the leave animation',
-    inject(function($compile, $rootScope, $templateCache, $animate) {
-      var item;
-      $templateCache.put('enter', [200, '<div>data</div>', {}]);
-      $rootScope.tpl = 'enter';
-      element = $compile(html(
-        '<div><div ' +
-          'ng-include="tpl">' +
-        '</div></div>'
-      ))($rootScope);
-      $rootScope.$digest();
-
-      var animation = $animate.queue.shift();
-      expect(animation.event).toBe('enter');
-      expect(animation.element.text()).toBe('data');
+      expect(onload).toHaveBeenCalledOnce();
 
       $rootScope.tpl = '';
       $rootScope.$digest();
+      dealoc(element);
+    }));
 
-      animation = $animate.queue.shift();
-      expect(animation.event).toBe('leave');
-      expect(animation.element.text()).toBe('data');
-    })
-  );
 
-  it('should animate two separate ngInclude elements',
-    inject(function($compile, $rootScope, $templateCache, $animate) {
-      var item;
-      $templateCache.put('one', [200, 'one', {}]);
-      $templateCache.put('two', [200, 'two', {}]);
-      $rootScope.tpl = 'one';
-      element = $compile(html(
-        '<div><div ' +
-          'ng-include="tpl">' +
-        '</div></div>'
-      ))($rootScope);
+    it('should not break attribute bindings on the same element', inject(function($compile, $rootScope, $httpBackend) {
+      // regression #3793
+
+      element = $compile('<div><span foo="#/{{hrefUrl}}" ng:include="includeUrl"></span></div>')($rootScope);
+      $httpBackend.expect('GET', 'url1').respond('template text 1');
+      $rootScope.hrefUrl = 'fooUrl1';
+      $rootScope.includeUrl = 'url1';
       $rootScope.$digest();
+      $httpBackend.flush();
+      expect(element.text()).toBe('template text 1');
+      expect(element.find('span').attr('foo')).toBe('#/fooUrl1');
 
-      var item1 = $animate.queue.shift().element;
-      expect(item1.text()).toBe('one');
-
-      $rootScope.tpl = 'two';
+      $httpBackend.expect('GET', 'url2').respond('template text 2');
+      $rootScope.includeUrl = 'url2';
       $rootScope.$digest();
+      $httpBackend.flush();
+      expect(element.text()).toBe('template text 2');
+      expect(element.find('span').attr('foo')).toBe('#/fooUrl1');
 
-      var itemA = $animate.queue.shift().element;
-      var itemB = $animate.queue.shift().element;
-      expect(itemA.attr('ng-include')).toBe('tpl');
-      expect(itemB.attr('ng-include')).toBe('tpl');
-      expect(itemA).not.toEqual(itemB);
-    })
-  );
+      $rootScope.hrefUrl = 'fooUrl2';
+      $rootScope.$digest();
+      expect(element.text()).toBe('template text 2');
+      expect(element.find('span').attr('foo')).toBe('#/fooUrl2');
+    }));
 
-  it('should destroy the previous leave animation if a new one takes place', function() {
-    module(function($provide) {
-      $provide.decorator('$animate', function($delegate, $$q) {
-        var emptyPromise = $$q.defer().promise;
-        $delegate.leave = function() {
-          return emptyPromise;
-        };
-        return $delegate;
+
+    it('should exec scripts when jQuery is included', inject(function($compile, $rootScope, $httpBackend) {
+      if (!jQuery) {
+        return;
+      }
+
+      element = $compile('<div><span ng-include="includeUrl"></span></div>')($rootScope);
+
+      // the element needs to be appended for the script to run
+      element.appendTo(window.document.body);
+      window._ngIncludeCausesScriptToRun = false;
+      $httpBackend.expect('GET', 'url1').respond('<script>window._ngIncludeCausesScriptToRun = true;</script>');
+      $rootScope.includeUrl = 'url1';
+      $rootScope.$digest();
+      $httpBackend.flush();
+
+      expect(window._ngIncludeCausesScriptToRun).toBe(true);
+
+      delete window._ngIncludeCausesScriptToRun;
+    }));
+
+
+    it('should construct SVG template elements with correct namespace', function() {
+      if (!window.SVGRectElement) return;
+      module(function($compileProvider) {
+        $compileProvider.directive('test', valueFn({
+          templateNamespace: 'svg',
+          templateUrl: 'my-rect.html',
+          replace: true
+        }));
+      });
+      inject(function($compile, $rootScope, $httpBackend) {
+        $httpBackend.expectGET('my-rect.html').respond('<g ng-include="\'include.svg\'"></g>');
+        $httpBackend.expectGET('include.svg').respond('<rect></rect><rect></rect>');
+        element = $compile('<svg><test></test></svg>')($rootScope);
+        $httpBackend.flush();
+        var child = element.find('rect');
+        expect(child.length).toBe(2);
+        // eslint-disable-next-line no-undef
+        expect(child[0] instanceof SVGRectElement).toBe(true);
       });
     });
-    inject(function($compile, $rootScope, $animate, $templateCache) {
-      var item;
-      var $scope = $rootScope.$new();
-      element = $compile(html(
-        '<div>' +
-          '<div ng-include="inc">Yo</div>' +
-        '</div>'
-      ))($scope);
 
-      $templateCache.put('one', [200, '<div>one</div>', {}]);
-      $templateCache.put('two', [200, '<div>two</div>', {}]);
 
-      $scope.$apply('inc = "one"');
+    it('should compile only the template content of an SVG template', function() {
+      if (!window.SVGRectElement) return;
+      module(function($compileProvider) {
+        $compileProvider.directive('test', valueFn({
+          templateNamespace: 'svg',
+          templateUrl: 'my-rect.html',
+          replace: true
+        }));
+      });
+      inject(function($compile, $rootScope, $httpBackend) {
+        $httpBackend.expectGET('my-rect.html').respond('<g ng-include="\'include.svg\'"><a></a></g>');
+        $httpBackend.expectGET('include.svg').respond('<rect></rect><rect></rect>');
+        element = $compile('<svg><test></test></svg>')($rootScope);
+        $httpBackend.flush();
+        expect(element.find('a').length).toBe(0);
+      });
+    });
 
-      var destroyed, inner = element.children(0);
-      inner.on('$destroy', function() {
-        destroyed = true;
+
+    it('should not compile template if original scope is destroyed', function() {
+      module(function($provide) {
+        $provide.decorator('$compile', function($delegate) {
+          var result = jasmine.createSpy('$compile').and.callFake($delegate);
+          result.$$createComment = $delegate.$$createComment;
+          return result;
+        });
+      });
+      inject(function($rootScope, $httpBackend, $compile) {
+        $httpBackend.when('GET', 'url').respond('template text');
+        $rootScope.show = true;
+        element = $compile('<div ng-if="show"><div ng-include="\'url\'"></div></div>')($rootScope);
+        $rootScope.$digest();
+        $rootScope.show = false;
+        $rootScope.$digest();
+        $compile.calls.reset();
+        $httpBackend.flush();
+        expect($compile).not.toHaveBeenCalled();
+      });
+    });
+
+
+    describe('autoscroll', function() {
+      var autoScrollSpy;
+
+      function spyOnAnchorScroll() {
+        return function($provide) {
+          autoScrollSpy = jasmine.createSpy('$anchorScroll');
+          $provide.value('$anchorScroll', autoScrollSpy);
+        };
+      }
+
+      function compileAndLink(tpl) {
+        return function($compile, $rootScope) {
+          element = $compile(tpl)($rootScope);
+        };
+      }
+
+      beforeEach(module(spyOnAnchorScroll(), 'ngAnimateMock'));
+      beforeEach(inject(
+          putIntoCache('template.html', 'CONTENT'),
+          putIntoCache('another.html', 'CONTENT')));
+
+      it('should call $anchorScroll if autoscroll attribute is present', inject(
+          compileAndLink('<div><ng:include src="tpl" autoscroll></ng:include></div>'),
+          function($rootScope, $animate, $timeout) {
+
+        $rootScope.$apply(function() {
+          $rootScope.tpl = 'template.html';
+        });
+
+        expect(autoScrollSpy).not.toHaveBeenCalled();
+
+        $animate.flush();
+        $rootScope.$digest();
+
+        expect($animate.queue.shift().event).toBe('enter');
+        expect(autoScrollSpy).toHaveBeenCalledOnce();
+      }));
+
+
+      it('should call $anchorScroll if autoscroll evaluates to true',
+        inject(function($rootScope, $compile, $animate, $timeout) {
+
+        element = $compile('<div><ng:include src="tpl" autoscroll="value"></ng:include></div>')($rootScope);
+
+        $rootScope.$apply(function() {
+          $rootScope.tpl = 'template.html';
+          $rootScope.value = true;
+        });
+
+        expect($animate.queue.shift().event).toBe('enter');
+
+        $rootScope.$apply(function() {
+          $rootScope.tpl = 'another.html';
+          $rootScope.value = 'some-string';
+        });
+
+        expect($animate.queue.shift().event).toBe('leave');
+        expect($animate.queue.shift().event).toBe('enter');
+
+        $rootScope.$apply(function() {
+          $rootScope.tpl = 'template.html';
+          $rootScope.value = 100;
+        });
+
+        expect($animate.queue.shift().event).toBe('leave');
+        expect($animate.queue.shift().event).toBe('enter');
+
+        $animate.flush();
+        $rootScope.$digest();
+
+        expect(autoScrollSpy).toHaveBeenCalled();
+        expect(autoScrollSpy).toHaveBeenCalledTimes(3);
+      }));
+
+
+      it('should not call $anchorScroll if autoscroll attribute is not present', inject(
+          compileAndLink('<div><ng:include src="tpl"></ng:include></div>'),
+          function($rootScope, $animate, $timeout) {
+
+        $rootScope.$apply(function() {
+          $rootScope.tpl = 'template.html';
+        });
+
+        expect($animate.queue.shift().event).toBe('enter');
+        expect(autoScrollSpy).not.toHaveBeenCalled();
+      }));
+
+
+      it('should not call $anchorScroll if autoscroll evaluates to false',
+        inject(function($rootScope, $compile, $animate, $timeout) {
+
+        element = $compile('<div><ng:include src="tpl" autoscroll="value"></ng:include></div>')($rootScope);
+
+        $rootScope.$apply(function() {
+          $rootScope.tpl = 'template.html';
+          $rootScope.value = false;
+        });
+
+        expect($animate.queue.shift().event).toBe('enter');
+
+        $rootScope.$apply(function() {
+          $rootScope.tpl = 'template.html';
+          $rootScope.value = undefined;
+        });
+
+        $rootScope.$apply(function() {
+          $rootScope.tpl = 'template.html';
+          $rootScope.value = null;
+        });
+
+        expect(autoScrollSpy).not.toHaveBeenCalled();
+      }));
+
+      it('should only call $anchorScroll after the "enter" animation completes', inject(
+          compileAndLink('<div><ng:include src="tpl" autoscroll></ng:include></div>'),
+          function($rootScope, $animate, $timeout) {
+            expect(autoScrollSpy).not.toHaveBeenCalled();
+
+            $rootScope.$apply('tpl = \'template.html\'');
+            expect($animate.queue.shift().event).toBe('enter');
+
+            $animate.flush();
+            $rootScope.$digest();
+
+            expect(autoScrollSpy).toHaveBeenCalledOnce();
+          }
+      ));
+    });
+  });
+
+  describe('and transcludes', function() {
+    var element, directive;
+
+    beforeEach(module(function($compileProvider) {
+      element = null;
+      directive = $compileProvider.directive;
+    }));
+
+    afterEach(function() {
+      if (element) {
+        dealoc(element);
+      }
+    });
+
+    it('should allow access to directive controller from children when used in a replace template', function() {
+      var controller;
+      module(function() {
+        directive('template', valueFn({
+          template: '<div ng-include="\'include.html\'"></div>',
+          replace: true,
+          controller: function() {
+            this.flag = true;
+          }
+        }));
+        directive('test', valueFn({
+          require: '^template',
+          link: function(scope, el, attr, ctrl) {
+            controller = ctrl;
+          }
+        }));
+      });
+      inject(function($compile, $rootScope, $httpBackend) {
+        $httpBackend.expectGET('include.html').respond('<div><div test></div></div>');
+        element = $compile('<div><div template></div></div>')($rootScope);
+        $rootScope.$apply();
+        $httpBackend.flush();
+        expect(controller.flag).toBe(true);
+      });
+    });
+
+    it('should compile its content correctly (although we remove it later)', function() {
+      var testElement;
+      module(function() {
+        directive('test', function() {
+          return {
+            link: function(scope, element) {
+              testElement = element;
+            }
+          };
+        });
+      });
+      inject(function($compile, $rootScope, $httpBackend) {
+        $httpBackend.expectGET('include.html').respond(' ');
+        element = $compile('<div><div ng-include="\'include.html\'"><div test></div></div></div>')($rootScope);
+        $rootScope.$apply();
+        $httpBackend.flush();
+        expect(testElement[0].nodeName).toBe('DIV');
       });
 
-      $scope.$apply('inc = "two"');
+    });
 
-      $scope.$apply('inc = "one"');
+    it('should link directives on the same element after the content has been loaded', function() {
+      var contentOnLink;
+      module(function() {
+        directive('test', function() {
+          return {
+            link: function(scope, element) {
+              contentOnLink = element.text();
+            }
+          };
+        });
+      });
+      inject(function($compile, $rootScope, $httpBackend) {
+        $httpBackend.expectGET('include.html').respond('someContent');
+        element = $compile('<div><div ng-include="\'include.html\'" test></div>')($rootScope);
+        $rootScope.$apply();
+        $httpBackend.flush();
+        expect(contentOnLink).toBe('someContent');
+      });
+    });
 
-      $scope.$apply('inc = "two"');
+    it('should add the content to the element before compiling it', function() {
+      var root;
+      module(function() {
+        directive('test', function() {
+          return {
+            link: function(scope, element) {
+              root = element.parent().parent();
+            }
+          };
+        });
+      });
+      inject(function($compile, $rootScope, $httpBackend) {
+        $httpBackend.expectGET('include.html').respond('<span test></span>');
+        element = $compile('<div><div ng-include="\'include.html\'"></div>')($rootScope);
+        $rootScope.$apply();
+        $httpBackend.flush();
+        expect(root[0]).toBe(element[0]);
+      });
+    });
+  });
 
-      expect(destroyed).toBe(true);
+  describe('and animations', function() {
+    var body, element, $rootElement;
+
+    function html(content) {
+      $rootElement.html(content);
+      element = $rootElement.children().eq(0);
+      return element;
+    }
+
+    beforeEach(module(function() {
+      // we need to run animation on attached elements;
+      return function(_$rootElement_) {
+        $rootElement = _$rootElement_;
+        body = jqLite(window.document.body);
+        body.append($rootElement);
+      };
+    }));
+
+    afterEach(function() {
+      dealoc(body);
+      dealoc(element);
+    });
+
+    beforeEach(module('ngAnimateMock'));
+
+    afterEach(function() {
+      dealoc(element);
+    });
+
+    it('should fire off the enter animation',
+      inject(function($compile, $rootScope, $templateCache, $animate) {
+        var item;
+
+        $templateCache.put('enter', [200, '<div>data</div>', {}]);
+        $rootScope.tpl = 'enter';
+        element = $compile(html(
+          '<div><div ' +
+            'ng-include="tpl">' +
+          '</div></div>'
+        ))($rootScope);
+        $rootScope.$digest();
+
+        var animation = $animate.queue.pop();
+        expect(animation.event).toBe('enter');
+        expect(animation.element.text()).toBe('data');
+      })
+    );
+
+    it('should fire off the leave animation',
+      inject(function($compile, $rootScope, $templateCache, $animate) {
+        var item;
+        $templateCache.put('enter', [200, '<div>data</div>', {}]);
+        $rootScope.tpl = 'enter';
+        element = $compile(html(
+          '<div><div ' +
+            'ng-include="tpl">' +
+          '</div></div>'
+        ))($rootScope);
+        $rootScope.$digest();
+
+        var animation = $animate.queue.shift();
+        expect(animation.event).toBe('enter');
+        expect(animation.element.text()).toBe('data');
+
+        $rootScope.tpl = '';
+        $rootScope.$digest();
+
+        animation = $animate.queue.shift();
+        expect(animation.event).toBe('leave');
+        expect(animation.element.text()).toBe('data');
+      })
+    );
+
+    it('should animate two separate ngInclude elements',
+      inject(function($compile, $rootScope, $templateCache, $animate) {
+        var item;
+        $templateCache.put('one', [200, 'one', {}]);
+        $templateCache.put('two', [200, 'two', {}]);
+        $rootScope.tpl = 'one';
+        element = $compile(html(
+          '<div><div ' +
+            'ng-include="tpl">' +
+          '</div></div>'
+        ))($rootScope);
+        $rootScope.$digest();
+
+        var item1 = $animate.queue.shift().element;
+        expect(item1.text()).toBe('one');
+
+        $rootScope.tpl = 'two';
+        $rootScope.$digest();
+
+        var itemA = $animate.queue.shift().element;
+        var itemB = $animate.queue.shift().element;
+        expect(itemA.attr('ng-include')).toBe('tpl');
+        expect(itemB.attr('ng-include')).toBe('tpl');
+        expect(itemA).not.toEqual(itemB);
+      })
+    );
+
+    it('should destroy the previous leave animation if a new one takes place', function() {
+      module(function($provide) {
+        $provide.decorator('$animate', function($delegate, $$q) {
+          var emptyPromise = $$q.defer().promise;
+
+          $delegate.leave = function() {
+            return emptyPromise;
+          };
+          return $delegate;
+        });
+      });
+      inject(function($compile, $rootScope, $animate, $templateCache) {
+        var item;
+        var $scope = $rootScope.$new();
+        element = $compile(html(
+          '<div>' +
+            '<div ng-include="inc">Yo</div>' +
+          '</div>'
+        ))($scope);
+
+        $templateCache.put('one', [200, '<div>one</div>', {}]);
+        $templateCache.put('two', [200, '<div>two</div>', {}]);
+
+        $scope.$apply('inc = "one"');
+
+        var destroyed, inner = element.children(0);
+        inner.on('$destroy', function() {
+          destroyed = true;
+        });
+
+        $scope.$apply('inc = "two"');
+
+        $scope.$apply('inc = "one"');
+
+        $scope.$apply('inc = "two"');
+
+        expect(destroyed).toBe(true);
+      });
     });
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
perf


**What is the current behavior? (You can also link to an open issue here)**
Structural animations such as ngIf trigger an additional digest after $animate.leave completes

**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- ~[ ] Docs have been added / updated (for bug fixes / features)~

