### PR TITLE
docs(linky): mark "target" param as optional in linky filter

### DIFF
--- a/src/ngSanitize/filter/linky.js
+++ b/src/ngSanitize/filter/linky.js
@@ -12,7 +12,7 @@
  * Requires the {@link ngSanitize `ngSanitize`} module to be installed.
  *
  * @param {string} text Input text.
- * @param {string} target Window (`_blank|_self|_parent|_top`) or named frame to open links in.
+ * @param {string} [target] Window (`_blank|_self|_parent|_top`) or named frame to open links in.
  * @param {object|function(url)} [attributes] Add custom attributes to the link element.
  *
  *    Can be one of:


### PR DESCRIPTION
This argument is optional in practice, and it is not provided in many of the examples in the documentation.
Its optional presence is handled here:
https://github.com/angular/angular.js/blob/master/src/ngSanitize/filter/linky.js#L185.

<!-- General PR submission guidelines https://github.com/angular/angular.js/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs update


**What is the current behavior? (You can also link to an open issue here)**
The second argument to ngSanitize's "linky" filter is marked as non-optional, it is handled as optional and usage shows it as being optional.


**What is the new behavior (if this is a feature change)?**
ngSanitize's "linky" filter has it's second parameter marked as optional.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](../DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](../DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

