### PR TITLE
fix(ngModel): do not throw if view value changes on destroyed scope

### DIFF
--- a/src/ng/directive/ngModel.js
+++ b/src/ng/directive/ngModel.js
@@ -287,6 +287,7 @@ function NgModelController($scope, $exceptionHandler, $attr, $element, $parse, $
   this.$$currentValidationRunId = 0;
 
   this.$$scope = $scope;
+  this.$$rootScope = $scope.$root;
   this.$$attr = $attr;
   this.$$element = $element;
   this.$$animate = $animate;
@@ -864,7 +865,7 @@ NgModelController.prototype = {
       this.$$pendingDebounce = this.$$timeout(function() {
         that.$commitViewValue();
       }, debounceDelay);
-    } else if (this.$$scope.$root.$$phase) {
+    } else if (this.$$rootScope.$$phase) {
       this.$commitViewValue();
     } else {
       this.$$scope.$apply(function() {

--- a/test/ng/directive/ngModelSpec.js
+++ b/test/ng/directive/ngModelSpec.js
@@ -6,7 +6,7 @@ describe('ngModel', function() {
 
   describe('NgModelController', function() {
     /* global NgModelController: false */
-    var ctrl, scope, ngModelAccessor, element, parentFormCtrl;
+    var ctrl, scope, element, parentFormCtrl;
 
     beforeEach(inject(function($rootScope, $controller) {
       var attrs = {name: 'testAlias', ngModel: 'value'};
@@ -21,7 +21,6 @@ describe('ngModel', function() {
       element = jqLite('<form><input></form>');
 
       scope = $rootScope;
-      ngModelAccessor = jasmine.createSpy('ngModel accessor');
       ctrl = $controller(NgModelController, {
         $scope: scope,
         $element: element.find('input'),
@@ -438,6 +437,13 @@ describe('ngModel', function() {
         expect(ctrl.$modelValue).toBe('c');
         expect(scope.value).toBe('c');
       }));
+
+
+      it('should not throw an error if the scope has been destroyed', function() {
+        scope.$destroy();
+        ctrl.$setViewValue('some-val');
+        expect(ctrl.$viewValue).toBe('some-val');
+      });
     });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.


**What is the current behavior? (You can also link to an open issue here)**
If the scope associted with an `NgModelController` instance is destroyed between the view value changing and actually calling `$$debounceViewValueCommit()`, an error is throwing when we try to check `this.$$scope.$root.$$phase` (since `$root` has been set to `null` as part of `$destroy()`).

This could, for example, happen if updating the value is debounced either by asynchronously calling `$setViewValue()` or via `ngModelOptions`.

See also #16583.


**What is the new behavior (if this is a feature change)?**
No error \o/


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] ~~Fix/Feature: [Docs]~~(https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
Fixes #16583.