### PR TITLE
refactor(jQlite): Add the ability to use query selector without jQuery

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -284,7 +284,7 @@ function JQLite(element) {
   }
   if (!(this instanceof JQLite)) {
     if (argIsString && element.charAt(0) !== '<') {
-      return new JQLite(document.querySelector(element));
+      return new JQLite(window.document.querySelector(element));
     }
     return new JQLite(element);
   }

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -45,9 +45,9 @@
  * <div class="alert alert-info">**Note:** All element references in AngularJS are always wrapped with jQuery or
  * jqLite (such as the element argument in a directive's compile / link function). They are never raw DOM references.</div>
  *
- * <div class="alert alert-warning">**Note:** Keep in mind that this function will not find elements
- * by tag name / CSS selector. For lookups by tag name, try instead `angular.element(document).find(...)`
- * or `$document.find()`, or use the standard DOM APIs, e.g. `document.querySelectorAll()`.</div>
+ * <div class="alert alert-info">**Note:** This function will find elements
+ * by tag name / CSS selector and wrap it in a jQlite object, or in a jQuery object if it's available. You can also query the DOM like `angular.element(document).find(...)`
+ * or `$document.find()`, or use the standard DOM APIs, e.g. `document.querySelectorAll()`, without the wrapper.</div>
  *
  * ## AngularJS's jqLite
  * jqLite provides only the following jQuery methods:
@@ -284,7 +284,7 @@ function JQLite(element) {
   }
   if (!(this instanceof JQLite)) {
     if (argIsString && element.charAt(0) !== '<') {
-      throw jqLiteMinErr('nosel', 'Looking up elements via selectors is not supported by jqLite! See: http://docs.angularjs.org/api/angular.element');
+      return new JQLite(document.querySelector(element));
     }
     return new JQLite(element);
   }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
refactor


**What is the current behavior? (You can also link to an open issue here)**
`angular.element('.my-selector')` throws an error if jQuery is not included.


**What is the new behavior (if this is a feature change)?**
`angular.element('.my-selector')` now finds the element and wraps it in a jQlite (or jQuery) object.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

`angular.element` threw an error if we tried to use query selector
directly without jQuery. I thought that this was a silly little
fix for the framework.

A lot of the projects that I've worked for
the past years are only including jQuery to use query selectors on
the app (I know that are options for this), and I'm only making this PR
because I think it's unnecessary to use
`angular.element(document).find()` to accomplish such a small thing and
to get the jQlite wrapper with the goodies.

Now we can do this, without jQuery:

`angular.element('.something')`

And get the same result.