### PR TITLE
fix(ngValue): setting binding to undefined should update the DOM value to an empty string

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2142,6 +2142,8 @@ var ngValueDirective = function() {
    *  makes it possible to use ngValue as a sort of one-way bind.
    */
   function updateElementValue(element, attr, value) {
+    // Support: IE9 only
+    // In IE9 values are converted to string (e.g. `input.value = null` results in `input.value === 'null'`).
     var propValue = isDefined(value) ? value : (msie === 9) ? '' : null;
     element.prop('value', propValue);
     attr.$set('value', value);

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2142,7 +2142,7 @@ var ngValueDirective = function() {
    *  makes it possible to use ngValue as a sort of one-way bind.
    */
   function updateElementValue(element, attr, value) {
-    var propValue = angular.isDefined(value) ? value : (msie === 9) ? '' : null;
+    var propValue = isDefined(value) ? value : (msie === 9) ? '' : null;
     element.prop('value', propValue);
     attr.$set('value', value);
   }

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2142,7 +2142,7 @@ var ngValueDirective = function() {
    *  makes it possible to use ngValue as a sort of one-way bind.
    */
   function updateElementValue(element, attr, value) {
-    element.prop('value', value);
+    element.prop('value', angular.isUndefined(value) ? null : value);
     attr.$set('value', value);
   }
 

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -2142,7 +2142,8 @@ var ngValueDirective = function() {
    *  makes it possible to use ngValue as a sort of one-way bind.
    */
   function updateElementValue(element, attr, value) {
-    element.prop('value', angular.isUndefined(value) ? null : value);
+    var propValue = angular.isDefined(value) ? value : (msie === 9) ? '' : null;
+    element.prop('value', propValue);
     attr.$set('value', value);
   }
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -4211,7 +4211,7 @@ describe('input', function() {
       expect(inputElm[0].getAttribute('value')).toBe('something');
     });
 
-    it('should update the dom "value" to "" and attribute to null when the binding is set to undefined', function() {
+    it('should clear the "dom" value property and attribute when the value is undefined', function() {
       var inputElm = helper.compileInput('<input type="text" ng-value="value">');
 
       $rootScope.$apply('value = "something"');

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -4214,7 +4214,7 @@ describe('input', function() {
     it('should update the dom "value" to "" and attribute to null when the binding is set to undefined', function() {
       var inputElm = helper.compileInput('<input type="text" ng-value="value">');
 
-      $rootScope.$apply('value = \'something\'');
+      $rootScope.$apply('value = "something"');
 
       expect(inputElm[0].value).toBe('something');
       expect(inputElm[0].getAttribute('value')).toBe('something');
@@ -4224,7 +4224,11 @@ describe('input', function() {
       });
 
       expect(inputElm[0].value).toBe('');
-      expect(inputElm[0].getAttribute('value')).toBe(null);
+      // Support: IE 9-11
+      // In IE it is not possible to remove the `value` attribute from an input element.
+      if (!msie) {
+        expect(inputElm[0].getAttribute('value')).toBeNull();
+      }
     });
 
     they('should update the $prop "value" property and attribute after the bound expression changes', {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -4211,7 +4211,7 @@ describe('input', function() {
       expect(inputElm[0].getAttribute('value')).toBe('something');
     });
 
-    it('should update the dom "value" to "" and attribute to null when the binding is set to undefind', function() {
+    it('should update the dom "value" to "" and attribute to null when the binding is set to undefined', function() {
       var inputElm = helper.compileInput('<input type="text" ng-value="value">');
 
       $rootScope.$apply('value = \'something\'');

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -4211,7 +4211,7 @@ describe('input', function() {
       expect(inputElm[0].getAttribute('value')).toBe('something');
     });
 
-    it('should update the dom "value" "" and attribute to null when the binding is set to undefind', function() {
+    it('should update the dom "value" to "" and attribute to null when the binding is set to undefind', function() {
       var inputElm = helper.compileInput('<input type="text" ng-value="value">');
 
       $rootScope.$apply('value = \'something\'');

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -4218,11 +4218,11 @@ describe('input', function() {
 
       expect(inputElm[0].value).toBe('something');
       expect(inputElm[0].getAttribute('value')).toBe('something');
-      
+
       $rootScope.$apply(function() {
         delete $rootScope.value;
       });
-      
+
       expect(inputElm[0].value).toBe('');
       expect(inputElm[0].getAttribute('value')).toBe(null);
     });

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -4211,6 +4211,22 @@ describe('input', function() {
       expect(inputElm[0].getAttribute('value')).toBe('something');
     });
 
+    it('should update the dom "value" "" and attribute to null when the binding is set to undefind', function() {
+      var inputElm = helper.compileInput('<input type="text" ng-value="value">');
+
+      $rootScope.$apply('value = \'something\'');
+
+      expect(inputElm[0].value).toBe('something');
+      expect(inputElm[0].getAttribute('value')).toBe('something');
+      
+      $rootScope.$apply(function() {
+        delete $rootScope.value;
+      });
+      
+      expect(inputElm[0].value).toBe('');
+      expect(inputElm[0].getAttribute('value')).toBe(null);
+    });
+
     they('should update the $prop "value" property and attribute after the bound expression changes', {
       input: '<input type="text" ng-value="value">',
       textarea: '<textarea ng-value="value"></textarea>'


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
Setting the binding to undefined calls jqLite/jQuery's `prop()` function, passing undefined as the second argument: `element.prop('value', undefined)`.
This is identical to `element.prop('value')` and will retrieve the dom value instead of updating it.

See: https://github.com/angular/angular.js/issues/15603

**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

