### PR TITLE
feat(ngMock, ngMockE2E): add option to match latest definition for $h…

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1509,10 +1509,42 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
     return chain;
   };
 
-  $httpBackend.matchLatestDefinition = function(value) {
-
+  /**
+   * @ngdoc method
+   * @name  $httpBackend#matchLatestDefinition
+   * @description
+   * This method can be used to change which mocked responses `$httpBackend` returns, when defining
+   * them with {@link ngMock.$httpBackend#when $httpBackend.when()} (and shortcut methods).
+   * By default, `$httpBackend` returns the first definition that matches. When setting
+   * `$http.matchLatestDefinition(true)`, it will use the last response that matches, i.e. the
+   * one that was added last.
+   *
+   * ```js
+   * hb.when('GET', '/url1').respond(200, 'content', {});
+   * hb.when('GET', '/url1').respond(201, 'another', {});
+   * hb('GET', '/url1'); // receives "content"
+   *
+   * $http.matchLatestDefinition(true)
+   * hb('GET', '/url1'); // receives "another"
+   *
+   * hb.when('GET', '/url1').respond(201, 'onemore', {});
+   * hb('GET', '/url1'); // receives "onemore"
+   * ```
+   *
+   * This is useful if a you have a default response that is overriden inside specific tests.
+   *
+   * Note that different from config methods on providers, `matchLatestDefinition()` can be changed
+   * even when the application is already running.
+   *
+   * @param  {Boolean=} value value to set, either `true` or `false`. Default is `false`.
+   *                          If omitted, it will return the current value.
+   * @return {$httpBackend|Boolean} self when used as a setter, and the current value when used
+   *                                as a getter
+   */
+  $httpBackend.matchLatestDefinitionEnabled = function(value) {
     if (isDefined(value)) {
       matchLatestDefinition = value;
+      return this;
     } else {
       return matchLatestDefinition;
     }

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1342,6 +1342,7 @@ angular.mock.$httpBackendDecorator =
 function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
   var definitions = [],
       expectations = [],
+      matchLatestDefinition = false,
       responses = [],
       responsesPush = angular.bind(responses, responses.push),
       copy = angular.copy,
@@ -1430,8 +1431,9 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
       wasExpected = true;
     }
 
-    var i = -1, definition;
-    while ((definition = definitions[++i])) {
+    var i = matchLatestDefinition ? definitions.length : -1, definition;
+
+    while ((definition = definitions[matchLatestDefinition ? --i : ++i])) {
       if (definition.match(method, url, data, headers || {})) {
         if (definition.response) {
           // if $browser specified, we do auto flush all requests
@@ -1505,6 +1507,15 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
 
     definitions.push(definition);
     return chain;
+  };
+
+  $httpBackend.matchLatestDefinition = function(value) {
+
+    if (isDefined(value)) {
+      matchLatestDefinition = value;
+    } else {
+      return matchLatestDefinition;
+    }
   };
 
   /**

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1090,7 +1090,7 @@ describe('ngMock', function() {
     });
 
 
-    it('should respond with first matched definition', function() {
+    it('should respond with first matched definition by default', function() {
       hb.when('GET', '/url1').respond(200, 'content', {});
       hb.when('GET', '/url1').respond(201, 'another', {});
 
@@ -1106,25 +1106,76 @@ describe('ngMock', function() {
     });
 
 
-    it('should respond with latest matched definition when $httpBackend.matchLatestDefinition(true)',
-      function() {
-        hb.matchLatestDefinition(true);
+    describe('matchLatestDefinitionEnabled()', function() {
 
-        hb.when('GET', '/url1').respond(200, 'content', {});
-        hb.when('GET', '/url1').respond(200, 'middle', {});
-        hb.when('GET', '/url1').respond(201, 'another', {});
+      it('should be set to false by default', function() {
+        expect(hb.matchLatestDefinitionEnabled()).toBe(false);
+      });
 
-        callback.and.callFake(function(status, response) {
-          expect(status).toBe(201);
-          expect(response).toBe('another');
-        });
 
-        hb('GET', '/url1', null, callback);
-        expect(callback).not.toHaveBeenCalled();
-        hb.flush();
-        expect(callback).toHaveBeenCalledOnce();
-      }
-    );
+      it('should allow to change the value', function() {
+        hb.matchLatestDefinitionEnabled(true);
+        expect(hb.matchLatestDefinitionEnabled()).toBe(true);
+      });
+
+
+      it('should return the httpBackend when used as a setter', function() {
+        expect(hb.matchLatestDefinitionEnabled(true)).toBe(hb);
+      });
+
+
+      it('should respond with the first matched definition when false',
+        function() {
+          hb.matchLatestDefinitionEnabled(false);
+
+          hb.when('GET', '/url1').respond(200, 'content', {});
+          hb.when('GET', '/url1').respond(201, 'another', {});
+
+          callback.and.callFake(function(status, response) {
+            expect(status).toBe(200);
+            expect(response).toBe('content');
+          });
+
+          hb('GET', '/url1', null, callback);
+          expect(callback).not.toHaveBeenCalled();
+          hb.flush();
+          expect(callback).toHaveBeenCalledOnce();
+        }
+      );
+
+
+      it('should respond with latest matched definition when true',
+        function() {
+          hb.matchLatestDefinitionEnabled(true);
+
+          hb.when('GET', '/url1').respond(200, 'match1', {});
+          hb.when('GET', '/url1').respond(200, 'match2', {});
+          hb.when('GET', '/url2').respond(204, 'nomatch', {});
+
+          callback.and.callFake(function(status, response) {
+            expect(status).toBe(200);
+            expect(response).toBe('match2');
+          });
+
+          hb('GET', '/url1', null, callback);
+
+          // Check if a newly added match is used
+          hb.when('GET', '/url1').respond(201, 'match3', {});
+
+          var callback2 = jasmine.createSpy();
+
+          callback2.and.callFake(function(status, response) {
+            expect(status).toBe(201);
+            expect(response).toBe('match3');
+          });
+
+          hb('GET', '/url1', null, callback2);
+          expect(callback).not.toHaveBeenCalled();
+          hb.flush();
+          expect(callback).toHaveBeenCalledOnce();
+        }
+      );
+    });
 
 
     it('should respond with a copy of the mock data', function() {

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1106,6 +1106,27 @@ describe('ngMock', function() {
     });
 
 
+    it('should respond with latest matched definition when $httpBackend.matchLatestDefinition(true)',
+      function() {
+        hb.matchLatestDefinition(true);
+
+        hb.when('GET', '/url1').respond(200, 'content', {});
+        hb.when('GET', '/url1').respond(200, 'middle', {});
+        hb.when('GET', '/url1').respond(201, 'another', {});
+
+        callback.and.callFake(function(status, response) {
+          expect(status).toBe(201);
+          expect(response).toBe('another');
+        });
+
+        hb('GET', '/url1', null, callback);
+        expect(callback).not.toHaveBeenCalled();
+        hb.flush();
+        expect(callback).toHaveBeenCalledOnce();
+      }
+    );
+
+
     it('should respond with a copy of the mock data', function() {
       var mockObject = {a: 'b'};
 


### PR DESCRIPTION
…ttpBackend request

Closes #16251
Closes #11637

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature


**What is the current behavior? (You can also link to an open issue here)**
See #11637 


**What is the new behavior (if this is a feature change)?**
Config option to change the behavior


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ?] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
First draft to discuss the API.
As noted in #16251, it's not possible (afaics) to put the option on the httpBackendProvider, because they cannot be decorated. It's also not useful to put the method on the ng.httpBackendProvider, because that's not where it's needed. The option to switch it directly from httpBackend could also be used to migrate tests step by step or use it only for new tests. Another option would be a new "$httpBackendMocksProvider" or similar (but I don't think that's very useful).
