### PR TITLE
fix(security): do not auto-bootstrap when loaded from an extension.

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -97,9 +97,6 @@
   NODE_TYPE_DOCUMENT,
   NODE_TYPE_DOCUMENT_FRAGMENT
 */
-/* global
-  console
-*/
 
 ////////////////////////////////////
 
@@ -1626,8 +1623,8 @@ function angularInit(element, bootstrap) {
   });
   if (appElement) {
     if (!isAutoBootstrapAllowed) {
-      console.error('Angular: disabling automatic bootstrap. <script> protocol indicates an ' +
-          'extension, document.location.href does not match.');
+      window.console.error('Angular: disabling automatic bootstrap. <script> protocol indicates ' +
+          'an extension, document.location.href does not match.');
       return;
     }
     config.strictDi = getNgAttribute(appElement, 'strict-di') !== null;

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -104,6 +104,8 @@
     "getBlockNodes": false,
     "createMap": false,
     "VALIDITY_STATE_PROPERTY": true,
+    "allowAutoBootstrap": false,
+    "isAutoBootstrapAllowed": false,
 
     /* AngularPublic.js */
     "version": false,

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1682,6 +1682,27 @@ describe('angular', function() {
 
       dealoc(appElement);
     });
+
+    it('should not bootstrap from an extension into a non-extension document', function() {
+      var src = 'resource://something';
+      // Fake a minimal document object (the actual document.currentScript is readonly).
+      var fakeDoc = {
+        currentScript: { getAttribute: function() { return src; } },
+        location: {protocol: 'http:'},
+        createElement: document.createElement.bind(document)
+      };
+      expect(allowAutoBootstrap(fakeDoc)).toBe(false);
+
+      src = 'file://whatever';
+      expect(allowAutoBootstrap(fakeDoc)).toBe(true);
+    });
+
+    it('should not bootstrap if bootstrapping is disabled', function() {
+      isAutoBootstrapAllowed = false;
+      angularInit(jqLite('<div ng-app></div>')[0], bootstrapSpy);
+      expect(bootstrapSpy).not.toHaveBeenCalled();
+      isAutoBootstrapAllowed = true;
+    });
   });
 
 


### PR DESCRIPTION
Extension URIs (`resource://...`) bypass Content-Security-Policy in Chrome and
Firefox and can always be loaded. Now if a site already has a XSS bug, and uses
CSP to protect itself, but the user has an extension installed that uses
Angular, an attacked can load Angular from the extension, and Angular's
auto-bootstrapping can be used to bypass the victim site's CSP protection.

Notes:
- `isAutoBootstrapAllowed` must be initialized on load, so that `currentScript`
  is set correctly.
- The tests are a bit indirect as reproducing the actual scenario is too
  complicated to reproduce (requires signing an extension etc). I have confirmed
  this to be working manually.