### PR TITLE
fix($parse): do not shallow-watch inputs to one-time intercepted expressions

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1977,7 +1977,11 @@ function $ParseProvider() {
       } else if (!interceptorFn.$stateful) {
         // Treat interceptor like filters - assume non-stateful by default and use the inputsWatchDelegate
         fn.$$watchDelegate = inputsWatchDelegate;
-        fn.inputs = (parsedExpression.inputs ? parsedExpression.inputs : [parsedExpression]).map(function(e) {
+        fn.inputs = parsedExpression.inputs ? parsedExpression.inputs : [parsedExpression];
+      }
+
+      if (fn.inputs) {
+        fn.inputs = fn.inputs.map(function(e) {
               // Remove the isPure flag of inputs when it is not absolute because they are now wrapped in a
               // potentially non-pure interceptor function.
               if (e.isPure === PURITY_RELATIVE) {

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -532,6 +532,20 @@ describe('ngClass', function() {
     })
   );
 
+  it('should support a one-time mixed literal-array/object variable', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-class="::[classVar1, classVar2]"></div>')($rootScope);
+
+      $rootScope.classVar1 = {orange: true};
+      $rootScope.$digest();
+      expect(element).toHaveClass('orange');
+
+      $rootScope.classVar1.orange = false;
+      $rootScope.$digest();
+
+      expect(element).not.toHaveClass('orange');
+    })
+  );
+
 
   it('should do value stabilization as expected when one-time binding',
     inject(function($rootScope, $compile) {


### PR DESCRIPTION
This was missed in aac5623247a86681cbe0e1c8179617b816394c1d

Depends on #15958, will be fixed in master by #16015 (I've added the test there as well).