### PR TITLE
fix(select): keep original selection when using shift to add options …

### DIFF
--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -607,8 +607,17 @@ var selectDirective = function() {
         // Write value now needs to set the selected property of each matching option
         selectCtrl.writeValue = function writeMultipleValue(value) {
           forEach(element.find('option'), function(option) {
-            option.selected = !!value && (includes(value, option.value) ||
-                                          includes(value, selectCtrl.selectValueMap[option.value]));
+            var shouldBeSelected = !!value && (includes(value, option.value) ||
+                                               includes(value, selectCtrl.selectValueMap[option.value]));
+            var currentlySelected = option.selected;
+
+            // IE and Edge will de-select selected options when you set the selected property again, e.g.
+            // when you add to the selection via shift+click/UP/DOWN
+            // Therefore, only set it if necessary
+            if ((shouldBeSelected && !currentlySelected) || (!shouldBeSelected && currentlySelected)) {
+              option.selected = shouldBeSelected;
+            }
+
           });
         };
 

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -1098,13 +1098,21 @@ describe('select', function() {
         scope.selection = ['A'];
       });
 
+      var optionElements = element.find('option');
+
       expect(element).toEqualSelect(['A'], 'B');
+      expect(optionElements[0]).toBeMarkedAsSelected();
+      expect(optionElements[1]).not.toBeMarkedAsSelected();
 
       scope.$apply(function() {
         scope.selection.push('B');
       });
 
+      optionElements = element.find('option');
+
       expect(element).toEqualSelect(['A'], ['B']);
+      expect(optionElements[0]).toBeMarkedAsSelected();
+      expect(optionElements[1]).toBeMarkedAsSelected();
     });
 
     it('should work with optgroups', function() {


### PR DESCRIPTION
…in IE/Edge

In IE9-11 + Edge, the selected options were previously incorrect under the following
circumstances:
- at least two options are selected
- shift+click or shift+down/up is used to add to the selection (any number of options)

In these cases, only the last of the previously selected options and the newly selected
options would be selected.

The problems seems to be that the render engine gets confused when an option that
already has selected = true gets selected = true set again.

Note that this is not testable via unit test because it's not possible to simulate
click / keyboard events on option elements (the events are delegated to the select element
change event).

Fixes #15675

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bugfix


**What is the current behavior? (You can also link to an open issue here)**
See #15675

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- ~~[ ] Tests for the changes have been added (for bug fixes / features)~~
- ~~[ ] Docs have been added / updated (for bug fixes / features)~~

**Other information**:

