### PR TITLE
chore: properly isolate module tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -141,7 +141,16 @@ module.exports = function(grunt) {
       'jquery-2.2': 'karma-jquery-2.2.conf.js',
       'jquery-2.1': 'karma-jquery-2.1.conf.js',
       docs: 'karma-docs.conf.js',
-      modules: 'karma-modules.conf.js'
+      'modules-ngAnimate': 'ngAnimate',
+      'modules-ngAria': 'ngAria',
+      'modules-ngCookies': 'ngCookies',
+      'modules-ngMessageFormat': 'ngMessageFormat',
+      'modules-ngMessages': 'ngMessages',
+      'modules-ngMock': 'ngMock',
+      'modules-ngResource': 'ngResource',
+      'modules-ngRoute': 'ngRoute',
+      'modules-ngSanitize': 'ngSanitize',
+      'modules-ngTouch': 'ngTouch'
     },
 
 
@@ -430,7 +439,16 @@ module.exports = function(grunt) {
   grunt.registerTask('test:jquery-2.1', 'Run the jQuery 2.1 unit tests with Karma', ['tests:jquery-2.1']);
   grunt.registerTask('test:modules', 'Run the Karma module tests with Karma', [
     'build',
-    'tests:modules'
+    'tests:modules-ngAnimate',
+    'tests:modules-ngAria',
+    'tests:modules-ngCookies',
+    'tests:modules-ngMessageFormat',
+    'tests:modules-ngMessages',
+    'tests:modules-ngMock',
+    'tests:modules-ngResource',
+    'tests:modules-ngRoute',
+    'tests:modules-ngSanitize',
+    'tests:modules-ngTouch'
   ]);
   grunt.registerTask('test:docs', 'Run the doc-page tests with Karma', ['package', 'tests:docs']);
   grunt.registerTask('test:unit', 'Run unit, jQuery and Karma module tests with Karma', [

--- a/angularFiles.js
+++ b/angularFiles.js
@@ -189,21 +189,84 @@ var angularFiles = {
     'src/angular.bind.js'
   ],
 
-  'karmaModules': [
+  'karmaModulesBase': [
     'build/angular.js',
-    '@angularSrcModules',
+    'build/angular-mocks.js',
     'test/modules/no_bootstrap.js',
-    'test/helpers/*.js',
-    'test/ngAnimate/*.js',
-    'test/ngMessageFormat/*.js',
-    'test/ngMessages/*.js',
-    'test/ngMock/*.js',
-    'test/ngCookies/*.js',
-    'test/ngRoute/**/*.js',
-    'test/ngResource/*.js',
-    'test/ngSanitize/**/*.js',
-    'test/ngTouch/**/*.js',
-    'test/ngAria/*.js'
+    'test/helpers/matchers.js',
+    'test/helpers/privateMocks.js',
+    'test/helpers/support.js',
+    'test/helpers/testabilityPatch.js'
+  ],
+
+  'karmaModules-ngAnimate': [
+    '@karmaModulesBase',
+    '@angularSrcModuleNgAnimate',
+    'test/ngAnimate/**/*.js'
+  ],
+
+  'karmaModules-ngAria': [
+    '@karmaModulesBase',
+    '@angularSrcModuleNgAria',
+    'test/ngAria/**/*.js'
+  ],
+
+  'karmaModules-ngCookies': [
+    '@karmaModulesBase',
+    '@angularSrcModuleNgCookies',
+    'test/ngCookies/**/*.js'
+  ],
+
+  'karmaModules-ngMessageFormat': [
+    '@karmaModulesBase',
+    '@angularSrcModuleNgMessageFormat',
+    'test/ngMessageFormat/**/*.js'
+  ],
+
+  'karmaModules-ngMessages': [
+    '@karmaModulesBase',
+    'build/angular-animate.js',
+    '@angularSrcModuleNgMessages',
+    'test/ngMessages/**/*.js'
+  ],
+
+  // ngMock doesn't include the base because it must use the ngMock src files
+  'karmaModules-ngMock': [
+    'build/angular.js',
+    'src/ngMock/*.js',
+    'test/modules/no_bootstrap.js',
+    'test/helpers/matchers.js',
+    'test/helpers/privateMocks.js',
+    'test/helpers/support.js',
+    'test/helpers/testabilityPatch.js',
+    'src/routeToRegExp.js',
+    'build/angular-animate.js',
+    'test/ngMock/**/*.js'
+  ],
+
+  'karmaModules-ngResource': [
+    '@karmaModulesBase',
+    '@angularSrcModuleNgResource',
+    'test/ngResource/**/*.js'
+  ],
+
+  'karmaModules-ngRoute': [
+    '@karmaModulesBase',
+    'build/angular-animate.js',
+    '@angularSrcModuleNgRoute',
+    'test/ngRoute/**/*.js'
+  ],
+
+  'karmaModules-ngSanitize': [
+    '@karmaModulesBase',
+    '@angularSrcModuleNgSanitize',
+    'test/ngSanitize/**/*.js'
+  ],
+
+  'karmaModules-ngTouch': [
+    '@karmaModulesBase',
+    '@angularSrcModuleNgTouch',
+    'test/ngTouch/**/*.js'
   ],
 
   'karmaJquery': [
@@ -231,6 +294,16 @@ var angularFiles = {
       return path;
     });
 });
+
+angularFiles['angularSrcModuleNgAnimate'] = angularFiles['angularModules']['ngAnimate'];
+angularFiles['angularSrcModuleNgAria'] = angularFiles['angularModules']['ngAria'];
+angularFiles['angularSrcModuleNgCookies'] = angularFiles['angularModules']['ngCookies'];
+angularFiles['angularSrcModuleNgMessageFormat'] = angularFiles['angularModules']['ngMessageFormat'];
+angularFiles['angularSrcModuleNgMessages'] = angularFiles['angularModules']['ngMessages'];
+angularFiles['angularSrcModuleNgResource'] = angularFiles['angularModules']['ngResource'];
+angularFiles['angularSrcModuleNgRoute'] = angularFiles['angularModules']['ngRoute'];
+angularFiles['angularSrcModuleNgSanitize'] = angularFiles['angularModules']['ngSanitize'];
+angularFiles['angularSrcModuleNgTouch'] = angularFiles['angularModules']['ngTouch'];
 
 angularFiles['angularSrcModules'] = [].concat(
   angularFiles['angularModules']['ngAnimate'],

--- a/karma-modules.conf.js
+++ b/karma-modules.conf.js
@@ -4,14 +4,11 @@ var angularFiles = require('./angularFiles');
 var sharedConfig = require('./karma-shared.conf');
 
 module.exports = function(config) {
-  sharedConfig(config, {testName: 'AngularJS: modules', logFile: 'karma-modules.log'});
+  var angularModule = process.env.KARMA_MODULE;
+
+  sharedConfig(config, {testName: 'AngularJS: module ' + angularModule, logFile: 'karma-modules-' + angularModule + '.log'});
 
   config.set({
-    files: angularFiles.mergeFilesFor('karmaModules'),
-
-    junitReporter: {
-      outputFile: 'test_out/modules.xml',
-      suite: 'modules'
-    }
+    files: angularFiles.mergeFilesFor('karmaModules-' + angularModule)
   });
 };

--- a/lib/grunt/plugins.js
+++ b/lib/grunt/plugins.js
@@ -43,7 +43,16 @@ module.exports = function(grunt) {
 
 
   grunt.registerMultiTask('tests', '**Use `grunt test` instead**', function() {
-    util.startKarma(this.data, true, this.async());
+    var configFile;
+
+    if (this.nameArgs.includes('modules')) {
+      configFile = 'karma-modules.conf.js';
+      process.env.KARMA_MODULE = this.data;
+    } else {
+      configFile = this.data;
+    }
+
+    util.startKarma(configFile, true, this.async());
   });
 
 

--- a/src/ngMessageFormat/messageFormatService.js
+++ b/src/ngMessageFormat/messageFormatService.js
@@ -215,10 +215,10 @@ var noop;
 var toJson;
 var $$stringify;
 
-var module = window['angular']['module']('ngMessageFormat', ['ng']);
-module['info']({ 'angularVersion': '"NG_VERSION_FULL"' });
-module['factory']('$$messageFormat', $$MessageFormatFactory);
-module['config'](['$provide', function($provide) {
+var ngModule = window['angular']['module']('ngMessageFormat', ['ng']);
+ngModule['info']({ 'angularVersion': '"NG_VERSION_FULL"' });
+ngModule['factory']('$$messageFormat', $$MessageFormatFactory);
+ngModule['config'](['$provide', function($provide) {
   $interpolateMinErr = window['angular']['$interpolateMinErr'];
   isFunction = window['angular']['isFunction'];
   noop = window['angular']['noop'];

--- a/test/ngCookies/cookieWriterSpec.js
+++ b/test/ngCookies/cookieWriterSpec.js
@@ -132,6 +132,7 @@ describe('$$cookieWriter', function() {
 
 describe('cookie options', function() {
   var fakeDocument, $$cookieWriter;
+  var isUndefined = angular.isUndefined;
 
   function getLastCookieAssignment(key) {
     return fakeDocument[0].cookie

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1,7 +1,9 @@
 'use strict';
 
 describe('ngMock', function() {
+
   var noop = angular.noop;
+  var extend = angular.extend;
 
   describe('TzDate', function() {
 
@@ -1107,11 +1109,13 @@ describe('ngMock', function() {
         var mock = { log: 'module' };
 
         beforeEach(function() {
+          angular.module('stringRefModule', []).service('stringRef', function() {});
+
           module({
               'service': mock,
               'other': { some: 'replacement'}
             },
-            'ngResource',
+            'stringRefModule',
             function($provide) { $provide.value('example', 'win'); }
           );
         });
@@ -1130,9 +1134,9 @@ describe('ngMock', function() {
         });
 
         it('should integrate with string and function', function() {
-          inject(function(service, $resource, example) {
+          inject(function(service, stringRef, example) {
             expect(service).toEqual(mock);
-            expect($resource).toBeDefined();
+            expect(stringRef).toBeDefined();
             expect(example).toEqual('win');
           });
         });
@@ -2833,6 +2837,10 @@ describe('ngMock', function() {
 
 
 describe('ngMockE2E', function() {
+
+  var noop = angular.noop;
+  var extend = angular.extend;
+
   describe('$httpBackend', function() {
     var hb, realHttpBackend, realHttpBackendBrowser, $http, callback;
 
@@ -3175,7 +3183,7 @@ describe('ngMockE2E', function() {
 
         if (!browserSupportsCssAnimations()) return;
 
-        var element = jqLite('<div></div>');
+        var element = angular.element('<div></div>');
         $rootElement.append(element);
 
         // Make sure the animation has valid $animateCss options

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1,6 +1,8 @@
 'use strict';
 
 describe('resource', function() {
+  var noop = angular.noop;
+  var extend = angular.extend;
 
 describe('basic usage', function() {
   var $resource, CreditCard, callback, $httpBackend, resourceProvider, $q;


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**
Previously, our module tests weren't running in isolation. Theroetically, we wanted to test if the angular.js *build*  file works well with the individual module *source* files (Note that we don't use the module *build* files because we sometimes test non-public apis).
However, we bundled all module files together with the build file, and this messed up the results as some modules assign angular helpers like isDefined in the current scope, which means all following modules have access to them too, which essentially defeats the purpose of these tests. See #16702.


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

