### PR TITLE
test($sanitize): exclude elclob test in Edge 17

### DIFF
--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -261,7 +261,7 @@ describe('HTML', function() {
       });
     });
 
-    if (!/Edge\/16/.test(window.navigator.userAgent)) {
+    if (!/Edge\/(16|17)/.test(window.navigator.userAgent)) {
       // Skip test on Edge 16 due to browser bug.
       it('should throw on a form with an input named "nextSibling"', function() {
         inject(function($sanitize) {


### PR DESCRIPTION
We don't exclude Edge completely to know if the bug has been fixed
in the next version

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

