### PR TITLE
fix($rootScope): deallocate $$listeners array when empty

### DIFF
--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -955,7 +955,6 @@ function $RootScopeProvider() {
         // Disable listeners, watchers and apply/digest methods
         this.$destroy = this.$digest = this.$apply = this.$evalAsync = this.$applyAsync = noop;
         this.$on = this.$watch = this.$watchGroup = function() { return noop; };
-        this.$$listeners = {};
 
         // Disconnect the next sibling to prevent `cleanUpScope` destroying those too
         this.$$nextSibling = null;
@@ -1364,6 +1363,7 @@ function $RootScopeProvider() {
 
         if (current.$$listenerCount[name] === 0) {
           delete current.$$listenerCount[name];
+          delete current.$$listeners[name];
         }
       } while ((current = current.$parent));
     }

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -2562,6 +2562,26 @@ describe('Scope', function() {
             expect(secondListener).not.toHaveBeenCalled();
           });
         });
+
+
+        it('should deallocate the $$listenerCount entry when reaching 0', inject(function($rootScope) {
+          var child = $rootScope.$new();
+
+          child.$on('abc', noop)();
+
+          expect('abc' in $rootScope.$$listenerCount).toBe(false);
+          expect('abc' in child.$$listenerCount).toBe(false);
+        }));
+
+
+        it('should deallocate the $$listeners entry when empty', inject(function($rootScope) {
+          var child = $rootScope.$new();
+
+          child.$on('abc', noop)();
+
+          expect('abc' in $rootScope.$$listeners).toBe(false);
+          expect('abc' in child.$$listeners).toBe(false);
+        }));
       });
     });
 


### PR DESCRIPTION
I think making `$$listenerCount[name]` and `$$listeners[name]` behave the same makes sense. Today the `$$listeners` array might also grow and never be cleaned up unless an event is fired (#16135), however if there are [no listeners](https://github.com/angular/angular.js/blob/v1.6.6/src/ng/rootScope.js#L840) then even firing an event won't clean it up, but this will in that case.