### PR TITLE
chore(*): stop testing on Edge 15 due to its instability

### DIFF
--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -11,12 +11,14 @@ export SAUCE_ACCESS_KEY
 BROWSER_STACK_ACCESS_KEY=$(echo "$BROWSER_STACK_ACCESS_KEY" | rev)
 SAUCE_ACCESS_KEY=$(echo "$SAUCE_ACCESS_KEY" | rev)
 
+# TODO: restore "SL_EDGE-1" once Sauce Labs adds Edge 17 and "SL_EDGE-1" refers
+# to version 16. Edge 15 disconnects from Karma frequently causing extreme build instability.
 BROWSERS="SL_Chrome,SL_Chrome-1,\
 SL_Firefox,SL_Firefox-1,\
 SL_Safari,SL_Safari-1,\
 SL_iOS_10,SL_iOS_11,\
 SL_IE_9,SL_IE_10,SL_IE_11,\
-SL_EDGE,SL_EDGE-1"
+SL_EDGE"
 
 case "$JOB" in
   "ci-checks")


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Chore.

**What is the current behavior? (You can also link to an open issue here)**

Edge 15 & 16 are tested.

**What is the new behavior (if this is a feature change)?**

Only Edge 16 is tested.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- ~~Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated~~
- ~~Fix/Feature: Tests have been added; existing tests pass~~

**Other information**:

Edge 15 disconnects from Karma frequently causing extreme build instability.
We are testing on Edge 16 & Edge 17 should be released soon anyway.