### PR TITLE
docs(ng-model-options): remove extra quotes in example, incorrect syntax

### DIFF
--- a/src/ng/directive/ngModelOptions.js
+++ b/src/ng/directive/ngModelOptions.js
@@ -102,7 +102,7 @@ defaultModelOptions = new ModelOptions({
  *
  * The `ngModelOptions` settings are found by evaluating the value of the attribute directive as
  * an AngularJS expression. This expression should evaluate to an object, whose properties contain
- * the settings. For example: `<div "ng-model-options"="{ debounce: 100 }"`.
+ * the settings. For example: `<div ng-model-options="{ debounce: 100 }"`.
  *
  * ## Inheriting Options
  *


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update - fix incorrect syntax used in example of ng-model-options attribute directive in documentation at https://docs.angularjs.org/api/ng/directive/ngModelOptions

**What is the current behavior? (You can also link to an open issue here)**
Current docs show quotes are around the attribute name within the element tag: 
`<div "ng-model-options"="{ debounce: 100 }"`


**What is the new behavior (if this is a feature change)?**
No quotes around the attribute name within the element tag: 
`<div ng-model-options="{ debounce: 100 }"`


**Does this PR introduce a breaking change?**
No

