### PR TITLE
fix($parse): respect the interceptor.$stateful flag

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -91,12 +91,6 @@ function classDirective(name, selector) {
         }
 
         function ngClassWatchAction(newClassString) {
-          // When using a one-time binding the newClassString will return
-          // the pre-interceptor value until the one-time is complete
-          if (!isString(newClassString)) {
-            newClassString = toClassString(newClassString);
-          }
-
           if (oldModulo === selector) {
             updateClasses(oldClassString, newClassString);
           }

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -532,6 +532,20 @@ describe('ngClass', function() {
     })
   );
 
+  it('should support a one-time mixed literal-array/object variable', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-class="::[classVar1, classVar2]"></div>')($rootScope);
+
+      $rootScope.classVar1 = {orange: true};
+      $rootScope.$digest();
+      expect(element).toHaveClass('orange');
+
+      $rootScope.classVar1.orange = false;
+      $rootScope.$digest();
+
+      expect(element).not.toHaveClass('orange');
+    })
+  );
+
 
   it('should do value stabilization as expected when one-time binding',
     inject(function($rootScope, $compile) {

--- a/test/ng/interpolateSpec.js
+++ b/test/ng/interpolateSpec.js
@@ -149,6 +149,22 @@ describe('$interpolate', function() {
       expect($rootScope.$countWatchers()).toBe(0);
     }));
 
+    it('should respect one-time bindings for literals', inject(function($interpolate, $rootScope) {
+      var calls = [];
+      $rootScope.$watch($interpolate('{{ ::{x: x} }}'), function(val) {
+        calls.push(val);
+      });
+
+      $rootScope.$apply();
+      expect(calls.pop()).toBe('{}');
+
+      $rootScope.$apply('x = 1');
+      expect(calls.pop()).toBe('{"x":1}');
+
+      $rootScope.$apply('x = 2');
+      expect(calls.pop()).toBeUndefined();
+    }));
+
     it('should stop watching strings with no expressions after first execution',
       inject(function($interpolate, $rootScope) {
         var spy = jasmine.createSpy();


### PR DESCRIPTION
~~This actually depends on #16009 because that (unnecessary) `$stateful` flag was previously being ignored in the case of the failing test.~~