### PR TITLE
fix(input): allow overriding timezone for date input types

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -79,6 +79,7 @@
     "toJsonReplacer": false,
     "toJson": false,
     "fromJson": false,
+    "addDateMinutes": false,
     "convertTimezoneToLocal": false,
     "timezoneToOffset": false,
     "startingTag": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -75,6 +75,7 @@
   fromJson,
   convertTimezoneToLocal,
   timezoneToOffset,
+  addDateMinutes,
   startingTag,
   tryDecodeURIComponent,
   parseKeyValue,

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1468,11 +1468,13 @@ function createDateInputType(type, regexp, parseDate, format) {
   return function dynamicDateInputType(scope, element, attr, ctrl, $sniffer, $browser, $filter) {
     badInputChecker(scope, element, attr, ctrl, type);
     baseInputType(scope, element, attr, ctrl, $sniffer, $browser);
-    var timezone = ctrl && ctrl.$options.getOption('timezone');
     var previousDate;
 
     ctrl.$parsers.push(function(value) {
-      if (ctrl.$isEmpty(value)) return null;
+      if (ctrl.$isEmpty(value)) {
+        previousDate = null;
+        return null;
+      }
       if (regexp.test(value)) {
         // Note: We cannot read ctrl.$modelValue, as there might be a different
         // parser/formatter in the processing chain so that the model
@@ -1489,6 +1491,7 @@ function createDateInputType(type, regexp, parseDate, format) {
       }
       if (isValidDate(value)) {
         previousDate = value;
+        var timezone = ctrl.$options.getOption('timezone');
         if (previousDate && timezone) {
           previousDate = convertTimezoneToLocal(previousDate, timezone, true);
         }
@@ -1532,6 +1535,8 @@ function createDateInputType(type, regexp, parseDate, format) {
 
     function parseDateAndConvertTimeZoneToLocal(value, previousDate) {
       var parsedDate = parseDate(value, previousDate);
+      var timezone = ctrl.$options.getOption('timezone');
+
       if (!isNaN(parsedDate) && timezone) {
         parsedDate = convertTimezoneToLocal(parsedDate, timezone);
       }

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1535,14 +1535,15 @@ function createDateInputType(type, regexp, parseDate, format) {
     }
 
     function parseDateAndConvertTimeZoneToLocal(value, previousDate) {
-      if (timezone && previousTimezone && previousTimezone !== timezone) {
-        // If the timezone has changed, adjust the previousDate to the default timzeone
+      var timezone = ctrl.$options.getOption('timezone');
+
+      if (previousTimezone && previousTimezone !== timezone) {
+        // If the timezone has changed, adjust the previousDate to the default timezone
         // so that the new date is converted with the correct timezone offset
-        previousDate = addDateMinutes(previousDate, timezoneToOffset(previousTimezone, 0));
+        previousDate = addDateMinutes(previousDate, timezoneToOffset(previousTimezone));
       }
 
       var parsedDate = parseDate(value, previousDate);
-      var timezone = ctrl.$options.getOption('timezone');
 
       if (!isNaN(parsedDate) && timezone) {
         parsedDate = convertTimezoneToLocal(parsedDate, timezone);

--- a/src/ng/directive/ngModelOptions.js
+++ b/src/ng/directive/ngModelOptions.js
@@ -462,6 +462,8 @@ defaultModelOptions = new ModelOptions({
  *     continental US time zone abbreviations, but for general use, use a time zone offset, for
  *     example, `'+0430'` (4 hours, 30 minutes east of the Greenwich meridian)
  *     If not specified, the timezone of the browser will be used.
+ *     Note that changing the timezone will have no effect on the current date, and is only applied after
+ *     the next input / model change.
  *
  */
 var ngModelOptionsDirective = function() {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1022,15 +1022,23 @@ describe('input', function() {
     it('should be possible to override the timezone', function() {
       var inputElm = helper.compileInput('<input type="week" ng-model="value" ng-model-options="{timezone: \'UTC\'}" />');
 
-      helper.changeInputValueTo('2013-W03');
-      expect(+$rootScope.value).toBe(Date.UTC(2013, 0, 17));
-
-      inputElm.controller('ngModel').$overrideModelOptions({timezone: '+5000'});
-
+      // January 19 2013 is a Saturday
       $rootScope.$apply(function() {
-        // the 17. with an offset of +5000 moves the date into next week
-        $rootScope.value = new Date(Date.UTC(2013, 0, 18));
+        $rootScope.value = new Date(Date.UTC(2013, 0, 19));
       });
+
+      expect(inputElm.val()).toBe('2013-W03');
+
+      inputElm.controller('ngModel').$overrideModelOptions({timezone: '+2400'});
+
+      // To check that the timezone overwrite works, apply an offset of +24 hours.
+      // Since January 19 is a Saturday, +24 will turn the formatted Date into January 20 - Sunday -
+      // which is in calendar week 4 instead of 3.
+      $rootScope.$apply(function() {
+        $rootScope.value = new Date(Date.UTC(2013, 0, 19));
+      });
+
+      // Verifying that the displayed week is week 4 confirms that overriding the timezone worked
       expect(inputElm.val()).toBe('2013-W04');
     });
 
@@ -2092,29 +2100,33 @@ describe('input', function() {
       dealoc(formElm);
     });
 
-    it('should not reuse the hour part of a previous date object after changing the timezone', function() {
+    it('should not reuse the hours part of a previous date object after changing the timezone', function() {
       var inputElm = helper.compileInput('<input type="date" ng-model="value" ng-model-options="{timezone: \'UTC\'}" />');
 
       helper.changeInputValueTo('2000-01-01');
+      // The Date parser sets the hours part of the Date to 0 (00:00) (UTC)
       expect(+$rootScope.value).toBe(Date.UTC(2000, 0, 1, 0));
 
       // Change the timezone offset so that the display date is a day earlier
       // This does not change the model, but our implementation
       // internally caches a Date object with this offset
-      // and re-uses it if part of the date changes
+      // and re-uses it if part of the Date changes.
+      // See https://github.com/angular/angular.js/commit/1a1ef62903c8fdf4ceb81277d966a8eff67f0a96
       inputElm.controller('ngModel').$overrideModelOptions({timezone: '-0500'});
       $rootScope.$apply(function() {
         $rootScope.value = new Date(Date.UTC(2000, 0, 1, 0));
       });
       expect(inputElm.val()).toBe('1999-12-31');
 
-      // Emptying the input should clear the cached date object
-      helper.changeInputValueTo('');
-
+      // At this point, the cached Date has its hours set to to 19 (00:00 - 05:00 = 19:00)
       inputElm.controller('ngModel').$overrideModelOptions({timezone: 'UTC'});
+
+      // When changing the timezone back to UTC, the hours part of the Date should be set to
+      // the default 0 (UTC) and not use the modified value of the cached Date object.
       helper.changeInputValueTo('2000-01-01');
       expect(+$rootScope.value).toBe(Date.UTC(2000, 0, 1, 0));
     });
+
 
     describe('min', function() {
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -727,9 +727,9 @@ describe('input', function() {
       inputElm.controller('ngModel').$overrideModelOptions({timezone: '-0500'});
 
       $rootScope.$apply(function() {
-        $rootScope.value = new Date(Date.UTC(2014, 6, 1));
+        $rootScope.value = new Date(Date.UTC(2013, 6, 1));
       });
-      expect(inputElm.val()).toBe('2014-06');
+      expect(inputElm.val()).toBe('2013-06');
     });
 
 
@@ -1028,9 +1028,10 @@ describe('input', function() {
       inputElm.controller('ngModel').$overrideModelOptions({timezone: '+5000'});
 
       $rootScope.$apply(function() {
-        $rootScope.value = new Date(Date.UTC(2014, 0, 17));
+        // the 17. with an offset of +5000 moves the date into next week
+        $rootScope.value = new Date(Date.UTC(2013, 0, 18));
       });
-      expect(inputElm.val()).toBe('2014-W04');
+      expect(inputElm.val()).toBe('2013-W04');
     });
 
 
@@ -2002,7 +2003,7 @@ describe('input', function() {
 
       inputElm.controller('ngModel').$overrideModelOptions({timezone: 'UTC'});
       helper.changeInputValueTo('2000-01-01');
-      expect(+$rootScope.value).toBe(Date.UTC(2000, 0, 1, 19));
+      expect(+$rootScope.value).toBe(Date.UTC(2000, 0, 1, 0));
     });
 
 
@@ -2091,11 +2092,11 @@ describe('input', function() {
       dealoc(formElm);
     });
 
-    it('should not reuse the hour part of a previous date object after emptying the input', function() {
+    it('should not reuse the hour part of a previous date object after changing the timezone', function() {
       var inputElm = helper.compileInput('<input type="date" ng-model="value" ng-model-options="{timezone: \'UTC\'}" />');
 
       helper.changeInputValueTo('2000-01-01');
-      expect(+$rootScope.value).toBe(Date.UTC(2000, 0, 1));
+      expect(+$rootScope.value).toBe(Date.UTC(2000, 0, 1, 0));
 
       // Change the timezone offset so that the display date is a day earlier
       // This does not change the model, but our implementation
@@ -2103,9 +2104,9 @@ describe('input', function() {
       // and re-uses it if part of the date changes
       inputElm.controller('ngModel').$overrideModelOptions({timezone: '-0500'});
       $rootScope.$apply(function() {
-        $rootScope.value = new Date(Date.UTC(2001, 0, 1));
+        $rootScope.value = new Date(Date.UTC(2000, 0, 1, 0));
       });
-      expect(inputElm.val()).toBe('2000-12-31');
+      expect(inputElm.val()).toBe('1999-12-31');
 
       // Emptying the input should clear the cached date object
       helper.changeInputValueTo('');


### PR DESCRIPTION
Fixes #13382
Closes #16181

<!-- General PR submission guidelines https://github.com/angular/angular.js/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
fix


**What is the current behavior? (You can also link to an open issue here)**
See https://github.com/angular/angular.js/issues/16181


**What is the new behavior (if this is a feature change)?**
overrideModelOptions can be used to change the timezone.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](../DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](../DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

