### PR TITLE
fix($rootScope): correctly propagate async changes after local `$digest()`

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -799,6 +799,10 @@ function $RootScopeProvider() {
           }
           asyncQueue.length = 0;
 
+          if (this === $rootScope) {
+            hasRootScopeDigestRun = true;
+          }
+
           traverseScopesLoop:
           do { // "traverse the scopes" loop
             if ((watchers = current.$$watchers)) {
@@ -1014,8 +1018,9 @@ function $RootScopeProvider() {
         // if we are outside of an $digest loop and this is the first time we are scheduling async
         // task also schedule async auto-flush
         if (!$rootScope.$$phase && !asyncQueue.length) {
+          hasRootScopeDigestRun = false;
           $browser.defer(function() {
-            if (asyncQueue.length) {
+            if (!hasRootScopeDigestRun || asyncQueue.length) {
               $rootScope.$digest();
             }
           });
@@ -1333,6 +1338,7 @@ function $RootScopeProvider() {
     var postDigestQueue = $rootScope.$$postDigestQueue = [];
     var applyAsyncQueue = $rootScope.$$applyAsyncQueue = [];
 
+    var hasRootScopeDigestRun = false;
     var postDigestQueuePosition = 0;
 
     return $rootScope;

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1498,6 +1498,26 @@ describe('Scope', function() {
         $browser.defer.flush(100000);
         expect(log).toEqual(['eval-ed 1!', 'eval-ed 2!']);
       });
+
+
+      it('should not have execution affected by a local `$digest` call', function() {
+        var scope1 = $rootScope.$new();
+        var scope2 = $rootScope.$new();
+
+        scope1.$watch('value', function(value) {
+          scope1.result = value;
+        });
+
+        scope1.$evalAsync(function() {
+          scope1.value = 'bar';
+        });
+
+        scope2.$digest();
+
+        $browser.defer.flush(0);
+
+        expect(scope1.result).toBe('bar');
+      });
     });
   });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.


**What is the current behavior? (You can also link to an open issue here)**
If an async task is scheduled (via `$evalAsync()`) on a scope and `$digest()` happens to be called on another, unrelated scope (local digest), then the `asyncQueue` will be drained but `$rootScope.$digest()` will not be called (potentially preventing the changes to propagate correctly through the app).
See #15127.

**What is the new behavior (if this is a feature change)?**
Angular keeps track on whether `$digest()` has been called on `$rootScope` or not and calls `$rootScope.$digest()` if necessary (even if the `asyncQueue` has been drained by a local `$digest()`).


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
This is a more targeted alternative to #15494.
Fixes #15127.