### PR TITLE
fix (ngResource) dynamic params escaping fix

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1440,7 +1440,8 @@ function encodeUriSegment(val) {
   return encodeUriQuery(val, true).
              replace(/%26/gi, '&').
              replace(/%3D/gi, '=').
-             replace(/%2B/gi, '+');
+             replace(/%2B/gi, '+').
+             replace(/%5c/gi, '\\');
 }
 
 

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1440,8 +1440,7 @@ function encodeUriSegment(val) {
   return encodeUriQuery(val, true).
              replace(/%26/gi, '&').
              replace(/%3D/gi, '=').
-             replace(/%2B/gi, '+').
-             replace(/%5c/gi, '\\');
+             replace(/%2B/gi, '+');
 }
 
 

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -593,7 +593,7 @@ angular.module('ngResource', ['ng']).
           // then replace collapse `/.` if found in the last URL path segment before the query
           // E.g. `http://url.com/id./format?q=x` becomes `http://url.com/id.format?q=x`
           url = url.replace(/\/\.(?=\w+($|\?))/, '.');
-          // replace escaped `/\.` with `/.`
+          // replace escaped `/\.` with `/.` (`%5C` is url encoded backslash `\`)
           config.url = protocolAndIpv6 + url.replace(/\/(\\|%5C)\./, '/.');
 
 

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -594,7 +594,7 @@ angular.module('ngResource', ['ng']).
           // E.g. `http://url.com/id./format?q=x` becomes `http://url.com/id.format?q=x`
           url = url.replace(/\/\.(?=\w+($|\?))/, '.');
           // replace escaped `/\.` with `/.`
-          config.url = protocolAndIpv6 + url.replace(/\/\\\./, '/.');
+          config.url = protocolAndIpv6 + url.replace(/\/(\\|%5C)\./, '/.');
 
 
           // set params - delegate param encoding to $http

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1456,6 +1456,18 @@ describe('basic usage', function() {
         $httpBackend.expect('POST', '/users/.json').respond();
         $resource('/users/\\.json').save({});
       });
+      it('should work with save() if dynamic params', function() {
+        $httpBackend.expect('POST', '/users/.json').respond();
+        $resource('/users/:json', {json: '\\.json'}).save({});
+      });
+      it('should work with query() if dynamic params', function() {
+        $httpBackend.expect('GET', '/users/.json').respond();
+        $resource('/users/:json', {json: '\\.json'}).query();
+      });
+      it('should work with get() if dynamic params', function() {
+        $httpBackend.expect('GET', '/users/.json').respond();
+        $resource('/users/:json', {json: '\\.json'}).get();
+      });
     });
   });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
It doesn't work correctly according to [docs](https://docs.angularjs.org/api/ngResource/service/$resource) if url params are dynamic. So, for instance, this is gonna work: 

```javascript
// In SomeResourceName factory:
$resouce('/path/\\.json',  ...).save({});
```

but almost the same code works incorrectly: 

```javascript
// In SomeResourceName factory:
$resouce('/path/:json',  {json: '\\.json'}, ...).save({});
```
it sends request to ` :path/%5C.json`


**Does this PR introduce a breaking change?**
Might be


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

