### PR TITLE
feat(ngMessages): add support for default message

### DIFF
--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -18,7 +18,7 @@ var jqLite;
  * sequencing based on the order of how the messages are defined in the template.
  *
  * Currently, the ngMessages module only contains the code for the `ngMessages`, `ngMessagesInclude`
- * `ngMessage` and `ngMessageExp` directives.
+ * `ngMessage`, `ngMessageExp` and `ngMessageDefault` directives.
  *
  * ## Usage
  * The `ngMessages` directive allows keys in a key/value collection to be associated with a child element
@@ -257,7 +257,21 @@ var jqLite;
  * .some-message.ng-leave.ng-leave-active {}
  * ```
  *
- * {@link ngAnimate Click here} to learn how to use JavaScript animations or to learn more about ngAnimate.
+ * {@link ngAnimate See the ngAnimate docs} to learn how to use JavaScript animations or to learn
+ * more about ngAnimate.
+ *
+ * ## Displaying a default message
+ * If the ngMessages renders no inner ngMessage directive (that is to say when the key values does not
+ * match the attribute value present on each ngMessage directive), then it will render a default message
+ * using the {@link ngMessageDefault} directive.
+ *
+ * ```html
+ * <div ng-messages="myForm.myField.$error" role="alert">
+ *   <div ng-message="required">This field is required</div>
+ *   <div ng-message="minlength">This field is too short</div>
+ *   <div ng-message-default>This field has an input error</div>
+ * </div>
+ * ```
  */
 angular.module('ngMessages', [], function initAngularHelpers() {
   // Access helpers from AngularJS core.
@@ -286,8 +300,11 @@ angular.module('ngMessages', [], function initAngularHelpers() {
    * at a time and this depends on the prioritization of the messages within the template. (This can
    * be changed by using the `ng-messages-multiple` or `multiple` attribute on the directive container.)
    *
-   * A remote template can also be used to promote message reusability and messages can also be
-   * overridden.
+   * A remote template can also be used (With {@link ngMessagesInclude}) to promote message
+   * reusability and messages can also be overridden.
+   *
+   * A default message can also be displayed when no `ngMessage` directive is inserted, using the
+   * {@link ngMessageDefault} directive.
    *
    * {@link module:ngMessages Click here} to learn more about `ngMessages` and `ngMessage`.
    *
@@ -298,6 +315,7 @@ angular.module('ngMessages', [], function initAngularHelpers() {
    *   <ANY ng-message="stringValue">...</ANY>
    *   <ANY ng-message="stringValue1, stringValue2, ...">...</ANY>
    *   <ANY ng-message-exp="expressionValue">...</ANY>
+   *   <ANY ng-message-default>...</ANY>
    * </ANY>
    *
    * <!-- or by using element directives -->
@@ -305,6 +323,7 @@ angular.module('ngMessages', [], function initAngularHelpers() {
    *   <ng-message when="stringValue">...</ng-message>
    *   <ng-message when="stringValue1, stringValue2, ...">...</ng-message>
    *   <ng-message when-exp="expressionValue">...</ng-message>
+   *   <ng-message-default>...</ng-message-default>
    * </ng-messages>
    * ```
    *
