### PR TITLE
docs($compile): remove a mention of preassigning bindings in controllers

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -374,12 +374,6 @@
  * `$onInit`, which is called after all the controllers on an element have been constructed and had their bindings
  * initialized.
  *
- * <div class="alert alert-warning">
- * **Deprecation warning:** although bindings for non-ES6 class controllers are currently
- * bound to `this` before the controller constructor is called, this use is now deprecated. Please place initialization
- * code that relies upon bindings inside a `$onInit` method on the controller, instead.
- * </div>
- *
  * It is also possible to set `bindToController` to an object hash with the same format as the `scope` property.
  * This will set up the scope bindings to the controller directly. Note that `scope` can still be used
  * to define which kind of scope is created. By default, no scope is created. Use `scope: {}` to create an isolate


### PR DESCRIPTION
The deprecation warning is no longer needed as the feature has been removed
in 1.7.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update.


**What is the current behavior? (You can also link to an open issue here)**
Preassigning bindings to controllers is described as deprecated but still working. This feature has been removed so the warning is no longer needed.


**What is the new behavior (if this is a feature change)?**
N/A


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] ~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

