### PR TITLE
$http: allow differentiation between Request Error, Abort and Timeout

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -1268,9 +1268,9 @@ function $HttpProvider() {
           } else {
             // serving from cache
             if (isArray(cachedResp)) {
-              resolvePromise(cachedResp[1], cachedResp[0], shallowCopy(cachedResp[2]), cachedResp[3]);
+              resolvePromise(cachedResp[1], cachedResp[0], shallowCopy(cachedResp[2]), cachedResp[3], cachedResp[4]);
             } else {
-              resolvePromise(cachedResp, 200, {}, 'OK');
+              resolvePromise(cachedResp, 200, {}, 'OK', 'Request Completed');
             }
           }
         } else {
@@ -1327,10 +1327,10 @@ function $HttpProvider() {
        *  - resolves the raw $http promise
        *  - calls $apply
        */
-      function done(status, response, headersString, statusText) {
+      function done(status, response, headersString, statusText, xhrStatus) {
         if (cache) {
           if (isSuccess(status)) {
-            cache.put(url, [status, response, parseHeaders(headersString), statusText]);
+            cache.put(url, [status, response, parseHeaders(headersString), statusText, xhrStatus]);
           } else {
             // remove promise from the cache
             cache.remove(url);
@@ -1338,7 +1338,7 @@ function $HttpProvider() {
         }
 
         function resolveHttpPromise() {
-          resolvePromise(response, status, headersString, statusText);
+          resolvePromise(response, status, headersString, statusText, xhrStatus);
         }
 
         if (useApplyAsync) {
@@ -1353,7 +1353,7 @@ function $HttpProvider() {
       /**
        * Resolves the raw $http promise.
        */
-      function resolvePromise(response, status, headers, statusText) {
+      function resolvePromise(response, status, headers, statusText, xhrStatus) {
         //status: HTTP response status code, 0, -1 (aborted by timeout / promise)
         status = status >= -1 ? status : 0;
 
@@ -1362,12 +1362,13 @@ function $HttpProvider() {
           status: status,
           headers: headersGetter(headers),
           config: config,
-          statusText: statusText
+          statusText: statusText,
+          xhrStatus: xhrStatus
         });
       }
 
       function resolvePromiseWithResult(result) {
-        resolvePromise(result.data, result.status, shallowCopy(result.headers()), result.statusText);
+        resolvePromise(result.data, result.status, shallowCopy(result.headers()), result.statusText, result.xhrStatus);
       }
 
       function removePendingReq() {

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -1270,7 +1270,7 @@ function $HttpProvider() {
             if (isArray(cachedResp)) {
               resolvePromise(cachedResp[1], cachedResp[0], shallowCopy(cachedResp[2]), cachedResp[3], cachedResp[4]);
             } else {
-              resolvePromise(cachedResp, 200, {}, 'OK', 'Request Completed');
+              resolvePromise(cachedResp, 200, {}, 'OK', 'success');
             }
           }
         } else {

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -64,7 +64,7 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
       var jsonpDone = jsonpReq(url, callbackPath, function(status, text) {
         // jsonpReq only ever sets status to 200 (OK), 404 (ERROR) or -1 (WAITING)
         var response = (status === 200) && callbacks.getResponse(callbackPath);
-        completeRequest(callback, status, response, '', text);
+        completeRequest(callback, status, response, '', text, '');
         callbacks.removeCallback(callbackPath);
       });
     } else {
@@ -99,18 +99,27 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
             status,
             response,
             xhr.getAllResponseHeaders(),
-            statusText);
+            statusText,
+            'Request Completed');
       };
 
       var requestError = function() {
         // The response is always empty
         // See https://xhr.spec.whatwg.org/#request-error-steps and https://fetch.spec.whatwg.org/#concept-network-error
-        completeRequest(callback, -1, null, null, '');
+        completeRequest(callback, -1, null, null, '', 'Request Error');
+      };
+
+      var requestAborted = function() {
+        completeRequest(callback, -1, null, null, '', 'Request Aborted');
+      };
+
+      var requestTimedOut = function() {
+        completeRequest(callback, -1, null, null, '', 'Request Timed Out');
       };
 
       xhr.onerror = requestError;
-      xhr.onabort = requestError;
-      xhr.ontimeout = requestError;
+      xhr.onabort = requestAborted;
+      xhr.ontimeout = requestTimedOut;
 
       forEach(eventHandlers, function(value, key) {
           xhr.addEventListener(key, value);
@@ -160,14 +169,14 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
       }
     }
 
-    function completeRequest(callback, status, response, headersString, statusText) {
+    function completeRequest(callback, status, response, headersString, statusText, xhrStatus) {
       // cancel timeout and subsequent timeout promise resolution
       if (isDefined(timeoutId)) {
         $browserDefer.cancel(timeoutId);
       }
       jsonpDone = xhr = null;
 
-      callback(status, response, headersString, statusText);
+      callback(status, response, headersString, statusText, xhrStatus);
     }
   };
 

--- a/src/ng/httpBackend.js
+++ b/src/ng/httpBackend.js
@@ -100,21 +100,21 @@ function createHttpBackend($browser, createXhr, $browserDefer, callbacks, rawDoc
             response,
             xhr.getAllResponseHeaders(),
             statusText,
-            'Request Completed');
+            'success');
       };
 
       var requestError = function() {
         // The response is always empty
         // See https://xhr.spec.whatwg.org/#request-error-steps and https://fetch.spec.whatwg.org/#concept-network-error
-        completeRequest(callback, -1, null, null, '', 'Request Error');
+        completeRequest(callback, -1, null, null, '', 'error');
       };
 
       var requestAborted = function() {
-        completeRequest(callback, -1, null, null, '', 'Request Aborted');
+        completeRequest(callback, -1, null, null, '', 'abort');
       };
 
       var requestTimedOut = function() {
-        completeRequest(callback, -1, null, null, '', 'Request Timed Out');
+        completeRequest(callback, -1, null, null, '', 'timeout');
       };
 
       xhr.onerror = requestError;

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -90,7 +90,7 @@ describe('$httpBackend', function() {
   });
 
   it('should call completion function with xhr.statusText if present', function() {
-    callback.and.callFake(function(status, response, headers, statusText) {
+    callback.and.callFake(function(status, response, headers, statusText, xhrStatus) {
       expect(statusText).toBe('OK');
     });
 
@@ -102,7 +102,7 @@ describe('$httpBackend', function() {
   });
 
   it('should call completion function with empty string if not present', function() {
-    callback.and.callFake(function(status, response, headers, statusText) {
+    callback.and.callFake(function(status, response, headers, statusText, xhrStatus) {
       expect(statusText).toBe('');
     });
 
@@ -155,11 +155,12 @@ describe('$httpBackend', function() {
   });
 
   it('should not try to read response data when request is aborted', function() {
-    callback.and.callFake(function(status, response, headers, statusText) {
+    callback.and.callFake(function(status, response, headers, statusText, xhrStatus) {
       expect(status).toBe(-1);
       expect(response).toBe(null);
       expect(headers).toBe(null);
       expect(statusText).toBe('');
+      expect(xhrStatus).toBe('Request Aborted');
     });
     $backend('GET', '/url', null, callback, {}, 2000);
     xhr = MockXhr.$$lastInstance;
@@ -174,11 +175,12 @@ describe('$httpBackend', function() {
   });
 
   it('should complete the request on timeout', function() {
-    callback.and.callFake(function(status, response, headers, statusText) {
+    callback.and.callFake(function(status, response, headers, statusText, xhrStatus) {
       expect(status).toBe(-1);
       expect(response).toBe(null);
       expect(headers).toBe(null);
       expect(statusText).toBe('');
+      expect(xhrStatus).toBe('Request Timed Out');
     });
     $backend('GET', '/url', null, callback, {});
     xhr = MockXhr.$$lastInstance;
@@ -511,4 +513,3 @@ describe('$httpBackend', function() {
     });
   });
 });
-

--- a/test/ng/httpBackendSpec.js
+++ b/test/ng/httpBackendSpec.js
@@ -90,7 +90,7 @@ describe('$httpBackend', function() {
   });
 
   it('should call completion function with xhr.statusText if present', function() {
-    callback.and.callFake(function(status, response, headers, statusText, xhrStatus) {
+    callback.and.callFake(function(status, response, headers, statusText) {
       expect(statusText).toBe('OK');
     });
 
@@ -102,7 +102,7 @@ describe('$httpBackend', function() {
   });
 
   it('should call completion function with empty string if not present', function() {
-    callback.and.callFake(function(status, response, headers, statusText, xhrStatus) {
+    callback.and.callFake(function(status, response, headers, statusText) {
       expect(statusText).toBe('');
     });
 
@@ -160,7 +160,7 @@ describe('$httpBackend', function() {
       expect(response).toBe(null);
       expect(headers).toBe(null);
       expect(statusText).toBe('');
-      expect(xhrStatus).toBe('Request Aborted');
+      expect(xhrStatus).toBe('abort');
     });
     $backend('GET', '/url', null, callback, {}, 2000);
     xhr = MockXhr.$$lastInstance;
@@ -180,7 +180,7 @@ describe('$httpBackend', function() {
       expect(response).toBe(null);
       expect(headers).toBe(null);
       expect(statusText).toBe('');
-      expect(xhrStatus).toBe('Request Timed Out');
+      expect(xhrStatus).toBe('timeout');
     });
     $backend('GET', '/url', null, callback, {});
     xhr = MockXhr.$$lastInstance;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adding param xhrStatus to response and separate handlers for `onerror`, `onabort` and `ontimeout`


**What is the current behavior? (You can also link to an open issue here)**
Same handler for all error events


**What is the new behavior (if this is a feature change)?**
Separate handlers


**Does this PR introduce a breaking change?**
Probably not


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Some additional tests might be required in `httpSpec.js` and the docs would need updating as well.