### PR TITLE
docs(*): don't hide results for middle-clicks

### DIFF
--- a/docs/app/src/search.js
+++ b/docs/app/src/search.js
@@ -67,6 +67,12 @@ angular.module('search', [])
     clearResults();
     $scope.q = '';
   };
+
+  $scope.handleResultClicked = function($event) {
+    if ($event.which === 1 && !$event.ctrlKey && !$event.metaKey) {
+      $scope.hideResults();
+    }
+  };
 }])
 
 

--- a/docs/config/templates/app/indexPage.template.html
+++ b/docs/config/templates/app/indexPage.template.html
@@ -132,7 +132,7 @@
                 <div ng-repeat="(key, value) in results track by key" class="search-results-group" ng-class="colClassName + ' col-group-' + key" ng-show="value.length > 0">
                   <h4 class="search-results-group-heading">{{ key }}</h4>
                   <ul class="search-results">
-                    <li ng-repeat="item in value" class="search-result"><a ng-click="hideResults()" ng-href="{{ item.path }}">{{ item.name }}</a></li>
+                    <li ng-repeat="item in value" class="search-result"><a ng-click="handleResultClicked($event)" ng-href="{{ item.path }}">{{ item.name }}</a></li>
                   </ul>
                 </div>
               </div>


### PR DESCRIPTION
Middle-clicking opens a link in a new tab; it shouldn't close the results list
as the user may want to open more of those links.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs fix.


**What is the current behavior? (You can also link to an open issue here)**
Middle-clicking on a link in the results list (which opens a link in a new tab) closes the list.


**What is the new behavior (if this is a feature change)?**
List is kept open in such a case.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- ~~Tests for the changes have been added (for bug fixes / features)~~
- ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:

