### PR TITLE
docs($log): add blackboxing hint

### DIFF
--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -10,6 +10,9 @@
  * into the browser's console (if present).
  *
  * The main purpose of this service is to simplify debugging and troubleshooting.
+ * 
+ * To reveal the location of the calls to `$log` in the JavaScript console,
+ * "blackbox" the Angular source in your browser.
  *
  * The default is to log `debug` messages. You can use
  * {@link ng.$logProvider ng.$logProvider#debugEnabled} to change this.


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Document update

**What is the current behavior? (You can also link to an open issue here)**

The documentation for $log doesn't mention blackboxing, by which a developer can see the originating line of calls to $log.

**What is the new behavior (if this is a feature change)?**

A brief, browser-agnostic mention of blackboxing was added to the page.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

