### PR TITLE
feat($compile): Lower the security context of SVG's a and image xlink:href

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1674,7 +1674,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             (nodeName === 'img' && key === 'src') ||
             (nodeName === 'image' && key === 'xlinkHref')) {
           // sanitize a[href] and img[src] values
-          this[key] = value = $$sanitizeUri(value, key === 'src');
+          this[key] = value =
+              $$sanitizeUri(value, nodeName === 'img' || nodeName === 'image');
         } else if (nodeName === 'img' && key === 'srcset' && isDefined(value)) {
           // sanitize img[srcset] values
           var result = '';

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1671,7 +1671,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         nodeName = nodeName_(this.$$element);
 
         if ((nodeName === 'a' && (key === 'href' || key === 'xlinkHref')) ||
-            (nodeName === 'img' && key === 'src')) {
+            (nodeName === 'img' && key === 'src') ||
+            (nodeName === 'image' && key === 'xlinkHref')) {
           // sanitize a[href] and img[src] values
           this[key] = value = $$sanitizeUri(value, key === 'src');
         } else if (nodeName === 'img' && key === 'srcset' && isDefined(value)) {
@@ -3254,8 +3255,10 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         if (['img', 'video', 'audio', 'source', 'track'].indexOf(tag) === -1) {
           return $sce.RESOURCE_URL;
         }
-      // maction[xlink:href] can source SVG.  It's not limited to <maction>.
-      } else if (attrNormalizedName === 'xlinkHref' ||
+      } else if (
+          // Some xlink:href are okay, most aren't
+          (attrNormalizedName === 'xlinkHref' && (tag !== 'image' && tag !== 'a')) ||
+          // Formaction
           (tag === 'form' && attrNormalizedName === 'action') ||
           // If relative URLs can go where they are not expected to, then
           // all sorts of trust issues can arise.


### PR DESCRIPTION
They should go through regular sanitization, RESOURCE_URL is overkill there.
This does not change the context for the rest of xlink:href attributes.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Minor breaking change. 

**What is the current behavior? (You can also link to an open issue here)**
xlink:href are always RESOURCE_URL context, so they go through the $sce whitelist, but aren't sanitized. That context is intended for links to things that are potentially executed as scripts in your origin, which isn't the case here.

**What is the new behavior (if this is a feature change)?**
image and a xlink:href are now sanitized as link URLs (like a href), and won't complain on different-origin links anymore.

**Does this PR introduce a breaking change?**
This is breaking, but only in marginal (and probably unsafe) cases. If you whitelisted something for a xlink:href binding on one of those two, you'll need to change the aHrefSanitizationWhitelist instead. In the overwhelming majority of cases, everything that works with the default settings will keep working, and those defaults aren't usually modified.

**Other information**:
I'm almost sure there are issues around ng-href in svg lying around, and probably general svg bindings security issues too :/ ng-href security context currently doesn't match the xlink:href ones. It can't be fixed without breaking changes though, so that's for another PR. Some simple tests: https://plnkr.co/edit/PbR1FH2v4luScSYdU16t?p=preview

