### PR TITLE
refactor($compile): avoid catastrophic backtracking when parsing bindings

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1014,11 +1014,13 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
   var bindingCache = createMap();
 
   function parseIsolateBindings(scope, directiveName, isController) {
-    var LOCAL_REGEXP = /^\s*([@&<]|=(\*?))(\??)\s*([\w$]*)\s*$/;
+    var LOCAL_REGEXP = /^([@&<]|=(\*?))(\??)\s*([\w$]*)$/;
 
     var bindings = createMap();
 
     forEach(scope, function(definition, scopeName) {
+      definition = definition.trim();
+
       if (definition in bindingCache) {
         bindings[scopeName] = bindingCache[definition];
         return;


### PR DESCRIPTION
This isn't expected to have any actual impact, since AngularJS is only intended to be used in the browser (not the server) and for this RegExp to be exploited by malicious user code the developer would have to have to give the user rights to execute arbitrary JavaScript code anyway.
Fixing as a general good practice and to avoid encouraging use of a similar RegExp in other environments where it might actually matter.
