### PR TITLE
docs($rootScope): add note about watching File objects

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -297,6 +297,8 @@ function $RootScopeProvider() {
        *   according to the {@link angular.equals} function. To save the value of the object for
        *   later comparison, the {@link angular.copy} function is used. This therefore means that
        *   watching complex objects will have adverse memory and performance implications.
+       * - This should not be used to watch for changes in objects that are
+       *   or contain `File` objects due to limitations with `angular.copy`.
        * - The watch `listener` may change the model, which may trigger other `listener`s to fire.
        *   This is achieved by rerunning the watchers until no changes are detected. The rerun
        *   iteration limit is 10 to prevent an infinite loop deadlock.


### PR DESCRIPTION
- Add note recommending against watching `File` objects with deep watchers

This should address #14352