### PR TITLE
Fix newline bug in date-filter

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -534,6 +534,8 @@ var DATE_FORMATS_SPLIT = /((?:[^yMLdHhmsaZEwG']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+
  *   `"h 'in the morning'"`). In order to output a single quote, escape it - i.e., two single quotes in a sequence
  *   (e.g. `"h 'o''clock'"`).
  *
+ *   Any other characters in the `format` string will be output as-is.
+ *
  * @param {(Date|number|string)} date Date to format either as Date object, milliseconds (string or
  *    number) or various ISO 8601 datetime string formats (e.g. yyyy-MM-ddTHH:mm:ss.sssZ and its
  *    shorter versions like yyyy-MM-ddTHH:mmZ, yyyy-MM-dd or yyyyMMddTHHmmssZ). If no timezone is

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -475,7 +475,7 @@ var DATE_FORMATS = {
      GGGG: longEraGetter
 };
 
-var DATE_FORMATS_SPLIT = /((?:[^yMLdHhmsaZEwG']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|L+|d+|H+|h+|m+|s+|a|Z|G+|w+))(.*)/,
+var DATE_FORMATS_SPLIT = /((?:[^yMLdHhmsaZEwG']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|L+|d+|H+|h+|m+|s+|a|Z|G+|w+))([\s\S]*)/,
     NUMBER_STRING = /^-?\d+$/;
 
 /**

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -504,6 +504,11 @@ describe('filters', function() {
       expect(date(morning, 'yy/xxx')).toEqual('10/xxx');
     });
 
+    it('should allow newlines in format', function() {
+      expect(date(midnight, 'EEE\nMMM d\'\n\'yy/xxx\n')).
+                      toEqual('Fri\nSep 3\n10/xxx\n');
+    });
+
     it('should support various iso8061 date strings with timezone as input', function() {
       var format = 'yyyy-MM-dd ss';
 

--- a/test/ng/filter/filtersSpec.js
+++ b/test/ng/filter/filtersSpec.js
@@ -505,8 +505,7 @@ describe('filters', function() {
     });
 
     it('should allow newlines in format', function() {
-      expect(date(midnight, 'EEE\nMMM d\'\n\'yy/xxx\n')).
-                      toEqual('Fri\nSep 3\n10/xxx\n');
+      expect(date(midnight, 'EEE\nMMM d\'\n\'yy/xxx\n')).toEqual('Fri\nSep 3\n10/xxx\n');
     });
 
     it('should support various iso8061 date strings with timezone as input', function() {


### PR DESCRIPTION
Formatting a date across 2 lines fails:
```html
<span>{{ '2017-03-09' | date: 'MMM\nyyyy' }}</span>
```

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
The date format is only processed up to the newline.  i.e. as though the sample code was:

```html
<span>{{ '2017-03-09' | date: 'MMM' }}</span>
```

Producing:
```html
<span>Mar</span>
```

**What is the new behavior (if this is a feature change)?**
The full date format string is processed, producing:
```html
<span>Mar
2017</span>
```

**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

