### PR TITLE
fix(ngSanitize): IE11 memory leak

### DIFF
--- a/src/ngSanitize/sanitize.js
+++ b/src/ngSanitize/sanitize.js
@@ -308,6 +308,11 @@ function $SanitizeProvider() {
   }
 
   var inertBodyElement;
+  // Fix for IE11 memory leak https://github.com/angular/angular.js/issues/13800
+  window.cleanInertBodyElement = function() {
+    inertBodyElement = null;
+  };
+
   (function(window) {
     var doc;
     if (window.document && window.document.implementation) {


### PR DESCRIPTION
Originally proposed by @sjulescu in https://github.com/angular/angular.js/issues/13800#issuecomment-251385968 fix #13800

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bugfix


**What is the current behavior? (You can also link to an open issue here)**
IE11 leaks 20-50 MB per page refresh


**What is the new behavior (if this is a feature change)?**
No memory leak


**Does this PR introduce a breaking change?**
Nope


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
