### PR TITLE
fix(input[number]): validate min/max against viewValue

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1604,8 +1604,8 @@ function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   var maxVal;
 
   if (isDefined(attr.min) || attr.ngMin) {
-    ctrl.$validators.min = function(value) {
-      return ctrl.$isEmpty(value) || isUndefined(minVal) || value >= minVal;
+    ctrl.$validators.min = function(modelValue, viewValue) {
+      return ctrl.$isEmpty(viewValue) || isUndefined(minVal) || viewValue >= minVal;
     };
 
     attr.$observe('min', function(val) {
@@ -1616,8 +1616,8 @@ function numberInputType(scope, element, attr, ctrl, $sniffer, $browser) {
   }
 
   if (isDefined(attr.max) || attr.ngMax) {
-    ctrl.$validators.max = function(value) {
-      return ctrl.$isEmpty(value) || isUndefined(maxVal) || value <= maxVal;
+    ctrl.$validators.max = function(modelValue, viewValue) {
+      return ctrl.$isEmpty(viewValue) || isUndefined(maxVal) || viewValue <= maxVal;
     };
 
     attr.$observe('max', function(val) {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2284,6 +2284,15 @@ describe('input', function() {
 
   describe('number', function() {
 
+    // Helpers for min / max tests
+    var subtract = function(value) {
+      return value - 5;
+    };
+
+    var add = function(value) {
+      return value + 5;
+    };
+
     it('should reset the model if view is invalid', function() {
       var inputElm = helper.compileInput('<input type="number" ng-model="age"/>');
 
@@ -2465,6 +2474,29 @@ describe('input', function() {
         expect($rootScope.form.alias.$error.min).toBeFalsy();
       });
 
+
+      it('should validate against the viewValue', function() {
+        var inputElm = helper.compileInput(
+          '<input type="number" ng-model-options="{allowInvalid: true}" ng-model="value" name="alias" min="10" />');
+
+        var ngModelCtrl = inputElm.controller('ngModel');
+        ngModelCtrl.$parsers.push(subtract);
+
+        helper.changeInputValueTo('10');
+        expect(inputElm).toBeValid();
+        expect($rootScope.value).toBe(5);
+        expect($rootScope.form.alias.$error.min).toBeFalsy();
+
+        ngModelCtrl.$parsers.pop();
+        ngModelCtrl.$parsers.push(add);
+
+        helper.changeInputValueTo('5');
+        expect(inputElm).toBeInvalid();
+        expect($rootScope.form.alias.$error.min).toBeTruthy();
+        expect($rootScope.value).toBe(10);
+      });
+
+
       it('should validate even if min value changes on-the-fly', function() {
         $rootScope.min = undefined;
         var inputElm = helper.compileInput('<input type="number" ng-model="value" name="alias" min="{{min}}" />');
@@ -2510,6 +2542,28 @@ describe('input', function() {
         expect($rootScope.value).toBe(100);
         expect($rootScope.form.alias.$error.min).toBeFalsy();
       });
+
+
+      it('should validate against the viewValue', function() {
+        var inputElm = helper.compileInput(
+          '<input type="number" ng-model-options="{allowInvalid: true}" ng-model="value" name="alias" ng-min="10" />');
+        var ngModelCtrl = inputElm.controller('ngModel');
+        ngModelCtrl.$parsers.push(subtract);
+
+        helper.changeInputValueTo('10');
+        expect(inputElm).toBeValid();
+        expect($rootScope.value).toBe(5);
+        expect($rootScope.form.alias.$error.min).toBeFalsy();
+
+        ngModelCtrl.$parsers.pop();
+        ngModelCtrl.$parsers.push(add);
+
+        helper.changeInputValueTo('5');
+        expect(inputElm).toBeInvalid();
+        expect($rootScope.form.alias.$error.min).toBeTruthy();
+        expect($rootScope.value).toBe(10);
+      });
+
 
       it('should validate even if the ngMin value changes on-the-fly', function() {
         $rootScope.min = undefined;
@@ -2558,6 +2612,28 @@ describe('input', function() {
         expect($rootScope.form.alias.$error.max).toBeFalsy();
       });
 
+
+      it('should validate against the viewValue', function() {
+        var inputElm = helper.compileInput('<input type="number"' +
+          'ng-model-options="{allowInvalid: true}" ng-model="value" name="alias" max="10" />');
+        var ngModelCtrl = inputElm.controller('ngModel');
+        ngModelCtrl.$parsers.push(add);
+
+        helper.changeInputValueTo('10');
+        expect(inputElm).toBeValid();
+        expect($rootScope.value).toBe(15);
+        expect($rootScope.form.alias.$error.max).toBeFalsy();
+
+        ngModelCtrl.$parsers.pop();
+        ngModelCtrl.$parsers.push(subtract);
+
+        helper.changeInputValueTo('15');
+        expect(inputElm).toBeInvalid();
+        expect($rootScope.form.alias.$error.max).toBeTruthy();
+        expect($rootScope.value).toBe(10);
+      });
+
+
       it('should validate even if max value changes on-the-fly', function() {
         $rootScope.max = undefined;
         var inputElm = helper.compileInput('<input type="number" ng-model="value" name="alias" max="{{max}}" />');
@@ -2603,6 +2679,28 @@ describe('input', function() {
         expect($rootScope.value).toBe(0);
         expect($rootScope.form.alias.$error.max).toBeFalsy();
       });
+
+
+      it('should validate against the viewValue', function() {
+        var inputElm = helper.compileInput('<input type="number"' +
+          'ng-model-options="{allowInvalid: true}" ng-model="value" name="alias" ng-max="10" />');
+        var ngModelCtrl = inputElm.controller('ngModel');
+        ngModelCtrl.$parsers.push(add);
+
+        helper.changeInputValueTo('10');
+        expect(inputElm).toBeValid();
+        expect($rootScope.value).toBe(15);
+        expect($rootScope.form.alias.$error.max).toBeFalsy();
+
+        ngModelCtrl.$parsers.pop();
+        ngModelCtrl.$parsers.push(subtract);
+
+        helper.changeInputValueTo('15');
+        expect(inputElm).toBeInvalid();
+        expect($rootScope.form.alias.$error.max).toBeTruthy();
+        expect($rootScope.value).toBe(10);
+      });
+
 
       it('should validate even if the ngMax value changes on-the-fly', function() {
         $rootScope.max = undefined;


### PR DESCRIPTION
This brings the validation in line with HTML5 validation and all other
validators.

Fixes #12761

BREAKING CHANGE

....

<!-- General PR submission guidelines https://github.com/angular/angular.js/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix / normalization


**What is the current behavior? (You can also link to an open issue here)**
See #12761


**What is the new behavior (if this is a feature change)?**
validation of min / max against viewValue


**Does this PR introduce a breaking change?**
Yes


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](../DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](../DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

I believe the BC is moderate enough to be included in 1.7

To switch the validation to the modelValue, it's as easy as adding this into a directive:

```
var minValidator = ngModelCtrl.$validators.max;

        ngModelCtrl.$validators.max = function(modelValue, viewValue) {
          return minValidator(modelValue, modelValue);
        };
```

I could even publish this is as a configurable third party directive that allows you to do this for any validator.


