### PR TITLE
chore(anchorScroll): remove a Jasmine toHaveBeenCalled workaround

### DIFF
--- a/test/ng/anchorScrollSpec.js
+++ b/test/ng/anchorScrollSpec.js
@@ -87,15 +87,7 @@ describe('$anchorScroll', function() {
 
     return function($window) {
       forEach(elmSpy, function(spy, id) {
-        var count = map[id] || 0;
-        // TODO(gkalpak): `toHaveBeenCalledTimes()` works correctly with 0 since
-        // https://github.com/jasmine/jasmine/commit/342f0eb9a38194ecb8559e7df872c72afc0fe52e
-        // Fix when we upgrade to a version that contains the fix.
-        if (count > 0) {
-          expect(spy).toHaveBeenCalledTimes(count);
-        } else {
-          expect(spy).not.toHaveBeenCalled();
-        }
+        expect(spy).toHaveBeenCalledTimes(map[id] || 0);
       });
       expect($window.scrollTo).not.toHaveBeenCalled();
     };
@@ -401,14 +393,7 @@ describe('$anchorScroll', function() {
 
       return function($rootScope, $window) {
         inject(expectScrollingTo(identifierCountMap));
-        // TODO(gkalpak): `toHaveBeenCalledTimes()` works correctly with 0 since
-        // https://github.com/jasmine/jasmine/commit/342f0eb9a38194ecb8559e7df872c72afc0fe52e
-        // Fix when we upgrade to a version that contains the fix.
-        if (list.length > 0) {
-          expect($window.scrollBy).toHaveBeenCalledTimes(list.length);
-        } else {
-          expect($window.scrollBy).not.toHaveBeenCalled();
-        }
+        expect($window.scrollBy).toHaveBeenCalledTimes(list.length);
         forEach(list, function(offset, idx) {
           // Due to sub-pixel rendering, there is a +/-1 error margin in the actual offset
           var args = $window.scrollBy.calls.argsFor(idx);


### PR DESCRIPTION
The Jasmine fix landed long time ago and we've updated Jasmine since that
happened.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Tests update.


**What is the current behavior? (You can also link to an open issue here)**
A Jasmine workaround is applied.


**What is the new behavior (if this is a feature change)?**
It's removed.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] ~~Tests for the changes have been added (for bug fixes / features)~~
- [x] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:

