### PR TITLE
feat($compile): set preAssignBindingsEnabled to false by default

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1379,7 +1379,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    *
    * The default value is true in Angular 1.5.x but will switch to false in Angular 1.6.x.
    */
-  var preAssignBindingsEnabled = true;
+  var preAssignBindingsEnabled = false;
   this.preAssignBindingsEnabled = function(enabled) {
     if (isDefined(enabled)) {
       preAssignBindingsEnabled = enabled;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -171,7 +171,9 @@ describe('$compile', function() {
 
     it('should allow preAssignBindingsEnabled to be configured', function() {
       module(function($compileProvider) {
-        expect($compileProvider.preAssignBindingsEnabled()).toBe(true); // the default
+        expect($compileProvider.preAssignBindingsEnabled()).toBe(false); // the default
+        $compileProvider.preAssignBindingsEnabled(true);
+        expect($compileProvider.preAssignBindingsEnabled()).toBe(true);
         $compileProvider.preAssignBindingsEnabled(false);
         expect($compileProvider.preAssignBindingsEnabled()).toBe(false);
       });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
A breaking change.


**What is the current behavior? (You can also link to an open issue here)**
#15350


**What is the new behavior (if this is a feature change)?**
No.


**Does this PR introduce a breaking change?**
Yes


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) (docs were already there)

**Other information**:

Fixes #15350

BREAKING CHANGE: Previously, $compileProvider.preAssignBindingsEnabled was
set to true by default. This means bindings were pre-assigned in component
constructors. In Angular 1.5+ the place to put the initialization logic
relying on bindings being present is the controller $onInit method.

To migrate follow the example below:

Before:

```js
angular.module('myApp', [])
  .component('myComponent', {
    controller: 'MyController',
    template: '<div>{{ $ctrl.a }} + {{ $ctrl.b }} = {{ $ctrl.sum }}</div>',
    bindings: {
      a: '<',
      b: '<'
    }
  })
  .controller('MyController', function() {
    this.sum = this.a + this.b;
  });
```

After:
```js
angular.module('myApp', [])
  .component('myComponent', {
    controller: 'MyController',
    template: '<div>{{ $ctrl.a }} + {{ $ctrl.b }} = {{ $ctrl.sum }}</div>',
    bindings: {
      a: '<',
      b: '<'
    }
  })
  .controller('MyController', function() {
    this.$onInit = function () {
      this.sum = this.a + this.b;
    };
  });
```

If you need to support both Angular 1.4 and 1.6, e.g. you're writing a library,
you need to check for Angular version and apply proper logic. Follow the
example below:

Before:
```js
angular.module('myApp', [])
  .directive('myDirective', function() {
    return {
      controller: 'MyController',
      template: '<div>{{ $ctrl.a }} + {{ $ctrl.b }} = {{ $ctrl.sum }}</div>',
      scope: {
        a: '=',
        b: '='
      },
      bindToController: true,
      controllerAs: '$ctrl'
    };
  })
  .controller('MyController', function($scope) {
    this.sum = this.a + this.b;
  });
```

After:
```js
angular.module('myApp', [])
  .directive('myDirective', function() {
    return {
      controller: 'MyController',
      template: '<div>{{ $ctrl.a }} + {{ $ctrl.b }} = {{ $ctrl.sum }}</div>',
      scope: {
        a: '=',
        b: '='
      },
      bindToController: true,
      controllerAs: '$ctrl'
    };
  })
  .controller('MyController', function($scope) {
    this.$onInit = function() {
      this.sum = this.a + this.b;
    };
    if (angular.version.major === 1 && angular.version.minor <= 4) {
      this.$onInit();
    }
  });
```