### PR TITLE
Feat input timeformat

### DIFF
--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1591,16 +1591,15 @@ function createDateInputType(type, regexp, parseDate, format) {
       var targetFormat = format;
 
       if (isTimeType && isString(ctrl.$options.getOption('timeSecondsFormat'))) {
-        targetFormat = format.replace('ss.sss', ctrl.$options.getOption('timeSecondsFormat'));
-        if (targetFormat[targetFormat.length - 1] === ':') {
-          targetFormat = targetFormat.slice(0, -1);
-        }
+        targetFormat = format
+          .replace('ss.sss', ctrl.$options.getOption('timeSecondsFormat'))
+          .replace(/:$/, '');
       }
 
       var formatted =  $filter('date')(value, targetFormat, timezone);
 
       if (isTimeType && ctrl.$options.getOption('timeStripEmptySeconds')) {
-        formatted = formatted.replace(/(:00)?(\.000)?$/, '');
+        formatted = formatted.replace(/(?::00)?(?:\.000)?$/, '');
       }
 
       return formatted;

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1590,8 +1590,11 @@ function createDateInputType(type, regexp, parseDate, format) {
     function formatter(value, timezone) {
       var targetFormat = format;
 
-      if (isTimeType && isString(ctrl.$options.getOption('timeFormat'))) {
-        targetFormat = ctrl.$options.getOption('timeFormat');
+      if (isTimeType && isString(ctrl.$options.getOption('timeSecondsFormat'))) {
+        targetFormat = format.replace('ss.sss', ctrl.$options.getOption('timeSecondsFormat'));
+        if (targetFormat[targetFormat.length - 1] === ':') {
+          targetFormat = targetFormat.slice(0, -1);
+        }
       }
 
       var formatted =  $filter('date')(value, targetFormat, timezone);

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -257,7 +257,7 @@ var inputType = {
     *
     * The format of the displayed time can be adjusted with the
     * {@link ng.directive:ngModelOptions#ngModelOptions-arguments ngModelOptions} `timeSecondsFormat`
-    * and `timeStripEmptySeconds`.
+    * and `timeStripZeroSeconds`.
     *
     * @param {string} ngModel Assignable AngularJS expression to data-bind to.
     * @param {string=} name Property name of the form under which the control is published.
@@ -365,7 +365,7 @@ var inputType = {
    *
    * The format of the displayed time can be adjusted with the
    * {@link ng.directive:ngModelOptions#ngModelOptions-arguments ngModelOptions} `timeSecondsFormat`
-   * and `timeStripEmptySeconds`.
+   * and `timeStripZeroSeconds`.
    *
    * @param {string} ngModel Assignable AngularJS expression to data-bind to.
    * @param {string=} name Property name of the form under which the control is published.
@@ -1598,7 +1598,7 @@ function createDateInputType(type, regexp, parseDate, format) {
 
       var formatted =  $filter('date')(value, targetFormat, timezone);
 
-      if (isTimeType && ctrl.$options.getOption('timeStripEmptySeconds')) {
+      if (isTimeType && ctrl.$options.getOption('timeStripZeroSeconds')) {
         formatted = formatted.replace(/(?::00)?(?:\.000)?$/, '');
       }
 

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -1514,11 +1514,22 @@ function createDateInputType(type, regexp, parseDate, format) {
       if (isValidDate(value)) {
         previousDate = value;
         var timezone = ctrl.$options.getOption('timezone');
+
         if (timezone) {
           previousTimezone = timezone;
           previousDate = convertTimezoneToLocal(previousDate, timezone, true);
         }
-        return $filter('date')(value, format, timezone);
+
+        var adjustedFormat = (type === 'time' && ctrl.$options.getOption('timeFormat')) || format;
+
+        var formatted =  $filter('date')(value, adjustedFormat, timezone);
+
+        console.log('formatted', formatted);
+        if (ctrl.$options.getOption('timeRemoveZeroes')) {
+          formatted = formatted.replace(/(:00)?(\.000)?$/, '');
+        }
+
+        return formatted;
       } else {
         previousDate = null;
         previousTimezone = null;

--- a/src/ng/directive/input.js
+++ b/src/ng/directive/input.js
@@ -256,8 +256,8 @@ var inputType = {
     * {@link ng.directive:ngModelOptions ngModelOptions}. By default, this is the timezone of the browser.
     *
     * The format of the displayed time can be adjusted with the
-    * {@link ng.directive:ngModelOptions#ngModelOptions-arguments ngModelOptions} `timeFormat` and
-    * `timeStripEmptySeconds`.
+    * {@link ng.directive:ngModelOptions#ngModelOptions-arguments ngModelOptions} `timeSecondsFormat`
+    * and `timeStripEmptySeconds`.
     *
     * @param {string} ngModel Assignable AngularJS expression to data-bind to.
     * @param {string=} name Property name of the form under which the control is published.
@@ -364,8 +364,8 @@ var inputType = {
    * this is the timezone of the browser.
    *
    * The format of the displayed time can be adjusted with the
-   * {@link ng.directive:ngModelOptions#ngModelOptions-arguments ngModelOptions} `timeFormat` and
-   * `timeStripEmptySeconds`.
+   * {@link ng.directive:ngModelOptions#ngModelOptions-arguments ngModelOptions} `timeSecondsFormat`
+   * and `timeStripEmptySeconds`.
    *
    * @param {string} ngModel Assignable AngularJS expression to data-bind to.
    * @param {string=} name Property name of the form under which the control is published.

--- a/src/ng/directive/ngModelOptions.js
+++ b/src/ng/directive/ngModelOptions.js
@@ -425,8 +425,8 @@ defaultModelOptions = new ModelOptions({
  *
  * ## Formatting the value of `time` and `datetime-local`
  *
- * With the options `timeFormat` and `timeStripEmptySeconds` it is possible to adjust the value
- * that is displayed in the browser control. Note that browsers may apply their own formatting
+ * With the options `timeSecondsFormat` and `timeStripEmptySeconds` it is possible to adjust the value
+ * that is displayed in the control. Note that browsers may apply their own formatting
  * in the user interface.
  *
    <example name="ngModelOptions-time-format" module="timeExample">
@@ -449,7 +449,7 @@ defaultModelOptions = new ModelOptions({
 
               this.optionChange = function() {
                 this.timeForm.timeFormatted.$overrideModelOptions(this.options);
-                this.time.value = new Date(this.time.value.getTime());
+                this.time.value = new Date(this.time.value);
               };
             }
           });
@@ -527,19 +527,22 @@ defaultModelOptions = new ModelOptions({
  *     Note that changing the timezone will have no effect on the current date, and is only applied after
  *     the next input / model change.
  *
- *   - `timeFormat`: Defines if the `time` and `datetime-local` types should show seconds and
+ *   - `timeSecondsFormat`: Defines if the `time` and `datetime-local` types should show seconds and
  *     milliseconds. The option follows the format string of {@link date date filter}.
- *     By default, the options is `undefined` which is equal to
- *     `HH:mm:ss.sss` (shows hours, minutes, seconds and milliseconds). The other options are
- *     `HH:mm:ss` (strips milliseconds), and `HH:mm`, which strips both seconds and milliseconds.
- *     Note that browsers that support `time` and `datetime-local` may show the value differently
- *     in the user interface.
+ *     By default, the options is `undefined` which is equal to `ss.sss` (seconds and milliseconds).
+ *     The other options are `ss` (strips milliseconds), and `` (empty string), which strips both
+ *     seconds and milliseconds.
+ *     Note that browsers that support `time` and `datetime-local` require the hour and minutes
+ *     part of the time, and may show the value differently in the user interface.
  *     {@link ngModelOptions#formatting-the-value-of-time-and-datetime-local- See the example}.
  *
- *   - `timeStripEmptySeconds`: Defines if the `time` and `datetime-local` types should trim the
- *     seconds and milliseconds if they are zero. This option is useful for browsers that either don't
- *     have a special interface for `time` and `date` input types, or those that don't hide seconds
- *     and milliseconds if they are empty. This option is applied after `timeFormat`.
+ *   - `timeStripEmptySeconds`: Defines if the `time` and `datetime-local` types should strip the
+ *     seconds and milliseconds from the formatted value if they are zero. This option is applied
+ *     after `timeSecondsFormat`.
+ *     This option can be used to make the formatting consistent over different browsers, as some
+ *     browsers with support for `time` will natively hide the milliseconds and
+ *     seconds if they are zero, but others won't, and browsers without `support` will always show
+ *     the full string.
  *     {@link ngModelOptions#formatting-the-value-of-time-and-datetime-local- See the example}.
  *
  */

--- a/src/ng/directive/ngModelOptions.js
+++ b/src/ng/directive/ngModelOptions.js
@@ -439,11 +439,11 @@ defaultModelOptions = new ModelOptions({
             templateUrl: 'timeExample.html',
             controller: function() {
               this.time = {
-                value: new Date(1970, 0, 1, 14, 57, 30)
+                value: new Date(1970, 0, 1, 14, 57, 0)
               };
 
               this.options = {
-                timeFormat: 'HH:mm:ss',
+                timeSecondsFormat: 'ss',
                 timeStripEmptySeconds: true
               };
 
@@ -463,10 +463,10 @@ defaultModelOptions = new ModelOptions({
          <br>
 
          Options:<br>
-         <code>timeFormat</code>:
+         <code>timeSecondsFormat</code>:
          <input
            type="text"
-           ng-model="$ctrl.options.timeFormat"
+           ng-model="$ctrl.options.timeSecondsFormat"
            ng-change="$ctrl.optionChange()">
          <br>
          <code>timeStripEmptySeconds</code>:

--- a/src/ng/directive/ngModelOptions.js
+++ b/src/ng/directive/ngModelOptions.js
@@ -425,7 +425,7 @@ defaultModelOptions = new ModelOptions({
  *
  * ## Formatting the value of `time` and `datetime-local`
  *
- * With the options `timeSecondsFormat` and `timeStripEmptySeconds` it is possible to adjust the value
+ * With the options `timeSecondsFormat` and `timeStripZeroSeconds` it is possible to adjust the value
  * that is displayed in the control. Note that browsers may apply their own formatting
  * in the user interface.
  *
@@ -442,7 +442,7 @@ defaultModelOptions = new ModelOptions({
 
               this.options = {
                 timeSecondsFormat: 'ss',
-                timeStripEmptySeconds: true
+                timeStripZeroSeconds: true
               };
 
               this.optionChange = function() {
@@ -467,10 +467,10 @@ defaultModelOptions = new ModelOptions({
            ng-model="$ctrl.options.timeSecondsFormat"
            ng-change="$ctrl.optionChange()">
          <br>
-         <code>timeStripEmptySeconds</code>:
+         <code>timeStripZeroSeconds</code>:
          <input
            type="checkbox"
-           ng-model="$ctrl.options.timeStripEmptySeconds"
+           ng-model="$ctrl.options.timeStripZeroSeconds"
            ng-change="$ctrl.optionChange()">
         </form>
       </file>
@@ -527,20 +527,20 @@ defaultModelOptions = new ModelOptions({
  *
  *   - `timeSecondsFormat`: Defines if the `time` and `datetime-local` types should show seconds and
  *     milliseconds. The option follows the format string of {@link date date filter}.
- *     By default, the options is `undefined` which is equal to `ss.sss` (seconds and milliseconds).
- *     The other options are `ss` (strips milliseconds), and `` (empty string), which strips both
+ *     By default, the options is `undefined` which is equal to `'ss.sss'` (seconds and milliseconds).
+ *     The other options are `'ss'` (strips milliseconds), and `''` (empty string), which strips both
  *     seconds and milliseconds.
  *     Note that browsers that support `time` and `datetime-local` require the hour and minutes
- *     part of the time, and may show the value differently in the user interface.
+ *     part of the time string, and may show the value differently in the user interface.
  *     {@link ngModelOptions#formatting-the-value-of-time-and-datetime-local- See the example}.
  *
- *   - `timeStripEmptySeconds`: Defines if the `time` and `datetime-local` types should strip the
+ *   - `timeStripZeroSeconds`: Defines if the `time` and `datetime-local` types should strip the
  *     seconds and milliseconds from the formatted value if they are zero. This option is applied
  *     after `timeSecondsFormat`.
  *     This option can be used to make the formatting consistent over different browsers, as some
  *     browsers with support for `time` will natively hide the milliseconds and
- *     seconds if they are zero, but others won't, and browsers without `support` will always show
- *     the full string.
+ *     seconds if they are zero, but others won't, and browsers that don't implement these input
+ *     types will always show the full string.
  *     {@link ngModelOptions#formatting-the-value-of-time-and-datetime-local- See the example}.
  *
  */

--- a/src/ng/directive/ngModelOptions.js
+++ b/src/ng/directive/ngModelOptions.js
@@ -406,12 +406,6 @@ defaultModelOptions = new ModelOptions({
  * </example>
  *
  *
- * ## Specifying timezones
- *
- * You can specify the timezone that date/time input directives expect by providing its name in the
- * `timezone` property.
- *
- *
  * ## Programmatically changing options
  *
  * The `ngModelOptions` expression is only evaluated once when the directive is linked; it is not
@@ -423,8 +417,72 @@ defaultModelOptions = new ModelOptions({
  * Default events, extra triggers, and catch-all debounce values}.
  *
  *
+ * ## Specifying timezones
+ *
+ * You can specify the timezone that date/time input directives expect by providing its name in the
+ * `timezone` property.
+ *
+ *
+ * ## Formatting the value of `time` and `datetime-local`
+ *
+ * With the options `timeFormat` and `timeStripEmptySeconds` it is possible to adjust the value
+ * that is displayed in the browser control. Note that browsers may apply their own formatting
+ * in the user interface.
+ *
+   <example name="ngModelOptions-time-format" module="timeExample">
+     <file name="index.html">
+       <time-example></time-example>
+     </file>
+     <file name="script.js">
+        angular.module('timeExample', [])
+          .component('timeExample', {
+            templateUrl: 'timeExample.html',
+            controller: function() {
+              this.time = {
+                value: new Date(1970, 0, 1, 14, 57, 30)
+              };
+
+              this.options = {
+                timeFormat: 'HH:mm:ss',
+                timeStripEmptySeconds: true
+              };
+
+              this.optionChange = function() {
+                this.timeForm.timeFormatted.$overrideModelOptions(this.options);
+                this.time.value = new Date(this.time.value.getTime());
+              };
+            }
+          });
+     </file>
+     <file name="timeExample.html">
+       <form name="$ctrl.timeForm">
+         <strong>Default</strong>:
+         <input type="time" ng-model="$ctrl.time.value" step="any" /><br>
+         <strong>With options</strong>:
+         <input type="time" name="timeFormatted" ng-model="$ctrl.time.value" step="any" ng-model-options="$ctrl.options" />
+         <br>
+
+         Options:<br>
+         <code>timeFormat</code>:
+         <input
+           type="text"
+           ng-model="$ctrl.options.timeFormat"
+           ng-change="$ctrl.optionChange()">
+         <br>
+         <code>timeStripEmptySeconds</code>:
+         <input
+           type="checkbox"
+           ng-model="$ctrl.options.timeStripEmptySeconds"
+           ng-change="$ctrl.optionChange()">
+        </form>
+      </file>
+ *  </example>
+ *
  * @param {Object} ngModelOptions options to apply to {@link ngModel} directives on this element and
- *   and its descendents. Valid keys are:
+ *   and its descendents.
+ *
+ * **General options**:
+ *
  *   - `updateOn`: string specifying which event should the input be bound to. You can set several
  *     events using an space delimited list. There is a special event called `default` that
  *     matches the default events belonging to the control. These are the events that are bound to
@@ -457,6 +515,10 @@ defaultModelOptions = new ModelOptions({
  *     not validate correctly instead of the default behavior of setting the model to undefined.
  *   - `getterSetter`: boolean value which determines whether or not to treat functions bound to
  *     `ngModel` as getters/setters.
+ *
+ *
+ *  **Input-type specific options**:
+ *
  *   - `timezone`: Defines the timezone to be used to read/write the `Date` instance in the model for
  *     `<input type="date" />`, `<input type="time" />`, ... . It understands UTC/GMT and the
  *     continental US time zone abbreviations, but for general use, use a time zone offset, for
@@ -464,6 +526,21 @@ defaultModelOptions = new ModelOptions({
  *     If not specified, the timezone of the browser will be used.
  *     Note that changing the timezone will have no effect on the current date, and is only applied after
  *     the next input / model change.
+ *
+ *   - `timeFormat`: Defines if the `time` and `datetime-local` types should show seconds and
+ *     milliseconds. The option follows the format string of {@link date date filter}.
+ *     By default, the options is `undefined` which is equal to
+ *     `HH:mm:ss.sss` (shows hours, minutes, seconds and milliseconds). The other options are
+ *     `HH:mm:ss` (strips milliseconds), and `HH:mm`, which strips both seconds and milliseconds.
+ *     Note that browsers that support `time` and `datetime-local` may show the value differently
+ *     in the user interface.
+ *     {@link ngModelOptions#formatting-the-value-of-time-and-datetime-local- See the example}.
+ *
+ *   - `timeStripEmptySeconds`: Defines if the `time` and `datetime-local` types should trim the
+ *     seconds and milliseconds if they are zero. This option is useful for browsers that either don't
+ *     have a special interface for `time` and `date` input types, or those that don't hide seconds
+ *     and milliseconds if they are empty. This option is applied after `timeFormat`.
+ *     {@link ngModelOptions#formatting-the-value-of-time-and-datetime-local- See the example}.
  *
  */
 var ngModelOptionsDirective = function() {

--- a/src/ng/directive/ngModelOptions.js
+++ b/src/ng/directive/ngModelOptions.js
@@ -438,9 +438,7 @@ defaultModelOptions = new ModelOptions({
           .component('timeExample', {
             templateUrl: 'timeExample.html',
             controller: function() {
-              this.time = {
-                value: new Date(1970, 0, 1, 14, 57, 0)
-              };
+              this.time = new Date(1970, 0, 1, 14, 57, 0);
 
               this.options = {
                 timeSecondsFormat: 'ss',
@@ -449,7 +447,7 @@ defaultModelOptions = new ModelOptions({
 
               this.optionChange = function() {
                 this.timeForm.timeFormatted.$overrideModelOptions(this.options);
-                this.time.value = new Date(this.time.value);
+                this.time = new Date(this.time);
               };
             }
           });
@@ -457,9 +455,9 @@ defaultModelOptions = new ModelOptions({
      <file name="timeExample.html">
        <form name="$ctrl.timeForm">
          <strong>Default</strong>:
-         <input type="time" ng-model="$ctrl.time.value" step="any" /><br>
+         <input type="time" ng-model="$ctrl.time" step="any" /><br>
          <strong>With options</strong>:
-         <input type="time" name="timeFormatted" ng-model="$ctrl.time.value" step="any" ng-model-options="$ctrl.options" />
+         <input type="time" name="timeFormatted" ng-model="$ctrl.time" step="any" ng-model-options="$ctrl.options" />
          <br>
 
          Options:<br>

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2,7 +2,7 @@
 
 /* globals generateInputCompilerHelper: false */
 
-describe('input', function() {
+fdescribe('input', function() {
   var helper = {}, $compile, $rootScope, $browser, $sniffer;
 
   // UA sniffing to exclude Edge from some date input tests
@@ -1581,7 +1581,7 @@ describe('input', function() {
   });
 
 
-  describe('time', function() {
+  fdescribe('time', function() {
     it('should throw if model is not a Date object', function() {
       var inputElm = helper.compileInput('<input type="time" ng-model="lunchtime"/>');
 
@@ -1593,7 +1593,7 @@ describe('input', function() {
     });
 
 
-    it('should set the view if the model if a valid Date object.', function() {
+    it('should set the view if the model is a valid Date object.', function() {
       var inputElm = helper.compileInput('<input type="time" ng-model="threeFortyOnePm"/>');
 
       $rootScope.$apply(function() {
@@ -1623,7 +1623,7 @@ describe('input', function() {
     });
 
 
-    it('should render as blank if null', function() {
+    it('should set blank if null', function() {
       var inputElm = helper.compileInput('<input type="time" ng-model="test" />');
 
       $rootScope.$apply('test = null');
@@ -1633,7 +1633,7 @@ describe('input', function() {
     });
 
 
-    it('should come up blank when no value specified', function() {
+    it('should set blank when no value specified', function() {
       var inputElm = helper.compileInput('<input type="time" ng-model="test" />');
 
       expect(inputElm.val()).toBe('');
@@ -1642,6 +1642,91 @@ describe('input', function() {
 
       expect($rootScope.test).toBeNull();
       expect(inputElm.val()).toBe('');
+    });
+
+    fit('should use the timeFormat specified in ngModelOptions', function() {
+      var inputElm = helper.compileInput('<input type="time" ng-model-options="{timeFormat: \'HH:mm\'}" ng-model="time"/>');
+
+      var ctrl = inputElm.controller('ngModel');
+
+      $rootScope.$apply(function() {
+        $rootScope.time = new Date(1970, 0, 1, 15, 41, 0, 500);
+      });
+      expect(inputElm.val()).toBe('15:41');
+
+      $rootScope.$apply(function() {
+        $rootScope.time = new Date(1970, 0, 1, 15, 41, 50, 500);
+      });
+      expect(inputElm.val()).toBe('15:41');
+
+      ctrl.$overrideModelOptions({timeFormat: 'HH:mm:s'});
+
+      $rootScope.$apply(function() {
+        $rootScope.time = new Date(1970, 0, 1, 15, 41, 5, 500);
+      });
+      expect(inputElm.val()).toBe('15:41:5');
+
+      ctrl.$overrideModelOptions({timeFormat: 'HH:mm:ss'});
+
+      $rootScope.$apply(function() {
+        $rootScope.time = new Date(1970, 0, 1, 15, 41, 5, 500);
+      });
+      expect(inputElm.val()).toBe('15:41:05');
+
+      ctrl.$overrideModelOptions({timeFormat: 'HH:mm:ss.sss'});
+
+      $rootScope.$apply(function() {
+        $rootScope.time = new Date(1970, 0, 1, 15, 41, 50, 50);
+      });
+      expect(inputElm.val()).toBe('15:41:50.050');
+
+    });
+
+
+    it('should strip empty milliseconds and seconds if specified in ngModelOptions', function() {
+      var inputElm = helper.compileInput('<input type="time" ng-model-options="{timeRemoveZeroes: true}" ng-model="threeFortyOnePm"/>');
+
+      $rootScope.$apply(function() {
+        $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 50, 500);
+      });
+
+      expect(inputElm.val()).toBe('15:41:50.500');
+
+      $rootScope.$apply(function() {
+        $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 0, 500);
+      });
+
+      expect(inputElm.val()).toBe('15:41:00.500');
+
+      $rootScope.$apply(function() {
+        $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 50, 0);
+      });
+
+      expect(inputElm.val()).toBe('15:41:50');
+
+      $rootScope.$apply(function() {
+        $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 0, 0);
+      });
+
+      expect(inputElm.val()).toBe('15:41');
+    });
+
+
+    it('should apply timeRemoveZeroes after timeFormat', function() {
+      // var inputElm = helper.compileInput('<input type="time" ng-model="threeFortyOnePm"/>');
+      var inputElm = helper.compileInput('<input type="time" ng-model-options="{timeFormat: \'HH:mm:ss\', timeRemoveZeroes: true}" ng-model="threeFortyOnePm"/>');
+
+      $rootScope.$apply(function() {
+        $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 50, 500);
+      });
+
+      expect(inputElm.val()).toBe('15:41:50');
+
+      $rootScope.$apply(function() {
+        $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 0, 500);
+      });
+
+      expect(inputElm.val()).toBe('15:41');
     });
 
 

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -2,7 +2,7 @@
 
 /* globals generateInputCompilerHelper: false */
 
-fdescribe('input', function() {
+describe('input', function() {
   var helper = {}, $compile, $rootScope, $browser, $sniffer;
 
   // UA sniffing to exclude Edge from some date input tests
@@ -1384,6 +1384,89 @@ fdescribe('input', function() {
       expect($rootScope.form.alias.$error.datetimelocal).toBeTruthy();
     });
 
+    it('should use the timeFormat specified in ngModelOptions', function() {
+      var inputElm = helper.compileInput(
+        '<input type="datetime-local" ng-model-options="{timeFormat: \'HH:mm\'}" ng-model="time"/>'
+      );
+
+      var ctrl = inputElm.controller('ngModel');
+
+      $rootScope.$apply(function() {
+        $rootScope.time = new Date(1970, 0, 1, 15, 41, 0, 500);
+      });
+      expect(inputElm.val()).toBe('1970-01-01T15:41');
+
+      $rootScope.$apply(function() {
+        $rootScope.time = new Date(1970, 0, 1, 15, 41, 50, 500);
+      });
+      expect(inputElm.val()).toBe('1970-01-01T15:41');
+
+      ctrl.$overrideModelOptions({timeFormat: 'HH:mm:ss'});
+
+      $rootScope.$apply(function() {
+        $rootScope.time = new Date(1970, 0, 1, 15, 41, 5, 500);
+      });
+      expect(inputElm.val()).toBe('1970-01-01T15:41:05');
+
+      ctrl.$overrideModelOptions({timeFormat: 'HH:mm:ss.sss'});
+
+      $rootScope.$apply(function() {
+        $rootScope.time = new Date(1970, 0, 1, 15, 41, 50, 50);
+      });
+      expect(inputElm.val()).toBe('1970-01-01T15:41:50.050');
+
+    });
+
+
+    it('should strip empty milliseconds and seconds if specified in ngModelOptions', function() {
+      var inputElm = helper.compileInput(
+        '<input type="datetime-local" ng-model-options="{timeStripEmptySeconds: true}" ng-model="threeFortyOnePm"/>'
+      );
+
+      $rootScope.$apply(function() {
+        $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 50, 500);
+      });
+
+      expect(inputElm.val()).toBe('1970-01-01T15:41:50.500');
+
+      $rootScope.$apply(function() {
+        $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 0, 500);
+      });
+
+      expect(inputElm.val()).toBe('1970-01-01T15:41:00.500');
+
+      $rootScope.$apply(function() {
+        $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 50, 0);
+      });
+
+      expect(inputElm.val()).toBe('1970-01-01T15:41:50');
+
+      $rootScope.$apply(function() {
+        $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 0, 0);
+      });
+
+      expect(inputElm.val()).toBe('1970-01-01T15:41');
+    });
+
+
+    it('should apply timeStripEmptySeconds after timeFormat', function() {
+      var inputElm = helper.compileInput('<input type="datetime-local"' +
+        ' ng-model-options="{timeFormat: \'HH:mm:ss\', timeStripEmptySeconds: true}"' +
+        ' ng-model="threeFortyOnePm"/>');
+
+      $rootScope.$apply(function() {
+        $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 50, 500);
+      });
+
+      expect(inputElm.val()).toBe('15:41:50');
+
+      $rootScope.$apply(function() {
+        $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 0, 500);
+      });
+
+      expect(inputElm.val()).toBe('15:41');
+    });
+
     describe('min', function() {
       var inputElm;
       beforeEach(function() {
@@ -1581,7 +1664,7 @@ fdescribe('input', function() {
   });
 
 
-  fdescribe('time', function() {
+  describe('time', function() {
     it('should throw if model is not a Date object', function() {
       var inputElm = helper.compileInput('<input type="time" ng-model="lunchtime"/>');
 
@@ -1604,7 +1687,7 @@ fdescribe('input', function() {
     });
 
 
-    it('should set the model undefined if the view is invalid', function() {
+    it('should set the model to undefined if the view is invalid', function() {
       var inputElm = helper.compileInput('<input type="time" ng-model="breakMe"/>');
 
       $rootScope.$apply(function() {
@@ -1644,8 +1727,10 @@ fdescribe('input', function() {
       expect(inputElm.val()).toBe('');
     });
 
-    fit('should use the timeFormat specified in ngModelOptions', function() {
-      var inputElm = helper.compileInput('<input type="time" ng-model-options="{timeFormat: \'HH:mm\'}" ng-model="time"/>');
+    it('should use the timeFormat specified in ngModelOptions', function() {
+      var inputElm = helper.compileInput(
+        '<input type="time" ng-model-options="{timeFormat: \'HH:mm\'}" ng-model="time"/>'
+      );
 
       var ctrl = inputElm.controller('ngModel');
 
@@ -1658,13 +1743,6 @@ fdescribe('input', function() {
         $rootScope.time = new Date(1970, 0, 1, 15, 41, 50, 500);
       });
       expect(inputElm.val()).toBe('15:41');
-
-      ctrl.$overrideModelOptions({timeFormat: 'HH:mm:s'});
-
-      $rootScope.$apply(function() {
-        $rootScope.time = new Date(1970, 0, 1, 15, 41, 5, 500);
-      });
-      expect(inputElm.val()).toBe('15:41:5');
 
       ctrl.$overrideModelOptions({timeFormat: 'HH:mm:ss'});
 
@@ -1684,7 +1762,9 @@ fdescribe('input', function() {
 
 
     it('should strip empty milliseconds and seconds if specified in ngModelOptions', function() {
-      var inputElm = helper.compileInput('<input type="time" ng-model-options="{timeRemoveZeroes: true}" ng-model="threeFortyOnePm"/>');
+      var inputElm = helper.compileInput(
+        '<input type="time" ng-model-options="{timeStripEmptySeconds: true}" ng-model="threeFortyOnePm"/>'
+      );
 
       $rootScope.$apply(function() {
         $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 50, 500);
@@ -1712,9 +1792,9 @@ fdescribe('input', function() {
     });
 
 
-    it('should apply timeRemoveZeroes after timeFormat', function() {
+    it('should apply timeStripEmptySeconds after timeFormat', function() {
       // var inputElm = helper.compileInput('<input type="time" ng-model="threeFortyOnePm"/>');
-      var inputElm = helper.compileInput('<input type="time" ng-model-options="{timeFormat: \'HH:mm:ss\', timeRemoveZeroes: true}" ng-model="threeFortyOnePm"/>');
+      var inputElm = helper.compileInput('<input type="time" ng-model-options="{timeFormat: \'HH:mm:ss\', timeStripEmptySeconds: true}" ng-model="threeFortyOnePm"/>');
 
       $rootScope.$apply(function() {
         $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 50, 500);

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1419,7 +1419,7 @@ describe('input', function() {
 
     it('should strip empty milliseconds and seconds if specified in ngModelOptions', function() {
       var inputElm = helper.compileInput(
-        '<input type="datetime-local" ng-model-options="{timeStripEmptySeconds: true}" ng-model="threeFortyOnePm"/>'
+        '<input type="datetime-local" ng-model-options="{timeStripZeroSeconds: true}" ng-model="threeFortyOnePm"/>'
       );
 
       $rootScope.$apply(function() {
@@ -1448,9 +1448,9 @@ describe('input', function() {
     });
 
 
-    it('should apply timeStripEmptySeconds after timeSecondsFormat', function() {
+    it('should apply timeStripZeroSeconds after timeSecondsFormat', function() {
       var inputElm = helper.compileInput('<input type="datetime-local"' +
-        ' ng-model-options="{timeSecondsFormat: \'ss\', timeStripEmptySeconds: true}"' +
+        ' ng-model-options="{timeSecondsFormat: \'ss\', timeStripZeroSeconds: true}"' +
         ' ng-model="threeFortyOnePm"/>');
 
       $rootScope.$apply(function() {
@@ -1761,7 +1761,7 @@ describe('input', function() {
 
     it('should strip empty milliseconds and seconds if specified in ngModelOptions', function() {
       var inputElm = helper.compileInput(
-        '<input type="time" ng-model-options="{timeStripEmptySeconds: true}" ng-model="threeFortyOnePm"/>'
+        '<input type="time" ng-model-options="{timeStripZeroSeconds: true}" ng-model="threeFortyOnePm"/>'
       );
 
       $rootScope.$apply(function() {
@@ -1790,9 +1790,9 @@ describe('input', function() {
     });
 
 
-    it('should apply timeStripEmptySeconds after timeSecondsFormat', function() {
+    it('should apply timeStripZeroSeconds after timeSecondsFormat', function() {
       var inputElm = helper.compileInput('<input type="time"' +
-        ' ng-model-options="{timeSecondsFormat: \'ss\', timeStripEmptySeconds: true}"' +
+        ' ng-model-options="{timeSecondsFormat: \'ss\', timeStripZeroSeconds: true}"' +
         ' ng-model="threeFortyOnePm"/>');
 
       $rootScope.$apply(function() {

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1384,9 +1384,9 @@ describe('input', function() {
       expect($rootScope.form.alias.$error.datetimelocal).toBeTruthy();
     });
 
-    it('should use the timeFormat specified in ngModelOptions', function() {
+    it('should use the timeSecondsFormat specified in ngModelOptions', function() {
       var inputElm = helper.compileInput(
-        '<input type="datetime-local" ng-model-options="{timeFormat: \'HH:mm\'}" ng-model="time"/>'
+        '<input type="datetime-local" ng-model-options="{timeSecondsFormat: \'\'}" ng-model="time"/>'
       );
 
       var ctrl = inputElm.controller('ngModel');
@@ -1401,14 +1401,14 @@ describe('input', function() {
       });
       expect(inputElm.val()).toBe('1970-01-01T15:41');
 
-      ctrl.$overrideModelOptions({timeFormat: 'HH:mm:ss'});
+      ctrl.$overrideModelOptions({timeSecondsFormat: 'ss'});
 
       $rootScope.$apply(function() {
         $rootScope.time = new Date(1970, 0, 1, 15, 41, 5, 500);
       });
       expect(inputElm.val()).toBe('1970-01-01T15:41:05');
 
-      ctrl.$overrideModelOptions({timeFormat: 'HH:mm:ss.sss'});
+      ctrl.$overrideModelOptions({timeSecondsFormat: 'ss.sss'});
 
       $rootScope.$apply(function() {
         $rootScope.time = new Date(1970, 0, 1, 15, 41, 50, 50);
@@ -1449,22 +1449,22 @@ describe('input', function() {
     });
 
 
-    it('should apply timeStripEmptySeconds after timeFormat', function() {
+    it('should apply timeStripEmptySeconds after timeSecondsFormat', function() {
       var inputElm = helper.compileInput('<input type="datetime-local"' +
-        ' ng-model-options="{timeFormat: \'HH:mm:ss\', timeStripEmptySeconds: true}"' +
+        ' ng-model-options="{timeSecondsFormat: \'ss\', timeStripEmptySeconds: true}"' +
         ' ng-model="threeFortyOnePm"/>');
 
       $rootScope.$apply(function() {
         $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 50, 500);
       });
 
-      expect(inputElm.val()).toBe('15:41:50');
+      expect(inputElm.val()).toBe('1970-01-01T15:41:50');
 
       $rootScope.$apply(function() {
         $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 0, 500);
       });
 
-      expect(inputElm.val()).toBe('15:41');
+      expect(inputElm.val()).toBe('1970-01-01T15:41');
     });
 
     describe('min', function() {
@@ -1727,9 +1727,9 @@ describe('input', function() {
       expect(inputElm.val()).toBe('');
     });
 
-    it('should use the timeFormat specified in ngModelOptions', function() {
+    it('should use the timeSecondsFormat specified in ngModelOptions', function() {
       var inputElm = helper.compileInput(
-        '<input type="time" ng-model-options="{timeFormat: \'HH:mm\'}" ng-model="time"/>'
+        '<input type="time" ng-model-options="{timeSecondsFormat: \'\'}" ng-model="time"/>'
       );
 
       var ctrl = inputElm.controller('ngModel');
@@ -1744,14 +1744,14 @@ describe('input', function() {
       });
       expect(inputElm.val()).toBe('15:41');
 
-      ctrl.$overrideModelOptions({timeFormat: 'HH:mm:ss'});
+      ctrl.$overrideModelOptions({timeSecondsFormat: 'ss'});
 
       $rootScope.$apply(function() {
         $rootScope.time = new Date(1970, 0, 1, 15, 41, 5, 500);
       });
       expect(inputElm.val()).toBe('15:41:05');
 
-      ctrl.$overrideModelOptions({timeFormat: 'HH:mm:ss.sss'});
+      ctrl.$overrideModelOptions({timeSecondsFormat: 'ss.sss'});
 
       $rootScope.$apply(function() {
         $rootScope.time = new Date(1970, 0, 1, 15, 41, 50, 50);
@@ -1792,9 +1792,10 @@ describe('input', function() {
     });
 
 
-    it('should apply timeStripEmptySeconds after timeFormat', function() {
-      // var inputElm = helper.compileInput('<input type="time" ng-model="threeFortyOnePm"/>');
-      var inputElm = helper.compileInput('<input type="time" ng-model-options="{timeFormat: \'HH:mm:ss\', timeStripEmptySeconds: true}" ng-model="threeFortyOnePm"/>');
+    it('should apply timeStripEmptySeconds after timeSecondsFormat', function() {
+      var inputElm = helper.compileInput('<input type="time"' +
+        ' ng-model-options="{timeSecondsFormat: \'ss\', timeStripEmptySeconds: true}"' +
+        ' ng-model="threeFortyOnePm"/>');
 
       $rootScope.$apply(function() {
         $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 50, 500);

--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1414,7 +1414,6 @@ describe('input', function() {
         $rootScope.time = new Date(1970, 0, 1, 15, 41, 50, 50);
       });
       expect(inputElm.val()).toBe('1970-01-01T15:41:50.050');
-
     });
 
 
@@ -1757,7 +1756,6 @@ describe('input', function() {
         $rootScope.time = new Date(1970, 0, 1, 15, 41, 50, 50);
       });
       expect(inputElm.val()).toBe('15:41:50.050');
-
     });
 
 


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature


**What is the current behavior? (You can also link to an open issue here)**
Browser differences when displaying input time and datetime-local


**What is the new behavior (if this is a feature change)?**
Option to adjust the format


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
Closes #10721
Closes #16510 

There are two options:

timeFormatSeconds can be used to configure if seconds or milliseconds should be displayed in general.
timeStripEmptySeconds mimics the behavior of Chrome to hide the seconds completely if they are zero.
