### PR TITLE
feat: add new module "ngStyle" support css loading via component

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -230,6 +230,10 @@ module.exports = function(grunt) {
         dest: 'build/angular-messages.js',
         src: util.wrap(files['angularModules']['ngMessages'], 'module')
       },
+      style: {
+        dest: 'build/angular-style.js',
+        src: util.wrap(files['angularModules']['ngStyle'], 'module')
+      },
       animate: {
         dest: 'build/angular-animate.js',
         src: util.wrap(files['angularModules']['ngAnimate'], 'module')
@@ -268,6 +272,7 @@ module.exports = function(grunt) {
       resource: 'build/angular-resource.js',
       route: 'build/angular-route.js',
       sanitize: 'build/angular-sanitize.js',
+      style: 'build/angular-style.js',
       aria: 'build/angular-aria.js',
       parseext: 'build/angular-parse-ext.js'
     },

--- a/angularFiles.js
+++ b/angularFiles.js
@@ -40,6 +40,7 @@ var angularFiles = {
     'src/ng/sanitizeUri.js',
     'src/ng/sce.js',
     'src/ng/sniffer.js',
+    'src/ng/styleComponent.js',
     'src/ng/templateRequest.js',
     'src/ng/testability.js',
     'src/ng/timeout.js',
@@ -139,6 +140,9 @@ var angularFiles = {
       'src/ngSanitize/sanitize.js',
       'src/ngSanitize/filter/linky.js'
     ],
+    'ngStyle': [
+      'src/ngStyle/style.js'
+    ],
     'ngMock': [
       'src/ngMock/angular-mocks.js',
       'src/ngMock/browserTrigger.js'
@@ -202,7 +206,8 @@ var angularFiles = {
     'test/jquery_alias.js',
     'src/angular-bootstrap.js',
     'src/ngScenario/angular-bootstrap.js',
-    'src/angular.bind.js'
+    'src/angular.bind.js',
+    'src/ngStyle/style.js'
   ],
 
   'karmaScenario': [
@@ -240,7 +245,8 @@ var angularFiles = {
     'src/angular-bootstrap.js',
     'src/ngScenario/angular-bootstrap.js',
     'test/jquery_remove.js',
-    'src/angular.bind.js'
+    'src/angular.bind.js',
+    'src/ngStyle/style.js'
   ]
 };
 
@@ -263,6 +269,7 @@ angularFiles['angularSrcModules'] = [].concat(
   angularFiles['angularModules']['ngResource'],
   angularFiles['angularModules']['ngRoute'],
   angularFiles['angularModules']['ngSanitize'],
+  angularFiles['angularModules']['ngStyle'],
   angularFiles['angularModules']['ngMock'],
   angularFiles['angularModules']['ngTouch'],
   angularFiles['angularModules']['ngAria']

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -94,7 +94,8 @@
   $$RAFProvider,
   $WindowProvider,
   $$jqLiteProvider,
-  $$CookieReaderProvider
+  $$CookieReaderProvider,
+  $$StyleComponentProvider
 */
 
 
@@ -254,6 +255,7 @@ function publishExternalAPI(angular) {
         $sce: $SceProvider,
         $sceDelegate: $SceDelegateProvider,
         $sniffer: $SnifferProvider,
+        $$styleComponent: $$StyleComponentProvider,
         $templateCache: $TemplateCacheProvider,
         $templateRequest: $TemplateRequestProvider,
         $$testability: $$TestabilityProvider,

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2542,7 +2542,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             childTranscludeFn.$$slots = slots;
           }
         }
-        
+
         if (directive.styles) {
             $$styleComponent.registerStyles(directiveName, directive.styles);
         } else if (directive.styleUrls) {
@@ -2725,7 +2725,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
           if ($$styleComponent.isRegistered(directiveName)) {
             $$styleComponent.loadStyles(directiveName);
-            isolateScope.$on('$destroy', function () {
+            isolateScope.$on('$destroy', function() {
               $$styleComponent.unLoadStyles(controllerDirective.name);
             });
           }

--- a/src/ng/styleComponent.js
+++ b/src/ng/styleComponent.js
@@ -12,15 +12,15 @@
  *
  * To see the functional implementation check out `src/ngStyle/style.js`.
  */
-  var $$StyleComponentProvider = /** @this */ function () {
+  var $$StyleComponentProvider = /** @this */ function() {
 
-    this.$get = [function () {
+    this.$get = [function() {
         return {
           registerStyles: noop,
           registerStyleUrls: noop,
           loadStyles: noop,
           unLoadStyles: noop,
-          isRegistered: function () { return false; }
+          isRegistered: function() { return false; }
         };
       }];
   };

--- a/src/ng/styleComponent.js
+++ b/src/ng/styleComponent.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/**
+ * @ngdoc provider
+ * @name $$styleComponentProvider
+ *
+ * @description
+ * Default implementation of $style that doesn't perform any action, instead just
+ * synchronously resolves the returned promise.
+ *
+ * In order to enable style the `ngStyle` module has to be loaded.
+ *
+ * To see the functional implementation check out `src/ngStyle/style.js`.
+ */
+  var $$StyleComponentProvider = /** @this */ function () {
+
+    this.$get = [function () {
+        return {
+          registerStyles: noop,
+          registerStyleUrls: noop,
+          loadStyles: noop,
+          unLoadStyles: noop,
+          isRegistered: function () { return false; }
+        };
+      }];
+  };

--- a/src/ngStyle/style.js
+++ b/src/ngStyle/style.js
@@ -15,8 +15,8 @@ var $styleMinErr = angular.$$minErr('ngStyle');
  * # ngStyle
  *
  * The `ngStyle` module provides styles requset, styles caching and style management for
- * AngularJS apps. The module also provide new ability for components to add styles url or style text.  
- * 
+ * AngularJS apps. The module also provide new ability for components to add styles url or style text.
+ *
  * ## Example
  * See {@link ngRoute.$route#example $route} for an example of configuring and using `ngRoute`.
  *
@@ -44,7 +44,7 @@ ngStyleModule.provider('$$styleComponent', $$StyleComponentProvider);
 function $StyleProvider() {
 
     this.$get = ['$exceptionHandler', '$styleRequest', '$q',
-        function ($exceptionHandler, $styleRequest, $q) {
+        function($exceptionHandler, $styleRequest, $q) {
             var activeRequests = {};
 
             return {
@@ -63,15 +63,15 @@ function $StyleProvider() {
                  *
                  * ### Example
                  *   ```js
-                 * 
+                 *
                  *     // using path
                  *     $style.addStyleUrls('./path/to/css/file.css').then(function(stylesArray){
-                 *          
+                 *
                  *     });
                  *
                  *     // or using multiple pathes
                  *     $style.addStyleUrls(['./path/to/css/file1.css', './path/to/css/file2.css']).then(function(stylesArray){
-                 *          
+                 *
                  *     });
                  *
                  *   ```
@@ -92,9 +92,9 @@ function $StyleProvider() {
                  *
                  * ### Example
                  *   ```js
-                 *     // use id 
+                 *     // use id
                  *     $style.removeStyles('myElementId');
-                 * 
+                 *
                  *     // or you can use path
                  *     $style.removeStyles('./path/to/css/file.css');
                  *
@@ -126,7 +126,7 @@ function $StyleProvider() {
             };
 
             function getStyleElement(path) {
-                return document.getElementById(path);
+                return window.document.getElementById(path);
             }
 
             function addStyleUrls(path) {
@@ -139,7 +139,7 @@ function $StyleProvider() {
                     path = [path];
                 }
 
-                return loadStyleUrls(path).then(function (data) {
+                return loadStyleUrls(path).then(function(data) {
                     var styles = [], i, l, id, css;
 
                     for (i = 0, l = path.length; i < l; i++) {
@@ -154,7 +154,7 @@ function $StyleProvider() {
                     }
 
                     if (styles.length)
-                        angular.element(document.head).append(styles.join(''));
+                        angular.element(window.document.head).append(styles.join(''));
                 });
             }
 
@@ -166,16 +166,16 @@ function $StyleProvider() {
                 }
 
                 if (isArray(path)) {
-                    forEach(path, function (url) {
+                    forEach(path, function(url) {
                         if (!activeRequests[url]) {
                             activeRequests[url] = $styleRequest(url);
                         }
 
-                        this.push(activeRequests[url]);
+                        requests.push(activeRequests[url]);
                     }, requests);
 
-                    return $q.all(requests).finally(function () {
-                        forEach(path, function (url) {
+                    return $q.all(requests).finally(function() {
+                        forEach(path, function(url) {
                             delete activeRequests[url];
                         }, requests);
                     });
@@ -190,7 +190,7 @@ function $StyleProvider() {
                 if (isString(path)) {
                     path = [path];
                 }
-                forEach(path, function (url) {
+                forEach(path, function(url) {
                     elements.push(getStyleElement(url));
                 });
 
@@ -204,7 +204,7 @@ function $StyleProvider() {
                 }
 
                 if (isString(id) && isString(css) && !getStyleElement(id)) {
-                    angular.element(document.head).append('<style type="text/css" id="' + id + '">' + css + '</style>');
+                    angular.element(window.document.head).append('<style type="text/css" id="' + id + '">' + css + '</style>');
                 }
             }
         }];
@@ -236,14 +236,14 @@ function $StyleRequestProvider() {
      * The options to be passed to the {@link $http} service when making the request.
      * You can use this to override options such as the "Accept" header for template requests.
      *
-     * The {@link $styleRequest} will set the `cache` 
+     * The {@link $styleRequest} will set the `cache`
      *
      * @param {string=} value new value for the {@link $http} options.
      * @returns {string|self} Returns the {@link $http} options when used as getter and self if used as setter.
      *
      */
 
-    this.httpOptions = function (val) {
+    this.httpOptions = function(val) {
         if (val) {
             httpOptions = val;
             return this;
@@ -274,7 +274,7 @@ function $StyleRequestProvider() {
      * @property {number} totalPendingRequests total amount of pending template requests being downloaded.
      */
     this.$get = ['$exceptionHandler', '$styleCache', '$http', '$q', '$sce',
-        function ($exceptionHandler, $styleCache, $http, $q, $sce) {
+        function($exceptionHandler, $styleCache, $http, $q, $sce) {
 
             function handleRequestFn(styleUrl, ignoreRequestError) {
                 handleRequestFn.totalPendingRequests++;
@@ -287,10 +287,10 @@ function $StyleRequestProvider() {
                 httpOptions.transformResponse = null;
 
                 return $http.get(styleUrl, httpOptions)
-                    .finally(function () {
+                    .finally(function() {
                         handleRequestFn.totalPendingRequests--;
                     })
-                    .then(function (response) {
+                    .then(function(response) {
                         $styleCache.put(styleUrl, response.data);
                         return response.data;
                     }, handleError);
@@ -344,7 +344,7 @@ function $StyleRequestProvider() {
  * Or to retrieve multiple styles later, simply use it in your component:
  * ```js
  * myApp.component('myComponent', {
- *    styleUrls: ['styleId1.css', 'styleId2.css'] 
+ *    styleUrls: ['styleId1.css', 'styleId2.css']
  * });
  * ```
  *
@@ -359,13 +359,13 @@ function $StyleRequestProvider() {
  * Requires the {@link ngStyle `ngStyle`} module to be installed.
  */
 function $StyleCacheProvider() {
-    this.$get = ['$cacheFactory', function ($cacheFactory) {
+    this.$get = ['$cacheFactory', function($cacheFactory) {
         return $cacheFactory('styles');
     }];
 }
 
 ///
-/// used by the applyDirectivesToNode function to add dynamicaly styles if decalared 
+/// used by the applyDirectivesToNode function to add dynamicaly styles if decalared
 /// on the component definition object using the styleUrls property or styles.
 /// see component example to learn more
 function $$StyleComponentProvider() {
@@ -375,14 +375,14 @@ function $$StyleComponentProvider() {
      * @ngdoc method
      * @name $$StyleComponentProvider#shouldRemoveComponentsStyles
      * @description
-     * The value passed should decide whether remove style when no component existing 
+     * The value passed should decide whether remove style when no component existing
      * anymore in the view or not.
      *
      * @param {bool=} value new value.
      * @returns {string|self} Returns the value when used as getter and self if used as setter.
      *
      */
-    this.shouldRemoveComponentsStyles = function (val) {
+    this.shouldRemoveComponentsStyles = function(val) {
         if (!isUndefined(val)) {
             shouldRemoveComponentsStyles = !!val;
             return this;
@@ -394,7 +394,7 @@ function $$StyleComponentProvider() {
 
 
     this.$get = ['$style', '$q', '$exceptionHandler',
-        function ($style, $q, $exceptionHandler) {
+        function($style, $q, $exceptionHandler) {
             var componentStyles = {},
                 stylesUsage = {};
 
@@ -409,7 +409,7 @@ function $$StyleComponentProvider() {
                 loadStyles: loadStyles,
                 // unload component style once component its destroyed
                 unLoadStyles: unLoadStyles,
-                // 
+                //
                 isRegistered: isRegistered
             };
 
@@ -465,7 +465,7 @@ function $$StyleComponentProvider() {
                     incrementUrls(componentStyle.styleUrls);
 
                     if (shouldDoUrlLoading) {
-                        $style.addStyleUrls(componentStyle.styleUrls).finally(function () {
+                        $style.addStyleUrls(componentStyle.styleUrls).finally(function() {
                             removeComponentLoader(componentName);
                         });
                     }
@@ -495,7 +495,7 @@ function $$StyleComponentProvider() {
             // for each url styleUsage is incremented.
             function incrementUrls(urls) {
                 if (isArray(urls)) {
-                    forEach(urls, function (url) {
+                    forEach(urls, function(url) {
                         stylesUsage[url] = stylesUsage[url] || 0;
                         stylesUsage[url]++;
                     });
@@ -505,7 +505,7 @@ function $$StyleComponentProvider() {
             // decrement counter per url. once the style is not in use we remove it.
             function decrementUrls(urls) {
                 if (isArray(urls)) {
-                    forEach(urls, function (url) {
+                    forEach(urls, function(url) {
                         if (stylesUsage[url]) {
                             stylesUsage[url]--;
 
@@ -518,21 +518,20 @@ function $$StyleComponentProvider() {
                 }
             }
 
-            // since i didn't want to make huge changes in the applyDirectivesToNode method to 
+            // since i didn't want to make huge changes in the applyDirectivesToNode method to
             // support async style i did that trick to hide the component till we will get the style response.
             function setComponentLoader(componentName) {
-                return angular.element(document.head).append('<style type="text/css" id="' + componentName + '-loader">' + componentNormalize(componentName) + ':{display:none !important;}</style>');
+                return angular.element(window.document.head).append('<style type="text/css" id="' + componentName + '-loader">' + componentNormalize(componentName) + ':{display:none !important;}</style>');
             }
 
             // once the component styles are fetch or failed i am showing the component.
             function removeComponentLoader(componentName) {
-                angular.element(document.head.querySelector('#' + componentName + '-loader')).remove();
+                angular.element(window.document.head.querySelector('#' + componentName + '-loader')).remove();
             }
 
             // change the js component name to html tag name. for example `myCmp` will be `my-cmp`.
             function componentNormalize(name) {
-                return name.replace(/([A-Z])/g, "-$1").toLowerCase();
+                return name.replace(/([A-Z])/g, '-$1').toLowerCase();
             }
         }];
-
 }

--- a/src/ngStyle/style.js
+++ b/src/ngStyle/style.js
@@ -1,0 +1,538 @@
+'use strict';
+
+var isArray = angular.isArray;
+var isUndefined = angular.isUndefined;
+var isString = angular.isString;
+var forEach = angular.forEach;
+
+var $styleMinErr = angular.$$minErr('ngStyle');
+
+/**
+ * @ngdoc module
+ * @name ngStyle
+ * @description
+ *
+ * # ngStyle
+ *
+ * The `ngStyle` module provides styles requset, styles caching and style management for
+ * AngularJS apps. The module also provide new ability for components to add styles url or style text.  
+ * 
+ * ## Example
+ * See {@link ngRoute.$route#example $route} for an example of configuring and using `ngRoute`.
+ *
+ *
+ * <div doc-module-components="ngStyle"></div>
+ */
+var ngStyleModule = angular.module('ngStyle', []);
+
+ngStyleModule.provider('$style', $StyleProvider);
+ngStyleModule.provider('$styleRequest', $StyleRequestProvider);
+ngStyleModule.provider('$styleCache', $StyleCacheProvider);
+ngStyleModule.provider('$$styleComponent', $$StyleComponentProvider);
+
+/**
+ * @ngdoc provider
+ * @name $StyleProvider
+ * @this
+ *
+ * @description
+ * Used to set or remove styles dynamicaly. the styles can be used via style urls or styles text
+ *
+ * ## Dependencies
+ * Requires the {@link ngStyle `ngStyle`} module to be installed.
+ */
+function $StyleProvider() {
+
+    this.$get = ['$exceptionHandler', '$styleRequest', '$q',
+        function ($exceptionHandler, $styleRequest, $q) {
+            var activeRequests = {};
+
+            return {
+                /**
+                 * @ngdoc method
+                 * @name $StyleProvider#addStyleUrls
+                 * @kind function
+                 *
+                 * @description
+                 * Add the css styles, using path related to index.html, to the head.
+                 *
+                 * @param {string|Array} path one or more pathes strings to the css style.
+                 *
+                 * @returns {promise} A promise which will resolved once styles fetched
+                 *  and added to the head. the promise return array of the style texts.
+                 *
+                 * ### Example
+                 *   ```js
+                 * 
+                 *     // using path
+                 *     $style.addStyleUrls('./path/to/css/file.css').then(function(stylesArray){
+                 *          
+                 *     });
+                 *
+                 *     // or using multiple pathes
+                 *     $style.addStyleUrls(['./path/to/css/file1.css', './path/to/css/file2.css']).then(function(stylesArray){
+                 *          
+                 *     });
+                 *
+                 *   ```
+                 *
+                 */
+                addStyleUrls: addStyleUrls,
+                loadStyleUrls: loadStyleUrls,
+                /**
+                 * @ngdoc method
+                 * @name $StyleProvider#removeStyles
+                 * @kind function
+                 *
+                 * @description
+                 * Remove the css styles, using path related to index.html, to the head.
+                 * note: the path is case sensitive
+                 *
+                 * @param {string|Array} path one or more pathes strings to the css style.
+                 *
+                 * ### Example
+                 *   ```js
+                 *     // use id 
+                 *     $style.removeStyles('myElementId');
+                 * 
+                 *     // or you can use path
+                 *     $style.removeStyles('./path/to/css/file.css');
+                 *
+                 *     // or you can use multiple pathes
+                 *     $style.removeStyles(['./path/to/css/file1.css', './path/to/css/file2.css']);
+                 *
+                 *   ```
+                 *
+                 */
+                removeStyles: removeStyles,
+                /**
+                 * @ngdoc method
+                 * @name $StyleProvider#addStyles
+                 * @kind function
+                 *
+                 * @description
+                 * Add the css styles, using style text, to the head.
+                 *
+                 * @param {string} id An id for the new style element.
+                 *
+                 * @param {string} css Css text.
+                 *
+                 * ### Example
+                 *   ```js
+                 *     $style.addStyles('myElementId', '.element-example { background-color: red; }');
+                 *   ```
+                 */
+                addStyles: addStyles
+            };
+
+            function getStyleElement(path) {
+                return document.getElementById(path);
+            }
+
+            function addStyleUrls(path) {
+                if (window.angular.$$csp().noInlineStyle) {
+                    $exceptionHandler($styleMinErr('styleload', 'Failed to load style due to csp restriction'));
+                    return $q.reject();
+                }
+
+                if (isString(path)) {
+                    path = [path];
+                }
+
+                return loadStyleUrls(path).then(function (data) {
+                    var styles = [], i, l, id, css;
+
+                    for (i = 0, l = path.length; i < l; i++) {
+                        id = path[i];
+                        css = data[i];
+
+                        if (isString(id) && isString(css) && !getStyleElement(id)) {
+                            styles.push('<style type="text/css" id="' + id + '">' + css + '</style>');
+                        }
+
+                        delete activeRequests[id];
+                    }
+
+                    if (styles.length)
+                        angular.element(document.head).append(styles.join(''));
+                });
+            }
+
+            function loadStyleUrls(path) {
+                var requests = [];
+
+                if (isString(path)) {
+                    path = [path];
+                }
+
+                if (isArray(path)) {
+                    forEach(path, function (url) {
+                        if (!activeRequests[url]) {
+                            activeRequests[url] = $styleRequest(url);
+                        }
+
+                        this.push(activeRequests[url]);
+                    }, requests);
+
+                    return $q.all(requests).finally(function () {
+                        forEach(path, function (url) {
+                            delete activeRequests[url];
+                        }, requests);
+                    });
+                }
+
+                return $q.reject();
+            }
+
+            function removeStyles(path) {
+                var elements = [];
+
+                if (isString(path)) {
+                    path = [path];
+                }
+                forEach(path, function (url) {
+                    elements.push(getStyleElement(url));
+                });
+
+                angular.element(elements).remove();
+            }
+
+            function addStyles(id, css) {
+                if (window.angular.$$csp().noInlineStyle) {
+                    $exceptionHandler($styleMinErr('styleload', 'Failed to load style due to csp restriction'));
+                    return;
+                }
+
+                if (isString(id) && isString(css) && !getStyleElement(id)) {
+                    angular.element(document.head).append('<style type="text/css" id="' + id + '">' + css + '</style>');
+                }
+            }
+        }];
+
+}
+
+/**
+ * @ngdoc provider
+ * @name $StyleRequestProvider
+ * @this
+ *
+ * @description
+ * Used to configure the options passed to the {@link $http} service when making a style request.
+ *
+ * For example, it can be used for specifying the "Accept" header that is sent to the server, when
+ * requesting a style.
+ *
+ * ## Dependencies
+ * Requires the {@link ngStyle `ngStyle`} module to be installed.
+ */
+function $StyleRequestProvider() {
+
+    var httpOptions = {};
+
+    /**
+     * @ngdoc method
+     * @name $styleRequestProvider#httpOptions
+     * @description
+     * The options to be passed to the {@link $http} service when making the request.
+     * You can use this to override options such as the "Accept" header for template requests.
+     *
+     * The {@link $styleRequest} will set the `cache` 
+     *
+     * @param {string=} value new value for the {@link $http} options.
+     * @returns {string|self} Returns the {@link $http} options when used as getter and self if used as setter.
+     *
+     */
+
+    this.httpOptions = function (val) {
+        if (val) {
+            httpOptions = val;
+            return this;
+        }
+        return httpOptions;
+    };
+
+    /**
+     * @ngdoc service
+     * @name $styleRequest
+     *
+     * @description
+     * The `$styleRequest` downloads the provided style using
+     * `$http` and, upon success, stores the contents inside of `$styleCache`. If the HTTP request
+     * fails or the response data of the HTTP request is empty, a `$compile` error will be thrown (the
+     * exception can be thwarted by setting the 2nd parameter of the function to true). Note that the
+     * contents of `$styleCache` are trusted, so the call to `$sce.getTrustedUrl(styleUrl)` is omitted
+     * when `styleUrl` is of type string and `$styleCache` has the matching entry.
+     *
+     * If you want to pass custom options to the `$http` service, such as setting the Accept header you
+     * can configure this via {@link $templateRequestProvider#httpOptions}.
+     *
+     * @param {string|TrustedResourceUrl} styleUrl The HTTP request style URL
+     * @param {boolean=} ignoreRequestError Whether or not to ignore the exception when the request fails or the template is empty
+     *
+     * @return {Promise} a promise for the HTTP response data of the given URL.
+     *
+     * @property {number} totalPendingRequests total amount of pending template requests being downloaded.
+     */
+    this.$get = ['$exceptionHandler', '$styleCache', '$http', '$q', '$sce',
+        function ($exceptionHandler, $styleCache, $http, $q, $sce) {
+
+            function handleRequestFn(styleUrl, ignoreRequestError) {
+                handleRequestFn.totalPendingRequests++;
+
+                if (!isString(styleUrl) || isUndefined($styleCache.get(styleUrl))) {
+                    styleUrl = $sce.getTrustedResourceUrl(styleUrl);
+                }
+
+                httpOptions.cache = $styleCache;
+                httpOptions.transformResponse = null;
+
+                return $http.get(styleUrl, httpOptions)
+                    .finally(function () {
+                        handleRequestFn.totalPendingRequests--;
+                    })
+                    .then(function (response) {
+                        $styleCache.put(styleUrl, response.data);
+                        return response.data;
+                    }, handleError);
+
+                function handleError(resp) {
+                    if (!ignoreRequestError) {
+                        resp = $styleMinErr('styleload',
+                            'Failed to load style: {0} (HTTP status: {1} {2})',
+                            styleUrl, resp.status, resp.statusText);
+
+                        $exceptionHandler(resp);
+                    }
+
+                    return $q.reject(resp);
+                }
+            }
+
+            handleRequestFn.totalPendingRequests = 0;
+
+            return handleRequestFn;
+        }
+    ];
+}
+
+/**
+ * @ngdoc service
+ * @name $styleCache
+ * @this
+ *
+ * @description
+ * The first time a style is used, it is loaded in the style cache for quick retrieval. You
+ * can load style directly into the cache in a `script` tag, or by consuming the
+ * `$styleCache` service directly.
+ *
+ * Adding via the `$styleCache` service:
+ *
+ * ```js
+ * var myApp = angular.module('myApp', []);
+ * myApp.run(function($styleCache) {
+ *   $styleCache.put('styleId.css', 'This is the content of the style');
+ * });
+ * ```
+ *
+ * To retrieve the style later, simply use it in your component:
+ * ```js
+ * myApp.component('myComponent', {
+ *    styleUrls: 'styleId.css'
+ * });
+ * ```
+ *
+ * Or to retrieve multiple styles later, simply use it in your component:
+ * ```js
+ * myApp.component('myComponent', {
+ *    styleUrls: ['styleId1.css', 'styleId2.css'] 
+ * });
+ * ```
+ *
+ * or get it via the `$styleCache` service:
+ * ```js
+ * $styleCache.get('styleId.css')
+ * ```
+ *
+ * See {@link ng.$cacheFactory $cacheFactory}.
+ *
+ * ## Dependencies
+ * Requires the {@link ngStyle `ngStyle`} module to be installed.
+ */
+function $StyleCacheProvider() {
+    this.$get = ['$cacheFactory', function ($cacheFactory) {
+        return $cacheFactory('styles');
+    }];
+}
+
+///
+/// used by the applyDirectivesToNode function to add dynamicaly styles if decalared 
+/// on the component definition object using the styleUrls property or styles.
+/// see component example to learn more
+function $$StyleComponentProvider() {
+    var shouldRemoveComponentsStyles = false;
+
+    /**
+     * @ngdoc method
+     * @name $$StyleComponentProvider#shouldRemoveComponentsStyles
+     * @description
+     * The value passed should decide whether remove style when no component existing 
+     * anymore in the view or not.
+     *
+     * @param {bool=} value new value.
+     * @returns {string|self} Returns the value when used as getter and self if used as setter.
+     *
+     */
+    this.shouldRemoveComponentsStyles = function (val) {
+        if (!isUndefined(val)) {
+            shouldRemoveComponentsStyles = !!val;
+            return this;
+        }
+
+        return shouldRemoveComponentsStyles;
+    };
+
+
+
+    this.$get = ['$style', '$q', '$exceptionHandler',
+        function ($style, $q, $exceptionHandler) {
+            var componentStyles = {},
+                stylesUsage = {};
+
+
+
+            return {
+                // register component styles once component initiated
+                registerStyles: registerStyles,
+                // register component with style urls once component initiated
+                registerStyleUrls: registerStyleUrls,
+                // load component style once component its linked
+                loadStyles: loadStyles,
+                // unload component style once component its destroyed
+                unLoadStyles: unLoadStyles,
+                // 
+                isRegistered: isRegistered
+            };
+
+            function registerStyleUrls(componentName, styleUrls) {
+                if (isUndefined(styleUrls)) {
+                    $exceptionHandler($styleMinErr('styleload', '{0} is missing styleUrls', componentName));
+                    return;
+                }
+
+                if (isString(styleUrls)) {
+                    styleUrls = [styleUrls];
+                }
+
+                if (!componentStyles[componentName]) {
+                    componentStyles[componentName] = { counter: 0, styleUrls: styleUrls, styles: null };
+                    $style.loadStyleUrls(styleUrls);
+                }
+            }
+
+            function registerStyles(componentName, styles) {
+                if (isUndefined(componentName)) {
+                    $exceptionHandler($styleMinErr('styleload', 'component name is undifined'));
+                    return;
+                }
+
+                if (!isString(styles)) {
+                    $exceptionHandler($styleMinErr('styleload', 'styles should be plain text'));
+                    return;
+                }
+
+                if (!componentStyles[componentName]) {
+                    componentStyles[componentName] = { counter: 0, styleUrls: [], styles: styles };
+                }
+            }
+
+            function loadStyles(componentName) {
+                var shouldDoUrlLoading = false,
+                    componentStyle = componentStyles[componentName];
+
+                if (componentStyle && (shouldRemoveComponentsStyles || componentStyle.counter < 1)) {
+                    if (componentStyle.counter === 0) {
+                        if (isString(componentStyles[componentName].styles)) {
+                            $style.addStyles(componentName, componentStyles[componentName].styles);
+                        } else if (componentStyles[componentName].styleUrls.length > 0) {
+                            setComponentLoader(componentName);
+                            shouldDoUrlLoading = true;
+                        }
+
+
+                    }
+
+                    componentStyle.counter++;
+                    incrementUrls(componentStyle.styleUrls);
+
+                    if (shouldDoUrlLoading) {
+                        $style.addStyleUrls(componentStyle.styleUrls).finally(function () {
+                            removeComponentLoader(componentName);
+                        });
+                    }
+                }
+            }
+
+            function unLoadStyles(componentName) {
+                var componentStyle = componentStyles[componentName];
+
+                if (componentStyle && shouldRemoveComponentsStyles) {
+                    componentStyle.counter--;
+
+                    decrementUrls(componentStyle.styleUrls);
+                    if (componentStyle.counter <= 0) {
+                        if (componentStyle.styles) {
+                            $style.removeStyles(componentName);
+                        }
+                    }
+                }
+            }
+
+            function isRegistered(componentName) {
+                return !!componentStyles[componentName];
+            }
+
+            // counter per url since same styles could be used by different components.
+            // for each url styleUsage is incremented.
+            function incrementUrls(urls) {
+                if (isArray(urls)) {
+                    forEach(urls, function (url) {
+                        stylesUsage[url] = stylesUsage[url] || 0;
+                        stylesUsage[url]++;
+                    });
+                }
+            }
+
+            // decrement counter per url. once the style is not in use we remove it.
+            function decrementUrls(urls) {
+                if (isArray(urls)) {
+                    forEach(urls, function (url) {
+                        if (stylesUsage[url]) {
+                            stylesUsage[url]--;
+
+                            if (shouldRemoveComponentsStyles && stylesUsage[url] === 0) {
+                                $style.removeStyles(url);
+                                delete stylesUsage[url];
+                            }
+                        }
+                    });
+                }
+            }
+
+            // since i didn't want to make huge changes in the applyDirectivesToNode method to 
+            // support async style i did that trick to hide the component till we will get the style response.
+            function setComponentLoader(componentName) {
+                return angular.element(document.head).append('<style type="text/css" id="' + componentName + '-loader">' + componentNormalize(componentName) + ':{display:none !important;}</style>');
+            }
+
+            // once the component styles are fetch or failed i am showing the component.
+            function removeComponentLoader(componentName) {
+                angular.element(document.head.querySelector('#' + componentName + '-loader')).remove();
+            }
+
+            // change the js component name to html tag name. for example `myCmp` will be `my-cmp`.
+            function componentNormalize(name) {
+                return name.replace(/([A-Z])/g, "-$1").toLowerCase();
+            }
+        }];
+
+}

--- a/src/ngStyle/style.js
+++ b/src/ngStyle/style.js
@@ -10,6 +10,8 @@ var $styleMinErr = angular.$$minErr('ngStyle');
 /**
  * @ngdoc module
  * @name ngStyle
+ * @this
+ *
  * @description
  *
  * # ngStyle

--- a/src/ngStyle/style.js
+++ b/src/ngStyle/style.js
@@ -10,7 +10,6 @@ var $styleMinErr = angular.$$minErr('ngStyle');
 /**
  * @ngdoc module
  * @name ngStyle
- * @this
  *
  * @description
  *
@@ -366,10 +365,11 @@ function $StyleCacheProvider() {
     }];
 }
 
-///
-/// used by the applyDirectivesToNode function to add dynamicaly styles if decalared
-/// on the component definition object using the styleUrls property or styles.
-/// see component example to learn more
+//
+// used by the applyDirectivesToNode function to add dynamicaly styles if decalared
+// on the component definition object using the styleUrls property or styles.
+// see component example to learn more
+/** @this */
 function $$StyleComponentProvider() {
     var shouldRemoveComponentsStyles = false;
 

--- a/src/ngStyle/style.js
+++ b/src/ngStyle/style.js
@@ -521,7 +521,8 @@ function $$StyleComponentProvider() {
             // since i didn't want to make huge changes in the applyDirectivesToNode method to
             // support async style i did that trick to hide the component till we will get the style response.
             function setComponentLoader(componentName) {
-                return angular.element(window.document.head).append('<style type="text/css" id="' + componentName + '-loader">' + componentNormalize(componentName) + ':{display:none !important;}</style>');
+                var styleTag = '<style type="text/css" id="' + componentName + '-loader">' + componentNormalize(componentName) + ':{display:none !important;}</style>';
+                return angular.element(window.document.head).append(styleTag);
             }
 
             // once the component styles are fetch or failed i am showing the component.


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feat


**What is the current behavior? (You can also link to an open issue here)**
Exist in angular 2, not yet in angular 1.x


**What is the new behavior (if this is a feature change)?**
Add new module to load css styles via components like angular 2 does.

for example: 
```js
var mod = angular.module('helloStylesApp', ['ng', 'ngStyle']);
mod.component('helloStyles', {
  templateUrl: 'hello-styles/hello-styles.html',
  // add dynamically styles for comopnent
  styleUrls: ['./base.css', './hello-styles/hello-styles.css'],  // or styles: 'a {color: red; } h2 {color: green;}',
  // another option is to use:
  controller: ['$style', '$styleRequest', '$timeout', function ($style, $styleRequest, $timeout) {
    // Add style dynamically 
    $style.addStyleUrls(['./base.css', './hello-styles/hello-styles.css']).then(function (data) {
      ... 
    });
  
    // Remove style dynamically 
    $style.removeStyle(['./hello-styles/hello-styles.css']);
    
    // Or just fetch the style for js manipulation
    $styleRequest('./hello-styles/hello-styles.css').then(function(cssText){
      ...
    });
  }]
});
```

**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

The implementation of this feature considered the minimum changes to the compile function in order to keep the code as is.

