### PR TITLE
docs(version-support-status): remove outdated info, resolve inconsistencies

### DIFF
--- a/docs/content/misc/version-support-status.ngdoc
+++ b/docs/content/misc/version-support-status.ngdoc
@@ -7,25 +7,8 @@
 This page describes the support status of the significant versions of AngularJS.
 
 <div class="alert alert-info">
-  AngularJS is planning one more significant release, version 1.7, and on July 1, 2018 it will enter a 3 year Long Term Support period.
+  On July 1, 2018 AngularJS entered a 3 year Long Term Support period.
 </div>
-
-### Until July 1st 2018
-
-Any version branch not shown in the following table (e.g. 1.5.x) is no longer being developed.
-
-<table class="dev-status table table-bordered">
-<thead>
-  <tr><th>Version</th><th>Status</th><th>Comments</th></tr>
-</thead>
-<tbody>
-  <tr class="security"><td><span>1.2.x</span></td><td>Security patches only</td><td>Last version to provide IE 8 support</td></tr>
-  <tr class="stable"><td><span>1.6.x</span></td><td>Patch Releases</td><td>Minor features, bug fixes, security patches - no breaking changes</td></tr>
-  <tr class="current"><td><span>1.7.x</span></td><td>Active Development</td><td>1.7.0 (not yet released) will be the last release of AngularJS to contain breaking changes</td></tr>
-</tbody>
-</table>
-
-### After July 1st 2018
 
 Any version branch not shown in the following table (e.g. 1.6.x) is no longer being developed.
 
@@ -36,7 +19,7 @@ Any version branch not shown in the following table (e.g. 1.6.x) is no longer be
   <tbody>
     <tr class="security">
       <td><span>1.2.x</span></td>
-      <td>Long Term Support</td>
+      <td>Security patches only</td>
       <td>Last version to provide IE 8 support</td>
     </tr>
     <tr class="stable">
@@ -49,13 +32,15 @@ Any version branch not shown in the following table (e.g. 1.6.x) is no longer be
 
 ### Long Term Support
 
-On July 1st 2018, we will enter a Long Term Support period for AngularJS.
+On July 1st 2018, AngularJS entered a Long Term Support period for AngularJS.
 
-At this time we will focus exclusively on providing fixes to bugs that satisfy at least one of the following criteria:
+We now focus exclusively on providing fixes to bugs that satisfy at least one of the following criteria:
 
 * A security flaw is detected in the 1.7.x branch of the framework
 * One of the major browsers releases a version that will cause current production applications using AngularJS 1.7.x to stop working
 * The jQuery library releases a version that will cause current production applications using AngularJS 1.7.x to stop working.
+
+AngularJS 1.2.x will get a new version if and only if a new severe security issue is discovered.
 
 ### Blog Post
 


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs update.

**What is the current behavior? (You can also link to an open issue here)**

https://docs.angularjs.org/misc/version-support-status is outdated, it talks about August 2018 in future tense.

**What is the new behavior (if this is a feature change)?**

Outdated info is removed, inconsistencies (e.g. around 1.2 support) are resolved.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- ~~Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated~~
- ~~Fix/Feature: Tests have been added; existing tests pass~~

**Other information**:

