### PR TITLE
Allow NgModelController to be copied

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -890,8 +890,8 @@ function setupModelWatcher(ctrl) {
   //    -> scope value did not change since the last digest as
   //       ng-change executes in apply phase
   // 4. view should be changed back to 'a'
-  ctrl.$$scope.$watch(function ngModelWatch() {
-    var modelValue = ctrl.$$ngModelGet(ctrl.$$scope);
+  ctrl.$$scope.$watch(function ngModelWatch(scope) {
+    var modelValue = ctrl.$$ngModelGet(scope);
 
     // if scope model value and ngModel value are out of sync
     // TODO(perf): why not move this to the action fn?

--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -281,7 +281,9 @@ function NgModelController($scope, $exceptionHandler, $attr, $element, $parse, $
 
   this.$$currentValidationRunId = 0;
 
-  this.$$scope = $scope;
+  // https://github.com/angular/angular.js/issues/15833
+  // Prevent `$$scope` from being iterated over by `copy` when NgModelController is deep watched
+  Object.defineProperty(this, '$$scope', {value: $scope});
   this.$$attr = $attr;
   this.$$element = $element;
   this.$$animate = $animate;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -5858,6 +5858,29 @@ describe('$compile', function() {
               expect(componentScope.owRef).toEqual({name: 'lucas', item: {name: 'martin'}});
             }));
 
+            // https://github.com/angular/angular.js/issues/15833
+            it('should work with ng-model inputs', function() {
+              var componentScope;
+
+              module(function($compileProvider) {
+                $compileProvider.directive('undi', function() {
+                  return {
+                    restrict: 'A',
+                    scope: {
+                      undi: '<'
+                    },
+                    link: function($scope) { componentScope = $scope; }
+                  };
+                });
+              });
+
+              inject(function($compile, $rootScope) {
+                element = $compile('<form name="f" undi="[f.i]"><input name="i" ng-model="a"/></form>')($rootScope);
+                $rootScope.$apply();
+                expect(componentScope.undi).toBeDefined();
+              });
+            });
+
 
             it('should not complain when the isolated scope changes', inject(function() {
               compile('<div><span my-component ow-ref="{name: name}">');


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
fix


**What is the current behavior? (You can also link to an open issue here)**
`copy` throws when copying a `NgModelController` instance. This will occur when deep watching such as when doing `<e ref="[myNgModel]">` (#15833)


**What is the new behavior (if this is a feature change)?**
The internal `NgModelController` `$$scope` is hidden


**Does this PR introduce a breaking change?**
no, unless someone is doing something crazy that depends on `$$scope` being enumerable?


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
I've split the commit up into 3.  I think the refactor + (modified) test should go into 1.7. I don't think the actual fix should go into 1.7.  The specific test case (watched a literal containing an ng-model) will no longer fail in 1.7. If we want to prevent other cases like manually deep-watching or manually `copy`ing an ng-model I think we should do it differently in 1.7...
