### PR TITLE
Set request timeout response status

### DIFF
--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -108,9 +108,14 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
         completeRequest(callback, -1, null, null, '');
       };
 
+      var requestTimeout = function() {
+        // Set standard request timeout status code: 408
+        completeRequest(callback, 408, null, null, '');
+      };
+
       xhr.onerror = requestError;
       xhr.onabort = requestError;
-      xhr.ontimeout = requestError;
+      xhr.ontimeout = requestTimeout;
 
       forEach(eventHandlers, function(value, key) {
           xhr.addEventListener(key, value);

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -175,7 +175,7 @@ describe('$httpBackend', function() {
 
   it('should complete the request on timeout', function() {
     callback.and.callFake(function(status, response, headers, statusText) {
-      expect(status).toBe(-1);
+      expect(status).toBe(408);
       expect(response).toBe(null);
       expect(headers).toBe(null);
       expect(statusText).toBe('');


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Returns status 408 in case of xhr timeout


**What is the current behavior? (You can also link to an open issue here)**
Status returned is -1 which does not help differentiate from other requests returning empty response.


**What is the new behavior (if this is a feature change)?**
Status returned (408) is standard HTTP response code for request timeout.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
