### PR TITLE
fix($route): correctly extract path params if path contains question mark or hash

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1771,7 +1771,7 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
    * See {@link ngMock.$httpBackend#when `when`} for more info.
    */
   $httpBackend.whenRoute = function(method, url) {
-    var pathObj = routeToRegExp(url, {caseInsensitiveMatch: true, ignoreTrailingSlashes: true});
+    var pathObj = routeToRegExp(url, {caseInsensitiveMatch: true, ignoreTrailingSlashes: true, isUrl: true});
     return $httpBackend.when(method, pathObj.regexp, undefined, undefined, pathObj.keys);
   };
 
@@ -1955,7 +1955,7 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
    * See {@link ngMock.$httpBackend#expect `expect`} for more info.
    */
   $httpBackend.expectRoute = function(method, url) {
-    var pathObj = routeToRegExp(url, {caseInsensitiveMatch: true, ignoreTrailingSlashes: true});
+    var pathObj = routeToRegExp(url, {caseInsensitiveMatch: true, ignoreTrailingSlashes: true, isUrl: true});
     return $httpBackend.expect(method, pathObj.regexp, undefined, undefined, pathObj.keys);
   };
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1771,8 +1771,8 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
    * See {@link ngMock.$httpBackend#when `when`} for more info.
    */
   $httpBackend.whenRoute = function(method, url) {
-    var pathObj = routeToRegExp(url, {caseInsensitiveMatch: true, ignoreTrailingSlashes: true, isUrl: true});
-    return $httpBackend.when(method, pathObj.regexp, undefined, undefined, pathObj.keys);
+    var parsed = parseRouteUrl(url);
+    return $httpBackend.when(method, parsed.regexp, undefined, undefined, parsed.keys);
   };
 
   /**
@@ -1955,8 +1955,8 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
    * See {@link ngMock.$httpBackend#expect `expect`} for more info.
    */
   $httpBackend.expectRoute = function(method, url) {
-    var pathObj = routeToRegExp(url, {caseInsensitiveMatch: true, ignoreTrailingSlashes: true, isUrl: true});
-    return $httpBackend.expect(method, pathObj.regexp, undefined, undefined, pathObj.keys);
+    var parsed = parseRouteUrl(url);
+    return $httpBackend.expect(method, parsed.regexp, undefined, undefined, parsed.keys);
   };
 
 
@@ -2083,6 +2083,12 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
         return $httpBackend[prefix](method, url, data, headers, keys);
       };
     });
+  }
+
+  function parseRouteUrl(url) {
+    var strippedUrl = stripQueryAndHash(url);
+    var parseOptions = {caseInsensitiveMatch: true, ignoreTrailingSlashes: true};
+    return routeToRegExp(strippedUrl, parseOptions);
   }
 }
 

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2092,6 +2092,9 @@ function assertArgDefined(args, index, name) {
   }
 }
 
