### PR TITLE
fix(jenkins): get rid of Opera from the Jenkins build script, it doesn't work

### DIFF
--- a/docs/content/misc/contribute.ngdoc
+++ b/docs/content/misc/contribute.ngdoc
@@ -140,13 +140,13 @@ tests once on Chrome run:
 grunt test:unit
 ```
 
-To run the tests on other browsers (Chrome, ChromeCanary, Firefox, Opera and Safari are pre-configured) use:
+To run the tests on other browsers (Chrome, ChromeCanary, Firefox and Safari are pre-configured) use:
 
 ```shell
-grunt test:unit --browsers=Opera,Firefox
+grunt test:unit --browsers=Chrome,Firefox
 ```
 
-Note there should be _no spaces between browsers_. `Opera, Firefox` is INVALID.
+Note there should be _no spaces between browsers_. `Chrome, Firefox` is INVALID.
 
 During development, however, it's more productive to continuously run unit tests every time the source or test files
 change. To execute tests in this mode run:

--- a/scripts/jenkins/build.sh
+++ b/scripts/jenkins/build.sh
@@ -12,7 +12,7 @@ set -xe
 # This is the default set of browsers to use on the CI server unless overridden via env variable
 if [[ -z "$BROWSERS" ]]
 then
-  BROWSERS="Chrome,Firefox,Opera,/Users/jenkins/bin/safari.sh"
+  BROWSERS="Chrome,Firefox,/Users/jenkins/bin/safari.sh"
 fi
 
 # CLEAN #

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -255,8 +255,8 @@ function Browser(window, document, $log, $sniffer) {
   self.onUrlChange = function(callback) {
     // TODO(vojta): refactor to use node's syntax for events
     if (!urlChangeInit) {
-      // We listen on both (hashchange/popstate) when available, as some browsers (e.g. Opera)
-      // don't fire popstate when user change the address bar and don't fire hashchange when url
+      // We listen on both (hashchange/popstate) when available, as some browsers don't
+      // fire popstate when user changes the address bar and don't fire hashchange when url
       // changed by push/replaceState
 
       // html5 history api - popstate event

--- a/src/ng/urlUtils.js
+++ b/src/ng/urlUtils.js
@@ -20,7 +20,7 @@ var baseUrlParsingNode;
  * URL will be resolved into an absolute URL in the context of the application document.
  * Parsing means that the anchor node's host, hostname, protocol, port, pathname and related
  * properties are all populated to reflect the normalized URL.  This approach has wide
- * compatibility - Safari 1+, Mozilla 1+, Opera 7+,e etc.  See
+ * compatibility - Safari 1+, Mozilla 1+ etc.  See
  * http://www.aptana.com/reference/html/api/HTMLAnchorElement.html
  *
  * Implementation Notes for IE

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -923,7 +923,7 @@ describe('ngMock', function() {
       }));
 
       describe('error stack trace when called outside of spec context', function() {
-        // - Chrome, Firefox, Edge, Opera give us the stack trace as soon as an Error is created
+        // - Chrome, Firefox, Edge give us the stack trace as soon as an Error is created
         // - IE10+, PhantomJS give us the stack trace only once the error is thrown
         // - IE9 does not provide stack traces
         var stackTraceSupported = (function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix


**What is the current behavior? (You can also link to an open issue here)**
Jenkins fails because the Opera Karma launcher is missing.


**What is the new behavior (if this is a feature change)?**
Opera is not tried to be launched.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] ~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
Another commit removes Opera mentions from source as we no longer support it officially.
