### PR TITLE
test($compile): work around Chrome (Windows) bug with reported size for `<foreignObject>`

### DIFF
--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -452,7 +452,12 @@ describe('$compile', function() {
         var testElem = element.find('div');
         expect(isHTMLElement(testElem[0])).toBe(true);
         var bounds = testElem[0].getBoundingClientRect();
-        expect(bounds.width === 20 && bounds.height === 20).toBe(true);
+
+        // Support: Chrome 53-54+ (Windows 10)
+        // `<foreignObject>` and its children are reported by `getBoundingClientRect()`
+        // as 25% larger in each dimension than they actually are.
+        expect(bounds.width).toBeGreaterThanOrEqual(20);
+        expect(bounds.height).toBeGreaterThanOrEqual(20);
       }));
 
       it('should handle custom svg containers that transclude to foreignObject that transclude html', inject(function() {
@@ -465,7 +470,12 @@ describe('$compile', function() {
         var testElem = element.find('div');
         expect(isHTMLElement(testElem[0])).toBe(true);
         var bounds = testElem[0].getBoundingClientRect();
-        expect(bounds.width === 20 && bounds.height === 20).toBe(true);
+
+        // Support: Chrome 53-54+ (Windows 10)
+        // `<foreignObject>` and its children are reported by `getBoundingClientRect()`
+        // as 25% larger in each dimension than they actually are.
+        expect(bounds.width).toBeGreaterThanOrEqual(20);
+        expect(bounds.height).toBeGreaterThanOrEqual(20);
       }));
 
       // NOTE: This test may be redundant.


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixes two tests on Chrome 53-54+ (on Windows).


**What is the current behavior? (You can also link to an open issue here)**
[These tests][1] are currently failing on Chrome+Windows, because the reported size of the inner divs is `25x25` (instead of the expected `20x20`).
See also #15333.

**What is the new behavior (if this is a feature change)?**
The assertion condition is relaxed and the tests pass. This is OK, because what we need to assert is that the content haas been transcluded correctly. Whether the style of `width: 20px` is applied/reported correctly by the browser is not the focus of the test.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Chrome 53-54+ on Windows (only) reports a 25% larger size for `<foreignObject>` elements and their
descendants (although the size is actually correct on the page). For example,
`<foreignObject style="width: 100px; height: 100px;">...</foreignObject>`, will be reported by
`getBoundingClientRect()` as being `125px` x `125px`, although it will be `100px` x `100px` as
expected.

Fixes #15333

[1]: https://github.com/angular/angular.js/blob/f1db7d735b475a7954023cc63f2b3f0ef685ea7e/test/ng/compileSpec.js#L445-L469