### PR TITLE
docs(guide/Controllers): remove the word 'hides'

### DIFF
--- a/docs/content/guide/controller.ngdoc
+++ b/docs/content/guide/controller.ngdoc
@@ -253,9 +253,9 @@ scopes being created for our view:
 
 - The root scope
 - The `MainController` scope, which contains `timeOfDay` and `name` properties
-- The `ChildController` scope, which inherits the `timeOfDay` property but overrides (hides) the `name`
-property from the previous
-- The `GrandChildController` scope, which overrides (hides) both the `timeOfDay` property defined in `MainController`
+- The `ChildController` scope, which inherits the `timeOfDay` property but overrides the `name`
+property from the previous scope
+- The `GrandChildController` scope, which overrides both the `timeOfDay` property defined in `MainController`
 and the `name` property defined in `ChildController`
 
 Inheritance works with methods in the same way as it does with properties. So in our previous


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update.


**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:


Hiding a property and overriding a property seem to me fundamentally different things. I thought while reading that the '(hides)' did not offer any more clarification than just saying overrides, and caused me to pause unnecessarily to understand it.