### PR TITLE
fix(Angular): deprecate angular.merge

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -421,6 +421,20 @@ function extend(dst) {
 * Unlike {@link angular.extend extend()}, `merge()` recursively descends into object properties of source
 * objects, performing a deep copy.
 *
+* @deprecated
+* sinceVersion="1.6.5"
+* This function is deprecated, but will not be removed in the 1.x lifecycle.
+* There are a edge cases (see {@link angular.merge#known-issues known issues}) that are not
+* supported by this function. We suggest
+* using [lodash's merge()](https://lodash.com/docs/4.17.4#merge) instead.
+*
+* @knownIssue
+* This is a list of (known) object types that cannot be / are incorrectly handled by this function:
+* - [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob)
+* - [`MediaStream`](https://developer.mozilla.org/docs/Web/API/MediaStream)
+* - [`CanvasGradient`](https://developer.mozilla.org/docs/Web/API/CanvasGradient)
+* - AngularJS {@link $rootScope.Scope scopes};
+*
 * @param {Object} dst Destination object.
 * @param {...Object} src Source object(s).
 * @returns {Object} Reference to `dst`.

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -424,12 +424,12 @@ function extend(dst) {
 * @deprecated
 * sinceVersion="1.6.5"
 * This function is deprecated, but will not be removed in the 1.x lifecycle.
-* There are a edge cases (see {@link angular.merge#known-issues known issues}) that are not
+* There are edge cases (see {@link angular.merge#known-issues known issues}) that are not
 * supported by this function. We suggest
 * using [lodash's merge()](https://lodash.com/docs/4.17.4#merge) instead.
 *
 * @knownIssue
-* This is a list of (known) object types that cannot be / are incorrectly handled by this function:
+* This is a list of (known) object types that are not handled correctly by this function:
 * - [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob)
 * - [`MediaStream`](https://developer.mozilla.org/docs/Web/API/MediaStream)
 * - [`CanvasGradient`](https://developer.mozilla.org/docs/Web/API/CanvasGradient)


### PR DESCRIPTION
This function has problems with special object types but since it's not used in core,
it is not worth implementing fixes for these cases.
A general purpose library like lodash (provides `merge`) should be used instead.

Closes #12653
Closes #14941
Closes #15180
Closes #15992

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Deprecation


**What is the current behavior? (You can also link to an open issue here)**
Unclear API support


**What is the new behavior (if this is a feature change)?**
Deprecation / docs update


**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- ~[ ] Tests for the changes have been added (for bug fixes / features)~
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
Not sure if this should be marked fix or feat
~If we deprecate only in 1.7.0, then the known issue section can still go in 1.6.x~
