### PR TITLE
docs($exceptionHandler): Bypass a circular dependency that occurs when services that depend on $exceptionHandler are injected into custom $exceptionHandler

### DIFF
--- a/src/ng/exceptionHandler.js
+++ b/src/ng/exceptionHandler.js
@@ -26,7 +26,7 @@
  *     factory('$exceptionHandler',  function($injector) {
  *
  *       return function myExceptionHandler(exception, cause) {
- *      
+ *
  *         var $log = $injector.get('$log');
  *
  *         var logErrorsToBackend = $injector.get('logErrorsToBackend');
@@ -34,6 +34,7 @@
  *         logErrorsToBackend(exception, cause);
  *
  *         $log.warn(exception, cause);
+ *
  *       };
  *     });
  * ```

--- a/src/ng/exceptionHandler.js
+++ b/src/ng/exceptionHandler.js
@@ -23,12 +23,19 @@
  * ```js
  *   angular.
  *     module('exceptionOverwrite', []).
- *     factory('$exceptionHandler', ['$log', 'logErrorsToBackend', function($log, logErrorsToBackend) {
+ *     factory('$exceptionHandler',  function($injector) {
+ *
  *       return function myExceptionHandler(exception, cause) {
+ *      
+ *         var $log = $injector.get('$log');
+ *
+ *         var logErrorsToBackend = $injector.get('logErrorsToBackend');
+ *
  *         logErrorsToBackend(exception, cause);
+ *
  *         $log.warn(exception, cause);
  *       };
- *     }]);
+ *     });
  * ```
  *
  * <hr />


### PR DESCRIPTION
…n modules such as $http which depends on $exceptionHandler are injected in to the custom error handler

In the original code, If user attempts to inject a module that depends on $exceptionHanlder, it causes a circular dependency. It throws something like 'Circular dependency: $http <- $exceptionHandler <- $rootScope....'. The error happens even when a factory that depends on $http is injected.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug Fix


**What is the current behavior? (You can also link to an open issue here)**
 If user attempts to inject a module that depends on $exceptionHanlder, it causes a circular dependency. It throws something like 'Circular dependency: $http <- $exceptionHandler <- $rootScope....'. The error happens even when a factory that depends on $http is injected.


**What is the new behavior (if this is a feature change)?**
Circular dependency chain is broken and the system works as expected.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

