### PR TITLE
test(*): run class-related tests everywhere; fix eval syntax

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -176,6 +176,7 @@
     "browserSupportsCssAnimations": false,
     "browserTrigger": false,
     "jqLiteCacheSize": false,
-    "createAsync": false
+    "createAsync": false,
+    "support": false
   }
 }

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* globals support: false */
-
 describe('injector.modules', function() {
     it('should expose the loaded module info on the instance injector', function() {
       var test1 = angular.module('test1', ['test2']).info({ version: '1.1' });
@@ -327,26 +325,24 @@ describe('injector', function() {
           expect(instance.aVal()).toEqual('a-value');
         });
 
-        if (/chrome/.test(window.navigator.userAgent)) {
-          they('should detect ES6 classes regardless of whitespace/comments ($prop)', [
-            'class Test {}',
-            'class Test{}',
-            'class //<--ES6 stuff\nTest {}',
-            'class//<--ES6 stuff\nTest {}',
-            'class {}',
-            'class{}',
-            'class //<--ES6 stuff\n {}',
-            'class//<--ES6 stuff\n {}',
-            'class/* Test */{}',
-            'class /* Test */ {}'
-          ], function(classDefinition) {
-            // eslint-disable-next-line no-eval
-            var Clazz = eval('(' + classDefinition + ')');
-            var instance = injector.invoke(Clazz);
+        they('should detect ES6 classes regardless of whitespace/comments ($prop)', [
+          'class Test {}',
+          'class Test{}',
+          'class //<--ES6 stuff\nTest {}',
+          'class//<--ES6 stuff\nTest {}',
+          'class {}',
+          'class{}',
+          'class //<--ES6 stuff\n {}',
+          'class//<--ES6 stuff\n {}',
+          'class/* Test */{}',
+          'class /* Test */ {}'
+        ], function(classDefinition) {
+          // eslint-disable-next-line no-eval
+          var Clazz = eval('(' + classDefinition + ')');
+          var instance = injector.invoke(Clazz);
 
-            expect(instance).toEqual(jasmine.any(Clazz));
-          });
-        }
+          expect(instance).toEqual(jasmine.any(Clazz));
+        });
       }
     });
 

--- a/test/helpers/testabilityPatch.js
+++ b/test/helpers/testabilityPatch.js
@@ -4,7 +4,7 @@
 if (window.bindJQuery) bindJQuery();
 
 var supportTests = {
-  classes: '(class {})',
+  classes: '/^class\\b/.test((class C {}).toString())',
   fatArrow: 'a => a',
   ES6Function: '({ fn(x) { return; } })'
 };
@@ -15,8 +15,7 @@ for (var prop in supportTests) {
   if (supportTests.hasOwnProperty(prop)) {
     try {
       // eslint-disable-next-line no-eval
-      eval(supportTests[prop]);
-      support[prop] = true;
+      support[prop] = !!eval(supportTests[prop]);
     } catch (e) {
       support[prop] = false;
     }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -6175,10 +6175,10 @@ describe('$compile', function() {
     });
 
     it('should eventually expose isolate scope variables on ES6 class controller with controllerAs when bindToController is true', function() {
-      if (!/chrome/i.test(window.navigator.userAgent)) return;
+      if (!support.classes) return;
       var controllerCalled = false;
       // eslint-disable-next-line no-eval
-      var Controller = eval(
+      var Controller = eval('(\n' +
         'class Foo {\n' +
         '  constructor($scope) {}\n' +
         '  $onInit() {\n' +
@@ -6194,7 +6194,8 @@ describe('$compile', function() {
         '    expect(this.fn()).toBe(\'called!\');\n' +
         '    controllerCalled = true;\n' +
         '  }\n' +
-        '}');
+        '}\n' +
+        ')');
       spyOn(Controller.prototype, '$onInit').and.callThrough();
 
       module(function($compileProvider) {

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -2100,7 +2100,7 @@ describe('ngMock', function() {
     );
 
 
-    if (/chrome/.test(window.navigator.userAgent)) {
+    if (support.classes) {
       it('should support assigning bindings to class-based controller', function() {
         var called = false;
         var data = [


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Test fixes.

**What is the current behavior? (You can also link to an open issue here)**

There was a syntax error in class-related tests; the test wasn't failing only because it was disabled everywhere outside of Chrome and Chrome <59 incorrectly accepted it.

**What is the new behavior (if this is a feature change)?**

1. Wrap an evaled class definition in parens; previously they weren't.
2. The classes support test was modified to check not only if a class definition parses but also if it stringifies correctly which is required by AngularJS. This restriction disables class-related tests in current Firefox (53) but will work in v55 or newer.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

