### PR TITLE
chore(*): remove manualLowercase & manualUppercase functions

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -28,8 +28,6 @@
     "REGEX_STRING_REGEXP" : false,
     "lowercase": false,
     "uppercase": false,
-    "manualLowercase": false,
-    "manualUppercase": false,
     "isArrayLike": false,
     "forEach": false,
     "forEachSorted": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -21,8 +21,6 @@
 
   lowercase,
   uppercase,
-  manualLowercase,
-  manualUppercase,
   nodeName_,
   isArrayLike,
   forEach,
@@ -146,31 +144,6 @@ var lowercase = function(string) {return isString(string) ? string.toLowerCase()
  * @returns {string} Uppercased string.
  */
 var uppercase = function(string) {return isString(string) ? string.toUpperCase() : string;};
-
-
-var manualLowercase = function(s) {
-  /* eslint-disable no-bitwise */
-  return isString(s)
-      ? s.replace(/[A-Z]/g, function(ch) {return String.fromCharCode(ch.charCodeAt(0) | 32);})
-      : s;
-  /* eslint-enable */
-};
-var manualUppercase = function(s) {
-  /* eslint-disable no-bitwise */
-  return isString(s)
-      ? s.replace(/[a-z]/g, function(ch) {return String.fromCharCode(ch.charCodeAt(0) & ~32);})
-      : s;
-  /* eslint-enable */
-};
-
-
-// String#toLowerCase and String#toUpperCase don't produce correct results in browsers with Turkish
-// locale, for this reason we need to detect this case and redefine lowercase/uppercase methods
-// with correct but slower alternatives. See https://github.com/angular/angular.js/issues/11387
-if ('i' !== 'I'.toLowerCase()) {
-  lowercase = manualLowercase;
-  uppercase = manualUppercase;
-}
 
 
 var

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -43,8 +43,6 @@
 
     "lowercase": false,
     "uppercase": false,
-    "manualLowercase": false,
-    "manualUppercase": false,
     "isArrayLike": false,
     "forEach": false,
     "reverseParams": false,

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -19,9 +19,12 @@ describe('angular', function() {
   describe('case', function() {
     it('should change case', function() {
       expect(lowercase('ABC90')).toEqual('abc90');
-      expect(manualLowercase('ABC90')).toEqual('abc90');
       expect(uppercase('abc90')).toEqual('ABC90');
-      expect(manualUppercase('abc90')).toEqual('ABC90');
+    });
+
+    it('should change case of non-ASCII letters', function() {
+      expect(lowercase('Ω')).toEqual('ω');
+      expect(uppercase('ω')).toEqual('Ω');
     });
   });
 


### PR DESCRIPTION
The `manualLowercase` & `manualUppercase` functions were inspired by Google Caja
code. Caja is written in Java, though, where problems with `toLowerCase`
working differently in Turkish locale are well known[1]. In JavaScript
`String#toLowerCase` is defined in the ECMAScript spec and all implementations
are required to lowercase I in the same way, regardless of the current locale.
Differences may (and do) happen only in `String#toLocaleLowerCase`.

Other libraries doing string normalization, like jQuery or DOMPurify don't
apply special lowercasing logic in a Turkish environment.

Therefore, the `manualLowercase` & `manualUppercase` logic is dead code in
AngularJS and can be removed.

Also, the `manualLowercase` & `manualUppercase` functions are incomplete; they
only lowercase ASCII characters which is different to native
`String#toLowerCase`. Since those functions are used in many places in the
library, they would break a lot of code. For example, the lowercase filter would
not lowercase Ω to ω but leave it as Ω.

[1] https://garygregory.wordpress.com/2015/11/03/java-lowercase-conversion-turkey/

Ref #11387

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Dead code removal.


**What is the current behavior? (You can also link to an open issue here)**
The `manualLowercase` & `manualUppercase` functions are defined & used if `'I'.toLowerCase() !== 'i'`.


**What is the new behavior (if this is a feature change)?**
`String#toLowerCase` is used everywhere.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:

