### PR TITLE
chore(doc-gen): fix script paths in plnkr for examples with deps

### DIFF
--- a/docs/config/services/deployments/production.js
+++ b/docs/config/services/deployments/production.js
@@ -7,22 +7,23 @@ var angularCodeUrl = '//code.angularjs.org/';
 
 var cdnUrl = googleCdnUrl + versionInfo.cdnVersion;
 
-// The "examplesCdnUrl" here applies to the examples when they are opened in plnkr.co.
+// The "examplesDependencyPath" here applies to the examples when they are opened in plnkr.co.
 // The embedded examples instead always include the files from the *default* deployment,
 // to ensure that the source files are always available.
 // The plnkr examples must always use the code.angularjs.org source files.
 // We cannot rely on the CDN files here, because they are not deployed by the time
 // docs.angularjs.org and code.angularjs.org need them.
-var examplesDependencyPath = versionInfo.currentVersion.isSnapshot ?
-  (angularCodeUrl + 'snapshot') :
-  (angularCodeUrl + (versionInfo.currentVersion.version || versionInfo.currentVersion.version));
+var versionPath = versionInfo.currentVersion.isSnapshot ?
+  'snapshot' :
+  (versionInfo.currentVersion.version || versionInfo.currentVersion.version);
+var examplesDependencyPath = angularCodeUrl + versionPath + '/';
 
 module.exports = function productionDeployment(getVersion) {
   return {
     name: 'production',
     examples: {
       commonFiles: {
-        scripts: [examplesDependencyPath + '/angular.min.js']
+        scripts: [examplesDependencyPath + 'angular.min.js']
       },
       dependencyPath: examplesDependencyPath
     },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Chore.


**What is the current behavior? (You can also link to an open issue here)**
Docs examples with deps result into broken plnkrs due to incorrect script paths (for the production deployment mode).
E.g. `<example ... deps="angular-animate.js">` results in:
```html
<script src="//code.angularjs.org/snapshotangular-animate.min.js"></script>
```


**What is the new behavior (if this is a feature change)?**
Correct script paths in plnkrs for examples with deps.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**
You can see it in action is the examples [here][1] (which depend on `ngAnimate`).

[1]: https://docs.angularjs.org/guide/animations