### PR TITLE
chore(docs-app): fix vertical scrolling offset after recent re-design

### DIFF
--- a/docs/config/templates/app/indexPage.template.html
+++ b/docs/config/templates/app/indexPage.template.html
@@ -70,7 +70,7 @@
 </head>
 <body class="homepage">
   <div id="wrapper">
-    <header class="header" scroll-y-offset-element>
+    <header class="header">
       <nav id="navbar-main" class="navbar navbar-fixed-top">
         <div class="navbar-inner" ng-controller="DocsSearchCtrl">
           <div class="container">
@@ -156,7 +156,7 @@
           </div>
         </div>
       </nav>
-      <nav id="navbar-sub" class="sup-header navbar navbar-fixed-top">
+      <nav id="navbar-sub" class="sup-header navbar navbar-fixed-top" scroll-y-offset-element>
         <div class="container main-grid main-header-grid">
           <div class="grid-left">
             <version-picker></version-picker>


### PR DESCRIPTION
Previously, the `yOffset` pointed to the `<header>` element, which had a height
of 0 (since all its children have fixed positions). This caused scrolled items
to have 0 vertical offset, essentially hiding the top part behind the static
`<nav>` items.
This commit fixes the vertical scrolling offset, by setting `yOffset` to the
last (lowest) `<nav>` item.
