### PR TITLE
fix(angular.element): do not break on `cleanData()` if `_data()` returns undefined

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1909,7 +1909,7 @@ function bindJQuery() {
   jqLite.cleanData = function(elems) {
     var events;
     for (var i = 0, elem; (elem = elems[i]) != null; i++) {
-      events = jqLite._data(elem).events;
+      events = (jqLite._data(elem) || {}).events;
       if (events && events.$destroy) {
         jqLite(elem).triggerHandler('$destroy');
       }

--- a/test/jqLiteSpec.js
+++ b/test/jqLiteSpec.js
@@ -501,6 +501,12 @@ describe('jqLite', function() {
       expect(jqLite(c).data('prop')).toBeUndefined();
     });
 
+    it('should not break on cleanData(), if element has no data', function() {
+      var selected = jqLite([a, b, c]);
+      spyOn(jqLite, '_data').and.returnValue(undefined);
+      expect(function() { jqLite.cleanData(selected); }).not.toThrow();
+    });
+
 
     it('should add and remove data on SVGs', function() {
       var svg = jqLite('<svg><rect></rect></svg>');


### PR DESCRIPTION
This shouldn't happen in supported jQuery versions (2+), but if someone uses the unsupported 1.x version the app will break. The change that causes this new behavior was introduced in b7d396b8b.

Even though jQuery 1.x is not supported, it is worth avoiding the unnecessary breakage (given how simple).

Fixes #16641.