### PR TITLE
fix($rootScope): fix potential memory leak when removing scope listeners 

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -1207,7 +1207,10 @@ function $RootScopeProvider() {
         return function() {
           var indexOfListener = namedListeners.indexOf(listener);
           if (indexOfListener !== -1) {
-            namedListeners[indexOfListener] = null;
+            // Use delete in the hope of the browser deallocating the memory for the array entry,
+            // while not shifting the array indexes of other listeners.
+            // See issue https://github.com/angular/angular.js/issues/16135
+            delete namedListeners[indexOfListener];
             decrementListenerCount(self, 1, name);
           }
         };

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1903,6 +1903,90 @@ describe('Scope', function() {
         }));
 
 
+        it('should call next listener after removing the current listener via its own handler', inject(function($rootScope) {
+          var listener1 = jasmine.createSpy('listener1').and.callFake(function() { remove1(); });
+          var remove1 = $rootScope.$on('abc', listener1);
+
+          var listener2 = jasmine.createSpy('listener2');
+          var remove2 = $rootScope.$on('abc', listener2);
+
+          var listener3 = jasmine.createSpy('listener3');
+          var remove3 = $rootScope.$on('abc', listener3);
+
+          $rootScope.$broadcast('abc');
+          expect(listener1).toHaveBeenCalled();
+          expect(listener2).toHaveBeenCalled();
+          expect(listener3).toHaveBeenCalled();
+
+          listener1.calls.reset();
+          listener2.calls.reset();
+          listener3.calls.reset();
+
+          $rootScope.$broadcast('abc');
+          expect(listener1).not.toHaveBeenCalled();
+          expect(listener2).toHaveBeenCalled();
+          expect(listener3).toHaveBeenCalled();
+        }));
+
+
+        it('should call all subsequent listeners when a previous listener is removed via a handler', inject(function($rootScope) {
+          var listener1 = jasmine.createSpy();
+          var remove1 = $rootScope.$on('abc', listener1);
+
+          var listener2 = jasmine.createSpy().and.callFake(remove1);
+          var remove2 = $rootScope.$on('abc', listener2);
+
+          var listener3 = jasmine.createSpy();
+          var remove3 = $rootScope.$on('abc', listener3);
+
+          $rootScope.$broadcast('abc');
+          expect(listener1).toHaveBeenCalled();
+          expect(listener2).toHaveBeenCalled();
+          expect(listener3).toHaveBeenCalled();
+
+          listener1.calls.reset();
+          listener2.calls.reset();
+          listener3.calls.reset();
+
+          $rootScope.$broadcast('abc');
+          expect(listener1).not.toHaveBeenCalled();
+          expect(listener2).toHaveBeenCalled();
+          expect(listener3).toHaveBeenCalled();
+        }));
+
+
+        it('should not call listener when removed by previous', inject(function($rootScope) {
+          var listener1 = jasmine.createSpy('listener1');
+          var remove1 = $rootScope.$on('abc', listener1);
+
+          var listener2 = jasmine.createSpy('listener2').and.callFake(function() { remove3(); });
+          var remove2 = $rootScope.$on('abc', listener2);
+
+          var listener3 = jasmine.createSpy('listener3');
+          var remove3 = $rootScope.$on('abc', listener3);
+
+          var listener4 = jasmine.createSpy('listener4');
+          var remove4 = $rootScope.$on('abc', listener4);
+
+          $rootScope.$broadcast('abc');
+          expect(listener1).toHaveBeenCalled();
+          expect(listener2).toHaveBeenCalled();
+          expect(listener3).not.toHaveBeenCalled();
+          expect(listener4).toHaveBeenCalled();
+
+          listener1.calls.reset();
+          listener2.calls.reset();
+          listener3.calls.reset();
+          listener4.calls.reset();
+
+          $rootScope.$broadcast('abc');
+          expect(listener1).toHaveBeenCalled();
+          expect(listener2).toHaveBeenCalled();
+          expect(listener3).not.toHaveBeenCalled();
+          expect(listener4).toHaveBeenCalled();
+        }));
+
+
         it('should decrement ancestor $$listenerCount entries', inject(function($rootScope) {
           var child1 = $rootScope.$new(),
               child2 = child1.$new(),

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1903,6 +1903,21 @@ describe('Scope', function() {
         }));
 
 
+        // See issue https://github.com/angular/angular.js/issues/16135
+        it('should deallocate the listener array entry', inject(function($rootScope) {
+          var remove1 = $rootScope.$on('abc', noop);
+          $rootScope.$on('abc', noop);
+
+          expect($rootScope.$$listeners['abc'].length).toBe(2);
+          expect(0 in $rootScope.$$listeners['abc']).toBe(true);
+
+          remove1();
+
+          expect($rootScope.$$listeners['abc'].length).toBe(2);
+          expect(0 in $rootScope.$$listeners['abc']).toBe(false);
+        }));
+
+
         it('should call next listener after removing the current listener via its own handler', inject(function($rootScope) {
           var listener1 = jasmine.createSpy('listener1').and.callFake(function() { remove1(); });
           var remove1 = $rootScope.$on('abc', listener1);


### PR DESCRIPTION
This attempts to fix #16135, but is assuming that browsers will use some type of memory efficient array implementation for sparse arrays (which they appear to do, see [1](https://stackoverflow.com/questions/614126/why-is-array-push-sometimes-faster-than-arrayn-value/614255#614255), [2](https://www.safaribooksonline.com/library/view/javascript-the-definitive/9781449393854/ch07s03.html), [3](https://www.html5rocks.com/en/tutorials/speed/v8/#toc-topic-numbers)).  In the worst case this ~~should have no change~~ may cause some extra swapping of array implementations and/or not fix the bug, in the best case it will be more memory efficient in this edge case.

Also added a couple tests that show why we don't simply use `splice`.

Thanks @jvilk for investigating this `delete` solution.