### PR TITLE
chore(jenkins): do not publish to code.angularjs.org snapshot

### DIFF
--- a/scripts/code.angularjs.org/publish.sh
+++ b/scripts/code.angularjs.org/publish.sh
@@ -62,7 +62,11 @@ function _update_code() {
 
   for backend in "$@" ; do
     echo "-- Refreshing code.angularjs.org: backend=$backend"
-    curl http://$backend:8003/gitFetchSite.php
+
+    # FIXME: We gave up publishing to code.angularjs.org because the GCE automatically removes firewall
+    # rules that allow access to port 8003.
+
+    # curl http://$backend:8003/gitFetchSite.php
   done
 }
 


### PR DESCRIPTION
While the firewall continues to block the update ports
we will not try to publish there.
