### PR TITLE
fix(angular.copy) support for Map and Set

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1032,17 +1032,23 @@ function copy(source, destination, maxDepth) {
       case '[object Blob]':
         return new source.constructor([source], {type: source.type});
       case '[object Map]':
-        var copied = new source.constructor();
-        source.forEach(function(value, key){
-          copied.set(key, value);
+        // If we're in this case we know the environment supports Map
+        /* eslint-disable no-undef */
+        var copiedMap = new Map();
+        /* eslint-enable */
+        source.forEach(function(value, key) {
+          copiedMap.set(key, value);
         });
-        return copied;
+        return copiedMap;
       case '[object Set]':
-        var copied = new source.constructor();
-        source.forEach(function(value){
-          copied.add(value);
-        })
-        return copied;
+        // If we're in this case we know the environment supports Set
+        /* eslint-disable no-undef */
+        var copiedSet = new Set();
+        /* eslint-enable */
+        source.forEach(function(value) {
+          copiedSet.add(value);
+        });
+        return copiedSet;
     }
 
     if (isFunction(source.cloneNode)) {

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1031,6 +1031,9 @@ function copy(source, destination, maxDepth) {
 
       case '[object Blob]':
         return new source.constructor([source], {type: source.type});
+      case '[object Map]':
+      case '[object Set]':
+        return new source.constructor(source);
     }
 
     if (isFunction(source.cloneNode)) {

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1032,8 +1032,17 @@ function copy(source, destination, maxDepth) {
       case '[object Blob]':
         return new source.constructor([source], {type: source.type});
       case '[object Map]':
+        var copied = new source.constructor();
+        source.forEach(function(value, key){
+          copied.set(key, value);
+        });
+        return copied;
       case '[object Set]':
-        return new source.constructor(source);
+        var copied = new source.constructor();
+        source.forEach(function(value){
+          copied.add(value);
+        })
+        return copied;
     }
 
     if (isFunction(source.cloneNode)) {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -3,7 +3,7 @@
 // Lots of typed array globals are used in this file and ESLint is
 // not smart enough to understand the `typeof !== 'undefined'` guards.
 /* globals Blob, Uint8ClampedArray, Uint16Array, Uint32Array, Int8Array, Int16Array, Int32Array,
-Float32Array, Float64Array,  */
+Float32Array, Float64Array, Map, Set  */
 
 describe('angular', function() {
   var element, document;
@@ -250,7 +250,7 @@ describe('angular', function() {
     });
 
     it('should handle Map objects', function() {
-      if (typeof Map !== 'undefined'){
+      if (typeof Map !== 'undefined') {
         var src = new Map();
         src.set('foo', 'bar');
         var dst = copy(src);
@@ -262,7 +262,7 @@ describe('angular', function() {
     });
 
     it('should handle Set objects', function() {
-      if (typeof Set !== 'undefined'){
+      if (typeof Set !== 'undefined') {
         var src = new Set();
         src.add('foo');
         var dst = copy(src);

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -249,6 +249,30 @@ describe('angular', function() {
       }
     });
 
+    it('should handle Map objects', function() {
+      if (typeof Map !== 'undefined'){
+        var src = new Map();
+        src.set('foo', 'bar');
+        var dst = copy(src);
+        expect(dst).not.toBe(src);
+        expect(dst.size).toBe(1);
+        expect(dst instanceof Map).toBeTruthy();
+        expect(dst.get('foo')).toBe('bar');
+      }
+    });
+
+    it('should handle Set objects', function() {
+      if (typeof Set !== 'undefined'){
+        var src = new Set();
+        src.add('foo');
+        var dst = copy(src);
+        expect(dst).not.toBe(src);
+        expect(dst.size).toBe(1);
+        expect(dst instanceof Set).toBeTruthy();
+        expect(dst.has('foo')).toBeTruthy();
+      }
+    });
+
     it('should handle Uint16Array subarray', function() {
       if (typeof Uint16Array !== 'undefined') {
         var arr = new Uint16Array(4);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bug fix


**What is the current behavior? (You can also link to an open issue here)**
the copied Map or Set will fail to call functions with an error such as:
TypeError: Method Map.prototype.size called on incompatible receiver #<Map>


**What is the new behavior (if this is a feature change)?**
angular.copy will now property create new Map or Set objects with the same values as the source.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)

**Other information**:

