### PR TITLE
Issue with priority of execution in filters

### DIFF
--- a/docs/content/error/filter/notarray.ngdoc
+++ b/docs/content/error/filter/notarray.ngdoc
@@ -49,3 +49,12 @@ You could as well convert the object to an array using a filter such as
   {{ item }}
 </div>
 ```
+
+This error might occur as a type error when track by $index is used (Where the value of $index is 0 for the first element which will be used for filtering instead of the array) such as
+```html
+<input ng-model="search">
+<div ng-repeat="item in items track by $index | filter:search">
+  {{ item }}
+</div>
+```
+You can use the track by $index method at the end after using filters.


### PR DESCRIPTION
Need to use track by $index at the end in ng-repeat or else the filter considers $index as a value that should be filtered out. This seems to be common issue.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs update


**What is the current behavior? (You can also link to an open issue here)**
priority of execution is important while using filters, limit, and track by $index


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

