### PR TITLE
provide isError and use it in place of instanceof Error

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -50,6 +50,7 @@
     "isNumber": false,
     "isNumberNaN": false,
     "isDate": false,
+    "isError": false,
     "isArray": false,
     "isFunction": false,
     "isRegExp": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -45,6 +45,7 @@
   isNumber,
   isNumberNaN,
   isDate,
+  isError,
   isArray,
   isFunction,
   isRegExp,
@@ -672,6 +673,24 @@ function isDate(value) {
  * @returns {boolean} True if `value` is an `Array`.
  */
 var isArray = Array.isArray;
+
+/**
+ * @description
+ * Determines if a reference is an `Error`.
+ * Loosely based on https://www.npmjs.com/package/iserror
+ *
+ * @param {*} value Reference to check.
+ * @returns {boolean} True if `value` is an `Error`.
+ */
+function isError(value) {
+  var tag = toString.call(value);
+  switch (tag) {
+    case '[object Error]': return true;
+    case '[object Exception]': return true;
+    case '[object DOMException]': return true;
+    default: return value instanceof Error;
+  }
+}
 
 /**
  * @ngdoc function

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3098,7 +3098,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           }
           linkQueue = null;
         }).catch(function(error) {
-          if (error instanceof Error) {
+          if (isError(error)) {
             $exceptionHandler(error);
           }
         });

--- a/src/ng/log.js
+++ b/src/ng/log.js
@@ -132,7 +132,7 @@ function $LogProvider() {
     };
 
     function formatError(arg) {
-      if (arg instanceof Error) {
+      if (isError(arg)) {
         if (arg.stack && formatStackTrace) {
           arg = (arg.message && arg.stack.indexOf(arg.message) === -1)
               ? 'Error: ' + arg.message + '\n' + arg.stack

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -381,7 +381,7 @@ function qFactory(nextTick, exceptionHandler, errorOnUnhandledRejections) {
       if (!toCheck.pur) {
         toCheck.pur = true;
         var errorMessage = 'Possibly unhandled rejection: ' + toDebugString(toCheck.value);
-        if (toCheck.value instanceof Error) {
+        if (isError(toCheck.value)) {
           exceptionHandler(toCheck.value, errorMessage);
         } else {
           exceptionHandler(errorMessage);

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -64,6 +64,7 @@
     "isNumber": false,
     "isNumberNaN": false,
     "isDate": false,
+    "isError": false,
     "isArray": false,
     "isFunction": false,
     "isRegExp": false,

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1880,6 +1880,43 @@ describe('angular', function() {
     });
   });
 
+  describe('isError', function() {
+    function testErrorFromDifferentContext(createError) {
+      var iframe = document.createElement('iframe');
+      document.body.appendChild(iframe);
+      try {
+        var error = createError(iframe.contentWindow);
+        expect(isError(error)).toBe(true);
+      } finally {
+        iframe.parentElement.removeChild(iframe);
+      }
+    }
+
+    it('should not assume objects are errors', function() {
+      var fakeError = { message: 'A fake error', stack: 'no stack here'};
+      expect(isError(fakeError)).toBe(false);
+    });
+
+    it('should detect simple error instances', function() {
+      expect(isError(new Error())).toBe(true);
+    });
+
+    it('should detect errors from another context', function() {
+      testErrorFromDifferentContext(function(win) {
+        return new win.Error();
+      });
+    });
+
+    it('should detect DOMException errors from another context', function() {
+      testErrorFromDifferentContext(function(win) {
+        try {
+          win.document.querySelectorAll('');
+        } catch (e) {
+          return e;
+        }
+      });
+    });
+  });
 
   describe('isRegExp', function() {
     it('should return true for RegExp object', function() {

--- a/test/ng/qSpec.js
+++ b/test/ng/qSpec.js
@@ -37,7 +37,7 @@ describe('q', function() {
   // The following private functions are used to help with logging for testing invocation of the
   // promise callbacks.
   function _argToString(arg) {
-    return (typeof arg === 'object' && !(arg instanceof Error)) ? toJson(arg) : '' + arg;
+    return (typeof arg === 'object' && !(isError(arg))) ? toJson(arg) : '' + arg;
   }
 
   function _argumentsToString(args) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feature/bug

**What is the current behavior? (You can also link to an open issue here)**


**What is the new behavior (if this is a feature change)?**

Angular should pass them on to the correct excetion handler, and there's an angular.isError function now.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

re-implimented https://github.com/yefremov/iserror/blob/master/index.js to avoid license and make code faster.

Fixes #15868