### PR TITLE
docs(guide/Migrating from Previous Versions): fix typo "indentifiers"

### DIFF
--- a/docs/content/guide/migration.ngdoc
+++ b/docs/content/guide/migration.ngdoc
@@ -1296,7 +1296,7 @@ Due to [b71d7c3f](https://github.com/angular/angular.js/commit/b71d7c3f3c04e65b0
 falsy values (`''`, `0`, `false` and `null`) are properly recognized as option group identifiers for
 options passed to `ngOptions`. Previously, all of these values were ignored and the option was not
 assigned to any group. `undefined` is still interpreted as "no group".
-If you have options with falsy group indentifiers that should still not be assigned to any group,
+If you have options with falsy group identifiers that should still not be assigned to any group,
 then you must filter the values before passing them to `ngOptions`, converting falsy values to
 `undefined`.
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update.

**What is the current behavior? (You can also link to an open issue here)**
The word "identifiers" is misspelled as "indentifiers".

**What is the new behavior (if this is a feature change)?**
N/A

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [ X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

