### PR TITLE
feat(errorHandlingConfig): add an option not to encode stack in URL

### DIFF
--- a/src/minErr.js
+++ b/src/minErr.js
@@ -7,7 +7,8 @@
 */
 
 var minErrConfig = {
-  objectMaxDepth: 5
+  objectMaxDepth: 5,
+  isUrlParameters:true
 };
 
 /**
@@ -30,11 +31,16 @@ var minErrConfig = {
  * * `objectMaxDepth`  **{Number}** - The max depth for stringifying objects. Setting to a
  *   non-positive or non-numeric value, removes the max depth limit.
  *   Default: 5
+ * * `isUrlParameters`  **{Boolean}** - Specifies wether the generated url error will contain the paramters or not.
+ *   Default: true
  */
 function errorHandlingConfig(config) {
   if (isObject(config)) {
     if (isDefined(config.objectMaxDepth)) {
       minErrConfig.objectMaxDepth = isValidObjectMaxDepth(config.objectMaxDepth) ? config.objectMaxDepth : NaN;
+    }
+    if (isDefined(config.isUrlParameters) && isBoolean(config.isUrlParameters)) {
+      minErrConfig.isUrlParameters =   config.isUrlParameters;
     }
   } else {
     return minErrConfig;
@@ -49,6 +55,7 @@ function errorHandlingConfig(config) {
 function isValidObjectMaxDepth(maxDepth) {
   return isNumber(maxDepth) && maxDepth > 0;
 }
+
 
 /**
  * @description
@@ -103,9 +110,10 @@ function minErr(module, ErrorConstructor) {
 
     message += '\nhttp://errors.angularjs.org/"NG_VERSION_FULL"/' +
       (module ? module + '/' : '') + code;
-
-    for (i = 0, paramPrefix = '?'; i < templateArgs.length; i++, paramPrefix = '&') {
-      message += paramPrefix + 'p' + i + '=' + encodeURIComponent(templateArgs[i]);
+    if (minErrConfig.isUrlParameters) {
+      for (i = 0, paramPrefix = '?'; i < templateArgs.length; i++, paramPrefix = '&') {
+        message += paramPrefix + 'p' + i + '=' + encodeURIComponent(templateArgs[i]);
+      }
     }
 
     return new ErrorConstructor(message);

--- a/test/minErrSpec.js
+++ b/test/minErrSpec.js
@@ -2,32 +2,53 @@
 
 describe('errors', function() {
   var originalObjectMaxDepthInErrorMessage = minErrConfig.objectMaxDepth;
-
+  var originalIsUrlParameters =  minErrConfig.isUrlParameters;
   afterEach(function() {
     minErrConfig.objectMaxDepth = originalObjectMaxDepthInErrorMessage;
+    minErrConfig.isUrlParameters = originalIsUrlParameters;
   });
 
   describe('errorHandlingConfig', function() {
-    it('should get default objectMaxDepth', function() {
-      expect(errorHandlingConfig().objectMaxDepth).toBe(5);
+    describe('objectMaxDepth',function() {
+      it('should get default objectMaxDepth', function() {
+        expect(errorHandlingConfig().objectMaxDepth).toBe(5);
+      });
+
+      it('should set objectMaxDepth', function() {
+        errorHandlingConfig({objectMaxDepth: 3});
+        expect(errorHandlingConfig().objectMaxDepth).toBe(3);
+      });
+
+      it('should not change objectMaxDepth when undefined is supplied', function() {
+        errorHandlingConfig({objectMaxDepth: undefined});
+        expect(errorHandlingConfig().objectMaxDepth).toBe(originalObjectMaxDepthInErrorMessage);
+      });
+
+      they('should set objectMaxDepth to NaN when $prop is supplied',
+          [NaN, null, true, false, -1, 0], function(maxDepth) {
+            errorHandlingConfig({objectMaxDepth: maxDepth});
+            expect(errorHandlingConfig().objectMaxDepth).toBeNaN();
+          }
+      );
     });
 
-    it('should set objectMaxDepth', function() {
-      errorHandlingConfig({objectMaxDepth: 3});
-      expect(errorHandlingConfig().objectMaxDepth).toBe(3);
+
+    describe('isUrlParameters',function() {
+      it('should get default isUrlParameters', function() {
+        expect(errorHandlingConfig().isUrlParameters).toBe(true);
+      });
+      it('should set isUrlParameters', function() {
+        errorHandlingConfig({isUrlParameters:false});
+        expect(errorHandlingConfig().isUrlParameters).toBe(false);
+        errorHandlingConfig({isUrlParameters:true});
+        expect(errorHandlingConfig().isUrlParameters).toBe(true);
+      });
+      it('should not change its value when non-boolean is supplied', function() {
+        errorHandlingConfig({isUrlParameters:123});
+        expect(errorHandlingConfig().isUrlParameters).toBe(originalIsUrlParameters);
+      });
     });
 
-    it('should not change objectMaxDepth when undefined is supplied', function() {
-      errorHandlingConfig({objectMaxDepth: undefined});
-      expect(errorHandlingConfig().objectMaxDepth).toBe(originalObjectMaxDepthInErrorMessage);
-    });
-
-    they('should set objectMaxDepth to NaN when $prop is supplied',
-        [NaN, null, true, false, -1, 0], function(maxDepth) {
-          errorHandlingConfig({objectMaxDepth: maxDepth});
-          expect(errorHandlingConfig().objectMaxDepth).toBeNaN();
-        }
-    );
   });
 
   describe('minErr', function() {
@@ -164,5 +185,13 @@ describe('errors', function() {
       expect(testError('acode', 'aproblem', 'a', 'b', 'value with space').message)
         .toMatch(/^[\s\S]*\?p0=a&p1=b&p2=value%20with%20space$/);
     });
+
+    it('should not generate URL query parameters when isUrlParameters is  false', function() {
+
+      errorHandlingConfig({isUrlParameters:false});
+      expect(testError('acode', 'aproblem', 'a', 'b', 'c').message)
+        .not.toContain('?p0=a&p1=b&p2=c');
+    });
+
   });
 });


### PR DESCRIPTION




**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature

**What is the current behavior? (You can also link to an open issue here)**

When there is an error in loading a module then all modules that are dependent will fail also in
loading. The throwed error contains the URL for each error. The URL contains encoded stack which leads sometimes to long URL.

**What is the new behavior (if this is a feature change)?**
Adding an option so that the generated URL contains only the erorr code which is informative enough
to find out the problem. closes #14744.


**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

