### PR TITLE
fix(ngAria): do not scroll when pressing spacebar on custom buttons

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -387,7 +387,10 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
           if ($aria.config('bindKeydown') && !attr.ngKeydown && !attr.ngKeypress && !attr.ngKeyup) {
             elem.on('keydown', function(event) {
               var keyCode = event.which || event.keyCode;
-              if (keyCode === 32 || keyCode === 13) {
+
+              if (keyCode === 13 || keyCode === 32) {
+                // Prevent the default browser behavior (e.g. scrolling when pressing spacebar).
+                event.preventDefault();
                 scope.$apply(callback);
               }
 

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -929,11 +929,12 @@ describe('$aria', function() {
       clickEvents = [];
       scope.onClick = jasmine.createSpy('onClick').and.callFake(function(evt) {
         var nodeName = evt ? evt.target.nodeName.toLowerCase() : '';
-        clickEvents.push(nodeName);
+        var prevented = !!(evt && evt.defaultPrevented);
+        clickEvents.push(nodeName + '(' + prevented + ')');
       });
     });
 
-    it('should trigger a click from the keyboard', function() {
+    it('should trigger a click from the keyboard (and prevent default action)', function() {
       compileElement(
         '<section>' +
           '<div ng-click="onClick($event)"></div>' +
@@ -948,7 +949,7 @@ describe('$aria', function() {
       divElement.triggerHandler({type: 'keydown', keyCode: 32});
       liElement.triggerHandler({type: 'keydown', keyCode: 32});
 
-      expect(clickEvents).toEqual(['div', 'li', 'div', 'li']);
+      expect(clickEvents).toEqual(['div(true)', 'li(true)', 'div(true)', 'li(true)']);
     });
 
     it('should trigger a click in browsers that provide `event.which` instead of `event.keyCode`',
@@ -967,7 +968,7 @@ describe('$aria', function() {
         divElement.triggerHandler({type: 'keydown', which: 32});
         liElement.triggerHandler({type: 'keydown', which: 32});
 
-        expect(clickEvents).toEqual(['div', 'li', 'div', 'li']);
+        expect(clickEvents).toEqual(['div(true)', 'li(true)', 'div(true)', 'li(true)']);
       }
     );
 

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -929,7 +929,7 @@ describe('$aria', function() {
       clickEvents = [];
       scope.onClick = jasmine.createSpy('onClick').and.callFake(function(evt) {
         var nodeName = evt ? evt.target.nodeName.toLowerCase() : '';
-        var prevented = !!(evt && evt.defaultPrevented);
+        var prevented = !!(evt && evt.isDefaultPrevented());
         clickEvents.push(nodeName + '(' + prevented + ')');
       });
     });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.


**What is the current behavior? (You can also link to an open issue here)**
By default, pressing spacebar causes the browser to scroll down. However, when a native button is focused, the button is clicked instead.

`ngAria`'s `ngClick` directive, sets elements up to behave like buttons. For example, it adds `role="button"` and forwards `ENTER` and `SPACEBAR` keypresses to the `click` handler (to emulate the behavior of native buttons).

Yet, pressing spacebar on such an element, still invokes the default browser behavior of scrolling down, which is undesirable.


**What is the new behavior (if this is a feature change)?**
`ngAria#ngClick` calls `preventDefault()` on the keyboard event, thus preventing the default scrolling behavior and making custom buttons behave closer to native ones.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] ~~Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated~~
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
Supercedes and closes #14665, which didn't include tests.