### PR TITLE
refactor($browser): remove workaround for old ff bug

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -173,8 +173,7 @@ function Browser(window, document, $log, $sniffer) {
       // - pendingLocation is needed as browsers don't allow to read out
       //   the new location.href if a reload happened or if there is a bug like in iOS 9 (see
       //   https://openradar.appspot.com/22186109).
-      // - the replacement is a workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=407172
-      return pendingLocation || location.href.replace(/%27/g,'\'');
+      return pendingLocation || location.href;
     }
   };
 

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -383,11 +383,6 @@ describe('browser', function() {
       expect(browser.url('http://any.com', true, state).url('http://any.com', true, state)).toBe(browser);
     });
 
-    it('should decode single quotes to work around FF bug 407273', function() {
-      fakeWindow.location.href = 'http://ff-bug/?single%27quote';
-      expect(browser.url()).toBe('http://ff-bug/?single\'quote');
-    });
-
     it('should not set URL when the URL is already set', function() {
       var current = fakeWindow.location.href;
       sniffer.history = false;


### PR DESCRIPTION
- https://bugzilla.mozilla.org/show_bug.cgi?id=407172 was fixed in ff 40

FF 40 is probably old enough we can remove this?