### PR TITLE
Revert "fix($parse): standardize one-time literal vs non-literal and interceptors"

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -14,6 +14,13 @@ function classDirective(name, selector) {
     return {
       restrict: 'AC',
       link: function(scope, element, attr) {
+        var expression = attr[name].trim();
+        var isOneTime = (expression.charAt(0) === ':') && (expression.charAt(1) === ':');
+
+        var watchInterceptor = isOneTime ? toFlatValue : toClassString;
+        var watchExpression = $parse(expression, watchInterceptor);
+        var watchAction = isOneTime ? ngClassOneTimeWatchAction : ngClassWatchAction;
+
         var classCounts = element.data('$classCounts');
         var oldModulo = true;
         var oldClassString;
@@ -36,7 +43,7 @@ function classDirective(name, selector) {
           scope.$watch(indexWatchExpression, ngClassIndexWatchAction);
         }
 
-        scope.$watch($parse(attr[name], toClassString), ngClassWatchAction);
+        scope.$watch(watchExpression, watchAction, isOneTime);
 
         function addClasses(classString) {
           classString = digestClassCounts(split(classString), 1);
@@ -78,9 +85,9 @@ function classDirective(name, selector) {
         }
 
         function ngClassIndexWatchAction(newModulo) {
-          // This watch-action should run before the `ngClassWatchAction()`, thus it
+          // This watch-action should run before the `ngClass[OneTime]WatchAction()`, thus it
           // adds/removes `oldClassString`. If the `ngClass` expression has changed as well, the
-          // `ngClassWatchAction()` will update the classes.
+          // `ngClass[OneTime]WatchAction()` will update the classes.
           if (newModulo === selector) {
             addClasses(oldClassString);
           } else {
@@ -90,13 +97,15 @@ function classDirective(name, selector) {
           oldModulo = newModulo;
         }
 
-        function ngClassWatchAction(newClassString) {
-          // When using a one-time binding the newClassString will return
-          // the pre-interceptor value until the one-time is complete
-          if (!isString(newClassString)) {
-            newClassString = toClassString(newClassString);
-          }
+        function ngClassOneTimeWatchAction(newClassValue) {
+          var newClassString = toClassString(newClassValue);
 
+          if (newClassString !== oldClassString) {
+            ngClassWatchAction(newClassString);
+          }
+        }
+
+        function ngClassWatchAction(newClassString) {
           if (oldModulo === selector) {
             updateClasses(oldClassString, newClassString);
           }
@@ -142,6 +151,34 @@ function classDirective(name, selector) {
     }
 
     return classString;
+  }
+
+  function toFlatValue(classValue) {
+    var flatValue = classValue;
+
+    if (isArray(classValue)) {
+      flatValue = classValue.map(toFlatValue);
+    } else if (isObject(classValue)) {
+      var hasUndefined = false;
+
+      flatValue = Object.keys(classValue).filter(function(key) {
+        var value = classValue[key];
+
+        if (!hasUndefined && isUndefined(value)) {
+          hasUndefined = true;
+        }
+
+        return value;
+      });
+
+      if (hasUndefined) {
+        // Prevent the `oneTimeLiteralWatchInterceptor` from unregistering
+        // the watcher, by including at least one `undefined` value.
+        flatValue.push(undefined);
+      }
+    }
+
+    return flatValue;
   }
 }
 

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -2688,86 +2688,82 @@ describe('parser', function() {
             expect($parse('::    ').literal).toBe(true);
           }));
 
-          [true, false].forEach(function(isDeep) {
-            describe(isDeep ? 'deepWatch' : 'watch', function() {
-              it('should only become stable when all the properties of an object have defined values', inject(function($parse, $rootScope, log) {
-                var fn = $parse('::{foo: foo, bar: bar}');
-                $rootScope.$watch(fn, function(value) { log(value); }, isDeep);
+          it('should only become stable when all the properties of an object have defined values', inject(function($parse, $rootScope, log) {
+            var fn = $parse('::{foo: foo, bar: bar}');
+            $rootScope.$watch(fn, function(value) { log(value); }, true);
 
-                expect(log.empty()).toEqual([]);
-                expect($rootScope.$$watchers.length).toBe(1);
+            expect(log.empty()).toEqual([]);
+            expect($rootScope.$$watchers.length).toBe(1);
 
-                $rootScope.$digest();
-                expect($rootScope.$$watchers.length).toBe(1);
-                expect(log.empty()).toEqual([{foo: undefined, bar: undefined}]);
+            $rootScope.$digest();
+            expect($rootScope.$$watchers.length).toBe(1);
+            expect(log.empty()).toEqual([{foo: undefined, bar: undefined}]);
 
-                $rootScope.foo = 'foo';
-                $rootScope.$digest();
-                expect($rootScope.$$watchers.length).toBe(1);
-                expect(log.empty()).toEqual([{foo: 'foo', bar: undefined}]);
+            $rootScope.foo = 'foo';
+            $rootScope.$digest();
+            expect($rootScope.$$watchers.length).toBe(1);
+            expect(log.empty()).toEqual([{foo: 'foo', bar: undefined}]);
 
-                $rootScope.foo = 'foobar';
-                $rootScope.bar = 'bar';
-                $rootScope.$digest();
-                expect($rootScope.$$watchers.length).toBe(0);
-                expect(log.empty()).toEqual([{foo: 'foobar', bar: 'bar'}]);
+            $rootScope.foo = 'foobar';
+            $rootScope.bar = 'bar';
+            $rootScope.$digest();
+            expect($rootScope.$$watchers.length).toBe(0);
+            expect(log.empty()).toEqual([{foo: 'foobar', bar: 'bar'}]);
 
-                $rootScope.foo = 'baz';
-                $rootScope.$digest();
-                expect($rootScope.$$watchers.length).toBe(0);
-                expect(log.empty()).toEqual([]);
-              }));
+            $rootScope.foo = 'baz';
+            $rootScope.$digest();
+            expect($rootScope.$$watchers.length).toBe(0);
+            expect(log.empty()).toEqual([]);
+          }));
 
-              it('should only become stable when all the elements of an array have defined values', inject(function($parse, $rootScope, log) {
-                var fn = $parse('::[foo,bar]');
-                $rootScope.$watch(fn, function(value) { log(value); }, isDeep);
+          it('should only become stable when all the elements of an array have defined values', inject(function($parse, $rootScope, log) {
+            var fn = $parse('::[foo,bar]');
+            $rootScope.$watch(fn, function(value) { log(value); }, true);
 
-                expect(log.empty()).toEqual([]);
-                expect($rootScope.$$watchers.length).toBe(1);
+            expect(log.empty()).toEqual([]);
+            expect($rootScope.$$watchers.length).toBe(1);
 
-                $rootScope.$digest();
-                expect($rootScope.$$watchers.length).toBe(1);
-                expect(log.empty()).toEqual([[undefined, undefined]]);
+            $rootScope.$digest();
+            expect($rootScope.$$watchers.length).toBe(1);
+            expect(log.empty()).toEqual([[undefined, undefined]]);
 
-                $rootScope.foo = 'foo';
-                $rootScope.$digest();
-                expect($rootScope.$$watchers.length).toBe(1);
-                expect(log.empty()).toEqual([['foo', undefined]]);
+            $rootScope.foo = 'foo';
+            $rootScope.$digest();
+            expect($rootScope.$$watchers.length).toBe(1);
+            expect(log.empty()).toEqual([['foo', undefined]]);
 
-                $rootScope.foo = 'foobar';
-                $rootScope.bar = 'bar';
-                $rootScope.$digest();
-                expect($rootScope.$$watchers.length).toBe(0);
-                expect(log.empty()).toEqual([['foobar', 'bar']]);
+            $rootScope.foo = 'foobar';
+            $rootScope.bar = 'bar';
+            $rootScope.$digest();
+            expect($rootScope.$$watchers.length).toBe(0);
+            expect(log.empty()).toEqual([['foobar', 'bar']]);
 
-                $rootScope.foo = 'baz';
-                $rootScope.$digest();
-                expect($rootScope.$$watchers.length).toBe(0);
-                expect(log.empty()).toEqual([]);
-              }));
+            $rootScope.foo = 'baz';
+            $rootScope.$digest();
+            expect($rootScope.$$watchers.length).toBe(0);
+            expect(log.empty()).toEqual([]);
+          }));
 
-              it('should only become stable when all the elements of an array have defined values at the end of a $digest', inject(function($parse, $rootScope, log) {
-                var fn = $parse('::[foo]');
-                $rootScope.$watch(fn, function(value) { log(value); }, isDeep);
-                $rootScope.$watch('foo', function() { if ($rootScope.foo === 'bar') {$rootScope.foo = undefined; } });
+          it('should only become stable when all the elements of an array have defined values at the end of a $digest', inject(function($parse, $rootScope, log) {
+            var fn = $parse('::[foo]');
+            $rootScope.$watch(fn, function(value) { log(value); }, true);
+            $rootScope.$watch('foo', function() { if ($rootScope.foo === 'bar') {$rootScope.foo = undefined; } });
 
-                $rootScope.foo = 'bar';
-                $rootScope.$digest();
-                expect($rootScope.$$watchers.length).toBe(2);
-                expect(log.empty()).toEqual([['bar'], [undefined]]);
+            $rootScope.foo = 'bar';
+            $rootScope.$digest();
+            expect($rootScope.$$watchers.length).toBe(2);
+            expect(log.empty()).toEqual([['bar'], [undefined]]);
 
-                $rootScope.foo = 'baz';
-                $rootScope.$digest();
-                expect($rootScope.$$watchers.length).toBe(1);
-                expect(log.empty()).toEqual([['baz']]);
+            $rootScope.foo = 'baz';
+            $rootScope.$digest();
+            expect($rootScope.$$watchers.length).toBe(1);
+            expect(log.empty()).toEqual([['baz']]);
 
-                $rootScope.bar = 'qux';
-                $rootScope.$digest();
-                expect($rootScope.$$watchers.length).toBe(1);
-                expect(log).toEqual([]);
-              }));
-            });
-          });
+            $rootScope.bar = 'qux';
+            $rootScope.$digest();
+            expect($rootScope.$$watchers.length).toBe(1);
+            expect(log).toEqual([]);
+          }));
         });
       });
 


### PR DESCRIPTION
Reverts 60394a9d91dad8932fa900af7c8529837f1d4557 to fix #15905 in 1.6. Currently plan is to NOT revert in 1.7.

Fixes #15905 