### PR TITLE
feat($rootScope): Implement stopPropatagion for $broadcast events

### DIFF
--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -2326,6 +2326,38 @@ describe('Scope', function() {
           expect(result.name).toBe('some');
           expect(result.targetScope).toBe(child1);
         });
+
+
+        it('should not descend past scopes that stop propagation', inject(function($rootScope) {
+          child1.$on('myEvent', function(event) {
+            event.stopPropagation();
+          });
+
+          $rootScope.$broadcast('myEvent');
+          expect(log).toBe('0>1>2>21>211>22>23>3>');
+        }));
+
+        it('should continue to pass through and past sibling scopes to one that stopped propagation',
+            inject(function($rootScope) {
+          grandChild21.$on('myEvent', function(event) {
+            event.stopPropagation();
+          });
+
+          $rootScope.$broadcast('myEvent');
+          expect(log).toBe('0>1>11>2>21>22>23>3>');
+        }));
+
+        it('should allow multiple separate subtrees to stop propagation independently', inject(function($rootScope) {
+          var stopPropagation = function(event) {
+            event.stopPropagation();
+          };
+          child1.$on('myEvent', stopPropagation);
+          grandChild21.$on('myEvent', stopPropagation);
+          grandChild22.$on('myEvent', stopPropagation);
+
+          $rootScope.$broadcast('myEvent');
+          expect(log).toBe('0>1>2>21>22>23>3>');
+        }));
       });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature


**What is the current behavior? (You can also link to an open issue here)**
$scope.$broadcast events cannot be cancelled and do not have a stopPropagation() function/method


**What is the new behavior (if this is a feature change)?**
This change allows any scope to prevent it's children from receiving that
event by calling stopPropagation on the event object. Other listeners on the scope which called
stopPropagation will continue to receive the event, as will siblings of that scope and any
children of those siblings.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

