### PR TITLE
fix(ngMock/$controller): respect `$compileProvider.preAssignBindingsEnabled()`

### DIFF
--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -2055,27 +2055,15 @@ describe('ngMock', function() {
 
 
   describe('$controllerDecorator', function() {
-    it('should support creating controller with bindings', function() {
-      var called = false;
-      var data = [
-        { name: 'derp1', id: 0 },
-        { name: 'testname', id: 1 },
-        { name: 'flurp', id: 2 }
-      ];
-      module(function($controllerProvider) {
-        $controllerProvider.register('testCtrl', function() {
-          called = true;
-          expect(this.data).toBe(data);
-        });
-      });
-      inject(function($controller, $rootScope) {
-        $controller('testCtrl', { scope: $rootScope }, { data: data });
-        expect(called).toBe(true);
-      });
-    });
 
-    it('should support assigning bindings when a value is returned from the constructor',
-      function() {
+    describe('with `preAssignBindingsEnabled(true)`', function() {
+
+      beforeEach(module(function($compileProvider) {
+        $compileProvider.preAssignBindingsEnabled(true);
+      }));
+
+
+      it('should support creating controller with bindings', function() {
         var called = false;
         var data = [
           { name: 'derp1', id: 0 },
@@ -2084,10 +2072,8 @@ describe('ngMock', function() {
         ];
         module(function($controllerProvider) {
           $controllerProvider.register('testCtrl', function() {
-            called = true;
             expect(this.data).toBe(data);
-
-            return {};
+            called = true;
           });
         });
         inject(function($controller, $rootScope) {
@@ -2095,11 +2081,64 @@ describe('ngMock', function() {
           expect(ctrl.data).toBe(data);
           expect(called).toBe(true);
         });
-      }
-    );
+      });
 
-    if (/chrome/.test(window.navigator.userAgent)) {
-      it('should support assigning bindings to class-based controller', function() {
+
+      it('should support assigning bindings when a value is returned from the constructor',
+        function() {
+          var called = false;
+          var data = [
+            { name: 'derp1', id: 0 },
+            { name: 'testname', id: 1 },
+            { name: 'flurp', id: 2 }
+          ];
+          module(function($controllerProvider) {
+            $controllerProvider.register('testCtrl', function() {
+              expect(this.data).toBe(data);
+              called = true;
+              return {};
+            });
+          });
+          inject(function($controller, $rootScope) {
+            var ctrl = $controller('testCtrl', { scope: $rootScope }, { data: data });
+            expect(ctrl.data).toBe(data);
+            expect(called).toBe(true);
+          });
+        }
+      );
+
+
+      if (/chrome/.test(window.navigator.userAgent)) {
+        it('should support assigning bindings to class-based controller', function() {
+          var called = false;
+          var data = [
+            { name: 'derp1', id: 0 },
+            { name: 'testname', id: 1 },
+            { name: 'flurp', id: 2 }
+          ];
+          module(function($controllerProvider) {
+            // eslint-disable-next-line no-eval
+            var TestCtrl = eval('(class { constructor() { called = true; } })');
+            $controllerProvider.register('testCtrl', TestCtrl);
+          });
+          inject(function($controller, $rootScope) {
+            var ctrl = $controller('testCtrl', { scope: $rootScope }, { data: data });
+            expect(ctrl.data).toBe(data);
+            expect(called).toBe(true);
+          });
+        });
+      }
+    });
+
+
+    describe('with `preAssignBindingsEnabled(false)`', function() {
+
+      beforeEach(module(function($compileProvider) {
+        $compileProvider.preAssignBindingsEnabled(false);
+      }));
+
+
+      it('should support creating controller with bindings', function() {
         var called = false;
         var data = [
           { name: 'derp1', id: 0 },
@@ -2107,9 +2146,10 @@ describe('ngMock', function() {
           { name: 'flurp', id: 2 }
         ];
         module(function($controllerProvider) {
-          // eslint-disable-next-line no-eval
-          var TestCtrl = eval('(class { constructor() { called = true; } })');
-          $controllerProvider.register('testCtrl', TestCtrl);
+          $controllerProvider.register('testCtrl', function() {
+            expect(this.data).toBeUndefined();
+            called = true;
+          });
         });
         inject(function($controller, $rootScope) {
           var ctrl = $controller('testCtrl', { scope: $rootScope }, { data: data });
@@ -2117,7 +2157,53 @@ describe('ngMock', function() {
           expect(called).toBe(true);
         });
       });
-    }
+
+
+      it('should support assigning bindings when a value is returned from the constructor',
+        function() {
+          var called = false;
+          var data = [
+            { name: 'derp1', id: 0 },
+            { name: 'testname', id: 1 },
+            { name: 'flurp', id: 2 }
+          ];
+          module(function($controllerProvider) {
+            $controllerProvider.register('testCtrl', function() {
+              expect(this.data).toBeUndefined();
+              called = true;
+              return {};
+            });
+          });
+          inject(function($controller, $rootScope) {
+            var ctrl = $controller('testCtrl', { scope: $rootScope }, { data: data });
+            expect(ctrl.data).toBe(data);
+            expect(called).toBe(true);
+          });
+        }
+      );
+
+
+      if (/chrome/.test(window.navigator.userAgent)) {
+        it('should support assigning bindings to class-based controller', function() {
+          var called = false;
+          var data = [
+            { name: 'derp1', id: 0 },
+            { name: 'testname', id: 1 },
+            { name: 'flurp', id: 2 }
+          ];
+          module(function($controllerProvider) {
+            // eslint-disable-next-line no-eval
+            var TestCtrl = eval('(class { constructor() { called = true; } })');
+            $controllerProvider.register('testCtrl', TestCtrl);
+          });
+          inject(function($controller, $rootScope) {
+            var ctrl = $controller('testCtrl', { scope: $rootScope }, { data: data });
+            expect(ctrl.data).toBe(data);
+            expect(called).toBe(true);
+          });
+        });
+      }
+    });
   });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.


**What is the current behavior? (You can also link to an open issue here)**
`ngMock`'s `$controller` service always pre-assigns bindings (if available), regardless of the value of `$compileProvider.preAssignBindingsEnabled()`. This may cause false positives or negatives in tests.
See #15387.


**What is the new behavior (if this is a feature change)?**
`ngMock`'s `$controller` service does not pre-assign bindings (if available), unless `$compileProvider.preAssignBindingsEnabled()` returns true.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
Fixes #15387