### PR TITLE
docs(directive): consistent usage of `hr`

### DIFF
--- a/docs/content/guide/accessibility.ngdoc
+++ b/docs/content/guide/accessibility.ngdoc
@@ -71,7 +71,7 @@ attributes (if they have not been explicitly specified by the developer):
         Custom checkbox
       </custom-checkbox>
     </form>
-    <hr />
+    <hr>
     <b>Is checked:</b> {{ !!checked }}
   </file>
   <file name="script.js">

--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -84,7 +84,7 @@ For example, the following forms are all equivalent and match the {@link ngBind}
 <example module="docsBindExample" name="directive-bind">
   <file name="index.html">
     <div ng-controller="Controller">
-      Hello <input ng-model='name'> <hr/>
+      Hello <input ng-model='name'> <hr>
       <span ng-bind="name"></span> <br/>
       <span ng:bind="name"></span> <br/>
       <span ng_bind="name"></span> <br/>
@@ -594,7 +594,7 @@ We also want to remove the `$interval` if the directive is deleted so we don't i
   </file>
   <file name="index.html">
     <div ng-controller="Controller">
-      Date format: <input ng-model="format"> <hr/>
+      Date format: <input ng-model="format"> <hr>
       Current time is: <span my-current-time="format"></span>
     </div>
   </file>

--- a/docs/content/guide/migration.ngdoc
+++ b/docs/content/guide/migration.ngdoc
@@ -310,7 +310,7 @@ $scope.$watch('something', function() {
 })
 ```
 
-<hr />
+<hr>
 <minor />
 **Due to [7bc71a](https://github.com/angular/angular.js/commit/7bc71adc63bb6bb609b44dd2d3ea8fb0cd3f300b)**,
 the values returned by synchronous validators are always treated as boolean. Previously, only a
@@ -389,7 +389,7 @@ hardly affect any applications, as the values of options are usually not relevan
 application logic. (Although, it may affect tests that check the `value` attribute of `<option>`
 elements.)
 
-<hr />
+<hr>
 <tests-only />
 **Due to [e8c2e1](https://github.com/angular/angular.js/commit/e8c2e119758e58e18fe43932d09a8ff9f506aa9d)**,
 `<option>` elements will no longer have their value attribute set from their text value when their
@@ -484,7 +484,7 @@ lifecycle hook), you may need to manually call `$onInit()` from your constructor
 })
 ```
 
