### PR TITLE
feat(ngMocks): add $httpBackend.whenOverride method

### DIFF
--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1084,6 +1084,16 @@ describe('ngMock', function() {
     });
 
 
+    it('should provide "whenOverride" methods for each HTTP verb', function() {
+      expect(typeof hb.whenOverrideGET).toBe('function');
+      expect(typeof hb.whenOverridePOST).toBe('function');
+      expect(typeof hb.whenOverridePUT).toBe('function');
+      expect(typeof hb.whenOverridePATCH).toBe('function');
+      expect(typeof hb.whenOverrideDELETE).toBe('function');
+      expect(typeof hb.whenOverrideHEAD).toBe('function');
+    });
+
+
     it('should provide "route" shortcuts for expect and when', function() {
       expect(typeof hb.whenRoute).toBe('function');
       expect(typeof hb.expectRoute).toBe('function');
@@ -1097,6 +1107,22 @@ describe('ngMock', function() {
       callback.and.callFake(function(status, response) {
         expect(status).toBe(200);
         expect(response).toBe('content');
+      });
+
+      hb('GET', '/url1', null, callback);
+      expect(callback).not.toHaveBeenCalled();
+      hb.flush();
+      expect(callback).toHaveBeenCalledOnce();
+    });
+
+
+    it('should match against whenOverride() handlers before normal when() handlers', function() {
+      hb.when('GET', '/url1').respond(200, 'content', {});
+      hb.whenOverride('GET', '/url1').respond(201, 'another', {});
+
+      callback.and.callFake(function(status, response) {
+        expect(status).toBe(201);
+        expect(response).toBe('another');
       });
 
       hb('GET', '/url1', null, callback);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature


**What is the current behavior? (You can also link to an open issue here)**
As discussed in https://github.com/angular/angular.js/issues/11637 currently `$httpBackend.when` adds new definitions to the end of the list, making it hard to override any existing definitions.


**What is the new behavior (if this is a feature change)?**
This PR adds a new method `$httpBackend.whenOverride` and its short methods (`whenOverrideGET` etc.) that work almost exactly like `$httpBackend.when`, but they add definition the the beginning of the list, allowing to override the existing definitions.


**Does this PR introduce a breaking change?**
Nope.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Other information**:
I'm not sure if I should simply copy docs for `$httpBackend.when` method and all the "short" methods (e.g. `$httpBackend.whenGET` etc.) or if I should somehow modify/simplify them.

CC @petebacondarwin 