### PR TITLE
perf(jqLite): avoid repeated add/removeAttribute in jqLiteRemoveClass

### DIFF
--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -422,13 +422,16 @@ function jqLiteRemoveClass(element, cssClasses) {
   if (cssClasses && element.setAttribute) {
     var existingClasses = (' ' + (element.getAttribute('class') || '') + ' ')
                             .replace(/[\n\t]/g, ' ');
+    var newClasses = existingClasses;
 
     forEach(cssClasses.split(' '), function(cssClass) {
       cssClass = trim(cssClass);
-      existingClasses = existingClasses.replace(' ' + cssClass + ' ', ' ');
+      newClasses = newClasses.replace(' ' + cssClass + ' ', ' ');
     });
 
-    element.setAttribute('class', trim(existingClasses));
+    if (newClasses !== existingClasses) {
+      element.setAttribute('class', trim(newClasses));
+    }
   }
 }
 
@@ -436,15 +439,18 @@ function jqLiteAddClass(element, cssClasses) {
   if (cssClasses && element.setAttribute) {
     var existingClasses = (' ' + (element.getAttribute('class') || '') + ' ')
                             .replace(/[\n\t]/g, ' ');
+    var newClasses = existingClasses;
 
     forEach(cssClasses.split(' '), function(cssClass) {
       cssClass = trim(cssClass);
-      if (existingClasses.indexOf(' ' + cssClass + ' ') === -1) {
-        existingClasses += cssClass + ' ';
+      if (newClasses.indexOf(' ' + cssClass + ' ') === -1) {
+        newClasses += cssClass + ' ';
       }
     });
 
-    element.setAttribute('class', trim(existingClasses));
+    if (newClasses !== existingClasses) {
+      element.setAttribute('class', trim(newClasses));
+    }
   }
 }
 

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -420,13 +420,15 @@ function jqLiteHasClass(element, selector) {
 
 function jqLiteRemoveClass(element, cssClasses) {
   if (cssClasses && element.setAttribute) {
+    var existingClasses = (' ' + (element.getAttribute('class') || '') + ' ')
+                            .replace(/[\n\t]/g, ' ');
+
     forEach(cssClasses.split(' '), function(cssClass) {
-      element.setAttribute('class', trim(
-          (' ' + (element.getAttribute('class') || '') + ' ')
-          .replace(/[\n\t]/g, ' ')
-          .replace(' ' + trim(cssClass) + ' ', ' '))
-      );
+      cssClass = trim(cssClass);
+      existingClasses = existingClasses.replace(' ' + cssClass + ' ', ' ');
     });
+
+    element.setAttribute('class', trim(existingClasses));
   }
 }
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -914,6 +914,23 @@ describe('jqLite', function() {
       });
 
 
+      // JQLite specific implementation/performance tests
+      if (_jqLiteMode) {
+        it('should only get/set the attribute once when multiple classes added', function() {
+          var fakeElement = {
+            nodeType: 1,
+            setAttribute: jasmine.createSpy(),
+            getAttribute: jasmine.createSpy().and.returnValue('')
+          };
+          var jqA = jqLite(fakeElement);
+
+          jqA.addClass('foo bar baz');
+          expect(fakeElement.getAttribute).toHaveBeenCalledOnceWith('class');
+          expect(fakeElement.setAttribute).toHaveBeenCalledOnceWith('class', 'foo bar baz');
+        });
+      }
+
+
       it('should not add duplicate classes', function() {
         var jqA = jqLite(a);
         expect(a.className).toBe('');
@@ -1031,6 +1048,23 @@ describe('jqLite', function() {
         jqA.removeClass('foo baz noexistent');
         expect(a.className).toBe('bar');
       });
+
+
+      // JQLite specific implementation/performance tests
+      if (_jqLiteMode) {
+        it('should get/set the attribute once when removing multiple classes', function() {
+          var fakeElement = {
+            nodeType: 1,
+            setAttribute: jasmine.createSpy(),
+            getAttribute: jasmine.createSpy().and.returnValue('foo bar baz')
+          };
+          var jqA = jqLite(fakeElement);
+
+          jqA.removeClass('foo baz noexistent');
+          expect(fakeElement.getAttribute).toHaveBeenCalledOnceWith('class');
+          expect(fakeElement.setAttribute).toHaveBeenCalledOnceWith('class', 'bar');
+        });
+      }
     });
   });
 

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -928,6 +928,20 @@ describe('jqLite', function() {
           expect(fakeElement.getAttribute).toHaveBeenCalledOnceWith('class');
           expect(fakeElement.setAttribute).toHaveBeenCalledOnceWith('class', 'foo bar baz');
         });
+
+
+        it('should not set the attribute when classes not changed', function() {
+          var fakeElement = {
+            nodeType: 1,
+            setAttribute: jasmine.createSpy(),
+            getAttribute: jasmine.createSpy().and.returnValue('foo bar')
+          };
+          var jqA = jqLite(fakeElement);
+
+          jqA.addClass('foo');
+          expect(fakeElement.getAttribute).toHaveBeenCalledOnceWith('class');
+          expect(fakeElement.setAttribute).not.toHaveBeenCalled();
+        });
       }
 
 
@@ -1063,6 +1077,20 @@ describe('jqLite', function() {
           jqA.removeClass('foo baz noexistent');
           expect(fakeElement.getAttribute).toHaveBeenCalledOnceWith('class');
           expect(fakeElement.setAttribute).toHaveBeenCalledOnceWith('class', 'bar');
+        });
+
+
+        it('should not set the attribute when classes not changed', function() {
+          var fakeElement = {
+            nodeType: 1,
+            setAttribute: jasmine.createSpy(),
+            getAttribute: jasmine.createSpy().and.returnValue('foo bar')
+          };
+          var jqA = jqLite(fakeElement);
+
+          jqA.removeClass('noexistent');
+          expect(fakeElement.getAttribute).toHaveBeenCalledOnceWith('class');
+          expect(fakeElement.setAttribute).not.toHaveBeenCalled();
         });
       }
     });


### PR DESCRIPTION
This does something similar to what was suggested in #16078, although keeps it a little more like `jqLiteAddClass` for now.