+function stripQueryAndHash(url) {
+  return url.replace(/[?#].*$/, '');
+}
 
 function MockHttpExpectation(method, url, data, headers, keys) {
 
@@ -2146,15 +2149,17 @@ function MockHttpExpectation(method, url, data, headers, keys) {
 
   this.params = function(u) {
     var queryStr = u.indexOf('?') === -1 ? '' : u.substring(u.indexOf('?') + 1);
+    var strippedUrl = stripQueryAndHash(u);
 
-    return angular.extend(parseQuery(queryStr), pathParams());
+    return angular.extend(parseQuery(queryStr), pathParams(strippedUrl));
 
-    function pathParams() {
+    function pathParams(strippedUrl) {
       var keyObj = {};
       if (!url || !angular.isFunction(url.test) || !keys || keys.length === 0) return keyObj;
 
-      var m = url.exec(u);
+      var m = url.exec(strippedUrl);
       if (!m) return keyObj;
+
       for (var i = 1, len = m.length; i < len; ++i) {
         var key = keys[i - 1];
         var val = m[i];

--- a/src/ngRoute/route.js
+++ b/src/ngRoute/route.js
@@ -225,6 +225,7 @@ function $RouteProvider() {
     }
     routes[path] = angular.extend(
       routeCopy,
+      {originalPath: path},
       path && routeToRegExp(path, routeCopy)
     );
 
@@ -235,7 +236,7 @@ function $RouteProvider() {
             : path + '/';
 
       routes[redirectPath] = angular.extend(
-        {redirectTo: path},
+        {originalPath: path, redirectTo: path},
         routeToRegExp(redirectPath, routeCopy)
       );
     }

--- a/src/routeToRegExp.js
+++ b/src/routeToRegExp.js
@@ -36,7 +36,6 @@ function routeToRegExp(pathOrUrl, opts) {
   }
 
   return {
-    originalPath: pathOrUrl,
     keys: keys,
     regexp: new RegExp(
       '^' + pattern + '(?:[?#]|$)',

--- a/src/routeToRegExp.js
+++ b/src/routeToRegExp.js
@@ -3,29 +3,30 @@
 /* global routeToRegExp: true */
 
 /**
- * @param pathOrUrl {string} path or url
- * @param opts {Object} options
- * @return {?Object}
+ * @param {string} path - The path to parse. (It is assumed to have query and hash stripped off.)
+ * @param {Object} opts - Options.
+ * @return {Object} - An object containing an array of path parameter names (`keys`) and a regular
+ *     expression (`regexp`) that can be used to identify a matching URL and extract the path
+ *     parameter values.
  *
  * @description
- * Normalizes the given path, returning a regular expression
- * and the original path.
+ * Parses the given path, extracting path parameter names and a regular expression to match URLs.
  *
- * Inspired by pathRexp in visionmedia/express/lib/utils.js.
+ * Originally inspired by `pathRexp` in `visionmedia/express/lib/utils.js`.
  */
-function routeToRegExp(pathOrUrl, opts) {
+function routeToRegExp(path, opts) {
   var keys = [];
 
-  var pattern = pathOrUrl
+  var pattern = path
     .replace(/([().])/g, '\\$1')
     .replace(/(\/)?:(\w+)(\*\?|[?*])?/g, function(_, slash, key, option) {
       var optional = option === '?' || option === '*?';
       var star = option === '*' || option === '*?';
-      keys.push({ name: key, optional: optional });
+      keys.push({name: key, optional: optional});
       slash = slash || '';
       return (
         (optional ? '(?:' + slash : slash + '(?:') +
-        (opts.isUrl ? (star ? '([^?#]+?)' : '([^/?#]+)') : (star ? '(.+?)' : '([^/]+)')) +
+        (star ? '(.+?)' : '([^/]+)') +
         (optional ? '?)?' : ')')
       );
     })

--- a/src/routeToRegExp.js
+++ b/src/routeToRegExp.js
@@ -3,7 +3,7 @@
 /* global routeToRegExp: true */
 
 /**
- * @param path {string} path
+ * @param pathOrUrl {string} path or url
  * @param opts {Object} options
  * @return {?Object}
  *
@@ -13,10 +13,10 @@
  *
  * Inspired by pathRexp in visionmedia/express/lib/utils.js.
  */
-function routeToRegExp(path, opts) {
+function routeToRegExp(pathOrUrl, opts) {
   var keys = [];
 
-  var pattern = path
+  var pattern = pathOrUrl
     .replace(/([().])/g, '\\$1')
     .replace(/(\/)?:(\w+)(\*\?|[?*])?/g, function(_, slash, key, option) {
       var optional = option === '?' || option === '*?';
@@ -25,7 +25,7 @@ function routeToRegExp(path, opts) {
       slash = slash || '';
       return (
         (optional ? '(?:' + slash : slash + '(?:') +
-        (star ? '([^?#]+?)' : '([^/?#]+)') +
+        (opts.isUrl ? (star ? '([^?#]+?)' : '([^/?#]+)') : (star ? '(.+?)' : '([^/]+)')) +
         (optional ? '?)?' : ')')
       );
     })
@@ -36,7 +36,7 @@ function routeToRegExp(path, opts) {
   }
 
   return {
-    originalPath: path,
+    originalPath: pathOrUrl,
     keys: keys,
     regexp: new RegExp(
       '^' + pattern + '(?:[?#]|$)',

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -2251,7 +2251,7 @@ describe('ngMock', function() {
           }
         );
         they('should ignore query params when matching in ' + routeShortcut + ' $prop method', methods,
-          function() {
+          function(method) {
             angular.forEach([
               {route: '/route1/:id', url: '/route1/Alpha', expectedParams: {id: 'Alpha'}},
               {route: '/route2/:id', url: '/route2/Bravo/?', expectedParams: {id: 'Bravo'}},
@@ -2268,14 +2268,14 @@ describe('ngMock', function() {
             ], function(testDataEntry) {
               callback.calls.reset();
               var paramsSpy = jasmine.createSpy('params');
-              hb[routeShortcut](this, testDataEntry.route).respond(
+              hb[routeShortcut](method, testDataEntry.route).respond(
                 function(method, url, data, headers, params) {
                   paramsSpy(params);
                   // status, response, headers, statusText, xhrStatus
                   return [200, 'path', { 'x-header': 'foo' }, 'OK', 'complete'];
                 }
               );
-              hb(this, testDataEntry.url, undefined, callback);
+              hb(method, testDataEntry.url, undefined, callback);
               hb.flush();
               expect(callback).toHaveBeenCalledOnceWith(200, 'path', 'x-header: foo', 'OK', 'complete');
               expect(paramsSpy).toHaveBeenCalledOnceWith(testDataEntry.expectedParams);

--- a/test/ngRoute/routeParamsSpec.js
+++ b/test/ngRoute/routeParamsSpec.js
@@ -77,5 +77,24 @@ describe('$routeParams', function() {
     });
   });
 
+  it('should correctly extract path params containing hashes and/or question marks', function() {
+    module(function($routeProvider) {
+      $routeProvider.when('/foo/:bar', {});
+    });
+
+    inject(function($rootScope, $route, $location, $routeParams) {
+      $location.path('/foo/bar#baz');
+      $rootScope.$digest();
+      expect($routeParams).toEqual({bar: 'bar#baz'});
+
+      $location.path('/foo/bar?baz');
+      $rootScope.$digest();
+      expect($routeParams).toEqual({bar: 'bar?baz'});
+
+      $location.path('/foo/bar#baz?qux');
+      $rootScope.$digest();
+      expect($routeParams).toEqual({bar: 'bar#baz?qux'});
+    });
+  });
 
 });

--- a/test/ngRoute/routeParamsSpec.js
+++ b/test/ngRoute/routeParamsSpec.js
@@ -80,20 +80,41 @@ describe('$routeParams', function() {
   it('should correctly extract path params containing hashes and/or question marks', function() {
     module(function($routeProvider) {
       $routeProvider.when('/foo/:bar', {});
+      $routeProvider.when('/zoo/:bar/:baz/:qux', {});
     });
 
-    inject(function($rootScope, $route, $location, $routeParams) {
-      $location.path('/foo/bar#baz');
-      $rootScope.$digest();
-      expect($routeParams).toEqual({bar: 'bar#baz'});
-
+    inject(function($location, $rootScope, $routeParams) {
       $location.path('/foo/bar?baz');
       $rootScope.$digest();
       expect($routeParams).toEqual({bar: 'bar?baz'});
 
+      $location.path('/foo/bar?baz=val');
+      $rootScope.$digest();
+      expect($routeParams).toEqual({bar: 'bar?baz=val'});
+
+      $location.path('/foo/bar#baz');
+      $rootScope.$digest();
+      expect($routeParams).toEqual({bar: 'bar#baz'});
+
+      $location.path('/foo/bar?baz#qux');
+      $rootScope.$digest();
+      expect($routeParams).toEqual({bar: 'bar?baz#qux'});
+
+      $location.path('/foo/bar?baz=val#qux');
+      $rootScope.$digest();
+      expect($routeParams).toEqual({bar: 'bar?baz=val#qux'});
+
       $location.path('/foo/bar#baz?qux');
       $rootScope.$digest();
       expect($routeParams).toEqual({bar: 'bar#baz?qux'});
+
+      $location.path('/zoo/bar?p1=v1#h1/baz?p2=v2#h2/qux?p3=v3#h3');
+      $rootScope.$digest();
+      expect($routeParams).toEqual({
+        bar: 'bar?p1=v1#h1',
+        baz: 'baz?p2=v2#h2',
+        qux: 'qux?p3=v3#h3'
+      });
     });
   });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix (and refactorings).


**What is the current behavior? (You can also link to an open issue here)**
The `routeToRegExp()` function, introduced by 840b5f0, cannot extract path params if the path contains question mark or hash. Although these characters would normally be encoded in the path, they are decoded by `$location.path()`, before being passed to the RegExp returned by `routeToRegExp()`.

`routeToRegExp()` has to be able to deal with both encoded URL and decoded path, because it is being shared between `ngRoute` and `ngMocks`.


**What is the new behavior (if this is a feature change)?**
The RegExp returned by `routeToRegExp()` only deals with the path part and the callers are responsible for stripping off the query and hash parts (if any).

(This PR contains the code from #16670, plus some refactoring to simplify the implementation).


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass


**Other information**:
Closes #16670.
