### PR TITLE
Update(orderBy): Guaranteed stable sort

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -49,9 +49,8 @@
  * second, or `1` otherwise.
  *
  * In order to ensure that the sorting will be deterministic across platforms, if none of the
- * specified predicates can distinguish between two items, `orderBy` will automatically introduce a
- * dummy predicate that returns the item's index as `value`.
- * (If you are using a custom comparator, make sure it can handle this predicate as well.)
+ * specified predicates nor the custom comparator can distinguish between two items, `orderBy` will
+ * automatically introduce a dummy predicate that returns the item's index as `value`.
  *
  * Finally, in an attempt to simplify things, if a predicate returns an object as the extracted
  * value for an item, `orderBy` will try to convert that object to a primitive value, before passing
@@ -599,7 +598,7 @@ function orderByFilter($parse) {
         }
       }
 
-      return compare(v1.tieBreaker, v2.tieBreaker) * descending;
+      return (compare(v1.tieBreaker, v2.tieBreaker) || defaultCompare(v1.tieBreaker, v2.tieBreaker)) * descending;
     }
   };
 

--- a/test/ng/filter/orderBySpec.js
+++ b/test/ng/filter/orderBySpec.js
@@ -457,6 +457,19 @@ describe('Filter: orderBy', function() {
 
         expect(orderBy(items, expr, reverse, comparator)).toEqual(sorted);
       });
+
+      it('should use the default comparator to break ties on a provided comparator', function() {
+        // Some list that won't be sorted "naturally", i.e. should sort to ['a', 'B', 'c']
+        var items = ['c', 'a', 'B'];
+        var expr = null;
+        function comparator() {
+          return 0;
+        }
+        var reversed = ['B', 'a', 'c'];
+
+        expect(orderBy(items, expr, false, comparator)).toEqual(items);
+        expect(orderBy(items, expr, true, comparator)).toEqual(reversed);
+      });
     });
 
     describe('(object as `value`)', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature

**What is the current behavior? (You can also link to an open issue here)**

#14881 

**What is the new behavior (if this is a feature change)?**

Falls back on built-in comparison function if user-provided comparison function fails to break a tie between elements being ordered.

**Does this PR introduce a breaking change?**

Yes

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

BREAKING CHANGE: Using `orderBy` with a custom `comparator` function while
simultaneously setting `reverse` to `true` results in a potentially different
list order than previously.

Specifically, when the custom `comparator` fails to sort two objects (compares
them as being "equal"), the objects would previously have remained in their
original order in the array relative to each other. They will now switch places
as the `reverse` will be more accurately respected.

To migrate, make sure that your custom `comparator` properly differentiates
between all cases that your code base cares about and that "equal" cases are
not order dependent. We expect that due to the nature of this change, since the
entries are considered "equal", that very few projects will be affected by this
change in all but a minor visual manor that still respects the expected
operation being performed.