### PR TITLE
fix($compile): throw error in $onChanges immediately

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1557,7 +1557,6 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
         }
         // We must run this hook in an apply since the $$postDigest runs outside apply
         $rootScope.$apply(function() {
-          var errors = [];
           for (var i = 0, ii = onChangesQueue.length; i < ii; ++i) {
             try {
               onChangesQueue[i]();

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1562,14 +1562,11 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
             try {
               onChangesQueue[i]();
             } catch (e) {
-              errors.push(e);
+              $exceptionHandler(e);
             }
           }
           // Reset the queue to trigger a new schedule next time there is a change
           onChangesQueue = undefined;
-          if (errors.length) {
-            throw errors;
-          }
         });
       } finally {
         onChangesTtl++;

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -5075,8 +5075,7 @@ describe('$compile', function() {
           $rootScope.$apply('a = 42');
 
           // The first component's error should be logged
-          var errors = $exceptionHandler.errors.pop();
-          expect(errors[0]).toEqual(new Error('bad hook'));
+          expect($exceptionHandler.errors.pop()).toEqual(new Error('bad hook'));
 
           // The second component's changes should still be called
           expect($log.info.logs.pop()).toEqual(['onChange']);
@@ -5084,7 +5083,7 @@ describe('$compile', function() {
       });
 
 
-      it('should collect up all `$onChanges` errors into one throw', function() {
+      it('should throw `$onChanges` errors immediately', function() {
         function ThrowingController() {
           this.$onChanges = function(change) {
             throw new Error('bad hook: ' + this.prop);
@@ -5113,10 +5112,9 @@ describe('$compile', function() {
 
           $rootScope.$apply('a = 42');
 
-          // Both component's error should be logged
-          var errors = $exceptionHandler.errors.pop();
-          expect(errors.pop()).toEqual(new Error('bad hook: 84'));
-          expect(errors.pop()).toEqual(new Error('bad hook: 42'));
+          // Both component's error should be logged individually
+          expect($exceptionHandler.errors.pop()).toEqual(new Error('bad hook: 84'));
+          expect($exceptionHandler.errors.pop()).toEqual(new Error('bad hook: 42'));
         });
       });
     });


### PR DESCRIPTION
This brings it in line with how we throw errors in a digest cycle.

Closes https://github.com/angular/angular.js/issues/15578

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

