### PR TITLE
chore(doc-gen): insert current tagged version if missing from list of…

### DIFF
--- a/docs/config/processors/versions-data.js
+++ b/docs/config/processors/versions-data.js
@@ -47,6 +47,14 @@ module.exports = function generateVersionDocProcessor(gitData) {
 
         var latestMap = {};
 
+        // When the docs are built on a tagged commit, yarn info won't include the latest release,
+        // so we add it manually based on the local version.json file.
+        var missesCurrentVersion = !currentVersion.isSnapshot && !versions.find(function(version) {
+          return version === currentVersion.version;
+        });
+
+        if (missesCurrentVersion) versions.push(currentVersion.version);
+
         versions = versions
             .filter(function(versionStr) {
               return blacklist.indexOf(versionStr) === -1;
@@ -70,6 +78,7 @@ module.exports = function generateVersionDocProcessor(gitData) {
             })
             .reverse();
 
+        // List the latest version for each branch
         var latest = sortObject(latestMap, reverse(semver.compare))
             .map(function(version) { return makeOption(version, 'Latest'); });
 


### PR DESCRIPTION
… all versions

In commit ce49edc08b3d642f3768f4282d391062d2f83037, we switched to npm info (now yarn info)
instead of the local git repository information to get the list of currently available versions for
the docs app. This means that during a release the version that is currently tagged is not yet
available on npm, and therefore our list of available versions is incomplete.

We now simply add the current build version (read from build/version.json) to the list of all
versions if it fulfills the following conditions:

- it is not a snapshot build
- it is not already part of the list of all versions (i.e. if you are building locally)

Closes #15741

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
chore


**What is the current behavior? (You can also link to an open issue here)**
see above


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format

**Other information**:

