### PR TITLE
docs: add calrification for RegExp in ngPattern

### DIFF
--- a/docs/content/guide/expression.ngdoc
+++ b/docs/content/guide/expression.ngdoc
@@ -37,7 +37,8 @@ AngularJS expressions are like JavaScript expressions with the following differe
     even inside `ng-init` directive.
 
   * **No RegExp Creation With Literal Notation:** You cannot create regular expressions
-    in an AngularJS expression.
+    in an AngularJS expression. An exception to this rule is {@link ngPattern `ng-pattern`} which accepts valid
+    RegExp.
 
   * **No Object Creation With New Operator:** You cannot use `new` operator in an AngularJS expression.
 


### PR DESCRIPTION
`ngPattern` accepts only valid regExp pattern, hence it should be excepted from the `No RegExp Creation With Literal Notation` rule.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs

**What is the current behavior? (You can also link to an open issue here)**

States that RegExp are not valid in expressions.

**What is the new behavior (if this is a feature change)?**

State that RegExp is valid in ngPattern.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

