### PR TITLE
fix(angularInit): allow auto-bootstraping from inline script

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1479,12 +1479,16 @@ function getNgAttribute(element, ngAttr) {
 }
 
 function allowAutoBootstrap(document) {
-  if (!document.currentScript) {
+  var script = document.currentScript;
+  var src = script && script.getAttribute('src');
+
+  if (!src) {
     return true;
   }
-  var src = document.currentScript.getAttribute('src');
+
   var link = document.createElement('a');
   link.href = src;
+
   if (document.location.origin === link.origin) {
     // Same-origin resources are always allowed, even for non-whitelisted schemes.
     return true;

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1684,7 +1684,8 @@ describe('angular', function() {
     });
 
     it('should bootstrap from an extension into an extension document for same-origin documents only', function() {
-      if (msie) return;  // IE does not support document.currentScript (nor extensions with protocol), so skip test.
+      // IE does not support `document.currentScript` (nor extensions with protocol), so skip test.
+      if (msie) return;
 
       // Extension URLs are browser-specific, so we must choose a scheme that is supported by the browser to make
       // sure that the URL is properly parsed.
@@ -1715,8 +1716,28 @@ describe('angular', function() {
       expect(allowAutoBootstrap(fakeDoc)).toBe(false);
     });
 
+    it('should bootstrap from a script with an empty or missing `src` attribute', function() {
+      // IE does not support `document.currentScript` (nor extensions with protocol), so skip test.
+      if (msie) return;
+
+      // Fake a minimal document object (the actual document.currentScript is readonly).
+      var src;
+      var fakeDoc = {
+        createElement: document.createElement.bind(document),
+        currentScript: {getAttribute: function() { return src; }},
+        location: {origin: 'some-value', protocol: 'http:'}
+      };
+
+      src = null;
+      expect(allowAutoBootstrap(fakeDoc)).toBe(true);
+
+      src = '';
+      expect(allowAutoBootstrap(fakeDoc)).toBe(true);
+    });
+
     it('should not bootstrap from an extension into a non-extension document', function() {
-      if (msie) return;  // IE does not support document.currentScript (nor extensions with protocol), so skip test.
+      // IE does not support `document.currentScript` (nor extensions with protocol), so skip test.
+      if (msie) return;
 
       var src = 'resource://something';
       // Fake a minimal document object (the actual document.currentScript is readonly).


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.


**What is the current behavior? (You can also link to an open issue here)**
Some browsers (e.g. Safari 9.x, PhantomJS) do not set `link.origin/protocol` correctly, when setting `link.href` to `null`, which prevents auto-bootstraping Angular from scripts without a `src` attribute (i.e. inline scripts).
See also #15567.

**What is the new behavior (if this is a feature change)?**
Auto-bootstraping Angular from inline scripts is allowed.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Inline scripts are on the same origin as the loading page, so auto-bootstraping
should be allowed.

Fixes #15567.