### PR TITLE
docs(*): replace master/slave with leader/follower

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -843,7 +843,7 @@ function arrayRemove(array, value) {
           <button ng-click="update(user)">SAVE</button>
         </form>
         <pre>form = {{user | json}}</pre>
-        <pre>master = {{master | json}}</pre>
+        <pre>leader = {{leader | json}}</pre>
       </div>
     </file>
     <file name="script.js">
@@ -851,16 +851,16 @@ function arrayRemove(array, value) {
       angular.
         module('copyExample', []).
         controller('ExampleController', ['$scope', function($scope) {
-          $scope.master = {};
+          $scope.leader = {};
 
           $scope.reset = function() {
             // Example with 1 argument
-            $scope.user = angular.copy($scope.master);
+            $scope.user = angular.copy($scope.leader);
           };
 
           $scope.update = function(user) {
             // Example with 2 arguments
-            angular.copy(user, $scope.master);
+            angular.copy(user, $scope.leader);
           };
 
           $scope.reset();

--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -205,14 +205,14 @@
  * @example
     <example name="ng-checked">
       <file name="index.html">
-        <label>Check me to check both: <input type="checkbox" ng-model="master"></label><br/>
-        <input id="checkSlave" type="checkbox" ng-checked="master" aria-label="Slave input">
+        <label>Check me to check both: <input type="checkbox" ng-model="leader"></label><br/>
+        <input id="checkFollower" type="checkbox" ng-checked="leader" aria-label="Follower input">
       </file>
       <file name="protractor.js" type="protractor">
         it('should check both checkBoxes', function() {
-          expect(element(by.id('checkSlave')).getAttribute('checked')).toBeFalsy();
-          element(by.model('master')).click();
-          expect(element(by.id('checkSlave')).getAttribute('checked')).toBeTruthy();
+          expect(element(by.id('checkFollower')).getAttribute('checked')).toBeFalsy();
+          element(by.model('leader')).click();
+          expect(element(by.id('checkFollower')).getAttribute('checked')).toBeTruthy();
         });
       </file>
     </example>

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -1761,26 +1761,26 @@ describe('jqLite', function() {
 
     it('should deregister specific listener for multiple types separated by spaces', function() {
       var aElem = jqLite(a),
-          masterSpy = jasmine.createSpy('master'),
+          leaderSpy = jasmine.createSpy('leader'),
           extraSpy = jasmine.createSpy('extra');
 
-      aElem.on('click', masterSpy);
+      aElem.on('click', leaderSpy);
       aElem.on('click', extraSpy);
-      aElem.on('mouseover', masterSpy);
+      aElem.on('mouseover', leaderSpy);
 
       browserTrigger(a, 'click');
       browserTrigger(a, 'mouseover');
-      expect(masterSpy).toHaveBeenCalledTimes(2);
+      expect(leaderSpy).toHaveBeenCalledTimes(2);
       expect(extraSpy).toHaveBeenCalledOnce();
 
-      masterSpy.calls.reset();
+      leaderSpy.calls.reset();
       extraSpy.calls.reset();
 
-      aElem.off('click mouseover', masterSpy);
+      aElem.off('click mouseover', leaderSpy);
 
       browserTrigger(a, 'click');
       browserTrigger(a, 'mouseover');
-      expect(masterSpy).not.toHaveBeenCalled();
+      expect(leaderSpy).not.toHaveBeenCalled();
       expect(extraSpy).toHaveBeenCalledOnce();
     });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update


**What is the current behavior? (You can also link to an open issue here)**
Previously, the docs made use of `master/slave`, which is offensive.


**What is the new behavior (if this is a feature change)?**
This commit removes the usage of these terms and replace them with `leader/follower`.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
https://github.com/angular/angular.js/issues/16201

Updated the docs according to the logged issue. I might have made changes which do not directly use both `master` **and** `slave`, feel free to let me know to undo those changes. I thought it wasn't bad to stay consistent.
