### PR TITLE
fix($animateCss): avoid flicker caused by temporary classes

### DIFF
--- a/src/ngAnimate/animateCss.js
+++ b/src/ngAnimate/animateCss.js
@@ -835,6 +835,11 @@ var $AnimateCssProvider = ['$animateProvider', /** @this */ function($animatePro
           return;
         }
 
+        if (options.tempClasses) {
+          $$jqLite.addClass(element, options.tempClasses);
+          options.tempClasses = null;
+        }
+
         // even though we only pause keyframe animations here the pause flag
         // will still happen when transitions are used. Only the transition will
         // not be paused since that is not possible. If the animation ends when

--- a/src/ngAnimate/animateJs.js
+++ b/src/ngAnimate/animateJs.js
@@ -90,6 +90,11 @@ var $$AnimateJsProvider = ['$animateProvider', /** @this */ function($animatePro
             return runner;
           }
 
+          if (options.tempClasses) {
+            $$jqLite.addClass(element, options.tempClasses);
+            options.tempClasses = null;
+          }
+
           runner = new $$AnimateRunner();
           var closeActiveAnimations;
           var chain = [];

--- a/src/ngAnimate/animation.js
+++ b/src/ngAnimate/animation.js
@@ -134,7 +134,6 @@ var $$AnimationProvider = ['$animateProvider', /** @this */ function($animatePro
       var tempClasses = options.tempClasses;
       if (tempClasses) {
         classes += ' ' + tempClasses;
-        options.tempClasses = null;
       }
 
       var prepareClassName;
@@ -185,9 +184,8 @@ var $$AnimationProvider = ['$animateProvider', /** @this */ function($animatePro
           toBeSortedAnimations.push({
             domNode: getDomNode(animationEntry.from ? animationEntry.from.element : animationEntry.element),
             fn: function triggerAnimationStart() {
-              // it's important that we apply the `ng-animate` CSS class and the
-              // temporary classes before we do any driver invoking since these
-              // CSS classes may be required for proper CSS detection.
+              // It is important that we apply the `ng-animate` CSS class before we do any driver
+              // invoking since these CSS classes may be required for proper CSS detection.
               animationEntry.beforeStart();
 
               var startAnimationFn, closeFn = animationEntry.close;
@@ -359,10 +357,11 @@ var $$AnimationProvider = ['$animateProvider', /** @this */ function($animatePro
       }
 
       function beforeStart() {
+        // Note: `tempClasses` are not added here, since the actual animation may not start right
+        // away (`$animateCss` for example forces a reflow first). It is the responsibility of the
+        // respective animation driver to add them (if necessary).
+
         element.addClass(NG_ANIMATE_CLASSNAME);
-        if (tempClasses) {
-          $$jqLite.addClass(element, tempClasses);
-        }
         if (prepareClassName) {
           $$jqLite.removeClass(element, prepareClassName);
           prepareClassName = null;

--- a/test/ngAnimate/animateCssSpec.js
+++ b/test/ngAnimate/animateCssSpec.js
@@ -1641,6 +1641,26 @@ describe('ngAnimate $animateCss', function() {
       expect(element).toHaveClass('super-active');
     }));
 
+    it('should apply `tempClasses` when starting the animation',
+      inject(function($animateCss, $document, $rootElement) {
+
+      var element = angular.element('<div></div>');
+      $rootElement.append(element);
+      $document.find('body').append($rootElement);
+
+      $animateCss(element, {
+        event: 'super',
+        duration: 1000,
+        to: fakeStyle,
+        tempClasses: 'foo'
+      }).start();
+
+      expect(element).not.toHaveClass('foo');
+
+      triggerAnimationStartFrame();
+      expect(element).toHaveClass('foo');
+    }));
+
     describe('structural animations', function() {
       they('should decorate the element with the ng-$prop CSS class',
         ['enter', 'leave', 'move'], function(event) {

--- a/test/ngAnimate/animateJsSpec.js
+++ b/test/ngAnimate/animateJsSpec.js
@@ -193,7 +193,7 @@ describe('ngAnimate $$animateJs', function() {
     });
   });
 
-  it('should always run the provided animation in atleast one RAF frame if defined', function() {
+  it('should always run the provided animation in at least one RAF frame if defined', function() {
     var before, after, endCalled;
     module(function($animateProvider) {
       $animateProvider.register('.the-end', function() {
@@ -322,6 +322,23 @@ describe('ngAnimate $$animateJs', function() {
       $rootScope.$digest();
       expect(done).toBe(false);
       expect(cancelled).toBe(true);
+    });
+  });
+
+  it('should apply `tempClasses` when starting the animation', function() {
+    module(function($animateProvider) {
+      $animateProvider.register('.foo-element', function() {
+        return {foo: noop};
+      });
+    });
+    inject(function($$animateJs) {
+      var element = jqLite('<div class="foo-element"></div>');
+      var animator = $$animateJs(element, 'foo', 'foo-element', {tempClasses: 'temp'});
+
+      expect(element).not.toHaveClass('temp');
+
+      animator.start();
+      expect(element).toHaveClass('temp');
     });
   });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.


**What is the current behavior? (You can also link to an open issue here)**
Adding the temporary classes immediately, while forcing a reflow before starting the animation, could cause flickering. Currently, only `ngHide`/`ngShow` animations are affected (but theoretically any future animation relying on `tempClasses` would be).
See #14015.


**What is the new behavior (if this is a feature change)?**
The temporary classes are not applied until the animation actually starts, which avoids the flickering.


**Does this PR introduce a breaking change?**
No. (Since `tempClasses` was an undocumented, private feature (currently only used for `ngHide`/`ngShow`), no other built-in or custom animations will be affected).


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
This is an alternative approach to #15463.
Fixes #14015.