### PR TITLE
perf(ngOptions): prevent initial options repaiting

### DIFF
--- a/test/ng/directive/ngOptionsSpec.js
+++ b/test/ng/directive/ngOptionsSpec.js
@@ -2641,6 +2641,25 @@ describe('ngOptions', function() {
       dealoc(element);
     }));
 
+
+    it('should remove all comments inside the select element except the initial falsy ngIf empty option', function() {
+      scope.values = [
+        {name:'black'},
+        {name:'white'},
+        {name:'red'}
+      ];
+      scope.isBlank = false;
+
+      createSingleSelect('<!-- test comment -->'
+                          + '<option ng-if="isBlank" value="">blank</option>'
+                          + '<!-- test comment 2 -->');
+      scope.$apply('isBlank = true');
+
+      expect(element.find('option')[0].value).toBe('');
+      expect(element.find('option')[0].textContent).toBe('blank');
+      expect(element.find('option')[1].textContent).toBe('black');
+    });
+
   });
 
 

--- a/test/ng/directive/ngOptionsSpec.js
+++ b/test/ng/directive/ngOptionsSpec.js
@@ -779,6 +779,32 @@ describe('ngOptions', function() {
     expect(options[2]).not.toBeMarkedAsSelected();
   });
 
+
+  it('should render the initial options only one time', function() {
+    scope.values = ['black', 'white', 'red'];
+    // Insert a select element into the DOM without ng-options to suscribe to DOM change events
+    createSelect({
+      'ng-model': 'value'
+    });
+
+    // Add ngOptions as attribute before recompiling the select element
+    element.attr('ng-options', 'value for value in values');
+
+    var repaint = 0;
+    // Detect only when the childNodes count changes
+    var lastElementChildrenCount = -1;
+    element[0].addEventListener('DOMSubtreeModified', function(ev) {
+      var childrenCount = jqLite(ev.target).contents().length;
+      if (childrenCount !== lastElementChildrenCount) {
+        repaint++;
+        lastElementChildrenCount = childrenCount;
+        expect(repaint).toBeLessThan(2);
+      }
+    });
+
+    $compile(element)(scope);
+  });
+
   describe('disableWhen expression', function() {
 
     describe('on single select', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.


**What is the current behavior? (You can also link to an open issue here)**
Refers to this issue: [ngOptions slow performance in IE due to option rerendering](https://github.com/angular/angular.js/issues/15801)


**What is the new behavior (if this is a feature change)?**
Now the options are loaded once when we create the `<select ng-options>` directive. Also, if we add an `<option>` element with an ng-if directive, it is not deleted now.


**Does this PR introduce a breaking change?**
No. 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
None.