### PR TITLE
docs(orderBy): Clarify that orderBy does not work on JavaScript objects. 

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -13,7 +13,7 @@
  * `[{id: 'bar'}, {id: 'foo'}]`.
  *
  * The `collection` can be an Array or array-like object (e.g. NodeList, jQuery object, TypedArray,
- * String, etc).
+ * String, etc). This will not work on a JavaScript object. 
  *
  * The `expression` can be a single predicate, or a list of predicates each serving as a tie-breaker
  * for the preceding one. The `expression` is evaluated against each item and the output is used

--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -13,7 +13,7 @@
  * `[{id: 'bar'}, {id: 'foo'}]`.
  *
  * The `collection` can be an Array or array-like object (e.g. NodeList, jQuery object, TypedArray,
- * String, etc). This will not work on a JavaScript object. 
+ * String, etc). Please note that `orderBy` does not work on Object Literals. 
  *
  * The `expression` can be a single predicate, or a list of predicates each serving as a tie-breaker
  * for the preceding one. The `expression` is evaluated against each item and the output is used


### PR DESCRIPTION
This PR specifies that orderBy does not work on JavaScript objects. This is unclear in the documentation, and users would benefit from clarification here.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs update. 

**What is the current behavior? (You can also link to an open issue here)**

Currently, `orderBy` does not work on objects. I think that the documentation would benefit from making this abundantly clear! 

**What is the new behavior (if this is a feature change)?**

N/A

**Does this PR introduce a breaking change?**

N/A

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

