### PR TITLE
fix(httpParamSerializerJQLike): Follow jQuery for `null` and `undefined`

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -110,7 +110,6 @@ function $HttpParamSerializerJQLikeProvider() {
       return parts.join('&');
 
       function serialize(toSerialize, prefix, topLevel) {
-        if (toSerialize === null || isUndefined(toSerialize)) return;
         if (isArray(toSerialize)) {
           forEach(toSerialize, function(value, index) {
             serialize(value, prefix + '[' + (isObject(value) ? index : '') + ']');
@@ -123,7 +122,8 @@ function $HttpParamSerializerJQLikeProvider() {
                 (topLevel ? '' : ']'));
           });
         } else {
-          parts.push(encodeUriQuery(prefix) + '=' + encodeUriQuery(serializeValue(toSerialize)));
+          parts.push(encodeUriQuery(prefix) + '=' +
+              (toSerialize == null ? '' : encodeUriQuery(serializeValue(toSerialize))));
         }
       }
     };

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -2306,5 +2306,11 @@ describe('$http param serializers', function() {
          'a%5B%5D=b&a%5B%5D=c&d%5B0%5D%5Be%5D=f&d%5B0%5D%5Bg%5D=h&d%5B%5D=i&d%5B2%5D%5Bj%5D=k');
          //a[]=b&a[]=c&d[0][e]=f&d[0][g]=h&d[]=i&d[2][j]=k
     });
+
+    it('should serialize `null` and `undefined` elements as empty', function() {
+      expect(jqrSer({items:['foo', 'bar', null, undefined, 'baz'], x: null, y: undefined})).toEqual(
+         'items%5B%5D=foo&items%5B%5D=bar&items%5B%5D=&items%5B%5D=&items%5B%5D=baz&x=&y=');
+         //items[]=foo&items[]=bar&items[]=&items[]=&items[]=baz&x=&y=
+    });
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Follow jQuery when serializing `null` and `undefined`.


**What is the current behavior? (You can also link to an open issue here)**
```js
$httpParamSerializerJQLike({items:['foo', 'bar', null, undefined]}) ==
  'items%5B%5D=foo&items%5B%5D=bar';
```

**What is the new behavior (if this is a feature change)?**
```js
$httpParamSerializerJQLike({items:['foo', 'bar', null, undefined]}) ==
  'items%5B%5D=foo&items%5B%5D=bar&items%5B%5D=&items%5B%5D=';
```

**Does this PR introduce a breaking change?**
Yes, but does so to follow the implementation in jQuery.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Closes: #15969