### PR TITLE
fix(select): do not break when removing the element (e.g. via `ngIf`)

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -76,11 +76,9 @@ var SelectController =
     }
   };
 
-  var scopeDestroyed = false;
   $scope.$on('$destroy', function() {
     // disable unknown option so that we don't do work when the whole select is being destroyed
     self.renderUnknownOption = noop;
-    scopeDestroyed = true;
   });
 
   // Read the value of the select control, the implementation of this changes depending
@@ -184,7 +182,7 @@ var SelectController =
     updateScheduled = true;
 
     $scope.$$postDigest(function() {
-      if (scopeDestroyed) return;
+      if ($scope.$$destroyed) return;
 
       updateScheduled = false;
       self.ngModelCtrl.$setViewValue(self.readValue());

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -76,9 +76,11 @@ var SelectController =
     }
   };
 
+  var scopeDestroyed = false;
   $scope.$on('$destroy', function() {
     // disable unknown option so that we don't do work when the whole select is being destroyed
     self.renderUnknownOption = noop;
+    scopeDestroyed = true;
   });
 
   // Read the value of the select control, the implementation of this changes depending
@@ -182,6 +184,8 @@ var SelectController =
     updateScheduled = true;
 
     $scope.$$postDigest(function() {
+      if (scopeDestroyed) return;
+
       updateScheduled = false;
       self.ngModelCtrl.$setViewValue(self.readValue());
       if (renderAfter) self.ngModelCtrl.$render();

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -7,7 +7,7 @@ describe('select', function() {
     formElement = jqLite('<form name="form">' + html + '</form>');
     element = formElement.find('select');
     $compile(formElement)(scope);
-    scope.$apply();
+    scope.$digest();
   }
 
   function compileRepeatedOptions() {
@@ -767,6 +767,20 @@ describe('select', function() {
         expect(element).toEqualSelect([unknownValue()], '1', '2', '3');
       }
     );
+
+
+    it('should not throw when removing the element and all its children', function() {
+      var template =
+        '<select ng-model="mySelect" ng-if="visible">' +
+          '<option value="">--- Select ---</option>' +
+        '</select>';
+      scope.visible = true;
+
+      compile(template);
+
+      // It should not throw when removing the element
+      scope.$apply('visible = false');
+    });
   });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.


**What is the current behavior? (You can also link to an open issue here)**
When removing `<option>` elements, we schedule some operations on the `ngModelCtrl`. For performance reasons, these operation are scheduled to be run as a post-digest operation. If the `<select>` element happens to be removed as well (and its scope destroyed), an error may be thrown due to certain values not being available on the `$scope`.
See #15466.

**What is the new behavior (if this is a feature change)?**
Nothing breaks.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Fixes #15466.