### PR TITLE
fix(ngAnimate): correctly animate transcluded clones with `templateUrl`

### DIFF
--- a/benchmarks/animation-bp/app.js
+++ b/benchmarks/animation-bp/app.js
@@ -1,0 +1,44 @@
+'use strict';
+
+angular
+  .module('animationBenchmark', ['ngAnimate'], config)
+  .controller('BenchmarkController', BenchmarkController);
+
+// Functions - Definitions
+function config($compileProvider) {
+  $compileProvider
+    .commentDirectivesEnabled(false)
+    .cssClassDirectivesEnabled(false)
+    .debugInfoEnabled(false);
+}
+
+function BenchmarkController($scope) {
+  var self = this;
+  var itemCount = 1000;
+  var items = (new Array(itemCount + 1)).join('.').split('');
+
+  benchmarkSteps.push({
+    name: 'create',
+    fn: function() {
+      $scope.$apply(function() {
+        self.items = items;
+      });
+    }
+  });
+
+  benchmarkSteps.push({
+    name: '$digest',
+    fn: function() {
+      $scope.$root.$digest();
+    }
+  });
+
+  benchmarkSteps.push({
+    name: 'destroy',
+    fn: function() {
+      $scope.$apply(function() {
+        self.items = [];
+      });
+    }
+  });
+}

--- a/benchmarks/animation-bp/bp.conf.js
+++ b/benchmarks/animation-bp/bp.conf.js
@@ -1,0 +1,22 @@
+/* eslint-env node */
+
+'use strict';
+
+module.exports = function(config) {
+  config.set({
+    scripts: [
+      {
+        id: 'jquery',
+        src: 'jquery-noop.js'
+      }, {
+        id: 'angular',
+        src: '/build/angular.js'
+      }, {
+        id: 'angular-animate',
+        src: '/build/angular-animate.js'
+      }, {
+        src: 'app.js'
+      }
+    ]
+  });
+};

--- a/benchmarks/animation-bp/jquery-noop.js
+++ b/benchmarks/animation-bp/jquery-noop.js
@@ -1,0 +1,1 @@
+// Override me with ?jquery=/bower_components/jquery/dist/jquery.js

--- a/benchmarks/animation-bp/main.html
+++ b/benchmarks/animation-bp/main.html
@@ -1,0 +1,28 @@
+<style>
+  [ng-cloak] { display: none !important; }
+  .animation-container .ng-enter,
+  .animation-container .ng-leave {
+    transition: all 0.1s;
+  }
+
+  .animation-container .ng-enter,
+  .animation-container .ng-leave.ng-leave-active {
+    opacity: 0;
+  }
+
+  .animation-container .ng-enter.ng-enter-active,
+  .animation-container .ng-leave {
+    opacity: 1;
+  }
+</style>
+<div ng-app="animationBenchmark" ng-cloak ng-controller="BenchmarkController as bm">
+  <div class="container-fluid">
+    <h2>Large collection of elements animated in and out with ngAnimate</h2>
+
+    <div class="animation-container">
+      <div ng-repeat="i in bm.items track by $index">
+        Just a plain ol' element
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -181,10 +181,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       return this === arg || !!(this.compareDocumentPosition(arg) & 16);
     };
 
