### PR TITLE
docs: Clarify documentation of input[week]

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -458,7 +458,8 @@ var inputType = {
     * Invalid `Date` objects (dates whose `getTime()` is `NaN`) will be rendered as an empty string.
     *
     * The value of the resulting Date object will be set to Thursday at 00:00:00 of the requested week,
-    * due to ISO-8601 week numbering standards.
+    * due to ISO-8601 week numbering standards. Information on ISO's system for numbering the weeks of the
+    * year can be found at: https://en.wikipedia.org/wiki/ISO_8601#Week_dates
     *
     * The timezone to be used to read/write the `Date` instance in the model can be defined using
     * {@link ng.directive:ngModelOptions ngModelOptions}. By default, this is the timezone of the browser.

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -457,6 +457,9 @@ var inputType = {
     * The model must always be a Date object, otherwise AngularJS will throw an error.
     * Invalid `Date` objects (dates whose `getTime()` is `NaN`) will be rendered as an empty string.
     *
+    * The value of the resulting Date object will be set to Thursday at 00:00:00 of the requested week,
+    * due to ISO-8601 week numbering standards.
+    *
     * The timezone to be used to read/write the `Date` instance in the model can be defined using
     * {@link ng.directive:ngModelOptions ngModelOptions}. By default, this is the timezone of the browser.
     *


### PR DESCRIPTION
Add a note to documentation of input[week] to explicitly state that the
resulting Date object's value is set to Thursday at midnight of the
specified week

Resolves #15883

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

docs update

**What is the current behavior? (You can also link to an open issue here)**

https://github.com/angular/angular.js/issues/15883
The docs do not specify the day and time of a Date created by input[week]

**What is the new behavior (if this is a feature change)?**

The docs now explicitly state that the resulting Date object's value is set to Thursday at midnight of the
specified week

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
Thought this looked like a nice opportunity for baby's first pull request! Hope I did everything right...
