### PR TITLE
chore(doc-gen): render @example tag for ngdoc @method

### DIFF
--- a/docs/config/templates/ngdoc/api/api.template.html
+++ b/docs/config/templates/ngdoc/api/api.template.html
@@ -51,7 +51,7 @@
 
   {% block examples %}
   {%- if doc.examples %}
-  <h2 id="example">Example</h2>
+  <h2 id="example">Examples</h2>
   {%- for example in doc.examples -%}
     {$ example | marked $}
   {%- endfor -%}

--- a/docs/config/templates/ngdoc/lib/methods.template.html
+++ b/docs/config/templates/ngdoc/lib/methods.template.html
@@ -26,6 +26,13 @@
     {$ lib.typeInfo(method.returns) $}
     {% endif %}
 
+    {%- if method.examples %}
+    <h4 id="{$ doc.name $}.{$ method.name $}-examples">Examples</h4>
+    {%- for example in method.examples -%}
+      {$ example | marked $}
+    {%- endfor -%}
+    {% endif -%}
+
   </li>
   {% endfor -%}
 </ul>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feat / fix to the docs app


**What is the current behavior? (You can also link to an open issue here)**
`@example` in  `@method` is not rendered

**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
