### PR TITLE
fix($compile): work around Firefox `DocumentFragment` bug

### DIFF
--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -2620,11 +2620,12 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               for (var slotName in slots) {
                 if (slots[slotName]) {
                   // Only define a transclusion function if the slot was filled
-                  slots[slotName] = compilationGenerator(mightHaveMultipleTransclusionError, slots[slotName].childNodes, transcludeFn);
+                  var slotCompileNodes = jqLite(slots[slotName].childNodes);
+                  slots[slotName] = compilationGenerator(mightHaveMultipleTransclusionError, slotCompileNodes, transcludeFn);
                 }
               }
 
-              $template = $template.childNodes;
+              $template = jqLite($template.childNodes);
             }
 
             $compileNode.empty(); // clear contents


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Browser bug work-around.


**What is the current behavior? (You can also link to an open issue here)**
DOM nodes passed to `compilationGenerator()` will eventually be wrapped in `jqLite`, when the compilation actually happens. In Firefox 60+, there seems to be a `DocumentFragment`-related bug that sometimes causes the `childNodes` to be empty at the time the compilation happens.


**What is the new behavior (if this is a feature change)?**
This commit works around this bug by eagerly wrapping `childNodes` in `jqLite`.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] ~~Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated~~
- [ ] ~~Fix/Feature: Tests have been added; existing tests pass~~

**Other information**:
Fixes #16607.

NOTE:
The wrapped nodes have references to their `DocumentFragment` container. This is "by design", since we want to be able to traverse the nodes via `nextSibling` (in order to correctly handle multi-element directives).

Once the nodes are compiled, they will be either moved to a new container element or the `jqLite` wrapper is release making them eligible for garbage collection. In both cases, the original `DocumentFragment` container should be eligible for garbage collection too.
