### PR TITLE
docs(guide/Components): add replace option

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -78,6 +78,7 @@ It's also possible to add components via {@link $compileProvider#component} in a
 | link functions    | Yes                  | No       |
 | multiElement      | Yes                  | No       |
 | priority          | Yes                  | No       |
+| replace           | Yes (deprecated)     | No       |
 | require           | Yes                  | Yes      |
 | restrict          | Yes                  | No (restricted to elements only)      |
 | scope             | Yes (default: false) | No (scope is always isolate)      |


### PR DESCRIPTION
Adds "replace" in the comparison to directives. The replace option is deprecated, but it still exists in directives, so it's worth pointing out as a difference between directives and components.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs

**What is the current behavior? (You can also link to an open issue here)**

n/a

**What is the new behavior (if this is a feature change)?**

n/a

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [n/a] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:

I wanted to link to this question on Stack Overflow, but I'm not sure whether to use Markdown or some other syntax. https://stackoverflow.com/questions/24194972/why-is-replace-deprecated-in-angularjs
