### PR TITLE
fix($parse): do not pass scope/locals to interceptors of one-time bindings

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1907,7 +1907,7 @@ function $ParseProvider() {
         if (isDone(lastValue)) {
           scope.$$postDigest(unwatchIfDone);
         }
-        return post(lastValue, scope, locals);
+        return post(lastValue);
       }
     }
 

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3246,6 +3246,20 @@ describe('parser', function() {
             expect(args).toEqual([1]);
           }));
 
+          it('should only be passed the intercepted value when wrapping one-time', inject(function($parse) {
+            var args;
+            function interceptor(v) {
+              args = sliceArgs(arguments);
+              return v;
+            }
+
+            scope.$watch($parse('::a', interceptor));
+
+            scope.a = 1;
+            scope.$digest();
+            expect(args).toEqual([1]);
+          }));
+
           it('should only be passed the intercepted value when double-intercepted',
               inject(function($parse) {
             var args1;


### PR DESCRIPTION
2ee5033967d5f87a516bad137686b0592e25d26b should not have added these args (see 529550d0da3d88514ce9efb038fb935fbf90f971 which dropped them elsewhere)