### PR TITLE
fix(Angular): do not autobootstrap if the `src` exists but is empty

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1543,15 +1543,19 @@ function allowAutoBootstrap(document) {
     return false;
   }
 
-  var srcs = [script.getAttribute('src'), script.getAttribute('href'), script.getAttribute('xlink:href')];
+  var attributes = script.attributes;
+  var srcs = [attributes.getNamedItem('src'), attributes.getNamedItem('href'), attributes.getNamedItem('xlink:href')];
 
   return srcs.every(function(src) {
     if (!src) {
       return true;
     }
+    if (!src.value) {
+      return false;
+    }
 
     var link = document.createElement('a');
-    link.href = src;
+    link.href = src.value;
 
     if (document.location.origin === link.origin) {
       // Same-origin resources are always allowed, even for non-whitelisted schemes.

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1752,16 +1752,17 @@ describe('angular', function() {
           expect(allowAutoBootstrap(createFakeDoc({src: protocol + '//something-else'}, protocol))).toBe(false);
         });
 
-        it('should bootstrap from a script with empty or no source (e.g. src, href or xlink:href attributes)', function() {
+        it('should bootstrap from a script with no source (e.g. src, href or xlink:href attributes)', function() {
 
           expect(allowAutoBootstrap(createFakeDoc({src: null}))).toBe(true);
-          expect(allowAutoBootstrap(createFakeDoc({src: ''}))).toBe(true);
-
           expect(allowAutoBootstrap(createFakeDoc({href: null}))).toBe(true);
-          expect(allowAutoBootstrap(createFakeDoc({href: ''}))).toBe(true);
-
           expect(allowAutoBootstrap(createFakeDoc({'xlink:href': null}))).toBe(true);
-          expect(allowAutoBootstrap(createFakeDoc({'xlink:href': ''}))).toBe(true);
+        });
+
+        it('should not bootstrap from a script with an empty source (e.g. `src=""`)', function() {
+          expect(allowAutoBootstrap(createFakeDoc({src: ''}))).toBe(false);
+          expect(allowAutoBootstrap(createFakeDoc({href: ''}))).toBe(false);
+          expect(allowAutoBootstrap(createFakeDoc({'xlink:href': ''}))).toBe(false);
         });
 
 


### PR DESCRIPTION
In Chrome an empty `src` attribute will be ignored, but in Firefox it seems
happy to prepend the `base[href]` and try to load whatever that is.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

