### PR TITLE
fix(sanitizeUri): sanitize URIs that contain IDEOGRAPHIC SPACE chars

### DIFF
--- a/src/ng/sanitizeUri.js
+++ b/src/ng/sanitizeUri.js
@@ -62,7 +62,7 @@ function $$SanitizeUriProvider() {
     return function sanitizeUri(uri, isImage) {
       var regex = isImage ? imgSrcSanitizationWhitelist : aHrefSanitizationWhitelist;
       var normalizedVal;
-      normalizedVal = urlResolve(uri).href;
+      normalizedVal = urlResolve(uri && uri.trim()).href;
       if (normalizedVal !== '' && !normalizedVal.match(regex)) {
         return 'unsafe:' + normalizedVal;
       }

--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -237,11 +237,9 @@ describe('HTML', function() {
       .toEqual('');
   });
 
-  if (isChrome) {
-    it('should prevent mXSS attacks', function() {
-      expectHTML('<a href="&#x3000;javascript:alert(1)">CLICKME</a>').toBe('<a>CLICKME</a>');
-    });
-  }
+  it('should prevent mXSS attacks', function() {
+    expectHTML('<a href="&#x3000;javascript:alert(1)">CLICKME</a>').toBe('<a>CLICKME</a>');
+  });
 
   it('should strip html comments', function() {
     expectHTML('<!-- comment 1 --><p>text1<!-- comment 2 -->text2</p><!-- comment 3 -->')


### PR DESCRIPTION
Chrome 62 was not sanitizing dangerous URLs containing
JavaScript, if they started with these "whitespace" characters.

Closes #16288

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

fix

**What is the current behavior? (You can also link to an open issue here)**

#16288

**What is the new behavior (if this is a feature change)?**

URIs are sanitized correctly on Chrome 62

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

