### PR TITLE
refactor(production): remove duplicate expression

### DIFF
--- a/docs/config/services/deployments/production.js
+++ b/docs/config/services/deployments/production.js
@@ -15,7 +15,7 @@ var cdnUrl = googleCdnUrl + versionInfo.cdnVersion;
 // docs.angularjs.org and code.angularjs.org need them.
 var versionPath = versionInfo.currentVersion.isSnapshot ?
   'snapshot' :
-  (versionInfo.currentVersion.version || versionInfo.currentVersion.version);
+  versionInfo.currentVersion.version;
 var examplesDependencyPath = angularCodeUrl + versionPath + '/';
 
 module.exports = function productionDeployment(getVersion) {


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Refactors a (suspected) redundant check on duplicate subexpressions.

**What is the current behavior? (You can also link to an open issue here)**

The line  is:
```js
var versionPath = versionInfo.currentVersion.isSnapshot ?
  'snapshot' :
  (versionInfo.currentVersion.version || versionInfo.currentVersion.version);
```

**What is the new behavior (if this is a feature change)?**

Should be the same. The change removes a duplicate subexpression (the left and right sides of `||` both check `versionInfo.currentVersion.version`).

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- ~~Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated~~
- ~~Fix/Feature: Tests have been added; existing tests pass~~

**Other information**:

[This commit](https://github.com/angular/angular.js/blob/48f0957dde728b050e2d8f76db81cbf12cffd42a/docs/config/services/deployments/production.js#L18) is the most recent I found where these expressions differ. My best guess is the duplicated expression can be removed, unless I'm missing something.

