### PR TITLE
fix(sce/urlUtils): Use baseURI for same-origin checks, and bump base#href to RESOURCE_URL 

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3256,6 +3256,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       // maction[xlink:href] can source SVG.  It's not limited to <maction>.
       } else if (attrNormalizedName === 'xlinkHref' ||
           (tag === 'form' && attrNormalizedName === 'action') ||
+          // base href is just plain weird and scary. If relative URLs don't go where they are
+          // expected to, all bets are off.
+          (tag === 'base' && attrNormalizedName === 'href') ||
           // links can be stylesheets or imports, which can run script in the current origin
           (tag === 'link' && attrNormalizedName === 'href')
       ) {

--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -235,6 +235,7 @@ function $SceDelegateProvider() {
     }
 
     function isResourceUrlAllowedByPolicy(url) {
+      // The urlResolve step should take care of baseURI if it's set.
       var parsedUrl = urlResolve(url.toString());
       var i, n, allowed = false;
       // Ensure that at least one item from the whitelist allows this url.

--- a/src/ng/urlUtils.js
+++ b/src/ng/urlUtils.js
@@ -7,7 +7,13 @@
 // exactly the behavior needed here.  There is little value is mocking these out for this
 // service.
 var urlParsingNode = window.document.createElement('a');
-var originUrl = urlResolve(window.location.href);
+
+// We use the baseURI instead of the location. The behavior of relative URIs is more intuitive
+// this way when mixed with a base tag, and the $sce security checks will rely on this. Also note
+// that baseURI can evolve over time, so we need to reevaluate.
+var getOriginUrl = function() {
+  return urlResolve(window.document.baseURI);
+};
 
 
 /**
@@ -85,6 +91,8 @@ function urlResolve(url) {
 
 /**
  * Parse a request URL and determine whether this is a same-origin request as the application document.
+ * We rely on document.baseURI to determine our origin, to make applications that use base behave as
+ * expected with relative URIs.
  *
  * @param {string|object} requestUrl The url of the request as a string that will be resolved
  * or a parsed URL object.
@@ -92,6 +100,6 @@ function urlResolve(url) {
  */
 function urlIsSameOrigin(requestUrl) {
   var parsed = (isString(requestUrl)) ? urlResolve(requestUrl) : requestUrl;
-  return (parsed.protocol === originUrl.protocol &&
-          parsed.host === originUrl.host);
+  return (parsed.protocol === getOriginUrl().protocol &&
+          parsed.host === getOriginUrl().host);
 }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -11162,6 +11162,22 @@ describe('$compile', function() {
     }));
   });
 
+  describe('base[href]', function() {
+    it('should be a RESOURCE_URL context', inject(function($compile, $rootScope, $sce) {
+      element = $compile('<base href="{{testUrl}}"/>')($rootScope);
+
+      $rootScope.testUrl = $sce.trustAsResourceUrl('https://example.com/');
+      $rootScope.$apply();
+      expect(element.attr('href')).toContain('https://example.com/');
+
+      $rootScope.testUrl = 'https://not.example.com/';
+      expect(function() { $rootScope.$apply(); }).toThrowMinErr(
+          '$interpolate', 'interr', 'Can\'t interpolate: {{testUrl}}\nError: [$sce:insecurl] Blocked ' +
+          'loading resource from url not allowed by $sceDelegate policy.  URL: ' +
+          'https://not.example.com/');
+    }));
+  });
+
   // Support: IE 9-10 only
   // IEs <11 don't support srcdoc
   if (!msie || msie === 11) {

--- a/test/ng/urlUtilsSpec.js
+++ b/test/ng/urlUtilsSpec.js
@@ -45,8 +45,8 @@ describe('urlUtils', function() {
 
 
     it('should follow document.baseURI', inject(function($document) {
-      $document[0].body.appendChild($document[0].createElement('base'));
-      $document[0].body.lastChild.href = 'http://example.com/';
+      $document[0].head.appendChild($document[0].createElement('base'));
+      $document[0].head.lastChild.href = 'http://example.com/';
       expectIsSameOrigin('path', true);
       var origin = urlResolve($document[0].location.href);
 
@@ -55,6 +55,7 @@ describe('urlUtils', function() {
 
       // But the baseURI should.
       expectIsSameOrigin('http://example.com/path', true);
+      $document[0].head.lastChild.href = null;
     }));
   });
 });

--- a/test/ng/urlUtilsSpec.js
+++ b/test/ng/urlUtilsSpec.js
@@ -24,11 +24,13 @@ describe('urlUtils', function() {
   });
 
   describe('isSameOrigin', function() {
+
+    function expectIsSameOrigin(url, expectedValue) {
+      expect(urlIsSameOrigin(url)).toBe(expectedValue);
+      expect(urlIsSameOrigin(urlResolve(url))).toBe(expectedValue);
+    }
+
     it('should support various combinations of urls - both string and parsed', inject(function($document) {
-      function expectIsSameOrigin(url, expectedValue) {
-        expect(urlIsSameOrigin(url)).toBe(expectedValue);
-        expect(urlIsSameOrigin(urlResolve(url))).toBe(expectedValue);
-      }
       expectIsSameOrigin('path', true);
       var origin = urlResolve($document[0].location.href);
       expectIsSameOrigin('//' + origin.host + '/path', true);
@@ -39,6 +41,20 @@ describe('urlUtils', function() {
       // Should not match when the ports are different.
       // This assumes that the test is *not* running on port 22 (very unlikely).
       expectIsSameOrigin('//' + origin.hostname + ':22/path', false);
+    }));
+
+
+    it('should follow document.baseURI', inject(function($document) {
+      $document[0].body.appendChild($document[0].createElement('base'));
+      $document[0].body.lastChild.href = 'http://example.com/';
+      expectIsSameOrigin('path', true);
+      var origin = urlResolve($document[0].location.href);
+
+      // Real origin shouldn't be considered okay anymore.
+      expectIsSameOrigin('//' + origin.host + '/path', false);
+
+      // But the baseURI should.
+      expectIsSameOrigin('http://example.com/path', true);
     }));
   });
 });


### PR DESCRIPTION
When a base tag is set in the page, relative links will be resolved to its href
attribute. However, isSameOrigin currently checks against the location, so relative
links wouldn't be considered same-origin for security purposes. This commit changes
to baseURI: it should behave the same when baseURI is left to the default value, but
that preserves the $sce's implicit trust in relative URIs when baseURI is changed (which
was #15144). 

And while I'm at it, bump base#href to RESOURCE_URL, since it affects security behavior.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix for #15144 + fix the wrong base#href context.

**What is the current behavior? (You can also link to an open issue here)**

Base#href is just URL context, isUrlSameOrigin looks at the location for same-origin checks.

**Does this PR introduce a breaking change?**

Yes, if you dynamically set base#href or rely on your old origin being trusted after changing baseURI. I don't think that represents many apps, but it's hard to tell?

======

"End of the week" turned out to be optimistic, I'm sorry about the delay :/ 

I was wary of the way baseURI is handled, which differs a lot depending on browsers. Try setting base href="data:text/", and a href="html,foo", you'll see that chrome sets the baseURI but sets the href to the empty string, while Firefox keeps the href but doesn't set the baseURI. It's all very strange and I was afraid the checks wouldn't follow the behavior of the browser, but it's a red herring in this case. Angular just shouldn't let base href be controlled by an attacker (= RESOURCE_URL). 