### PR TITLE
fix($$cookieReader): safe get cookie

### DIFF
--- a/src/ng/cookieReader.js
+++ b/src/ng/cookieReader.js
@@ -14,6 +14,14 @@ function $$CookieReader($document) {
   var lastCookies = {};
   var lastCookieString = '';
 
+  function safeGetCookie(rawDocument) {
+    try {
+      return rawDocument.cookie || '';
+    } catch (e) {
+      return '';
+    }
+  }
+
   function safeDecodeURIComponent(str) {
     try {
       return decodeURIComponent(str);
@@ -24,7 +32,7 @@ function $$CookieReader($document) {
 
   return function() {
     var cookieArray, cookie, i, index, name;
-    var currentCookieString = rawDocument.cookie || '';
+    var currentCookieString = safeGetCookie(rawDocument);
 
     if (currentCookieString !== lastCookieString) {
       lastCookieString = currentCookieString;

--- a/test/ng/cookieReaderSpec.js
+++ b/test/ng/cookieReaderSpec.js
@@ -103,3 +103,30 @@ describe('$$cookieReader', function() {
 
 });
 
+
+describe('$$cookieReader with mock $document', function() {
+
+  var $$cookieReader, mockDocument;
+
+  beforeEach(function() {
+    mockDocument = {};
+    module(function($provide) {
+      $provide.constant('$document', [mockDocument]);
+    });
+    inject(function(_$$cookieReader_) {
+      $$cookieReader = _$$cookieReader_;
+    });
+  });
+
+  describe('getAll via $$cookieReader()', function() {
+
+    it('should return an empty object if cookies cannot be read', function() {
+      var cookieSpy = jasmine.createSpy('cookie').and.throwError('Can\'t touch this!');
+      Object.defineProperty(mockDocument, 'cookie', { get: cookieSpy });
+      expect($$cookieReader()).toEqual({});
+      expect(cookieSpy).toHaveBeenCalled();
+    });
+
+  });
+
+});


### PR DESCRIPTION
Return an empty string when an error is catched while getting cookie.

Closes #15523

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

https://github.com/angular/angular.js/issues/15523

**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