-<hr />
+<hr>
 <minor />
 **Due to [13c252](https://github.com/angular/angular.js/commit/13c2522baf7c8f616b2efcaab4bffd54c8736591)**,
 on **IE11 only**, consecutive text nodes will always get merged. Previously, they would not get
@@ -492,7 +492,7 @@ merged if they had no parent. The new behavior, which fixes an IE11 bug affectin
 under certain circumstances, might in some edge-cases have unexpected side effects that you should
 be aware of. Please, check the commit message for more details.
 
-<hr />
+<hr>
 <minor />
 **Due to [04cad4](https://github.com/angular/angular.js/commit/04cad41d26ebaf44b5ee0c29a152d61f235f3efa)**,
 `link[href]` attributes are now protected via `$sce`, which prevents interpolated values that fail
@@ -507,7 +507,7 @@ By default, only URLs with the same domain and protocol as the application docum
 safe in the `RESOURCE_URL` context. To use URLs from other domains and/or protocols, you may either
 whitelist them or wrap them into a trusted value by calling `$sce.trustAsResourceUrl(url)`.
 
-<hr />
+<hr>
 <minor />
 **Due to [97bbf8](https://github.com/angular/angular.js/commit/97bbf86a1979d099802f0d631c17c54b87563b40)**,
 whitespace in attributes is no longer trimmed automatically. This includes leading and trailing
@@ -534,7 +534,7 @@ $attrs.$observe('myAttr', function(newVal) {
 Note that `$parse` trims expressions automatically, so attributes with expressions (e.g. directive
 bindings) should not be affected by this change.
 
-<hr />
+<hr>
 <minor />
 **Due to [13c252](https://github.com/angular/angular.js/commit/13c2522baf7c8f616b2efcaab4bffd54c8736591)**,
 on **IE11 only**, consecutive text nodes will always get merged. Previously, they would not get
@@ -542,7 +542,7 @@ merged if they had no parent. The new behavior, which fixes an IE11 bug affectin
 under certain circumstances, might in some edge-cases have unexpected side effects that you should
 be aware of. Please, check the commit message for more details.
 
-<hr />
+<hr>
 <tests-only />
 **Due to [b89c21](https://github.com/angular/angular.js/commit/b89c2181a9a165e06c027390164e08635ec449f4)**,
 using interpolation in any `on*` event attribute (e.g. `<button onclick="{{myVar}}">`) will now
@@ -576,7 +576,7 @@ $http.json('trusted/url');
 $http.json('other/trusted/url', {jsonpCallbackParam: 'cb'});
 ```
 
-<hr />
+<hr>
 <minor />
 <a name="commit-6476af"></a>
 **Due to [6476af](https://github.com/angular/angular.js/commit/6476af83cd0418c84e034a955b12a842794385c4)**,
@@ -604,7 +604,7 @@ trust a URL:
     var promise = $http.jsonp($sce.trustAsResourceUrl(url));
     ```
 
-<hr />
+<hr>
 <tests-only />
 **Due to [4f6f2b](https://github.com/angular/angular.js/commit/4f6f2bce4ac93b85320e42e5023c09d099779b7d)**,
 HTTP requests now update the outstanding request count synchronously. Previously, the request count
@@ -615,7 +615,7 @@ The new behavior will also allow end-2-end tests to more correctly detect when A
 but there is a chance it may change the observed behaviour in cases where an async request
 interceptor is being used.
 
-<hr />
+<hr>
 <minor />
 **Due to [b54a39](https://github.com/angular/angular.js/commit/b54a39e2029005e0572fbd2ac0e8f6a4e5d69014)**,
 `$http`'s deprecated custom callback methods - `success()` and `error()` - have been removed. You
@@ -755,7 +755,7 @@ object, will no longer result in a call to `$exceptionHandler()` if they throw a
 that, everything will continue to behave in the same way; i.e. the promises will be rejected, route
 transition will be cancelled, `$routeChangeError` events will be broadcasted etc.
 
-<hr />
+<hr>
 <minor />
 **Due to [c9dffde](https://github.com/angular/angular.js/commit/c9dffde1cb167660120753181cb6d01dc1d1b3d0)**,
 possibly unhandled rejected promises will be logged to the `$exceptionHandler`. Normally, that means
@@ -820,7 +820,7 @@ elem.data()['fooBar'] = 2;
 elem.data('foo-bar'); // 2
 ```
 
-<hr />
+<hr>
 <major />
 **Due to [73050c](https://github.com/angular/angular.js/commit/73050cdda04675bfa6705dc841ddbbb6919eb048)**,
 the way jqLite camelCases keys passed to `.css()` is aligned with jQuery. Previously, when using
@@ -882,7 +882,7 @@ var bgColor = elem.css('background-color');
 var bgColor = elem.css('backgroundColor');
 ```
 
-<hr />
+<hr>
 <major />
 **Due to [7ceb5f](https://github.com/angular/angular.js/commit/7ceb5f6fcc43d35d1b66c3151ce6a71c60309304)**,
 getting/setting boolean attributes will no longer take the corresponding properties into account.
@@ -924,7 +924,7 @@ elem1.prop('checked', true);
 elem2.prop('checked', false);
 ```
 
-<hr />
+<hr>
 <major />
 **Due to [3faf45](https://github.com/angular/angular.js/commit/3faf4505732758165083c9d21de71fa9b6983f4a)**,
 calling `.attr(attrName, '')` (with `attrName` being a boolean attribute) will no longer remove the
@@ -934,14 +934,14 @@ calling `.attr(attrName, '')` would remove the boolean attribute.
 If you want to remove a boolean attribute now, you have to call `.attr()` with `false` or `null`.
 E.g.: `.attr(attrName, false)`
 
-<hr />
+<hr>
 <minor />
 **Due to [4e3624](https://github.com/angular/angular.js/commit/4e3624552284d0e725bf6262b2e468cd2c7682fa)**,
 calling `.attr(attrName, null)` will remove the attribute. Previously, it would set the
 `attrName` attribute value to the string `'null'`. If you want to set the attribute value to the
 string `'null'`, you have to explicitly call `.attr(attrName, 'null')`.
 
-<hr />
+<hr>
 <major />
 **Due to [d882fd](https://github.com/angular/angular.js/commit/d882fde2e532216e7cf424495db1ccb5be1789f8)**,
 calling the `.val()` getter on a jqLite element representing a `<select multiple>` element with no
@@ -1122,7 +1122,7 @@ If you want to have a custom `$isEmpty()` method, you need to overwrite the defa
 })
 ```
 
-<hr />
+<hr>
 <minor />
 **Due to [9978de1](https://github.com/angular/angular.js/commit/9978de11b7295fec1a2f4cb8fbeb9b62b54cb711)**,
 the `role` attribute will no longer be added to native control elements (textarea, button, select,
@@ -1149,7 +1149,7 @@ or indirectly) triggered anyway, before calling `verifyNoOutstandingRequest()`. 
 that a test needs to verify the timing of a request with respect to the digest cycle, you should
 rely on other means, such as mocking and/or spying.
 
-<hr />
+<hr>
 <tests-only />
 **Due to [7551b8](https://github.com/angular/angular.js/commit/7551b8975a91ee286cc2cf4af5e78f924533575e)**,
 it is no longer valid to explicitly pass `undefined` as the `url` argument to any of the
@@ -1190,7 +1190,7 @@ Foo.get({id: 42, bar: 'baz', toString: 'hmm'});
     // Note that `toString` _is_ included in the query, as expected :)
 ```
 
-<hr />
+<hr>
 <tests-only />
 **Due to [2456ab](https://github.com/angular/angular.js/commit/2456ab63a613902d21c151445f9c697a76ab43b3)**,
 semicolon has been added to the list of delimiters that are not encoded in URL params. Although it
@@ -1219,13 +1219,13 @@ request will be made for the default route's template. If not properly "trained"
 will complain about this unexpected request. You can restore the previous behavior (and avoid
 unexpected requests in tests), by using `$routeProvider.eagerInstantiationEnabled(false)`.
 
-<hr />
+<hr>
 <minor />
 **Due to [e98656](https://github.com/angular/angular.js/commit/e9865654b39c71be71034c38581a8c7bd16bc716)**,
 if a `redirectTo` function throws an Error, a `$routeChangeError` event will be fired. Previously,
 execution would be aborted without firing a `$routeChangeError` event.
 
-<hr />
+<hr>
 <minor />
 **Due to [7f4b35](https://github.com/angular/angular.js/commit/7f4b356c2bebb87f0c26b57a20415b004b20bcd1)**,
 the `$route` service will no longer instantiate controllers nor call `resolve` or

--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -317,7 +317,7 @@ The web server is configured to use port 8000. If the port is already in use (fo
 instance of a running web server) you will get an `EADDRINUSE` error. Make sure the port is
 available, before running `npm start`.
 
-<hr />
+<hr>
 
 Now that you have set up your local machine, let's get started with the tutorial:
 {@link step_00 Step 0 - Bootstrapping}

--- a/src/ng/anchorScroll.js
+++ b/src/ng/anchorScroll.js
@@ -109,7 +109,7 @@ function $AnchorScrollProvider() {
        </file>
      </example>
    *
-   * <hr />
+   * <hr>
    * The example below illustrates the use of a vertical scroll-offset (specified as a fixed value).
    * See {@link ng.$anchorScroll#yOffset $anchorScroll.yOffset} for more details.
    *

--- a/src/ng/directive/ngInclude.js
+++ b/src/ng/directive/ngInclude.js
@@ -58,7 +58,7 @@
         <option value="">(blank)</option>
        </select>
        url of the template: <code>{{template.url}}</code>
-       <hr/>
+       <hr>
        <div class="slide-animate-container">
          <div class="slide-animate" ng-include="template.url"></div>
        </div>

--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -184,7 +184,7 @@ var ngOptionsMinErr = minErr('ngOptions');
               <button ng-click="colors.push({})">add</button>
             </li>
           </ul>
-          <hr/>
+          <hr>
           <label>Color (null not allowed):
             <select ng-model="myColor" ng-options="color.name for color in colors"></select>
           </label><br/>
@@ -210,7 +210,7 @@ var ngOptionsMinErr = minErr('ngOptions');
 
           Select <button ng-click="myColor = { name:'not in list', shade: 'other' }">bogus</button>.
           <br/>
-          <hr/>
+          <hr>
           Currently selected: {{ {selected_color:myColor} }}
           <div style="border:solid 1px black; height:20px"
                ng-style="{'background-color':myColor.name}">

--- a/src/ng/directive/ngShowHide.js
+++ b/src/ng/directive/ngShowHide.js
@@ -130,7 +130,7 @@ var NG_HIDE_IN_PROGRESS_CLASS = 'ng-hide-animate';
     </file>
   </example>
  *
- * <hr />
+ * <hr>
  * @example
  * A more complex example, featuring different show/hide animations:
  *
@@ -333,7 +333,7 @@ var ngShowDirective = ['$animate', function($animate) {
     </file>
   </example>
  *
- * <hr />
+ * <hr>
  * @example
  * A more complex example, featuring different show/hide animations:
  *

--- a/src/ng/directive/ngSwitch.js
+++ b/src/ng/directive/ngSwitch.js
@@ -67,7 +67,7 @@
         <select ng-model="selection" ng-options="item for item in items">
         </select>
         <code>selection={{selection}}</code>
-        <hr/>
+        <hr>
         <div class="animate-switch-container"
           ng-switch on="selection">
             <div class="animate-switch" ng-switch-when="settings|options" ng-switch-when-separator="|">Settings Div</div>

--- a/src/ng/exceptionHandler.js
+++ b/src/ng/exceptionHandler.js
@@ -31,7 +31,7 @@
  *     }]);
  * ```
  *
- * <hr />
+ * <hr>
  * Note, that code executed in event-listeners (even those registered using jqLite's `on`/`bind`
  * methods) does not delegate exceptions to the {@link ng.$exceptionHandler $exceptionHandler}
  * (unless executed during a digest).

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -185,7 +185,7 @@
        });
      </file>
    </example>
- * <hr />
+ * <hr>
  *
  * @example
  * ### Changing parameters dynamically
@@ -197,9 +197,9 @@
      <file name="index.html">
        <div ng-controller="ExampleController">
          <pre>Sort by = {{propertyName}}; reverse = {{reverse}}</pre>
-         <hr/>
+         <hr>
          <button ng-click="propertyName = null; reverse = false">Set to unsorted</button>
-         <hr/>
+         <hr>
          <table class="friends">
            <tr>
              <th>
@@ -316,7 +316,7 @@
        });
      </file>
    </example>
- * <hr />
+ * <hr>
  *
  * @example
  * ### Using `orderBy` inside a controller
@@ -329,9 +329,9 @@
      <file name="index.html">
        <div ng-controller="ExampleController">
          <pre>Sort by = {{propertyName}}; reverse = {{reverse}}</pre>
-         <hr/>
+         <hr>
          <button ng-click="sortBy(null)">Set to unsorted</button>
-         <hr/>
+         <hr>
          <table class="friends">
            <tr>
              <th>
@@ -450,7 +450,7 @@
        });
      </file>
    </example>
- * <hr />
+ * <hr>
  *
  * @example
  * ### Using a custom comparator

--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -119,9 +119,9 @@ function $IntervalProvider() {
       *
       *   <div>
       *     <div ng-controller="ExampleController">
-      *       <label>Date format: <input ng-model="format"></label> <hr/>
+      *       <label>Date format: <input ng-model="format"></label> <hr>
       *       Current time is: <span my-current-time="format"></span>
-      *       <hr/>
+      *       <hr>
       *       Blood 1 : <font color='red'>{{blood_1}}</font>
       *       Blood 2 : <font color='red'>{{blood_2}}</font>
       *       <button type="button" data-ng-click="fight()">Fight</button>

--- a/src/ngAnimate/module.js
+++ b/src/ngAnimate/module.js
@@ -533,7 +533,7 @@
            animations="true">
     <file name="index.html">
       <a href="#!/">Home</a>
-      <hr />
+      <hr>
       <div class="view-container">
         <div ng-view class="view"></div>
       </div>

--- a/src/ngRoute/directive/ngView.js
+++ b/src/ngRoute/directive/ngView.js
@@ -53,7 +53,7 @@ ngRouteModule.directive('ngView', ngViewFillContentFactory);
           <div class="view-animate-container">
             <div ng-view class="view-animate"></div>
           </div>
-          <hr />
+          <hr>
 
           <pre>$location.path() = {{main.$location.path()}}</pre>
           <pre>$route.current.templateUrl = {{main.$route.current.templateUrl}}</pre>

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -407,7 +407,7 @@ function $RouteProvider() {
      *
      *       <div ng-view></div>
      *
-     *       <hr />
+     *       <hr>
      *
      *       <pre>$location.path() = {{$location.path()}}</pre>
      *       <pre>$route.current.templateUrl = {{$route.current.templateUrl}}</pre>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update


**What is the current behavior? (You can also link to an open issue here)**
Previously, the docs for a directive used both `<hr>` as `<hr />` which is far from consistent.

See #15702

**What is the new behavior (if this is a feature change)?**
This commit ensures only a single notation (`<hr>`) is used.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

