### PR TITLE
test($parse): add one-time/interceptor tests

### DIFF
--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3340,6 +3340,32 @@ describe('parser', function() {
             scope.$digest();
             expect(called).toBe(true);
           }));
+
+          it('should not affect when a one-time binding becomes stable', inject(function($parse) {
+            scope.$watch($parse('::x'));
+            scope.$watch($parse('::x', identity));
+            scope.$watch($parse('::x', function() { return 1; }));  //interceptor that returns non-undefined
+
+            scope.$digest();
+            expect(scope.$$watchersCount).toBe(3);
+
+            scope.x = 1;
+            scope.$digest();
+            expect(scope.$$watchersCount).toBe(0);
+          }));
+
+          it('should not affect when a one-time literal binding becomes stable', inject(function($parse) {
+            scope.$watch($parse('::[x]'));
+            scope.$watch($parse('::[x]', identity));
+            scope.$watch($parse('::[x]', function() { return 1; }));  //interceptor that returns non-literal
+
+            scope.$digest();
+            expect(scope.$$watchersCount).toBe(3);
+
+            scope.x = 1;
+            scope.$digest();
+            expect(scope.$$watchersCount).toBe(0);
+          }));
         });
 
         describe('literals', function() {


### PR DESCRIPTION
I realized that https://github.com/angular/angular.js/commit/189461f9bf6fda18ddbd16c42f2e959cf939c3da changed this a little - previously the second test failed for two reasons
1. one-time literals [did not use .inputs](https://github.com/angular/angular.js/blob/93879b3c721f4c0273c90e9bfeb368425b0078c4/src/ng/parse.js#L1881) unlike the normal [one-time delegate](https://github.com/angular/angular.js/blob/93879b3c721f4c0273c90e9bfeb368425b0078c4/src/ng/parse.js#L1856), so the `identity` interceptor would throw an infdig because the literal recreated each digest was being watched
2. one-time literals with interceptors [only check `isDefined`](https://github.com/angular/angular.js/blob/93879b3c721f4c0273c90e9bfeb368425b0078c4/src/ng/parse.js#L1933) to determine when the one time is "done" which is unlike [the one-time watch delegate](https://github.com/angular/angular.js/blob/93879b3c721f4c0273c90e9bfeb368425b0078c4/src/ng/parse.js#L1881) that checks all the values in the literal, so the interceptor thought the "one-time" was done right away for literals

I think both of these changes are correct and want to make sure we don't revert them. This should probably only go into 1.7 since this change will [probably be reverted](https://github.com/angular/angular.js/pull/15958) in 1.6.