### PR TITLE
test($http): ensure json deserialization errors are forwarded to erro…

### DIFF
--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1368,6 +1368,20 @@ describe('$http', function() {
               expect(callback.calls.argsFor(1)[0].data).toEqual('{"is": "not"} ["json"]');
             }
           );
+
+          it('should forward json deserialization errors to the http error handler',
+              function() {
+            var errCallback = jasmine.createSpy('error');
+
+            $httpBackend.expect('GET', '/url').respond('abcd', {'Content-Type': 'application/json'});
+            $http({method: 'GET', url: '/url'}).then(callback).catch(errCallback);
+            $httpBackend.flush();
+
+            expect(callback).not.toHaveBeenCalled();
+            expect(errCallback).toHaveBeenCalledOnce();
+            expect(errCallback.calls.mostRecent().args[0]).toEqual(jasmine.any(SyntaxError));
+          });
+
         });
 
 


### PR DESCRIPTION
…r handler

Since https://github.com/angular/angular.js/commit/e13eeabd7e34a78becec06cfbe72c23f2dcb85f9,
errors thrown from onFulfilled and onRejected handlers are passed to the regular http
error handlers. Before this, JSON deserialization errors lead to hard application errors, and could
not be handled by application code. This behavior was introduced in https://github.com/angular/angular.js/commit/7b6c1d08aceba6704a40302f373400aed9ed0e0b, and originally, a malformed JSON string was forwarded
as the data to the http success response handler.

This commit adds a specifc test case, even though the behavior is unlikely to break in the future without
a change in the $q rejection handling.

Related #11433

