### PR TITLE
Add traceback to unhandled promise rejections, Fixes: #14631

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -381,7 +381,11 @@ function qFactory(nextTick, exceptionHandler, errorOnUnhandledRejections) {
       if (!toCheck.pur) {
         toCheck.pur = true;
         var errorMessage = 'Possibly unhandled rejection: ' + toDebugString(toCheck.value);
-        exceptionHandler(errorMessage);
+        if (toCheck.value instanceof Error) {
+          exceptionHandler(toCheck.value, errorMessage);
+        } else {
+          exceptionHandler(errorMessage);
+        }
       }
     }
   }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature


**What is the current behavior? (You can also link to an open issue here)**
Console is filled with meaningless:  `Possibly unhandled rejection: {}` errors


**What is the new behavior (if this is a feature change)?**
Console is filled with juicy traceback info.


**Does this PR introduce a breaking change?**
I don't think so


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**: