### PR TITLE
docs(error/numfmt): Add priority 1 to string-to-number directive example

### DIFF
--- a/docs/content/error/ngModel/numfmt.ngdoc
+++ b/docs/content/error/ngModel/numfmt.ngdoc
@@ -41,6 +41,7 @@ directive to convert it into the format the `input[number]` directive expects.
 
   .directive('stringToNumber', function() {
     return {
+      priority: 1,
       require: 'ngModel',
       link: function(scope, element, attrs, ngModel) {
         ngModel.$parsers.push(function(value) {


### PR DESCRIPTION
This directive does not work with default priority. Took forever to find out what the real issue is.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

doc update

**What is the current behavior? (You can also link to an open issue here)**
does not work in some situations (I cannot articulate exactly what conditions, but another page used priority and it made this directive work for me. I was using this in a template, with an extended JSON object assigned to ng-model after fetching from a database..


**What is the new behavior (if this is a feature change)?**
probably works in all situations


**Does this PR introduce a breaking change?**
No, not that I am aware.


**Please check if the PR fulfills these requirements**
- [X ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

My first PR for a doc change and I didn't know about the commit comment format. Assuming the github prompting handles it for you, since there is only one line on the comment field, not entirely clear. I found the solution here: http://stackoverflow.com/questions/25657130/how-to-convert-string-to-number-or-date-in-angularjs-expression, so I can't take any claim to finding it, just for submitting to update the doc for future angular-nauts.
