### PR TITLE
fix($snifferProvider): allow history for nwjs applications

### DIFF
--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -20,17 +20,19 @@
 function $SnifferProvider() {
   this.$get = ['$window', '$document', function($window, $document) {
     var eventSupport = {},
+        isNw = $window.nw && $window.nw.process,
         // Chrome Packaged Apps are not allowed to access `history.pushState`.
         // If not sandboxed, they can be detected by the presence of `chrome.app.runtime`
         // (see https://developer.chrome.com/apps/api_index). If sandboxed, they can be detected by
         // the presence of an extension runtime ID and the absence of other Chrome runtime APIs
         // (see https://developer.chrome.com/apps/manifest/sandbox).
         isChromePackagedApp =
+            !isNw && 
             $window.chrome &&
             ($window.chrome.app && $window.chrome.app.runtime ||
                 !$window.chrome.app && $window.chrome.runtime && $window.chrome.runtime.id),
-        isNw = $window.nw && $window.nw.process,
-        hasHistoryPushState = (isNw || !isChromePackagedApp) && $window.history && $window.history.pushState,
+        
+        hasHistoryPushState = !isChromePackagedApp && $window.history && $window.history.pushState,
         android =
           toInt((/android (\d+)/.exec(lowercase(($window.navigator || {}).userAgent)) || [])[1]),
         boxee = /Boxee/i.test(($window.navigator || {}).userAgent),

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -29,7 +29,8 @@ function $SnifferProvider() {
             $window.chrome &&
             ($window.chrome.app && $window.chrome.app.runtime ||
                 !$window.chrome.app && $window.chrome.runtime && $window.chrome.runtime.id),
-        hasHistoryPushState = !isChromePackagedApp && $window.history && $window.history.pushState,
+        isNw = $window.nw && $window.nw.process,
+        hasHistoryPushState = (isNw || !isChromePackagedApp) && $window.history && $window.history.pushState,
         android =
           toInt((/android (\d+)/.exec(lowercase(($window.navigator || {}).userAgent)) || [])[1]),
         boxee = /Boxee/i.test(($window.navigator || {}).userAgent),

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -27,7 +27,7 @@ function $SnifferProvider() {
         // the presence of an extension runtime ID and the absence of other Chrome runtime APIs
         // (see https://developer.chrome.com/apps/manifest/sandbox).
         isChromePackagedApp =
-            !isNw && 
+            !isNw &&
             $window.chrome &&
             ($window.chrome.app && $window.chrome.app.runtime ||
                 !$window.chrome.app && $window.chrome.runtime && $window.chrome.runtime.id),

--- a/src/ng/sniffer.js
+++ b/src/ng/sniffer.js
@@ -31,7 +31,6 @@ function $SnifferProvider() {
             $window.chrome &&
             ($window.chrome.app && $window.chrome.app.runtime ||
                 !$window.chrome.app && $window.chrome.runtime && $window.chrome.runtime.id),
-        
         hasHistoryPushState = !isChromePackagedApp && $window.history && $window.history.pushState,
         android =
           toInt((/android (\d+)/.exec(lowercase(($window.navigator || {}).userAgent)) || [])[1]),

--- a/test/ng/snifferSpec.js
+++ b/test/ng/snifferSpec.js
@@ -25,6 +25,25 @@ describe('$sniffer', function() {
     });
 
 
+    it('should be true if running inside nw.js', function() {
+      var mockWindow = {
+        nw: {
+          process: noop
+        },
+        history: {
+          pushState: noop
+        },
+        chrome: {
+          app: {
+            runtime: noop
+          }
+        }
+      };
+
+      expect(sniffer(mockWindow).history).toBe(true);
+    });
+
+
     it('should be false if history or pushState not defined', function() {
       expect(sniffer({}).history).toBe(false);
       expect(sniffer({history: {}}).history).toBe(false);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
`sniffer` incorrectly detects NW.js applications as `chromePackagedApp` disallowing them to make use of the history API.


**What is the new behavior (if this is a feature change)?**
Correctly detecting NW.js applications allowing them to make use of the History API.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
#15474
