### PR TITLE
Turkish Lira unicode character

### DIFF
--- a/src/ngLocale/angular-locale_tr.js
+++ b/src/ngLocale/angular-locale_tr.js
@@ -90,7 +90,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "TL",
+    "CURRENCY_SYM": "\U+20BA",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [


### PR DESCRIPTION
I recommend adding the Turkish Lira Unicode character as it will be more informative than just TL and will also look great on recipes.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Adds Turkish lira Unicode character instead of TL

**What is the current behavior? (You can also link to an open issue here)**

Shows TL instead of the Lira symbol

**What is the new behavior (if this is a feature change)?**

This feature will change the current TL to ₺

**Does this PR introduce a breaking change?**

NO



