### PR TITLE
test(e2e): replace browser.getLocationAbsUrl() deprecated function with browser.getCurrentUrl()

### DIFF
--- a/docs/content/tutorial/step_08.ngdoc
+++ b/docs/content/tutorial/step_08.ngdoc
@@ -83,7 +83,7 @@ HTTP request to an invalid location.
       query.sendKeys('nexus');
 
       element.all(by.css('.phones li a')).first().click();
-      expect(browser.getLocationAbsUrl()).toBe('/phones/nexus-s');
+      expect(browser.getCurrentUrl()).toBe('/phones/nexus-s');
     });
 
     ...

--- a/docs/content/tutorial/step_09.ngdoc
+++ b/docs/content/tutorial/step_09.ngdoc
@@ -363,7 +363,7 @@ various URLs and verifying that the correct view was rendered.
 
   it('should redirect `index.html` to `index.html#!/phones', function() {
     browser.get('index.html');
-    expect(browser.getLocationAbsUrl()).toBe('/phones');
+    expect(browser.getCurrentUrl()).toBe('/phones');
   });
 
   ...

--- a/test/e2e/tests/base-tag.spec.js
+++ b/test/e2e/tests/base-tag.spec.js
@@ -7,7 +7,7 @@ describe('SCE URL policy when base tags are present', function() {
 
 
   it('allows the page URL (location.href)', function() {
-    expectToBeTrusted(browser.getLocationAbsUrl(), true);
+    expectToBeTrusted(browser.getCurrentUrl(), true);
   });
 
   it('blocks off-origin URLs', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Test


**What is the current behavior? (You can also link to an open issue here)**
There are many references to `browser.getLocationAbsUrl()` deprecated function (Protractor).
A warning appears when e2e tests are running, it recommend using `browser.getCurrentUrl()` instead.


**What is the new behavior (if this is a feature change)?**


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
Tutorial documentation references also updated.
