### PR TITLE
fix(httpParamSerializerJQLike): First array element always non-indexed

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -112,7 +112,7 @@ function $HttpParamSerializerJQLikeProvider() {
       function serialize(toSerialize, prefix, topLevel) {
         if (isArray(toSerialize)) {
           forEach(toSerialize, function(value, index) {
-            serialize(value, prefix + '[' + (isObject(value) ? index : '') + ']');
+            serialize(value, prefix + '[' + ((index > 0 && isObject(value)) ? index : '') + ']');
           });
         } else if (isObject(toSerialize) && !isDate(toSerialize)) {
           forEachSorted(toSerialize, function(value, key) {

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -2292,7 +2292,7 @@ describe('$http param serializers', function() {
 
     it('should serialize objects by repeating param name with [key] suffix', function() {
       expect(jqrSer({a: 'b', foo: {'bar': 'barv', 'baz': 'bazv'}})).toEqual('a=b&foo%5Bbar%5D=barv&foo%5Bbaz%5D=bazv');
-                                                                           //a=b&foo[bar]=barv&foo[baz]=bazv
+                                                                            //a=b&foo[bar]=barv&foo[baz]=bazv
     });
 
     it('should serialize nested objects by repeating param name with [key] suffix', function() {
@@ -2303,8 +2303,8 @@ describe('$http param serializers', function() {
 
     it('should serialize objects inside array elements using their index', function() {
       expect(jqrSer({a: ['b', 'c'], d: [{e: 'f', g: 'h'}, 'i', {j: 'k'}]})).toEqual(
-         'a%5B%5D=b&a%5B%5D=c&d%5B0%5D%5Be%5D=f&d%5B0%5D%5Bg%5D=h&d%5B%5D=i&d%5B2%5D%5Bj%5D=k');
-         //a[]=b&a[]=c&d[0][e]=f&d[0][g]=h&d[]=i&d[2][j]=k
+         'a%5B%5D=b&a%5B%5D=c&d%5B%5D%5Be%5D=f&d%5B%5D%5Bg%5D=h&d%5B%5D=i&d%5B2%5D%5Bj%5D=k');
+         //a[]=b&a[]=c&d[][e]=f&d[][g]=h&d[]=i&d[2][j]=k
     });
 
     it('should serialize `null` and `undefined` elements as empty', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

Serializing an array of objects with `$httpParamSerializerJQLike` is ambiguous with serializing an object with numeric keys.

```javascript
params = { a: [{ b: 1 }, { c: 2 }] }
=> a[0][b]=1&a[1][c]=2
```

This *could* falsely be deserialized as: `{ a: { "0": { b: 1 }, "1": { c: 2 } } }` (and it absolutely will).

**What is the new behavior (if this is a feature change)?**

```javascript
params = { a: [{ b: 1 }, { c: 2 }] }
=> a[][b]=1&a[1][c]=2
```

This first element ensures `a` should be considered an array.

**Does this PR introduce a breaking change?**

Unfortunately this is not backward compatibly (would actually break rack before it pulls the mentioned request), but this is somewhat mandatory as you simply cannot properly serialize some scenarios (see the tests in rack's PR for more scenarios). Should this be a configuration option somewhere?

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

This follows these PR's in jQuery and rack: jquery/jquery#3666, rack/rack#1165

This PR is pretty much copied from the jQuery PR, and it should probably only be accepted after jQuery accepts their PR (since this method is a clone of theirs).