### PR TITLE
fix($compile): do not swallow thrown errors in test

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3156,7 +3156,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           if (error instanceof Error) {
             $exceptionHandler(error);
           }
-        }).catch(noop);
+        });
 
       return function delayedNodeLinkFn(ignoreChildLinkFn, scope, node, rootElement, boundTranscludeFn) {
         var childBoundTranscludeFn = boundTranscludeFn;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -1881,15 +1881,14 @@ describe('$compile', function() {
 
 
         it('should throw an error and clear element content if the template fails to load',
-          inject(function($compile, $exceptionHandler, $httpBackend, $rootScope) {
+          inject(function($compile, $httpBackend, $rootScope) {
             $httpBackend.expect('GET', 'hello.html').respond(404, 'Not Found!');
             element = $compile('<div><b class="hello">content</b></div>')($rootScope);
 
-            $httpBackend.flush();
-
+            expect(function() {
+              $httpBackend.flush();
+            }).toThrowMinErr('$compile', 'tpload', 'Failed to load template: hello.html');
             expect(sortedHtml(element)).toBe('<div><b class="hello"></b></div>');
-            expect($exceptionHandler.errors[0]).toEqualMinErr('$compile', 'tpload',
-                'Failed to load template: hello.html');
           })
         );
 
@@ -1905,13 +1904,13 @@ describe('$compile', function() {
               templateUrl: 'template.html'
             }));
           });
-          inject(function($compile, $exceptionHandler, $httpBackend) {
+          inject(function($compile, $httpBackend) {
             $httpBackend.whenGET('template.html').respond('<p>template.html</p>');
 
-            $compile('<div><div class="sync async"></div></div>');
-            $httpBackend.flush();
-
-            expect($exceptionHandler.errors[0]).toEqualMinErr('$compile', 'multidir',
+            expect(function() {
+              $compile('<div><div class="sync async"></div></div>');
+              $httpBackend.flush();
+            }).toThrowMinErr('$compile', 'multidir',
                 'Multiple directives [async, sync] asking for template on: ' +
                 '<div class="sync async">');
           });
@@ -2122,15 +2121,15 @@ describe('$compile', function() {
               'multiple root elements': '<div></div><div></div>'
             }, function(directiveTemplate) {
 
-              inject(function($compile, $templateCache, $rootScope, $exceptionHandler) {
+              inject(function($compile, $templateCache, $rootScope) {
                 $templateCache.put('template.html', directiveTemplate);
-                $compile('<p template></p>')($rootScope);
-                $rootScope.$digest();
 
-                expect($exceptionHandler.errors.pop()).toEqualMinErr('$compile', 'tplrt',
-                  'Template for directive \'template\' must have exactly one root element. ' +
-                  'template.html'
-                );
+                expect(function() {
+                  $compile('<p template></p>')($rootScope);
+                  $rootScope.$digest();
+                }).toThrowMinErr('$compile', 'tplrt',
+                    'Template for directive \'template\' must have exactly one root element. ' +
+                    'template.html');
               });
           });
 
@@ -2657,13 +2656,13 @@ describe('$compile', function() {
         );
 
         it('should not allow more than one isolate/new scope creation per element regardless of `templateUrl`',
-          inject(function($exceptionHandler, $httpBackend) {
+          inject(function($httpBackend) {
             $httpBackend.expect('GET', 'tiscope.html').respond('<div>Hello, world !</div>');
 
-            compile('<div class="tiscope-a; scope-b"></div>');
-            $httpBackend.flush();
-
-            expect($exceptionHandler.errors[0]).toEqualMinErr('$compile', 'multidir',
+            expect(function() {
+              compile('<div class="tiscope-a; scope-b"></div>');
+              $httpBackend.flush();
+            }).toThrowMinErr('$compile', 'multidir',
                 'Multiple directives [scopeB, tiscopeA] asking for new/isolated scope on: ' +
                 '<div class="tiscope-a; scope-b ng-scope">');
           })
@@ -8997,18 +8996,17 @@ describe('$compile', function() {
               }));
             });
 
-            inject(function($compile, $exceptionHandler, $rootScope, $templateCache) {
+            inject(function($compile, $rootScope, $templateCache) {
               $templateCache.put('noTransBar.html',
                 '<div>' +
                   // This ng-transclude is invalid. It should throw an error.
                   '<div class="bar" ng-transclude></div>' +
                 '</div>');
 
-              element = $compile('<div trans-foo>content</div>')($rootScope);
-              $rootScope.$digest();
-
-              expect($exceptionHandler.errors[0][1]).toBe('<div class="bar" ng-transclude="">');
-              expect($exceptionHandler.errors[0][0]).toEqualMinErr('ngTransclude', 'orphan',
+              expect(function() {
+                element = $compile('<div trans-foo>content</div>')($rootScope);
+                $rootScope.$digest();
+              }).toThrowMinErr('ngTransclude', 'orphan',
                   'Illegal use of ngTransclude directive in the template! ' +
                   'No parent directive that requires a transclusion found. ' +
                   'Element: <div class="bar" ng-transclude="">');
@@ -9821,13 +9819,13 @@ describe('$compile', function() {
                 transclude: 'element'
               }));
             });
-            inject(function($compile, $exceptionHandler, $httpBackend) {
+            inject(function($compile, $httpBackend) {
               $httpBackend.expectGET('template.html').respond('<p second>template.html</p>');
 
-              $compile('<div template first></div>');
-              $httpBackend.flush();
-
-              expect($exceptionHandler.errors[0]).toEqualMinErr('$compile', 'multidir',
+              expect(function() {
+                $compile('<div template first></div>');
+                $httpBackend.flush();
+              }).toThrowMinErr('$compile', 'multidir',
                   'Multiple directives [first, second] asking for transclusion on: <p ');
             });
           });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.


**What is the current behavior? (You can also link to an open issue here)**
Since e13eeab, errors/rejections produces during fetching the template or compiling an asynchronous directive, where overzealously silenced. This doesn't make any difference in (most) production apps, where `$exceptionHandler` does not rethrow the errors. In tests though (where `$exceptionHandler` rethrows by default), it can unexpectedly "swallow" thrown errors.
See also #15629.


**What is the new behavior (if this is a feature change)?**
The extraneous `.catch(noop)` has been removed, thus letting errors thrown by `$exceptionHandler` to surface.


**Does this PR introduce a breaking change?**
No
<sub>(It is possible that exceptions might pop up in tests, but they where previously incorrectly hidden. Also note that the only modification in tests were to restore them to their pre-1.6.0-rc.0 state.)</sub>


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
The changes in 'compileSpec.js' essentially revert the modifications that were unnecessarily (and incorrectly) done in e13eeab (and also one incorrect modification from [c22615c][1]).

Fixes #15629

[1]: https://github.com/angular/angular.js/commit/c22615cbfbaa7d1712e79b6bf2ace6eb41313bac#diff-348c2f3781ed66a24894c2046a52c628L2084