### PR TITLE
fix(copy): angular copy should throw exception when source and destin…

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -820,6 +820,10 @@ function copy(source, destination) {
   var stackDest = [];
 
   if (destination) {
+    if (toString.call(destination) !== toString.call(source)) {
+      throw ngMinErr('cpi', 'Can\'t copy! Source({0} type) and destination({1} type) aren\'t the same type.',
+          toString.call(source), toString.call(destination));
+    }
     if (isTypedArray(destination) || isArrayBuffer(destination)) {
       throw ngMinErr('cpta', 'Can\'t copy! TypedArray destination cannot be mutated.');
     }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

bug

**What is the current behavior? (You can also link to an open issue here)**
https://github.com/angular/angular.js/issues/15444


**What is the new behavior (if this is a feature change)?**
when angular copy source and destination are not the same type, it throw an exception

**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:


…ation are not the same type

Closes #15444