### PR TITLE
fix($q): allow third-party promises

### DIFF
--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -677,10 +677,11 @@ function qFactory(nextTick, exceptionHandler, errorOnUnhandledRejections) {
 }
 
 function isStateExceptionHandled(state) {
+  if (!state) return true;
   return !!state.pur;
 }
 function markQStateExceptionHandled(state) {
-  state.pur = true;
+  if (state) state.pur = true;
 }
 function markQExceptionHandled(q) {
   markQStateExceptionHandled(q.$$state);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
For testing, it can be useful to run with other promise
implementations like Bluebird.js + angular-bluebird-promises. This
broke in angularjs 1.6 with a "TypeError: Cannot set property 'pur' of
undefined".

Closes #16164



**What is the current behavior? (You can also link to an open issue here)**
Raises TypeError: Cannot set property 'pur' of undefined


**What is the new behavior (if this is a feature change)?**
N/A

**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

