### PR TITLE
docs(guide/Unit Testing): Changed $scope = {} to $scope = $rootScope.…

### DIFF
--- a/docs/content/guide/unit-testing.ngdoc
+++ b/docs/content/guide/unit-testing.ngdoc
@@ -149,16 +149,17 @@ for instantiating controllers.
 describe('PasswordController', function() {
   beforeEach(module('app'));
 
-  var $controller;
+  var $controller, $rootScope;
 
-  beforeEach(inject(function(_$controller_){
+  beforeEach(inject(function(_$controller_, _$rootScope_){
     // The injector unwraps the underscores (_) from around the parameter names when matching
     $controller = _$controller_;
+    $rootScope = _$rootScope_;
   }));
 
   describe('$scope.grade', function() {
     it('sets the strength to "strong" if the password length is >8 chars', function() {
-      var $scope = {};
+      var $scope = $rootScope.$new();
       var controller = $controller('PasswordController', { $scope: $scope });
       $scope.password = 'longerthaneightchars';
       $scope.grade();


### PR DESCRIPTION
…$new()

{} will just create an empty object. This will break if the module uses for example $watch or others.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

