### PR TITLE
feature($resource): Add Resource To Response For Error Interceptors

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -192,7 +192,8 @@ function shallowClearAndCopy(src, dst) {
  *     [requestType](https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest#responseType).
  *   - **`interceptor`** - `{Object=}` - The interceptor object has two optional methods -
  *     `response` and `responseError`. Both `response` and `responseError` interceptors get called
- *     with `http response` object. See {@link ng.$http $http interceptors}.
+ *     with `http response` object. See {@link ng.$http $http interceptors}. In addition, The
+ *     resource object is accessible by the `resource` property of the `http response` object.
  *   - **`hasBody`** - `{boolean}` - allows to specify if a request body should be included or not.
  *     If not specified only POST, PUT and PATCH requests will have a body.
  *
@@ -776,6 +777,9 @@ angular.module('ngResource', ['ng']).
               response.resource = value;
 
               return response;
+            }, function(response) {
+              response.resource = value;
+              return $q.reject(response);
             });
 
             promise = promise['finally'](function() {

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1205,6 +1205,7 @@ describe('basic usage', function() {
       expect(callback).toHaveBeenCalledOnce();
 
       var response = callback.calls.mostRecent().args[0];
+      expect(response.resource).toBe(ccs);
       expect(response.status).toBe(404);
       expect(response.config).toBeDefined();
     });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Similar to how the resource object (which is to be populated later) is added to the response for a successful request and accessible to the response interceptor, this change attaches the resource object to the response for a failed request and is accessible by the responseError interceptor.


**What is the current behavior? (You can also link to an open issue here)**
The resource object is not accessible from the responseError interceptor.


**What is the new behavior (if this is a feature change)?**
The resource object is accessible from the responseError interceptor.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

