### PR TITLE
fix(ngStyle): skip setting empty value when new style has the property

### DIFF
--- a/src/ng/directive/ngStyle.js
+++ b/src/ng/directive/ngStyle.js
@@ -55,9 +55,9 @@ var ngStyleDirective = ngDirective(function(scope, element, attr) {
   scope.$watchCollection(attr.ngStyle, function ngStyleWatchAction(newStyles, oldStyles) {
     if (oldStyles && (newStyles !== oldStyles)) {
       forEach(oldStyles, function(val, style) {
-          if (!(newStyles && newStyles.hasOwnProperty(style))) {
-              element.css(style, '');
-          }
+        if (!(newStyles && newStyles.hasOwnProperty(style))) {
+          element.css(style, '');
+        }
       });
     }
     if (newStyles) element.css(newStyles);

--- a/src/ng/directive/ngStyle.js
+++ b/src/ng/directive/ngStyle.js
@@ -54,9 +54,12 @@
 var ngStyleDirective = ngDirective(function(scope, element, attr) {
   scope.$watchCollection(attr.ngStyle, function ngStyleWatchAction(newStyles, oldStyles) {
     if (oldStyles && (newStyles !== oldStyles)) {
+      if (!newStyles) {
+        newStyles = {};
+      }
       forEach(oldStyles, function(val, style) {
-        if (!(newStyles && newStyles[style])) {
-          element.css(style, '');
+        if (newStyles[style] == null) {
+          newStyles[style] = '';
         }
       });
     }

--- a/src/ng/directive/ngStyle.js
+++ b/src/ng/directive/ngStyle.js
@@ -54,7 +54,11 @@
 var ngStyleDirective = ngDirective(function(scope, element, attr) {
   scope.$watchCollection(attr.ngStyle, function ngStyleWatchAction(newStyles, oldStyles) {
     if (oldStyles && (newStyles !== oldStyles)) {
-      forEach(oldStyles, function(val, style) { element.css(style, '');});
+      forEach(oldStyles, function(val, style) {
+          if (!(newStyles && newStyles.hasOwnProperty(style))) {
+              element.css(style, '');
+          }
+      });
     }
     if (newStyles) element.css(newStyles);
   });

--- a/src/ng/directive/ngStyle.js
+++ b/src/ng/directive/ngStyle.js
@@ -55,7 +55,7 @@ var ngStyleDirective = ngDirective(function(scope, element, attr) {
   scope.$watchCollection(attr.ngStyle, function ngStyleWatchAction(newStyles, oldStyles) {
     if (oldStyles && (newStyles !== oldStyles)) {
       forEach(oldStyles, function(val, style) {
-        if (!(newStyles && newStyles.hasOwnProperty(style))) {
+        if (!(newStyles && newStyles[style])) {
           element.css(style, '');
         }
       });

--- a/test/ng/directive/ngStyleSpec.js
+++ b/test/ng/directive/ngStyleSpec.js
@@ -120,5 +120,16 @@ describe('ngStyle', function() {
       expect(element.css(preCompStyle)).not.toBe('88px');
       expect(element.css(postCompStyle)).not.toBe('99px');
     });
+
+    it('should clear style when the value is falsy', function() {
+      scope.styleObj = {'height': '99px', 'width': '88px'};
+      scope.$apply();
+      expect(element.css(preCompStyle)).toBe('88px');
+      expect(element.css(postCompStyle)).toBe('99px');
+      scope.styleObj = {'height': undefined, 'width': null};
+      scope.$apply();
+      expect(element.css(preCompStyle)).not.toBe('88px');
+      expect(element.css(postCompStyle)).not.toBe('99px');
+    });
   });
 });

--- a/test/ng/directive/ngStyleSpec.js
+++ b/test/ng/directive/ngStyleSpec.js
@@ -121,7 +121,7 @@ describe('ngStyle', function() {
       expect(element.css(postCompStyle)).not.toBe('99px');
     });
 
-    it('should clear style when the value is falsy', function() {
+    it('should clear style when the value is undefined or null', function() {
       scope.styleObj = {'height': '99px', 'width': '88px'};
       scope.$apply();
       expect(element.css(preCompStyle)).toBe('88px');
@@ -130,6 +130,17 @@ describe('ngStyle', function() {
       scope.$apply();
       expect(element.css(preCompStyle)).not.toBe('88px');
       expect(element.css(postCompStyle)).not.toBe('99px');
+    });
+
+    it('should set style when the value is zero', function() {
+      scope.styleObj = {'height': '99px', 'width': '88px'};
+      scope.$apply();
+      expect(element.css(preCompStyle)).toBe('88px');
+      expect(element.css(postCompStyle)).toBe('99px');
+      scope.styleObj = {'height': 0, 'width': 0};
+      scope.$apply();
+      expect(element.css(preCompStyle)).toBe('0px');
+      expect(element.css(postCompStyle)).toBe('0px');
     });
   });
 });

--- a/test/ng/directive/ngStyleSpec.js
+++ b/test/ng/directive/ngStyleSpec.js
@@ -121,6 +121,17 @@ describe('ngStyle', function() {
       expect(element.css(postCompStyle)).not.toBe('99px');
     });
 
+    it('should clear style when the new model is null', function() {
+      scope.styleObj = {'height': '99px', 'width': '88px'};
+      scope.$apply();
+      expect(element.css(preCompStyle)).toBe('88px');
+      expect(element.css(postCompStyle)).toBe('99px');
+      scope.styleObj = null;
+      scope.$apply();
+      expect(element.css(preCompStyle)).not.toBe('88px');
+      expect(element.css(postCompStyle)).not.toBe('99px');
+    });
+
     it('should clear style when the value is undefined or null', function() {
       scope.styleObj = {'height': '99px', 'width': '88px'};
       scope.$apply();


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix.

**What is the current behavior? (You can also link to an open issue here)**
Using ng-style with CSS transition with jQuery 3.3.1 (currently the latest tag), the animation is disabled in certain circumstances.
https://jsfiddle.net/qz5a46yc/1/

Without jQuery (using jqLite.css) or using jQuery 3.2.1, the div animates. I reported to the jQuery dev on this behavior difference: https://github.com/jquery/jquery/issues/4185. I think this is a bug in jQuery.

This pull request suggests a workaround on the disabled animation issue. I'm not sure how the report to the jQuery will be handled, but we can fix the behavior with reasonable changes in AngularJS. Skipping the common properties with newStyles will fix the animation issue with jQuery 3.3.1, which can be confirmed by https://jsfiddle.net/g3st70fh/1/. I think the diff is reasonable and also improves the performance because the properties in oldStyles and newStyles are same in most cases.

**What is the new behavior (if this is a feature change)?**
I believe there's no changes except for fixing the animation issue.

**Does this PR introduce a breaking change?**
No, I believe.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

