### PR TITLE
[fix] #15331 Guard against no parent

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -979,6 +979,9 @@ forEach({
 
   after: function(element, newElement) {
     var index = element, parent = element.parentNode;
+    if (!parent) {
+      return;
+    }
     newElement = new JQLite(newElement);
 
     for (var i = 0, ii = newElement.length; i < ii; i++) {


### PR DESCRIPTION
See issue #15331 

This patch silently ignores the after operation if the element does not have a parent node, following the implementation in jQuery.