### PR TITLE
fix($http): add check for functions in request

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -41,7 +41,7 @@ function $HttpParamSerializerProvider() {
       if (!params) return '';
       var parts = [];
       forEachSorted(params, function(value, key) {
-        if (value === null || isUndefined(value)) return;
+        if (value === null || isUndefined(value) || isFunction(value)) return;
         if (isArray(value)) {
           forEach(value, function(v) {
             parts.push(encodeUriQuery(key)  + '=' + encodeUriQuery(serializeValue(v)));

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -2345,6 +2345,10 @@ describe('$http param serializers', function() {
       expect(jqrSer({someDate: new Date('2014-07-15T17:30:00.000Z')})).toEqual('someDate=2014-07-15T17:30:00.000Z');
     });
 
+    it('should NOT serialize functions', function() {
+      expect(defSer({foo: 'foov', bar: function() {}})).toEqual('bar=barv');
+    });
+
   });
 
   describe('default array serialization', function() {

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -2345,9 +2345,7 @@ describe('$http param serializers', function() {
       expect(jqrSer({someDate: new Date('2014-07-15T17:30:00.000Z')})).toEqual('someDate=2014-07-15T17:30:00.000Z');
     });
 
-    it('should NOT serialize functions', function() {
-      expect(defSer({foo: 'foov', bar: function() {}})).toEqual('foo=foov');
-    });
+    
 
   });
 
@@ -2355,6 +2353,10 @@ describe('$http param serializers', function() {
 
     it('should serialize arrays by repeating param name', function() {
       expect(defSer({a: 'b', foo: ['bar', 'baz']})).toEqual('a=b&foo=bar&foo=baz');
+    });
+    
+    it('should NOT serialize functions', function() {
+      expect(defSer({foo: 'foov', bar: function() {}})).toEqual('foo=foov');
     });
   });
 

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -2346,7 +2346,7 @@ describe('$http param serializers', function() {
     });
 
     it('should NOT serialize functions', function() {
-      expect(defSer({foo: 'foov', bar: function() {}})).toEqual('bar=barv');
+      expect(defSer({foo: 'foov', bar: function() {}})).toEqual('foo=foov');
     });
 
   });

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -2344,9 +2344,6 @@ describe('$http param serializers', function() {
       expect(defSer({someDate: new Date('2014-07-15T17:30:00.000Z')})).toEqual('someDate=2014-07-15T17:30:00.000Z');
       expect(jqrSer({someDate: new Date('2014-07-15T17:30:00.000Z')})).toEqual('someDate=2014-07-15T17:30:00.000Z');
     });
-
-    
-
   });
 
   describe('default array serialization', function() {
@@ -2354,7 +2351,7 @@ describe('$http param serializers', function() {
     it('should serialize arrays by repeating param name', function() {
       expect(defSer({a: 'b', foo: ['bar', 'baz']})).toEqual('a=b&foo=bar&foo=baz');
     });
-    
+
     it('should NOT serialize functions', function() {
       expect(defSer({foo: 'foov', bar: function() {}})).toEqual('foo=foov');
     });


### PR DESCRIPTION
Avoid that functions in `params` object (like getter or setter) will be encoded in the url.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.


**What is the current behavior? (You can also link to an open issue here)**
 Functions in class-object are encoded in url.


**What is the new behavior (if this is a feature change)?**
 Functions in class-object are no more encoded in url


**Does this PR introduce a breaking change?**
no


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
See example of bug here: https://embed.plnkr.co/tspyPWVcm6jMpVDBl6WK/ (open console)

