### PR TITLE
docs(directive): show arguments as a subsection of the usage section

### DIFF
--- a/docs/config/templates/ngdoc/api/directive.template.html
+++ b/docs/config/templates/ngdoc/api/directive.template.html
@@ -61,12 +61,12 @@
   </div>
   {% endblock -%}
 
+  {% include "lib/params.template.html" %}
+  {% include "lib/events.template.html" %}
+
   {%- if doc.animations %}
   <h2 id="animations">Animations</h2>
   {$ doc.animations | marked $}
   {$ 'module:ngAnimate.$animate' | link('Click here', doc) $} to learn more about the steps involved in the animation.
   {%- endif -%}
-
-  {% include "lib/params.template.html" %}
-  {% include "lib/events.template.html" %}
 {% endblock %}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs update


**What is the current behavior? (You can also link to an open issue here)**
Previously, on the docs of directives which include the `animation` section, `arguments` are shown as an `h3` element below the `animation` `h2` element, making it look like it's a subsection of `animations`.

#15645


**What is the new behavior (if this is a feature change)?**
This commit ensures that the àrgument` `h3`element is rendered correctly after the `usage` `h2` element by moving the ànimation`section to the end of the template file.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

