### PR TITLE
Fix broken link - point to list of Pluralsight courses on AngularJS

### DIFF
--- a/docs/content/guide/external-resources.ngdoc
+++ b/docs/content/guide/external-resources.ngdoc
@@ -139,7 +139,7 @@ You can find a larger list of AngularJS external libraries at [ngmodules.org](ht
   [CodeAcademy](http://www.codecademy.com/courses/javascript-advanced-en-2hJ3J/0/1),
   [CodeSchool](https://www.codeschool.com/courses/shaping-up-with-angular-js)
 * **Paid online:**
-  [Pluralsight (3 courses)](http://www.pluralsight.com/training/Courses/Find?highlight=true&searchTerm=angularjs),
+  [Pluralsight](https://app.pluralsight.com/library/search?q=angularjs),
   [Tuts+](https://tutsplus.com/course/easier-js-apps-with-angular/),
   [lynda.com](http://www.lynda.com/AngularJS-tutorials/Up-Running-AngularJS/133318-2.html),
   [WintellectNOW (4 lessons)](http://www.wintellectnow.com/Course/Detail/mastering-angularjs),

--- a/docs/content/guide/external-resources.ngdoc
+++ b/docs/content/guide/external-resources.ngdoc
@@ -139,7 +139,7 @@ You can find a larger list of AngularJS external libraries at [ngmodules.org](ht
   [CodeAcademy](http://www.codecademy.com/courses/javascript-advanced-en-2hJ3J/0/1),
   [CodeSchool](https://www.codeschool.com/courses/shaping-up-with-angular-js)
 * **Paid online:**
-  [Pluralsight](https://app.pluralsight.com/library/search?q=angularjs),
+  [Pluralsight](https://www.pluralsight.com/search?q=angularjs),
   [Tuts+](https://tutsplus.com/course/easier-js-apps-with-angular/),
   [lynda.com](http://www.lynda.com/AngularJS-tutorials/Up-Running-AngularJS/133318-2.html),
   [WintellectNOW (4 lessons)](http://www.wintellectnow.com/Course/Detail/mastering-angularjs),


### PR DESCRIPTION
AngularJS docs update: Currently, the link to Pluralsight at the bottom of the page https://docs.angularjs.org/guide/external-resources is broken. This will edit the link to a generic list of all AngularJs course on Pluralsight. This is an isolated UI change to a public facing document, therefore there are no breaking changes anticipated.
