### PR TITLE
docs(ngNonBindable): Document effect on attributes

### DIFF
--- a/src/ng/directive/ngNonBindable.js
+++ b/src/ng/directive/ngNonBindable.js
@@ -9,9 +9,10 @@
  *
  * @description
  * The `ngNonBindable` directive tells AngularJS not to compile or bind the contents of the current
- * DOM element. This is useful if the element contains what appears to be AngularJS directives and
- * bindings but which should be ignored by AngularJS. This could be the case if you have a site that
- * displays snippets of code, for instance.
+ * DOM element (including the attributes of the element itself). This is useful if the element
+ * contains what appears to be AngularJS directives and bindings but which should be ignored by
+ * AngularJS. This could be the case if you have a site that displays snippets of code, for
+ * instance.
  *
  * @example
  * In this example there are two locations where a simple interpolation binding (`{{}}`) is present,

--- a/src/ng/directive/ngNonBindable.js
+++ b/src/ng/directive/ngNonBindable.js
@@ -9,13 +9,10 @@
  *
  * @description
  * The `ngNonBindable` directive tells AngularJS not to compile or bind the contents of the current
- * DOM element.AngularJS will generally ignore each attribute of the element itself. Attributes will
- * *not* be ignored if they are part of a directive that has a higher priority than that of the
- * `ngNonBindable` directive.
- *
- * This is useful if the element contains what appears to be AngularJS directives and bindings but
- * which should be ignored by AngularJS. This could be the case if you have a site that displays
- * snippets of code, for instance.
+ * DOM element, including directives on the element itself that have a lower priority than
+ * `ngNonBindable`. This is useful if the element contains what appears to be AngularJS directives
+ * and bindings but which should be ignored by AngularJS. This could be the case if you have a site
+ * that displays snippets of code, for instance.
  *
  * @example
  * In this example there are two locations where a simple interpolation binding (`{{}}`) is present,

--- a/src/ng/directive/ngNonBindable.js
+++ b/src/ng/directive/ngNonBindable.js
@@ -9,10 +9,13 @@
  *
  * @description
  * The `ngNonBindable` directive tells AngularJS not to compile or bind the contents of the current
- * DOM element (including the attributes of the element itself). This is useful if the element
- * contains what appears to be AngularJS directives and bindings but which should be ignored by
- * AngularJS. This could be the case if you have a site that displays snippets of code, for
- * instance.
+ * DOM element.AngularJS will generally ignore each attribute of the element itself. Attributes will
+ * *not* be ignored if they are part of a directive that has a higher priority than that of the
+ * `ngNonBindable` directive.
+ *
+ * This is useful if the element contains what appears to be AngularJS directives and bindings but
+ * which should be ignored by AngularJS. This could be the case if you have a site that displays
+ * snippets of code, for instance.
  *
  * @example
  * In this example there are two locations where a simple interpolation binding (`{{}}`) is present,


### PR DESCRIPTION
The phrase "contents of the current DOM element" may be interpreted either as
inclusive of the DOM element's attributes or as exclusive of the attributes.
This situation concerns markup such as:

    <div ng-non-bindable ng-controller="MyController"></div>

In practice, AngularJS does not compile or bind attribute values for elements
which specify the `ng-non-bindable` directive. Extend the documentation to
definitely describe this behavior.

<!-- General PR submission guidelines https://github.com/angular/angular.js/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](../DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](../DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

