### PR TITLE
docs(guide/Providers): clarification about Service

### DIFF
--- a/docs/content/guide/providers.ngdoc
+++ b/docs/content/guide/providers.ngdoc
@@ -398,7 +398,7 @@ To wrap it up, let's summarize the most important points:
 <tr>
   <td>object available in config phase</td>
   <td class="error">no</td>
-  <td class="error">no</td>
+  <td class="error">no\*\*\*</td>
   <td class="error">no</td>
   <td class="success">yes</td>
   <td class="success">yes\*\*</td>
@@ -426,4 +426,6 @@ To wrap it up, let's summarize the most important points:
 
 \*\* the service object is not available during the config phase, but the provider instance is
 (see the `unicornLauncherProvider` example above).
+
+\*\*\* service can be injected to the config by adding the suffix "Provider" to its name, but this is the wrong way, Provider should be used instead in case a configuration is required. 
 


### PR DESCRIPTION
Сlarification for completeness of information about Service.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs update.

**What is the current behavior? (You can also link to an open issue here)**

Docs says that Service object isn't available in config phase, but it's available by adding "Provider" suffix to service name. Then $get function can be used then and it's caused extra call of this function if same service, for example, has also been injected in controller.

**What is the new behavior (if this is a feature change)?**

Docs says that Service object is available in config phase, but it not the right way and Provider should be used instead in case a configuration is required.

**Does this PR introduce a breaking change?**

Nope.