### PR TITLE
fix($parse): fix infinite digest errors when watching objects with .valueOf in literals

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1788,14 +1788,14 @@ function $ParseProvider() {
         return newValue === oldValueOfValue;
       }
 
-      if (typeof newValue === 'object' && !compareObjectIdentity) {
+      if (typeof newValue === 'object') {
 
         // attempt to convert the value to a primitive type
         // TODO(docs): add a note to docs that by implementing valueOf even objects and arrays can
         //             be cheaply dirty-checked
         newValue = getValueOf(newValue);
 
-        if (typeof newValue === 'object') {
+        if (typeof newValue === 'object' && !compareObjectIdentity) {
           // objects/arrays are not supported - deep-watching them would be too expensive
           return false;
         }


### PR DESCRIPTION
I think this is an edge case of https://github.com/angular/angular.js/commit/7084deccaac5855d7148fb6d91dcb83c16b079c4 (and [1.6.x](https://github.com/angular/angular.js/commit/25f008f541d68b09efd7b428b648c6d4899e6972)) that was not handled. If those objects (in the literals) have a `.valueOf` function that returns something other then `this` it will cause an infinite digest.

This should probably also go into 1.6?