### PR TITLE
test(ngMock): fix Firefox crashes on Travis

### DIFF
--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -358,12 +358,12 @@ describe('ngMock', function() {
       $interval(function() { counterA++; });
       $interval(function() { counterB++; }, 0);
 
-      $interval.flush(1000);
-      expect(counterA).toBe(1000);
-      expect(counterB).toBe(1000);
-      $interval.flush(1000);
-      expect(counterA).toBe(2000);
-      expect(counterB).toBe(2000);
+      $interval.flush(100);
+      expect(counterA).toBe(100);
+      expect(counterB).toBe(100);
+      $interval.flush(100);
+      expect(counterA).toBe(200);
+      expect(counterB).toBe(200);
     }));
 
 


### PR DESCRIPTION
This test keeps causing Firefox 47 (currently used on Travis) to crash and fail the build. The test passes locally (on Firefox 53). Lowering the loop count from 1000 to 100 seems to fix the issue.
(Note: The crach only affects the mocked implementation of `$interval` and does not happen locally.)