### PR TITLE
fix(*): remove text-shadow from prettify theme

### DIFF
--- a/docs/app/assets/css/prettify.css
+++ b/docs/app/assets/css/prettify.css
@@ -46,6 +46,5 @@ ol.linenums li {
   font-size:12px;
   color: #bebec5;
   line-height: 18px;
-  text-shadow: 0 1px 0 #fff;
   list-style-type:decimal!important;
 }


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Styling improvement


**What is the current behavior? (You can also link to an open issue here)**
The styling on the AngularJS bits (tags, attributes, placeholders) in the code examples include a white colored text-shadow on a light blue background. This makes text difficult to read.



**What is the new behavior (if this is a feature change)?**
This commit removes this shadow to improve readability.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
 #16495
