### PR TITLE
docs(ngAnimate): Improve Staggering config for animations

### DIFF
--- a/src/ngAnimate/module.js
+++ b/src/ngAnimate/module.js
@@ -177,6 +177,9 @@
  *   /&#42; As of 1.4.4, this must always be set: it signals ngAnimate
  *     to not accidentally inherit a delay property from another CSS class &#42;/
  *   transition-duration: 0s;
+ *   /&#42; if you are using animations instead of transitions you should configure as follows: 
+ *     animation-delay: 0.1s; 
+ *     animation-duration: 0s; &#42;/
  * }
  * .my-animation.ng-enter.ng-enter-active {
  *   /&#42; standard transition styles &#42;/


### PR DESCRIPTION
After console.log the output from the computeCachedCssStaggerStyles function I realized that I need set animation-duration to 0s and animation-delay on my stagger class as I am using animations instead of transitions.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

