### PR TITLE
chore(doc-gen, docs-app): generate version for stable snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,9 @@ notifications:
 jobs:
   include:
     - stage: deploy
+      # Don't deploy from PRs.
+      # The deployment logic for pushed branches is defined in scripts\travis\build.sh
+      if: type != pull_request
       env:
         - JOB=deploy
       before_script: skip
@@ -75,8 +78,7 @@ jobs:
           on:
             repo: angular/angular.js
             all_branches: true
-            # deploy a new docs version when the commit is tagged on the "latest" npm version
-            condition: $TRAVIS_TAG != '' && $( jq ".distTag" "package.json" | tr -d "\"[:space:]" ) = latest
+            condition: $DEPLOY_DOCS
         - provider: gcs
           skip_cleanup: true
           access_key_id: GOOGLDB7W2J3LFHICF3R
@@ -88,6 +90,5 @@ jobs:
           on:
             repo: angular/angular.js
             all_branches: true
-            # upload the build when the commit is tagged or the branch is "master"
-            condition: $TRAVIS_TAG != '' || ($TRAVIS_PULL_REQUEST = false && $TRAVIS_BRANCH = master)
+            condition: $DEPLOY_CODE
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,7 +63,11 @@ module.exports = function(grunt) {
   NG_VERSION.cdn = versionInfo.cdnVersion;
   var dist = 'angular-' + NG_VERSION.full;
 
-  var deployVersion = NG_VERSION.isSnapshot ? 'snapshot' : NG_VERSION.full;
+  var deployVersion = NG_VERSION.full;
+
+  if (NG_VERSION.isSnapshot) {
+    deployVersion = NG_VERSION.distTag === 'latest' ? 'snapshot-stable' : 'snapshot';
+  }
 
   if (versionInfo.cdnVersion == null) {
     throw new Error('Unable to read CDN version, are you offline or has the CDN not been properly pushed?\n' +

--- a/docs/app/src/versions.js
+++ b/docs/app/src/versions.js
@@ -12,10 +12,16 @@ angular.module('versions', ['currentVersionData', 'allVersionsData'])
             /** @this VersionPickerController */
             function VersionPickerController($location, $window, CURRENT_NG_VERSION, ALL_NG_VERSIONS) {
 
-      var versionStr = CURRENT_NG_VERSION.isSnapshot ? 'snapshot' : CURRENT_NG_VERSION.version;
+      var versionStr = CURRENT_NG_VERSION.version;
+
+      if (CURRENT_NG_VERSION.isSnapshot) {
+        versionStr = CURRENT_NG_VERSION.distTag === 'latest' ? 'snapshot-stable' : 'snapshot';
+      }
 
       this.versions  = ALL_NG_VERSIONS;
-      this.selectedVersion = find(ALL_NG_VERSIONS, function(value) { return value.version.version === versionStr; });
+      this.selectedVersion = find(ALL_NG_VERSIONS, function(value) {
+        return value.version.version === versionStr;
+      });
 
       this.jumpToDocsVersion = function(value) {
         var currentPagePath = $location.path().replace(/\/$/, '');

--- a/lib/versions/version-info.js
+++ b/lib/versions/version-info.js
@@ -210,6 +210,7 @@ var getSnapshotVersion = function() {
   version.format();
   version.full = version.version + '+' + version.build;
   version.branch = 'master';
+  version.distTag = currentPackage.distTag;
 
   return version;
 };

--- a/scripts/code.angularjs.org-firebase/readme.firebase.code.md
+++ b/scripts/code.angularjs.org-firebase/readme.firebase.code.md
@@ -6,6 +6,9 @@ This folder contains the Google Firebase scripts for the code.angularjs.org setu
 firebase.json contains the rewrite rules that route every subdirectory request to the cloud function
 in functions/index.js that serves the docs from the Firebase Google Cloud Storage bucket.
 
+functions/index.js also contains a rule that deletes outdated build zip files
+from the snapshot and snapshot-stable folders when new zip files are uploaded.
+
 The deployment to the Google Cloud Storage bucket happens automatically via Travis. See the travis.yml
 file in the repository root.
 


### PR DESCRIPTION
The "stable snapshot" is based on the latest commit on the current stable
branch, i.e. a preview of the next patch version.

Next thing:
- update the Firebase deployment so that on the branch with distTag = latest gets deployed to docs.angularjs.org and as to gcs as snapshot-stable


