### PR TITLE
fix($parse): support constants in computed keys

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -745,12 +745,13 @@ function findConstantAndWatchExpressions(ast, $filter, parentIsPure) {
     argsToWatch = [];
     forEach(ast.properties, function(property) {
       findConstantAndWatchExpressions(property.value, $filter, astIsPure);
-      allConstants = allConstants && property.value.constant && !property.computed;
+      allConstants = allConstants && property.value.constant;
       if (!property.value.constant) {
         argsToWatch.push.apply(argsToWatch, property.value.toWatch);
       }
       if (property.computed) {
         findConstantAndWatchExpressions(property.key, $filter, astIsPure);
+        allConstants = allConstants && property.key.constant;
         if (!property.key.constant) {
           argsToWatch.push.apply(argsToWatch, property.key.toWatch);
         }

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -4009,6 +4009,11 @@ describe('parser', function() {
           expect($parse('5 != null').constant).toBe(true);
           expect($parse('{standard: 4/3, wide: 16/9}').constant).toBe(true);
           expect($parse('{[standard]: 4/3, wide: 16/9}').constant).toBe(false);
+          expect($parse('{["key"]: 1}').constant).toBe(true);
+          expect($parse('[0].length').constant).toBe(true);
+          expect($parse('[0][0]').constant).toBe(true);
+          expect($parse('{x: 1}.x').constant).toBe(true);
+          expect($parse('{x: 1}["x"]').constant).toBe(true);
         }));
 
         it('should not mark any expression involving variables or function calls as constant', inject(function($parse) {


### PR DESCRIPTION
Came across this while looking at computed keys. Super minor and mainly just to make the code more consistent...  Previously `$parse('{["key"]: 1}').constant` would be `false`.