@@ -333,6 +352,7 @@ angular.module('ngMessages', [], function initAngularHelpers() {
    *         <div ng-message="required">You did not enter a field</div>
    *         <div ng-message="minlength">Your field is too short</div>
    *         <div ng-message="maxlength">Your field is too long</div>
+   *         <div ng-message-default>This field has an input error</div>
    *       </div>
    *     </form>
    *   </file>
@@ -409,8 +429,15 @@ angular.module('ngMessages', [], function initAngularHelpers() {
           });
 
           if (unmatchedMessages.length !== totalMessages) {
+            // Unset default message if set
+            if (ctrl.default) ctrl.default.detach();
+
             $animate.setClass($element, ACTIVE_CLASS, INACTIVE_CLASS);
           } else {
+
+            // Set default message if no other matched
+            if (ctrl.default) ctrl.default.attach();
+
             $animate.setClass($element, INACTIVE_CLASS, ACTIVE_CLASS);
           }
         };
@@ -428,23 +455,31 @@ angular.module('ngMessages', [], function initAngularHelpers() {
           }
         };
 
-        this.register = function(comment, messageCtrl) {
-          var nextKey = latestKey.toString();
-          messages[nextKey] = {
-            message: messageCtrl
-          };
-          insertMessageNode($element[0], comment, nextKey);
-          comment.$$ngMessageNode = nextKey;
-          latestKey++;
+        this.register = function(comment, messageCtrl, isDefault) {
+          if (isDefault) {
+            ctrl.default = messageCtrl;
+          } else {
+            var nextKey = latestKey.toString();
+            messages[nextKey] = {
+              message: messageCtrl
+            };
+            insertMessageNode($element[0], comment, nextKey);
+            comment.$$ngMessageNode = nextKey;
+            latestKey++;
+          }
 
           ctrl.reRender();
         };
 
-        this.deregister = function(comment) {
-          var key = comment.$$ngMessageNode;
-          delete comment.$$ngMessageNode;
-          removeMessageNode($element[0], comment, key);
-          delete messages[key];
+        this.deregister = function(comment, isDefault) {
+          if (isDefault) {
+            delete ctrl.default;
+          } else {
+            var key = comment.$$ngMessageNode;
+            delete comment.$$ngMessageNode;
+            removeMessageNode($element[0], comment, key);
+            delete messages[key];
+          }
           ctrl.reRender();
         };
 
@@ -647,9 +682,41 @@ angular.module('ngMessages', [], function initAngularHelpers() {
    *
    * @param {expression} ngMessageExp|whenExp an expression value corresponding to the message key.
    */
-  .directive('ngMessageExp', ngMessageDirectiveFactory());
+  .directive('ngMessageExp', ngMessageDirectiveFactory())
 
-function ngMessageDirectiveFactory() {
+  /**
+   * @ngdoc directive
+   * @name ngMessageDefault
+   * @restrict AE
+   * @scope
+   *
+   * @description
+   * `ngMessageDefault` is a directive with the purpose to show and hide a default message for
+   * {@link ngMessages}, when none of provided messages matches.
+   *
+   * More information about using `ngMessageDefault` can be found in the
+   * {@link module:ngMessages `ngMessages` module documentation}.
+   *
+   * @usage
+   * ```html
+   * <!-- using attribute directives -->
+   * <ANY ng-messages="expression" role="alert">
+   *   <ANY ng-message="stringValue">...</ANY>
+   *   <ANY ng-message="stringValue1, stringValue2, ...">...</ANY>
+   *   <ANY ng-message-default>...</ANY>
+   * </ANY>
+   *
+   * <!-- or by using element directives -->
+   * <ng-messages for="expression" role="alert">
+   *   <ng-message when="stringValue">...</ng-message>
+   *   <ng-message when="stringValue1, stringValue2, ...">...</ng-message>
+   *   <ng-message-default>...</ng-message-default>
+   * </ng-messages>
+   *
+  */
+  .directive('ngMessageDefault', ngMessageDirectiveFactory(true));
+
+function ngMessageDirectiveFactory(isDefault) {
   return ['$animate', function($animate) {
     return {
       restrict: 'AE',
@@ -658,25 +725,28 @@ function ngMessageDirectiveFactory() {
       terminal: true,
       require: '^^ngMessages',
       link: function(scope, element, attrs, ngMessagesCtrl, $transclude) {
-        var commentNode = element[0];
+        var commentNode, records, staticExp, dynamicExp;
 
-        var records;
-        var staticExp = attrs.ngMessage || attrs.when;
-        var dynamicExp = attrs.ngMessageExp || attrs.whenExp;
-        var assignRecords = function(items) {
-          records = items
-              ? (isArray(items)
-                  ? items
-                  : items.split(/[\s,]+/))
-              : null;
-          ngMessagesCtrl.reRender();
-        };
+        if (!isDefault) {
+          commentNode = element[0];
+          staticExp = attrs.ngMessage || attrs.when;
+          dynamicExp = attrs.ngMessageExp || attrs.whenExp;
 
-        if (dynamicExp) {
-          assignRecords(scope.$eval(dynamicExp));
-          scope.$watchCollection(dynamicExp, assignRecords);
-        } else {
-          assignRecords(staticExp);
+          var assignRecords = function(items) {
+            records = items
+                ? (isArray(items)
+                      ? items
+                      : items.split(/[\s,]+/))
+                : null;
+            ngMessagesCtrl.reRender();
+          };
+
+          if (dynamicExp) {
+            assignRecords(scope.$eval(dynamicExp));
+            scope.$watchCollection(dynamicExp, assignRecords);
+          } else {
+            assignRecords(staticExp);
+          }
         }
 
         var currentElement, messageCtrl;
@@ -701,7 +771,7 @@ function ngMessageDirectiveFactory() {
                   // If the message element was removed via a call to `detach` then `currentElement` will be null
                   // So this handler only handles cases where something else removed the message element.
                   if (currentElement && currentElement.$$attachId === $$attachId) {
-                    ngMessagesCtrl.deregister(commentNode);
+                    ngMessagesCtrl.deregister(commentNode, isDefault);
                     messageCtrl.detach();
                   }
                   newScope.$destroy();
@@ -716,14 +786,14 @@ function ngMessageDirectiveFactory() {
               $animate.leave(elm);
             }
           }
-        });
+        }, isDefault);
 
         // We need to ensure that this directive deregisters itself when it no longer exists
         // Normally this is done when the attached element is destroyed; but if this directive
         // gets removed before we attach the message to the DOM there is nothing to watch
         // in which case we must deregister when the containing scope is destroyed.
         scope.$on('$destroy', function() {
-          ngMessagesCtrl.deregister(commentNode);
+          ngMessagesCtrl.deregister(commentNode, isDefault);
         });
       }
     };

--- a/src/ngMessages/messages.js
+++ b/src/ngMessages/messages.js
@@ -275,6 +275,8 @@ var jqLite;
  *   <div ng-message-default>This field has an input error</div>
  * </div>
  * ```
+ *
+
  */
 angular.module('ngMessages', [], function initAngularHelpers() {
   // Access helpers from AngularJS core.
@@ -436,16 +438,18 @@ angular.module('ngMessages', [], function initAngularHelpers() {
             messageCtrl.detach();
           });
 
-          if (unmatchedMessages.length !== totalMessages) {
-            // Unset default message if set
-            if (ctrl.default) ctrl.default.detach();
+          var messageMatched = unmatchedMessages.length !== totalMessages;
+          var attachDefault = ctrl.default && !messageMatched && truthyKeys > 0;
 
+          if (attachDefault) {
+            ctrl.default.attach();
+          } else if (ctrl.default) {
+            ctrl.default.detach();
+          }
+
+          if (messageMatched || attachDefault) {
             $animate.setClass($element, ACTIVE_CLASS, INACTIVE_CLASS);
           } else {
-
-            // Set default message if keys in collection do not match any message
-            if (ctrl.default && truthyKeys > 0) ctrl.default.attach();
-
             $animate.setClass($element, INACTIVE_CLASS, ACTIVE_CLASS);
           }
         };

--- a/test/ngMessages/messagesSpec.js
+++ b/test/ngMessages/messagesSpec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-fdescribe('ngMessages', function() {
+describe('ngMessages', function() {
   beforeEach(inject.strictDi());
   beforeEach(module('ngMessages'));
 

--- a/test/ngMessages/messagesSpec.js
+++ b/test/ngMessages/messagesSpec.js
@@ -667,16 +667,56 @@ describe('ngMessages', function() {
                          '  <div ng-message="val">Message is set</div>' +
                          '  <div ng-message-default>Default message is set</div>' +
                          '</div>')($rootScope);
+      $rootScope.$apply(function() {
+        $rootScope.col = { unexpected: false };
+      });
+
       $rootScope.$digest();
+
+      expect(element.text().trim()).toBe('');
+
+      $rootScope.$apply(function() {
+        $rootScope.col = { unexpected: true };
+      });
 
       expect(element.text().trim()).toBe('Default message is set');
 
       $rootScope.$apply(function() {
-        $rootScope.col = { val: true };
+        $rootScope.col = { val: true, unexpected: true };
       });
 
       expect(element.text().trim()).toBe('Message is set');
     }));
+
+    it('should not render a default message with ng-messages-multiple if another error matches',
+      inject(function($rootScope, $compile) {
+        element = $compile('<div ng-messages="col" ng-messages-multiple>' +
+                           '  <div ng-message="val">Message is set</div>' +
+                           '  <div ng-message="other">Other message is set</div>' +
+                           '  <div ng-message-default>Default message is set</div>' +
+                           '</div>')($rootScope);
+
+        expect(element.text().trim()).toBe('');
+
+        $rootScope.$apply(function() {
+          $rootScope.col = { val: true, other: false, unexpected: false };
+        });
+
+        expect(element.text().trim()).toBe('Message is set');
+
+        $rootScope.$apply(function() {
+          $rootScope.col = { val: true, other: true, unexpected: true };
+        });
+
+        expect(element.text().trim()).toBe('Message is set  Other message is set');
+
+        $rootScope.$apply(function() {
+          $rootScope.col = { val: false, other: false, unexpected: true };
+        });
+
+        expect(element.text().trim()).toBe('Default message is set');
+      })
+    );
 
     it('should handle a default message with ngIf', inject(function($rootScope, $compile) {
       element = $compile('<div ng-messages="col">' +
@@ -684,6 +724,7 @@ describe('ngMessages', function() {
                          '  <div ng-if="default" ng-message-default>Default message is set</div>' +
                          '</div>')($rootScope);
       $rootScope.default = true;
+      $rootScope.col = {unexpected: true};
       $rootScope.$digest();
 
       expect(element.text().trim()).toBe('Default message is set');

--- a/test/ngMessages/messagesSpec.js
+++ b/test/ngMessages/messagesSpec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('ngMessages', function() {
+fdescribe('ngMessages', function() {
   beforeEach(inject.strictDi());
   beforeEach(module('ngMessages'));
 
@@ -674,18 +674,28 @@ describe('ngMessages', function() {
       $rootScope.$digest();
 
       expect(element.text().trim()).toBe('');
+      expect(element).not.toHaveClass('ng-active');
 
       $rootScope.$apply(function() {
         $rootScope.col = { unexpected: true };
       });
 
       expect(element.text().trim()).toBe('Default message is set');
+      expect(element).toHaveClass('ng-active');
+
+      $rootScope.$apply(function() {
+        $rootScope.col = { unexpected: false };
+      });
+
+      expect(element.text().trim()).toBe('');
+      expect(element).not.toHaveClass('ng-active');
 
       $rootScope.$apply(function() {
         $rootScope.col = { val: true, unexpected: true };
       });
 
       expect(element.text().trim()).toBe('Message is set');
+      expect(element).toHaveClass('ng-active');
     }));
 
     it('should not render a default message with ng-messages-multiple if another error matches',

--- a/test/ngMessages/messagesSpec.js
+++ b/test/ngMessages/messagesSpec.js
@@ -661,6 +661,49 @@ describe('ngMessages', function() {
   );
 
 
+  describe('default message', function() {
+    it('should render a default message when no message matches', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-messages="col">' +
+                         '  <div ng-message="val">Message is set</div>' +
+                         '  <div ng-message-default>Default message is set</div>' +
+                         '</div>')($rootScope);
+      $rootScope.$digest();
+
+      expect(element.text().trim()).toBe('Default message is set');
+
+      $rootScope.$apply(function() {
+        $rootScope.col = { val: true };
+      });
+
+      expect(element.text().trim()).toBe('Message is set');
+    }));
+
+    it('should handle a default message with ngIf', inject(function($rootScope, $compile) {
+      element = $compile('<div ng-messages="col">' +
+                         '  <div ng-message="val">Message is set</div>' +
+                         '  <div ng-if="default" ng-message-default>Default message is set</div>' +
+                         '</div>')($rootScope);
+      $rootScope.default = true;
+      $rootScope.$digest();
+
+      expect(element.text().trim()).toBe('Default message is set');
+
+      $rootScope.$apply('default = false');
+
+      expect(element.text().trim()).toBe('');
+
+      $rootScope.$apply('default = true');
+
+      expect(element.text().trim()).toBe('Default message is set');
+
+      $rootScope.$apply(function() {
+        $rootScope.col = { val: true };
+      });
+
+      expect(element.text().trim()).toBe('Message is set');
+    }));
+  });
+
   describe('when including templates', function() {
     they('should work with a dynamic collection model which is managed by ngRepeat',
       {'<div ng-messages-include="...">': '<div ng-messages="item">' +


### PR DESCRIPTION
Added support for showing default message when no values are mapped with ng-message.

Closes #12008

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

