### PR TITLE
docs($exceptionHandler): replace Exception with the JS standard: Error.

### DIFF
--- a/src/ng/exceptionHandler.js
+++ b/src/ng/exceptionHandler.js
@@ -7,7 +7,7 @@
  * @this
  *
  * @description
- * Any uncaught exception in angular expressions is delegated to this service.
+ * Any uncaught Error in angular expressions is delegated to this service.
  * The default implementation simply delegates to `$log.error` which logs it into
  * the browser console.
  *
@@ -22,31 +22,33 @@
  *
  * ```js
  *   angular.
- *     module('exceptionOverwrite', []).
+ *     module('errorOverwrite', []).
  *     factory('$exceptionHandler', ['$log', 'logErrorsToBackend', function($log, logErrorsToBackend) {
- *       return function myExceptionHandler(exception, cause) {
- *         logErrorsToBackend(exception, cause);
- *         $log.warn(exception, cause);
+ *       return function myErrorHandler(exception, cause) {
+ *         logErrorsToBackend(error, cause);
+ *         $log.warn(error, cause);
  *       };
  *     }]);
  * ```
  *
  * <hr />
  * Note, that code executed in event-listeners (even those registered using jqLite's `on`/`bind`
- * methods) does not delegate exceptions to the {@link ng.$exceptionHandler $exceptionHandler}
+ * methods) does not delegate errors to the {@link ng.$exceptionHandler $exceptionHandler}
  * (unless executed during a digest).
- *
+ * 
+ * Also note, that the serive is misnamed '$exceptionHandler' for legacy reasons, because JavaScript
+ * has no exceptions: only Errors.
  * If you wish, you can manually delegate exceptions, e.g.
  * `try { ... } catch(e) { $exceptionHandler(e); }`
  *
- * @param {Error} exception Exception associated with the error.
+ * @param {Error} error Error associated with the error.
  * @param {string=} cause Optional information about the context in which
  *       the error was thrown.
  *
  */
 function $ExceptionHandlerProvider() {
   this.$get = ['$log', function($log) {
-    return function(exception, cause) {
+    return function(error, cause) {
       $log.error.apply($log, arguments);
     };
   }];

--- a/src/ng/exceptionHandler.js
+++ b/src/ng/exceptionHandler.js
@@ -36,7 +36,7 @@
  * methods) does not delegate errors to the {@link ng.$exceptionHandler $exceptionHandler}
  * (unless executed during a digest).
  * 
- * Also note, that the serive is misnamed '$exceptionHandler' for legacy reasons, because JavaScript
+ * Also note, that the service is misnamed '$exceptionHandler' for legacy reasons, because JavaScript
  * has no exceptions: only Errors.
  * If you wish, you can manually delegate exceptions, e.g.
  * `try { ... } catch(e) { $exceptionHandler(e); }`


### PR DESCRIPTION
JS doesn't have Exceptions.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
doc fix.


**What is the current behavior? (You can also link to an open issue here)**
docs mention 'exceptions'. Is this Java or C#?


**What is the new behavior (if this is a feature change)?**
Use Errors. This is the ECMAScript term for stack traversing failures.


**Does this PR introduce a breaking change?**
Nope


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

