### PR TITLE
docs(ngMock/service/$httpBackend) Fix typo in $httpBackend document

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1108,7 +1108,7 @@ angular.mock.dump = function(object) {
  *
  * ## Flushing HTTP requests
  *
- * The $httpBackend used in production always responds to requests asynchronously. If we preserved
+ * The $http used in production always responds to requests asynchronously. If we preserved
  * this behavior in unit testing, we'd have to create async unit tests, which are hard to write,
  * to follow and to maintain. But neither can the testing mock respond synchronously; that would
  * change the execution of the code under test. For this reason, the mock $httpBackend has a


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs update. 
I believe what the document wants to say is `The $http used in production` rather than `The $httpBackend used in production`, since `$httpBackend` barely used in production environment.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

