### PR TITLE
Improve readability of logging on Travis

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -358,24 +358,73 @@ module.exports = function(grunt) {
   });
 
   //alias tasks
-  grunt.registerTask('test', 'Run unit, docs and e2e tests with Karma', ['eslint', 'package', 'test:unit', 'test:promises-aplus', 'tests:docs', 'test:protractor']);
+  grunt.registerTask('test', 'Run unit, docs and e2e tests with Karma', [
+    'eslint',
+    'package',
+    'test:unit',
+    'test:promises-aplus',
+    'tests:docs',
+    'test:protractor'
+  ]);
   grunt.registerTask('test:jqlite', 'Run the unit tests with Karma' , ['tests:jqlite']);
   grunt.registerTask('test:jquery', 'Run the jQuery (latest) unit tests with Karma', ['tests:jquery']);
   grunt.registerTask('test:jquery-2.2', 'Run the jQuery 2.2 unit tests with Karma', ['tests:jquery-2.2']);
   grunt.registerTask('test:jquery-2.1', 'Run the jQuery 2.1 unit tests with Karma', ['tests:jquery-2.1']);
-  grunt.registerTask('test:modules', 'Run the Karma module tests with Karma', ['build', 'tests:modules']);
+  grunt.registerTask('test:modules', 'Run the Karma module tests with Karma', [
+    'build',
+    'tests:modules'
+  ]);
   grunt.registerTask('test:docs', 'Run the doc-page tests with Karma', ['package', 'tests:docs']);
-  grunt.registerTask('test:unit', 'Run unit, jQuery and Karma module tests with Karma', ['test:jqlite', 'test:jquery', 'test:jquery-2.2', 'test:jquery-2.1', 'test:modules']);
-  grunt.registerTask('test:protractor', 'Run the end to end tests with Protractor and keep a test server running in the background', ['webdriver', 'connect:testserver', 'protractor:normal']);
-  grunt.registerTask('test:travis-protractor', 'Run the end to end tests with Protractor for Travis CI builds', ['connect:testserver', 'protractor:travis']);
-  grunt.registerTask('test:ci-protractor', 'Run the end to end tests with Protractor for Jenkins CI builds', ['webdriver', 'connect:testserver', 'protractor:jenkins']);
+  grunt.registerTask('test:unit', 'Run unit, jQuery and Karma module tests with Karma', [
+    'test:jqlite',
+    'test:jquery',
+    'test:jquery-2.2',
+    'test:jquery-2.1',
+    'test:modules'
+  ]);
+  grunt.registerTask('test:protractor', 'Run the end to end tests with Protractor and keep a test server running in the background', [
+    'webdriver',
+    'connect:testserver',
+    'protractor:normal'
+  ]);
+  grunt.registerTask('test:travis-protractor', 'Run the end to end tests with Protractor for Travis CI builds', [
+    'connect:testserver',
+    'protractor:travis'
+  ]);
+  grunt.registerTask('test:ci-protractor', 'Run the end to end tests with Protractor for Jenkins CI builds', [
+    'webdriver',
+    'connect:testserver',
+    'protractor:jenkins'
+  ]);
   grunt.registerTask('test:e2e', 'Alias for test:protractor', ['test:protractor']);
-  grunt.registerTask('test:promises-aplus',['build:promises-aplus-adapter', 'shell:promises-aplus-tests']);
-
-  grunt.registerTask('minify', ['bower', 'clean', 'build', 'minall']);
+  grunt.registerTask('test:promises-aplus',[
+    'build:promises-aplus-adapter',
+    'shell:promises-aplus-tests'
+  ]);
+  grunt.registerTask('minify', [
+    'bower',
+    'clean',
+    'build',
+    'minall'
+  ]);
   grunt.registerTask('webserver', ['connect:devserver']);
-  grunt.registerTask('package', ['bower', 'validate-angular-files', 'clean', 'buildall', 'minall', 'collect-errors', 'write', 'docs', 'copy', 'compress']);
-  grunt.registerTask('ci-checks', ['ddescribe-iit', 'merge-conflict', 'eslint']);
+  grunt.registerTask('package', [
+    'bower',
+    'validate-angular-files',
+    'clean',
+    'buildall',
+    'minall',
+    'collect-errors',
+    'write',
+    'docs',
+    'copy',
+    'compress'
+  ]);
+  grunt.registerTask('ci-checks', [
+    'ddescribe-iit',
+    'merge-conflict',
+    'eslint'
+  ]);
   grunt.registerTask('default', ['package']);
 };
 

