### PR TITLE
fix(ngModel, input): improve handling of built-in named parsers

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -277,6 +277,7 @@ function NgModelController($scope, $exceptionHandler, $attr, $element, $parse, $
   this.$$ngModelSet = this.$$parsedNgModelAssign;
   this.$$pendingDebounce = null;
   this.$$parserValid = undefined;
+  this.$$parserName = 'parse';
 
   this.$$currentValidationRunId = 0;
 
@@ -607,7 +608,8 @@ NgModelController.prototype = {
     processAsyncValidators();
 
     function processParseErrors() {
-      var errorKey = that.$$parserName || 'parse';
+      var errorKey = that.$$parserName;
+
       if (isUndefined(that.$$parserValid)) {
         setValidity(errorKey, null);
       } else {
@@ -619,6 +621,7 @@ NgModelController.prototype = {
             setValidity(name, null);
           });
         }
+
         // Set the parse error last, to prevent unsetting it, should a $validators key == parserName
         setValidity(errorKey, that.$$parserValid);
         return that.$$parserValid;
@@ -720,6 +723,10 @@ NgModelController.prototype = {
     var that = this;
 
     this.$$parserValid = isUndefined(modelValue) ? undefined : true;
+
+    // Reset any previous parse error
+    this.$setValidity(this.$$parserName, null);
+    this.$$parserName = 'parse';
 
     if (this.$$parserValid) {
       for (var i = 0; i < this.$parsers.length; i++) {

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -1378,13 +1378,13 @@ describe('ngModel', function() {
           }
         };
 
-        ctrl.$$parserName = 'parserOrValidator';
         ctrl.$parsers.push(function(value) {
           switch (value) {
             case 'allInvalid':
             case 'stillAllInvalid':
             case 'parseInvalid-validatorsValid':
             case 'stillParseInvalid-validatorsValid':
+              ctrl.$$parserName = 'parserOrValidator';
               return undefined;
             default:
               return value;


### PR DESCRIPTION
This commit changes how input elements use the private $$parserName
property on the ngModelController to name parse errors. Until now,
the input types (number, date etc.) would set $$parserName when
the inputs were initialized, which meant that any other parsers on
the ngModelController would also be named after that type. The
effect of that was that the `$error` property and the `ng-invalid-...`
class would always be that of the built-in parser, even if the custom
parser had nothing to do with it.

The new behavior is that the $$parserName is only set if the actual
parser is invalid, i.e. returns `undefined`.

Also, $$parserName has been removed from input[email] and input[url],
as these types do not have a built-in parser anymore.

BREAKING CHANGE:

Custom parsers that fail to parse on input types email, url, date, month, time,
datetime-local, week, do no longer set $error[inputType], and no longer set the class
`ng-invalid-[inputType]`. Instead, they set $error.parse and `ng-invalid-parse`.

Closes #14292 
Closes #10076

<!-- General PR submission guidelines https://github.com/angular/angular.js/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bugfix


**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**
Yes


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](../DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](../DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
This is a general fix to https://github.com/angular/angular.js/issues/10076 and also incorporates the changes in https://github.com/angular/angular.js/pull/14292.
While it's not a very common problem, I always found this section of the API very strange, especially since it uses an undocumented API (so if you stumble on it, it's even more difficult to find out what causes it).
Since https://github.com/angular/angular.js/pull/14292 is already a very small BC I thought a general solution to this issue would be welcome.
Note that I will include tests for the other input types if this implementation is approved.

