### PR TITLE
chore($resource): remove obsolete API

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -841,11 +841,6 @@ angular.module('ngResource', ['ng']).
           };
         });
 
-        Resource.bind = function(additionalParamDefaults) {
-          var extendedParamDefaults = extend({}, paramDefaults, additionalParamDefaults);
-          return resourceFactory(url, extendedParamDefaults, actions, options);
-        };
-
         return Resource;
       }
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -728,30 +728,6 @@ describe('basic usage', function() {
   });
 
 
-  it('should bind default parameters', function() {
-    $httpBackend.expect('GET', '/CreditCard/123.visa?minimum=0.05').respond({id: 123});
-    var Visa = CreditCard.bind({verb: '.visa', minimum: 0.05});
-    var visa = Visa.get({id: 123});
-    $httpBackend.flush();
-    expect(visa).toEqualData({id: 123});
-  });
-
-
-  it('should pass all original arguments when binding default params', function() {
-    $httpBackend.expect('GET', '/CancellableCreditCard/123.visa').respond({id: 123});
-
-    var CancellableCreditCard = $resource('/CancellableCreditCard/:id:verb', {},
-                                          {charge: {method: 'POST'}}, {cancellable: true});
-    var CancellableVisa = CancellableCreditCard.bind({verb: '.visa'});
-    var visa = CancellableVisa.get({id: 123});
-
-    $httpBackend.flush();
-
-    expect(visa.$charge).toEqual(jasmine.any(Function));
-    expect(visa.$cancelRequest).toEqual(jasmine.any(Function));
-  });
-
-
   it('should support dynamic default parameters (global)', function() {
     var currentGroup = 'students',
         Person = $resource('/Person/:group/:id', { group: function() { return currentGroup; }});


### PR DESCRIPTION
This code has been in the $resource service since 2010, but was
never documented and can therefore be removed. It'll save precious bytes!

Shout-out to @gkalpak for finding this.

Technically, we don't have to remove it, but it doesn't make sense to keep it in the repository either. It leads to devs fixing bugs in undocumented APIs: https://github.com/angular/angular.js/commit/6eb4ffc085cc0fde19cbac2c3da227ff47d71e4e ;)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
obsolete code removal

**Does this PR introduce a breaking change?**
No 😛 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been removed
- ~ [ ] Docs have been added / updated (for bug fixes / features) ~

**Other information**:

