### PR TITLE
feat($http): Added the ability to save a response from POST request with x-www-form-urlencoded 

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -1292,7 +1292,6 @@ function $HttpProvider() {
               ? /** @type {?} */ (defaults).cache
               : defaultCache;
         if (isPostUrlencoded) {
-          // Если это POST запрос, то к url прибавляем reqData
           cachedUrl = buildUrl(cachedUrl, reqData);
         }
       }

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -1293,7 +1293,7 @@ function $HttpProvider() {
               : defaultCache;
         if (isPostUrlencoded) {
           // Если это POST запрос, то к url прибавляем reqData
-          cachedUrl += '&' + reqData;
+          cachedUrl = buildUrl(cachedUrl, reqData);
         }
       }
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1551,7 +1551,7 @@ describe('$http', function() {
         expect(callback.calls.mostRecent().args[0].data).toBe('content2');
       });
 
-      it('should cache POST request if Content-Type application/x-www-form-urlencoded', inject(function ($httpParamSerializerJQLike) {
+      it('should cache POST request if Content-Type application/x-www-form-urlencoded', inject(function($httpParamSerializerJQLike) {
         $httpBackend.expect('POST', '/url').respond(200, 'content3');
         $http({
           method: 'POST',

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1551,6 +1551,31 @@ describe('$http', function() {
         expect(callback.calls.mostRecent().args[0].data).toBe('content2');
       });
 
+      it('should cache POST request if Content-Type application/x-www-form-urlencoded', inject(function ($httpParamSerializerJQLike) {
+        $httpBackend.expect('POST', '/url').respond(200, 'content3');
+        $http({
+          method: 'POST',
+          url: '/url',
+          data: $httpParamSerializerJQLike({param1: 'param1value'}),
+          cache: cache,
+          headers: {'Content-Type': 'application/x-www-form-urlencoded'}
+        });
+
+        $httpBackend.flush();
+
+        $http({
+          method: 'POST',
+          url: '/url',
+          data: $httpParamSerializerJQLike({param1: 'param1value'}),
+          cache: cache,
+          headers: {'Content-Type': 'application/x-www-form-urlencoded'}
+        }).then(callback);
+        $rootScope.$digest();
+
+        expect(callback).toHaveBeenCalledOnce();
+        expect(callback.calls.mostRecent().args[0].data).toBe('content3');
+      }));
+
 
       it('should not cache PUT request', function() {
         doFirstCacheRequest('PUT');


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature


**What is the current behavior? (You can also link to an open issue here)**
if request method is POST and it contains Content-Type header "application / x-www-form-urlencoded" then this request will not be cached 


**What is the new behavior (if this is a feature change)?**
Added the ability to save a response from the server in the cache if the request was sent by the POST method with the Content-Type header "application / x-www-form-urlencoded"


**Does this PR introduce a breaking change?**
no


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

