### PR TITLE
feat($compile): support expansion of special `ngBindon` attributes

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -147,6 +147,21 @@ components should follow a few simple conventions:
         });
       }
     ```
+  - A two-way binding can be simulated by using both a one-way binding as well as an output event.
+    ```js
+      bindings: {
+        hero: '<',
+        heroChange: '&'
+      }
+    ```
+    ```html
+      <hero-detail hero="$ctrl.hero" hero-change="$ctrl.hero = $event"></hero-detail>
+    ```
+  - Since that can be rather verbose, especially with repeated properties, we provide syntactic sugar for that pattern
+    via `ng-bindon-` attributes which expand to match the example above.
+    ```html
+      <hero-detail ng-bindon-hero="$ctrl.hero"></hero-detail>
+    ```
 
 - **Components have a well-defined lifecycle**
 Each component can implement "lifecycle hooks". These are methods that will be called at certain points in the life

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -11441,6 +11441,36 @@ describe('$compile', function() {
     });
   });
 
+  describe('ngBindon attributes', function() {
+    it('should expand `ng-bindon-foo` to both an input and an output expression', function() {
+      module(function($compileProvider) {
+        $compileProvider.component('test', {
+          bindings: {
+            foo: '<',
+            fooChange: '&'
+          }
+        });
+      });
+
+      inject(function($compile, $rootScope) {
+        $rootScope.bar = 0;
+
+        element = $compile('<test ng-bindon-foo="bar"></test>')($rootScope);
+        var testController = element.controller('test');
+        $rootScope.$digest();
+
+        expect(testController.foo).toBe(0);
+        $rootScope.$apply('bar=1');
+        expect(testController.foo).toBe(1);
+        $rootScope.$apply(function() {
+          testController.fooChange({ $event: 2 });
+        });
+
+        expect($rootScope.bar).toBe(2);
+        expect(testController.foo).toBe(2);
+      });
+    });
+  });
 
   describe('when an attribute has an underscore-separated name', function() {
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feat

**What is the current behavior? (You can also link to an open issue here)**

Supporting unidirectional data-flow is rather verbose

**What is the new behavior (if this is a feature change)?**

Supporting unidirectional data-flow is less verbose

**Does this PR introduce a breaking change?**

Nope

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

In order to reduce some of the verbosity associated with conforming to the
ideas behind unidirectional data-flow, we can introduce a special
attribute syntax that will be automatically expanded in order to simulate
two-way data binding.

For example,

`<my-component ng-bindon-foo="bar">` will be expanded into
`<my-component foo="bar" foo-changed="bar = $event">`

Fixes #15455