### PR TITLE
docs(guide/Internet Explorer Compatibility): Include warnings for usage of 'disabled' attribute

### DIFF
--- a/docs/content/guide/ie.ngdoc
+++ b/docs/content/guide/ie.ngdoc
@@ -39,12 +39,12 @@ To ensure your AngularJS application works on IE please consider:
    of `placeholder="{{ someExpression }}"`. If using the latter, Internet Explorer will error
    on accessing the `nodeValue` on a parentless `TextNode` in Internet Explorer 10 & 11
    (see [issue 5025](https://github.com/angular/angular.js/issues/5025)).
-5. Using `disabled` as the identifier of a custom attribute on an element that has
+5. Using the `disabled` attribute on an element that has
    descendant form controls can result in unexpected behavior in Internet Explorer 11.
-   Examples include the value of descendant input elements with `ng-model` not being reflective
-   of the model (or changes to the model), and the value of the `placeholder` attribute being
+   For example, the value of descendant input elements with `ng-model` will not reflect
+   the model (or changes to the model), and the value of the `placeholder` attribute will be
    inserted as the input's value. Descendant select elements will also be inoperable, as if they
-   had the `disabled` attribute applied to them, which may not be the intended effect. To work
-   around this unexpected behavior, 1) avoid using the identifier `disabled` for custom attribute
+   had the `disabled` attribute applied to them, which may not be the intended effect.
+   To work around this unexpected behavior, 1) avoid using the identifier `disabled` for custom attribute
    directives that are on elements with descendant form controls, and 2) avoid using `disabled` as an identifier
    for an attribute passed to a custom directive that has descendant form controls.

--- a/docs/content/guide/ie.ngdoc
+++ b/docs/content/guide/ie.ngdoc
@@ -39,9 +39,12 @@ To ensure your AngularJS application works on IE please consider:
    of `placeholder="{{ someExpression }}"`. If using the latter, Internet Explorer will error
    on accessing the `nodeValue` on a parentless `TextNode` in Internet Explorer 10 & 11
    (see [issue 5025](https://github.com/angular/angular.js/issues/5025)).
-5. For the `disabled` attribute, when used on an element that has input elements as descendants,
-   Internet Explorer 11 will insert the text of the `placeholder` attribute (when specified) into the
-   element value. Changes to the field value also will no longer be reflected in the model.
-   It will also make disable the descendant form controls that are `select` elements. This should be
-   kept in mind when using `disabled`, `ng-disabled` (which conditionally sets `disabled`),
-   or any directives/components that is named `disabled` or takes an attribute named `disabled` as an input/output attribute.
+5. Using `disabled` as the identifier of a custom attribute on an element that has
+   descedant form controls can result in unexpected behavior in Internet Explorer 11.
+   Examples include the value of descendant input elements with `ng-model` not being reflective
+   of the model (or changes to the model), and the value of the `placeholder` attribute being
+   inserted as the input's value. Descendant select elements will also be inoperable, as if they
+   had the `disabled` attribute applied to them, which may not be the intended effect. To work
+   around this unexpected behavior, 1) avoid using the identifier `disabled` for custom attribute
+   directives that are on elements with descendant form controls, and 2) avoid using `disabled` as an identifier
+   for an attribute passed to a custom directive that has descendant form controls.

--- a/docs/content/guide/ie.ngdoc
+++ b/docs/content/guide/ie.ngdoc
@@ -39,3 +39,8 @@ To ensure your AngularJS application works on IE please consider:
    of `placeholder="{{ someExpression }}"`. If using the latter, Internet Explorer will error
    on accessing the `nodeValue` on a parentless `TextNode` in Internet Explorer 10 & 11
    (see [issue 5025](https://github.com/angular/angular.js/issues/5025)).
+5. For the `disabled` attribute, when used on an element that has input elements as descendants,
+   Internet Explorer 11 will insert the text of the `placeholder` attribute (when specified) into the
+   element value. It will also make disable the descendant form controls that are `select` elements. This should be
+   kept in mind when using `disabled`, `ng-disabled` (which conditionally sets `disabled`),
+   or any directives/components that is named `disabled` or takes an attribute named `disabled` as an input/output attribute.

--- a/docs/content/guide/ie.ngdoc
+++ b/docs/content/guide/ie.ngdoc
@@ -40,7 +40,7 @@ To ensure your AngularJS application works on IE please consider:
    on accessing the `nodeValue` on a parentless `TextNode` in Internet Explorer 10 & 11
    (see [issue 5025](https://github.com/angular/angular.js/issues/5025)).
 5. Using `disabled` as the identifier of a custom attribute on an element that has
-   descedant form controls can result in unexpected behavior in Internet Explorer 11.
+   descendant form controls can result in unexpected behavior in Internet Explorer 11.
    Examples include the value of descendant input elements with `ng-model` not being reflective
    of the model (or changes to the model), and the value of the `placeholder` attribute being
    inserted as the input's value. Descendant select elements will also be inoperable, as if they

--- a/docs/content/guide/ie.ngdoc
+++ b/docs/content/guide/ie.ngdoc
@@ -41,6 +41,7 @@ To ensure your AngularJS application works on IE please consider:
    (see [issue 5025](https://github.com/angular/angular.js/issues/5025)).
 5. For the `disabled` attribute, when used on an element that has input elements as descendants,
    Internet Explorer 11 will insert the text of the `placeholder` attribute (when specified) into the
-   element value. It will also make disable the descendant form controls that are `select` elements. This should be
+   element value. Changes to the field value also will no longer be reflected in the model.
+   It will also make disable the descendant form controls that are `select` elements. This should be
    kept in mind when using `disabled`, `ng-disabled` (which conditionally sets `disabled`),
    or any directives/components that is named `disabled` or takes an attribute named `disabled` as an input/output attribute.


### PR DESCRIPTION
Setting the 'disabled' attribute on an element that has descendant elements has unexpected behavior in Internet Explorer 11.

* Input elements that are descendants have the text content of the 'placeholder' attribute inserted as the value (and it is not removed when typing in the field). Changes to the field are not reflected in the model value.
* Select elements that are descendants are disabled.

To avoid this issue, it is important to not set `disabled` or `ng-disabled` on an element that has descendant form elements. Normally these should only be used on actual form controls so the issue would not manifest.

The issue can also appear if a directive/component is named 'disabled' or takes an attribute named 'disabled' as an input/output attribute, so avoid these.

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update


**What is the current behavior? (You can also link to an open issue here)**
Docs do not mention IE11 bug regarding the disabled attribute on elements with descendants (though it shouldn't be used on non-form controls, this issue can prop up when making custom elements/attributes).

A previous issue noticed the incorrect behavior regarding the 'placeholder' attribute on input elements but incorrectly thought the behavior to be a bug with AngularJS:
https://github.com/angular/angular.js/issues/15700

I am able to reproduce the issue in the Plunkr created by @Narretz on the aforementioned issue:
http://plnkr.co/edit/jDJv5NtwwDSsp9hRT2rf?p=preview

Also, here's an updated version of the Plunkr showing model value is not updating due to the 'disabled' attribute:
http://plnkr.co/edit/AHix3x3dOzySygDOcfJA?p=preview

**What is the new behavior (if this is a feature change)?**
Docs mention the bug and suggest preventative measures.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
