### PR TITLE
fix($parse): Make sure ES6 object computed property to be watched

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -815,6 +815,13 @@ function findConstantAndWatchExpressions(ast, $filter) {
       if (!property.value.constant) {
         argsToWatch.push.apply(argsToWatch, property.value.toWatch);
       }
+      if (property.computed) {
+        findConstantAndWatchExpressions(property.key, $filter);
+        if (!property.key.constant) {
+          argsToWatch.push.apply(argsToWatch, property.key.toWatch);
+        }
+      }
+
     });
     ast.constant = allConstants;
     ast.toWatch = argsToWatch;

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3872,20 +3872,19 @@ describe('parser', function() {
         it('should watch ES6 object computed property changes', function() {
           var count = 0;
           var values = [];
-          var firstValue = {'undefined': true};
 
-          scope.$watch('{[a]: true}', function(val, oldVal) {
+          scope.$watch('{[a]: true}', function(val) {
             count++;
             values.push(val);
           }, true);
 
           scope.$digest();
           expect(count).toBe(1);
-          expect(values[0]).toEqual(firstValue);
+          expect(values[0]).toEqual({'undefined': true});
 
           scope.$digest();
           expect(count).toBe(1);
-          expect(values[0]).toEqual(firstValue);
+          expect(values[0]).toEqual({'undefined': true});
 
           scope.a = true;
           scope.$digest();

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3868,6 +3868,41 @@ describe('parser', function() {
           scope.$digest();
           expect(objB.value).toBe(scope.input);
         }));
+
+        it('should watch ES6 object computed property changes', function() {
+          var count = 0;
+          var values = [];
+          var firstValue = {'undefined': true};
+
+          scope.$watch('{[a]: true}', function(val, oldVal) {
+            count++;
+            values.push(val);
+          }, true);
+
+          scope.$digest();
+          expect(count).toBe(1);
+          expect(values[0]).toEqual(firstValue);
+
+          scope.$digest();
+          expect(count).toBe(1);
+          expect(values[0]).toEqual(firstValue);
+
+          scope.a = true;
+          scope.$digest();
+          expect(count).toBe(2);
+          expect(values[1]).toEqual({'true': true});
+
+          scope.a = 'abc';
+          scope.$digest();
+          expect(count).toBe(3);
+          expect(values[2]).toEqual({'abc': true});
+
+          scope.a = undefined;
+          scope.$digest();
+          expect(count).toBe(4);
+          expect(values[3]).toEqual({'undefined': true});
+        });
+
       });
 
       describe('locals', function() {


### PR DESCRIPTION
Adding the missing watches for ES6 object property which added in #14407

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
`$scope.$watch` can not work as expected.


**What is the new behavior (if this is a feature change)?**
`$scope.$watch` works (NOT a feature change)


**Does this PR introduce a breaking change?**
NO


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

