### PR TITLE
docs(guide/Components): add link to documentation for component method

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -25,7 +25,7 @@ When not to use Components:
 
 ## Creating and configuring a Component
 
-Components can be registered using the `.component()` method of an AngularJS module (returned by {@link module `angular.module()`}). The method takes two arguments:
+Components can be registered using the {@link ng.$compileProvider#component `.component()`} method of an AngularJS module (returned by {@link module `angular.module()`}). The method takes two arguments:
 
   * The name of the Component (as string).
   * The Component config object. (Note that, unlike the `.directive()` method, this method does **not** take a factory function.)


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

docs

**What is the current behavior? (You can also link to an open issue here)**

Does not link to API of method which shows all syntaxes

**What is the new behavior (if this is a feature change)?**

Links to API of method

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

