### PR TITLE
wip: feat(ngModel): run formatters / setModelValue

### DIFF
--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -603,6 +603,113 @@ describe('ngModel', function() {
         expect(ctrl.$modelValue).toBeNaN();
 
       }));
+
+      describe('$processModelValue', function() {
+        // Emulate setting the model on the scope
+        function setModelValue(ctrl, value) {
+          ctrl.$modelValue = ctrl.$$rawModelValue = value;
+          ctrl.$$parserValid = undefined;
+        }
+
+        it('should run the model -> view pipeline', function() {
+          var log = [];
+          var input = ctrl.$$element;
+
+          ctrl.$formatters.unshift(function(value) {
+            log.push(value);
+            return value + 2;
+          });
+
+          ctrl.$formatters.unshift(function(value) {
+            log.push(value);
+            return value + '';
+          });
+
+          spyOn(ctrl, '$render');
+
+          setModelValue(ctrl, 3);
+
+          expect(ctrl.$modelValue).toBe(3);
+
+          ctrl.$processModelValue();
+
+          expect(ctrl.$modelValue).toBe(3);
+          expect(log).toEqual([3, 5]);
+          expect(ctrl.$viewValue).toBe('5');
+          expect(ctrl.$render).toHaveBeenCalledOnce();
+        });
+
+        it('should add the validation and empty-state classes',
+          inject(function($compile, $rootScope, $animate) {
+            var input = $compile('<input name="myControl" maxlength="1" ng-model="value" >')($rootScope);
+            $rootScope.$digest();
+
+            spyOn($animate, 'addClass');
+            spyOn($animate, 'removeClass');
+
+            var ctrl = input.controller('ngModel');
+
+            expect(input).toHaveClass('ng-empty');
+            expect(input).toHaveClass('ng-valid');
+
+            setModelValue(ctrl, 3);
+            ctrl.$processModelValue();
+
+            // $animate adds / removes classes in the $$postDigest, which
+            // we cannot trigger with $digest, because that would set the model from the scope,
+            // so we simply check if the functions have been called
+            expect($animate.removeClass.calls.mostRecent().args[0][0]).toBe(input[0]);
+            expect($animate.removeClass.calls.mostRecent().args[1]).toBe('ng-empty');
+
+            expect($animate.addClass.calls.mostRecent().args[0][0]).toBe(input[0]);
+            expect($animate.addClass.calls.mostRecent().args[1]).toBe('ng-not-empty');
+
+            $animate.removeClass.calls.reset();
+            $animate.addClass.calls.reset();
+
+            setModelValue(ctrl, 35);
+            ctrl.$processModelValue();
+
+            expect($animate.addClass.calls.argsFor(1)[0][0]).toBe(input[0]);
+            expect($animate.addClass.calls.argsFor(1)[1]).toBe('ng-invalid');
+
+            expect($animate.addClass.calls.argsFor(2)[0][0]).toBe(input[0]);
+            expect($animate.addClass.calls.argsFor(2)[1]).toBe('ng-invalid-maxlength');
+          })
+        );
+
+        // this is analogue to $setViewValue
+        it('should run the model -> view pipeline even if the value has not changed', function() {
+          var log = [];
+
+          ctrl.$formatters.unshift(function(value) {
+            log.push(value);
+            return value + 2;
+          });
+
+          ctrl.$formatters.unshift(function(value) {
+            log.push(value);
+            return value + '';
+          });
+
+          spyOn(ctrl, '$render');
+
+          setModelValue(ctrl, 3);
+          ctrl.$processModelValue();
+
+          expect(ctrl.$modelValue).toBe(3);
+          expect(ctrl.$viewValue).toBe('5');
+          expect(log).toEqual([3, 5]);
+          expect(ctrl.$render).toHaveBeenCalledOnce();
+
+          ctrl.$processModelValue();
+          expect(ctrl.$modelValue).toBe(3);
+          expect(ctrl.$viewValue).toBe('5');
+          expect(log).toEqual([3, 5, 3, 5]);
+          // $render() is not called if the viewValue didn't change
+          expect(ctrl.$render).toHaveBeenCalledOnce();
+        });
+      });
     });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature


**What is the current behavior? (You can also link to an open issue here)**
There's currently no way to manually run the model -> view pipeline / formatters


**What is the new behavior (if this is a feature change)?**
An API to run the whole pipeline / the formatters is introduced.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

The PR includes both a `$format` and a `$setModelValue` function. I think only one is needed, we just need to decide which one.

$format:

- PRO: does the most needed thing, very straightforward: run the formatters and updates the viewValue
- CON: developer must run $render manually
- CON: empty classes are set even though the DOM is not updated. Could be moved to $render()
- CON: no equivalent on the view -> model side (inconsistent API)

$setModelValue
- PRO: equivalent to $setViewValue, runs the whole pipeline
- CON: unintuitive that the function argument should / must be set to the current $modelValue, so the control does not get out of sync with the scope (same behavior as $setViewValue though)
- CON: only runs $render if the viewValue has actually changed.
- CON: always runs the validation, even though it might not be necessary

Both methods can handle the basic case, where an app developer wants to run the formatters the view -> model pipeline has been run, see https://github.com/angular/angular.js/issues/3407 or https://github.com/angular/angular.js/pull/5221

I personally tend to introduce `$format` as it has the smaller surface area and introduces fewer side effects. The full model -> view pipeline is not really needed for most cases.

