### PR TITLE
feat(errorHandlingConfig): make the length of URL refrence in error m…

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -17,7 +17,7 @@
     "toString": false,
     "minErrConfig": false,
     "errorHandlingConfig": false,
-    "isValidObjectMaxDepth": false,
+    "isValidNumberForMinErrConfig": false,
     "ngMinErr": false,
     "_angular": false,
     "angularModule": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -12,7 +12,7 @@
   toString,
   minErrConfig,
   errorHandlingConfig,
-  isValidObjectMaxDepth,
+  isValidNumberForMinErrConfig,
   ngMinErr,
   angularModule,
   uid,
@@ -129,7 +129,8 @@ var VALIDITY_STATE_PROPERTY = 'validity';
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 var minErrConfig = {
-  objectMaxDepth: 5
+  objectMaxDepth: 5,
+  urlMaxLength: 2000
 };
 
  /**
@@ -143,6 +144,8 @@ var minErrConfig = {
  * current configuration if used as a getter. The following options are supported:
  *
  * - **objectMaxDepth**: The maximum depth to which objects are traversed when stringified for error messages.
+ * - **urlMaxLength**: The maximum length of the URL reference in the error messages.
+ * if the url exceeds the max length it will be truncated, so it will lack of information.
  *
  * Omitted or undefined options will leave the corresponding configuration values unchanged.
  *
@@ -152,11 +155,18 @@ var minErrConfig = {
  * * `objectMaxDepth`  **{Number}** - The max depth for stringifying objects. Setting to a
  *   non-positive or non-numeric value, removes the max depth limit.
  *   Default: 5
+ *
+ * * `urlMaxLength`  **{Number}** - The max length of the URL reference in the error messages. Setting to a
+ *   non-positive or non-numeric value, removes the url max length limit.
+ *   Default: 2000
  */
 function errorHandlingConfig(config) {
   if (isObject(config)) {
     if (isDefined(config.objectMaxDepth)) {
-      minErrConfig.objectMaxDepth = isValidObjectMaxDepth(config.objectMaxDepth) ? config.objectMaxDepth : NaN;
+      minErrConfig.objectMaxDepth = isValidNumberForMinErrConfig(config.objectMaxDepth) ? config.objectMaxDepth : NaN;
+    }
+    if (isDefined(config.urlMaxLength)) {
+      minErrConfig.urlMaxLength = isValidNumberForMinErrConfig(config.urlMaxLength) ? config.urlMaxLength : NaN;
     }
   } else {
     return minErrConfig;
@@ -165,11 +175,11 @@ function errorHandlingConfig(config) {
 
 /**
  * @private
- * @param {Number} maxDepth
+ * @param {Number} num
  * @return {boolean}
  */
-function isValidObjectMaxDepth(maxDepth) {
-  return isNumber(maxDepth) && maxDepth > 0;
+function isValidNumberForMinErrConfig(num) {
+  return isNumber(num) && num > 0;
 }
 
 /**
@@ -897,7 +907,7 @@ function arrayRemove(array, value) {
 function copy(source, destination, maxDepth) {
   var stackSource = [];
   var stackDest = [];
-  maxDepth = isValidObjectMaxDepth(maxDepth) ? maxDepth : NaN;
+  maxDepth = isValidNumberForMinErrConfig(maxDepth) ? maxDepth : NaN;
 
   if (destination) {
     if (isTypedArray(destination) || isArrayBuffer(destination)) {

--- a/src/minErr.js
+++ b/src/minErr.js
@@ -51,13 +51,19 @@ function minErr(module, ErrorConstructor) {
       return match;
     });
 
-    message += '\nhttp://errors.angularjs.org/"NG_VERSION_FULL"/' +
+    var url = 'http://errors.angularjs.org/"NG_VERSION_FULL"/' +
       (module ? module + '/' : '') + code;
 
     for (i = 0, paramPrefix = '?'; i < templateArgs.length; i++, paramPrefix = '&') {
-      message += paramPrefix + 'p' + i + '=' + encodeURIComponent(templateArgs[i]);
+      url += paramPrefix + 'p' + i + '=' + encodeURIComponent(templateArgs[i]);
+
+      if (url.length > minErrConfig.urlMaxLength) {
+        url = url.substr(0, minErrConfig.urlMaxLength - 3) + '...';
+        break;
+      }
     }
 
+    message += '\n' + url;
     return new ErrorConstructor(message);
   };
 }

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -8,7 +8,7 @@ function serializeObject(obj, maxDepth) {
   // There is no direct way to stringify object until reaching a specific depth
   // and a very deep object can cause a performance issue, so we copy the object
   // based on this specific depth and then stringify it.
-  if (isValidObjectMaxDepth(maxDepth)) {
+  if (isValidNumberForMinErrConfig(maxDepth)) {
     obj = copy(obj, null, maxDepth);
   }
   return JSON.stringify(obj, function(key, val) {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -7,6 +7,8 @@ Float32Array, Float64Array,  */
 
 describe('angular', function() {
   var element, document;
+  var originalObjectMaxDepthInErrorMessage = minErrConfig.objectMaxDepth;
+  var originalUrlMaxLengthInErrorMessage = minErrConfig.urlMaxLength;
 
   beforeEach(function() {
     document = window.document;
@@ -14,6 +16,58 @@ describe('angular', function() {
 
   afterEach(function() {
     dealoc(element);
+    minErrConfig.objectMaxDepth = originalObjectMaxDepthInErrorMessage;
+    minErrConfig.urlMaxLength = originalUrlMaxLengthInErrorMessage;
+  });
+
+  describe('errorHandlingConfig', function() {
+    it('should get default objectMaxDepth', function() {
+      expect(errorHandlingConfig().objectMaxDepth).toBe(5);
+    });
+
+    it('should set objectMaxDepth only', function() {
+      errorHandlingConfig({objectMaxDepth: 3});
+      expect(errorHandlingConfig()).toEqual({
+         objectMaxDepth: 3,
+         urlMaxLength: originalUrlMaxLengthInErrorMessage
+      });
+    });
+
+    it('should not change objectMaxDepth when undefined is supplied', function() {
+      errorHandlingConfig({objectMaxDepth: undefined});
+      expect(errorHandlingConfig().objectMaxDepth).toBe(originalObjectMaxDepthInErrorMessage);
+    });
+
+    they('should set objectMaxDepth to NAN when $prop is supplied',
+        [NaN, null, true, false, -1, 0], function(maxDepth) {
+          errorHandlingConfig({objectMaxDepth: maxDepth});
+          expect(errorHandlingConfig().objectMaxDepth).toBeNaN();
+        }
+    );
+
+    it('should get default urlMaxLength', function() {
+      expect(errorHandlingConfig().urlMaxLength).toBe(2000);
+    });
+
+    it('should set urlMaxLength only', function() {
+      errorHandlingConfig({urlMaxLength: 500});
+      expect(errorHandlingConfig()).toEqual({
+        'objectMaxDepth': originalObjectMaxDepthInErrorMessage,
+        'urlMaxLength': 500
+      });
+    });
+
+    it('should not change urlMaxLength when undefined is supplied', function() {
+      errorHandlingConfig({urlMaxLength: undefined});
+      expect(errorHandlingConfig().urlMaxLength).toBe(originalUrlMaxLengthInErrorMessage);
+    });
+
+    they('should set urlMaxLength to NAN when $prop is supplied',
+        [NaN, null, true, false, -1, 0], function(maxLength) {
+          errorHandlingConfig({urlMaxLength: maxLength});
+          expect(errorHandlingConfig().urlMaxLength).toBeNaN();
+        }
+    );
   });
 
   describe('case', function() {


### PR DESCRIPTION
…essages configurable

Closes #14744

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
Sometimes AngularJS throw error with long messages, very long URL referenced error
Will cause 414 Request-URI Too Large  as in Issue https://github.com/angular/angular.js/issues/14744

**What is the new behavior (if this is a feature change)?**
make the Url reference error length configurable.

        errorHandlingConfig({urlMaxLength: 500});


**Does this PR introduce a breaking change?**
NO

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
Microsoft Internet Explorer has a maximum uniform resource locator (URL) length of 2,083 characters. Internet Explorer also has a maximum path length of 2,048 characters. This limit applies to both POST request and GET request URLs. https://support.microsoft.com/en-us/help/208427/maximum-url-length-is-2,083-characters-in-internet-explorer which is less than all the other browsers, so i added the default value for url max length to be 2000 characters.

I don't know what should be the minimum length for URL reference error but i implemented it with a constrains to be more than 200.
