### PR TITLE
refactor($injector): remove the Chrome stringification hack

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -71,11 +71,7 @@ var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 var $injectorMinErr = minErr('$injector');
 
 function stringifyFn(fn) {
-  // Support: Chrome 50-51 only
-  // Creating a new string by adding `' '` at the end, to hack around some bug in Chrome v50/51
-  // (See https://github.com/angular/angular.js/issues/14487.)
-  // TODO (gkalpak): Remove workaround when Chrome v52 is released
-  return Function.prototype.toString.call(fn) + ' ';
+  return Function.prototype.toString.call(fn);
 }
 
 function extractArgs(fn) {

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -284,14 +284,6 @@ describe('injector', function() {
           // eslint-disable-next-line no-eval
           expect(annotate(eval('a => b => b'))).toEqual(['a']);
         });
-
-        // Support: Chrome 50-51 only
-        // TODO (gkalpak): Remove when Chrome v52 is released.
-        // it('should be able to inject fat-arrow function', function() {
-        //   inject(($injector) => {
-        //     expect($injector).toBeDefined();
-        //   });
-        // });
       }
 
       if (support.classes) {
@@ -324,19 +316,6 @@ describe('injector', function() {
             expect(instance).toEqual(jasmine.any(Clazz));
           });
         }
-
-        // Support: Chrome 50-51 only
-        // TODO (gkalpak): Remove when Chrome v52 is released.
-        // it('should be able to invoke classes', function() {
-        //   class Test {
-        //     constructor($injector) {
-        //       this.$injector = $injector;
-        //     }
-        //   }
-        //   var instance = injector.invoke(Test, null, null, 'Test');
-
-        //   expect(instance.$injector).toBe(injector);
-        // });
       }
     });
 


### PR DESCRIPTION
The Chrome stringification hack added in afcedff34c8a44dda0d558d9d6337962f5f03d7b
is no longer needed. I verified that both of the commented out tests pass
on Chrome 56.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Refactor


**What is the current behavior? (You can also link to an open issue here)**
There's a workaround in place for Chrome 50-51. Current stable version is 56.


**What is the new behavior (if this is a feature change)?**
N/A


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] ~~Tests for the changes have been added (for bug fixes / features)~~
- [x] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:

