### PR TITLE
test(*): fix tests involving `submit` on Chrome 60

### DIFF
--- a/karma-shared.conf.js
+++ b/karma-shared.conf.js
@@ -45,12 +45,12 @@ module.exports = function(config, specificOptions) {
       'SL_Chrome': {
         base: 'SauceLabs',
         browserName: 'chrome',
-        version: '51'
+        version: '59'
       },
       'SL_Firefox': {
         base: 'SauceLabs',
         browserName: 'firefox',
-        version: '47'
+        version: '54'
       },
       'SL_Safari_8': {
         base: 'SauceLabs',

--- a/test/ng/directive/ngEventDirsSpec.js
+++ b/test/ng/directive/ngEventDirsSpec.js
@@ -12,15 +12,20 @@ describe('event directives', function() {
   describe('ngSubmit', function() {
 
     it('should get called on form submit', inject(function($rootScope, $compile) {
-      element = $compile('<form action="/foo" ng-submit="submitted = true">' +
-        '<input type="submit"/>' +
+      element = $compile(
+        '<form action="/foo" ng-submit="submitted = true">' +
+          '<input type="submit" />' +
         '</form>')($rootScope);
       $rootScope.$digest();
+
+      // Support: Chrome 60+
+      // We need to add the form to the DOM in order for `submit` events to be properly fired.
+      window.document.body.appendChild(element[0]);
 
       // prevent submit within the test harness
       element.on('submit', function(e) { e.preventDefault(); });
 
-      expect($rootScope.submitted).not.toBeDefined();
+      expect($rootScope.submitted).toBeUndefined();
 
       browserTrigger(element.children()[0]);
       expect($rootScope.submitted).toEqual(true);
@@ -33,15 +38,20 @@ describe('event directives', function() {
         }
       };
 
-      element = $compile('<form action="/foo" ng-submit="formSubmission($event)">' +
-        '<input type="submit"/>' +
+      element = $compile(
+        '<form action="/foo" ng-submit="formSubmission($event)">' +
+          '<input type="submit" />' +
         '</form>')($rootScope);
       $rootScope.$digest();
+
+      // Support: Chrome 60+ (on Windows)
+      // We need to add the form to the DOM in order for `submit` events to be properly fired.
+      window.document.body.appendChild(element[0]);
 
       // prevent submit within the test harness
       element.on('submit', function(e) { e.preventDefault(); });
 
-      expect($rootScope.formSubmitted).not.toBeDefined();
+      expect($rootScope.formSubmitted).toBeUndefined();
 
       browserTrigger(element.children()[0]);
       expect($rootScope.formSubmitted).toEqual('foo');


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Test fix.


**What is the current behavior? (You can also link to an open issue here)**
Some tests involving `submit` fail on Windows with Chrome 60.


**What is the new behavior (if this is a feature change)?**
All tests pass.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
On Chrome 60 (at least on Windows) the `submit` event when clicking on a submit button is not fired on the form element, unless it is already part of the DOM.
