### PR TITLE
perf(jqLite): Add passive event listeners

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -851,6 +851,21 @@ function specialMouseHandlerWrapper(target, event, handler) {
 // These functions chain results into a single
 // selector.
 //////////////////////////////////////////
+function passiveOptionSupported() {
+  var supportsPassiveOption = false;
+  try {
+    var opts = Object.defineProperty({}, 'passive', {
+      get: function() {
+        supportsPassiveOption = true;
+      }
+    });
+    window.addEventListener('test', null, opts);
+    // eslint-disable-next-line no-empty
+  } catch (e) {
+  }
+  return supportsPassiveOption;
+}
+
 forEach({
   removeData: jqLiteRemoveData,
 
@@ -881,7 +896,7 @@ forEach({
         eventFns = events[type] = [];
         eventFns.specialHandlerWrapper = specialHandlerWrapper;
         if (type !== '$destroy' && !noEventListener) {
-          element.addEventListener(type, handle);
+          element.addEventListener(type, handle, passiveOptionSupported() ? { passive: true } : false);
         }
       }
 


### PR DESCRIPTION
perf(jqLite): Add passive event listeners

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Changes in sqLite to add passive event listeners


**What is the current behavior? (You can also link to an open issue here)**
Chrome warns with lots of messages telling us to add passive event listeners


**What is the new behavior (if this is a feature change)?**
Warnings disappear and there are less page blockings



**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

