### PR TITLE
feat(isArray): make angular.isArray support Array subclasses

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -219,8 +219,7 @@ function isArrayLike(obj) {
 
   // NodeList objects (with `item` method) and
   // other objects with suitable length characteristics are array-like
-  return isNumber(length) &&
-    (length >= 0 && ((length - 1) in obj || obj instanceof Array) || typeof obj.item === 'function');
+  return isNumber(length) && (length >= 0 && (length - 1) in obj || typeof obj.item === 'function');
 
 }
 
@@ -635,12 +634,14 @@ function isDate(value) {
  * @kind function
  *
  * @description
- * Determines if a reference is an `Array`. Alias of Array.isArray.
+ * Determines if a reference is an `Array`.
  *
  * @param {*} value Reference to check.
  * @returns {boolean} True if `value` is an `Array`.
  */
-var isArray = Array.isArray;
+function isArray(arr) {
+  return arr instanceof Array || Array.isArray(arr);
+}
 
 /**
  * @description

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1251,6 +1251,16 @@ describe('angular', function() {
     });
   });
 
+  describe('isArray', function() {
+
+    it('should return true if passed an object prototypically inherited from Array.prototype', function() {
+      function FooArray() {}
+      FooArray.prototype = [];
+      expect(isArray(new FooArray())).toBe(true);
+    });
+
+  });
+
   describe('isArrayLike', function() {
 
     it('should return false if passed a number', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feature

**What is the current behavior? (You can also link to an open issue here)**

Angular doesn't recognise objects prototypically inherited from `Array.prototype` as arrays.
See #15533

**What is the new behavior (if this is a feature change)?**

In particular, this change gets Angular to play nicely with MobX observable arrays. 

**Does this PR introduce a breaking change?**

Yes. `angular.isArray` is used throughout Angular. In particular, after this change, `angular.copy` will use the array-cloning logic for objects prototypically inherited from `Array.prototype` whereas now it uses the object-cloning logic for them. This, in turn, affects deep watchers and other parts of the framework that use `angular.copy`.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
