### PR TITLE
fix(angular.copy): copy own non-enumerable properties

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -941,6 +941,17 @@ function copy(source, destination, maxDepth) {
       for (key in source) {
         destination[key] = copyElement(source[key], maxDepth);
       }
+      // don't use Object.getOwnPropertyNames with RegExp to avoid copying RegExp lastIndex property
+    } else if (isObject(source) && typeof Object.getOwnPropertyNames === 'function' && !isRegExp(source)) {
+      Object.getOwnPropertyNames(source).forEach(function(key) {
+        var elementCopy = copyElement(source[key], maxDepth);
+
+        if (source.propertyIsEnumerable(key)) {
+          destination[key] = elementCopy;
+        } else {
+          Object.defineProperty(destination, key, {value: elementCopy});
+        }
+      });
     } else if (source && typeof source.hasOwnProperty === 'function') {
       // Slow path, which must rely on hasOwnProperty
       for (key in source) {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -620,6 +620,17 @@ describe('angular', function() {
       expect(dest).toEqual({a1: 1, b1: {b2: {b3: 1}}, c1: [1, {c2: 1}], d1: {d2: 1}});
     });
 
+    it('should copy own non-enumerable properties keeping them non-enumerable', function() {
+      var getter = function() { return Math.random(); };
+      var source = {};
+      var dest;
+
+      Object.defineProperty(source, 'getter', {value: getter});
+      dest = copy(source);
+      expect(dest.getter).toBe(getter);
+      expect(dest.propertyIsEnumerable('getter')).toBe(false);
+    });
+
     they('should copy source and ignore max depth when maxDepth = $prop',
       [NaN, null, undefined, true, false, -1, 0], function(maxDepth) {
         var source = {a1: 1, b1: {b2: {b3: 1}}, c1: [1, {c2: 1}], d1: {d2: 1}};


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

https://github.com/angular/angular.js/issues/15692

**Does this PR introduce a breaking change?**

not sure if this can be called a breaking change
