### PR TITLE
fix($http) No error for json-like repsonses without "application/json" content-type

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -137,11 +137,13 @@ function defaultHttpResponseTransform(data, headers) {
 
     if (tempData) {
       var contentType = headers('Content-Type');
-      if ((contentType && (contentType.indexOf(APPLICATION_JSON) === 0)) || isJsonLike(tempData)) {
+      var hasJsonContentType = contentType && (contentType.indexOf(APPLICATION_JSON) === 0);
+
+      if (hasJsonContentType || isJsonLike(tempData)) {
         try {
           data = fromJson(tempData);
         } catch (e) {
-          if (!contentType || contentType && contentType.indexOf(APPLICATION_JSON)) {
+          if (!hasJsonContentType) {
             return data;
           }
           throw $httpMinErr('baddata', 'Data must be a valid JSON object. Received: "{0}". ' +

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -141,8 +141,8 @@ function defaultHttpResponseTransform(data, headers) {
         try {
           data = fromJson(tempData);
         } catch (e) {
-          if ((contentType && (contentType.indexOf(APPLICATION_JSON) !== 0))) {
-            return tempData;
+          if (!contentType || contentType && contentType.indexOf(APPLICATION_JSON)) {
+            return data;
           }
           throw $httpMinErr('baddata', 'Data must be a valid JSON object. Received: "{0}". ' +
           'Parse error: "{1}"', data, e);

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -141,6 +141,9 @@ function defaultHttpResponseTransform(data, headers) {
         try {
           data = fromJson(tempData);
         } catch (e) {
+          if ((contentType && (contentType.indexOf(APPLICATION_JSON) !== 0))) {
+            return tempData;
+          }
           throw $httpMinErr('baddata', 'Data must be a valid JSON object. Received: "{0}". ' +
           'Parse error: "{1}"', data, e);
         }

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1381,25 +1381,21 @@ describe('$http', function() {
           });
 
           it('should not throw an error if JSON is invalid but content-type is not application/json', function() {
-            var errCallback = jasmine.createSpy('error');
             $httpBackend.expect('GET', '/url').respond('{abcd}', {'Content-Type': 'text/plain'});
 
-            $http.get('/url').then(callback).catch(errCallback);
+            $http.get('/url').then(callback);
             $httpBackend.flush();
 
             expect(callback).toHaveBeenCalledOnce();
-            expect(errCallback).not.toHaveBeenCalled();
           });
 
           it('should not throw an error if JSON is invalid but content-type is not specified', function() {
-            var errCallback = jasmine.createSpy('error');
             $httpBackend.expect('GET', '/url').respond('{abcd}');
 
-            $http.get('/url').then(callback).catch(errCallback);
+            $http.get('/url').then(callback);
             $httpBackend.flush();
 
             expect(callback).toHaveBeenCalledOnce();
-            expect(errCallback).not.toHaveBeenCalled();
           });
 
           it('should return response unprocessed if JSON is invalid but content-type is not application/json', function() {

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1380,8 +1380,28 @@ describe('$http', function() {
             expect(errCallback.calls.mostRecent().args[0]).toEqualMinErr('$http', 'baddata');
           });
 
-        });
+          it('should not throw an error if JSON is invalid but content-type is not application/json', function() {
+            var errCallback = jasmine.createSpy('error');
+            $httpBackend.expect('GET', '/url').respond('{abcd}', {'Content-Type': 'text/plain'});
 
+            $http.get('/url').then(callback).catch(errCallback);
+            $httpBackend.flush();
+
+            expect(callback).toHaveBeenCalledOnce();
+            expect(errCallback).not.toHaveBeenCalled();
+          });
+
+          it('should return response unprocessed if JSON is invalid but content-type is not application/json', function() {
+            var response = '{abcd}';
+            $httpBackend.expect('GET', '/url').respond(response, {'Content-Type': 'text/plain'});
+
+            $http.get('/url').then(callback);
+            $httpBackend.flush();
+
+            expect(callback.calls.mostRecent().args[0].data).toMatch(response);
+          });
+
+        });
 
         it('should have access to response headers', function() {
           $httpBackend.expect('GET', '/url').respond(200, 'response', {h1: 'header1'});

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1409,7 +1409,7 @@ describe('$http', function() {
             $http.get('/url').then(callback);
             $httpBackend.flush();
 
-            expect(callback.calls.mostRecent().args[0].data).toMatch(response);
+            expect(callback.calls.mostRecent().args[0].data).toBe(response);
           });
 
           it('should return response unprocessed if JSON is invalid but content-type is not specified', function() {
@@ -1419,7 +1419,7 @@ describe('$http', function() {
             $http.get('/url').then(callback);
             $httpBackend.flush();
 
-            expect(callback.calls.mostRecent().args[0].data).toMatch(response);
+            expect(callback.calls.mostRecent().args[0].data).toBe(response);
           });
 
         });

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1391,9 +1391,30 @@ describe('$http', function() {
             expect(errCallback).not.toHaveBeenCalled();
           });
 
+          it('should not throw an error if JSON is invalid but content-type is not specified', function() {
+            var errCallback = jasmine.createSpy('error');
+            $httpBackend.expect('GET', '/url').respond('{abcd}');
+
+            $http.get('/url').then(callback).catch(errCallback);
+            $httpBackend.flush();
+
+            expect(callback).toHaveBeenCalledOnce();
+            expect(errCallback).not.toHaveBeenCalled();
+          });
+
           it('should return response unprocessed if JSON is invalid but content-type is not application/json', function() {
             var response = '{abcd}';
             $httpBackend.expect('GET', '/url').respond(response, {'Content-Type': 'text/plain'});
+
+            $http.get('/url').then(callback);
+            $httpBackend.flush();
+
+            expect(callback.calls.mostRecent().args[0].data).toMatch(response);
+          });
+
+          it('should return response unprocessed if JSON is invalid but content-type is not specified', function() {
+            var response = '{abcd}';
+            $httpBackend.expect('GET', '/url').respond(response);
 
             $http.get('/url').then(callback);
             $httpBackend.flush();


### PR DESCRIPTION
Don't throw error if http response has json-like data but content-type is not "application/json". Instead return data unprocessed.

Fixes https://github.com/angular/angular.js/issues/16027
This is not a breaking change.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)