### PR TITLE
docs(currency): Add sample of currency from scope

### DIFF
--- a/src/ng/filter/filters.js
+++ b/src/ng/filter/filters.js
@@ -26,13 +26,15 @@ var ZERO_CHAR = '0';
          angular.module('currencyExample', [])
            .controller('ExampleController', ['$scope', function($scope) {
              $scope.amount = 1234.56;
+             $scope.symbol = "GBP£";
            }]);
        </script>
        <div ng-controller="ExampleController">
          <input type="number" ng-model="amount" aria-label="amount"> <br>
          default currency symbol ($): <span id="currency-default">{{amount | currency}}</span><br>
          custom currency identifier (USD$): <span id="currency-custom">{{amount | currency:"USD$"}}</span><br>
-         no fractions (0): <span id="currency-no-fractions">{{amount | currency:"USD$":0}}</span>
+         no fractions (0): <span id="currency-no-fractions">{{amount | currency:"USD$":0}}</span><br>
+         from scope ({{symbol}}): <span id="currency-from-scope">{{amount | currency:symbol}}</span>
        </div>
      </file>
      <file name="protractor.js" type="protractor">
@@ -40,6 +42,7 @@ var ZERO_CHAR = '0';
          expect(element(by.id('currency-default')).getText()).toBe('$1,234.56');
          expect(element(by.id('currency-custom')).getText()).toBe('USD$1,234.56');
          expect(element(by.id('currency-no-fractions')).getText()).toBe('USD$1,235');
+         expect(element(by.id('currency-from-scope')).getText()).toBe('GBP£1,235.56');
        });
        it('should update', function() {
          if (browser.params.browser === 'safari') {
@@ -52,6 +55,7 @@ var ZERO_CHAR = '0';
          expect(element(by.id('currency-default')).getText()).toBe('-$1,234.00');
          expect(element(by.id('currency-custom')).getText()).toBe('-USD$1,234.00');
          expect(element(by.id('currency-no-fractions')).getText()).toBe('-USD$1,234');
+         expect(element(by.id('currency-from-scope')).getText()).toBe('-GBP£1,234');
        });
      </file>
    </example>


### PR DESCRIPTION
docs(currency): Add sample of currency from scope

Added a sample line showing the use of a scope variable to set currency symbol.  E.g. for central i18n configuration.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This adds a docs update (example code).


**What is the current behavior? (You can also link to an open issue here)**
Shows currency symbols pulled from text strings.


**What is the new behavior (if this is a feature change)?**
Shows currency symbol pulled from scope.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [*] Tests for the changes have been added (for bug fixes / features)
- [*] Docs have been added / updated (for bug fixes / features)

**Other information**:

