### PR TITLE
fix($$RAFProvider): prevent a JavaScript error in Firefox

### DIFF
--- a/src/ng/raf.js
+++ b/src/ng/raf.js
@@ -13,9 +13,9 @@ function $$RAFProvider() { //rAF
     var rafSupported = !!requestAnimationFrame;
     var raf = rafSupported
       ? function(fn) {
-          var id = requestAnimationFrame(fn);
+          var id = requestAnimationFrame.bind($window, fn);
           return function() {
-            cancelAnimationFrame(id);
+            cancelAnimationFrame.bind($window, id);
           };
         }
       : function(fn) {

--- a/src/ng/raf.js
+++ b/src/ng/raf.js
@@ -13,10 +13,8 @@ function $$RAFProvider() { //rAF
     var rafSupported = !!requestAnimationFrame;
     var raf = rafSupported
       ? function(fn) {
-          var id = requestAnimationFrame.bind($window, fn);
-          return function() {
-            cancelAnimationFrame.bind($window, id);
-          };
+          var id = requestAnimationFrame.call($window, fn);
+          return cancelAnimationFrame.bind($window, id);
         }
       : function(fn) {
           var timer = $timeout(fn, 16.66, false); // 1000 / 60 = 16.666

--- a/test/extension/manifest.json
+++ b/test/extension/manifest.json
@@ -1,0 +1,15 @@
+{
+  "description": "Test extension for angular.js",
+  "manifest_version": 2,
+  "name": "Angular test",
+  "version": "1.0",
+  "content_scripts": [
+    {
+      "matches": ["https://www.google.ch/*"],
+      "js": [
+	"angular.js",
+	"test.js"]
+    }
+  ]
+
+}

--- a/test/extension/test.js
+++ b/test/extension/test.js
@@ -1,0 +1,9 @@
+var html = document.querySelector('html');
+html.setAttribute('ng-app', '');
+
+var buttonDiv = document.createElement('div');
+buttonDiv.setAttribute('ng-show', 'true');
+buttonDiv.innerHTML = 'Hello!';
+
+var hplogo = document.getElementById('hplogo');
+hplogo.insertBefore(buttonDiv, hplogo.childNodes[0]);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix: prevent a JavaScript error in Firefox.

**What is the current behavior? (You can also link to an open issue here)**

Firefox raises a Javascript Error "TypeError: 'requestAnimationFrame' called on an object that does not implement interface Window." with animated elements. This is because Window.requestAnimationFrame() is called without binding to a Window instance in the function which is returned from $$RAFProvider().

**What is the new behavior (if this is a feature change)?**

No error message.

**Does this PR introduce a breaking change?**

Not that I know of.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

I was not able to run local tests.