### PR TITLE
chore(browserstack): Update OS X, make iOS 8-10 available to test

### DIFF
--- a/karma-shared.conf.js
+++ b/karma-shared.conf.js
@@ -85,19 +85,19 @@ module.exports = function(config, specificOptions) {
         base: 'BrowserStack',
         browser: 'chrome',
         os: 'OS X',
-        os_version: 'Yosemite'
+        os_version: 'Sierra'
       },
       'BS_Safari': {
         base: 'BrowserStack',
         browser: 'safari',
         os: 'OS X',
-        os_version: 'Yosemite'
+        os_version: 'Sierra'
       },
       'BS_Firefox': {
         base: 'BrowserStack',
         browser: 'firefox',
         os: 'Windows',
-        os_version: '8'
+        os_version: '10'
       },
       'BS_IE_9': {
         base: 'BrowserStack',
@@ -120,11 +120,23 @@ module.exports = function(config, specificOptions) {
         os: 'Windows',
         os_version: '8.1'
       },
-      'BS_iOS': {
+      'BS_iOS_8': {
+        base: 'BrowserStack',
+        device: 'iPhone 6',
+        os: 'ios',
+        os_version: '8.3'
+      },
+      'BS_iOS_9': {
         base: 'BrowserStack',
         device: 'iPhone 6S',
         os: 'ios',
         os_version: '9.3'
+      },
+      'BS_iOS_10': {
+        base: 'BrowserStack',
+        device: 'iPhone 7',
+        os: 'ios',
+        os_version: '10.0'
       }
     }
   });

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -9,7 +9,7 @@ if [ "$JOB" == "ci-checks" ]; then
   grunt ci-checks
 elif [ "$JOB" == "unit" ]; then
   if [ "$BROWSER_PROVIDER" == "browserstack" ]; then
-    BROWSERS="BS_Chrome,BS_Safari,BS_Firefox,BS_IE_9,BS_IE_10,BS_IE_11,BS_iOS"
+    BROWSERS="BS_Chrome,BS_Safari,BS_Firefox,BS_IE_9,BS_IE_10,BS_IE_11,BS_iOS_8,BS_iOS_9"
   else
     BROWSERS="SL_Chrome,SL_Firefox,SL_Safari_8,SL_Safari_9,SL_IE_9,SL_IE_10,SL_IE_11,SL_iOS"
   fi


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Test config update.


**What is the current behavior? (You can also link to an open issue here)**
Only one iOS version can be tested via BrowserStack.


**What is the new behavior (if this is a feature change)?**
iOS 8.3, 9.3 & 10.0 can be tested.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- ~~Tests for the changes have been added (for bug fixes / features)~~
- ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Angular (2+) [supports iOS 7+](https://angular.io/docs/ts/latest/guide/browser-support.html) but iOS 7 is very flakey on BrowserStack (see https://github.com/angular/angular/issues/15916). It'd be good to at least try to support the same versions; making it possible to test via BrowserStack is the first step.