### PR TITLE
test($log): run all $log tests in IE9 & non-IE9 logging mode

### DIFF
--- a/test/ng/logSpec.js
+++ b/test/ng/logSpec.js
@@ -4,8 +4,6 @@
 describe('$log', function() {
   var $window, logger, log, warn, info, error, debug;
 
-
-
   beforeEach(module(function($provide) {
     $window = {
       navigator: {userAgent: window.navigator.userAgent},
@@ -67,147 +65,159 @@ describe('$log', function() {
     }
   ));
 
-  it('should work if $window.navigator not defined', inject(
-    function() {
-      delete $window.navigator;
-    },
-    function($log) {}
-  ));
+  runTests({ie9Mode: false});
+  runTests({ie9Mode: true});
 
-  describe('IE logging behavior', function() {
-    function removeApplyFunctionForIE() {
-      log.apply = log.call =
+  function runTests(options) {
+    var ie9Mode = options.ie9Mode;
+
+    function attachMockConsoleTo$window() {
+      // Support: IE 9 only
+      // Simulate missing apply on console methods in IE 9.
+      if (ie9Mode) {
+        log.apply = log.call =
         warn.apply = warn.call =
         info.apply = info.call =
         error.apply = error.call =
         debug.apply = debug.call = null;
+      }
 
-      $window.console = {log: log,
+      $window.console = {
+        log: log,
         warn: warn,
         info: info,
         error: error,
-        debug: debug};
+        debug: debug
+      };
     }
 
-    it('should work in IE where console.error doesn\'t have an apply method', inject(
-      removeApplyFunctionForIE,
-      function($log) {
+    describe(ie9Mode ? 'IE 9 logging behavior' : 'Modern browsers\' logging behavior', function() {
+      beforeEach(module(attachMockConsoleTo$window));
+
+      it('should work if $window.navigator not defined', inject(
+        function() {
+          delete $window.navigator;
+        },
+        function($log) {}
+      ));
+
+      it('should have a working apply method', inject(function($log) {
         $log.log.apply($log);
         $log.warn.apply($log);
         $log.info.apply($log);
         $log.error.apply($log);
         $log.debug.apply($log);
         expect(logger).toEqual('log;warn;info;error;debug;');
-      })
-    );
+      }));
 
-    // Support: Safari 9.1 only, iOS 9.3 only
-    // For some reason Safari thinks there is always 1 parameter passed here.
-    if (!/\b9\.\d(\.\d+)* safari/i.test(window.navigator.userAgent) &&
-      !/\biphone os 9_/i.test(window.navigator.userAgent)) {
-      it('should not attempt to log the second argument in IE if it is not specified', inject(
-        function() {
-          log = function(arg1, arg2) { logger += 'log,' + arguments.length + ';'; };
-          warn = function(arg1, arg2) { logger += 'warn,' + arguments.length + ';'; };
-          info = function(arg1, arg2) { logger += 'info,' + arguments.length + ';'; };
-          error = function(arg1, arg2) { logger += 'error,' + arguments.length + ';'; };
-          debug = function(arg1, arg2) { logger += 'debug,' + arguments.length + ';'; };
-        },
-        removeApplyFunctionForIE,
-        function($log) {
-          $log.log();
-          $log.warn();
-          $log.info();
-          $log.error();
-          $log.debug();
-          expect(logger).toEqual('log,0;warn,0;info,0;error,0;debug,0;');
-        })
-      );
-    }
-  });
-
-  describe('$log.debug', function() {
-
-    beforeEach(initService(false));
-
-    it('should skip debugging output if disabled', inject(
-      function() {
-        $window.console = {log: log,
-                           warn: warn,
-                           info: info,
-                           error: error,
-                           debug: debug};
-      },
-      function($log) {
-        $log.log();
-        $log.warn();
-        $log.info();
-        $log.error();
-        $log.debug();
-        expect(logger).toEqual('log;warn;info;error;');
+      // Support: Safari 9.1 only, iOS 9.3 only
+      // For some reason Safari thinks there is always 1 parameter passed here.
+      if (!/\b9\.\d(\.\d+)* safari/i.test(window.navigator.userAgent) &&
+        !/\biphone os 9_/i.test(window.navigator.userAgent)) {
+        it('should not attempt to log the second argument in IE if it is not specified', inject(
+          function() {
+            log = function(arg1, arg2) { logger += 'log,' + arguments.length + ';'; };
+            warn = function(arg1, arg2) { logger += 'warn,' + arguments.length + ';'; };
+            info = function(arg1, arg2) { logger += 'info,' + arguments.length + ';'; };
+            error = function(arg1, arg2) { logger += 'error,' + arguments.length + ';'; };
+            debug = function(arg1, arg2) { logger += 'debug,' + arguments.length + ';'; };
+          },
+          attachMockConsoleTo$window,
+          function($log) {
+            $log.log();
+            $log.warn();
+            $log.info();
+            $log.error();
+            $log.debug();
+            expect(logger).toEqual('log,0;warn,0;info,0;error,0;debug,0;');
+          })
+        );
       }
-    ));
 
-  });
+      describe('$log.debug', function() {
 
-  describe('$log.error', function() {
-    var e, $log;
+        beforeEach(initService(false));
 
-    function TestError() {
-      Error.prototype.constructor.apply(this, arguments);
-      this.message = undefined;
-      this.sourceURL = undefined;
-      this.line = undefined;
-      this.stack = undefined;
-    }
-    TestError.prototype = Object.create(Error.prototype);
-    TestError.prototype.constructor = TestError;
+        it('should skip debugging output if disabled', inject(
+          function() {
+            $window.console = {log: log,
+                               warn: warn,
+                               info: info,
+                               error: error,
+                               debug: debug};
+          },
+          function($log) {
+            $log.log();
+            $log.warn();
+            $log.info();
+            $log.error();
+            $log.debug();
+            expect(logger).toEqual('log;warn;info;error;');
+          }
+        ));
 
-    beforeEach(inject(
-      function() {
-        e = new TestError('');
-        $window.console = {
-          error: jasmine.createSpy('error')
-        };
-      },
-
-      function(_$log_) {
-        $log = _$log_;
-      }
-    ));
-
-    it('should pass error if does not have trace', function() {
-      $log.error('abc', e);
-      expect($window.console.error).toHaveBeenCalledWith('abc', e);
-    });
-
-    if (msie || /\bEdge\//.test(window.navigator.userAgent)) {
-      it('should print stack', function() {
-        e.stack = 'stack';
-        $log.error('abc', e);
-        expect($window.console.error).toHaveBeenCalledWith('abc', 'stack');
       });
-    } else {
-      it('should print a raw error', function() {
-        e.stack = 'stack';
-        $log.error('abc', e);
-        expect($window.console.error).toHaveBeenCalledWith('abc', e);
-      });
-    }
 
-    it('should print line', function() {
-      e.message = 'message';
-      e.sourceURL = 'sourceURL';
-      e.line = '123';
-      $log.error('abc', e);
-      expect($window.console.error).toHaveBeenCalledWith('abc', 'message\nsourceURL:123');
+      describe('$log.error', function() {
+        var e, $log;
+
+        function TestError() {
+          Error.prototype.constructor.apply(this, arguments);
+          this.message = undefined;
+          this.sourceURL = undefined;
+          this.line = undefined;
+          this.stack = undefined;
+        }
+        TestError.prototype = Object.create(Error.prototype);
+        TestError.prototype.constructor = TestError;
+
+        beforeEach(inject(
+          function() {
+            e = new TestError('');
+            $window.console = {
+              error: jasmine.createSpy('error')
+            };
+          },
+
+          function(_$log_) {
+            $log = _$log_;
+          }
+        ));
+
+        it('should pass error if does not have trace', function() {
+          $log.error('abc', e);
+          expect($window.console.error).toHaveBeenCalledWith('abc', e);
+        });
+
+        if (msie || /\bEdge\//.test(window.navigator.userAgent)) {
+          it('should print stack', function() {
+            e.stack = 'stack';
+            $log.error('abc', e);
+            expect($window.console.error).toHaveBeenCalledWith('abc', 'stack');
+          });
+        } else {
+          it('should print a raw error', function() {
+            e.stack = 'stack';
+            $log.error('abc', e);
+            expect($window.console.error).toHaveBeenCalledWith('abc', e);
+          });
+        }
+
+        it('should print line', function() {
+          e.message = 'message';
+          e.sourceURL = 'sourceURL';
+          e.line = '123';
+          $log.error('abc', e);
+          expect($window.console.error).toHaveBeenCalledWith('abc', 'message\nsourceURL:123');
+        });
+      });
     });
-  });
+  }
+
 
   function initService(debugEnabled) {
     return module(function($logProvider) {
       $logProvider.debugEnabled(debugEnabled);
     });
   }
-
 });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Tests update.

**What is the current behavior? (You can also link to an open issue here)**

IE 9 mode (missing `console.log.apply`) has a separate more restricted describe block.

**What is the new behavior (if this is a feature change)?**

All tests tha define `console.log` properly are run in both modes: with `apply` and without one.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

In IE 9 console methods don't inherit from Function.prototype and, hence, don't
have apply. Until recently IE 9 logging in AngularJS was restricted to the
first 2 parameters but that changed as we could just reuse
Function.prototype.apply everywhere, creating one code path for all browsers.
Therefore, we can now run all tests in modes where apply exists on logging
methods and where it doesn't.

Ref #15911
Ref b277e3ead7296ae27106fe7ac37696635c6bfda1