-    function findCallbacks(parent, element, event) {
-      var targetNode = getDomNode(element);
-      var targetParentNode = getDomNode(parent);
-
+    function findCallbacks(targetParentNode, targetNode, event) {
       var matches = [];
       var entries = callbackRegistry[event];
       if (entries) {
@@ -311,12 +308,9 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       // the input data when running `$animateCss`.
       var options = copy(initialOptions);
 
-      var node, parent;
       element = stripCommentsFromElement(element);
-      if (element) {
-        node = getDomNode(element);
-        parent = element.parent();
-      }
+      var node = getDomNode(element);
+      var parentNode = node && node.parentNode;
 
       options = prepareAnimationOptions(options);
 
@@ -381,7 +375,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       // there is no point in traversing the same collection of parent ancestors if a followup
       // animation will be run on the same element that already did all that checking work
       if (!skipAnimations && (!hasExistingAnimation || existingAnimation.state !== PRE_DIGEST_STATE)) {
-        skipAnimations = !areAnimationsAllowed(node, getDomNode(parent), event);
+        skipAnimations = !areAnimationsAllowed(node, parentNode, event);
       }
 
       if (skipAnimations) {
@@ -557,7 +551,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
 
       function notifyProgress(runner, event, phase, data) {
         runInNextPostDigestOrNow(function() {
-          var callbacks = findCallbacks(parent, element, event);
+          var callbacks = findCallbacks(parentNode, node, event);
           if (callbacks.length) {
             // do not optimize this call here to RAF because
             // we don't know how heavy the callback code here will

--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -482,7 +482,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       var counter = (existingAnimation.counter || 0) + 1;
       newAnimation.counter = counter;
 
-      markElementAnimationState(element, PRE_DIGEST_STATE, newAnimation);
+      markElementAnimationState(node, PRE_DIGEST_STATE, newAnimation);
 
       $rootScope.$$postDigest(function() {
         var animationDetails = activeAnimationsLookup.get(node);
@@ -535,7 +535,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
             ? 'setClass'
             : animationDetails.event;
 
-        markElementAnimationState(element, RUNNING_STATE);
+        markElementAnimationState(node, RUNNING_STATE);
         var realRunner = $$animation(element, event, animationDetails.options);
 
         // this will update the runner's flow-control events based on
@@ -700,11 +700,10 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       return allowAnimation && rootNodeDetected && bodyNodeDetected;
     }
 
-    function markElementAnimationState(element, state, details) {
+    function markElementAnimationState(node, state, details) {
       details = details || {};
       details.state = state;
 
-      var node = getDomNode(element);
       node.setAttribute(NG_ANIMATE_ATTR_NAME, state);
 
       var oldValue = activeAnimationsLookup.get(node);

--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -474,7 +474,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
 
       if (!isValidAnimation) {
         close();
-        clearElementAnimationState(element);
+        clearElementAnimationState(node);
         return runner;
       }
 
@@ -523,7 +523,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
           // isn't allowed to animate from here then we need to clear the state of the element
           // so that any future animations won't read the expired animation data.
           if (!isValidAnimation) {
-            clearElementAnimationState(element);
+            clearElementAnimationState(node);
           }
 
           return;
@@ -547,7 +547,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
           close(!status);
           var animationDetails = activeAnimationsLookup.get(node);
           if (animationDetails && animationDetails.counter === counter) {
-            clearElementAnimationState(getDomNode(element));
+            clearElementAnimationState(node);
           }
           notifyProgress(runner, event, 'close', {});
         });
@@ -603,8 +603,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       });
     }
 
-    function clearElementAnimationState(element) {
-      var node = getDomNode(element);
+    function clearElementAnimationState(node) {
       node.removeAttribute(NG_ANIMATE_ATTR_NAME);
       activeAnimationsLookup.remove(node);
     }

--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -36,9 +36,9 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
     }
   }
 
-  function isAllowed(ruleType, element, currentAnimation, previousAnimation) {
+  function isAllowed(ruleType, currentAnimation, previousAnimation) {
     return rules[ruleType].some(function(fn) {
-      return fn(element, currentAnimation, previousAnimation);
+      return fn(currentAnimation, previousAnimation);
     });
   }
 
@@ -48,40 +48,40 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
     return and ? a && b : a || b;
   }
 
-  rules.join.push(function(element, newAnimation, currentAnimation) {
+  rules.join.push(function(newAnimation, currentAnimation) {
     // if the new animation is class-based then we can just tack that on
     return !newAnimation.structural && hasAnimationClasses(newAnimation);
   });
 
-  rules.skip.push(function(element, newAnimation, currentAnimation) {
+  rules.skip.push(function(newAnimation, currentAnimation) {
     // there is no need to animate anything if no classes are being added and
     // there is no structural animation that will be triggered
     return !newAnimation.structural && !hasAnimationClasses(newAnimation);
   });
 
-  rules.skip.push(function(element, newAnimation, currentAnimation) {
+  rules.skip.push(function(newAnimation, currentAnimation) {
     // why should we trigger a new structural animation if the element will
     // be removed from the DOM anyway?
     return currentAnimation.event === 'leave' && newAnimation.structural;
   });
 
-  rules.skip.push(function(element, newAnimation, currentAnimation) {
+  rules.skip.push(function(newAnimation, currentAnimation) {
     // if there is an ongoing current animation then don't even bother running the class-based animation
     return currentAnimation.structural && currentAnimation.state === RUNNING_STATE && !newAnimation.structural;
   });
 
-  rules.cancel.push(function(element, newAnimation, currentAnimation) {
+  rules.cancel.push(function(newAnimation, currentAnimation) {
     // there can never be two structural animations running at the same time
     return currentAnimation.structural && newAnimation.structural;
   });
 
-  rules.cancel.push(function(element, newAnimation, currentAnimation) {
+  rules.cancel.push(function(newAnimation, currentAnimation) {
     // if the previous animation is already running, but the new animation will
     // be triggered, but the new animation is structural
     return currentAnimation.state === RUNNING_STATE && newAnimation.structural;
   });
 
-  rules.cancel.push(function(element, newAnimation, currentAnimation) {
+  rules.cancel.push(function(newAnimation, currentAnimation) {
     // cancel the animation if classes added / removed in both animation cancel each other out,
     // but only if the current animation isn't structural
 
@@ -408,7 +408,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       };
 
       if (hasExistingAnimation) {
-        var skipAnimationFlag = isAllowed('skip', element, newAnimation, existingAnimation);
+        var skipAnimationFlag = isAllowed('skip', newAnimation, existingAnimation);
         if (skipAnimationFlag) {
           if (existingAnimation.state === RUNNING_STATE) {
             close();
@@ -418,7 +418,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
             return existingAnimation.runner;
           }
         }
-        var cancelAnimationFlag = isAllowed('cancel', element, newAnimation, existingAnimation);
+        var cancelAnimationFlag = isAllowed('cancel', newAnimation, existingAnimation);
         if (cancelAnimationFlag) {
           if (existingAnimation.state === RUNNING_STATE) {
             // this will end the animation right away and it is safe
@@ -440,7 +440,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
           // a joined animation means that this animation will take over the existing one
           // so an example would involve a leave animation taking over an enter. Then when
           // the postDigest kicks in the enter will be ignored.
-          var joinAnimationFlag = isAllowed('join', element, newAnimation, existingAnimation);
+          var joinAnimationFlag = isAllowed('join', newAnimation, existingAnimation);
           if (joinAnimationFlag) {
             if (existingAnimation.state === RUNNING_STATE) {
               normalizeAnimationDetails(element, newAnimation);

--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -209,11 +209,11 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       });
     }
 
-    function cleanupEventListeners(phase, element) {
-      if (phase === 'close' && !element[0].parentNode) {
+    function cleanupEventListeners(phase, node) {
+      if (phase === 'close' && !node.parentNode) {
         // If the element is not attached to a parentNode, it has been removed by
         // the domOperation, and we can safely remove the event callbacks
-        $animate.off(element);
+        $animate.off(node);
       }
     }
 
@@ -567,10 +567,10 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
               forEach(callbacks, function(callback) {
                 callback(element, phase, data);
               });
-              cleanupEventListeners(phase, element);
+              cleanupEventListeners(phase, node);
             });
           } else {
-            cleanupEventListeners(phase, element);
+            cleanupEventListeners(phase, node);
           }
         });
         runner.progress(event, phase, data);

--- a/src/ngAnimate/animateQueue.js
+++ b/src/ngAnimate/animateQueue.js
@@ -393,7 +393,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       }
 
       if (isStructural) {
-        closeChildAnimations(element);
+        closeChildAnimations(node);
       }
 
       var newAnimation = {
@@ -585,8 +585,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       }
     }
 
-    function closeChildAnimations(element) {
-      var node = getDomNode(element);
+    function closeChildAnimations(node) {
       var children = node.querySelectorAll('[' + NG_ANIMATE_ATTR_NAME + ']');
       forEach(children, function(child) {
         var state = parseInt(child.getAttribute(NG_ANIMATE_ATTR_NAME), 10);

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -459,6 +459,28 @@ describe('animations', function() {
       expect(commentNode[0].parentNode).not.toBe(parentNode);
     }));
 
+    it('enter() should animate a transcluded clone with `templateUrl`', function() {
+      module(function($compileProvider) {
+        $compileProvider.directive('foo', function() {
+          return {templateUrl: 'foo.html'};
+        });
+      });
+
+      inject(function($animate, $compile, $rootScope, $templateCache) {
+        parent.append(jqLite('<foo ng-if="showFoo"></foo>'));
+        $templateCache.put('foo.html', '<div>FOO</div>');
+        $compile(parent)($rootScope);
+
+        expect(capturedAnimation).toBeNull();
+
+        $rootScope.$apply('showFoo = true');
+
+        expect(parent.text()).toBe('parentFOO');
+        expect(capturedAnimation[0].html()).toBe('<div>FOO</div>');
+        expect(capturedAnimation[1]).toBe('enter');
+      });
+    });
+
     it('enter() should issue an enter animation and fire the DOM operation right away before the animation kicks off', inject(function($animate, $rootScope) {
       expect(parent.children().length).toBe(0);
 
@@ -2437,7 +2459,6 @@ describe('animations', function() {
 
         return function($rootElement, $q, $animate, $$AnimateRunner, $document) {
           defaultFakeAnimationRunner = new $$AnimateRunner();
-          $animate.enabled(true);
 
           element = jqLite('<div class="element">element</div>');
           parent = jqLite('<div class="parent1">parent</div>');
@@ -2445,7 +2466,6 @@ describe('animations', function() {
 
           $rootElement.append(parent);
           $rootElement.append(parent2);
-          jqLite($document[0].body).append($rootElement);
         };
       }));
 

--- a/test/ngAnimate/animateSpec.js
+++ b/test/ngAnimate/animateSpec.js
@@ -168,7 +168,7 @@ describe('animations', function() {
       inject(function($animate, $rootScope) {
         $animate.enter(element, parent);
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
         expect(element[0].parentNode).toEqual(parent[0]);
 
         hidden = false;
@@ -188,7 +188,7 @@ describe('animations', function() {
 
         $animate.enter(element, parent);
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         element.addClass('only-allow-this-animation');
 
@@ -208,7 +208,7 @@ describe('animations', function() {
 
         $animate.enter(svgElement, parent);
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         svgElement.attr('class', 'element only-allow-this-animation-svg');
 
@@ -290,7 +290,7 @@ describe('animations', function() {
         $animate.leave(element);
         $rootScope.$digest();
 
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
         expect(element[0].parentNode).toBeFalsy();
       });
     });
@@ -314,9 +314,9 @@ describe('animations', function() {
 
         $animate.enter(element, parent);
 
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
       }));
 
       it('should disable all animations on the given element',
@@ -328,15 +328,15 @@ describe('animations', function() {
         expect($animate.enabled(element)).toBeFalsy();
 
         $animate.addClass(element, 'red');
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         $animate.enabled(element, true);
         expect($animate.enabled(element)).toBeTruthy();
 
         $animate.addClass(element, 'blue');
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
         $rootScope.$digest();
         expect(capturedAnimation).toBeTruthy();
       }));
@@ -347,14 +347,14 @@ describe('animations', function() {
         $animate.enabled(parent, false);
 
         $animate.enter(element, parent);
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         $animate.enabled(parent, true);
 
         $animate.enter(element, parent);
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
         $rootScope.$digest();
         expect(capturedAnimation).toBeTruthy();
       }));
@@ -370,11 +370,11 @@ describe('animations', function() {
 
         $animate.addClass(element, 'red');
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         $animate.addClass(child, 'red');
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         $animate.enabled(element, true);
 
@@ -402,7 +402,7 @@ describe('animations', function() {
       $rootScope.items = [1,2,3,4,5];
       $rootScope.$digest();
 
-      expect(capturedAnimation).toBeFalsy();
+      expect(capturedAnimation).toBeNull();
     }));
 
     it('should not attempt to perform an animation on a text node element',
@@ -414,7 +414,7 @@ describe('animations', function() {
       $animate.addClass(textNode, 'some-class');
       $rootScope.$digest();
 
-      expect(capturedAnimation).toBeFalsy();
+      expect(capturedAnimation).toBeNull();
     }));
 
     it('should not attempt to perform an animation on an empty jqLite collection',
@@ -426,7 +426,7 @@ describe('animations', function() {
         $animate.addClass(emptyNode, 'some-class');
         $rootScope.$digest();
 
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
       })
     );
 
@@ -439,7 +439,7 @@ describe('animations', function() {
 
       $animate.leave(textNode);
       $rootScope.$digest();
-      expect(capturedAnimation).toBeFalsy();
+      expect(capturedAnimation).toBeNull();
       expect(textNode[0].parentNode).not.toBe(parentNode);
     }));
 
@@ -455,7 +455,7 @@ describe('animations', function() {
 
       $animate.leave(commentNode);
       $rootScope.$digest();
-      expect(capturedAnimation).toBeFalsy();
+      expect(capturedAnimation).toBeNull();
       expect(commentNode[0].parentNode).not.toBe(parentNode);
     }));
 
@@ -667,13 +667,13 @@ describe('animations', function() {
 
         $animate.removeClass(element, 'something-to-remove');
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         element.addClass('something-to-add');
 
         $animate.addClass(element, 'something-to-add');
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
       }));
     });
 
@@ -689,7 +689,7 @@ describe('animations', function() {
           parent.append(element);
           $animate.animate(element, null, toStyle);
           $rootScope.$digest();
-          expect(capturedAnimation).toBeFalsy();
+          expect(capturedAnimation).toBeNull();
         });
       });
 
@@ -700,7 +700,7 @@ describe('animations', function() {
         parent.append(element);
         $animate.animate(element, fromStyle);
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
       }));
 
       it('should perform an animation if only from styles are provided as well as any valid classes',
@@ -712,7 +712,7 @@ describe('animations', function() {
         var options = { removeClass: 'goop' };
         $animate.animate(element, fromStyle, null, null, options);
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         fromStyle = { color: 'blue' };
         options = { addClass: 'goop' };
@@ -816,11 +816,11 @@ describe('animations', function() {
 
         var elm1 = $compile('<div class="animated"></div>')($rootScope);
 
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
         $animate.addClass(elm1, 'klass2');
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
       }));
 
       it('should skip animations if the element is attached to the $rootElement, but not apart of the body',
@@ -834,22 +834,22 @@ describe('animations', function() {
         newParent.append($rootElement);
         $rootElement.append(elm1);
 
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
         $animate.addClass(elm1, 'klass2');
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
       }));
 
       it('should skip the animation if the element is removed from the DOM before the post digest kicks in',
         inject(function($animate, $rootScope) {
 
         $animate.enter(element, parent);
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         element.remove();
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
       }));
 
       it('should be blocked when there is an ongoing structural parent animation occurring',
@@ -857,7 +857,7 @@ describe('animations', function() {
 
         parent.append(element);
 
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
         $animate.move(parent, parent2);
         $rootScope.$digest();
 
@@ -867,7 +867,7 @@ describe('animations', function() {
 
         $animate.addClass(element, 'blue');
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
       }));
 
       it('should disable all child animations for atleast one turn when a structural animation is issued',
@@ -917,7 +917,7 @@ describe('animations', function() {
 
         parent.append(element);
 
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
         $animate.addClass(parent, 'rogers');
         $rootScope.$digest();
 
@@ -940,7 +940,7 @@ describe('animations', function() {
           $animate.addClass(element, 'rumlow');
           $animate.move(parent, null, parent2);
 
-          expect(capturedAnimation).toBeFalsy();
+          expect(capturedAnimation).toBeNull();
           expect(capturedAnimationHistory.length).toBe(0);
           $rootScope.$digest();
 
@@ -1193,12 +1193,12 @@ describe('animations', function() {
         inject(function($animate, $rootScope) {
 
         $animate.enter(element, parent);
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         $animate.addClass(element, 'red');
         expect(element).not.toHaveClass('red');
 
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
         $rootScope.$digest();
 
         expect(capturedAnimation[1]).toBe('enter');
@@ -1227,7 +1227,7 @@ describe('animations', function() {
         $animate.removeClass(element, 'red');
         $rootScope.$digest();
 
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         $animate.addClass(element, 'blue');
         $rootScope.$digest();
@@ -1344,7 +1344,7 @@ describe('animations', function() {
         $animate.removeClass(element, 'four');
 
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
       }));
 
       it('but not skip the animation if it is a structural animation and if there are no classes to be animated',
@@ -1632,7 +1632,7 @@ describe('animations', function() {
 
         $animate.addClass(animateElement, 'red');
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         // Pin the element to the app root to enable animations
         $animate.pin(pinElement, $rootElement);
@@ -1676,13 +1676,13 @@ describe('animations', function() {
 
         $animate.addClass(animateElement, 'red');
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         $animate.pin(pinElement, pinTargetElement);
 
         $animate.addClass(animateElement, 'blue');
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         dealoc(pinElement);
       });
@@ -1720,7 +1720,7 @@ describe('animations', function() {
 
         $animate.addClass(animateElement, 'blue');
         $rootScope.$digest();
-        expect(capturedAnimation).toBeFalsy();
+        expect(capturedAnimation).toBeNull();
 
         $animate.enabled(pinHostElement, true);
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.


**What is the current behavior? (You can also link to an open issue here)**
`$animate` decides whether an animation should be cancelled based on some assumption that don't hold in specific cases (e.g. when animating transcluded clones with `templateUrl` directives on them for the first time). As a result, the entering elements will not be animated in such cases. This affects commonly used, structural built-in directives (`ngIf`, `ngRepeat`, `ngSwitch` etc).
See also #15510.


**What is the new behavior (if this is a feature change)?**
All entering animations work as expected (from the first time).


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
BTW, I believe this is a side effect of lazily compiling transcluded content.

In addition to the last `fix` commit that fixes the bug, this PR also includes several `refactor` commits that simplify `$animate` internally, mainly by removing unnecessary wrapping/unwrapping of DOM nodes in `jqLite`/`jQuery` collections. This changes may also positively affect performance, especially in animation-heavy apps (~~although I haven't benchmarked it - yet~~ it does indeed :wink:).
(It is probably easier to review one commit at a time.)

Party addresses #14074 and #14124.

Fixes #15510.
