### PR TITLE
Add traceback to unhandled promise rejections

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -381,7 +381,11 @@ function qFactory(nextTick, exceptionHandler, errorOnUnhandledRejections) {
       if (!toCheck.pur) {
         toCheck.pur = true;
         var errorMessage = 'Possibly unhandled rejection: ' + toDebugString(toCheck.value);
-        exceptionHandler(errorMessage);
+        if (toCheck.value instanceof Error) {
+          exceptionHandler(toCheck.value, errorMessage);
+        } else {
+          exceptionHandler(errorMessage);
+        }
       }
     }
   }

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -2167,45 +2167,53 @@ describe('q', function() {
 
 
   describe('when exceptionHandler is called', function() {
-    it('should log an unhandled rejected promise', function() {
-      var defer = q.defer();
-      defer.reject('foo');
-      mockNextTick.flush();
-      expect(exceptionHandlerStr()).toBe('Possibly unhandled rejection: foo');
-    });
+    var fixtures = [
+      { type: 'exception', value: new Error('Fail') },
+      { type: 'plain value', value: 'foo' }
+    ];
+    forEach(fixtures, function(fixture) {
+      var type = fixture.type;
+      var value = fixture.value;
+      it('should log an unhandled' + type + ' rejected promise', function() {
+        var defer = q.defer();
+        defer.reject('foo');
+        mockNextTick.flush();
+        expect(exceptionHandlerStr()).toBe('Possibly unhandled rejection: foo');
+      });
 
 
-    it('should not log an unhandled rejected promise if disabled', function() {
-      var defer = q_no_error.defer();
-      defer.reject('foo');
-      expect(exceptionHandlerStr()).toBe('');
-    });
+      it('should not log an unhandled' + type + ' rejected promise if disabled', function() {
+        var defer = q_no_error.defer();
+        defer.reject('foo');
+        expect(exceptionHandlerStr()).toBe('');
+      });
 
 
-    it('should log a handled rejected promise on a promise without rejection callbacks', function() {
-      var defer = q.defer();
-      defer.promise.then(noop);
-      defer.reject('foo');
-      mockNextTick.flush();
-      expect(exceptionHandlerStr()).toBe('Possibly unhandled rejection: foo');
-    });
+      it('should log a handled' + type ' rejected promise on a promise without rejection callbacks', function() {
+        var defer = q.defer();
+        defer.promise.then(noop);
+        defer.reject('foo');
+        mockNextTick.flush();
+        expect(exceptionHandlerStr()).toBe('Possibly unhandled rejection: foo');
+      });
 
 
-    it('should not log a handled rejected promise', function() {
-      var defer = q.defer();
-      defer.promise.catch(noop);
-      defer.reject('foo');
-      mockNextTick.flush();
-      expect(exceptionHandlerStr()).toBe('');
-    });
+      it('should not log a handled' + type + 'rejected promise', function() {
+        var defer = q.defer();
+        defer.promise.catch(noop);
+        defer.reject('foo');
+        mockNextTick.flush();
+        expect(exceptionHandlerStr()).toBe('');
+      });
 
 
-    it('should not log a handled rejected promise that is handled in a future tick', function() {
-      var defer = q.defer();
-      defer.promise.catch(noop);
-      defer.resolve(q.reject('foo'));
-      mockNextTick.flush();
-      expect(exceptionHandlerStr()).toBe('');
+      it('should not log a handled' + type ' rejected promise that is handled in a future tick', function() {
+        var defer = q.defer();
+        defer.promise.catch(noop);
+        defer.resolve(q.reject('foo'));
+        mockNextTick.flush();
+        expect(exceptionHandlerStr()).toBe('');
+      });
     });
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature


**What is the current behavior? (You can also link to an open issue here)**
Console is filled with meaningless:  `Possibly unhandled rejection: {}` errors


**What is the new behavior (if this is a feature change)?**
Console is filled with juicy traceback info.


**Does this PR introduce a breaking change?**
I don't think so


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

