### PR TITLE
fix($location): always decode special chars in `$location.url(value)`

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -422,7 +422,7 @@ var locationPrototype = {
     }
 
     var match = PATH_MATCH.exec(url);
-    if (match[1] || url === '') this.path((this.$$html5 ? decodeURI : decodeURIComponent)(match[1]));
+    if (match[1] || url === '') this.path(decodeURIComponent(match[1]));
     if (match[2] || match[1] || url === '') this.search(match[3] || '');
     this.hash(match[5] || '');
 

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -681,11 +681,11 @@ describe('$location', function() {
         expect(locationUrl.path()).toEqual('/foo:bar');
       });
 
-      it('url() should not decode non-component special characters in html5 mode', function() {
+      it('url() should decode non-component special characters in html5 mode', function() {
         var locationUrl = new LocationHtml5Url('http://host.com', 'http://host.com');
         locationUrl.$$parse('http://host.com');
         locationUrl.url('/foo%3Abar');
-        expect(locationUrl.path()).toEqual('/foo%3Abar');
+        expect(locationUrl.path()).toEqual('/foo:bar');
       });
     });
   });


### PR DESCRIPTION
See https://github.com/angular/angular.js/issues/16312#issuecomment-348268476


@bourey - can you check that with this regression fix your original issue is still resolved?