### PR TITLE
chore(docs): use correct script-URL for plnkr on snapshot

### DIFF
--- a/docs/config/services/deployments/production.js
+++ b/docs/config/services/deployments/production.js
@@ -15,7 +15,7 @@ var cdnUrl = googleCdnUrl + versionInfo.cdnVersion;
 // might not work (possibly in subtle ways).
 var examplesCdnUrl = versionInfo.currentVersion.isSnapshot ?
   (angularCodeUrl + 'snapshot') :
-  (googleCdnUrl + (versionInfo.version || versionInfo.currentVersion));
+  (googleCdnUrl + (versionInfo.currentVersion.version || versionInfo.currentVersion));
 
 module.exports = function productionDeployment(getVersion) {
   return {

--- a/docs/config/services/deployments/production.js
+++ b/docs/config/services/deployments/production.js
@@ -13,7 +13,7 @@ var cdnUrl = googleCdnUrl + versionInfo.cdnVersion;
 // The currentVersion may not be available on the cdn (e.g. if built locally, or hasn't been pushed
 // yet). This will lead to a 404, but this is preferable to loading a version with which the example
 // might not work (possibly in subtle ways).
-var examplesCdnUrl = versionInfo.isSnapshot ?
+var examplesCdnUrl = versionInfo.currentVersion.isSnapshot ?
   (angularCodeUrl + 'snapshot') :
   (googleCdnUrl + (versionInfo.version || versionInfo.currentVersion));
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix (for docs app).


**What is the current behavior? (You can also link to an open issue here)**
The URLs used for scripts when opening an example from the snapshot version in plnkr is incorrect and the code does not work.
See #15437.


**What is the new behavior (if this is a feature change)?**
The correct script URLs are used and the examples work.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Fixes #15437