### PR TITLE
fix(urlUtils): make IPv6 URL's hostname wrapped in square brackets in IE/Edge

### DIFF
--- a/src/ng/urlUtils.js
+++ b/src/ng/urlUtils.js
@@ -10,6 +10,12 @@ var urlParsingNode = window.document.createElement('a');
 var originUrl = urlResolve(window.location.href);
 var baseUrlParsingNode;
 
+urlParsingNode.href = 'http://[::1]';
+
+// Support: IE 9-11 only, Edge 16-17 only (fixed in 18 Preview)
+// IE/Edge don't wrap IPv6 addresses' hostnames in square brackets
+// when parsed out of an anchor element.
+var ipv6InBrackets = urlParsingNode.hostname === '[::1]';
 
 /**
  *
@@ -72,13 +78,19 @@ function urlResolve(url) {
 
   urlParsingNode.setAttribute('href', href);
 
+  var hostname = urlParsingNode.hostname;
+
+  if (!ipv6InBrackets && hostname.indexOf(':') > -1) {
+    hostname = '[' + hostname + ']';
+  }
+
   return {
     href: urlParsingNode.href,
     protocol: urlParsingNode.protocol ? urlParsingNode.protocol.replace(/:$/, '') : '',
     host: urlParsingNode.host,
     search: urlParsingNode.search ? urlParsingNode.search.replace(/^\?/, '') : '',
     hash: urlParsingNode.hash ? urlParsingNode.hash.replace(/^#/, '') : '',
-    hostname: urlParsingNode.hostname,
+    hostname: hostname,
     port: urlParsingNode.port,
     pathname: (urlParsingNode.pathname.charAt(0) === '/')
       ? urlParsingNode.pathname

--- a/test/ng/urlUtilsSpec.js
+++ b/test/ng/urlUtilsSpec.js
@@ -31,6 +31,19 @@ describe('urlUtils', function() {
       var parsed = urlResolve('/');
       expect(parsed.pathname).toBe('/');
     });
+
+    it('should return an IPv6 hostname wrapped in brackets', function() {
+      // Support: IE 9-11 only, Edge 16-17 only (fixed in 18 Preview)
+      // IE/Edge don't wrap IPv6 addresses' hostnames in square brackets
+      // when parsed out of an anchor element.
+      var parsed = urlResolve('http://[::1]/');
+      expect(parsed.hostname).toBe('[::1]');
+    });
+
+    it('should not put the domain in brackets for the hostname field', function() {
+      var parsed = urlResolve('https://google.com/');
+      expect(parsed.hostname).toBe('google.com');
+    });
   });
 
 


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

A bug fix.

**What is the current behavior? (You can also link to an open issue here)**

In IE 9-11 and Edge 16-17 (not in 18 Preview) `$location.host()` incorrectly returns hostnames of IPv6 addresses without wrapping in square brackets.

This is caused by and IE/Edge bug which incorrectly don't wrap IPv6 addresses' hostnames in square brackets when parsed out of an anchor element which is used by `$location` for the purpose of URL parsing.

Issue: #16692

**What is the new behavior (if this is a feature change)?**

For all supported browsers `$location.host()` returns an IPv6 address wrapped in square brackets.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

