### PR TITLE
test($parse): add tests for watching one-time array/object literals

### DIFF
--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -2840,6 +2840,46 @@ describe('parser', function() {
             expect(filterCalled).toBe(true);
           });
 
+          it('should not be invoked unless the input/arguments change within literals', function() {
+            var filterCalls = [];
+            $filterProvider.register('foo', valueFn(function(input) {
+              filterCalls.push(input);
+              return input;
+            }));
+
+            scope.$watch('[(a | foo:b:1), undefined]');
+            scope.a = 0;
+            scope.$digest();
+            expect(filterCalls).toEqual([0]);
+
+            scope.$digest();
+            expect(filterCalls).toEqual([0]);
+
+            scope.a++;
+            scope.$digest();
+            expect(filterCalls).toEqual([0, 1]);
+          });
+
+          it('should not be invoked unless the input/arguments change within literals (one-time)', function() {
+            var filterCalls = [];
+            $filterProvider.register('foo', valueFn(function(input) {
+              filterCalls.push(input);
+              return input;
+            }));
+
+            scope.$watch('::[(a | foo:b:1), undefined]');
+            scope.a = 0;
+            scope.$digest();
+            expect(filterCalls).toEqual([0]);
+
+            scope.$digest();
+            expect(filterCalls).toEqual([0]);
+
+            scope.a++;
+            scope.$digest();
+            expect(filterCalls).toEqual([0, 1]);
+          });
+
           it('should always be invoked if they are marked as having $stateful', function() {
             var filterCalled = false;
             $filterProvider.register('foo', valueFn(extend(function(input) {
@@ -2882,6 +2922,52 @@ describe('parser', function() {
             expect(filterCalls).toBe(1);
             expect(watcherCalls).toBe(1);
           }));
+
+          it('should ignore changes within nested objects', function() {
+            var watchCalls = [];
+            scope.$watch('[a]', function(a) { watchCalls.push(a[0]); });
+            scope.a = 0;
+            scope.$digest();
+            expect(watchCalls).toEqual([0]);
+
+            scope.$digest();
+            expect(watchCalls).toEqual([0]);
+
+            scope.a++;
+            scope.$digest();
+            expect(watchCalls).toEqual([0, 1]);
+
+            scope.a = {};
+            scope.$digest();
+            expect(watchCalls).toEqual([0, 1, {}]);
+
+            scope.a.foo = 42;
+            scope.$digest();
+            expect(watchCalls).toEqual([0, 1, {foo: 42}]);
+          });
+
+          it('should ignore changes within nested objects (one-time)', function() {
+            var watchCalls = [];
+            scope.$watch('::[a, undefined]', function(a) { watchCalls.push(a[0]); });
+            scope.a = 0;
+            scope.$digest();
+            expect(watchCalls).toEqual([0]);
+
+            scope.$digest();
+            expect(watchCalls).toEqual([0]);
+
+            scope.a++;
+            scope.$digest();
+            expect(watchCalls).toEqual([0, 1]);
+
+            scope.a = {};
+            scope.$digest();
+            expect(watchCalls).toEqual([0, 1, {}]);
+
+            scope.a.foo = 42;
+            scope.$digest();
+            expect(watchCalls).toEqual([0, 1, {foo: 42}]);
+          });
 
           describe('with non-primitive input', function() {
 


### PR DESCRIPTION
These are some examples of cases which 189461f9bf6fda18ddbd16c42f2e959cf939c3da enabled. All the one-time tests failed before that commit.

It's possible that these overlap with [these tests](https://github.com/angular/angular.js/blob/189461f9bf6fda18ddbd16c42f2e959cf939c3da/test/ng/parseSpec.js#L2692) a bit (the non-deep ones), but I think at least the `should ignore changes within nested objects` tests are a good addition.