### PR TITLE
docs(tutorial/14 - Animations): replace broken web platform docs link

### DIFF
--- a/docs/content/tutorial/step_14.ngdoc
+++ b/docs/content/tutorial/step_14.ngdoc
@@ -328,7 +328,7 @@ The applied CSS classes are much the same as with `ngRepeat`. Each time a new pa
 ensures that all views are contained within a single HTML element, which allows for easy animation
 control.
 
-For more on CSS animations, see the [Web Platform documentation][webplatform-animations].
+For more on CSS animations, see the [MDN web docs][mdn-animations].
 
 
 ## Animating `ngClass` with JavaScript
@@ -561,4 +561,4 @@ There you have it! We have created a web application in a relatively short amoun
 [caniuse-css-transitions]: http://caniuse.com/#feat=css-transitions
 [jquery]: https://jquery.com/
 [jquery-animate]: https://api.jquery.com/animate/
-[webplatform-animations]: https://docs.webplatform.org/wiki/css/properties/animations
+[mdn-animations]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update


**What is the current behavior? (You can also link to an open issue here)**
The Web Platform documentation link is broken (https://github.com/angular/angular.js/blob/master/docs/content/tutorial/step_14.ngdoc#L331). 
It returns a 404.


**What is the new behavior (if this is a feature change)?**
Replace broken link [webplatform-animations]: 
https://docs.webplatform.org/wiki/css/properties/animations 
with [mdn-animations]: 
https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations

Since the WebPlatform project has been discontinued, replace it with the MDN web docs.

**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Other information**:
The closest match that works is https://webplatform.github.io/docs/css/properties/animation. However, the notice at the top of the page reads, "The WebPlatform project, supported by various stewards between 2012 and 2015, has been discontinued."

The CSS animations guide on MDN web docs is not only current, but also more comprehensive.

