### PR TITLE
docs($http): update YQL currency exchange API example

### DIFF
--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -186,7 +186,7 @@ Right now, the `InvoiceController` contains all logic of our example. When the a
 is a good practice to move view-independent logic from the controller into a
 <a name="service">{@link services service}</a>, so it can be reused by other parts
 of the application as well. Later on, we could also change that service to load the exchange rates
-from the web, e.g. by calling the <a href="http://fixer.io" title="fixer" target="_blank">Fixer.io</a> exchange rate API, without changing the controller.
+from the web, e.g. by calling the [Fixer.io](http://fixer.io) exchange rate API, without changing the controller.
 
 Let's refactor our example and move the currency conversion into a service in another file:
 
@@ -300,7 +300,7 @@ to something shorter like `a`.
 
 ## Accessing the backend
 
-Let's finish our example by fetching the exchange rates from the <a href="http://fixer.io" title="fixer" target="_blank">Fixer.io</a> exchange rate API.
+Let's finish our example by fetching the exchange rates from the [Fixer.io](http://fixer.io) exchange rate API.
 The following example shows how this is done with AngularJS:
 
 <example name="guide-concepts-3" ng-app-included="true">

--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -331,7 +331,7 @@ The following example shows how this is done with AngularJS:
         };
 
         var refresh = function() {
-          var url = 'https://api.fixer.io/latest?base=USD&symbols='+currencies.join(",");
+          var url = 'https://api.fixer.io/latest?base=USD&symbols=' + currencies.join(",");
           return $http.get(url).then(function(response) {
             usdToForeignRates = response.data.rates;
             usdToForeignRates['USD'] = 1;

--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -186,7 +186,7 @@ Right now, the `InvoiceController` contains all logic of our example. When the a
 is a good practice to move view-independent logic from the controller into a
 <a name="service">{@link services service}</a>, so it can be reused by other parts
 of the application as well. Later on, we could also change that service to load the exchange rates
-from the web, e.g. by calling the Fixer.io exchange rate API, without changing the controller.
+from the web, e.g. by calling the <a href="http://fixer.io" title="fixer" target="_blank">Fixer.io</a> exchange rate API, without changing the controller.
 
 Let's refactor our example and move the currency conversion into a service in another file:
 
@@ -300,7 +300,7 @@ to something shorter like `a`.
 
 ## Accessing the backend
 
-Let's finish our example by fetching the exchange rates from the Fixer.io exchange rate API.
+Let's finish our example by fetching the exchange rates from the <a href="http://fixer.io" title="fixer" target="_blank">Fixer.io</a> exchange rate API.
 The following example shows how this is done with AngularJS:
 
 <example name="guide-concepts-3" ng-app-included="true">

--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -186,7 +186,7 @@ Right now, the `InvoiceController` contains all logic of our example. When the a
 is a good practice to move view-independent logic from the controller into a
 <a name="service">{@link services service}</a>, so it can be reused by other parts
 of the application as well. Later on, we could also change that service to load the exchange rates
-from the web, e.g. by calling the Yahoo Finance API, without changing the controller.
+from the web, e.g. by calling the Fixer.io exchange rate API, without changing the controller.
 
 Let's refactor our example and move the currency conversion into a service in another file:
 
@@ -300,7 +300,7 @@ to something shorter like `a`.
 
 ## Accessing the backend
 
-Let's finish our example by fetching the exchange rates from the Yahoo Finance API.
+Let's finish our example by fetching the exchange rates from the Fixer.io exchange rate API.
 The following example shows how this is done with AngularJS:
 
 <example name="guide-concepts-3" ng-app-included="true">
@@ -323,10 +323,6 @@ The following example shows how this is done with AngularJS:
   <file name="finance3.js">
     angular.module('finance3', [])
       .factory('currencyConverter', ['$http', function($http) {
-        var YAHOO_FINANCE_URL_PATTERN =
-              '//query.yahooapis.com/v1/public/yql?q=select * from ' +
-              'yahoo.finance.xchange where pair in ("PAIRS")&format=json&' +
-              'env=store://datatables.org/alltableswithkeys';
         var currencies = ['USD', 'EUR', 'CNY'];
         var usdToForeignRates = {};
 
@@ -335,15 +331,10 @@ The following example shows how this is done with AngularJS:
         };
 
         var refresh = function() {
-          var url = YAHOO_FINANCE_URL_PATTERN.
-                     replace('PAIRS', 'USD' + currencies.join('","USD'));
+          var url = 'https://api.fixer.io/latest?base=USD&symbols='+currencies.join(",");
           return $http.get(url).then(function(response) {
-            var newUsdToForeignRates = {};
-            angular.forEach(response.data.query.results.rate, function(rate) {
-              var currency = rate.id.substring(3,6);
-              newUsdToForeignRates[currency] = window.parseFloat(rate.Rate);
-            });
-            usdToForeignRates = newUsdToForeignRates;
+            usdToForeignRates = response.data.rates;
+            usdToForeignRates['USD'] = 1;
           });
         };
 

--- a/docs/content/guide/security.ngdoc
+++ b/docs/content/guide/security.ngdoc
@@ -100,8 +100,7 @@ Protection from JSON Hijacking is provided if the server prefixes all JSON reque
 AngularJS will automatically strip the prefix before processing it as JSON.
 For more information please visit {@link $http#json-vulnerability-protection JSON Hijacking Protection}.
 
-Bear in mind that calling `$http.jsonp`,
-gives the remote server (and, if the request is not secured, any Man-in-the-Middle attackers)
+Bear in mind that calling `$http.jsonp` gives the remote server (and, if the request is not secured, any Man-in-the-Middle attackers)
 instant remote code execution in your application: the result of these requests is handed off
 to the browser as regular `<script>` tag.
 

--- a/docs/content/guide/security.ngdoc
+++ b/docs/content/guide/security.ngdoc
@@ -100,7 +100,7 @@ Protection from JSON Hijacking is provided if the server prefixes all JSON reque
 AngularJS will automatically strip the prefix before processing it as JSON.
 For more information please visit {@link $http#json-vulnerability-protection JSON Hijacking Protection}.
 
-Bear in mind that calling `$http.jsonp`, like in [our Yahoo! finance example](https://docs.angularjs.org/guide/concepts#accessing-the-backend),
+Bear in mind that calling `$http.jsonp`, like in [our currency exchange example](https://docs.angularjs.org/guide/concepts#accessing-the-backend),
 gives the remote server (and, if the request is not secured, any Man-in-the-Middle attackers)
 instant remote code execution in your application: the result of these requests is handed off
 to the browser as regular `<script>` tag.

--- a/docs/content/guide/security.ngdoc
+++ b/docs/content/guide/security.ngdoc
@@ -100,7 +100,7 @@ Protection from JSON Hijacking is provided if the server prefixes all JSON reque
 AngularJS will automatically strip the prefix before processing it as JSON.
 For more information please visit {@link $http#json-vulnerability-protection JSON Hijacking Protection}.
 
-Bear in mind that calling `$http.jsonp`, like in [our currency exchange example](https://docs.angularjs.org/guide/concepts#accessing-the-backend),
+Bear in mind that calling `$http.jsonp`,
 gives the remote server (and, if the request is not secured, any Man-in-the-Middle attackers)
 instant remote code execution in your application: the result of these requests is handed off
 to the browser as regular `<script>` tag.


### PR DESCRIPTION
Closes #16130

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs update


**What is the current behavior? (You can also link to an open issue here)**
Currently, the example uses YQL to fetch currency exchange rates (#16130)


**What is the new behavior (if this is a feature change)?**
I have updated the example to a simpler solution that uses the Fixer.io API.  


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

