### PR TITLE
fix(jqLite): silently ignore `after()` if element has no parent

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -979,12 +979,15 @@ forEach({
 
   after: function(element, newElement) {
     var index = element, parent = element.parentNode;
-    newElement = new JQLite(newElement);
 
-    for (var i = 0, ii = newElement.length; i < ii; i++) {
-      var node = newElement[i];
-      parent.insertBefore(node, index.nextSibling);
-      index = node;
+    if (parent) {
+      newElement = new JQLite(newElement);
+
+      for (var i = 0, ii = newElement.length; i < ii; i++) {
+        var node = newElement[i];
+        parent.insertBefore(node, index.nextSibling);
+        index = node;
+      }
     }
   },
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -2187,6 +2187,7 @@ describe('jqLite', function() {
     it('should not throw when the element has no parent', function() {
       var span = jqLite('<span></span>');
       expect(function() { span.after('abc'); }).not.toThrow();
+      expect(span).toJqEqual(jqLite('<span></span>'));
     });
   });
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -2187,7 +2187,8 @@ describe('jqLite', function() {
     it('should not throw when the element has no parent', function() {
       var span = jqLite('<span></span>');
       expect(function() { span.after('abc'); }).not.toThrow();
-      expect(span).toJqEqual(jqLite('<span></span>'));
+      expect(span.length).toBe(1);
+      expect(span[0].outerHTML).toBe('<span></span>');
     });
   });
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -2182,6 +2182,12 @@ describe('jqLite', function() {
       span.after('abc');
       expect(root.html().toLowerCase()).toEqual('<span></span>abc');
     });
+
+
+    it('should not throw when the element has no parent', function() {
+      var span = jqLite('<span></span>');
+      expect(function() { span.after('abc'); }).not.toThrow();
+    });
   });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.


**What is the current behavior? (You can also link to an open issue here)**
The element was always assumed to have a parent and an error was thrown when that was not the case.


**What is the new behavior (if this is a feature change)?**
jqLite is now consistent with jQuery, which silently ignores a call on elements that do not have a parent.


**Does this PR introduce a breaking change?**
No. (This change only affects already broken code, that would otherwise throw an error.)


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Fixes #15331
Closes #15367