### PR TITLE
feat(form.FormController): add $getControls()

### DIFF
--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -4,7 +4,7 @@
  */
 var nullFormCtrl = {
   $addControl: noop,
-  $getControls: noop,
+  $getControls: valueFn([]),
   $$renameControl: nullFormRenameControl,
   $removeControl: noop,
   $setValidity: noop,
@@ -166,16 +166,18 @@ FormController.prototype = {
    * @returns {Array} the controls that are currently part of this form
    *
    * @description
-   * This method returns a **shallow copy** of the controls that are currently part of this form
-   * ({@link form.FormController `FormController`} /
-   * {@link ngModel.NgModelController `NgModelController`}) . This can be used
-   * for example to iterate over all controls to validate them.
+   * This method returns a **shallow copy** of the controls that are currently part of this form.
+   * The controls can be instances of {@link form.FormController `FormController`}
+   * ({@link ngForm "child-forms"}) and of {@link ngModel.NgModelController `NgModelController`}.
+   * If you need access to the controls of child-forms, you have to call `$getControls()`
+   * recursively on them.
+   * This can be used for example to iterate over all controls to validate them.
    *
-   * The controls can be accessed normally, but adding or removing controls from the array has no
-   * effect on the form. Instead, use {@link form.FormController#$addControl `$addControl()`} and
-   * {@link form.FormController#$removeControl `$removeControl()`}.
-   * Likewise, adding a control to / removing a control from the form is not reflected
-   * in the shallow copy. That means you should get a fresh copy from `$getControls` every time
+   * The controls can be accessed normally, but adding to, or removing controls from the array has
+   * no effect on the form. Instead, use {@link form.FormController#$addControl `$addControl()`} and
+   * {@link form.FormController#$removeControl `$removeControl()`} for this use-case.
+   * Likewise, adding a control to, or removing a control from the form is not reflected
+   * in the shallow copy. That means you should get a fresh copy from `$getControls()` every time
    * you need access to the controls.
    */
   $getControls: function() {

--- a/src/ng/directive/form.js
+++ b/src/ng/directive/form.js
@@ -4,6 +4,7 @@
  */
 var nullFormCtrl = {
   $addControl: noop,
+  $getControls: noop,
   $$renameControl: nullFormRenameControl,
   $removeControl: noop,
   $setValidity: noop,
@@ -157,6 +158,28 @@ FormController.prototype = {
     }
 
     control.$$parentForm = this;
+  },
+
+  /**
+   * @ngdoc method
+   * @name form.FormController#$getControls
+   * @returns {Array} the controls that are currently part of this form
+   *
+   * @description
+   * This method returns a **shallow copy** of the controls that are currently part of this form
+   * ({@link form.FormController `FormController`} /
+   * {@link ngModel.NgModelController `NgModelController`}) . This can be used
+   * for example to iterate over all controls to validate them.
+   *
+   * The controls can be accessed normally, but adding or removing controls from the array has no
+   * effect on the form. Instead, use {@link form.FormController#$addControl `$addControl()`} and
+   * {@link form.FormController#$removeControl `$removeControl()`}.
+   * Likewise, adding a control to / removing a control from the form is not reflected
+   * in the shallow copy. That means you should get a fresh copy from `$getControls` every time
+   * you need access to the controls.
+   */
+  $getControls: function() {
+    return shallowCopy(this.$$controls);
   },
 
   // Private API: rename a form control

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -1200,7 +1200,18 @@ describe('form', function() {
     });
   });
 
-  fdescribe('$getControls', function() {
+  describe('$getControls', function() {
+    it('should return an empty array if the controller has no controls', function() {
+      doc = $compile('<form name="testForm"></form>')(scope);
+
+      scope.$digest();
+
+      var form = doc,
+          formCtrl = scope.testForm;
+
+      expect(formCtrl.$getControls()).toEqual([]);
+    });
+
     it('should return a shallow copy of the form controls', function() {
       doc = $compile(
           '<form name="testForm">' +

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -1206,8 +1206,7 @@ describe('form', function() {
 
       scope.$digest();
 
-      var form = doc,
-          formCtrl = scope.testForm;
+      var formCtrl = scope.testForm;
 
       expect(formCtrl.$getControls()).toEqual([]);
     });

--- a/test/ng/directive/formSpec.js
+++ b/test/ng/directive/formSpec.js
@@ -1200,6 +1200,42 @@ describe('form', function() {
     });
   });
 
+  fdescribe('$getControls', function() {
+    it('should return a shallow copy of the form controls', function() {
+      doc = $compile(
+          '<form name="testForm">' +
+            '<input ng-model="named" name="foo">' +
+            '<div ng-form>' +
+              '<input ng-model="named" name="foo">' +
+            '</div>' +
+          '</form>')(scope);
+
+      scope.$digest();
+
+      var form = doc,
+          formCtrl = scope.testForm,
+          formInput = form.children('input').eq(0),
+          formInputCtrl = formInput.controller('ngModel'),
+          nestedForm = form.find('div'),
+          nestedFormCtrl = nestedForm.controller('form'),
+          nestedInput = nestedForm.children('input').eq(0),
+          nestedInputCtrl = nestedInput.controller('ngModel');
+
+      var controls = formCtrl.$getControls();
+
+      expect(controls).not.toBe(formCtrl.$$controls);
+
+      controls.push('something');
+      expect(formCtrl.$$controls).not.toContain('something');
+
+      expect(controls[0]).toBe(formInputCtrl);
+      expect(controls[1]).toBe(nestedFormCtrl);
+
+      var nestedControls = controls[1].$getControls();
+
+      expect(nestedControls[0]).toBe(nestedInputCtrl);
+    });
+  });
 
   it('should rename nested form controls when interpolated name changes', function() {
     scope.idA = 'A';


### PR DESCRIPTION
Fixes #14749
Closes #14517
Closes #13202

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feat


**What is the current behavior? (You can also link to an open issue here)**
there's no straight forward way to get all controls of a form


**What is the new behavior (if this is a feature change)?**
you can get a shallow copy of the form controls


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
I decided against a synchronized copy (https://github.com/angular/angular.js/issues/14749#issuecomment-230451318) because I don't see the clear benefit over a simple shallow copy + is slightly more involved to implmenent.
