### PR TITLE
feat(ngData): new ngData directive for injecting json-encoded data

### DIFF
--- a/angularFiles.js
+++ b/angularFiles.js
@@ -64,6 +64,7 @@ var angularFiles = {
     'src/ng/directive/ngCloak.js',
     'src/ng/directive/ngController.js',
     'src/ng/directive/ngCsp.js',
+    'src/ng/directive/ngData.js',
     'src/ng/directive/ngEventDirs.js',
     'src/ng/directive/ngIf.js',
     'src/ng/directive/ngInclude.js',

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -20,6 +20,7 @@
   ngClassOddDirective,
   ngCloakDirective,
   ngControllerDirective,
+  ngDataDirective,
   ngFormDirective,
   ngHideDirective,
   ngIfDirective,
@@ -220,7 +221,8 @@ function publishExternalAPI(angular) {
           ngInclude: ngIncludeFillContentDirective
         }).
         directive(ngAttributeAliasDirectives).
-        directive(ngEventDirectives);
+        directive(ngEventDirectives).
+        directive('script', ngDataDirective);
       $provide.provider({
         $anchorScroll: $AnchorScrollProvider,
         $animate: $AnimateProvider,

--- a/src/ng/directive/ngData.js
+++ b/src/ng/directive/ngData.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name ngData
+ * @restrict E
+ *
+ * @description
+ * Parse the content of a `<script>` element as JSON and inject it into the current scope, a service
+ * or a particular key underneath any of those.
+ * The type of the `<script>` element must be specified as `text/ng-data`.
+ *
+ * @param {string} type Must be set to `'text/ng-data'`.
+ * @param {string} service The service to inject the data into, otherwise the current scope.
+ * @param {string} key The key to inject the data into, otherwise the scope or service directly.
+ *
+ * @example
+ <example name="script-tag">
+   <file name="index.html">
+     <script type="text/ng-data">
+       {"content": "Content of the content key"}
+     </script>
+
+     <div id="content">{{ content }}</div>
+   </file>
+   <file name="protractor.js" type="protractor">
+     it('should inject the data into the current scope', function() {
+       expect(element(by.css('#content')).getText()).toMatch(/Content of the content key/);
+     });
+   </file>
+ </example>
+ */
+var ngDataDirective = ['$injector', '$parse', function($injector, $parse) {
+    return {
+        restrict: 'E',
+        terminal: true,
+        compile: function (element, attr) {
+            if (attr.type !== 'text/ng-data') {
+                return angular.noop;
+            }
+
+            return {
+                pre: function (scope, $element, $attr) {
+                    var target = scope,
+                        key = $attr.key,
+                        service = $attr.service,
+                        value = angular.fromJson($element[0].text),
+                        expression,
+                        keyTarget;
+
+                    if (service && $injector.has(service)) {
+                        target = $injector.get(service);
+                    }
+
+                    if (key) {
+                        expression = $parse(key);
+                        keyTarget = expression(target);
+
+                        if (isFunction(keyTarget)) {
+                            return keyTarget(value);
+                        }
+
+                        if (undefined === keyTarget) {
+                            expression.assign(target, value);
+                            return;
+                        }
+                    }
+
+                    angular.extend(target, value);
+                }
+            }
+        }
+    };
+}];

--- a/src/ng/directive/ngData.js
+++ b/src/ng/directive/ngData.js
@@ -34,13 +34,13 @@ var ngDataDirective = ['$injector', '$parse', function($injector, $parse) {
     return {
         restrict: 'E',
         terminal: true,
-        compile: function (element, attr) {
+        compile: function(element, attr) {
             if (attr.type !== 'text/ng-data') {
                 return angular.noop;
             }
 
             return {
-                pre: function (scope, $element, $attr) {
+                pre: function(scope, $element, $attr) {
                     var target = scope,
                         key = $attr.key,
                         service = $attr.service,
@@ -68,7 +68,7 @@ var ngDataDirective = ['$injector', '$parse', function($injector, $parse) {
 
                     angular.extend(target, value);
                 }
-            }
+            };
         }
     };
 }];

--- a/test/ng/directive/ngDataSpec.js
+++ b/test/ng/directive/ngDataSpec.js
@@ -3,15 +3,15 @@
 describe('ngDataDirective', function() {
     var element;
 
-    beforeEach(function () {
+    beforeEach(function() {
         module(function($provide) {
             var value;
 
             $provide.value('ng_data_test_service', {
-                setter: function (v) {
+                setter: function(v) {
                     value = v;
                 },
-                getter: function () {
+                getter: function() {
                     return value;
                 }
             });

--- a/test/ng/directive/ngDataSpec.js
+++ b/test/ng/directive/ngDataSpec.js
@@ -1,0 +1,91 @@
+'use strict';
+
+describe('ngDataDirective', function() {
+    var element;
+
+    beforeEach(function () {
+        module(function($provide) {
+            var value;
+
+            $provide.value('ng_data_test_service', {
+                setter: function (v) {
+                    value = v;
+                },
+                getter: function () {
+                    return value;
+                }
+            });
+        });
+    });
+
+    afterEach(function() {
+        dealoc(element);
+    });
+
+
+    it('should populate the current scope with contents of a ng-data script element', inject(
+        function($rootScope, $compile) {
+            element = $compile('<div>foo' +
+                '<script type="text/ng-data">{"content": "Some content"}</script>' +
+                '</div>')($rootScope);
+            expect($rootScope.content).toBe('Some content');
+        }
+    ));
+
+
+    it('should populate a given key on the current scope with contents of a ng-data script element', inject(
+        function($rootScope, $compile, $injector) {
+            element = $compile('<div>foo' +
+                '<script type="text/ng-data" data-key="value">{"content": "Some content"}</script>' +
+                '</div>')($rootScope);
+            expect($rootScope.value.content).toBe('Some content');
+        }
+    ));
+
+
+    it('should populate a service with contents of a ng-data script element', inject(
+        function($rootScope, $compile, $injector) {
+            element = $compile('<div>foo' +
+                '<script type="text/ng-data" data-service="ng_data_test_service">{"content": "Some content"}</script>' +
+                '</div>')($rootScope);
+            expect($injector.get('ng_data_test_service').content).toBe('Some content');
+        }
+    ));
+
+
+    it('should populate a given key on a service with contents of a ng-data script element', inject(
+        function($rootScope, $compile, $injector) {
+            element = $compile('<div>foo' +
+                '<script type="text/ng-data" data-service="ng_data_test_service" data-key="value">{"content": "Some content"}</script>' +
+                '</div>')($rootScope);
+            expect($injector.get('ng_data_test_service').value.content).toBe('Some content');
+        }
+    ));
+
+
+    it('should call a menthod on a service with contents of a ng-data script element', inject(
+        function($rootScope, $compile, $injector) {
+            element = $compile('<div>foo' +
+                '<script type="text/ng-data" data-service="ng_data_test_service" data-key="setter">{"content": "Some content"}</script>' +
+                '</div>')($rootScope);
+            expect($injector.get('ng_data_test_service').getter().content).toBe('Some content');
+        }
+    ));
+
+
+    it('should not compile scripts', inject(function($compile, $templateCache, $rootScope) {
+        var doc = jqLite('<div></div>');
+        // jQuery is too smart and removes script tags
+        doc[0].innerHTML = 'foo' +
+            '<script type="text/javascript">some {{binding}}</script>' +
+            '<script type="text/ng-data">{"content": "Some content"}</script>';
+
+        $compile(doc)($rootScope);
+        $rootScope.$digest();
+
+        var scripts = doc.find('script');
+        expect(scripts.eq(0)[0].text).toBe('some {{binding}}');
+        expect(scripts.eq(1)[0].text).toBe('{"content": "Some content"}');
+        dealoc(doc);
+    }));
+});


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature


**What is the current behavior? (You can also link to an open issue here)**
Without this directive, it can be hard to pass data from a backend implementation
to angular. Data from a backend has to be passed within module.config or via attributes,
which isn't always feasible, especially for larger, dynamically generated data.


**What is the new behavior (if this is a feature change)?**
This new directive provides an easy and effective way to pass data
from a backend implementation to angular by embedding
`<script type="text/ng-data">...JSON...</script>` in the HTML code.
Data can be merged into
- the current scope
- a specific key on the current scope (`data-key="..."`)
- a service (`data-service="..."`)
- a specific key on a service (`data-service="..." data-key="..."`)
If the specified target evaluates to a function the function will be called with
the data passed as the first argument.
If the specified target does not exist (when using key), it will be created.


**Does this PR introduce a breaking change?**
no


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass




