### PR TITLE
revert: fix($resource): allow params in `hostname` (except for IPv6 addresses)

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -427,7 +427,7 @@ function shallowClearAndCopy(src, dst) {
  */
 angular.module('ngResource', ['ng']).
   provider('$resource', function ResourceProvider() {
-    var PROTOCOL_AND_IPV6_REGEX = /^https?:\/\/\[[^\]]*][^/]*/;
+    var PROTOCOL_AND_DOMAIN_REGEX = /^https?:\/\/[^/]*/;
 
     var provider = this;
 
@@ -575,7 +575,7 @@ angular.module('ngResource', ['ng']).
             url = actionUrl || self.template,
             val,
             encodedVal,
-            protocolAndIpv6 = '';
+            protocolAndDomain = '';
 
           var urlParams = self.urlParams = {};
           forEach(url.split(/\W/), function(param) {
@@ -590,8 +590,8 @@ angular.module('ngResource', ['ng']).
             }
           });
           url = url.replace(/\\:/g, ':');
-          url = url.replace(PROTOCOL_AND_IPV6_REGEX, function(match) {
-            protocolAndIpv6 = match;
+          url = url.replace(PROTOCOL_AND_DOMAIN_REGEX, function(match) {
+            protocolAndDomain = match;
             return '';
           });
 
@@ -628,7 +628,7 @@ angular.module('ngResource', ['ng']).
           // E.g. `http://url.com/id./format?q=x` becomes `http://url.com/id.format?q=x`
           url = url.replace(/\/\.(?=\w+($|\?))/, '.');
           // replace escaped `/\.` with `/.`
-          config.url = protocolAndIpv6 + url.replace(/\/\\\./, '/.');
+          config.url = protocolAndDomain + url.replace(/\/\\\./, '/.');
 
 
           // set params - delegate param encoding to $http

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -300,35 +300,11 @@ describe('basic usage', function() {
   });
 
   it('should support IPv6 URLs', function() {
-    test('http://[2620:0:861:ed1a::1]',        {ed1a: 'foo'}, 'http://[2620:0:861:ed1a::1]');
-    test('http://[2620:0:861:ed1a::1]/',       {ed1a: 'foo'}, 'http://[2620:0:861:ed1a::1]/');
-    test('http://[2620:0:861:ed1a::1]/:ed1a',  {ed1a: 'foo'}, 'http://[2620:0:861:ed1a::1]/foo');
-    test('http://[2620:0:861:ed1a::1]/:ed1a',  {},            'http://[2620:0:861:ed1a::1]/');
-    test('http://[2620:0:861:ed1a::1]/:ed1a/', {ed1a: 'foo'}, 'http://[2620:0:861:ed1a::1]/foo/');
-    test('http://[2620:0:861:ed1a::1]/:ed1a/', {},            'http://[2620:0:861:ed1a::1]/');
-
-    // Helpers
-    function test(templateUrl, params, actualUrl) {
-      var R = $resource(templateUrl, null, null, {stripTrailingSlashes: false});
-      $httpBackend.expect('GET', actualUrl).respond(null);
-      R.get(params);
-    }
-  });
-
-  it('should support params in the `hostname` part of the URL', function() {
-    test('http://:hostname',            {hostname: 'foo.com'},              'http://foo.com');
-    test('http://:hostname/',           {hostname: 'foo.com'},              'http://foo.com/');
-    test('http://:l2Domain.:l1Domain',  {l1Domain: 'com', l2Domain: 'bar'}, 'http://bar.com');
-    test('http://:l2Domain.:l1Domain/', {l1Domain: 'com', l2Domain: 'bar'}, 'http://bar.com/');
-    test('http://127.0.0.:octet',       {octet: 42},                        'http://127.0.0.42');
-    test('http://127.0.0.:octet/',      {octet: 42},                        'http://127.0.0.42/');
-
-    // Helpers
-    function test(templateUrl, params, actualUrl) {
-      var R = $resource(templateUrl, null, null, {stripTrailingSlashes: false});
-      $httpBackend.expect('GET', actualUrl).respond(null);
-      R.get(params);
-    }
+    var R = $resource('http://[2620:0:861:ed1a::1]/:ed1a/', {}, {}, {stripTrailingSlashes: false});
+    $httpBackend.expect('GET', 'http://[2620:0:861:ed1a::1]/foo/').respond({});
+    $httpBackend.expect('GET', 'http://[2620:0:861:ed1a::1]/').respond({});
+    R.get({ed1a: 'foo'});
+    R.get({});
   });
 
   it('should support overriding provider default trailing-slash stripping configuration', function() {


### PR DESCRIPTION
This reverts commit 7f45b5fee79e2cb87d65bdd015d455304cec1ee4.