### PR TITLE
fix($location): fix infinite recursion/digest on URLs with special characters

### DIFF
--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -879,6 +879,13 @@ function $LocationProvider() {
 
     var IGNORE_URI_REGEXP = /^\s*(javascript|mailto):/i;
 
+    // Determine if two URLs are equal despite potentially having different encoding/normalizing
+    //  such as $location.absUrl() vs $browser.url()
+    // See https://github.com/angular/angular.js/issues/16592
+    function urlsEqual(a, b) {
+      return a === b || urlResolve(a).href === urlResolve(b).href;
+    }
+
     function setBrowserUrlWithFallback(url, replace, state) {
       var oldUrl = $location.url();
       var oldState = $location.$$state;
@@ -996,7 +1003,7 @@ function $LocationProvider() {
         var newUrl = trimEmptyHash($location.absUrl());
         var oldState = $browser.state();
         var currentReplace = $location.$$replace;
-        var urlOrStateChanged = oldUrl !== newUrl ||
+        var urlOrStateChanged = !urlsEqual(oldUrl, newUrl) ||
           ($location.$$html5 && $sniffer.history && oldState !== $location.$$state);
 
         if (initializing || urlOrStateChanged) {

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -747,6 +747,58 @@ describe('$location', function() {
     });
 
 
+    //https://github.com/angular/angular.js/issues/16592
+    it('should not infinitely digest when initial params contain a quote', function() {
+      initService({html5Mode:true,supportHistory:true});
+      mockUpBrowser({initialUrl:'http://localhost:9876/?q=\'', baseHref:'/'});
+      inject(function($location, $browser, $rootScope) {
+        expect(function() {
+          $rootScope.$digest();
+        }).not.toThrow();
+      });
+    });
+
+
+    //https://github.com/angular/angular.js/issues/16592
+    it('should not infinitely digest when initial params contain an escaped quote', function() {
+      initService({html5Mode:true,supportHistory:true});
+      mockUpBrowser({initialUrl:'http://localhost:9876/?q=%27', baseHref:'/'});
+      inject(function($location, $browser, $rootScope) {
+        expect(function() {
+          $rootScope.$digest();
+        }).not.toThrow();
+      });
+    });
+
+
+    //https://github.com/angular/angular.js/issues/16592
+    it('should not infinitely digest when updating params containing a quote (via $browser.url)', function() {
+      initService({html5Mode:true,supportHistory:true});
+      mockUpBrowser({initialUrl:'http://localhost:9876/', baseHref:'/'});
+      inject(function($location, $browser, $rootScope) {
+        $rootScope.$digest();
+        $browser.url('http://localhost:9876/?q=\'');
+        expect(function() {
+          $rootScope.$digest();
+        }).not.toThrow();
+      });
+    });
+
+
+    //https://github.com/angular/angular.js/issues/16592
+    it('should not infinitely digest when updating params containing a quote (via window.location + popstate)', function() {
+      initService({html5Mode:true,supportHistory:true});
+      mockUpBrowser({initialUrl:'http://localhost:9876/', baseHref:'/'});
+      inject(function($window, $location, $browser, $rootScope) {
+        $rootScope.$digest();
+        $window.location.href = 'http://localhost:9876/?q=\'';
+        expect(function() {
+          jqLite($window).triggerHandler('popstate');
+        }).not.toThrow();
+      });
+    });
+
+
     describe('when changing the browser URL/history directly during a `$digest`', function() {
 
       beforeEach(function() {
@@ -804,10 +856,13 @@ describe('$location', function() {
     });
 
 
-    function updatePathOnLocationChangeSuccessTo(newPath) {
+    function updatePathOnLocationChangeSuccessTo(newPath, newParams) {
       inject(function($rootScope, $location) {
         $rootScope.$on('$locationChangeSuccess', function(event, newUrl, oldUrl) {
           $location.path(newPath);
+          if (newParams) {
+            $location.search(newParams);
+          }
         });
       });
     }
@@ -948,6 +1003,25 @@ describe('$location', function() {
           expect($browser.url()).toEqual('http://server/app/');
           expect($location.path()).toEqual('/');
           expect($browserUrl).not.toHaveBeenCalled();
+        });
+      });
+
+      //https://github.com/angular/angular.js/issues/16592
+      it('should not infinite $digest when going to base URL with trailing slash when $locationChangeSuccess watcher changes query params to contain quote', function() {
+        initService({html5Mode: true, supportHistory: true});
+        mockUpBrowser({initialUrl:'http://server/app/', baseHref:'/app/'});
+        inject(function($rootScope, $injector, $browser) {
+          var $browserUrl = spyOnlyCallsWithArgs($browser, 'url').and.callThrough();
+
+          var $location = $injector.get('$location');
+          updatePathOnLocationChangeSuccessTo('/', {q: '\''});
+
+          $rootScope.$digest();
+
+          expect($browser.url()).toEqual('http://server/app/?q=%27');
+          expect($location.path()).toEqual('/');
+          expect($location.search()).toEqual({q: '\''});
+          expect($browserUrl).toHaveBeenCalledTimes(1);
         });
       });
     });
@@ -1137,6 +1211,42 @@ describe('$location', function() {
         expect($location.search()).toEqual({d: 'e'});
         expect($location.hash()).toBe('f');
         expect($location.state()).toEqual({b: 4});
+      });
+    });
+
+    //https://github.com/angular/angular.js/issues/16592
+    it('should not infinite $digest on pushState() with quote in param', function() {
+      initService({html5Mode: true, supportHistory: true});
+      mockUpBrowser({initialUrl:'http://server/app/', baseHref:'/app/'});
+      inject(function($rootScope, $injector, $browser, $window) {
+        var $location = $injector.get('$location');
+        $rootScope.$digest(); //allow $location initialization to finish
+
+        $window.history.pushState({}, null, 'http://server/app/Home?q=\'');
+        $rootScope.$digest();
+
+        expect($browser.url()).toEqual('http://server/app/Home?q=%27');
+        expect($location.absUrl()).toEqual('http://server/app/Home?q=\'');
+        expect($location.path()).toEqual('/Home');
+        expect($location.search()).toEqual({q: '\''});
+      });
+    });
+
+    //https://github.com/angular/angular.js/issues/16592
+    it('should not infinite $digest on popstate event with quote in param', function() {
+      initService({html5Mode: true, supportHistory: true});
+      mockUpBrowser({initialUrl:'http://server/app/', baseHref:'/app/'});
+      inject(function($rootScope, $injector, $browser, $window) {
+        var $location = $injector.get('$location');
+        $rootScope.$digest(); //allow $location initialization to finish
+
+        $window.location.href = 'http://server/app/Home?q=\'';
+        jqLite($window).triggerHandler('popstate');
+
+        expect($browser.url()).toEqual('http://server/app/Home?q=%27');
+        expect($location.absUrl()).toEqual('http://server/app/Home?q=\'');
+        expect($location.path()).toEqual('/Home');
+        expect($location.search()).toEqual({q: '\''});
       });
     });
 

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -1018,7 +1018,6 @@ describe('$location', function() {
 
           $rootScope.$digest();
 
-          expect($browser.url()).toEqual('http://server/app/?q=%27');
           expect($location.path()).toEqual('/');
           expect($location.search()).toEqual({q: '\''});
           expect($browserUrl).toHaveBeenCalledTimes(1);
@@ -1218,14 +1217,13 @@ describe('$location', function() {
     it('should not infinite $digest on pushState() with quote in param', function() {
       initService({html5Mode: true, supportHistory: true});
       mockUpBrowser({initialUrl:'http://server/app/', baseHref:'/app/'});
-      inject(function($rootScope, $injector, $browser, $window) {
+      inject(function($rootScope, $injector, $window) {
         var $location = $injector.get('$location');
         $rootScope.$digest(); //allow $location initialization to finish
 
         $window.history.pushState({}, null, 'http://server/app/Home?q=\'');
         $rootScope.$digest();
 
-        expect($browser.url()).toEqual('http://server/app/Home?q=%27');
         expect($location.absUrl()).toEqual('http://server/app/Home?q=\'');
         expect($location.path()).toEqual('/Home');
         expect($location.search()).toEqual({q: '\''});
@@ -1236,14 +1234,13 @@ describe('$location', function() {
     it('should not infinite $digest on popstate event with quote in param', function() {
       initService({html5Mode: true, supportHistory: true});
       mockUpBrowser({initialUrl:'http://server/app/', baseHref:'/app/'});
-      inject(function($rootScope, $injector, $browser, $window) {
+      inject(function($rootScope, $injector, $window) {
         var $location = $injector.get('$location');
         $rootScope.$digest(); //allow $location initialization to finish
 
         $window.location.href = 'http://server/app/Home?q=\'';
         jqLite($window).triggerHandler('popstate');
 
-        expect($browser.url()).toEqual('http://server/app/Home?q=%27');
         expect($location.absUrl()).toEqual('http://server/app/Home?q=\'');
         expect($location.path()).toEqual('/Home');
         expect($location.search()).toEqual({q: '\''});


### PR DESCRIPTION
Some characters are treated differently by `$location` compared to `$browser` and the native browser. When comparing URLs across these two services this must be taken into account.

Fixes #16592

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
fix


**What is the current behavior? (You can also link to an open issue here)**
`$browser` and `$location` persist URLs differently, so comparing them sometimes treats them as not-equal when they should be considered equal


**What is the new behavior (if this is a feature change)?**
`$location` compares a normalized version of the URLs


**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
All the added tests previously failed, some due to `infdig` and others due to `RangeError: Maximum call stack size exceeded`.

The tests all use the single-quote to trigger the error, but I assume there are similar cases where `$location` and `window.location.href` have different escaping/encoding.

#16606 partially fixed this (which I still don't quite understand), but some of the tests in this PR still failed.