### PR TITLE
docs(ngModel.NgModelController): correct the mistake of demos

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -459,7 +459,6 @@ NgModelController.prototype = {
    *           if (rollback) {
    *             $scope.myForm[value].$rollbackViewValue();
    *           }
-   *           $scope.model[value] = '';
    *         }
    *       };
    *     }]);


### PR DESCRIPTION
The demo of `$rollbackViewValue()` is kind of different from the doc.