### PR TITLE
fix(copy): support copying MediaStream object

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1005,6 +1005,9 @@ function copy(source, destination, maxDepth) {
 
       case '[object Blob]':
         return new source.constructor([source], {type: source.type});
+
+      case '[object MediaStream]':
+        return source.clone();
     }
 
     if (isFunction(source.cloneNode)) {

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -603,6 +603,18 @@ describe('angular', function() {
       /* eslint-enable */
     });
 
+    it('should copy media stream objects', function() {
+      var source = new MediaStream();
+      var destination = copy(source);
+
+      expect(destination.id).toMatch(/^((\w+)-){4}(\w+)$/);
+      expect(typeof destination.active).toBe('boolean');
+      expect(source.id).not.toBe(destination.id);
+      expect(source.active).toBe(destination.active);
+
+
+    });
+
     it('should copy source until reaching a given max depth', function() {
       var source = {a1: 1, b1: {b2: {b3: 1}}, c1: [1, {c2: 1}], d1: {d2: 1}};
       var dest;


### PR DESCRIPTION
use MediaStream clone method to clone mediastream object

Closes #16055

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug, fix Issue https://github.com/angular/angular.js/issues/16055


**What is the current behavior? (You can also link to an open issue here)**
angular.copy does not work with (Local)MediaStream objects. This affects the watchability of objects that contain such an object.


**What is the new behavior (if this is a feature change)?**
copy MediaStream object using `MediaStream.clone()` based on documentation
https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/clone


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
