### PR TITLE
docs(uppercase): Added an example

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -699,6 +699,7 @@ function jsonFilter() {
  * @description
  * Converts string to lowercase.
  * @see angular.lowercase
+ * @see angular.uppercase
  */
 var lowercaseFilter = valueFn(lowercase);
 
@@ -724,11 +725,6 @@ var lowercaseFilter = valueFn(lowercase);
          <!-- This title should be capitalized -->
          <h1>{{title | uppercase}}</h1>
        </div>
-     </file>
-     <file name="protractor.js" type="protractor">
-       it('should capitalize the text', function() {
-         expect(element(by.binding('title | uppercase')).getText()).toBe('THIS IS A TITLE');
-       });
      </file>
    </example>
  */

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -698,7 +698,9 @@ function jsonFilter() {
  * @kind function
  * @description
  * Converts string to lowercase.
- * {@link ng.filter.uppercase Reference the example in uppercase as they are nearly identical.}
+ *
+ * See the {@link ng.uppercase uppercase filter documentation} for a functionally identical example.
+ *
  * @see angular.lowercase
  */
 var lowercaseFilter = valueFn(lowercase);

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -709,6 +709,27 @@ var lowercaseFilter = valueFn(lowercase);
  * @kind function
  * @description
  * Converts string to uppercase.
- * @see angular.uppercase
+ * @example
+   <example name="filter-uppercase">
+     <file name="index.html">
+       <script>
+         angular.module('uppercaseFilterExample', [])
+           .controller('ExampleController', ['$scope', function($scope) {
+             $scope.title = 'This is a title';
+           }]);
+       </script>
+       <div ng-controller="ExampleController">
+         <!-- This title should be formatted normally -->
+         <h1>{{title}}</h1>
+         <!-- This title should be capitalized -->
+         <h1>{{title | uppercase}}</h1>
+       </div>
+     </file>
+     <file name="protractor.js" type="protractor">
+       it('should capitalize the text', function() {
+         expect(element(by.binding('title | uppercase')).getText()).toBe('THIS IS A TITLE');
+       });
+     </file>
+   </example>
  */
 var uppercaseFilter = valueFn(uppercase);

--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -698,8 +698,8 @@ function jsonFilter() {
  * @kind function
  * @description
  * Converts string to lowercase.
+ * {@link ng.filter.uppercase Reference the example in uppercase as they are nearly identical.}
  * @see angular.lowercase
- * @see angular.uppercase
  */
 var lowercaseFilter = valueFn(lowercase);
 
@@ -711,7 +711,7 @@ var lowercaseFilter = valueFn(lowercase);
  * @description
  * Converts string to uppercase.
  * @example
-   <example name="filter-uppercase">
+   <example module="uppercaseFilterExample" name="filter-uppercase">
      <file name="index.html">
        <script>
          angular.module('uppercaseFilterExample', [])


### PR DESCRIPTION
I saw that the uppercase filter had no example so I decided to add a minimal example to explain how the uppercase filter works.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update.


**What is the current behavior? (You can also link to an open issue here)**
There is currently no example for the `uppercase` filter, so I added one.


**What is the new behavior (if this is a feature change)?**
N/a


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:

