### PR TITLE
docs(ngClass): Add docs for ngClassOdd and ngClassEven regarding anim…

### DIFF
--- a/docs/content/guide/animations.ngdoc
+++ b/docs/content/guide/animations.ngdoc
@@ -229,11 +229,12 @@ triggered:
 | {@link ngRoute.directive:ngView#animations ngView}                            | enter and leave                                                           |
 | {@link module:ngMessages#animations ngMessage / ngMessageExp}                 | enter and leave                                                           |
 | {@link ng.directive:ngClass#animations ngClass / {{class&#125;&#8203;&#125;}  | add and remove                                                            |
-| {@link ng.directive:ngClass#animations ngClassEven / ngClassOdd}              | add and remove                                                            |
+| {@link ng.directive:ngClassEven#animations ngClassEven}                       | add and remove                                                            |
+| {@link ng.directive:ngClassOdd#animations ngClassOdd}                         | add and remove                                                            |
 | {@link ng.directive:ngHide#animations ngHide}                                 | add and remove (the `ng-hide` class)                                      |
 | {@link ng.directive:ngShow#animations ngShow}                                 | add and remove (the `ng-hide` class)                                      |
-| {@link ng.directive:ngModel#animations ngModel}                          | add and remove ({@link ng.directive:ngModel#css-classes various classes}) |
-| {@link ng.directive:form#animations form / ngForm}                       | add and remove ({@link ng.directive:form#css-classes various classes})    |
+| {@link ng.directive:ngModel#animations ngModel}                               | add and remove ({@link ng.directive:ngModel#css-classes various classes}) |
+| {@link ng.directive:form#animations form / ngForm}                            | add and remove ({@link ng.directive:form#css-classes various classes})    |
 | {@link module:ngMessages#animations ngMessages}                               | add and remove (the `ng-active`/`ng-inactive` classes)                    |
 
 For a full breakdown of the steps involved during each animation event, refer to the

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -338,6 +338,12 @@ var ngClassDirective = classDirective('', true);
  * This directive can be applied only within the scope of an
  * {@link ng.directive:ngRepeat ngRepeat}.
  *
+ * @animations
+ * | Animation                        | Occurs                              |
+ * |----------------------------------|-------------------------------------|
+ * | {@link ng.$animate#addClass addClass}       | just before the class is applied to the element   |
+ * | {@link ng.$animate#removeClass removeClass} | just before the class is removed from the element |
+ *
  * @element ANY
  * @param {expression} ngClassOdd {@link guide/expression Expression} to eval. The result
  *   of the evaluation can be a string representing space delimited class names or an array.
@@ -370,6 +376,51 @@ var ngClassDirective = classDirective('', true);
        });
      </file>
    </example>
+ *
+ *  <hr />
+ * @example
+ * An example on how to implement animations using ngClassOdd:
+ *
+   <example module="ngAnimate" deps="angular-animate.js" animations="true" name="ng-class-odd-animate">
+     <file name="index.html">
+       <ol ng-init="names=['John', 'Mary', 'Cate', 'Suz'];odd=false">
+         <li ng-repeat="name in names">
+           <span ng-class-odd="{ 'odd' : odd }"">
+            {{name}}
+           </span>
+         </li>
+       </ol>
+       <button ng-click="odd = !odd">Toggle</button>
+     </file>
+     <file name="style.css">
+       span {
+        color: #000000;
+       }
+       span.odd {
+        color: #ff0000;
+        font-size:3em;
+       }
+       span.odd-add,
+       span.odd-remove {
+          transition: linear 0.5s;
+        }
+     </file>
+     <file name="protractor.js" type="protractor">
+       it('should not have odd class by default', function() {
+        expect(element(by.repeater('name in names').row(0).column('name')).getAttribute('class')).not.
+           toMatch(/odd/);
+       });
+
+       it('should have odd class when button was clicked', function() {
+        var button = element(by.css('button'));
+
+        button.click();
+
+        expect(element(by.repeater('name in names').row(0).column('name')).getAttribute('class')).
+           toMatch(/odd/);
+       });
+     </file>
+   </example>
  */
 var ngClassOddDirective = classDirective('Odd', 0);
 
@@ -385,6 +436,12 @@ var ngClassOddDirective = classDirective('Odd', 0);
  *
  * This directive can be applied only within the scope of an
  * {@link ng.directive:ngRepeat ngRepeat}.
+ *
+ * @animations
+ * | Animation                        | Occurs                              |
+ * |----------------------------------|-------------------------------------|
+ * | {@link ng.$animate#addClass addClass}       | just before the class is applied to the element   |
+ * | {@link ng.$animate#removeClass removeClass} | just before the class is removed from the element |
  *
  * @element ANY
  * @param {expression} ngClassEven {@link guide/expression Expression} to eval. The
@@ -414,6 +471,51 @@ var ngClassOddDirective = classDirective('Odd', 0);
          expect(element(by.repeater('name in names').row(0).column('name')).getAttribute('class')).
            toMatch(/odd/);
          expect(element(by.repeater('name in names').row(1).column('name')).getAttribute('class')).
+           toMatch(/even/);
+       });
+     </file>
+   </example>
+ *
+ *  <hr />
+ * @example
+ * An example on how to implement animations using ngClassEven:
+ *
+   <example module="ngAnimate" deps="angular-animate.js" animations="true" name="ng-class-even-animate">
+     <file name="index.html">
+       <ol ng-init="names=['John', 'Mary', 'Cate', 'Suz'];even=false">
+         <li ng-repeat="name in names">
+           <span ng-class-even="{ 'even' : even }"">
+            {{name}}
+           </span>
+         </li>
+       </ol>
+       <button ng-click="even = !even">Toggle</button>
+     </file>
+     <file name="style.css">
+       span {
+        color: #000000;
+       }
+       span.even {
+        color: #0000ff;
+        font-size:3em;
+       }
+       span.even-add,
+       span.even-remove {
+        transition: linear 0.5s;
+       }
+     </file>
+     <file name="protractor.js" type="protractor">
+       it('should not have even class by default', function() {
+        expect(element(by.repeater('name in names').row(1).column('name')).getAttribute('class')).not.
+           toMatch(/even/);
+       });
+
+       it('should have even class when button was clicked', function() {
+        var button = element(by.css('button'));
+
+        button.click();
+
+        expect(element(by.repeater('name in names').row(1).column('name')).getAttribute('class')).
            toMatch(/even/);
        });
      </file>

--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -377,47 +377,58 @@ var ngClassDirective = classDirective('', true);
      </file>
    </example>
  *
- *  <hr />
+ * <hr />
  * @example
- * An example on how to implement animations using ngClassOdd:
+ * An example on how to implement animations using `ngClassOdd`:
  *
    <example module="ngAnimate" deps="angular-animate.js" animations="true" name="ng-class-odd-animate">
      <file name="index.html">
-       <ol ng-init="names=['John', 'Mary', 'Cate', 'Suz'];odd=false">
-         <li ng-repeat="name in names">
-           <span ng-class-odd="{ 'odd' : odd }"">
-            {{name}}
-           </span>
-         </li>
-       </ol>
-       <button ng-click="odd = !odd">Toggle</button>
+       <div ng-init="items=['Item 3', 'Item 2', 'Item 1', 'Item 0']">
+         <button ng-click="items.unshift('Item ' + items.length)">Add item</button>
+         <hr />
+         <table>
+           <tr ng-repeat="item in items" ng-class-odd="'odd'">
+             <td>{{ item }}</td>
+           </tr>
+         </table>
+       </div>
      </file>
      <file name="style.css">
-       span {
-        color: #000000;
+       .odd {
+         background: rgba(255, 255, 0, 0.25);
        }
-       span.odd {
-        color: #ff0000;
-        font-size:3em;
+
+       .odd-add, .odd-remove {
+         transition: 1.5s;
        }
-       span.odd-add,
-       span.odd-remove {
-          transition: linear 0.5s;
-        }
      </file>
      <file name="protractor.js" type="protractor">
-       it('should not have odd class by default', function() {
-        expect(element(by.repeater('name in names').row(0).column('name')).getAttribute('class')).not.
-           toMatch(/odd/);
+       it('should add new entries to the beginning of the list', function() {
+         var button = element(by.buttonText('Add item'));
+         var rows = element.all(by.repeater('item in items'));
+
+         expect(rows.count()).toBe(4);
+         expect(rows.get(0).getText()).toBe('Item 3');
+         expect(rows.get(1).getText()).toBe('Item 2');
+
+         button.click();
+
+         expect(rows.count()).toBe(5);
+         expect(rows.get(0).getText()).toBe('Item 4');
+         expect(rows.get(1).getText()).toBe('Item 3');
        });
 
-       it('should have odd class when button was clicked', function() {
-        var button = element(by.css('button'));
+       it('should add odd class to odd entries', function() {
+         var button = element(by.buttonText('Add item'));
+         var rows = element.all(by.repeater('item in items'));
 
-        button.click();
+         expect(rows.get(0).getAttribute('class')).toMatch(/odd/);
+         expect(rows.get(1).getAttribute('class')).not.toMatch(/odd/);
 
-        expect(element(by.repeater('name in names').row(0).column('name')).getAttribute('class')).
-           toMatch(/odd/);
+         button.click();
+
+         expect(rows.get(0).getAttribute('class')).toMatch(/odd/);
+         expect(rows.get(1).getAttribute('class')).not.toMatch(/odd/);
        });
      </file>
    </example>
@@ -476,47 +487,58 @@ var ngClassOddDirective = classDirective('Odd', 0);
      </file>
    </example>
  *
- *  <hr />
+ * <hr />
  * @example
- * An example on how to implement animations using ngClassEven:
+ * An example on how to implement animations using `ngClassEven`:
  *
    <example module="ngAnimate" deps="angular-animate.js" animations="true" name="ng-class-even-animate">
      <file name="index.html">
-       <ol ng-init="names=['John', 'Mary', 'Cate', 'Suz'];even=false">
-         <li ng-repeat="name in names">
-           <span ng-class-even="{ 'even' : even }"">
-            {{name}}
-           </span>
-         </li>
-       </ol>
-       <button ng-click="even = !even">Toggle</button>
+       <div ng-init="items=['Item 3', 'Item 2', 'Item 1', 'Item 0']">
+         <button ng-click="items.unshift('Item ' + items.length)">Add item</button>
+         <hr />
+         <table>
+           <tr ng-repeat="item in items" ng-class-even="'even'">
+             <td>{{ item }}</td>
+           </tr>
+         </table>
+       </div>
      </file>
      <file name="style.css">
-       span {
-        color: #000000;
+       .even {
+         background: rgba(255, 255, 0, 0.25);
        }
-       span.even {
-        color: #0000ff;
-        font-size:3em;
-       }
-       span.even-add,
-       span.even-remove {
-        transition: linear 0.5s;
+
+       .even-add, .even-remove {
+         transition: 1.5s;
        }
      </file>
      <file name="protractor.js" type="protractor">
-       it('should not have even class by default', function() {
-        expect(element(by.repeater('name in names').row(1).column('name')).getAttribute('class')).not.
-           toMatch(/even/);
+       it('should add new entries to the beginning of the list', function() {
+         var button = element(by.buttonText('Add item'));
+         var rows = element.all(by.repeater('item in items'));
+
+         expect(rows.count()).toBe(4);
+         expect(rows.get(0).getText()).toBe('Item 3');
+         expect(rows.get(1).getText()).toBe('Item 2');
+
+         button.click();
+
+         expect(rows.count()).toBe(5);
+         expect(rows.get(0).getText()).toBe('Item 4');
+         expect(rows.get(1).getText()).toBe('Item 3');
        });
 
-       it('should have even class when button was clicked', function() {
-        var button = element(by.css('button'));
+       it('should add even class to even entries', function() {
+         var button = element(by.buttonText('Add item'));
+         var rows = element.all(by.repeater('item in items'));
 
-        button.click();
+         expect(rows.get(0).getAttribute('class')).not.toMatch(/even/);
+         expect(rows.get(1).getAttribute('class')).toMatch(/even/);
 
-        expect(element(by.repeater('name in names').row(1).column('name')).getAttribute('class')).
-           toMatch(/even/);
+         button.click();
+
+         expect(rows.get(0).getAttribute('class')).not.toMatch(/even/);
+         expect(rows.get(1).getAttribute('class')).toMatch(/even/);
        });
      </file>
    </example>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs update


**What is the current behavior? (You can also link to an open issue here)**
The documentation has no information regarding using `animation` together with the `ngClassOdd` and `ngClassEven` directive.


**What is the new behavior (if this is a feature change)?**
This commit adds the same docs used by the `ngClass` directive to the `ngClassOdd` and `ngClassEven` docs and adds an extra example for both `ngClassOdd` and `ngClassEven`.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

