### PR TITLE
fix($injector): do not use inherited $inject

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -100,7 +100,8 @@ function annotate(fn, strictDi, name) {
       last;
 
   if (typeof fn === 'function') {
-    if (!($inject = fn.$inject)) {
+    $inject = fn.hasOwnProperty('$inject') ? fn.$inject : undefined;
+    if (!$inject) {
       $inject = [];
       if (fn.length) {
         if (strictDi) {

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -191,6 +191,21 @@ describe('injector', function() {
     });
 
 
+    it('should not use inherited $inject', function() {
+      function base() {}
+      base.$inject = ['a'];
+      function derived(b) {}
+      if (Object.setPrototypeOf) {
+        Object.setPrototypeOf(derived, base);
+      } else {
+        /* eslint-disable no-proto */
+        derived.__proto__ = base;
+        /* eslint-enable */
+      }
+      expect(annotate(derived)).toEqual(['b']);
+    });
+
+
     it('should create $inject', function() {
       var extraParams = angular.noop;
       /* eslint-disable space-before-function-paren */


### PR DESCRIPTION
Ensure that a function has its own $inject property, and not an inherited
property, when annotating. This ensures that derived functions / classes do not
get the dependencies of their super class.

Fixes #15536

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

#15536 

**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**

Yes

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

BREAKING CHANGE:

Prior to this PR, derived classes with no dependencies could extend base classes with dependencies, as long as the derived classes did not have constructors. As of this PR, the derived class would be seen as having no dependencies, and the base class's constructor would be called with no arguments.