### PR TITLE
(fix): merge URI query into fragment in non-html5 $location mode.

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -70,6 +70,10 @@ function stripBaseUrl(base, url) {
   }
 }
 
+function findSearch(url) {
+  var index = url.indexOf('?');
+  return index === -1 ? false : url.substr(index + 1, url.indexOf('#') === -1 ? url.length : url.indexOf('#') - index - 1);
+}
 
 function stripHash(url) {
   var index = url.indexOf('#');
@@ -205,6 +209,27 @@ function LocationHashbangUrl(appBase, appBaseNoFile, hashPrefix) {
         // There was no hashbang prefix so we just have a hash fragment
         withoutHashUrl = withoutBaseUrl;
       }
+
+      // apply any search params from the actual url to the withoutHashUrl
+      // appBase will already have the hash taken off at this point.
+      var paramRewrittenUrl = withoutHashUrl;
+      var search = findSearch(appBase);
+      if (search !== false) {
+        var indexOfAppFragment = withoutHashUrl.indexOf('#');
+        if (indexOfAppFragment !== -1) {
+          paramRewrittenUrl = withoutHashUrl.substr(0, indexOfAppFragment) + '?' + search + withoutHashUrl.substr(indexOfAppFragment, withoutHashUrl.length);
+        } else {
+          paramRewrittenUrl = withoutHashUrl + '?' + search;
+        }
+        // we know that there is a query param before the hash, as in the RFC.
+        if (findSearch(withoutHashUrl) !== false) {
+          var indexOfAppPath = withoutHashUrl.indexOf('?');
+          if (indexOfAppPath !== -1) {
+            paramRewrittenUrl = withoutHashUrl.substr(0, indexOfAppPath + 1) + search + '&' + withoutHashUrl.substr(indexOfAppPath + 1, withoutHashUrl.length);
+          }
+        }
+      }
+      withoutHashUrl = paramRewrittenUrl;
 
     } else {
       // There was no hashbang path nor hash fragment:

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -527,12 +527,37 @@ describe('$location', function() {
     it('should preserve query params in base', function() {
       var locationUrl = new LocationHashbangUrl('http://www.server.org:1234/base?base=param', 'http://www.server.org:1234/', '#');
       locationUrl.$$parse('http://www.server.org:1234/base?base=param#/path?a=b&c#hash');
-      expect(locationUrl.absUrl()).toBe('http://www.server.org:1234/base?base=param#/path?a=b&c#hash');
+      expect(locationUrl.absUrl()).toBe('http://www.server.org:1234/base?base=param#/path?base=param&a=b&c#hash');
 
+      expect(locationUrl.search()).toEqual({base: 'param', a: 'b', c: true});
       locationUrl.path('/new/path');
       locationUrl.search({one: 1});
       locationUrl.hash('hhh');
       expect(locationUrl.absUrl()).toBe('http://www.server.org:1234/base?base=param#/new/path?one=1#hhh');
+    });
+
+    it('should copy query params to fragment', function() {
+      var locationUrl = new LocationHashbangUrl('http://www.server.org:1234/base?base=param', 'http://www.server.org:1234/', '#');
+      locationUrl.$$parse('http://www.server.org:1234/base?base=param#/path');
+
+      expect(locationUrl.absUrl()).toBe('http://www.server.org:1234/base?base=param#/path?base=param');
+
+      expect(locationUrl.search()).toEqual({base: 'param'});
+      locationUrl.path('/new/path');
+      locationUrl.search({one: 1});
+      locationUrl.hash('hhh');
+      expect(locationUrl.absUrl()).toBe('http://www.server.org:1234/base?base=param#/new/path?one=1#hhh');
+
+      locationUrl.$$parse('http://www.server.org:1234/base?base=param#/path#trailingHash');
+
+      expect(locationUrl.absUrl()).toBe('http://www.server.org:1234/base?base=param#/path?base=param#trailingHash');
+
+      expect(locationUrl.search()).toEqual({base: 'param'});
+      locationUrl.path('/new/path');
+      locationUrl.search({one: 1});
+      locationUrl.hash('hhh');
+      expect(locationUrl.absUrl()).toBe('http://www.server.org:1234/base?base=param#/new/path?one=1#hhh');
+
     });
 
 


### PR DESCRIPTION
Angular does not currently include the non-fragment query portion
Of URLs in non-html5 $location mode. This commit merges the fragment
Query, if present, with the non-fragment query if it exists.

See #15856

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.


**What is the current behavior? (You can also link to an open issue here)**
AngularJS's $location service treats URLs differently depending on whether or not the browser supports the HTML5 history API or requires the use of the hashbang mode. URLs should be parsed into the same object regardless of browser mode. In the current behaviour, query parameters are lost.


**What is the new behavior (if this is a feature change)?**
In non-HTML5 hashbang mode, the query parameters that appear prior to the fragment identifier (`#`) are copied into the fragment identifier before the `parseAppUrl` function is called. Therefore, the query parameters outside of the fragment are included in both html5 and non-html5 modes.


**Does this PR introduce a breaking change?**
Not really.


**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)
Note that docs are essentially added as part of the discussion in the GitHub issue #15856 

**Other information**:
None.