### PR TITLE
docs(misc/FAQ): Correcting Misspell

### DIFF
--- a/docs/content/misc/faq.ngdoc
+++ b/docs/content/misc/faq.ngdoc
@@ -8,7 +8,7 @@
 
 ### Why is this project called "AngularJS"? Why is the namespace called "ng"?
 
-Because HTML has AngularJS brackets and "ng" sounds like "AngularJS".
+Because HTML has Angular brackets and "ng" sounds like "AngularJS".
 
 
 ### Is AngularJS a library, framework, plugin or a browser extension?

--- a/docs/content/misc/faq.ngdoc
+++ b/docs/content/misc/faq.ngdoc
@@ -8,7 +8,7 @@
 
 ### Why is this project called "AngularJS"? Why is the namespace called "ng"?
 
-Because HTML has Angular brackets and "ng" sounds like "AngularJS".
+Because HTML has angular brackets and "ng" sounds like "AngularJS".
 
 
 ### Is AngularJS a library, framework, plugin or a browser extension?


### PR DESCRIPTION
The HTML brackets are still just 'Angular' :-)

Fixing over-correction made in [this PR](https://github.com/angular/angular.js/commit/03043839d5a540b02208001fe12e812dfde00a8e)