### PR TITLE
chore(docs-gen): create plnkr examples with the correct version

### DIFF
--- a/docs/config/services/deployments/production.js
+++ b/docs/config/services/deployments/production.js
@@ -1,16 +1,30 @@
 'use strict';
 
 var versionInfo = require('../../../../lib/versions/version-info');
-var cdnUrl = '//ajax.googleapis.com/ajax/libs/angularjs/' + versionInfo.cdnVersion;
+
+var googleCdnUrl = '//ajax.googleapis.com/ajax/libs/angularjs/';
+var angularCodeUrl = '//code.angularjs.org/';
+
+var cdnUrl = googleCdnUrl + versionInfo.cdnVersion;
+
+// The plnkr examples must use the code.angularjs.org repo for the snapshot,
+// and the cdn for the tagged version and, if the build is not tagged, the currentVersion.
+//
+// The currentVersion may not be available on the cdn (e.g. if built locally, or hasn't been pushed
+// yet). This will lead to a 404, but this is preferable to loading a version with which the example
+// might not work (possibly in subtle ways).
+var examplesCdnUrl = versionInfo.isSnapshot ?
+  (angularCodeUrl + 'snapshot') :
+  (googleCdnUrl + (versionInfo.version || versionInfo.currentVersion));
 
 module.exports = function productionDeployment(getVersion) {
   return {
     name: 'production',
     examples: {
       commonFiles: {
-        scripts: [cdnUrl + '/angular.min.js']
+        scripts: [examplesCdnUrl + '/angular.min.js']
       },
-      dependencyPath: cdnUrl + '/'
+      dependencyPath: examplesCdnUrl + '/'
     },
     scripts: [
       cdnUrl + '/angular.min.js',


### PR DESCRIPTION
**What is the current behavior? (You can also link to an open issue here)**
Currently, plnkrs are opened with the cdnVersion of the built docs app, which means
that snapshot plunkers might not work because they use the cdn (stable version).


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format

**Other information**:

Should we update this info for the other deployments too?

