### PR TITLE
fix(ngResource): do not eat exceptions in success callback

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -784,18 +784,18 @@ angular.module('ngResource', ['ng']).
                 return value;
               },
               (hasError || hasResponseErrorInterceptor) ?
-              function(response) {
-                if (hasError) error(response);
-                return hasResponseErrorInterceptor ?
+                function(response) {
+                  if (hasError && !hasResponseErrorInterceptor) {
+                    // Avoid `Possibly Unhandled Rejection` error,
+                    // but still fulfill the returned promise with a rejection
+                    promise.catch(noop);
+                  }
+                  if (hasError) error(response);
+                  return hasResponseErrorInterceptor ?
                     responseErrorInterceptor(response) :
                     $q.reject(response);
-              } :
-              undefined);
-            if (hasError && !hasResponseErrorInterceptor) {
-              // Avoid `Possibly Unhandled Rejection` error,
-              // but still fulfill the returned promise with a rejection
-              promise.catch(noop);
-            }
+                } :
+                undefined);
 
             if (!isInstanceCall) {
               // we are creating instance / collection

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1711,9 +1711,9 @@ describe('handling rejections', function() {
   );
 
 
-  it('should throw exception in success callback when error callback provided and no responseErrorInterceptor', function() {
-    $httpBackend.expect('GET', '/CreditCard/123').respond({ id: 123, number: '9876' });
-    var CreditCard = $resource('/CreditCard/:id:verb', { id: '@id.key' });
+  it('should not swallow exception in success callback when error callback provided', function() {
+    $httpBackend.expect('GET', '/CreditCard/123').respond(null);
+    var CreditCard = $resource('/CreditCard/:id');
     var cc = CreditCard.get({ id: 123 },
       function(res) {
         throw new Error('should be caught');
@@ -1725,9 +1725,9 @@ describe('handling rejections', function() {
   });
 
 
-  it('should throw exception in success callback when error callback not provided and no responseErrorInterceptor', function() {
-    $httpBackend.expect('GET', '/CreditCard/123').respond({ id: 123, number: '9876' });
-    var CreditCard = $resource('/CreditCard/:id:verb', { id: '@id.key' });
+  it('should not swallow exception in success callback when error callback not provided', function() {
+    $httpBackend.expect('GET', '/CreditCard/123').respond(null);
+    var CreditCard = $resource('/CreditCard/:id');
     var cc = CreditCard.get({ id: 123 },
       function(res) {
         throw new Error('should be caught');
@@ -1739,48 +1739,43 @@ describe('handling rejections', function() {
   });
 
 
-  it('should throw exception in success callback when error callback provided and has responseErrorInterceptor', function() {
-    inject(function($q) {
-
-      $httpBackend.expect('GET', '/CreditCard/123').respond({ id: 123, number: '9876' });
-      var CreditCard = $resource('/CreditCard/:id:verb', { id: '@id.key' }, {
-        'get': {
-          method: 'GET',
-          interceptor: { responseError: function() { return $q.reject({}); } }
-        }
-      });
-
-      var cc = CreditCard.get({ id: 123 },
-        function(res) {
-          throw new Error('should be caught');
-        }, function() { });
-
-      $httpBackend.flush();
-      expect($exceptionHandler.errors.length).toBe(1);
-      expect($exceptionHandler.errors[0]).toMatch(/^Error: should be caught/);
+  it('should not swallow exception in success callback when error callback provided and has responseError interceptor', function() {
+    $httpBackend.expect('GET', '/CreditCard/123').respond(null);
+    var CreditCard = $resource('/CreditCard/:id:verb', { id: '@id.key' }, {
+      'get': {
+        method: 'GET',
+        interceptor: { responseError: function() { return {}; }}
+      }
     });
+
+    var cc = CreditCard.get({ id: 123 },
+      function(res) {
+        throw new Error('should be caught');
+    }, function() { });
+
+    $httpBackend.flush();
+    expect($exceptionHandler.errors.length).toBe(1);
+    expect($exceptionHandler.errors[0]).toMatch(/^Error: should be caught/);
   });
 
 
-  it('should throw exception in success callback when error callback not provided and has responseErrorInterceptor', function() {
-    inject(function($q) {
-
-      $httpBackend.expect('GET', '/CreditCard/123').respond({ id: 123, number: '9876' });
-      var CreditCard = $resource('/CreditCard/:id:verb', { id: '@id.key' }, {
-        'get': {
-          method: 'GET',
-          interceptor: { responseError: function() { return $q.reject({}); } }
-        }
-      });
-      var cc = CreditCard.get({ id: 123 },
-        function(res) {
-          throw new Error('should be caught');
-        });
-
-      $httpBackend.flush();
-      expect($exceptionHandler.errors.length).toBe(1);
-      expect($exceptionHandler.errors[0]).toMatch(/^Error: should be caught/);
+  it('should not swallow exception in success callback when error callback not provided and has responseError interceptor', function() {
+    $httpBackend.expect('GET', '/CreditCard/123').respond(null);
+    var CreditCard = $resource('/CreditCard/:id:verb', { id: '@id.key' }, {
+      'get': {
+        method: 'GET',
+        interceptor: { responseError: function() { return {}; }}
+      }
     });
+
+    var cc = CreditCard.get({ id: 123 },
+      function(res) {
+        throw new Error('should be caught');
+    });
+
+    $httpBackend.flush();
+    expect($exceptionHandler.errors.length).toBe(1);
+    expect($exceptionHandler.errors[0]).toMatch(/^Error: should be caught/);
   });
 });
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1978,4 +1978,39 @@ describe('configuring `cancellable` on the provider', function() {
     expect(creditCard3.$cancelRequest).toBeDefined();
   });
 });
+
+  describe('exception handling in callbacks', function() {
+    var $resource;
+    var $httpBackend;
+    var CreditCard;
+    beforeEach(module('ngResource'));
+
+    beforeEach(inject(function($injector) {
+      $httpBackend = $injector.get('$httpBackend');
+      $resource = $injector.get('$resource');
+      CreditCard = $resource('/CreditCard/:id:verb', { id: '@id.key' });
+    }));
+
+    it('should throw exception in success callback when error callback provided', function() {
+      $httpBackend.expect('GET', '/CreditCard/123').respond({ id: 123, number: '9876' });
+
+      var cc = CreditCard.get({ id: 123 },
+        function(res) {
+          throw new Error('should be caught');
+        }, function() {});
+
+      expect($httpBackend.flush).toThrow(new Error('should be caught'));
+    });
+
+    it('should throw exception in success callback when error callback not provided', function() {
+      $httpBackend.expect('GET', '/CreditCard/123').respond({ id: 123, number: '9876' });
+
+      var cc = CreditCard.get({ id: 123 },
+        function(res) {
+          throw new Error('should be caught');
+        });
+
+      expect($httpBackend.flush).toThrow(new Error('should be caught'));
+    });
+  });
 });

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1711,13 +1711,13 @@ describe('handling rejections', function() {
   );
 
 
-  it('should throw exception in success callback when error callback provided and no responseErrorInterceptor', function () {
+  it('should throw exception in success callback when error callback provided and no responseErrorInterceptor', function() {
     $httpBackend.expect('GET', '/CreditCard/123').respond({ id: 123, number: '9876' });
     var CreditCard = $resource('/CreditCard/:id:verb', { id: '@id.key' });
     var cc = CreditCard.get({ id: 123 },
-      function (res) {
+      function(res) {
         throw new Error('should be caught');
-      }, function () { });
+      }, function() { });
 
     $httpBackend.flush();
     expect($exceptionHandler.errors.length).toBe(1);
@@ -1725,11 +1725,11 @@ describe('handling rejections', function() {
   });
 
 
-  it('should throw exception in success callback when error callback not provided and no responseErrorInterceptor', function () {
+  it('should throw exception in success callback when error callback not provided and no responseErrorInterceptor', function() {
     $httpBackend.expect('GET', '/CreditCard/123').respond({ id: 123, number: '9876' });
     var CreditCard = $resource('/CreditCard/:id:verb', { id: '@id.key' });
     var cc = CreditCard.get({ id: 123 },
-      function (res) {
+      function(res) {
         throw new Error('should be caught');
       });
 
@@ -1739,21 +1739,21 @@ describe('handling rejections', function() {
   });
 
 
-  it('should throw exception in success callback when error callback provided and has responseErrorInterceptor', function () {
-    inject(function ($q) {
+  it('should throw exception in success callback when error callback provided and has responseErrorInterceptor', function() {
+    inject(function($q) {
 
       $httpBackend.expect('GET', '/CreditCard/123').respond({ id: 123, number: '9876' });
       var CreditCard = $resource('/CreditCard/:id:verb', { id: '@id.key' }, {
         'get': {
           method: 'GET',
-          interceptor: { responseError: function () { return $q.reject({}); } }
+          interceptor: { responseError: function() { return $q.reject({}); } }
         }
       });
 
       var cc = CreditCard.get({ id: 123 },
-        function (res) {
+        function(res) {
           throw new Error('should be caught');
-        }, function () { });
+        }, function() { });
 
       $httpBackend.flush();
       expect($exceptionHandler.errors.length).toBe(1);
@@ -1762,18 +1762,18 @@ describe('handling rejections', function() {
   });
 
 
-  it('should throw exception in success callback when error callback not provided and has responseErrorInterceptor', function () {
-    inject(function ($q) {
+  it('should throw exception in success callback when error callback not provided and has responseErrorInterceptor', function() {
+    inject(function($q) {
 
       $httpBackend.expect('GET', '/CreditCard/123').respond({ id: 123, number: '9876' });
       var CreditCard = $resource('/CreditCard/:id:verb', { id: '@id.key' }, {
         'get': {
           method: 'GET',
-          interceptor: { responseError: function () { return $q.reject({}); } }
+          interceptor: { responseError: function() { return $q.reject({}); } }
         }
       });
       var cc = CreditCard.get({ id: 123 },
-        function (res) {
+        function(res) {
           throw new Error('should be caught');
         });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
Addresses bug identified in #15624.

**No error message is output in the console:**
```
var User = $resource('users/:id', {id: '@id'});
var user User.get({id: 123}, function (res) {
    y  = x + z; // this line not log any exception on the console
}, function () {
    console.log(arguments);
});
```
**Error message is output in the console:**

```
var User = $resource('users/:id', {id: '@id'});
var user User.get({id: 123}, function (res) {
    y  = x + z; // and this log the exception in the console
});
```

**What is the new behavior (if this is a feature change)?**
Now any exceptions thrown in the success callback will be thrown and not eaten.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

