### PR TITLE
chore(docs.angular.js): do not break when deploying

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -302,8 +302,8 @@ module.exports = {
     var fileName = docsScriptFolder + '/firebase.json';
     var json = grunt.file.readJSON(fileName);
 
-    json.hosting.public = 'deploy/docs';
-    json.functions.source = docsScriptFolder + '/functions';
+    (json.hosting || (json.hosting = {})).public = 'deploy/docs';
+    (json.functions || (json.functions = {})).source = docsScriptFolder + '/functions';
 
     grunt.file.write('firebase.json', JSON.stringify(json));
   }

--- a/scripts/docs.angularjs.org-firebase/firebase.json
+++ b/scripts/docs.angularjs.org-firebase/firebase.json
@@ -27,10 +27,5 @@
         "function": "sendFile"
       }
     ]
-  },
-  "functions": {
-    "predeploy": [
-      "npm --prefix $RESOURCE_DIR run lint"
-    ]
   }
 }

--- a/scripts/docs.angularjs.org-firebase/functions/package.json
+++ b/scripts/docs.angularjs.org-firebase/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint .",
+    "lint": "eslint .",
     "serve": "firebase serve --only functions",
     "shell": "firebase experimental:functions:shell",
     "start": "npm run shell",


### PR DESCRIPTION
Follow-up to #16451.

The firebase predeploy step (`npm run lint`) was failing because the dependencies had not been installed at that time. The predeploy step is not necessary, because we should be lnting the files as part of our `ci-checks` job.