### PR TITLE
feat($parse): enable optional access to the underlying AST

### DIFF
--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -4245,4 +4245,48 @@ describe('parser', function() {
       });
     });
   });
+
+  describe('hidden/unsupported features', function() {
+    describe('$$getAst()', function() {
+      it('should be a method exposed on the `$parse` service', inject(function($parse) {
+        expect(isFunction($parse.$$getAst)).toBeTruthy();
+      }));
+
+      it('should accept a string expression argument and return the corresponding AST', inject(function($parse) {
+        var ast = $parse.$$getAst('foo.bar');
+        expect(ast).toEqual({
+          type: 'Program',
+          body: [
+            {
+              type: 'ExpressionStatement',
+              expression: {
+                type: 'MemberExpression',
+                object: { type: 'Identifier', name: 'foo' },
+                property: { type: 'Identifier', name: 'bar' },
+                computed: false
+              }
+            }
+          ]
+        });
+      }));
+
+      it('should parse one time binding expressions', inject(function($parse) {
+        var ast = $parse.$$getAst('::foo.bar');
+        expect(ast).toEqual({
+          type: 'Program',
+          body: [
+            {
+              type: 'ExpressionStatement',
+              expression: {
+                type: 'MemberExpression',
+                object: { type: 'Identifier', name: 'foo' },
+                property: { type: 'Identifier', name: 'bar' },
+                computed: false
+              }
+            }
+          ]
+        });
+      }));
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a new private method to the `$parse` service, `$$getAst`,
which takes an Angular expression as its only argument and returns
the computed AST. This feature is not meant to be part of the public
API and might be subject to changes, so use it with caution.

Closes #16253

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature.

**What is the current behavior? (You can also link to an open issue here)**
https://github.com/angular/angular.js/issues/16253


**What is the new behavior (if this is a feature change)?**
The new opt-in behavior introduces a way to expose the ast.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
