### PR TITLE
feat(security): explicitly whitelist URL schemes for bootstrap.

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1455,12 +1455,20 @@ function allowAutoBootstrap(document) {
   link.href = src;
   var scriptProtocol = link.protocol;
   var docLoadProtocol = document.location.protocol;
-  if ((scriptProtocol === 'resource:' ||
-       scriptProtocol === 'chrome-extension:') &&
-      docLoadProtocol !== scriptProtocol) {
-    return false;
+  if (docLoadProtocol === scriptProtocol) {
+    return true;
   }
-  return true;
+  switch(scriptProtocol) {
+    case 'http:':
+    case 'https:':
+    case 'ftp:':
+    case 'blob:':
+    case 'file:':
+    case 'data:':
+      return true;
+    default:
+      return false;
+  }
 }
 
 // Cached as it has to run during loading so that document.currentScript is available.


### PR DESCRIPTION
Many browsers have some extension URL scheme. It is unclear how many of
those have the security issue of allowing parser-inserted loads of
extension URLs.

To be conservative, this code whitelists the URL schemes that are known
to be subject to CSP, i.e. the ones that are expected and safe.

Note: there is no change in tests as behavior does not change for any known URL.