### PR TITLE
test(errorHandlingConfig): add test for errorHandlingConfig() to be i…

### DIFF
--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -7,6 +7,7 @@ Float32Array, Float64Array,  */
 
 describe('angular', function() {
   var element, document;
+  var originalObjectMaxDepthInErrorMessage = minErrConfig.objectMaxDepth;
 
   beforeEach(function() {
     document = window.document;
@@ -14,6 +15,30 @@ describe('angular', function() {
 
   afterEach(function() {
     dealoc(element);
+    minErrConfig.objectMaxDepth = originalObjectMaxDepthInErrorMessage;
+  });
+
+  describe('errorHandlingConfig', function() {
+    it('should get default objectMaxDepth', function() {
+      expect(errorHandlingConfig().objectMaxDepth).toBe(5);
+    });
+
+    it('should set objectMaxDepth', function() {
+      errorHandlingConfig({objectMaxDepth: 3});
+      expect(errorHandlingConfig().objectMaxDepth).toBe(3);
+    });
+
+    it('should not change objectMaxDepth when undefined is supplied', function() {
+      errorHandlingConfig({objectMaxDepth: undefined});
+      expect(errorHandlingConfig().objectMaxDepth).toBe(originalObjectMaxDepthInErrorMessage);
+    });
+
+    they('should set objectMaxDepth to NaN when $prop is supplied',
+        [NaN, null, true, false, -1, 0], function(maxDepth) {
+          errorHandlingConfig({objectMaxDepth: maxDepth});
+          expect(errorHandlingConfig().objectMaxDepth).toBeNaN();
+        }
+    );
   });
 
   describe('case', function() {

--- a/test/minErrSpec.js
+++ b/test/minErrSpec.js
@@ -78,32 +78,27 @@ describe('minErr', function() {
 
     var myError = testError('26', 'a when objectMaxDepth is default=5 is {0}', a);
     expect(myError.message).toMatch(/a when objectMaxDepth is default=5 is {"b":{"c":{"d":{"e":{"f":"..."}}}}}/);
-    expect(errorHandlingConfig().objectMaxDepth).toBe(5);
 
     errorHandlingConfig({objectMaxDepth: 1});
     myError = testError('26', 'a when objectMaxDepth is set to 1 is {0}', a);
     expect(myError.message).toMatch(/a when objectMaxDepth is set to 1 is {"b":"..."}/);
-    expect(errorHandlingConfig().objectMaxDepth).toBe(1);
 
     errorHandlingConfig({objectMaxDepth: 2});
     myError = testError('26', 'a when objectMaxDepth is set to 2 is {0}', a);
     expect(myError.message).toMatch(/a when objectMaxDepth is set to 2 is {"b":{"c":"..."}}/);
-    expect(errorHandlingConfig().objectMaxDepth).toBe(2);
 
     errorHandlingConfig({objectMaxDepth: undefined});
     myError = testError('26', 'a when objectMaxDepth is set to undefined is {0}', a);
     expect(myError.message).toMatch(/a when objectMaxDepth is set to undefined is {"b":{"c":"..."}}/);
-    expect(errorHandlingConfig().objectMaxDepth).toBe(2);
   });
 
   they('should handle arguments that are objects and ignore max depth when objectMaxDepth = $prop',
     [NaN, null, true, false, -1, 0], function(maxDepth) {
-      var a = {b: {c: {d: 1}}};
+      var a = {b: {c: {d: {e: {f: {g: 1}}}}}};
 
       errorHandlingConfig({objectMaxDepth: maxDepth});
       var myError = testError('26', 'a is {0}', a);
-      expect(myError.message).toMatch(/a is {"b":{"c":{"d":1}}}/);
-      expect(errorHandlingConfig().objectMaxDepth).toBeNaN();
+      expect(myError.message).toMatch(/a is {"b":{"c":{"d":{"e":{"f":{"g":1}}}}}}/);
     }
   );
 


### PR DESCRIPTION
…ndependent of minErr

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
test


**What is the current behavior? (You can also link to an open issue here)**
There is no test for errorHandlingConfig
**What is the new behavior (if this is a feature change)?**
Add tests to errorHandlingConfig independent of minErr tests


**Does this PR introduce a breaking change?**
no


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
These tests was added in https://github.com/angular/angular.js/pull/15707 , but it looks like there are some problems in the PR, so i have added the missing tests in this PR.