--- a/karma-shared.conf.js
+++ b/karma-shared.conf.js
@@ -10,8 +10,16 @@ module.exports = function(config, specificOptions) {
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 2,
     browserNoActivityTimeout: 30000,
-
-
+    reporters: ['spec'],
+    specReporter: {
+      maxLogLines: 5,             // limit number of lines logged per test
+      suppressErrorSummary: true, // do not print error summary
+      suppressFailed: false,      // do not print information about failed tests
+      suppressPassed: true,      // do not print information about passed tests
+      suppressSkipped: false,      // do not print information about skipped tests
+      showSpecTiming: false,      // print the time elapsed for each spec
+      failFast: false              // test would finish with error when a first fail occurs.
+    },
     // SauceLabs config for local development.
     sauceLabs: {
       testName: specificOptions.testName || 'AngularJS',

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "karma-ng-scenario": "^1.0.0",
     "karma-sauce-launcher": "^1.1.0",
     "karma-script-launcher": "^1.0.0",
+    "karma-spec-reporter": "^0.0.31",
     "load-grunt-tasks": "^3.5.0",
     "lodash": "~2.4.1",
     "log4js": "^0.6.27",

--- a/scripts/travis/before_build.sh
+++ b/scripts/travis/before_build.sh
@@ -4,15 +4,26 @@ set -e
 
 yarn global add grunt-cli@1.2.0
 
-mkdir -p $LOGS_DIR
+mkdir -p "$LOGS_DIR"
 
-if [ $JOB != "ci-checks" ]; then
+if [ "$JOB" != "ci-checks" ]; then
   echo "start_browser_provider"
   ./scripts/travis/start_browser_provider.sh
 fi
 
-if [ $JOB != "ci-checks" ]; then
+# ci-checks and unit tests do not run against the packaged code
+if [ "$JOB" != "ci-checks" ] && [ "$JOB" != "unit" ]; then
   grunt package
+fi
+
+# unit runs the docs tests too which need a built version of the code
+if [ "$JOB" = "unit" ]; then
+  grunt build
+fi
+
+# check this after the package, because at this point the browser_provider
+# has probably arrived
+if [ "$JOB" != "ci-checks" ]; then
   echo "wait_for_browser_provider"
   ./scripts/travis/wait_for_browser_provider.sh
 fi

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -15,8 +15,8 @@ elif [ "$JOB" == "unit" ]; then
   fi
 
   grunt test:promises-aplus
-  grunt test:unit --browsers="$BROWSERS" --reporters=dots
-  grunt tests:docs --browsers="$BROWSERS" --reporters=dots
+  grunt test:unit --browsers="$BROWSERS" --reporters=spec
+  grunt tests:docs --browsers="$BROWSERS" --reporters=spec
 elif [ "$JOB" == "docs-e2e" ]; then
   grunt test:travis-protractor --specs="docs/app/e2e/**/*.scenario.js"
 elif [ "$JOB" == "e2e" ]; then

--- a/yarn.lock
+++ b/yarn.lock
@@ -1093,7 +1093,7 @@ colors@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
-colors@^1.1.0, colors@~1.1.2:
+colors@^1.1.0, colors@^1.1.2, colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
@@ -3648,6 +3648,12 @@ karma-sauce-launcher@^1.1.0:
 karma-script-launcher@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/karma-script-launcher/-/karma-script-launcher-1.0.0.tgz#cd017c4de5ef09e5a9da793276176108dd4b542d"
+
+karma-spec-reporter@^0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/karma-spec-reporter/-/karma-spec-reporter-0.0.31.tgz#4830dc7148a155c7d7a186e632339a0d80fadec3"
+  dependencies:
+    colors "^1.1.2"
 
 karma@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
chore: 
- it hides the dots for unit tests on Travis, which makes it easier to find the separate test tasks and results.
- avoids building package for unit tests (makes the unit test job slightly faster)
- re-arranges the grunt task list to make it easier to read

