### PR TITLE
docs ($compile): add error documentation for noslot error in $compile

### DIFF
--- a/docs/content/error/$compile/noslot.ngdoc
+++ b/docs/content/error/$compile/noslot.ngdoc
@@ -3,9 +3,10 @@
 @fullName No matching slot in parent directive
 @description
 
-This error occurs when declaring a specific slot in a ng-transclude which does not map to a specific slot defined in the transclude property of the directive.
+This error occurs when declaring a specific slot in a {@link ng.ngTransclude `ngTransclude`} 
+which does not map to a specific slot defined in the transclude property of the directive.
 
-In this example the template has a declared slot missing from the transclude definition.
+In this example the template has declared a slot missing from the transclude definition.
 This example will generate a noslot error.
 ```js
 var componentConfig = {
@@ -21,7 +22,7 @@ var componentConfig = {
 };
 ```
 
-If we make the following change we will no longer get noslot error.
+If we make the following change we will no longer get the noslot error.
 ```js
 var componentConfig = {
   template: '<div>' +

--- a/docs/content/error/$compile/noslot.ngdoc
+++ b/docs/content/error/$compile/noslot.ngdoc
@@ -24,7 +24,7 @@ var componentConfig = {
 If we make the following change we will no longer get noslot error.
 ```js
 var componentConfig = {
-  template: '<div style="border: 1px solid black;">' +
+  template: '<div>' +
                 '<div ng-transclude="slotProvided"></div>' +
                 '<div ng-transclude="noSlotProvided"></div>' +
             '</div>',

--- a/docs/content/error/$compile/noslot.ngdoc
+++ b/docs/content/error/$compile/noslot.ngdoc
@@ -3,41 +3,33 @@
 @fullName No matching slot in parent directive
 @description
 
-This error occurs when declaring a specific slot in a ng-transclude which does not map to the transclude property of the directive.
+This error occurs when declaring a specific slot in a ng-transclude which does not map to a specific slot defined in the transclude property of the directive.
 
+In this example the template has a declared slot missing from the transclude definition.
+This example will generate a noslot error.
 ```js
-// In this example the template has a declared slot missing from the transclude definition.
-// This example will generate a no slot error.
-
 var componentConfig = {
-  template: '<div style="border: 1px solid black;">' +
+  template: '<div>' +
                 '<div ng-transclude="slotProvided"></div>' +
                 '<div ng-transclude="noSlotProvided"></div>' +
             '</div>',
   transclude: {
   	// The key value pairs here are considered "slots" that are provided for components to slot into.
-    slotProvided: 'slottedComponent', // mandatory transclusion,
-    optionalSlot: '?optionalComponent',  // optional transclusion
-    // there is no slot provided for the transclude 'noSlotProvided' declared in the above template
+    slotProvided: 'slottedComponent', // mandatory transclusion
+    // There is no slot provided here for the transclude 'noSlotProvided' declared in the above template.
   }
 };
-
-angular
-  .module('doc')
-  .component('myComponent', componentConfig)
-
 ```
 
+If we the following change we will no longer get no slot error.
 ```js
-\\ if we the following change we will no longer get no slot error.
 var componentConfig = {
   template: '<div style="border: 1px solid black;">' +
                 '<div ng-transclude="slotProvided"></div>' +
                 '<div ng-transclude="noSlotProvided"></div>' +
             '</div>',
   transclude: {
-    slotProvided: 'slottedComponent', // mandatory transclusion,
-    optionalSlot: '?optionalComponent',  // optional transclusion,
+    slotProvided: 'slottedComponent',
     noSlotProvided: 'otherComponent' // now it is declared and the error should cease
   }
 };

--- a/docs/content/error/$compile/noslot.ngdoc
+++ b/docs/content/error/$compile/noslot.ngdoc
@@ -21,7 +21,7 @@ var componentConfig = {
 };
 ```
 
-If we the following change we will no longer get no slot error.
+If we make the following change we will no longer get no slot error.
 ```js
 var componentConfig = {
   template: '<div style="border: 1px solid black;">' +

--- a/docs/content/error/$compile/noslot.ngdoc
+++ b/docs/content/error/$compile/noslot.ngdoc
@@ -21,7 +21,7 @@ var componentConfig = {
 };
 ```
 
-If we make the following change we will no longer get no slot error.
+If we make the following change we will no longer get noslot error.
 ```js
 var componentConfig = {
   template: '<div style="border: 1px solid black;">' +

--- a/docs/content/error/$compile/noslot.ngdoc
+++ b/docs/content/error/$compile/noslot.ngdoc
@@ -1,0 +1,45 @@
+@ngdoc error
+@name $compile:noslot
+@fullName No matching slot in parent directive
+@description
+
+This error occurs when declaring a specific slot in a ng-transclude which does not map to the transclude property of the directive.
+
+```js
+// In this example the template has a declared slot missing from the transclude definition.
+// This example will generate a no slot error.
+
+var componentConfig = {
+  template: '<div style="border: 1px solid black;">' +
+                '<div ng-transclude="slotProvided"></div>' +
+                '<div ng-transclude="noSlotProvided"></div>' +
+            '</div>',
+  transclude: {
+  	// The key value pairs here are considered "slots" that are provided for components to slot into.
+    slotProvided: 'slottedComponent', // mandatory transclusion,
+    optionalSlot: '?optionalComponent',  // optional transclusion
+    // there is no slot provided for the transclude 'noSlotProvided' declared in the above template
+  }
+};
+
+angular
+  .module('doc')
+  .component('myComponent', componentConfig)
+
+```
+
+```js
+\\ if we the following change we will no longer get no slot error.
+var componentConfig = {
+  template: '<div style="border: 1px solid black;">' +
+                '<div ng-transclude="slotProvided"></div>' +
+                '<div ng-transclude="noSlotProvided"></div>' +
+            '</div>',
+  transclude: {
+    slotProvided: 'slottedComponent', // mandatory transclusion,
+    optionalSlot: '?optionalComponent',  // optional transclusion,
+    noSlotProvided: 'otherComponent' // now it is declared and the error should cease
+  }
+};
+
+```


### PR DESCRIPTION
there was no error page for the $compile:noslot error

this resolves #15790

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

