### PR TITLE
perf($rootScope): do not mark $watchCollectionInterceptor as $stateful

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1944,6 +1944,7 @@ function $ParseProvider() {
         return second(first(value));
       }
       chainedInterceptor.$stateful = first.$stateful || second.$stateful;
+      chainedInterceptor.$$pure = first.$$pure && second.$$pure;
 
       return chainedInterceptor;
     }
@@ -1979,14 +1980,18 @@ function $ParseProvider() {
       // If the expression itself has no inputs then use the full expression as an input.
       if (!interceptorFn.$stateful) {
         useInputs = !parsedExpression.inputs;
-        fn.inputs = (parsedExpression.inputs ? parsedExpression.inputs : [parsedExpression]).map(function(e) {
+        fn.inputs = parsedExpression.inputs ? parsedExpression.inputs : [parsedExpression];
+
+        if (!interceptorFn.$$pure) {
+          fn.inputs = fn.inputs.map(function(e) {
               // Remove the isPure flag of inputs when it is not absolute because they are now wrapped in a
-              // potentially non-pure interceptor function.
+              // non-pure interceptor function.
               if (e.isPure === PURITY_RELATIVE) {
                 return function depurifier(s) { return e(s); };
               }
               return e;
             });
+        }
       }
 
       return addWatchDelegate(fn);

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -581,7 +581,11 @@ function $RootScopeProvider() {
        *    de-registration function is executed, the internal watch operation is terminated.
        */
       $watchCollection: function(obj, listener) {
-        $watchCollectionInterceptor.$stateful = true;
+        // Mark the interceptor as
+        // ... $$pure when literal since the instance will change when any input changes
+        $watchCollectionInterceptor.$$pure = $parse(obj).literal;
+        // ... $stateful when non-literal since we must read the state of the collection
+        $watchCollectionInterceptor.$stateful = !$watchCollectionInterceptor.$$pure;
 
         var self = this;
         // the current value, updated on each dirty-check run


### PR DESCRIPTION
I think this was a mistake [from the start](https://github.com/angular/angular.js/commit/fca6be71274e537c7df86ae9e27a3bd1597e9ffa?diff=unified#diff-44d3307b66bf51b52e110307fa57e196R518).  This interceptor doesn't actually store any state, it just reads the inner/complex state of its input. EDIT: actually it had a purpose originally, although may no longer be as significant, see https://github.com/angular/angular.js/pull/16009#issuecomment-311543600

Removing the `$stateful` flag will allow some expressions (those with `inputs` such as array/object literals) to avoid invoking `$watchCollectionInterceptor` and avoid creating the literals etc. on each digest.