### PR TITLE
fix(input[text]): composing function dosen't works properly in IE

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1248,6 +1248,16 @@ function baseInputType(scope, element, attr, ctrl, $sniffer, $browser) {
       composing = true;
     });
 
+    // Support: IE9+
+    element.on('compositionupdate', function(ev) {
+      // End composition when ev.data is empty string on 'compositionupdate' event.
+      // When the input de-focusses (e.g. by clicking away), IE triggers 'compositionupdate'
+      // instead of 'compositionend'.
+      if (isUndefined(ev.data) || ev.data === '') {
+        composing = false;
+      }
+    });
+
     element.on('compositionend', function() {
       composing = false;
       listener();

--- a/src/ngMock/browserTrigger.js
+++ b/src/ngMock/browserTrigger.js
@@ -132,6 +132,24 @@
       evnt.keyCode = eventData.keyCode;
       evnt.charCode = eventData.charCode;
       evnt.which = eventData.which;
+    } else if (/composition/.test(eventType)) {
+      try {
+        evnt = new window.CompositionEvent(eventType, {
+          data: eventData.data
+        });
+      } catch (e) {
+        // Support: IE9+
+        evnt = window.document.createEvent('CompositionEvent', {});
+        evnt.initCompositionEvent(
+          eventType,
+          eventData.bubbles,
+          eventData.cancelable,
+          window,
+          eventData.data,
+          null
+        );
+      }
+
     } else {
       evnt = window.document.createEvent('MouseEvents');
       x = x || 0;

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -134,6 +134,20 @@ describe('input', function() {
       browserTrigger(inputElm, 'compositionend');
       expect($rootScope.name).toEqual('caitp');
     });
+
+
+    it('should end composition on "compositionupdate" when event.data is ""', function() {
+      // This tests a bug workaround for IE9-11
+      // During composition, when an input is de-focussed by clicking away from it,
+      // the compositionupdate event is called with '', followed by a change event.
+      var inputElm = helper.compileInput('<input type="text" ng-model="name" name="alias" />');
+      browserTrigger(inputElm, 'compositionstart');
+      helper.changeInputValueTo('caitp');
+      expect($rootScope.name).toBeUndefined();
+      browserTrigger(inputElm, 'compositionupdate', {data: ''});
+      browserTrigger(inputElm, 'change');
+      expect($rootScope.name).toEqual('caitp');
+    });
   });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

Composing function dosen't works properly in IE. Please refer to https://github.com/angular/angular.js/issues/6656 and "Other information" below.

**What is the new behavior (if this is a feature change)?**

It works properly in IE.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

I have investigated on #6656 issue and I found composing function works differently in only IE.
I confirmed this by the scenario below.
 - Code changes to investigate this problem(just added console.log)
    ![2017-10-12 17_53_02-engineering-system - c__users_jileeon_documents_git_engineering-system - _p](https://user-images.githubusercontent.com/5166067/31534128-7aac2cba-b030-11e7-8fb6-5a4754dcb0ed.png)
 - Scenario
  1. Just type '이재익' and focusout.(in IE and Chrome)
 - Result(attached images show differences)
   console.log in Chrome
    ![2017-10-12 18_57_52-developer tools - http___127 0 0 1_8888_system_requests_2279](https://user-images.githubusercontent.com/5166067/31534418-ccd3e2d4-b031-11e7-980e-009b635d0bba.png)
   console.log in IE
    ![2017-10-12 18_58_43-f12](https://user-images.githubusercontent.com/5166067/31534528-39585bba-b032-11e7-9486-34f9f479b6e9.png)
   It shows that last values of $viewValue are different. '이재이'(IE) != '이재익'(Chrome)
   Because 'compositionend' event is not occurred in IE. So $viewValue is not updated with last value in the textbox. It means that IE triggers composition events('compositionstart', 'compositionupdate', 'compositionend') wrong.
   So I added additional condition(ev.originalEvent.data !== undefined) on 'if (composing) return;' statement.
   As you saw these console logs(IE and Chrome) above, this additional condition makes composing function works properly in IE.(by checking ev.originalEvent.data value. if its value is undefined, $viewValue going to be updated with last value in the textbox in IE. So it works like 'compositionend').
   In addition, When IE fixes this wrong event triggering, It works fine without any problems. 