### PR TITLE
fix($filter): change documentation of $filter to reflect optional com…

### DIFF
--- a/src/ng/filter/filter.js
+++ b/src/ng/filter/filter.js
@@ -41,9 +41,9 @@
  *
  *     The final result is an array of those elements that the predicate returned true for.
  *
- * @param {function(actual, expected)|true|undefined} comparator Comparator which is used in
+ * @param {function(actual, expected)|true|false} [comparator] Comparator which is used in
  *     determining if the expected value (from the filter expression) and actual value (from
- *     the object in the array) should be considered a match.
+ *     the object in the array) should be considered a match. 
  *
  *   Can be one of:
  *
@@ -54,13 +54,13 @@
  *   - `true`: A shorthand for `function(actual, expected) { return angular.equals(actual, expected)}`.
  *     This is essentially strict comparison of expected and actual.
  *
- *   - `false|undefined`: A short hand for a function which will look for a substring match in case
+ *   - `false`: A short hand for a function which will look for a substring match in case
  *     insensitive way.
  *
  *     Primitive values are converted to strings. Objects are not compared against primitives,
- *     unless they have a custom `toString` method (e.g. `Date` objects).
+ *     unless they have a custom `toString` method (e.g. `Date` objects). By default `false`.
  *
- * @param {string=} anyPropertyKey The special property name that matches against any property.
+ * @param {string=} [anyPropertyKey] The special property name that matches against any property.
  *     By default `$`.
  *
  * @example


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
documentation update

**What is the current behavior? (You can also link to an open issue here)**
In the $filter documentation the comparator parameter is not identified as being optional. See issue [15312] (https://github.com/angular/angular.js/issues/15312).

**What is the new behavior (if this is a feature change)?**
In the documentation for $filter the comparator parameter is now marked optional and the default value is identified as being false.

**Does this PR introduce a breaking change?**
No

**Other information**:

change the documentation for $filter so that the comparator parameter is marked optional. Also specified that the default value is false.

Closes #15312