### PR TITLE
refactor($rootScope): consistently use noop as the default $watch listener

### DIFF
--- a/src/ng/interpolate.js
+++ b/src/ng/interpolate.js
@@ -331,9 +331,7 @@ function $InterpolateProvider() {
             var lastValue;
             return scope.$watchGroup(parseFns, /** @this */ function interpolateFnWatcher(values, oldValues) {
               var currValue = compute(values);
-              if (isFunction(listener)) {
-                listener.call(this, currValue, values !== oldValues ? lastValue : currValue, scope);
-              }
+              listener.call(this, currValue, values !== oldValues ? lastValue : currValue, scope);
               lastValue = currValue;
             });
           }

--- a/src/ng/rootScope.js
+++ b/src/ng/rootScope.js
@@ -394,14 +394,15 @@ function $RootScopeProvider() {
        */
       $watch: function(watchExp, listener, objectEquality, prettyPrintExpression) {
         var get = $parse(watchExp);
+        var fn = isFunction(listener) ? listener : noop;
 
         if (get.$$watchDelegate) {
-          return get.$$watchDelegate(this, listener, objectEquality, get, watchExp);
+          return get.$$watchDelegate(this, fn, objectEquality, get, watchExp);
         }
         var scope = this,
             array = scope.$$watchers,
             watcher = {
-              fn: listener,
+              fn: fn,
               last: initWatchVal,
               get: get,
               exp: prettyPrintExpression || watchExp,
@@ -409,10 +410,6 @@ function $RootScopeProvider() {
             };
 
         lastDirtyWatch = null;
-
-        if (!isFunction(listener)) {
-          watcher.fn = noop;
-        }
 
         if (!array) {
           array = scope.$$watchers = [];

--- a/src/ngMessageFormat/messageFormatCommon.js
+++ b/src/ngMessageFormat/messageFormatCommon.js
@@ -34,7 +34,7 @@ function parseTextLiteral(text) {
   parsedFn['$$watchDelegate'] = function watchDelegate(scope, listener, objectEquality) {
     var unwatch = scope['$watch'](noop,
         function textLiteralWatcher() {
-          if (isFunction(listener)) { listener(text, text, scope); }
+          listener(text, text, scope);
           unwatch();
         },
         objectEquality);
@@ -58,7 +58,7 @@ function subtractOffset(expressionFn, offset) {
   parsedFn['$$watchDelegate'] = function watchDelegate(scope, listener, objectEquality) {
     unwatch = scope['$watch'](expressionFn,
         function pluralExpressionWatchListener(newValue, oldValue) {
-          if (isFunction(listener)) { listener(minusOffset(newValue), minusOffset(oldValue), scope); }
+          listener(minusOffset(newValue), minusOffset(oldValue), scope);
         },
         objectEquality);
     return unwatch;

--- a/src/ngMessageFormat/messageFormatInterpolationParts.js
+++ b/src/ngMessageFormat/messageFormatInterpolationParts.js
@@ -122,9 +122,7 @@ function InterpolationPartsWatcher(interpolationParts, scope, listener, objectEq
 
 InterpolationPartsWatcher.prototype.watchListener = function watchListener(newExpressionValues, oldExpressionValues) {
   var result = this.interpolationParts.getResult(newExpressionValues);
-  if (isFunction(this.listener)) {
-    this.listener.call(null, result, newExpressionValues === oldExpressionValues ? result : this.previousResult, this.scope);
-  }
+  this.listener.call(null, result, newExpressionValues === oldExpressionValues ? result : this.previousResult, this.scope);
   this.previousResult = result;
 };
 

--- a/src/ngMessageFormat/messageFormatSelector.js
+++ b/src/ngMessageFormat/messageFormatSelector.js
@@ -66,9 +66,7 @@ MessageSelectorWatchers.prototype.expressionFnListener = function expressionFnLi
 };
 
 MessageSelectorWatchers.prototype.messageFnListener = function messageFnListener(newMessage, oldMessage) {
-  if (isFunction(this.listener)) {
-    this.listener.call(null, newMessage, newMessage === oldMessage ? newMessage : this.lastMessage, this.scope);
-  }
+  this.listener.call(null, newMessage, newMessage === oldMessage ? newMessage : this.lastMessage, this.scope);
   this.lastMessage = newMessage;
 };
 


### PR DESCRIPTION
By doing the `isFunction(listener)` check before delegating to `$$watchDelegate` it removes that check from some `$$watchDelegate` methods.