### PR TITLE
chore: unit test latest + latest-1 version of FF, Chrome, Edge

### DIFF
--- a/karma-shared.conf.js
+++ b/karma-shared.conf.js
@@ -45,12 +45,22 @@ module.exports = function(config, specificOptions) {
       'SL_Chrome': {
         base: 'SauceLabs',
         browserName: 'chrome',
-        version: '59'
+        version: 'latest'
+      },
+      'SL_Chrome-1': {
+        base: 'SauceLabs',
+        browserName: 'chrome',
+        version: 'latest-1'
       },
       'SL_Firefox': {
         base: 'SauceLabs',
         browserName: 'firefox',
-        version: '54'
+        version: 'latest'
+      },
+      'SL_Firefox-1': {
+        base: 'SauceLabs',
+        browserName: 'firefox',
+        version: 'latest-1'
       },
       'SL_Safari_8': {
         base: 'SauceLabs',
@@ -86,7 +96,13 @@ module.exports = function(config, specificOptions) {
         base: 'SauceLabs',
         browserName: 'microsoftedge',
         platform: 'Windows 10',
-        version: '14'
+        version: 'latest'
+      },
+      'SL_EDGE-1': {
+        base: 'SauceLabs',
+        browserName: 'microsoftedge',
+        platform: 'Windows 10',
+        version: 'latest-1'
       },
       'SL_iOS': {
         base: 'SauceLabs',
@@ -137,7 +153,6 @@ module.exports = function(config, specificOptions) {
       'BS_EDGE': {
         base: 'BrowserStack',
         browser: 'edge',
-        browser_version: '14',
         os: 'Windows',
         os_version: '10'
       },

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -21,7 +21,7 @@ case "$JOB" in
     if [ "$BROWSER_PROVIDER" == "browserstack" ]; then
       BROWSERS="BS_Chrome,BS_Safari,BS_Firefox,BS_IE_9,BS_IE_10,BS_IE_11,BS_EDGE,BS_iOS_8,BS_iOS_9"
     else
-      BROWSERS="SL_Chrome,SL_Firefox,SL_Safari_8,SL_Safari_9,SL_IE_9,SL_IE_10,SL_IE_11,SL_EDGE,SL_iOS"
+      BROWSERS="SL_Chrome,SL_Chrome-1,SL_Firefox,SL_Firefox-1,SL_Safari_8,SL_Safari_9,SL_IE_9,SL_IE_10,SL_IE_11,SL_EDGE,SL_EDGE-1,SL_iOS"
     fi
 
     grunt test:promises-aplus

--- a/yarn.lock
+++ b/yarn.lock
@@ -5609,13 +5609,17 @@ semver-diff@^0.1.0:
   dependencies:
     semver "^2.2.1"
 
-semver@*, "semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.2.0, semver@^5.3.0, semver@~5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-
 "semver@2 || 3 || 4", semver@^4.1.0, semver@~4.3.3:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
+
+"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.2.0, semver@^5.3.0, semver@~5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-2.2.1.tgz#7941182b3ffcc580bff1c17942acdf7951c0d213"
 
 semver@^2.2.1, semver@~2.3.0:
   version "2.3.2"
@@ -6335,7 +6339,7 @@ traceur@vojtajina/traceur-compiler#add-es6-pure-transformer-dist:
   dependencies:
     commander ">=1.1"
     q-io "~1.10.6"
-    semver "*"
+    semver "2.2.1"
 
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"


### PR DESCRIPTION
At the moment, we use fixed versions of these browsers to test - especially for FF and Chrome it's useful to test the latest, as they release faster.
For the future, we could also look into using  `latest-1` additionally.