### PR TITLE
fix(ngAria): do not set aria attributes on input[type="hidden"]

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -224,7 +224,10 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
 .directive('ngModel', ['$aria', function($aria) {
 
   function shouldAttachAttr(attr, normalizedAttr, elem, allowBlacklistEls) {
-    return $aria.config(normalizedAttr) && !elem.attr(attr) && (allowBlacklistEls || !isNodeOneOf(elem, nodeBlackList));
+    return $aria.config(normalizedAttr) &&
+      !elem.attr(attr) &&
+      (allowBlacklistEls || !isNodeOneOf(elem, nodeBlackList)) &&
+      (elem.attr('type') !== 'hidden' || elem[0].nodeName !== 'INPUT');
   }
 
   function shouldAttachRole(role, elem) {

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -420,6 +420,21 @@ describe('$aria', function() {
       scope.$apply('txtInput=\'LTten\'');
       expect(element.attr('aria-invalid')).toBe('userSetValue');
     });
+
+    it('should not attach if input is type="hidden"', function() {
+      compileElement('<input type="hidden" ng-model="txtInput">');
+      expect(element.attr('aria-invalid')).toBeUndefined();
+    });
+
+
+    it('should attach aria-invalid to custom control that is type="hidden"', function() {
+      compileElement('<div ng-model="txtInput" type="hidden" role="textbox" ng-minlength="10"></div>');
+      scope.$apply('txtInput=\'LTten\'');
+      expect(element.attr('aria-invalid')).toBe('true');
+
+      scope.$apply('txtInput=\'morethantencharacters\'');
+      expect(element.attr('aria-invalid')).toBe('false');
+    });
   });
 
   describe('aria-invalid when disabled', function() {


### PR DESCRIPTION
This fixes a error found by @edclements  using the Google Accessibility Developer Tools audit.
Input fields of type hidden shouldn't have aria attributes.
https://www.w3.org/TR/html-aria/#allowed-aria-roles-states-and-properties-1

Closes #15113

<!-- General PR submission guidelines https://github.com/angular/angular.js/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**
aria attributes added to input type hidden


**What is the new behavior (if this is a feature change)?**
Not anymore.


**Does this PR introduce a breaking change?**
I would say not actually, because the previous behavior didnt follow the spec and I can'T see why anyone would rely on this behavior. It was marked as breaking change in https://github.com/angular/angular.js/pull/15113, though


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](../DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](../DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

Rebased and updated version of https://github.com/angular/angular.js/pull/15113
