### PR TITLE
fix($rootScope): don't allow explicit digest calls to affect $evalAsync

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -764,7 +764,7 @@ function $RootScopeProvider() {
         var watch, value, last, fn, get,
             watchers,
             dirty, ttl = TTL,
-            next, current, target = this,
+            next, current, target = asyncQueue.length ? $rootScope : this,
             watchLog = [],
             logIdx, asyncTask;
 

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1498,6 +1498,25 @@ describe('Scope', function() {
         $browser.defer.flush(100000);
         expect(log).toEqual(['eval-ed 1!', 'eval-ed 2!']);
       });
+
+      it('should not have execution affected by an explicit $digest call', function() {
+        var scope1 = $rootScope.$new();
+        var scope2 = $rootScope.$new();
+
+        scope1.$watch('value', function(value) {
+          scope1.result = value;
+        });
+
+        scope1.$evalAsync(function() {
+          scope1.value = 'bar';
+        });
+
+        scope2.$digest();
+
+        $browser.defer.flush(0);
+
+        expect(scope1.result).toBe('bar');
+      });
     });
   });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

fix

**What is the current behavior? (You can also link to an open issue here)**

#15127

**What is the new behavior (if this is a feature change)?**

If an `$evalAsync` call occurs prior to a `$digest` being invoked on a scope other than the `$rootScope`, the target of the operation is changed to the `$rootScope` in order to allow the watchers that may have reacted to the `$evalAsync` operation to occur

**Does this PR introduce a breaking change?**

Nope

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:


Fixes #15127