### PR TITLE
fix($inject): enhance annotate function to work with inheritance

### DIFF
--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -440,6 +440,45 @@ describe('injector', function() {
     });
 
 
+    it('should handle inheritance without own args', function() {
+      function Base(a) {
+      }
+      function Sub() {
+        Base.apply(this, arguments);
+      }
+      Sub.prototype = Object.create(Base.prototype);
+      Sub.prototype.constructor = Sub;
+
+      expect(annotate(Base)).toEqual(['a']);
+      expect(annotate(Sub)).toEqual(['a']);
+
+      delete Base.$inject;
+      delete Sub.$inject;
+
+      expect(annotate(Sub)).toEqual(['a']);
+      expect(annotate(Base)).toEqual(['a']);
+    });
+
+    it('should handle inheritance with different args', function() {
+      function Base(a) {
+      }
+      function Sub(x, a) {
+        Base.call(this, a);
+      }
+      Sub.prototype = Object.create(Base.prototype);
+      Sub.prototype.constructor = Sub;
+
+      expect(annotate(Base)).toEqual(['a']);
+      expect(annotate(Sub)).toEqual(['x', 'a']);
+
+      delete Base.$inject;
+      delete Sub.$inject;
+
+      expect(annotate(Sub)).toEqual(['x', 'a']);
+      expect(annotate(Base)).toEqual(['a']);
+    });
+
+
     describe('es6', function() {
       if (support.shorthandMethods) {
         // The functions are generated using `eval` as just having the ES6 syntax can break some browsers.
@@ -500,6 +539,38 @@ describe('injector', function() {
           var instance = injector.invoke(Clazz);
 
           expect(instance).toEqual(jasmine.any(Clazz));
+        });
+
+        it('should annotate correctly when inheriting with different constructor args', function() {
+          // eslint-disable-next-line no-eval
+          var clazzes = eval('(() => { class Base { constructor(a) {} }; class Sub extends Base { constructor(x, a) {super(a);} }; return {Base,Sub}})()');
+          var Base = clazzes.Base;
+          var Sub = clazzes.Sub;
+
+          expect(annotate(Base)).toEqual(['a']);
+          expect(annotate(Sub)).toEqual(['x', 'a']);
+
+          delete Base.$inject;
+          delete Sub.$inject;
+
+          expect(annotate(Sub)).toEqual(['x', 'a']);
+          expect(annotate(Base)).toEqual(['a']);
+        });
+
+        it('should annotate correctly when inheriting without subclass constructor', function() {
+          // eslint-disable-next-line no-eval
+          var clazzes = eval('(() => { class Base { constructor(a) {} }; class Sub extends Base {}; return {Base,Sub}})()');
+          var Base = clazzes.Base;
+          var Sub = clazzes.Sub;
+
+          expect(annotate(Base)).toEqual(['a']);
+          expect(annotate(Sub)).toEqual(['a']);
+
+          delete Base.$inject;
+          delete Sub.$inject;
+
+          expect(annotate(Sub)).toEqual(['a']);
+          expect(annotate(Base)).toEqual(['a']);
         });
       }
     });


### PR DESCRIPTION
The annotate function now respects prototypical (ES5) or class (ES6)
inheritance so that you can use these concepts for controllers
without issues. Test cases to ensure proper functionality included.

<!-- General PR submission guidelines https://github.com/angular/angular.js/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
It changes how the `$inject` information is retrieved from a function/class in order to work with (prototypical) inheritance.


**What is the current behavior? (You can also link to an open issue here)**
When using ES6 classes and the super-class is annotated first, annotating the sub-class will always return the information of the super-class. If the sub-class requires different injections this will not work.


**What is the new behavior (if this is a feature change)?**
Now the annotate function respects an existing inheritance chain and computes the `$inject` array correctly.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](../DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](../DEVELOPERS.md#documentation) have been added/updated (no changes required)
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
No
