### PR TITLE
refactor($parse): do not pass scope,locals to interceptor fns

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1940,12 +1940,12 @@ function $ParseProvider() {
 
       function regularInterceptedExpression(scope, locals, assign, inputs) {
         var value = useInputs && inputs ? inputs[0] : parsedExpression(scope, locals, assign, inputs);
-        return interceptorFn(value, scope, locals);
+        return interceptorFn(value);
       }
 
       function oneTimeInterceptedExpression(scope, locals, assign, inputs) {
         var value = useInputs && inputs ? inputs[0] : parsedExpression(scope, locals, assign, inputs);
-        var result = interceptorFn(value, scope, locals);
+        var result = interceptorFn(value);
         // we only return the interceptor's result if the
         // initial value is defined (for bind-once)
         return isDone(value) ? result : value;

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3232,6 +3232,74 @@ describe('parser', function() {
         });
 
         describe('interceptorFns', function() {
+          it('should only be passed the intercepted value', inject(function($parse) {
+            var args;
+            function interceptor(v) {
+              args = sliceArgs(arguments);
+              return v;
+            }
+
+            scope.$watch($parse('a', interceptor));
+
+            scope.a = 1;
+            scope.$digest();
+            expect(args).toEqual([1]);
+          }));
+
+          it('should only be passed the intercepted value when double-intercepted',
+              inject(function($parse) {
+            var args1;
+            function int1(v) {
+              args1 = sliceArgs(arguments);
+              return v + 2;
+            }
+            var args2;
+            function int2(v) {
+              args2 = sliceArgs(arguments);
+              return v + 4;
+            }
+
+            scope.$watch($parse($parse('a', int1), int2));
+
+            scope.a = 1;
+            scope.$digest();
+            expect(args1).toEqual([1]);
+            expect(args2).toEqual([3]);
+          }));
+
+          it('should support locals', inject(function($parse) {
+            var args;
+            function interceptor(v) {
+              args = sliceArgs(arguments);
+              return v + 4;
+            }
+
+            var exp = $parse('a + b', interceptor);
+            scope.a = 1;
+
+            expect(exp(scope, {b: 2})).toBe(7);
+            expect(args).toEqual([3]);
+          }));
+
+          it('should support locals when double-intercepted', inject(function($parse) {
+            var args1;
+            function int1(v) {
+              args1 = sliceArgs(arguments);
+              return v + 4;
+            }
+            var args2;
+            function int2(v) {
+              args2 = sliceArgs(arguments);
+              return v + 8;
+            }
+
+            var exp = $parse($parse('a + b', int1), int2);
+
+            scope.a = 1;
+            expect(exp(scope, {b: 2})).toBe(15);
+            expect(args1).toEqual([3]);
+            expect(args2).toEqual([7]);
+          }));
 
           it('should always be invoked if they are flagged as having $stateful',
               inject(function($parse) {


### PR DESCRIPTION
After @lgalfaso's [comment](https://github.com/angular/angular.js/pull/16015/files#r126528737) I thought it would be a good idea to remove these params from interceptors. All the internal uses of interceptors are for doing things like data conversion/normalizing, never reading state out of the scope/locals. I think this is the intended use, and makes them like filters (which receive the input value + args).

Note that scope/locals still get passed through to the expression being wrapped/intercepted, it's just the interceptor-fn itself that now only receives the value.