### PR TITLE
refactor(injector): remove outdated workaround on function stringify

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -71,11 +71,7 @@ var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 var $injectorMinErr = minErr('$injector');
 
 function stringifyFn(fn) {
-  // Support: Chrome 50-51 only
-  // Creating a new string by adding `' '` at the end, to hack around some bug in Chrome v50/51
-  // (See https://github.com/angular/angular.js/issues/14487.)
-  // TODO (gkalpak): Remove workaround when Chrome v52 is released
-  return Function.prototype.toString.call(fn) + ' ';
+  return Function.prototype.toString.call(fn);
 }
 
 function extractArgs(fn) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Enhancement


**What is the current behavior? (You can also link to an open issue here)**
The injector annotator appends an empty string at the end of `Function.prototype.toString` to solve a bug found on Chrome 50-51 when trying to annotate functions by it's parameters name.


**What is the new behavior (if this is a feature change)?**
The injector annotator doesn't append the empty string anymore, as it's no longer necessary on Chrome's current version, 54.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Current tests are already covering this functionality on  `injectorSpec.js` on the `annotation` test context.

Remove an outdated workaround for Chrome 50-51 since Chrome is already on v54 for a bug in which
Function.prototype.toString didn't work as expected for the injector's annotation.