### PR TITLE
docs(guide/Templates): make directive name camelCase for consistency

### DIFF
--- a/docs/content/guide/templates.ngdoc
+++ b/docs/content/guide/templates.ngdoc
@@ -26,7 +26,7 @@ curly-brace {@link expression expression} bindings:
  <!-- Body tag augmented with ngController directive  -->
  <body ng-controller="MyController">
    <input ng-model="foo" value="bar">
-   <!-- Button tag with ng-click directive, and
+   <!-- Button tag with ngClick directive, and
           string expression 'buttonText'
           wrapped in "{{ }}" markup -->
    <button ng-click="changeFoo()">{{buttonText}}</button>


### PR DESCRIPTION
ng-controller in the comment above is written in camelcase, so make ng-click also camelcase.