### PR TITLE
docs : update unit-testing-component-controllers

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -460,24 +460,21 @@ shows how to do this for the `heroDetail` component from above.
 
 The examples use the [Jasmine](http://jasmine.github.io/) testing framework.
 
+<div class="alert alert-warning">
+The bindings passed to $componentController simulate the `bindToController` feature and no verifications are made to verify them against the bindings definition of the component.
+Use the {@link ng.$compile $compile} service if you want to test the component with its bindings and controller the same way as described in 
+'Testing Directives' and 'Testing Directives With External Templates' of {@link guide/unit-testing unit-testing}.
+</div>
+
 **Controller Test:**
 ```js
-describe('component: heroDetail', function() {
+describe('controller: heroDetail', function() {
   var $componentController;
 
   beforeEach(module('heroApp'));
   beforeEach(inject(function(_$componentController_) {
     $componentController = _$componentController_;
   }));
-
-  it('should expose a `hero` object', function() {
-    // Here we are passing actual bindings to the component
-    var bindings = {hero: {name: 'Wolverine'}};
-    var ctrl = $componentController('heroDetail', null, bindings);
-
-    expect(ctrl.hero).toBeDefined();
-    expect(ctrl.hero.name).toBe('Wolverine');
-  });
 
   it('should call the `onDelete` binding, when deleting the hero', function() {
     var onDeleteSpy = jasmine.createSpy('onDelete');


### PR DESCRIPTION
docs : update https://docs.angularjs.org/guide/component#unit-testing-component-controllers

In response to https://github.com/angular/angular.js/issues/15968 this is a first attempt to update the documentation in order to inform developers not to use $componentController to test their bindings.

WARNING : I do not know how to point to the sections 'Testing Directives' and 'Testing Directives With External Templates' of {@link guide/unit-testing unit-testing} so please help fix them before commiting.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

docs

**What is the current behavior? (You can also link to an open issue here)**

https://github.com/angular/angular.js/issues/15968

**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

