### PR TITLE
docs($resource): JSDoc Parsing of ) in Link

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -280,7 +280,7 @@ function shallowClearAndCopy(src, dst) {
  *     the Resource API. This object can be serialized through {@link angular.toJson} safely
  *     without attaching AngularJS-specific fields. Notice that `JSON.stringify` (and
  *     `angular.toJson`) automatically use this method when serializing a Resource instance
- *     (see [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior)).
+ *     (see [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON%28%29_behavior)).
  *
  * @example
  *


### PR DESCRIPTION
JSDoc to HTML converter was catching the close parenthesis in `[MDN](...#toJson()_behavior)` from the `toJson()` and treating it as the final close parenthesis.
End result was a link to MDN that didn't link to the correct section, but did resolve. It was followed by a non-link "_behavior)".
Updated version with percent encoding correct resolves to desired section and gets parsed to the correct link in JSDoc to HTML.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs update. Also sorta a bug.

**What is the current behavior? (You can also link to an open issue here)**

Link works, but doesn't point to desired section. Side-effect of leaving a literal "_behavior)" artifact in the docs.

**What is the new behavior (if this is a feature change)?**

Link work, and now points to correct section through the magic of percent encoding. Also removes artifact as expected.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

