### PR TITLE
feat(ngModelOptions): support catch-all ("*") debounce settings

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -812,7 +812,10 @@ NgModelController.prototype = {
 
     if (isNumber(debounceDelay[trigger])) {
       debounceDelay = debounceDelay[trigger];
+    } else if (isNumber(debounceDelay['*'])) {
+      debounceDelay = debounceDelay['*'];
     } else if (isNumber(debounceDelay['default'])) {
+      // for backwards compatibility we fallback on the `default` trigger
       debounceDelay = debounceDelay['default'];
     }
 

--- a/src/ng/directive/ngModelOptions.js
+++ b/src/ng/directive/ngModelOptions.js
@@ -313,7 +313,10 @@ defaultModelOptions = new ModelOptions({
  *   - `debounce`: integer value which contains the debounce model update value in milliseconds. A
  *     value of 0 triggers an immediate update. If an object is supplied instead, you can specify a
  *     custom value for each event. For example:
- *     `ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }"`
+ *     `ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }"`.
+ *     You can also use `"*"` as a catch-all debounce for all unspecified events. For example:
+ *     `ng-model-options="{ updateOn: 'default blur keyup', debounce: { 'default': 500, '*': 100 } }"`
+ *     will debounce the `blur` and `keyup` events by 100ms.
  *   - `allowInvalid`: boolean value which indicates that the model can be set with values that did
  *     not validate correctly instead of the default behavior of setting the model to undefined.
  *   - `getterSetter`: boolean value which determines whether or not to treat functions bound to

--- a/test/ng/directive/ngModelOptionsSpec.js
+++ b/test/ng/directive/ngModelOptionsSpec.js
@@ -515,6 +515,24 @@ describe('ngModelOptions', function() {
         expect($rootScope.name).toEqual('b');
       });
 
+
+      it('should allow a default debounce to be specified for unlisted trigger events', function() {
+        var inputElm = helper.compileInput(
+            '<input type="text" ng-model="name" name="alias" ' +
+              'ng-model-options="{' +
+                'updateOn: \'default blur foo\', ' +
+                'debounce: { default: 2000, blur: 5000, \'*\': 500 }' +
+              '}"' +
+            '/>');
+
+        helper.changeInputValueTo('a');
+        browserTrigger(inputElm, 'foo');
+        expect($rootScope.name).toBeUndefined();
+        $timeout.flush(500);
+        expect($rootScope.name).toEqual('a');
+      });
+
+
       it('should allow selecting different debounce timeouts for each event on checkboxes', function() {
         var inputElm = helper.compileInput('<input type="checkbox" ng-model="checkbox" ' +
           'ng-model-options="{ ' +


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feat

**What is the current behavior? (You can also link to an open issue here)**

the `default` key acts as a catch all for debounce events but this prevents one from being able to set a different debounce value for `default` than for other unspecified events.

**What is the new behavior (if this is a feature change)?**

the new `*` key acts as a catch all for unspecified events


**Does this PR introduce a breaking change?**

No!
If you do not use `*` as a key then the behaviour is unchanged.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:


This change enables the use of a `"*"` key in the `debounce` setting of
`ngModelOptions`, which will set the debounce value for all events that
do not have an explicit value.

Closes #15411