### PR TITLE
docs(tutorial/Tutorial): add a note to explain how to solve problems that arise when running end to end tests using Chrome 65

### DIFF
--- a/docs/content/tutorial/index.ngdoc
+++ b/docs/content/tutorial/index.ngdoc
@@ -311,6 +311,13 @@ the [Java Development Kit (JDK)][jdk] to be installed on your local machine. Che
 If JDK is not already installed, you can download it [here][jdk-download].
 
 <br />
+**Errors running Protractor**
+
+If your console throws errors like "Failed: unknown error: call function result missing 'value'" when you run 
+"npm run protractor" and you are running Chrome 65 or later, you might need to update the 'chromedriver' parameter to '2.37' in:
+/angular-phonecat/node_modules/protractor/node_modules/webdriver-manager/config.json
+
+<br />
 **Error running the web server**
 
 The web server is configured to use port 8000. If the port is already in use (for example by another


### PR DESCRIPTION
Add a note to explain how to solve problems that arise when running end to end tests using Chrome 65.

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs


**What is the current behavior? (You can also link to an open issue here)**
When using Chrome 65, errors are thrown due to an old version of chromedriver. 


**What is the new behavior (if this is a feature change)?**
Explain how to update the version of chromedriver being used


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [X] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [X] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [X] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

