### PR TITLE
fix(jqLite): make jqLite invoke jqLite.cleanData as a method

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -303,11 +303,10 @@ function jqLiteClone(element) {
 }
 
 function jqLiteDealoc(element, onlyDescendants) {
-  if (!onlyDescendants && element.nodeType === NODE_TYPE_ELEMENT) jqLite.cleanData([element]);
+  if (!onlyDescendants && jqLiteAcceptsData(element)) jqLite.cleanData([element]);
 
   if (element.querySelectorAll) {
-    var descendants = element.querySelectorAll('*');
-    jqLite.cleanData(descendants);
+    jqLite.cleanData(element.querySelectorAll('*'));
   }
 }
 

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -201,12 +201,6 @@ function jqLiteHasData(node) {
   return false;
 }
 
-function jqLiteCleanData(nodes) {
-  for (var i = 0, ii = nodes.length; i < ii; i++) {
-    jqLiteRemoveData(nodes[i]);
-  }
-}
-
 function jqLiteBuildFragment(html, context) {
   var tmp, tag, wrap,
       fragment = context.createDocumentFragment(),
@@ -309,13 +303,11 @@ function jqLiteClone(element) {
 }
 
 function jqLiteDealoc(element, onlyDescendants) {
-  if (!onlyDescendants) jqLiteRemoveData(element);
+  if (!onlyDescendants && element.nodeType === NODE_TYPE_ELEMENT) jqLite.cleanData([element]);
 
   if (element.querySelectorAll) {
     var descendants = element.querySelectorAll('*');
-    for (var i = 0, l = descendants.length; i < l; i++) {
-      jqLiteRemoveData(descendants[i]);
-    }
+    jqLite.cleanData(descendants);
   }
 }
 
@@ -613,7 +605,11 @@ forEach({
   data: jqLiteData,
   removeData: jqLiteRemoveData,
   hasData: jqLiteHasData,
-  cleanData: jqLiteCleanData
+  cleanData: function jqLiteCleanData(nodes) {
+    for (var i = 0, ii = nodes.length; i < ii; i++) {
+      jqLiteRemoveData(nodes[i]);
+    }
+  }
 }, function(fn, name) {
   JQLite[name] = fn;
 });

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -2100,28 +2100,26 @@ describe('$compile', function() {
 
           it('should work in jqLite and jQuery with jQuery.cleanData last patched by Angular', runTest);
 
-          if (jQuery) {
-            it('should work with another library patching jQuery.cleanData after Angular', function() {
-              var cleanedCount = 0;
-              var currentCleanData = jqLite.cleanData;
-              jqLite.cleanData = function(elems) {
-                cleanedCount += elems.length;
-                // Don't return the output and explicitly pass only the first parameter
-                // so that we're sure we're not relying on either of them. jQuery UI patch
-                // behaves in this way.
-                currentCleanData(elems);
-              };
+          it('should work with another library patching jqLite/jQuery.cleanData after Angular', function() {
+            var cleanedCount = 0;
+            var currentCleanData = jqLite.cleanData;
+            jqLite.cleanData = function(elems) {
+              cleanedCount += elems.length;
+              // Don't return the output and explicitly pass only the first parameter
+              // so that we're sure we're not relying on either of them. jQuery UI patch
+              // behaves in this way.
+              currentCleanData(elems);
+            };
 
-              runTest();
+            runTest();
 
-              // The initial ng-repeat div is dumped after parsing hence we expect cleanData
-              // count to be one larger than size of the iterated array.
-              expect(cleanedCount).toBe(is.length + 1);
+            // The initial ng-repeat div is dumped after parsing hence we expect cleanData
+            // count to be one larger than size of the iterated array.
+            expect(cleanedCount).toBe(is.length + 1);
 
-              // Restore the previous cleanData.
-              jqLite.cleanData = currentCleanData;
-            });
-          }
+            // Restore the previous cleanData.
+            jqLite.cleanData = currentCleanData;
+          });
         });
 
         describe('replace and not exactly one root element', function() {
@@ -8640,28 +8638,26 @@ describe('$compile', function() {
 
         it('should work without external libraries (except jQuery)', testCleanup);
 
-        if (jQuery) {
-          it('should work with another library patching jQuery.cleanData after AngularJS', function() {
-            var cleanedCount = 0;
-            var currentCleanData = jqLite.cleanData;
-            jqLite.cleanData = function(elems) {
-              cleanedCount += elems.length;
-              // Don't return the output and explicitly pass only the first parameter
-              // so that we're sure we're not relying on either of them. jQuery UI patch
-              // behaves in this way.
-              currentCleanData(elems);
-            };
+        it('should work with another library patching jqLite/jQuery.cleanData after AngularJS', function() {
+          var cleanedCount = 0;
+          var currentCleanData = jqLite.cleanData;
+          jqLite.cleanData = function(elems) {
+            cleanedCount += elems.length;
+            // Don't return the output and explicitly pass only the first parameter
+            // so that we're sure we're not relying on either of them. jQuery UI patch
+            // behaves in this way.
+            currentCleanData(elems);
+          };
 
-            testCleanup();
+          testCleanup();
 
-            // The ng-repeat template is removed/cleaned (the +1)
-            // and each clone of the ng-repeat template is also removed (xs.length)
-            expect(cleanedCount).toBe(xs.length + 1);
+          // The ng-repeat template is removed/cleaned (the +1)
+          // and each clone of the ng-repeat template is also removed (xs.length)
+          expect(cleanedCount).toBe(xs.length + 1);
 
-            // Restore the previous cleanData.
-            jqLite.cleanData = currentCleanData;
-          });
-        }
+          // Restore the previous cleanData.
+          jqLite.cleanData = currentCleanData;
+        });
       });
 
 


### PR DESCRIPTION
The previous implementation of jqLite didn't use cleanData from the jqLite
object but instead used a cached version which maede it impossible to
monkey-patch jqLite.cleanData similarly to how you can do it in jQuery.

The cleanData method is not meant to be called directly by userland code;
its purpose is mainly to be able to be monkey-patched; therefore, the previous
implementation didn't make a lot of sense.

This commit enables one of the tests so far run only with jQuery to run with
jqLite as well.

Ref #8486
Ref #8695

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix.


**What is the current behavior? (You can also link to an open issue here)**
`jqLite.cleanData` is not used directly so it can't be monkey-patched like its jQuery equivalent.


**What is the new behavior (if this is a feature change)?**
The opposite.


**Does this PR introduce a breaking change?**
I don't think so.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
This is a followup to #8695.
