### PR TITLE
docs($interpolate): typo

### DIFF
--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -138,7 +138,7 @@ function $InterpolateProvider() {
      * ```js
      *   var $interpolate = ...; // injected
      *   var exp = $interpolate('Hello {{name | uppercase}}!');
-     *   expect(exp({name:'AngularJS'})).toEqual('Hello ANGULAR!');
+     *   expect(exp({name:'AngularJS'})).toEqual('Hello ANGULARJS!');
      * ```
      *
      * `$interpolate` takes an optional fourth argument, `allOrNothing`. If `allOrNothing` is


### PR DESCRIPTION
There was missing `JS` at line 141.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs only, example fix.

**What is the current behavior? (You can also link to an open issue here)**

Somewhat confusing:
```
var exp = $interpolate('Hello {{name | uppercase}}!');
expect(exp({name:'AngularJS'})).toEqual('Hello ANGULAR!');
```

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format