### PR TITLE
docs(ngAnimate): add `animating any scope's variable change` section

### DIFF
--- a/src/ngAnimate/module.js
+++ b/src/ngAnimate/module.js
@@ -267,8 +267,21 @@
  * .message.ng-enter-prepare {
  *   opacity: 0;
  * }
- *
  * ```
+ *
+ * ### Animating between value changes
+ *
+ * Sometimes you need to animate between different expression states, whose values
+ * don't necessary need to be known or referenced in CSS styles.
+ * Unless possible with another ["animation aware" directive](#directive-support), that specific
+ * use case can always be covered with {@link ngAnimate.directive:ngAnimateSwap} as can be seen in
+ * {@link ngAnimate.directive:ngAnimateSwap#examples this example}.
+ *
+ * Note that {@link ngAnimate.directive:ngAnimateSwap} is a *structural directive*, which means it
+ * creates a new instance of the element (including any other/child directives it may have) and
+ * links it to a new scope every time *swap* happens. In some cases this might not be desirable
+ * (e.g. for performance reasons, or when you wish to retain internal state on the original
+ * element instance).
  *
  * ## JavaScript-based Animations
  *


### PR DESCRIPTION
Add a section which covers use case when user's need to animate upon every variable's value change.

Refers #16561

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Added new section to ngAnimate's module page.


**What is the current behavior? (You can also link to an open issue here)**
That's an effect of discussion which took place under #16561 


**What is the new behavior (if this is a feature change)?**
No, just docs.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

