### PR TITLE
fix($location): avoid unnecessary `$locationChange*` events due to empty hash

### DIFF
--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -1,5 +1,10 @@
 'use strict';
-/* global stripHash: true */
+/* global getHash: true, stripHash: false */
+
+function getHash(url) {
+  var index = url.indexOf('#');
+  return index === -1 ? '' : url.substr(index);
+}
 
 /**
  * ! This is a private undocumented service !
@@ -61,11 +66,6 @@ function Browser(window, document, $log, $sniffer, $$taskTrackerFactory) {
       };
 
   cacheState();
-
-  function getHash(url) {
-    var index = url.indexOf('#');
-    return index === -1 ? '' : url.substr(index);
-  }
 
   /**
    * @name $browser#url

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -1,5 +1,5 @@
 'use strict';
-/* global getHash: true, stripHash: false, trimEmptyHash: true */
+/* global getHash: true, stripHash: false */
 
 function getHash(url) {
   var index = url.indexOf('#');

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -1,5 +1,5 @@
 'use strict';
-/* global getHash: true, stripHash: false */
+/* global getHash: true, stripHash: false, trimEmptyHash: false */
 
 function getHash(url) {
   var index = url.indexOf('#');
@@ -143,7 +143,7 @@ function Browser(window, document, $log, $sniffer, $$taskTrackerFactory) {
       // - pendingLocation is needed as browsers don't allow to read out
       //   the new location.href if a reload happened or if there is a bug like in iOS 9 (see
       //   https://openradar.appspot.com/22186109).
-      return pendingLocation || location.href;
+      return pendingLocation || trimEmptyHash(location.href);
     }
   };
 

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -1,9 +1,13 @@
 'use strict';
-/* global getHash: true, stripHash: false, trimEmptyHash: false */
+/* global getHash: true, stripHash: false, trimEmptyHash: true */
 
 function getHash(url) {
   var index = url.indexOf('#');
   return index === -1 ? '' : url.substr(index);
+}
+
+function trimEmptyHash(url) {
+  return url.replace(/#$/, '');
 }
 
 /**
@@ -143,7 +147,7 @@ function Browser(window, document, $log, $sniffer, $$taskTrackerFactory) {
       // - pendingLocation is needed as browsers don't allow to read out
       //   the new location.href if a reload happened or if there is a bug like in iOS 9 (see
       //   https://openradar.appspot.com/22186109).
-      return pendingLocation || trimEmptyHash(location.href);
+      return trimEmptyHash(pendingLocation || location.href);
     }
   };
 

--- a/src/ng/browser.js
+++ b/src/ng/browser.js
@@ -76,20 +76,21 @@ function Browser(window, document, $log, $sniffer, $$taskTrackerFactory) {
    *
    * @description
    * GETTER:
-   * Without any argument, this method just returns current value of location.href.
+   * Without any argument, this method just returns current value of `location.href` (with a
+   * trailing `#` stripped of if the hash is empty).
    *
    * SETTER:
    * With at least one argument, this method sets url to new value.
-   * If html5 history api supported, pushState/replaceState is used, otherwise
-   * location.href/location.replace is used.
-   * Returns its own instance to allow chaining
+   * If html5 history api supported, `pushState`/`replaceState` is used, otherwise
+   * `location.href`/`location.replace` is used.
+   * Returns its own instance to allow chaining.
    *
-   * NOTE: this api is intended for use only by the $location service. Please use the
+   * NOTE: this api is intended for use only by the `$location` service. Please use the
    * {@link ng.$location $location service} to change url.
    *
    * @param {string} url New url (when used as setter)
    * @param {boolean=} replace Should new url replace current history record?
-   * @param {object=} state object to use with pushState/replaceState
+   * @param {object=} state State object to use with `pushState`/`replaceState`
    */
   self.url = function(url, replace, state) {
     // In modern browsers `history.state` is `null` by default; treating it separately

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -1,4 +1,5 @@
 'use strict';
+/* global stripHash: true */
 
 var PATH_MATCH = /^([^?#]*)(\?([^#]*))?(#(.*))?$/,
     DEFAULT_PORTS = {'http': 80, 'https': 443, 'ftp': 21};

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -102,7 +102,7 @@ function stripHash(url) {
 }
 
 function trimEmptyHash(url) {
-  return url.replace(/(#.+)|#$/, '$1');
+  return url.replace(/#$/, '');
 }
 
 

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -1,5 +1,5 @@
 'use strict';
-/* global stripHash: true */
+/* global stripHash: true, trimEmptyHash: true */
 
 var PATH_MATCH = /^([^?#]*)(\?([^#]*))?(#(.*))?$/,
     DEFAULT_PORTS = {'http': 80, 'https': 443, 'ftp': 21};

--- a/src/ng/location.js
+++ b/src/ng/location.js
@@ -1,5 +1,5 @@
 'use strict';
-/* global stripHash: true, trimEmptyHash: true */
+/* global stripHash: true */
 
 var PATH_MATCH = /^([^?#]*)(\?([^#]*))?(#(.*))?$/,
     DEFAULT_PORTS = {'http': 80, 'https': 443, 'ftp': 21};
@@ -95,16 +95,10 @@ function stripBaseUrl(base, url) {
   }
 }
 
-
 function stripHash(url) {
   var index = url.indexOf('#');
   return index === -1 ? url : url.substr(0, index);
 }
-
-function trimEmptyHash(url) {
-  return url.replace(/#$/, '');
-}
-
 
 function stripFile(url) {
   return url.substr(0, stripHash(url).lastIndexOf('/') + 1);
@@ -944,7 +938,7 @@ function $LocationProvider() {
 
 
     // rewrite hashbang url <> html5 url
-    if (trimEmptyHash($location.absUrl()) !== trimEmptyHash(initialUrl)) {
+    if ($location.absUrl() !== initialUrl) {
       $browser.url($location.absUrl(), true);
     }
 
@@ -963,7 +957,6 @@ function $LocationProvider() {
         var oldUrl = $location.absUrl();
         var oldState = $location.$$state;
         var defaultPrevented;
-        newUrl = trimEmptyHash(newUrl);
         $location.$$parse(newUrl);
         $location.$$state = newState;
 
@@ -991,8 +984,8 @@ function $LocationProvider() {
       if (initializing || $location.$$urlUpdatedByLocation) {
         $location.$$urlUpdatedByLocation = false;
 
-        var oldUrl = trimEmptyHash($browser.url());
-        var newUrl = trimEmptyHash($location.absUrl());
+        var oldUrl = $browser.url();
+        var newUrl = $location.absUrl();
         var oldState = $browser.state();
         var currentReplace = $location.$$replace;
         var urlOrStateChanged = !urlsEqual(oldUrl, newUrl) ||

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global routeToRegExp: false, trimEmptyHash: false */
+/* global routeToRegExp: false */
 
 /**
  * @ngdoc object
@@ -225,7 +225,8 @@ angular.mock.$Browser.prototype = {
       state = null;
     }
     if (url) {
-      this.$$url = trimEmptyHash(url);
+      // The `$browser` service trims empty hashes; simulate it.
+      this.$$url = url.replace(/#$/, '');
       // Native pushState serializes & copies the object; simulate it.
       this.$$state = angular.copy(state);
       return this;

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global routeToRegExp: false */
+/* global routeToRegExp: false, trimEmptyHash: false */
 
 /**
  * @ngdoc object
@@ -225,7 +225,7 @@ angular.mock.$Browser.prototype = {
       state = null;
     }
     if (url) {
-      this.$$url = url;
+      this.$$url = trimEmptyHash(url);
       // Native pushState serializes & copies the object; simulate it.
       this.$$state = angular.copy(state);
       return this;

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -404,6 +404,14 @@ describe('browser', function() {
       expect(browser.url()).toEqual('https://another.com');
     });
 
+    it('should strip an empty hash fragment', function() {
+      fakeWindow.location.href = 'http://test.com#';
+      expect(browser.url()).toEqual('http://test.com');
+
+      fakeWindow.location.href = 'https://another.com#foo';
+      expect(browser.url()).toEqual('https://another.com#foo');
+    });
+
     it('should use history.pushState when available', function() {
       sniffer.history = true;
       browser.url('http://new.org');
@@ -1045,6 +1053,32 @@ describe('browser', function() {
         fakeWindow.fire('hashchange');
 
         expect($location.absUrl()).toEqual('http://server/#otherHash');
+      });
+    });
+
+    // issue #16632
+    it('should not trigger `$locationChangeStart` more than once due to trailing `#`', function() {
+      setup({
+        history: true,
+        html5Mode: true
+      });
+
+      inject(function($flushPendingTasks, $location, $rootScope) {
+        $rootScope.$digest();
+
+        const spy = jasmine.createSpy('$locationChangeStart');
+        $rootScope.$on('$locationChangeStart', spy);
+
+        $rootScope.$evalAsync(function() {
+          fakeWindow.location.href += '#';
+        });
+        $rootScope.$digest();
+
+        expect(fakeWindow.location.href).toBe('http://server/#');
+        expect($location.absUrl()).toBe('http://server/');
+
+        expect(spy.calls.count()).toBe(0);
+        expect(spy).not.toHaveBeenCalled();
       });
     });
   });

--- a/test/ng/browserSpecs.js
+++ b/test/ng/browserSpecs.js
@@ -1066,7 +1066,7 @@ describe('browser', function() {
       inject(function($flushPendingTasks, $location, $rootScope) {
         $rootScope.$digest();
 
-        const spy = jasmine.createSpy('$locationChangeStart');
+        var spy = jasmine.createSpy('$locationChangeStart');
         $rootScope.$on('$locationChangeStart', spy);
 
         $rootScope.$evalAsync(function() {

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -711,6 +711,7 @@ describe('$location', function() {
       inject(function($browser, $location, $window) {
         expect($browser.url()).toBe('http://new.com/#');
         expect($location.absUrl()).toBe('http://new.com/');
+        expect($window.location.href).toBe('http://new.com/#');
       });
     });
 

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -709,7 +709,7 @@ describe('$location', function() {
       initService({html5Mode: true, supportHistory: true});
       mockUpBrowser({initialUrl: 'http://new.com/#', baseHref: '/'});
       inject(function($browser, $location, $window) {
-        expect($browser.url()).toBe('http://new.com/#');
+        expect($browser.url()).toBe('http://new.com/');
         expect($location.absUrl()).toBe('http://new.com/');
         expect($window.location.href).toBe('http://new.com/#');
       });

--- a/test/ng/locationSpec.js
+++ b/test/ng/locationSpec.js
@@ -693,10 +693,10 @@ describe('$location', function() {
 
   describe('location watch', function() {
 
-    it('should not update browser if only the empty hash fragment is cleared by updating the search', function() {
+    it('should not update browser if only the empty hash fragment is cleared', function() {
       initService({supportHistory: true});
-      mockUpBrowser({initialUrl:'http://new.com/a/b#', baseHref:'/base/'});
-      inject(function($rootScope, $browser, $location) {
+      mockUpBrowser({initialUrl: 'http://new.com/a/b#', baseHref: '/base/'});
+      inject(function($browser, $rootScope) {
         $browser.url('http://new.com/a/b');
         var $browserUrl = spyOnlyCallsWithArgs($browser, 'url').and.callThrough();
         $rootScope.$digest();
@@ -707,8 +707,8 @@ describe('$location', function() {
 
     it('should not replace browser url if only the empty hash fragment is cleared', function() {
       initService({html5Mode: true, supportHistory: true});
-      mockUpBrowser({initialUrl:'http://new.com/#', baseHref: '/'});
-      inject(function($browser, $location) {
+      mockUpBrowser({initialUrl: 'http://new.com/#', baseHref: '/'});
+      inject(function($browser, $location, $window) {
         expect($browser.url()).toBe('http://new.com/#');
         expect($location.absUrl()).toBe('http://new.com/');
       });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix (among others).


**What is the current behavior? (You can also link to an open issue here)**
#16632


**What is the new behavior (if this is a feature change)?**
No unnecessary `$locationChange*` events due to empty hash


**Does this PR introduce a breaking change?**
Hopefully not :grin:


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] ~~Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated~~
- [x] Fix/Feature: Tests have been added; existing tests pass
