### PR TITLE
chore(docs): improve version picker

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -346,7 +346,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('minify', ['bower', 'clean', 'build', 'minall']);
   grunt.registerTask('webserver', ['connect:devserver']);
-  grunt.registerTask('package', ['bower', 'validate-angular-files', 'clean', 'buildall', 'minall', 'collect-errors', 'docs', 'copy', 'write', 'compress']);
+  grunt.registerTask('package', ['bower', 'validate-angular-files', 'clean', 'buildall', 'minall', 'collect-errors', 'write', 'docs', 'copy', 'compress']);
   grunt.registerTask('ci-checks', ['ddescribe-iit', 'merge-conflict', 'eslint']);
   grunt.registerTask('default', ['package']);
 };

--- a/docs/app/src/app.js
+++ b/docs/app/src/app.js
@@ -6,7 +6,6 @@ angular.module('docsApp', [
   'ngSanitize',
   'ngAnimate',
   'DocsController',
-  'versionsData',
   'pagesData',
   'navData',
   'directives',

--- a/docs/app/src/docs.js
+++ b/docs/app/src/docs.js
@@ -1,12 +1,12 @@
 'use strict';
 
-angular.module('DocsController', [])
+angular.module('DocsController', ['currentVersionData'])
 
 .controller('DocsController', [
           '$scope', '$rootScope', '$location', '$window', '$cookies',
-              'NG_PAGES', 'NG_NAVIGATION', 'NG_VERSION',
+              'NG_PAGES', 'NG_NAVIGATION', 'CURRENT_NG_VERSION',
   function($scope, $rootScope, $location, $window, $cookies,
-              NG_PAGES, NG_NAVIGATION, NG_VERSION) {
+              NG_PAGES, NG_NAVIGATION, CURRENT_NG_VERSION) {
 
   $scope.navClass = function(navItem) {
     return {
@@ -58,8 +58,8 @@ angular.module('DocsController', [])
    Initialize
    ***********************************/
 
-  $scope.versionNumber = NG_VERSION.full;
-  $scope.version = NG_VERSION.full + ' ' + NG_VERSION.codeName;
+  $scope.versionNumber = CURRENT_NG_VERSION.full;
+  $scope.version = CURRENT_NG_VERSION.full + ' ' + CURRENT_NG_VERSION.codeName;
   $scope.loading = 0;
 
 

--- a/docs/app/src/versions.js
+++ b/docs/app/src/versions.js
@@ -1,37 +1,42 @@
 'use strict';
+/* global console */
 
-angular.module('versions', [])
+angular.module('versions', ['currentVersionData', 'allVersionsData'])
 
-.controller('DocsVersionsCtrl', ['$scope', '$location', '$window', 'NG_VERSIONS', function($scope, $location, $window, NG_VERSIONS) {
-  $scope.docs_version  = NG_VERSIONS[0];
-  $scope.docs_versions = NG_VERSIONS;
+.directive('versionPicker', function() {
+  return {
+    restrict: 'E',
+    scope: true,
+    controllerAs: '$ctrl',
+    controller: ['$location', '$window', 'CURRENT_NG_VERSION', 'ALL_NG_VERSIONS',
+            /** @this VersionPickerController */
+            function VersionPickerController($location, $window, CURRENT_NG_VERSION, ALL_NG_VERSIONS) {
 
-  for (var i = 0, minor = NaN; i < NG_VERSIONS.length; i++) {
-    var version = NG_VERSIONS[i];
-    if (version.isSnapshot) {
-      version.isLatest = true;
-      continue;
+      var versionStr = CURRENT_NG_VERSION.isSnapshot ? 'snapshot' : CURRENT_NG_VERSION.version;
+
+      this.versions  = ALL_NG_VERSIONS;
+      this.selectedVersion = find(ALL_NG_VERSIONS, function(value) { return value.version.version === versionStr; });
+
+      this.jumpToDocsVersion = function(value) {
+        var currentPagePath = $location.path().replace(/\/$/, '');
+        $window.location = value.docsUrl + currentPagePath;
+      };
+    }],
+    template:
+      '<div class="picker version-picker">' +
+      '  <select ng-options="v as v.label group by v.group for v in $ctrl.versions"' +
+      '          ng-model="$ctrl.selectedVersion"' +
+      '          ng-change="$ctrl.jumpToDocsVersion($ctrl.selectedVersion)"' +
+      '          class="docs-version-jump">' +
+      '  </select>' +
+      '</div>'
+  };
+
+  function find(collection, matcherFn) {
+    for (var i = 0, ii = collection.length; i < ii; ++i) {
+      if (matcherFn(collection[i])) {
+        return collection[i];
+      }
     }
-    // NaN will give false here
-    if (minor <= version.minor) {
-      continue;
-    }
-    version.isLatest = true;
-    minor = version.minor;
   }
-
-  $scope.getGroupName = function(v) {
-    return v.isLatest ? 'Latest' : ('v' + v.major + '.' + v.minor + '.x');
-  };
-
-  $scope.jumpToDocsVersion = function(version) {
-    var currentPagePath = $location.path().replace(/\/$/, ''),
-        url = '';
-    if (version.isOldDocsUrl) {
-      url = version.docsUrl;
-    } else {
-      url = version.docsUrl + currentPagePath;
-    }
-    $window.location = url;
-  };
-}]);
+});

--- a/docs/app/test/docsSpec.js
+++ b/docs/app/test/docsSpec.js
@@ -6,8 +6,13 @@ describe('DocsController', function() {
   angular.module('fake', [])
     .value('$cookies', {})
     .value('NG_PAGES', {})
-    .value('NG_NAVIGATION', {})
-    .value('NG_VERSION', {});
+    .value('NG_NAVIGATION', {});
+
+  angular.module('currentVersionData', [])
+    .value('CURRENT_NG_VERSION', {});
+
+  angular.module('allVersionsData', [])
+    .value('ALL_NG_VERSIONS', {});
 
   beforeEach(module('fake', 'DocsController'));
   beforeEach(inject(function($rootScope, $controller) {

--- a/docs/config/processors/versions-data.js
+++ b/docs/config/processors/versions-data.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var _ = require('lodash');
+var exec = require('shelljs').exec;
+var semver = require('semver');
 
 /**
  * @dgProcessor generateVersionDocProcessor
@@ -12,23 +13,96 @@ module.exports = function generateVersionDocProcessor(gitData) {
   return {
     $runAfter: ['generatePagesDataProcessor'],
     $runBefore: ['rendering-docs'],
+    // the blacklist is to remove rogue builds that are in npm but not on code.angularjs.org
+    blacklist: ['1.3.4-build.3588'],
     $process: function(docs) {
 
-      var versionDoc = {
-        docType: 'versions-data',
-        id: 'versions-data',
-        template: 'versions-data.template.js',
-        outputPath: 'js/versions-data.js',
-        currentVersion: gitData.version
-      };
+      var blacklist = this.blacklist;
+      var currentVersion = require('../../../build/version.json');
+      var output = exec('npm info angular versions --json', { silent: true }).stdout;
+      var allVersions = processAllVersionsResponse(JSON.parse(output));
 
-      versionDoc.versions = _(gitData.versions)
-        .filter(function(version) { return version.major > 0; })
-        .push(gitData.version)
-        .reverse()
-        .value();
+      docs.push({
+        docType: 'current-version-data',
+        id: 'current-version-data',
+        template: 'angular-service.template.js',
+        outputPath: 'js/current-version-data.js',
+        ngModuleName: 'currentVersionData',
+        serviceName: 'CURRENT_NG_VERSION',
+        serviceValue: currentVersion
+      });
 
-      docs.push(versionDoc);
+      docs.push({
+        docType: 'allversions-data',
+        id: 'allversions-data',
+        template: 'angular-service.template.js',
+        outputPath: 'js/all-versions-data.js',
+        ngModuleName: 'allVersionsData',
+        serviceName: 'ALL_NG_VERSIONS',
+        serviceValue: allVersions
+      });
+
+
+      function processAllVersionsResponse(versions) {
+
+        var latestMap = {};
+
+        versions = versions
+            .filter(function(versionStr) {
+              return blacklist.indexOf(versionStr) === -1;
+            })
+            .map(function(versionStr) {
+              return semver.parse(versionStr);
+            })
+            .filter(function(version) {
+              return version && version.major > 0;
+            })
+            .map(function(version) {
+              var key = version.major + '.' + version.minor;
+              var latest = latestMap[key];
+              if (!latest || version.compare(latest) > 0) {
+                latestMap[key] = version;
+              }
+              return version;
+            })
+            .map(function(version) {
+              return makeOption(version);
+            })
+            .reverse();
+
+        var latest = sortObject(latestMap, reverse(semver.compare))
+            .map(function(version) { return makeOption(version, 'Latest'); });
+
+        return [makeOption({version: 'snapshot'}, 'Latest', 'master')]
+            .concat(latest)
+            .concat(versions);
+      }
+
+      function makeOption(version, group, label) {
+        return {
+          version: version,
+          label: label || 'v' + version.raw,
+          group: group || 'v' + version.major + '.' + version.minor,
+          docsUrl: createDocsUrl(version)
+        };
+      }
+
+      function createDocsUrl(version) {
+        var url = 'https://code.angularjs.org/' + version.version + '/docs';
+        // Versions before 1.0.2 had a different docs folder name
+        if (version.major === 1 && version.minor === 0 && version.patch < 2) {
+          url += '-' + version.version;
+        }
+        return url;
+      }
+
+      function reverse(fn) {
+        return function(left, right) { return -fn(left, right); };
+      }
+
+      function sortObject(obj, cmp) {
+        return Object.keys(obj).map(function(key) { return obj[key]; }).sort(cmp);
+      }
     }
   };
 };

--- a/docs/config/services/deployments/debug.js
+++ b/docs/config/services/deployments/debug.js
@@ -22,7 +22,8 @@ module.exports = function debugDeployment(getVersion) {
       'components/lunr.js-' + getVersion('lunr.js') + '/lunr.js',
       'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/prettify.js',
       'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/lang-css.js',
-      'js/versions-data.js',
+      'js/current-version-data.js',
+      'js/all-versions-data.js',
       'js/pages-data.js',
       'js/nav-data.js',
       'js/docs.js'

--- a/docs/config/services/deployments/default.js
+++ b/docs/config/services/deployments/default.js
@@ -22,7 +22,8 @@ module.exports = function defaultDeployment(getVersion) {
       'components/lunr.js-' + getVersion('lunr.js') + '/lunr.min.js',
       'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/prettify.js',
       'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/lang-css.js',
-      'js/versions-data.js',
+      'js/current-version-data.js',
+      'js/all-versions-data.js',
       'js/pages-data.js',
       'js/nav-data.js',
       'js/docs.min.js'

--- a/docs/config/services/deployments/jquery.js
+++ b/docs/config/services/deployments/jquery.js
@@ -26,7 +26,8 @@ module.exports = function jqueryDeployment(getVersion) {
       'components/lunr.js-' + getVersion('lunr.js') + '/lunr.min.js',
       'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/prettify.js',
       'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/lang-css.js',
-      'js/versions-data.js',
+      'js/current-version-data.js',
+      'js/all-versions-data.js',
       'js/pages-data.js',
       'js/nav-data.js',
       'js/docs.min.js'

--- a/docs/config/services/deployments/production.js
+++ b/docs/config/services/deployments/production.js
@@ -39,7 +39,8 @@ module.exports = function productionDeployment(getVersion) {
       'components/lunr.js-' + getVersion('lunr.js') + '/lunr.min.js',
       'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/prettify.js',
       'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/lang-css.js',
-      'js/versions-data.js',
+      'js/current-version-data.js',
+      'https://code.angularjs.org/snapshot/docs/js/all-versions-data.js',
       'js/pages-data.js',
       'js/nav-data.js',
       'js/docs.min.js'

--- a/docs/config/templates/angular-service.template.js
+++ b/docs/config/templates/angular-service.template.js
@@ -1,0 +1,4 @@
+'use strict';
+
+angular.module('{$ doc.ngModuleName $}', [])
+  .value('{$ doc.serviceName $}', {$ doc.serviceValue | json $});

--- a/docs/config/templates/indexPage.template.html
+++ b/docs/config/templates/indexPage.template.html
@@ -165,13 +165,7 @@
       <section class="sup-header">
         <div class="container main-grid main-header-grid">
           <div class="grid-left">
-            <div ng-controller="DocsVersionsCtrl" class="picker version-picker">
-              <select ng-options="v as (v.isSnapshot ? v.branch : ('v' + v.version)) group by getGroupName(v) for v in docs_versions"
-                      ng-model="docs_version"
-                      ng-change="jumpToDocsVersion(docs_version)"
-                      class="docs-version-jump">
-              </select>
-            </div>
+            <version-picker></version-picker>
           </div>
           <div class="grid-right">
             <ul class="nav-breadcrumb">

--- a/docs/config/templates/versions-data.template.js
+++ b/docs/config/templates/versions-data.template.js
@@ -1,6 +1,0 @@
-'use strict';
-
-// Meta data used by the AngularJS docs app
-angular.module('versionsData', [])
-  .value('NG_VERSION', {$ doc.currentVersion | json $})
-  .value('NG_VERSIONS', {$ doc.versions | json $});

--- a/lib/versions/version-info.js
+++ b/lib/versions/version-info.js
@@ -53,7 +53,7 @@ var getGitRepoInfo = function() {
  * @return {String}         The codename if found, otherwise null/undefined
  */
 var getCodeName = function(tagName) {
-  var gitCatOutput = shell.exec('git cat-file -p ' + tagName, {silent:true}).output;
+  var gitCatOutput = shell.exec('git cat-file -p ' + tagName, {silent:true}).stdout;
   var tagMessage = gitCatOutput.match(/^.*codename.*$/mg)[0];
   var codeName = tagMessage && tagMessage.match(/codename\((.*)\)/)[1];
   if (!codeName) {
@@ -69,7 +69,7 @@ var getCodeName = function(tagName) {
  * @return {String} The build segment of the version
  */
 function getBuild() {
-  var hash = shell.exec('git rev-parse --short HEAD', {silent: true}).output.replace('\n', '');
+  var hash = shell.exec('git rev-parse --short HEAD', {silent: true}).stdout.replace('\n', '');
   return 'sha.' + hash;
 }
 
@@ -87,7 +87,7 @@ var getTaggedVersion = function() {
   var gitTagResult = shell.exec('git describe --exact-match', {silent:true});
 
   if (gitTagResult.code === 0) {
-    var tag = gitTagResult.output.trim();
+    var tag = gitTagResult.stdout.trim();
     var version = semver.parse(tag);
 
     if (version && checkBranchPattern(version.version, currentPackage.branchPattern)) {
@@ -113,7 +113,7 @@ var getPreviousVersions =  function() {
   var query = NO_REMOTE_REQUESTS ? 'git tag' : 'git ls-remote --tags ' + repo_url;
   var tagResults = shell.exec(query, {silent: true});
   if (tagResults.code === 0) {
-    return _(tagResults.output.match(/v[0-9].*[0-9]$/mg))
+    return _(tagResults.stdout.match(/v[0-9].*[0-9]$/mg))
       .map(function(tag) {
         var version = semver.parse(tag);
         return version;
@@ -159,7 +159,7 @@ var getCdnVersion = function() {
                                       {silent: true});
           if (cdnResult.code === 0) {
             // --write-out appends its content to the general request response, so extract it
-            var statusCode = cdnResult.output.split('\n').pop().trim();
+            var statusCode = cdnResult.stdout.split('\n').pop().trim();
             if (statusCode === '200') {
               cdnVersion = version;
             }

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -2463,11 +2463,11 @@
                     "abbrev": {
                       "version": "1.0.9"
                     },
-                    "ansi-styles": {
-                      "version": "2.2.1"
-                    },
                     "ansi-regex": {
                       "version": "2.0.0"
+                    },
+                    "ansi-styles": {
+                      "version": "2.2.1"
                     },
                     "aproba": {
                       "version": "1.0.4"
@@ -2484,11 +2484,11 @@
                     "async": {
                       "version": "1.5.2"
                     },
-                    "aws4": {
-                      "version": "1.4.1"
-                    },
                     "aws-sign2": {
                       "version": "0.6.0"
+                    },
+                    "aws4": {
+                      "version": "1.4.1"
                     },
                     "balanced-match": {
                       "version": "0.4.2"
@@ -2496,11 +2496,11 @@
                     "block-stream": {
                       "version": "0.0.9"
                     },
-                    "brace-expansion": {
-                      "version": "1.1.5"
-                    },
                     "boom": {
                       "version": "2.10.1"
+                    },
+                    "brace-expansion": {
+                      "version": "1.1.5"
                     },
                     "buffer-shims": {
                       "version": "1.0.0"
@@ -2511,11 +2511,11 @@
                     "chalk": {
                       "version": "1.1.3"
                     },
-                    "combined-stream": {
-                      "version": "1.0.5"
-                    },
                     "code-point-at": {
                       "version": "1.0.0"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5"
                     },
                     "commander": {
                       "version": "2.9.0"
@@ -2523,11 +2523,11 @@
                     "concat-map": {
                       "version": "0.0.1"
                     },
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
                     "console-control-strings": {
                       "version": "1.1.0"
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2"
                     },
                     "cryptiles": {
                       "version": "2.0.5"
@@ -2535,59 +2535,59 @@
                     "debug": {
                       "version": "2.2.0"
                     },
-                    "delayed-stream": {
-                      "version": "1.0.0"
-                    },
                     "deep-extend": {
                       "version": "0.4.1"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1"
                     },
                     "delegates": {
                       "version": "1.0.0"
                     },
-                    "extend": {
-                      "version": "3.0.0"
+                    "delayed-stream": {
+                      "version": "1.0.0"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5"
                     },
+                    "extend": {
+                      "version": "3.0.0"
+                    },
                     "extsprintf": {
                       "version": "1.0.2"
-                    },
-                    "form-data": {
-                      "version": "1.0.0-rc4"
                     },
                     "forever-agent": {
                       "version": "0.6.1"
                     },
-                    "fstream-ignore": {
-                      "version": "1.0.5"
-                    },
                     "fs.realpath": {
                       "version": "1.0.0"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc4"
                     },
                     "fstream": {
                       "version": "1.0.10"
                     },
-                    "generate-object-property": {
-                      "version": "1.2.0"
+                    "fstream-ignore": {
+                      "version": "1.0.5"
+                    },
+                    "generate-function": {
+                      "version": "2.0.0"
                     },
                     "gauge": {
                       "version": "2.6.0"
                     },
-                    "generate-function": {
-                      "version": "2.0.0"
+                    "generate-object-property": {
+                      "version": "1.2.0"
+                    },
+                    "glob": {
+                      "version": "7.0.5"
                     },
                     "graceful-fs": {
                       "version": "4.1.4"
                     },
                     "graceful-readlink": {
                       "version": "1.0.1"
-                    },
-                    "glob": {
-                      "version": "7.0.5"
                     },
                     "har-validator": {
                       "version": "2.0.6"
@@ -2598,23 +2598,26 @@
                     "has-color": {
                       "version": "0.1.7"
                     },
-                    "has-unicode": {
-                      "version": "2.0.1"
-                    },
                     "hawk": {
                       "version": "3.1.3"
+                    },
+                    "has-unicode": {
+                      "version": "2.0.1"
                     },
                     "hoek": {
                       "version": "2.16.3"
                     },
-                    "http-signature": {
-                      "version": "1.1.1"
-                    },
                     "inflight": {
                       "version": "1.0.5"
                     },
+                    "http-signature": {
+                      "version": "1.1.1"
+                    },
                     "inherits": {
                       "version": "2.0.1"
+                    },
+                    "ini": {
+                      "version": "1.3.4"
                     },
                     "is-fullwidth-code-point": {
                       "version": "1.0.0"
@@ -2625,20 +2628,17 @@
                     "is-property": {
                       "version": "1.0.2"
                     },
-                    "ini": {
-                      "version": "1.3.4"
-                    },
                     "is-typedarray": {
                       "version": "1.0.0"
                     },
                     "isarray": {
                       "version": "1.0.0"
                     },
-                    "isstream": {
-                      "version": "0.1.2"
-                    },
                     "jodid25519": {
                       "version": "1.0.2"
+                    },
+                    "isstream": {
+                      "version": "0.1.2"
                     },
                     "jsbn": {
                       "version": "0.1.0"
@@ -2652,23 +2652,23 @@
                     "jsonpointer": {
                       "version": "2.0.0"
                     },
-                    "mime-db": {
-                      "version": "1.23.0"
-                    },
                     "jsprim": {
                       "version": "1.3.0"
                     },
                     "mime-types": {
                       "version": "2.1.11"
                     },
+                    "mime-db": {
+                      "version": "1.23.0"
+                    },
                     "minimatch": {
                       "version": "3.0.2"
                     },
-                    "mkdirp": {
-                      "version": "0.5.1"
-                    },
                     "minimist": {
                       "version": "0.0.8"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1"
                     },
                     "ms": {
                       "version": "0.7.1"
@@ -2676,17 +2676,17 @@
                     "node-uuid": {
                       "version": "1.4.7"
                     },
-                    "nopt": {
-                      "version": "3.0.6"
-                    },
                     "number-is-nan": {
                       "version": "1.0.0"
                     },
-                    "oauth-sign": {
-                      "version": "0.8.2"
-                    },
                     "npmlog": {
                       "version": "3.1.2"
+                    },
+                    "nopt": {
+                      "version": "3.0.6"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.2"
                     },
                     "once": {
                       "version": "1.3.3"
@@ -2709,11 +2709,11 @@
                     "qs": {
                       "version": "6.2.0"
                     },
-                    "request": {
-                      "version": "2.73.0"
-                    },
                     "readable-stream": {
                       "version": "2.1.4"
+                    },
+                    "request": {
+                      "version": "2.73.0"
                     },
                     "rimraf": {
                       "version": "2.5.3"
@@ -2721,20 +2721,20 @@
                     "semver": {
                       "version": "5.2.0"
                     },
-                    "signal-exit": {
-                      "version": "3.0.0"
-                    },
                     "set-blocking": {
                       "version": "2.0.0"
                     },
-                    "string-width": {
-                      "version": "1.0.1"
+                    "signal-exit": {
+                      "version": "3.0.0"
                     },
                     "sntp": {
                       "version": "1.0.9"
                     },
                     "string_decoder": {
                       "version": "0.10.31"
+                    },
+                    "string-width": {
+                      "version": "1.0.1"
                     },
                     "stringstream": {
                       "version": "0.0.5"
@@ -2745,35 +2745,35 @@
                     "strip-json-comments": {
                       "version": "1.0.4"
                     },
-                    "tar-pack": {
-                      "version": "3.1.4"
-                    },
                     "supports-color": {
                       "version": "2.0.0"
                     },
                     "tar": {
                       "version": "2.2.1"
                     },
-                    "tweetnacl": {
-                      "version": "0.13.3"
+                    "tar-pack": {
+                      "version": "3.1.4"
                     },
                     "tough-cookie": {
                       "version": "2.2.2"
                     },
-                    "uid-number": {
-                      "version": "0.0.6"
-                    },
                     "tunnel-agent": {
                       "version": "0.4.3"
+                    },
+                    "tweetnacl": {
+                      "version": "0.13.3"
+                    },
+                    "uid-number": {
+                      "version": "0.0.6"
                     },
                     "util-deprecate": {
                       "version": "1.0.2"
                     },
-                    "wide-align": {
-                      "version": "1.1.0"
-                    },
                     "verror": {
                       "version": "1.3.6"
+                    },
+                    "wide-align": {
+                      "version": "1.1.0"
                     },
                     "wrappy": {
                       "version": "1.0.2"
@@ -9602,7 +9602,66 @@
       }
     },
     "shelljs": {
-      "version": "0.3.0"
+      "version": "0.7.5",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1",
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0"
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3"
+            },
+            "minimatch": {
+              "version": "3.0.3",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.6",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1"
+            }
+          }
+        },
+        "interpret": {
+          "version": "1.0.1"
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "dependencies": {
+            "resolve": {
+              "version": "1.1.7"
+            }
+          }
+        }
+      }
     },
     "sorted-object": {
       "version": "1.0.0"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3790,15 +3790,15 @@
                       "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
                     },
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "from": "ansi-styles@>=2.2.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                    },
                     "ansi-regex": {
                       "version": "2.0.0",
                       "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    },
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "ansi-styles@>=2.2.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                     },
                     "aproba": {
                       "version": "1.0.4",
@@ -3825,15 +3825,15 @@
                       "from": "async@>=1.5.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                     },
-                    "aws4": {
-                      "version": "1.4.1",
-                      "from": "aws4@>=1.2.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
-                    },
                     "aws-sign2": {
                       "version": "0.6.0",
                       "from": "aws-sign2@>=0.6.0 <0.7.0",
                       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                    },
+                    "aws4": {
+                      "version": "1.4.1",
+                      "from": "aws4@>=1.2.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
                     },
                     "balanced-match": {
                       "version": "0.4.2",
@@ -3845,15 +3845,15 @@
                       "from": "block-stream@*",
                       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
                     },
-                    "brace-expansion": {
-                      "version": "1.1.5",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz"
-                    },
                     "boom": {
                       "version": "2.10.1",
                       "from": "boom@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    },
+                    "brace-expansion": {
+                      "version": "1.1.5",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz"
                     },
                     "buffer-shims": {
                       "version": "1.0.0",
@@ -3870,15 +3870,15 @@
                       "from": "chalk@>=1.1.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
                     },
-                    "combined-stream": {
-                      "version": "1.0.5",
-                      "from": "combined-stream@>=1.0.5 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-                    },
                     "code-point-at": {
                       "version": "1.0.0",
                       "from": "code-point-at@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "from": "combined-stream@>=1.0.5 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
                     },
                     "commander": {
                       "version": "2.9.0",
@@ -3890,15 +3890,15 @@
                       "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     },
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
                     "console-control-strings": {
                       "version": "1.1.0",
                       "from": "console-control-strings@>=1.1.0 <1.2.0",
                       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.5",
@@ -3910,80 +3910,85 @@
                       "from": "debug@>=2.2.0 <2.3.0",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
                     },
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "from": "delayed-stream@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                    },
                     "deep-extend": {
                       "version": "0.4.1",
                       "from": "deep-extend@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     },
                     "delegates": {
                       "version": "1.0.0",
                       "from": "delegates@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                     },
-                    "extend": {
-                      "version": "3.0.0",
-                      "from": "extend@>=3.0.0 <3.1.0",
-                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
                       "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     },
+                    "extend": {
+                      "version": "3.0.0",
+                      "from": "extend@>=3.0.0 <3.1.0",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                    },
                     "extsprintf": {
                       "version": "1.0.2",
                       "from": "extsprintf@1.0.2",
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
-                    "form-data": {
-                      "version": "1.0.0-rc4",
-                      "from": "form-data@>=1.0.0-rc4 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
                     },
                     "forever-agent": {
                       "version": "0.6.1",
                       "from": "forever-agent@>=0.6.1 <0.7.0",
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                     },
-                    "fstream-ignore": {
-                      "version": "1.0.5",
-                      "from": "fstream-ignore@>=1.0.5 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
-                    },
                     "fs.realpath": {
                       "version": "1.0.0",
                       "from": "fs.realpath@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc4",
+                      "from": "form-data@>=1.0.0-rc4 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
                     },
                     "fstream": {
                       "version": "1.0.10",
                       "from": "fstream@>=1.0.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
                     },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                    "fstream-ignore": {
+                      "version": "1.0.5",
+                      "from": "fstream-ignore@>=1.0.5 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
+                    },
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "gauge": {
                       "version": "2.6.0",
                       "from": "gauge@>=2.6.0 <2.7.0",
                       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz"
                     },
-                    "generate-function": {
-                      "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                    },
+                    "glob": {
+                      "version": "7.0.5",
+                      "from": "glob@>=7.0.5 <8.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
                     },
                     "graceful-fs": {
                       "version": "4.1.4",
@@ -3994,11 +3999,6 @@
                       "version": "1.0.1",
                       "from": "graceful-readlink@>=1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    },
-                    "glob": {
-                      "version": "7.0.5",
-                      "from": "glob@>=7.0.5 <8.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
                     },
                     "har-validator": {
                       "version": "2.0.6",
@@ -4015,35 +4015,40 @@
                       "from": "has-color@>=0.1.7 <0.2.0",
                       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                     },
-                    "has-unicode": {
-                      "version": "2.0.1",
-                      "from": "has-unicode@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
-                    },
                     "hawk": {
                       "version": "3.1.3",
                       "from": "hawk@>=3.1.3 <3.2.0",
                       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+                    },
+                    "has-unicode": {
+                      "version": "2.0.1",
+                      "from": "has-unicode@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
                     },
                     "hoek": {
                       "version": "2.16.3",
                       "from": "hoek@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
-                    "http-signature": {
-                      "version": "1.1.1",
-                      "from": "http-signature@>=1.1.0 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
-                    },
                     "inflight": {
                       "version": "1.0.5",
                       "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
                     },
+                    "http-signature": {
+                      "version": "1.1.1",
+                      "from": "http-signature@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+                    },
                     "inherits": {
                       "version": "2.0.1",
                       "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@>=1.3.0 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                     },
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
@@ -4060,11 +4065,6 @@
                       "from": "is-property@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     },
-                    "ini": {
-                      "version": "1.3.4",
-                      "from": "ini@>=1.3.0 <1.4.0",
-                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                    },
                     "is-typedarray": {
                       "version": "1.0.0",
                       "from": "is-typedarray@>=1.0.0 <1.1.0",
@@ -4075,15 +4075,15 @@
                       "from": "isarray@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
-                    "isstream": {
-                      "version": "0.1.2",
-                      "from": "isstream@>=0.1.2 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                    },
                     "jodid25519": {
                       "version": "1.0.2",
                       "from": "jodid25519@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "from": "isstream@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                     },
                     "jsbn": {
                       "version": "0.1.0",
@@ -4105,11 +4105,6 @@
                       "from": "jsonpointer@2.0.0",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
-                    "mime-db": {
-                      "version": "1.23.0",
-                      "from": "mime-db@>=1.23.0 <1.24.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
-                    },
                     "jsprim": {
                       "version": "1.3.0",
                       "from": "jsprim@>=1.2.2 <2.0.0",
@@ -4120,20 +4115,25 @@
                       "from": "mime-types@>=2.1.7 <2.2.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
                     },
+                    "mime-db": {
+                      "version": "1.23.0",
+                      "from": "mime-db@>=1.23.0 <1.24.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                    },
                     "minimatch": {
                       "version": "3.0.2",
                       "from": "minimatch@>=3.0.2 <4.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz"
                     },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-                    },
                     "minimist": {
                       "version": "0.0.8",
                       "from": "minimist@0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
                     },
                     "ms": {
                       "version": "0.7.1",
@@ -4145,25 +4145,25 @@
                       "from": "node-uuid@>=1.4.7 <1.5.0",
                       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                     },
-                    "nopt": {
-                      "version": "3.0.6",
-                      "from": "nopt@>=3.0.1 <3.1.0",
-                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
-                    },
                     "number-is-nan": {
                       "version": "1.0.0",
                       "from": "number-is-nan@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     },
-                    "oauth-sign": {
-                      "version": "0.8.2",
-                      "from": "oauth-sign@>=0.8.1 <0.9.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-                    },
                     "npmlog": {
                       "version": "3.1.2",
                       "from": "npmlog@>=3.1.2 <3.2.0",
                       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz"
+                    },
+                    "nopt": {
+                      "version": "3.0.6",
+                      "from": "nopt@>=3.0.1 <3.1.0",
+                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.2",
+                      "from": "oauth-sign@>=0.8.1 <0.9.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
                     },
                     "once": {
                       "version": "1.3.3",
@@ -4200,15 +4200,15 @@
                       "from": "qs@>=6.2.0 <6.3.0",
                       "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
                     },
-                    "request": {
-                      "version": "2.73.0",
-                      "from": "request@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/request/-/request-2.73.0.tgz"
-                    },
                     "readable-stream": {
                       "version": "2.1.4",
                       "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+                    },
+                    "request": {
+                      "version": "2.73.0",
+                      "from": "request@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/request/-/request-2.73.0.tgz"
                     },
                     "rimraf": {
                       "version": "2.5.3",
@@ -4220,20 +4220,15 @@
                       "from": "semver@>=5.2.0 <5.3.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz"
                     },
-                    "signal-exit": {
-                      "version": "3.0.0",
-                      "from": "signal-exit@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
-                    },
                     "set-blocking": {
                       "version": "2.0.0",
                       "from": "set-blocking@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
                     },
-                    "string-width": {
-                      "version": "1.0.1",
-                      "from": "string-width@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
+                    "signal-exit": {
+                      "version": "3.0.0",
+                      "from": "signal-exit@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
@@ -4244,6 +4239,11 @@
                       "version": "0.10.31",
                       "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "string-width": {
+                      "version": "1.0.1",
+                      "from": "string-width@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
                     },
                     "stringstream": {
                       "version": "0.0.5",
@@ -4260,11 +4260,6 @@
                       "from": "strip-json-comments@>=1.0.4 <1.1.0",
                       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                     },
-                    "tar-pack": {
-                      "version": "3.1.4",
-                      "from": "tar-pack@>=3.1.0 <3.2.0",
-                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz"
-                    },
                     "supports-color": {
                       "version": "2.0.0",
                       "from": "supports-color@>=2.0.0 <3.0.0",
@@ -4275,40 +4270,45 @@
                       "from": "tar@>=2.2.0 <2.3.0",
                       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
                     },
-                    "tweetnacl": {
-                      "version": "0.13.3",
-                      "from": "tweetnacl@>=0.13.0 <0.14.0",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                    "tar-pack": {
+                      "version": "3.1.4",
+                      "from": "tar-pack@>=3.1.0 <3.2.0",
+                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz"
                     },
                     "tough-cookie": {
                       "version": "2.2.2",
                       "from": "tough-cookie@>=2.2.0 <2.3.0",
                       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
                     },
-                    "uid-number": {
-                      "version": "0.0.6",
-                      "from": "uid-number@>=0.0.6 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-                    },
                     "tunnel-agent": {
                       "version": "0.4.3",
                       "from": "tunnel-agent@>=0.4.1 <0.5.0",
                       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+                    },
+                    "tweetnacl": {
+                      "version": "0.13.3",
+                      "from": "tweetnacl@>=0.13.0 <0.14.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                    },
+                    "uid-number": {
+                      "version": "0.0.6",
+                      "from": "uid-number@>=0.0.6 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
                       "from": "util-deprecate@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     },
-                    "wide-align": {
-                      "version": "1.1.0",
-                      "from": "wide-align@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
-                    },
                     "verror": {
                       "version": "1.3.6",
                       "from": "verror@1.3.6",
                       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    },
+                    "wide-align": {
+                      "version": "1.1.0",
+                      "from": "wide-align@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
                     },
                     "wrappy": {
                       "version": "1.0.2",
@@ -13732,125 +13732,125 @@
     },
     "protractor": {
       "version": "4.0.10",
-      "from": "protractor@4.0.10",
+      "from": "https://registry.npmjs.org/protractor/-/protractor-4.0.10.tgz",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-4.0.10.tgz",
       "dependencies": {
         "@types/jasmine": {
           "version": "2.5.37",
-          "from": "@types/jasmine@>=2.5.36 <3.0.0",
+          "from": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.5.37.tgz",
           "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.5.37.tgz"
         },
         "@types/node": {
           "version": "6.0.46",
-          "from": "@types/node@>=6.0.46 <7.0.0",
+          "from": "https://registry.npmjs.org/@types/node/-/node-6.0.46.tgz",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.46.tgz"
         },
         "@types/q": {
           "version": "0.0.32",
-          "from": "@types/q@>=0.0.32 <0.0.33",
+          "from": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
           "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz"
         },
         "@types/selenium-webdriver": {
           "version": "2.53.34",
-          "from": "@types/selenium-webdriver@>=2.53.31 <2.54.0",
+          "from": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.34.tgz",
           "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.34.tgz"
         },
         "adm-zip": {
           "version": "0.4.7",
-          "from": "adm-zip@0.4.7",
+          "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
           "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
         },
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.3 <2.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "glob": {
           "version": "7.1.1",
-          "from": "glob@>=7.0.3 <8.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
-              "from": "fs.realpath@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
             },
             "inflight": {
               "version": "1.0.6",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "minimatch": {
               "version": "3.0.3",
-              "from": "minimatch@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.6",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.2",
-                      "from": "balanced-match@>=0.4.1 <0.5.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -13859,104 +13859,104 @@
             },
             "once": {
               "version": "1.4.0",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
             }
           }
         },
         "jasmine": {
           "version": "2.5.2",
-          "from": "jasmine@2.5.2",
+          "from": "https://registry.npmjs.org/jasmine/-/jasmine-2.5.2.tgz",
           "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.5.2.tgz",
           "dependencies": {
             "exit": {
               "version": "0.1.2",
-              "from": "exit@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "jasmine-core": {
               "version": "2.5.2",
-              "from": "jasmine-core@>=2.5.2 <2.6.0",
+              "from": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.5.2.tgz",
               "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.5.2.tgz"
             }
           }
         },
         "jasminewd2": {
           "version": "0.0.10",
-          "from": "jasminewd2@0.0.10",
+          "from": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.10.tgz",
           "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.10.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "q": {
           "version": "1.4.1",
-          "from": "q@1.4.1",
+          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
         },
         "saucelabs": {
           "version": "1.3.0",
-          "from": "saucelabs@>=1.3.0 <1.4.0",
+          "from": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.3.0.tgz",
           "dependencies": {
             "https-proxy-agent": {
               "version": "1.0.0",
-              "from": "https-proxy-agent@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
               "dependencies": {
                 "agent-base": {
                   "version": "2.0.1",
-                  "from": "agent-base@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
                   "dependencies": {
                     "semver": {
                       "version": "5.0.3",
-                      "from": "semver@>=5.0.1 <5.1.0",
+                      "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
                     }
                   }
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "extend": {
                   "version": "3.0.0",
-                  "from": "extend@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 }
               }
@@ -13965,68 +13965,68 @@
         },
         "source-map-support": {
           "version": "0.4.6",
-          "from": "source-map-support@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.6.tgz",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.6.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.6",
-              "from": "source-map@>=0.5.3 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
             }
           }
         },
         "webdriver-manager": {
           "version": "10.2.6",
-          "from": "webdriver-manager@>=10.2.6 <11.0.0",
+          "from": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-10.2.6.tgz",
           "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-10.2.6.tgz",
           "dependencies": {
             "del": {
               "version": "2.2.2",
-              "from": "del@>=2.2.0 <3.0.0",
+              "from": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
               "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
               "dependencies": {
                 "globby": {
                   "version": "5.0.0",
-                  "from": "globby@>=5.0.0 <6.0.0",
+                  "from": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
                   "dependencies": {
                     "array-union": {
                       "version": "1.0.2",
-                      "from": "array-union@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
                       "dependencies": {
                         "array-uniq": {
                           "version": "1.0.3",
-                          "from": "array-uniq@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
                         }
                       }
                     },
                     "arrify": {
                       "version": "1.0.1",
-                      "from": "arrify@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
                     }
                   }
                 },
                 "is-path-cwd": {
                   "version": "1.0.0",
-                  "from": "is-path-cwd@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
                 },
                 "is-path-in-cwd": {
                   "version": "1.0.0",
-                  "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
                   "dependencies": {
                     "is-path-inside": {
                       "version": "1.0.0",
-                      "from": "is-path-inside@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
                       "dependencies": {
                         "path-is-inside": {
                           "version": "1.0.2",
-                          "from": "path-is-inside@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
                         }
                       }
@@ -14035,22 +14035,22 @@
                 },
                 "object-assign": {
                   "version": "4.1.0",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                 },
                 "pify": {
                   "version": "2.3.0",
-                  "from": "pify@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
@@ -14059,127 +14059,127 @@
             },
             "ini": {
               "version": "1.3.4",
-              "from": "ini@>=1.3.4 <2.0.0",
+              "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
             },
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@>=1.2.0 <2.0.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             },
             "request": {
               "version": "2.78.0",
-              "from": "request@>=2.69.0 <3.0.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "from": "aws-sign2@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                 },
                 "aws4": {
                   "version": "1.5.0",
-                  "from": "aws4@>=1.2.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
                 },
                 "caseless": {
                   "version": "0.11.0",
-                  "from": "caseless@>=0.11.0 <0.12.0",
+                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "from": "combined-stream@>=1.0.5 <1.1.0",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "from": "delayed-stream@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     }
                   }
                 },
                 "extend": {
                   "version": "3.0.0",
-                  "from": "extend@>=3.0.0 <3.1.0",
+                  "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "from": "forever-agent@>=0.6.1 <0.7.0",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
                   "version": "2.1.1",
-                  "from": "form-data@>=2.1.1 <2.2.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-2.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.1.tgz",
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
-                      "from": "asynckit@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
                     }
                   }
                 },
                 "har-validator": {
                   "version": "2.0.6",
-                  "from": "har-validator@>=2.0.6 <2.1.0",
+                  "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.9.0",
-                      "from": "commander@>=2.9.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "from": "graceful-readlink@>=1.0.0",
+                          "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.15.0",
-                      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                      "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
-                          "from": "generate-function@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "from": "generate-object-property@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
-                              "from": "is-property@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "4.0.0",
-                          "from": "jsonpointer@>=4.0.0 <5.0.0",
+                          "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
                         },
                         "xtend": {
                           "version": "4.0.1",
-                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                         }
                       }
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
@@ -14188,111 +14188,111 @@
                 },
                 "hawk": {
                   "version": "3.1.3",
-                  "from": "hawk@>=3.1.3 <3.2.0",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.16.3",
-                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
                     "boom": {
                       "version": "2.10.1",
-                      "from": "boom@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "http-signature": {
                   "version": "1.1.1",
-                  "from": "http-signature@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
-                      "from": "assert-plus@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                     },
                     "jsprim": {
                       "version": "1.3.1",
-                      "from": "jsprim@>=1.2.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
                       "dependencies": {
                         "extsprintf": {
                           "version": "1.0.2",
-                          "from": "extsprintf@1.0.2",
+                          "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                         },
                         "json-schema": {
                           "version": "0.2.3",
-                          "from": "json-schema@0.2.3",
+                          "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
                           "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "from": "verror@1.3.6",
+                          "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                         }
                       }
                     },
                     "sshpk": {
                       "version": "1.10.1",
-                      "from": "sshpk@>=1.7.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
                       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
-                          "from": "asn1@>=0.2.3 <0.3.0",
+                          "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                         },
                         "assert-plus": {
                           "version": "1.0.0",
-                          "from": "assert-plus@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                         },
                         "dashdash": {
                           "version": "1.14.0",
-                          "from": "dashdash@>=1.12.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
                           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
                         },
                         "getpass": {
                           "version": "0.1.6",
-                          "from": "getpass@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
                           "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                         },
                         "jsbn": {
                           "version": "0.1.0",
-                          "from": "jsbn@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                         },
                         "tweetnacl": {
                           "version": "0.14.3",
-                          "from": "tweetnacl@>=0.14.0 <0.15.0",
+                          "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
                           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
                         },
                         "jodid25519": {
                           "version": "1.0.2",
-                          "from": "jodid25519@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
-                          "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                         },
                         "bcrypt-pbkdf": {
                           "version": "1.0.0",
-                          "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
                         }
                       }
@@ -14301,78 +14301,78 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
-                  "from": "is-typedarray@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "isstream@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.1.12",
-                  "from": "mime-types@>=2.1.7 <2.2.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.24.0",
-                      "from": "mime-db@>=1.24.0 <1.25.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.7",
-                  "from": "node-uuid@>=1.4.7 <1.5.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
-                  "from": "oauth-sign@>=0.8.1 <0.9.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
                 },
                 "qs": {
                   "version": "6.3.0",
-                  "from": "qs@>=6.3.0 <6.4.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.3.2",
-                  "from": "tough-cookie@>=2.3.0 <2.4.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
-                      "from": "punycode@>=1.4.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
                     }
                   }
                 },
                 "tunnel-agent": {
                   "version": "0.4.3",
-                  "from": "tunnel-agent@>=0.4.1 <0.5.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
                 }
               }
             },
             "rimraf": {
               "version": "2.5.4",
-              "from": "rimraf@>=2.5.2 <3.0.0",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
             },
             "semver": {
               "version": "5.3.0",
-              "from": "semver@>=5.3.0 <6.0.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
             }
           }
@@ -14789,9 +14789,98 @@
       }
     },
     "shelljs": {
-      "version": "0.3.0",
-      "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+      "version": "0.7.5",
+      "from": "shelljs@latest",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.5.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1",
+          "from": "glob@>=7.0.0 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "from": "fs.realpath@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.3",
+              "from": "minimatch@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.6",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "from": "balanced-match@>=0.4.1 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            }
+          }
+        },
+        "interpret": {
+          "version": "1.0.1",
+          "from": "interpret@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz"
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "from": "rechoir@>=0.6.2 <0.7.0",
+          "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+          "dependencies": {
+            "resolve": {
+              "version": "1.1.7",
+              "from": "resolve@>=1.1.6 <2.0.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+            }
+          }
+        }
+      }
     },
     "sorted-object": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "serve-favicon": "^2.3.0",
     "serve-index": "^1.8.0",
     "serve-static": "^1.11.1",
-    "shelljs": "~0.3.0",
+    "shelljs": "^0.7.5",
     "sorted-object": "^1.0.0",
     "stringmap": "^0.2.2"
   },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

chore

**What is the current behavior? (You can also link to an open issue here)**

Versions in the version picker are hard-coded into each build
This means that newer versions are never shown in older versions of the docs

**What is the new behavior (if this is a feature change)?**

Now the version information has split into the current and the list of all versions.
In the production deployment the version list is now read from the snapshot build, so we always
get the latest list.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:


Replaces #15381