### PR TITLE
avoid publishing new releases to deprecated bower

### DIFF
--- a/scripts/bower/publish.sh
+++ b/scripts/bower/publish.sh
@@ -74,8 +74,7 @@ function prepare {
   do
     echo "-- Updating version in bower-$repo to $NEW_VERSION"
     cd $TMP_DIR/bower-$repo
-    replaceJsonProp "bower.json" "version" ".*" "$NEW_VERSION"
-    replaceJsonProp "bower.json" "angular.*" ".*" "$NEW_VERSION"
+    rm -f "bower.json"
     replaceJsonProp "package.json" "version" ".*" "$NEW_VERSION"
     replaceJsonProp "package.json" "angular.*" ".*" "$NEW_VERSION"
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
N/A


**What is the current behavior? (You can also link to an open issue here)**
bower install angular
* installs latest version of angularjs *


**What is the new behavior (if this is a feature change)?**
bower install angular
installs old version of angular



**Does this PR introduce a breaking change?**
yes, no new bower releases.



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**: