### PR TITLE
fix(ngAnimate): remove event prepare class when skipping animation

### DIFF
--- a/src/ngAnimate/animation.js
+++ b/src/ngAnimate/animation.js
@@ -187,7 +187,7 @@ var $$AnimationProvider = ['$animateProvider', /** @this */ function($animatePro
           var element = animationEntry.from ? animationEntry.from.element : animationEntry.element;
           var extraClasses = options.addClass;
           extraClasses = (extraClasses ? (extraClasses + ' ') : '') + NG_ANIMATE_CLASSNAME;
-          var cacheKey = $$animateCache.cacheKey(node, event, extraClasses, options.removeClass);
+          var cacheKey = $$animateCache.cacheKey(node, animationEntry.event, extraClasses, options.removeClass);
 
           toBeSortedAnimations.push({
             element: element,
@@ -199,6 +199,7 @@ var $$AnimationProvider = ['$animateProvider', /** @this */ function($animatePro
               // and it's in fact an invalid animation (something that has duration = 0)
               // then we should skip all the heavy work from here on
               if ($$animateCache.containsCachedAnimationWithoutDuration(cacheKey)) {
+                removePrepareClass();
                 closeFn();
                 return;
               }
@@ -399,15 +400,19 @@ var $$AnimationProvider = ['$animateProvider', /** @this */ function($animatePro
         }
       }
 
-      function beforeStart() {
-        tempClasses = (tempClasses ? (tempClasses + ' ') : '') + NG_ANIMATE_CLASSNAME;
-        $$jqLite.addClass(element, tempClasses);
-
+      function removePrepareClass() {
         var prepareClassName = element.data(PREPARE_CLASSES_KEY);
         if (prepareClassName) {
           $$jqLite.removeClass(element, prepareClassName);
           prepareClassName = null;
         }
+      }
+
+      function beforeStart() {
+        tempClasses = (tempClasses ? (tempClasses + ' ') : '') + NG_ANIMATE_CLASSNAME;
+        $$jqLite.addClass(element, tempClasses);
+
+        removePrepareClass();
       }
 
       function updateAnimationRunners(animation, newRunner) {


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
It can happen that an element keeps the ng-enter-prepare css class (maybe for other events as well) when animation is skipped. This can result for example in unwanted invisible elements in your DOM in case prepare phase is using display:none or opacity:0 to avoid blink during animation.


**What is the new behavior (if this is a feature change)?**
Prepare class is removed when skipping animation. 


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

