### PR TITLE
fix($templateRequest): always return the template that is stored in the cache

### DIFF
--- a/src/ng/templateRequest.js
+++ b/src/ng/templateRequest.js
@@ -99,8 +99,7 @@ function $TemplateRequestProvider() {
             handleRequestFn.totalPendingRequests--;
           })
           .then(function(response) {
-            $templateCache.put(tpl, response.data);
-            return response.data;
+            return $templateCache.put(tpl, response.data);
           }, handleError);
 
         function handleError(resp) {

--- a/test/ng/templateRequestSpec.js
+++ b/test/ng/templateRequestSpec.js
@@ -114,6 +114,24 @@ describe('$templateRequest', function() {
     expect($templateCache.get('tpl.html')).toBe('matias');
   }));
 
+  it('should return the cached value on the first request',
+    inject(function($rootScope, $templateRequest, $templateCache, $httpBackend) {
+
+      $httpBackend.expectGET('tpl.html').respond('matias');
+      spyOn($templateCache, 'put').and.returnValue('_matias');
+
+      var content = [];
+      function tplRequestCb(html) {
+        content.push(html);
+      }
+
+      $templateRequest('tpl.html').then(tplRequestCb);
+      $rootScope.$digest();
+      $httpBackend.flush();
+
+      expect(content[0]).toBe('_matias');
+    }));
+
   it('should call `$exceptionHandler` on request error', function() {
     module(function($exceptionHandlerProvider) {
       $exceptionHandlerProvider.mode('log');


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix


**What is the current behavior? (You can also link to an open issue here)**
Currently, `$templateRequest`does not return the cached version returned by `$templateCache`. Instead, it returns the response retrieved from `$http`. This makes it impossible to decorate `$templateCache.put` as described in #16225 .


**What is the new behavior (if this is a feature change)?**
This commit ensures the cached value is returned instead of the `$http` response, allowing for proper decorating.


**Does this PR introduce a breaking change?**
Yes


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
#16225
