### PR TITLE
Fixes to select and ngOptions - "required" validation and behavior with empty / unknown option

### DIFF
--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -704,7 +704,6 @@ var ngOptionsDirective = ['$compile', '$document', '$parse', function($compile, 
             ngModelCtrl.$render();
           }
         }
-
       }
   }
 

--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -449,12 +449,12 @@ var ngOptionsDirective = ['$compile', '$document', '$parse', function($compile, 
       if (!multiple) {
 
         selectCtrl.writeValue = function writeNgOptionsValue(value) {
-          var selectedOption = options.selectValueMap[selectElement.val()];
+          var selectedOption = selectElement[0].options[selectElement[0].selectedIndex];
           var option = options.getOptionFromViewValue(value);
 
           // Make sure to remove the selected attribute from the previously selected option
           // Otherwise, screen readers might get confused
-          if (selectedOption) selectedOption.element.removeAttribute('selected');
+          if (selectedOption) selectedOption.removeAttribute('selected');
 
           if (option) {
             // Don't update the option when it is already selected.
@@ -464,7 +464,6 @@ var ngOptionsDirective = ['$compile', '$document', '$parse', function($compile, 
 
             if (selectElement[0].value !== option.selectValue) {
               selectCtrl.removeUnknownOption();
-              selectCtrl.unselectEmptyOption();
 
               selectElement[0].value = option.selectValue;
               option.element.selected = true;
@@ -472,15 +471,7 @@ var ngOptionsDirective = ['$compile', '$document', '$parse', function($compile, 
 
             option.element.setAttribute('selected', 'selected');
           } else {
-
-            if (value == null && providedEmptyOption) {
-              selectCtrl.removeUnknownOption();
-              selectCtrl.selectEmptyOption();
-            } else if (selectCtrl.unknownOption.parent().length) {
-              selectCtrl.updateUnknownOption(value);
-            } else {
-              selectCtrl.renderUnknownOption(value);
-            }
+            selectCtrl.selectUnknownOrEmptyOption(value);
           }
         };
 

--- a/src/ng/directive/ngOptions.js
+++ b/src/ng/directive/ngOptions.js
@@ -473,7 +473,8 @@ var ngOptionsDirective = ['$compile', '$document', '$parse', function($compile, 
             option.element.setAttribute('selected', 'selected');
           } else {
 
-            if (providedEmptyOption) {
+            if (value == null && providedEmptyOption) {
+              selectCtrl.removeUnknownOption();
               selectCtrl.selectEmptyOption();
             } else if (selectCtrl.unknownOption.parent().length) {
               selectCtrl.updateUnknownOption(value);
@@ -657,7 +658,12 @@ var ngOptionsDirective = ['$compile', '$document', '$parse', function($compile, 
 
         // Ensure that the empty option is always there if it was explicitly provided
         if (providedEmptyOption) {
-          selectElement.prepend(selectCtrl.emptyOption);
+
+          if (selectCtrl.unknownOption.parent().length) {
+            selectCtrl.unknownOption.after(selectCtrl.emptyOption);
+          } else {
+            selectElement.prepend(selectCtrl.emptyOption);
+          }
         }
 
         options.items.forEach(function addOption(option) {

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -86,7 +86,7 @@ var SelectController =
 
   self.unselectEmptyOption = function() {
     if (self.hasEmptyOption) {
-      self.emptyOption.removeAttr('selected');
+      setOptionSelectedStatus(self.emptyOption, false);
     }
   };
 
@@ -128,14 +128,7 @@ var SelectController =
       var selectedOption = $element[0].options[$element[0].selectedIndex];
       setOptionSelectedStatus(jqLite(selectedOption), true);
     } else {
-      if (value == null && self.emptyOption) {
-        self.removeUnknownOption();
-        self.selectEmptyOption();
-      } else if (self.unknownOption.parent().length) {
-        self.updateUnknownOption(value);
-      } else {
-        self.renderUnknownOption(value);
-      }
+      self.selectUnknownOrEmptyOption(value);
     }
   };
 
@@ -178,6 +171,16 @@ var SelectController =
     return !!optionsMap.get(value);
   };
 
+  self.selectUnknownOrEmptyOption = function(value) {
+    if (value == null && self.emptyOption) {
+      self.removeUnknownOption();
+      self.selectEmptyOption();
+    } else if (self.unknownOption.parent().length) {
+      self.updateUnknownOption(value);
+    } else {
+      self.renderUnknownOption(value);
+    }
+  };
 
   var renderScheduled = false;
   function scheduleRender() {

--- a/src/ng/directive/select.js
+++ b/src/ng/directive/select.js
@@ -44,11 +44,13 @@ var SelectController =
   // to create it in <select> and IE barfs otherwise.
   self.unknownOption = jqLite(window.document.createElement('option'));
 
-  // The empty option is an option with the value '' that te application developer can
-  // provide inside the select. When the model changes to a value that doesn't match an option,
-  // it is selected - so if an empty option is provided, no unknown option is generated.
-  // However, the empty option is not removed when the model matches an option. It is always selectable
-  // and indicates that a "null" selection has been made.
+  // The empty option is an option with the value '' that the application developer can
+  // provide inside the select. It is always selectable and indicates that a "null" selection has
+  // been made by the user.
+  // If the select has an empty option, and the model of the select is set to "undefined" or "null",
+  // the empty option is selected.
+  // If the model is set to a different unmatched value, the unknown option is rendered and
+  // selected, i.e both are present, because a "null" selection and an unknown value are different.
   self.hasEmptyOption = false;
   self.emptyOption = undefined;
 

--- a/test/helpers/matchers.js
+++ b/test/helpers/matchers.js
@@ -400,6 +400,27 @@ beforeEach(function() {
           return result;
         }
       };
+    },
+    toEqualSelect: function() {
+      return {
+        compare: function(actual, expected) {
+          var actualValues = [],
+              expectedValues = [].slice.call(arguments, 1);
+
+          forEach(actual.find('option'), function(option) {
+            actualValues.push(option.selected ? [option.value] : option.value);
+          });
+
+          var message = function() {
+            return 'Expected ' + toJson(actualValues) + ' to equal ' + toJson(expectedValues) + '.';
+          };
+
+          return {
+            pass: equals(expectedValues, actualValues),
+            message: message
+          };
+        }
+      };
     }
   });
 });

--- a/test/helpers/matchers.js
+++ b/test/helpers/matchers.js
@@ -365,13 +365,15 @@ beforeEach(function() {
       return {
         compare: function(actual) {
           var errors = [];
+          var optionVal = toJson(actual.value);
+
           if (actual.selected === null || typeof actual.selected === 'undefined' || actual.selected === false) {
-            errors.push('Expected option property "selected" to be truthy');
+            errors.push('Expected option with value ' + optionVal + ' to have property "selected" set to truthy');
           }
 
           // Support: IE 9 only
           if (msie !== 9 && actual.hasAttribute('selected') === false) {
-            errors.push('Expected option to have attribute "selected"');
+            errors.push('Expected option with value ' + optionVal + ' to have attribute "selected"');
           }
 
           var result = {
@@ -383,13 +385,15 @@ beforeEach(function() {
         },
         negativeCompare: function(actual) {
           var errors = [];
+          var optionVal = toJson(actual.value);
+
           if (actual.selected) {
-            errors.push('Expected option property "selected" to be falsy');
+            errors.push('Expected option with value ' + optionVal + ' property "selected" to be falsy');
           }
 
           // Support: IE 9 only
           if (msie !== 9 && actual.hasAttribute('selected')) {
-            errors.push('Expected option not to have attribute "selected"');
+            errors.push('Expected option with value ' + optionVal + ' not to have attribute "selected"');
           }
 
           var result = {

--- a/test/ng/directive/ngOptionsSpec.js
+++ b/test/ng/directive/ngOptionsSpec.js
@@ -773,12 +773,32 @@ describe('ngOptions', function() {
     expect(options[1]).not.toBeMarkedAsSelected();
     expect(options[2]).toBeMarkedAsSelected();
 
-    scope.selected = 'no match';
+    // This will select the empty option
+    scope.selected = null;
     scope.$digest();
 
     expect(options[0]).toBeMarkedAsSelected();
     expect(options[1]).not.toBeMarkedAsSelected();
     expect(options[2]).not.toBeMarkedAsSelected();
+
+    // This will add and select the unknown option
+    scope.selected = 'unmatched value';
+    scope.$digest();
+    options = element.find('option');
+
+    expect(options[0]).toBeMarkedAsSelected();
+    expect(options[1]).not.toBeMarkedAsSelected();
+    expect(options[2]).not.toBeMarkedAsSelected();
+    expect(options[3]).not.toBeMarkedAsSelected();
+
+    // Back to matched value
+    scope.selected = scope.values[1];
+    scope.$digest();
+    options = element.find('option');
+
+    expect(options[0]).not.toBeMarkedAsSelected();
+    expect(options[1]).not.toBeMarkedAsSelected();
+    expect(options[2]).toBeMarkedAsSelected();
   });
 
   describe('disableWhen expression', function() {
@@ -2195,6 +2215,20 @@ describe('ngOptions', function() {
     });
 
 
+  it('should insert and select temporary unknown option when no options-model match, empty ' +
+        'option is present and model is defined', function() {
+      scope.selected = 'C';
+      scope.values = [{name: 'A'}, {name: 'B'}];
+      createSingleSelect(true);
+
+      expect(element).toEqualSelect(['?'], '', 'object:3', 'object:4');
+
+      scope.$apply('selected = values[1]');
+
+      expect(element).toEqualSelect('', 'object:3', ['object:4']);
+    });
+
+
     it('should select correct input if previously selected option was "?"', function() {
       createSingleSelect();
 
@@ -2213,6 +2247,19 @@ describe('ngOptions', function() {
       expect(element.find('option').eq(0).prop('selected')).toBeTruthy();
     });
 
+
+    it('should remove unknown option when empty option exists and model is undefined', function() {
+      scope.selected = 'C';
+      scope.values = [{name: 'A'}, {name: 'B'}];
+      createSingleSelect(true);
+
+      expect(element).toEqualSelect(['?'], '', 'object:3', 'object:4');
+
+      scope.selected = undefined;
+      scope.$digest();
+
+      expect(element).toEqualSelect([''], 'object:3', 'object:4');
+    });
 
     it('should use exact same values as values in scope with one-time bindings', function() {
       scope.values = [{name: 'A'}, {name: 'B'}];
@@ -2955,7 +3002,7 @@ describe('ngOptions', function() {
       expect(ngModelCtrl.$error.required).toBeFalsy();
 
       // model -> view
-      scope.$apply('selection = "unmatched value"');
+      scope.$apply('selection = null');
       expect(options[0]).toBeMarkedAsSelected();
       expect(element).toBeInvalid();
       expect(ngModelCtrl.$error.required).toBeTruthy();

--- a/test/ng/directive/selectSpec.js
+++ b/test/ng/directive/selectSpec.js
@@ -86,28 +86,6 @@ describe('select', function() {
 
   beforeEach(function() {
     jasmine.addMatchers({
-      toEqualSelect: function() {
-        return {
-          compare: function(actual, expected) {
-            var actualValues = [],
-                expectedValues = [].slice.call(arguments, 1);
-
-            forEach(actual.find('option'), function(option) {
-              actualValues.push(option.selected ? [option.value] : option.value);
-            });
-
-            var message = function() {
-              return 'Expected ' + toJson(actualValues) + ' to equal ' + toJson(expectedValues) + '.';
-            };
-
-            return {
-              pass: equals(expectedValues, actualValues),
-              message: message
-            };
-          }
-        };
-      },
-
       toEqualSelectWithOptions: function() {
         return {
           compare: function(actual, expected) {
@@ -396,6 +374,7 @@ describe('select', function() {
 
     it('should remove the "selected" attribute from the previous option when the model changes', function() {
       compile('<select name="select" ng-model="selected">' +
+        '<option value="">--empty--</option>' +
         '<option value="a">A</option>' +
         '<option value="b">B</option>' +
       '</select>');
@@ -411,24 +390,45 @@ describe('select', function() {
       scope.$digest();
 
       options = element.find('option');
-      expect(options.length).toBe(2);
-      expect(options[0]).toBeMarkedAsSelected();
-      expect(options[1]).not.toBeMarkedAsSelected();
+      expect(options.length).toBe(3);
+      expect(options[0]).not.toBeMarkedAsSelected();
+      expect(options[1]).toBeMarkedAsSelected();
+      expect(options[2]).not.toBeMarkedAsSelected();
 
       scope.selected = 'b';
       scope.$digest();
 
       options = element.find('option');
       expect(options[0]).not.toBeMarkedAsSelected();
-      expect(options[1]).toBeMarkedAsSelected();
+      expect(options[1]).not.toBeMarkedAsSelected();
+      expect(options[2]).toBeMarkedAsSelected();
 
-      scope.selected = 'no match';
+      // This will select the empty option
+      scope.selected = null;
       scope.$digest();
 
-      options = element.find('option');
       expect(options[0]).toBeMarkedAsSelected();
       expect(options[1]).not.toBeMarkedAsSelected();
       expect(options[2]).not.toBeMarkedAsSelected();
+
+      // This will add and select the unknown option
+      scope.selected = 'unmatched value';
+      scope.$digest();
+      options = element.find('option');
+
+      expect(options[0]).toBeMarkedAsSelected();
+      expect(options[1]).not.toBeMarkedAsSelected();
+      expect(options[2]).not.toBeMarkedAsSelected();
+      expect(options[3]).not.toBeMarkedAsSelected();
+
+      // Back to matched value
+      scope.selected = 'b';
+      scope.$digest();
+      options = element.find('option');
+
+      expect(options[0]).not.toBeMarkedAsSelected();
+      expect(options[1]).not.toBeMarkedAsSelected();
+      expect(options[2]).toBeMarkedAsSelected();
     });
 
     describe('empty option', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bugfixes


**What is the current behavior? (You can also link to an open issue here)**
- (a) when the unknown option is selected and the select is "required", the required error is not set
- (b) ngOptions: when the model is unmatched and an empty option exists, the empty option is always selected, even if the model is not null / undefined.

**What is the new behavior (if this is a feature change)?**
- (a) the error is set
- (b) the unknown option is selected if the model is not null / undefined


**Does this PR introduce a breaking change?**
Possibly? For (a), the following situation is possible: The model is programatically set to a value that is no longer in select options, and the select is required. With this patch, the user cannot keep the unmatched value, because of the required error, which considers this value invalid (just realized this, so it's not in the commit message).

For (b), it's unlikely that anyone relied on the fact that the empty option is selected instead of the unmatched option - the fixd behavior was also present in regular select since the beginning.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

