### PR TITLE
docs(guide/Running in Production): more Information on debugInfoEnabled(false)

### DIFF
--- a/docs/content/guide/production.ngdoc
+++ b/docs/content/guide/production.ngdoc
@@ -20,6 +20,9 @@ and adds CSS classes to data-bound elements:
 CSS class are attached to the corresponding element. These scope references can then be accessed via
 `element.scope()` and `element.isolateScope()`.
 
+- Placeholder comments for structural directives will contain information about what directive
+and binding caused the placeholder. E.g. `<!-- ngIf: shouldShow() -->`.
+
 Tools like [Protractor](https://github.com/angular/protractor) and
 [Batarang](https://github.com/angular/angularjs-batarang) need this information to run,
 but you can disable this in production for a significant performance boost with:


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Improves documentation about what `$compileProvider.debugInfoEnabled(true)` does.

**Other information**:

Based on [compile.js](https://github.com/angular/angular.js/blob/b4d1e5e492df43c49c9e4215ea75d9155fd8ba88/src/ng/compile.js#L1819...L1851) source code.

Please feel free to improve the wording or come with feedback.

Related: #16154 

