### PR TITLE
feat(formController): add $setTouched to propagate touched state

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -271,6 +271,25 @@ FormController.prototype = {
 
   /**
    * @ngdoc method
+   * @name form.FormController#$setTouched
+   *
+   * @description
+   * Sets the form to its touched state.
+   *
+   * This method can be called to remove the 'ng-untouched' class and set the form controls to their
+   * touched state (ng-touched class).
+   *
+   * Setting a form controls to their touched state is often useful when submitting the form or for
+   * showing invalid controllers.
+   */
+  $setTouched: function() {
+    forEach(this.$$controls, function(control) {
+      control.$setTouched();
+    });
+  },
+
+  /**
+   * @ngdoc method
    * @name form.FormController#$setSubmitted
    *
    * @description

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -1081,6 +1081,38 @@ describe('form', function() {
     });
   });
 
+  describe('$setTouched', function() {
+    it('should trigger setTouched on form controls', function() {
+      var form = $compile(
+          '<form name="myForm">' +
+            '<input name="alias" type="text" ng-model="name" />' +
+          '</form>')(scope);
+      scope.$digest();
+
+      scope.myForm.alias.$setUntouched();
+      expect(scope.myForm.alias.$touched).toBe(false);
+      scope.myForm.$setTouched();
+      expect(scope.myForm.alias.$touched).toBe(true);
+      dealoc(form);
+    });
+
+    it('should trigger setTouched on form controls with nested forms', function() {
+      var form = $compile(
+          '<form name="myForm">' +
+            '<div class="ng-form" name="childForm">' +
+              '<input name="alias" type="text" ng-model="name" />' +
+            '</div>' +
+          '</form>')(scope);
+      scope.$digest();
+
+      scope.myForm.childForm.alias.$setUntouched();
+      expect(scope.myForm.childForm.alias.$touched).toBe(false);
+      scope.myForm.$setTouched();
+      expect(scope.myForm.childForm.alias.$touched).toBe(true);
+      dealoc(form);
+    });
+  });
+
 
   it('should rename nested form controls when interpolated name changes', function() {
     scope.idA = 'A';


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature


**What is the current behavior? (You can also link to an open issue here)**
Not implemented


**What is the new behavior (if this is a feature change)?**
Implemented


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

Use case:

```html
<form name="$ctrl.form">
    <input
      type="email"
      name="email"
      ng-class="{
        hasError: $ctrl.form.email.$invalid && $ctrl.form.email.$touched
      }">

    <input
      type="password"
      name="password"
      ng-class="{
        hasError: $ctrl.form.password.$invalid && $ctrl.form.password.$touched
      }">

  <button ng-click="$ctrl.form.$setTouched()">Sign In</button>
<form>
```

![example-light](https://user-images.githubusercontent.com/8445785/27739961-d32b5cda-5dc9-11e7-806d-a9f74cd578a6.gif)


