### PR TITLE
feat(ngMocks): Describe unflushed http requests

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1889,7 +1889,7 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
       for (var i = 0, len = responses.length; i < len; ++i) {
         unflushedDescriptions.push(responses[i].description);
       }
-      throw new Error('Unflushed requests: \n  ' +
+      throw new Error('Unflushed requests: ' + responses.length + '\n  ' +
                       unflushedDescriptions.join('\n  '));
     }
   };

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1378,6 +1378,7 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
         }
       }
 
+      handleResponse.description = method + ' ' + url;
       return handleResponse;
 
       function handleResponse() {
@@ -1884,7 +1885,12 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
   $httpBackend.verifyNoOutstandingRequest = function(digest) {
     if (digest !== false) $rootScope.$digest();
     if (responses.length) {
-      throw new Error('Unflushed requests: ' + responses.length);
+      var unflushedDescriptions = [];
+      for (var i = 0, len = responses.length; i < len; ++i) {
+        unflushedDescriptions.push(responses[i].description);
+      }
+      throw new Error('Unflushed requests: \n  ' +
+                      unflushedDescriptions.join('\n  '));
     }
   };
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1885,10 +1885,7 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
   $httpBackend.verifyNoOutstandingRequest = function(digest) {
     if (digest !== false) $rootScope.$digest();
     if (responses.length) {
-      var unflushedDescriptions = [];
-      for (var i = 0, len = responses.length; i < len; ++i) {
-        unflushedDescriptions.push(responses[i].description);
-      }
+      var unflushedDescriptions = responses.map(function(res) { return res.description; });
       throw new Error('Unflushed requests: ' + responses.length + '\n  ' +
                       unflushedDescriptions.join('\n  '));
     }

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1678,7 +1678,8 @@ describe('ngMock', function() {
 
         expect(function() {
           hb.verifyNoOutstandingRequest();
-        }).toThrowError('Unflushed requests: \n  GET /some');
+        }).toThrowError('Unflushed requests: 1\n' +
+                        '  GET /some');
       });
 
 
@@ -1690,8 +1691,23 @@ describe('ngMock', function() {
 
         expect(function() {
           hb.verifyNoOutstandingRequest();
-        }).toThrowError('Unflushed requests: \n  GET /some');
+        }).toThrowError('Unflushed requests: 1\n' +
+                        '  GET /some');
       }));
+
+
+      it('should describe multiple unflushed requests', function() {
+        hb.when('GET').respond(200);
+        hb.when('PUT').respond(200);
+        hb('GET', '/some', null, noop, {});
+        hb('PUT', '/elsewhere', null, noop, {});
+
+        expect(function() {
+          hb.verifyNoOutstandingRequest();
+        }).toThrowError('Unflushed requests: 2\n' +
+                        '  GET /some\n' +
+                        '  PUT /elsewhere');
+      });
     });
 
 

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1678,7 +1678,7 @@ describe('ngMock', function() {
 
         expect(function() {
           hb.verifyNoOutstandingRequest();
-        }).toThrowError('Unflushed requests: 1');
+        }).toThrowError('Unflushed requests: \n  GET /some');
       });
 
 
@@ -1690,7 +1690,7 @@ describe('ngMock', function() {
 
         expect(function() {
           hb.verifyNoOutstandingRequest();
-        }).toThrowError('Unflushed requests: 1');
+        }).toThrowError('Unflushed requests: \n  GET /some');
       }));
     });
 


### PR DESCRIPTION
The current implementation of $httpBackend.verifyNoOutstandingRequest
gives an integer number describing how many requests are unflushed.

While it's superficially easy to solve test errors from that message
by simply adding an additional $httpBackend.flush(), if a developer
is truly not expecting the code to make further requests this is
not ideal.

This change explicitly prints out which additional requests remain
unflushed in the error message, helping her determine if the code
needs changing, or if an additional flush is appropriate.

Before this change:

    Unflushed requests: 1

After this change:

    Unflushed requests:
      GET /some

Closes #10596

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

A feature improving the output of ngMocks "Unflushed requests" error message.

**What is the current behavior? (You can also link to an open issue here)**

The error message includes the number of requests remaining unflushed.

**What is the new behavior (if this is a feature change)?**

The error message now includes a brief description of which requests remain unflushed.

**Does this PR introduce a breaking change?**

No - unless the error messages are considered public API.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

