### PR TITLE
chore(*): update Sauce Connect from 4.4.12 to 4.5.1

### DIFF
--- a/lib/saucelabs/start_tunnel.sh
+++ b/lib/saucelabs/start_tunnel.sh
@@ -11,7 +11,7 @@ set -e
 # Curl and run this script as part of your .travis.yml before_script section:
 # before_script:
 #   - curl https://gist.github.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash
-SC_VERSION="4.4.12"
+SC_VERSION="4.5.1"
 CONNECT_URL="https://saucelabs.com/downloads/sc-$SC_VERSION-linux.tar.gz"
 CONNECT_DIR="/tmp/sauce-connect-$RANDOM"
 CONNECT_DOWNLOAD="sc-$SC_VERSION-linux.tar.gz"


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

An infra fix/update.

**What is the current behavior? (You can also link to an open issue here)**

The builds often terminate with a message like:
> Failed: The test with session id eaf6f785a1f146afaa66f0f9dabc8835 has already finished, and can't receive further commands.
This was build https://travis-ci.org/angular/angular.js/jobs/430937161

**What is the new behavior (if this is a feature change)?**

I hope the Sauce Connect update will eliminate those issues, especially that its changelog explicitly mentions they fixed "a major bug in connection state logic that caused clients to exit prematurely".
See https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy+Change+Logs

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- ~~Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated~~
- ~~Fix/Feature: Tests have been added; existing tests pass~~

**Other information**:

