### PR TITLE
docs(guide:external resources) removed 404 link

### DIFF
--- a/docs/content/guide/external-resources.ngdoc
+++ b/docs/content/guide/external-resources.ngdoc
@@ -12,7 +12,6 @@ This is a collection of external, 3rd party resources for learning and developin
 ### Introductory Material
 
 * [10 Reasons Why You Should Use AngularJS](http://www.sitepoint.com/10-reasons-use-angularjs/)
-* [10 Reasons Why Developers Should Learn AngularJS](http://wintellect.com/blogs/jlikness/10-reasons-web-developers-should-learn-angularjs)
 * [Design Principles of AngularJS (video)](https://www.youtube.com/watch?v=HCR7i5F5L8c)
 * [Fundamentals in 60 Minutes (video)](http://www.youtube.com/watch?v=i9MHigUZKEM)
 * [For folks with a jQuery background](http://stackoverflow.com/questions/14994391/how-do-i-think-in-angularjs-if-i-have-a-jquery-background)


### PR DESCRIPTION
I removed "10 reasons developers should learn angularjs" from the introductory material section because it no longer exists (404).

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

