### PR TITLE
test(ngMock): remove a broken jqLite cache clearing

### DIFF
--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -3123,10 +3123,6 @@ describe('sharedInjector', function() {
         define();
         sdescribe.root.run();
       } finally {
-        // avoid failing testability for the additional
-        // injectors etc created
-        angular.element.cache = {};
-
         // clear up
         module.$$beforeAllHook = null;
         module.$$afterAllHook = null;


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

A test change.

**What is the current behavior? (You can also link to an open issue here)**

`angular.element.cache` is reset to an empty object in one spec.

**What is the new behavior (if this is a feature change)?**

It's no longer reset at all.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- ~~Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated~~
- ~~Fix/Feature: Tests have been added; existing tests pass~~

**Other information**:

This is blocking PR #16512.