### PR TITLE
chore(*): silence ng-closure-runner warnings during `grunt minall`

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -120,6 +120,7 @@
 
     /* minErr.js */
     "minErr": false,
+    "noMinErr": false,
 
     /* loader.js */
     "setupModuleLoader": false,

--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -890,7 +890,7 @@ function createInjector(modulesToLoad, strictDi) {
           if (cache[serviceName] === INSTANTIATING) {
             delete cache[serviceName];
           }
-          throw err;
+          throw noMinErr('', '', err);
         } finally {
           path.shift();
         }

--- a/src/minErr.js
+++ b/src/minErr.js
@@ -79,7 +79,6 @@ function isValidObjectMaxDepth(maxDepth) {
  *   error from returned function, for cases when a particular type of error is useful.
  * @returns {function(code:string, template:string, ...templateArgs): Error} minErr instance
  */
-
 function minErr(module, ErrorConstructor) {
   ErrorConstructor = ErrorConstructor || Error;
   return function() {
@@ -110,4 +109,39 @@ function minErr(module, ErrorConstructor) {
 
     return new ErrorConstructor(message);
   };
+}
+
+/**
+ * @description
+ *
+ * In certain case (e.g. when catching and rethrowing an error), it is neither desirable nor
+ * necessary to pass the error through `minErr()`. You can use this function to avoid warnings
+ * produced by `ng-closire-runner` during `grunt minall`.
+ *
+ * Due to what arguments `ng-closure-runner` expects, the first two arguments must be static
+ * strings. Therefore, you have to pass the actual error as 3rd argument (see example below).
+ *
+ * **WARNING**
+ * Only use this function when you are certain that the thrown error should NOT be a `minErr`
+ * instance;
+ *
+ * Example usage:
+ *
+ * ```js
+ * try {
+ *   tryAndFail();
+ * } catch (err) {
+ *   doSomeThing(err);
+ *   throw noMinErr('', '', err);   // Functionally equivalent to `throw err`,
+ *                                  // but avoids `ng-closure-runner` warnings.
+ * }
+ * ```
+ *
+ * @param {string} ignoredCode - Ignored, but necessary for `ng-closure-runner`.
+ * @param {string} ignoredTemplate - Ignored, but necessary for `ng-closure-runner`.
+ * @param {*} error - The error object that will be returned.
+ * @returns {*} - The passed in error.
+ */
+function noMinErr(ignoredCode, ignoredTemplate, err) {
+  return err;
 }

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1566,7 +1566,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           // Reset the queue to trigger a new schedule next time there is a change
           onChangesQueue = undefined;
           if (errors.length) {
-            throw errors;
+            throw noMinErr('', '', errors);
           }
         });
       } finally {

--- a/src/ng/directive/ngModelOptions.js
+++ b/src/ng/directive/ngModelOptions.js
@@ -41,7 +41,7 @@ ModelOptions.prototype = {
     options = extend({}, options);
 
     // Inherit options from the parent if specified by the value `"$inherit"`
-    forEach(options, /* @this */ function(option, key) {
+    forEach(options, /** @this */ function(option, key) {
       if (option === '$inherit') {
         if (key === '*') {
           inheritAll = true;

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -147,7 +147,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
           // The json response type can be ignored if not supported, because JSON payloads are
           // parsed on the client-side regardless.
           if (responseType !== 'json') {
-            throw e;
+            throw noMinErr('', '', e);
           }
         }
       }

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -894,7 +894,7 @@ function $LocationProvider() {
         $location.url(oldUrl);
         $location.$$state = oldState;
 
-        throw e;
+        throw noMinErr('', '', e);
       }
     }
 

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -1192,7 +1192,7 @@ function $RootScopeProvider() {
           } catch (e) {
             $exceptionHandler(e);
             // eslint-disable-next-line no-unsafe-finally
-            throw e;
+            throw noMinErr('', '', e);
           }
         }
       },

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -117,6 +117,7 @@
 
     /* minerr.js */
     "minErr": false,
+    "noMinErr": false,
 
     /* loader.js */
     "setupModuleLoader": false,

--- a/test/minErrSpec.js
+++ b/test/minErrSpec.js
@@ -166,3 +166,13 @@ describe('errors', function() {
     });
   });
 });
+
+describe('noMinErr', function() {
+  it('should return the 3rd argument', function() {
+    expect(noMinErr('foo', 'bar', 'baz')).toBe('baz');
+    expect(noMinErr('foo', 'bar', null)).toBe(null);
+    expect(noMinErr('foo', 'bar')).toBeUndefined();
+    expect(noMinErr('foo')).toBeUndefined();
+    expect(noMinErr()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Chore/Refactor.


**What is the current behavior? (You can also link to an open issue here)**
During the `grunt minall` task, `ng-closure-runner` logs some warnings due to:
1. Throwing errors that do not seem to be `minErr` instances.
2. A `@this` annotation in a non-JSDoc comment. 


**What is the new behavior (if this is a feature change)?**
No warnings during `grunt minall`.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~
