### PR TITLE
fix($rootScope): fix potential memory leak when removing scope listeners (v2)

### DIFF
--- a/docs/content/error/$rootScope/inevt.ngdoc
+++ b/docs/content/error/$rootScope/inevt.ngdoc
@@ -1,0 +1,22 @@
+@ngdoc error
+@name $rootScope:inevt
+@fullName Recursive $emit/$broadcast event
+@description
+
+This error occurs when the an event is `$emit`ed or `$broadcast`ed recursively on a scope.
+
+For example, when an event listener fires the same event being listened to.
+
+```
+$scope.$on('foo', function() {
+    $scope.$emit('foo');
+});
+```
+
+Or when a parent element causes indirect recursion.
+
+```
+$scope.$on('foo', function() {
+    $rootScope.$broadcast('foo');
+});
+```


### PR DESCRIPTION
This is the alternative to #16161 that we discussed.

This simplifies the listener cleanup and avoids creating sparse listener arrays (unlike #16161) but introduces a new restriction that disallows recursive event $broadcast/$emit-ing.  We could remove this restriction but it would complicate everything event related by requiring a stack for the index.