### PR TITLE
GitHub Issue #15856 -- Fix query portion parsing when not in html5 mode.

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -70,6 +70,11 @@ function stripBaseUrl(base, url) {
   }
 }
 
+function findSearch(url)
+{
+  var index = url.indexOf('?');
+  return index === -1 ? false : url.substr(index, url.length);
+}
 
 function stripHash(url) {
   var index = url.indexOf('#');
@@ -204,6 +209,14 @@ function LocationHashbangUrl(appBase, appBaseNoFile, hashPrefix) {
       if (isUndefined(withoutHashUrl)) {
         // There was no hashbang prefix so we just have a hash fragment
         withoutHashUrl = withoutBaseUrl;
+      }
+
+      // apply any search params from the actual url to the withoutHashUrl
+      // appBase will already have the hash taken off at this point.
+      var search = findSearch(appBase);
+      if (search !== false)
+      {
+        withoutHashUrl = withoutHashUrl + search;
       }
 
     } else {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix for issue #15856  


**What is the current behavior? (You can also link to an open issue here)**
Issue #15856 


**What is the new behavior (if this is a feature change)?**
The query portion of the URL is appended to the parsed path once the fragment identifier has been removed. This occurs for the non-html5 mode.


**Does this PR introduce a breaking change?**
Not that I can tell.


**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

