### PR TITLE
refactor($rootScope): asyncQueue is pre-$parsed, no need to call $eval

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -786,12 +786,13 @@ function $RootScopeProvider() {
           current = target;
 
           // It's safe for asyncQueuePosition to be a local variable here because this loop can't
-          // be reentered recursively. Calling $digest from a function passed to $applyAsync would
+          // be reentered recursively. Calling $digest from a function passed to $evalAsync would
           // lead to a '$digest already in progress' error.
           for (var asyncQueuePosition = 0; asyncQueuePosition < asyncQueue.length; asyncQueuePosition++) {
             try {
               asyncTask = asyncQueue[asyncQueuePosition];
-              asyncTask.scope.$eval(asyncTask.expression, asyncTask.locals);
+              fn = asyncTask.fn;
+              fn(asyncTask.scope, asyncTask.locals);
             } catch (e) {
               $exceptionHandler(e);
             }
@@ -1025,7 +1026,7 @@ function $RootScopeProvider() {
           });
         }
 
-        asyncQueue.push({scope: this, expression: $parse(expr), locals: locals});
+        asyncQueue.push({scope: this, fn: $parse(expr), locals: locals});
       },
 
       $$postDigest: function(fn) {

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1444,9 +1444,9 @@ describe('Scope', function() {
       expect(childScope.$$asyncQueue).toBe($rootScope.$$asyncQueue);
       expect(isolateScope.$$asyncQueue).toBeUndefined();
       expect($rootScope.$$asyncQueue).toEqual([
-        {scope: $rootScope, expression: $parse('rootExpression'), locals: undefined},
-        {scope: childScope, expression: $parse('childExpression'), locals: undefined},
-        {scope: isolateScope, expression: $parse('isolateExpression'), locals: undefined}
+        {scope: $rootScope, fn: $parse('rootExpression'), locals: undefined},
+        {scope: childScope, fn: $parse('childExpression'), locals: undefined},
+        {scope: isolateScope, fn: $parse('isolateExpression'), locals: undefined}
       ]);
     }));
 
@@ -1499,6 +1499,14 @@ describe('Scope', function() {
         expect(log).toEqual(['eval-ed 1!', 'eval-ed 2!']);
       });
     });
+
+    it('should not pass anything as `this` to scheduled functions', inject(function($rootScope) {
+      var this1 = {};
+      var this2 = (function() { return this; })();
+      $rootScope.$evalAsync(function() { this1 = this; });
+      $rootScope.$digest();
+      expect(this1).toEqual(this2);
+    }));
   });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

minor refactoring

**Does this PR introduce a breaking change?**

no