### PR TITLE
fix: bootstrap check with alternate anchor properties

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1517,7 +1517,8 @@ function allowAutoBootstrap(document) {
     var link = document.createElement('a');
     link.href = src.value;
 
-    if (document.location.origin === link.origin) {
+    if (document.location.protocol === link.protocol && document.location.host === link.host &&
+      document.location.port === link.port) {
       // Same-origin resources are always allowed, even for non-whitelisted schemes.
       return true;
     }

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1517,7 +1517,7 @@ function allowAutoBootstrap(document) {
     var link = document.createElement('a');
     link.href = src.value;
 
-    if (document.location.protocol === link.protocol && document.location.host === link.host &&
+    if (document.location.protocol === link.protocol && document.location.hostname === link.hostname &&
       document.location.port === link.port) {
       // Same-origin resources are always allowed, even for non-whitelisted schemes.
       return true;

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1716,7 +1716,8 @@ describe('angular', function() {
         function createFakeDoc(attrs, protocol, currentScript) {
 
           protocol = protocol || 'http:';
-          var origin = protocol + '//something';
+          var hostname = 'something';
+          var origin = protocol + '//' + hostname;
 
           if (currentScript === undefined) {
             currentScript = document.createElement('script');
@@ -1726,7 +1727,7 @@ describe('angular', function() {
           // Fake a minimal document object (the actual document.currentScript is readonly).
           return {
             currentScript: currentScript,
-            location: {protocol: protocol, origin: origin},
+            location: {protocol: protocol, origin: origin, hostname: hostname, host: hostname, port: ''},
             createElement: document.createElement.bind(document)
           };
         }
@@ -1749,20 +1750,9 @@ describe('angular', function() {
           }
 
 
-          if (protocol === 'ms-browser-extension:') {
-            // Support: Edge 13-15
-            // In Edge, URLs with protocol 'ms-browser-extension:' return "null" for the origin,
-            // therefore it's impossible to know if a script is same-origin.
-            it('should not bootstrap for same-origin documents', function() {
-              expect(allowAutoBootstrap(createFakeDoc({src: protocol + '//something'}, protocol))).toBe(false);
-            });
-
-          } else {
-            it('should bootstrap for same-origin documents', function() {
-
-              expect(allowAutoBootstrap(createFakeDoc({src: protocol + '//something'}, protocol))).toBe(true);
-            });
-          }
+          it('should bootstrap for same-origin documents', function() {
+            expect(allowAutoBootstrap(createFakeDoc({src: protocol + '//something'}, protocol))).toBe(true);
+          });
 
           it('should not bootstrap for cross-origin documents', function() {
             expect(allowAutoBootstrap(createFakeDoc({src: protocol + '//something-else'}, protocol))).toBe(false);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix: microsoft edge does not support the origin property on anchor elements, so bootstrapping fails
for edge extensions. this fix simply changes the bootstrap origin check to use supported
anchor properties while having the same effect


**What is the current behavior? (You can also link to an open issue here)**
closes #16030 


**What is the new behavior (if this is a feature change)?**
n/a


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

