### PR TITLE
revert: refactor($compile): remove preAssignBindingsEnabled leftovers

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2790,6 +2790,10 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           };
         }
 
+        if (controllerDirectives) {
+          elementControllers = setupControllers($element, attrs, transcludeFn, controllerDirectives, isolateScope, scope, newIsolateScopeDirective);
+        }
+
         if (newIsolateScopeDirective) {
           // Initialize isolate scope bindings for new isolate scope directive.
           compile.$$addScopeInfo($element, isolateScope, true, !(templateDirective && (templateDirective === newIsolateScopeDirective ||
@@ -2805,69 +2809,53 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           }
         }
 
-        if (controllerDirectives) {
-          elementControllers = createMap();
-          for (var name in controllerDirectives) {
-            var directive = controllerDirectives[name];
-            var locals = {
-              $scope: directive === newIsolateScopeDirective || directive.$$isolateScope ? isolateScope : scope,
-              $element: $element,
-              $attrs: attrs,
-              $transclude: transcludeFn
-            };
+        // Initialize bindToController bindings
+        for (var name in elementControllers) {
+          var controllerDirective = controllerDirectives[name];
+          var controller = elementControllers[name];
+          var bindings = controllerDirective.$$bindings.bindToController;
 
-            var controllerConstructor = directive.controller;
-            if (controllerConstructor === '@') {
-              controllerConstructor = attrs[name];
-            }
-
-            var instance = $controller(controllerConstructor, locals, directive.controllerAs);
-
-            $element.data('$' + name + 'Controller', instance);
-
-            // Initialize bindToController bindings
-            var bindings = directive.$$bindings.bindToController;
-            var bindingInfo = initializeDirectiveBindings(controllerScope, attrs, instance, bindings, directive);
-
-            elementControllers[name] = { instance: instance, bindingInfo: bindingInfo };
+          controller.instance = controller();
+          $element.data('$' + controllerDirective.name + 'Controller', controller.instance);
+          controller.bindingInfo =
+            initializeDirectiveBindings(controllerScope, attrs, controller.instance, bindings, controllerDirective);
           }
 
-          // Bind the required controllers to the controller, if `require` is an object and `bindToController` is truthy
-          forEach(controllerDirectives, function(controllerDirective, name) {
-            var require = controllerDirective.require;
-            if (controllerDirective.bindToController && !isArray(require) && isObject(require)) {
-              extend(elementControllers[name].instance, getControllers(name, require, $element, elementControllers));
-            }
-          });
+        // Bind the required controllers to the controller, if `require` is an object and `bindToController` is truthy
+        forEach(controllerDirectives, function(controllerDirective, name) {
+          var require = controllerDirective.require;
+          if (controllerDirective.bindToController && !isArray(require) && isObject(require)) {
+            extend(elementControllers[name].instance, getControllers(name, require, $element, elementControllers));
+          }
+        });
 
-          // Handle the init and destroy lifecycle hooks on all controllers that have them
-          forEach(elementControllers, function(controller) {
-            var controllerInstance = controller.instance;
-            if (isFunction(controllerInstance.$onChanges)) {
-              try {
-                controllerInstance.$onChanges(controller.bindingInfo.initialChanges);
-              } catch (e) {
-                $exceptionHandler(e);
-              }
+        // Handle the init and destroy lifecycle hooks on all controllers that have them
+        forEach(elementControllers, function(controller) {
+          var controllerInstance = controller.instance;
+          if (isFunction(controllerInstance.$onChanges)) {
+            try {
+              controllerInstance.$onChanges(controller.bindingInfo.initialChanges);
+            } catch (e) {
+              $exceptionHandler(e);
             }
-            if (isFunction(controllerInstance.$onInit)) {
-              try {
-                controllerInstance.$onInit();
-              } catch (e) {
-                $exceptionHandler(e);
-              }
+          }
+          if (isFunction(controllerInstance.$onInit)) {
+            try {
+              controllerInstance.$onInit();
+            } catch (e) {
+              $exceptionHandler(e);
             }
-            if (isFunction(controllerInstance.$doCheck)) {
-              controllerScope.$watch(function() { controllerInstance.$doCheck(); });
-              controllerInstance.$doCheck();
-            }
-            if (isFunction(controllerInstance.$onDestroy)) {
-              controllerScope.$on('$destroy', function callOnDestroyHook() {
-                controllerInstance.$onDestroy();
-              });
-            }
-          });
-        }
+          }
+          if (isFunction(controllerInstance.$doCheck)) {
+            controllerScope.$watch(function() { controllerInstance.$doCheck(); });
+            controllerInstance.$doCheck();
+          }
+          if (isFunction(controllerInstance.$onDestroy)) {
+            controllerScope.$on('$destroy', function callOnDestroyHook() {
+              controllerInstance.$onDestroy();
+            });
+          }
+        });
 
         // PRELINKING
         for (i = 0, ii = preLinkFns.length; i < ii; i++) {
@@ -2993,6 +2981,34 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
       }
 
       return value || null;
+    }
+
+    function setupControllers($element, attrs, transcludeFn, controllerDirectives, isolateScope, scope, newIsolateScopeDirective) {
+      var elementControllers = createMap();
+      for (var controllerKey in controllerDirectives) {
+        var directive = controllerDirectives[controllerKey];
+        var locals = {
+          $scope: directive === newIsolateScopeDirective || directive.$$isolateScope ? isolateScope : scope,
+          $element: $element,
+          $attrs: attrs,
+          $transclude: transcludeFn
+        };
+
+        var controller = directive.controller;
+        if (controller === '@') {
+          controller = attrs[directive.name];
+        }
+
+        var controllerInstance = $controller(controller, locals, true, directive.controllerAs);
+
+        // For directives with element transclusion the element is a comment.
+        // In this case .data will not attach any data.
+        // Instead, we save the controllers for the element in a local hash and attach to .data
+        // later, once we have the actual element.
+        elementControllers[directive.name] = controllerInstance;
+        $element.data('$' + directive.name + 'Controller', controllerInstance.instance);
+      }
+      return elementControllers;
     }
 
     // Depending upon the context in which a directive finds itself it might need to have a new isolated

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2345,11 +2345,14 @@ angular.mock.$RootElementProvider = function() {
  */
 function createControllerDecorator() {
   angular.mock.$ControllerDecorator = ['$delegate', function($delegate) {
-    return function(expression, locals, bindings, ident) {
-      if (angular.isString(bindings)) ident = bindings;
-      var instance = $delegate(expression, locals, ident);
-      angular.extend(instance, bindings);
-      return instance;
+    return function(expression, locals, later, ident) {
+      if (later && typeof later === 'object') {
+        var instantiate = $delegate(expression, locals, true, ident);
+        var instance = instantiate();
+        angular.extend(instance, later);
+        return instance;
+      }
+      return $delegate(expression, locals, later, ident);
     };
   }];
 

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -482,6 +482,25 @@ describe('injector', function() {
           expect(instance).toEqual(new Clazz('a-value'));
           expect(instance.aVal()).toEqual('a-value');
         });
+
+        they('should detect ES6 classes regardless of whitespace/comments ($prop)', [
+          'class Test {}',
+          'class Test{}',
+          'class //<--ES6 stuff\nTest {}',
+          'class//<--ES6 stuff\nTest {}',
+          'class {}',
+          'class{}',
+          'class //<--ES6 stuff\n {}',
+          'class//<--ES6 stuff\n {}',
+          'class/* Test */{}',
+          'class /* Test */ {}'
+        ], function(classDefinition) {
+          // eslint-disable-next-line no-eval
+          var Clazz = eval('(' + classDefinition + ')');
+          var instance = injector.invoke(Clazz);
+
+          expect(instance).toEqual(jasmine.any(Clazz));
+        });
       }
     });
 


### PR DESCRIPTION
This reverts commit 8e104ee508418bc2ebb65e5b4ac73d22285cc224.

This internal clean-up turned out to break popular UI libraries (e.g.
`ngMaterial`, `ui-bootstrap`) and cause pain to developers.

Fixes #16594.