### PR TITLE
fix(ngClass): do not break on invalid values

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -125,6 +125,8 @@ function classDirective(name, selector) {
   }
 
   function toClassString(classValue) {
+    if (!classValue) return classValue;
+
     var classString = classValue;
 
     if (isArray(classValue)) {
@@ -133,6 +135,8 @@ function classDirective(name, selector) {
       classString = Object.keys(classValue).
         filter(function(key) { return classValue[key]; }).
         join(' ');
+    } else if (!isString(classValue)) {
+      classString = classValue + '';
     }
 
     return classString;

--- a/test/ng/directive/ngClassSpec.js
+++ b/test/ng/directive/ngClassSpec.js
@@ -88,6 +88,12 @@ describe('ngClass', function() {
     expect(element.hasClass('AnotB')).toBeFalsy();
   }));
 
+  it('should not break when passed non-string/array/object, truthy values', inject(function($rootScope, $compile) {
+    element = $compile('<div ng-class="42"></div>')($rootScope);
+    $rootScope.$digest();
+    expect(element.hasClass('42')).toBeTruthy();
+  }));
+
   it('should support adding multiple classes via an array mixed with conditionally via a map', inject(function($rootScope, $compile) {
     element = $compile('<div class="existing" ng-class="[\'A\', {\'B\': condition}]"></div>')($rootScope);
     $rootScope.$digest();


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.


**What is the current behavior? (You can also link to an open issue here)**
When an `ngClass` expression evaluates to something that is not a string, array or object (and is truthy), an error will be thrown while trying to call `.split()` on a non-string value. This error is not very helpful for the user to identify the root cause of the problem.
See #16697.


**What is the new behavior (if this is a feature change)?**
Such values are converted to string.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] ~~Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated~~
- [x] Fix/Feature: Tests have been added; existing tests pass


**Other information**:
Fixes #16697.
