### PR TITLE
docs($compileProvider): more information on debugInfoEnabled

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1389,8 +1389,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    * * `ng-binding` CSS class
    * * `ng-scope` and `ng-isolated-scope` CSS classes
    * * `$binding` data property containing an array of the binding expressions
-   * * `$scope`, `$isolateScope` or `$isolateScopeNoTemplate` data properties which are accessable via the
-   *   {@link angular.element#methods `scope()` or `isolateScope()` methods}.
+   * * Data properties used by the {@link angular.element#methods `scope()`/`isolateScope()` methods} to return
+   *   the element's scope.
    * * Placeholder comments will contain information about what directive and binding caused the placeholder.
    *   E.g. `<!-- ngIf: shouldShow() -->`
    *

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1387,7 +1387,12 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    * binding information and a reference to the current scope on to DOM elements.
    * If enabled, the compiler will add the following to DOM elements that have been bound to the scope
    * * `ng-binding` CSS class
+   * * `ng-scope` and `ng-isolated-scope` CSS classes
    * * `$binding` data property containing an array of the binding expressions
+   * * `$scope`, `$isolateScope` or `$isolateScopeNoTemplate` data properties which are accessable via the
+   *   {@link angular.element#methods `scope()` or `isolateScope()` methods}.
+   * * Placeholder comments will contain information about what directive and binding caused the placeholder.
+   *   E.g. `<!-- ngIf: shouldShow() -->`
    *
    * You may want to disable this in production for a significant performance boost. See
    * {@link guide/production#disabling-debug-data Disabling Debug Data} for more.


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Improves documentation about what `$compileProvider.debugInfoEnabled(true)` does.

**Other information**:

Based on [compile.js](https://github.com/angular/angular.js/blob/b4d1e5e492df43c49c9e4215ea75d9155fd8ba88/src/ng/compile.js#L1819...L1851) source code.

Please feel free to improve the wording or come with feedback.

Related: #16155