### PR TITLE
fix($parse): do not shallow-watch inputs when wrapped in an interceptor fn

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -622,6 +622,9 @@ function isStateless($filter, filterName) {
   return !fn.$stateful;
 }
 
+var PURITY_ABSOLUTE = 1;
+var PURITY_RELATIVE = 2;
+
 // Detect nodes which could depend on non-shallow state of objects
 function isPure(node, parentIsPure) {
   switch (node.type) {
@@ -634,18 +637,18 @@ function isPure(node, parentIsPure) {
 
     // Unary always convert to primative
     case AST.UnaryExpression:
-      return true;
+      return PURITY_ABSOLUTE;
 
     // The binary + operator can invoke a stateful toString().
     case AST.BinaryExpression:
-      return node.operator !== '+';
+      return node.operator !== '+' ? PURITY_ABSOLUTE : false;
 
     // Functions / filters probably read state from within objects
     case AST.CallExpression:
       return false;
   }
 
-  return (undefined === parentIsPure) || parentIsPure;
+  return (undefined === parentIsPure) ? PURITY_RELATIVE : parentIsPure;
 }
 
 function findConstantAndWatchExpressions(ast, $filter, parentIsPure) {
@@ -873,7 +876,7 @@ ASTCompiler.prototype = {
     forEach(inputs, function(input) {
       result.push('var ' + input.name + '=' + self.generateFunction(input.name, 's'));
       if (input.isPure) {
-        result.push(input.name, '.isPure=true;');
+        result.push(input.name, '.isPure=' + JSON.stringify(input.isPure) + ';');
       }
     });
     if (inputs.length) {
@@ -1960,10 +1963,16 @@ function $ParseProvider() {
         fn.$$watchDelegate = watchDelegate;
         fn.inputs = parsedExpression.inputs;
       } else if (!interceptorFn.$stateful) {
-        // If there is an interceptor, but no watchDelegate then treat the interceptor like
-        // we treat filters - it is assumed to be a pure function unless flagged with $stateful
+        // Treat interceptor like filters - assume non-stateful by default and use the inputsWatchDelegate
         fn.$$watchDelegate = inputsWatchDelegate;
-        fn.inputs = parsedExpression.inputs ? parsedExpression.inputs : [parsedExpression];
+        fn.inputs = (parsedExpression.inputs ? parsedExpression.inputs : [parsedExpression]).map(function(e) {
+              // Remove the isPure flag of inputs when it is not absolute because they are now wrapped in a
+              // potentially non-pure interceptor function.
+              if (e.isPure === PURITY_RELATIVE) {
+                return function depurifier(s) { return e(s); };
+              }
+              return e;
+            });
       }
 
       return fn;

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -517,6 +517,22 @@ describe('ngClass', function() {
     })
   );
 
+  // https://github.com/angular/angular.js/issues/15905
+  it('should support a mixed literal-array/object variable', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-class="[classVar]"></div>')($rootScope);
+
+      $rootScope.classVar = {orange: true};
+      $rootScope.$digest();
+      expect(element).toHaveClass('orange');
+
+      $rootScope.classVar.orange = false;
+      $rootScope.$digest();
+
+      expect(element).not.toHaveClass('orange');
+    })
+  );
+
+
   it('should do value stabilization as expected when one-time binding',
     inject(function($rootScope, $compile) {
       element = $compile('<div ng-class="::className"></div>')($rootScope);

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3277,6 +3277,25 @@ describe('parser', function() {
             expect(called).toBe(true);
           }));
 
+          it('should always be invoked if inputs are non-primitive', inject(function($parse) {
+            var called = false;
+            function interceptor(v) {
+              called = true;
+              return v.sub;
+            }
+
+            scope.$watch($parse('[o]', interceptor));
+            scope.o = {sub: 1};
+
+            called = false;
+            scope.$digest();
+            expect(called).toBe(true);
+
+            called = false;
+            scope.$digest();
+            expect(called).toBe(true);
+          }));
+
           it('should not be invoked unless the input.valueOf() changes even if the instance changes', inject(function($parse) {
             var called = false;
             function interceptor(v) {


### PR DESCRIPTION
Fixes #15905 

This basically applies the same as b5118ac6a9e0a327b31094b3fdcdc0432b23ad2f to interceptors.

For example normally when watching `[var]` the `var` only needs to be shallow-watched. But if that expression then gets wrapped in an interceptor such as `$parse('[var]', interceptor)` we must assume the `interceptor` is non-pure and might read state from within the `var` (just like filters/functions...).

This tries to preserve shallow watching of things behind operators such as `!` by distinguishing if an expression is pure due to an operator such as `!` ("absolute") or pure only if no parent operation wants to deep watch it ("relative").  This way when wrapped in an interceptor the "absolute" ones can still be shallow watched, while the "relative" ones that the interceptor has access to can no longer be shallow watched.

This still doesn't fully restore the 1.6.3 ng-class functionality because it still doesn't do a deep-watch for one-time bindings like 1.6.3 did. The one (famous last words...) remaining regression from 1.6.3 is demonstrated by the modified ng-class spec (objects-in-literals-with-interceptors-in-one-time bindings).  This is due to [this annoying condition](https://github.com/angular/angular.js/blob/b5118ac6a9e0a327b31094b3fdcdc0432b23ad2f/src/ng/parse.js#L1946-L1948) which I really wish I could find a better method of doing...