### PR TITLE
fix(ngMock): pass failed HTTP expectations to $errorHandler

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1510,16 +1510,25 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
       }
     }
 
+    function createFatalError(message) {
+      var error = new Error(message);
+      // In addition to being converted to a rejection, these errors also need to be passed to
+      // the $exceptionHandler and be rethrown (so that the test fails).
+      error.$$passToExceptionHandler = true;
+      return error;
+    }
+
     if (expectation && expectation.match(method, url)) {
       if (!expectation.matchData(data)) {
-        throw new Error('Expected ' + expectation + ' with different data\n' +
-            'EXPECTED: ' + prettyPrint(expectation.data) + '\nGOT:      ' + data);
+        throw createFatalError('Expected ' + expectation + ' with different data\n' +
+          'EXPECTED: ' + prettyPrint(expectation.data) + '\n' +
+          'GOT:      ' + data);
       }
 
       if (!expectation.matchHeaders(headers)) {
-        throw new Error('Expected ' + expectation + ' with different headers\n' +
-                        'EXPECTED: ' + prettyPrint(expectation.headers) + '\nGOT:      ' +
-                        prettyPrint(headers));
+        throw createFatalError('Expected ' + expectation + ' with different headers\n' +
+          'EXPECTED: ' + prettyPrint(expectation.headers) + '\n' +
+          'GOT:      ' + prettyPrint(headers));
       }
 
       expectations.shift();
@@ -1540,20 +1549,17 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
           ($browser ? $browser.defer : responsesPush)(wrapResponse(definition));
         } else if (definition.passThrough) {
           originalHttpBackend(method, url, data, callback, headers, timeout, withCredentials, responseType, eventHandlers, uploadEventHandlers);
-        } else throw new Error('No response defined !');
+        } else throw createFatalError('No response defined !');
         return;
       }
     }
-    var error = wasExpected ?
-        new Error('No response defined !') :
-        new Error('Unexpected request: ' + method + ' ' + url + '\n' +
-                  (expectation ? 'Expected ' + expectation : 'No more request expected'));
 
-    // In addition to be being converted to a rejection, this error also needs to be passed to
-    // the $exceptionHandler and be rethrown (so that the test fails).
-    error.$$passToExceptionHandler = true;
+    if (wasExpected) {
+      throw createFatalError('No response defined !');
+    }
 
-    throw error;
+    throw createFatalError('Unexpected request: ' + method + ' ' + url + '\n' +
+      (expectation ? 'Expected ' + expectation : 'No more request expected'));
   }
 
   /**

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1506,6 +1506,42 @@ describe('ngMock', function() {
     });
 
 
+    it('should throw error when expectation fails', function() {
+      expect(function() {
+        hb.expectPOST('/some', {foo: 1}).respond({});
+        hb('POST', '/some', {foo: 2}, callback);
+        hb.flush();
+      }).toThrowError(/^Expected POST \/some with different data/);
+    });
+
+
+    it('should throw error when expectation about headers fails', function() {
+      expect(function() {
+        hb.expectPOST('/some', {foo: 1}, {X: 'val1'}).respond({});
+        hb('POST', '/some', {foo: 1}, callback, {X: 'val2'});
+        hb.flush();
+      }).toThrowError(/^Expected POST \/some with different headers/);
+    });
+
+
+    it('should throw error about data when expectations about both data and headers fail', function() {
+      expect(function() {
+        hb.expectPOST('/some', {foo: 1}, {X: 'val1'}).respond({});
+        hb('POST', '/some', {foo: 2}, callback, {X: 'val2'});
+        hb.flush();
+      }).toThrowError(/^Expected POST \/some with different data/);
+    });
+
+
+    it('should throw error when response is not defined for a backend definition', function() {
+      expect(function() {
+        hb.whenGET('/some'); // no .respond(...) !
+        hb('GET', '/some', null, callback);
+        hb.flush();
+      }).toThrowError('No response defined !');
+    });
+
+
     it('should match headers if specified', function() {
       hb.when('GET', '/url', null, {'X': 'val1'}).respond(201, 'content1');
       hb.when('GET', '/url', null, {'X': 'val2'}).respond(202, 'content2');
@@ -2831,6 +2867,24 @@ describe('ngMockE2E', function() {
 
         hb.verifyNoOutstandingRequest();
       }).toThrowError('Unexpected request: GET /some\nNo more request expected');
+    });
+
+    it('should throw error when expectation fails - without error callback', function() {
+      expect(function() {
+        hb.expectPOST('/some', { foo: 1 }).respond({});
+        $http.post('/some', { foo: 2 }).then(noop);
+
+        hb.flush();
+      }).toThrowError(/^Expected POST \/some with different data/);
+    });
+
+    it('should throw error when unexpected request - with error callback', function() {
+      expect(function() {
+        hb.expectPOST('/some', { foo: 1 }).respond({});
+        $http.post('/some', { foo: 2 }).then(noop, noop);
+
+        hb.flush();
+      }).toThrowError(/^Expected POST \/some with different data/);
     });
 
 


### PR DESCRIPTION
This was only partially fixed by https://github.com/angular/angular.js/commit/f18dd2957caf1993bc2a3b4db7ebfeb797170aca

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix,

**What is the current behavior? (You can also link to an open issue here)**

The test doesn't fail in case of a failed `$httpBackend` expectation

**What is the new behavior (if this is a feature change)?**

The test does fail.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass
