### PR TITLE
docs(tutorial/3 - Components): Adding Tag to Angular Mapping Info

### DIFF
--- a/docs/content/tutorial/step_03.ngdoc
+++ b/docs/content/tutorial/step_03.ngdoc
@@ -197,14 +197,6 @@ Voilà! The resulting output should look the same, but let's see what we have ga
   inside our component, stays inside our component.
 * It's easier to test our component in isolation.
 
-<div class="alert alert-info">
-  <p>
-    The mapping of the HTML `<phone-list>` Tag to the AngularJS Controller is done on the
-    `component('phoneList', {` statement.  AngularJS maps the CamelCase of the phoneList component
-    name to the kebab-case of the HTML Tag.
-  </p>
-</div>
-
 <img class="diagram" src="img/tutorial/tutorial_03.png">
 
 <div class="alert alert-info">

--- a/docs/content/tutorial/step_03.ngdoc
+++ b/docs/content/tutorial/step_03.ngdoc
@@ -184,6 +184,14 @@ Voilà! The resulting output should look the same, but let's see what we have ga
   inside our component, stays inside our component.
 * It's easier to test our component in isolation.
 
+<div class="alert alert-info">
+  <p>
+    The mapping of the HTML `<phone-list>` Tag to the AngularJS Controller is done on the 
+    `component('phoneList', {` statement.  AngularJS maps the CamelCase of the phoneList component
+    name to the kebab-case of the HTML Tag.
+  </p>
+</div>
+
 <img class="diagram" src="img/tutorial/tutorial_03.png">
 
 <div class="alert alert-info">

--- a/docs/content/tutorial/step_03.ngdoc
+++ b/docs/content/tutorial/step_03.ngdoc
@@ -88,18 +88,6 @@ Let's see an example:
     });
 ```
 
-```html
-<html ng-app="myApp">
-<head>
-  <script src="bower_components/angular/angular.js"></script>
-  <script src="app.js"></script>
-</head>
-<body>
-   <!-- The following line is how to use the greetUser angular.js controller/directive above in your html doc-->
-  <greet-user></greet-user>
- </body>
-</html>
- ```
 
 Now, every time we include `<greet-user></greet-user>` in our view, AngularJS will expand it into a
 DOM sub-tree constructed using the provided `template` and managed by an instance of the specified
@@ -142,7 +130,7 @@ acquired skill.
   <!-- Use a custom component to render a list of phones -->
   <phone-list></phone-list>
 
-</body>         //This is what calls the phoneList angular.js component
+</body>         
 </html>
 ```
 
@@ -161,7 +149,7 @@ angular.module('phonecatApp', []);
 // Register `phoneList` component, along with its associated controller and template
 angular.
   module('phonecatApp').
-  component('phoneList', {           // This is what defines the html element <phone-list>
+  component('phoneList', {
     template:
         '<ul>' +
           '<li ng-repeat="phone in $ctrl.phones">' +

--- a/docs/content/tutorial/step_03.ngdoc
+++ b/docs/content/tutorial/step_03.ngdoc
@@ -88,6 +88,19 @@ Let's see an example:
     });
 ```
 
+```html
+<html ng-app="myApp">
+<head>
+  <script src="bower_components/angular/angular.js"></script>
+  <script src="app.js"></script>
+</head>
+<body>
+   <!-- The following line is how to use the greetUser angular.js controller/directive above in your html doc-->
+  <greet-user></greet-user>
+ </body>
+</html>
+ ```
+
 Now, every time we include `<greet-user></greet-user>` in our view, AngularJS will expand it into a
 DOM sub-tree constructed using the provided `template` and managed by an instance of the specified
 controller.
@@ -129,7 +142,7 @@ acquired skill.
   <!-- Use a custom component to render a list of phones -->
   <phone-list></phone-list>
 
-</body>
+</body>         //This is what calls the phoneList angular.js component
 </html>
 ```
 
@@ -148,7 +161,7 @@ angular.module('phonecatApp', []);
 // Register `phoneList` component, along with its associated controller and template
 angular.
   module('phonecatApp').
-  component('phoneList', {
+  component('phoneList', {           // This is what defines the html element <phone-list>
     template:
         '<ul>' +
           '<li ng-repeat="phone in $ctrl.phones">' +
@@ -186,7 +199,7 @@ Voilà! The resulting output should look the same, but let's see what we have ga
 
 <div class="alert alert-info">
   <p>
-    The mapping of the HTML `<phone-list>` Tag to the AngularJS Controller is done on the 
+    The mapping of the HTML `<phone-list>` Tag to the AngularJS Controller is done on the
     `component('phoneList', {` statement.  AngularJS maps the CamelCase of the phoneList component
     name to the kebab-case of the HTML Tag.
   </p>


### PR DESCRIPTION
I was confused when reading the tutorial on how the HTML phone-list tag was mapped to the AngularJS component name.  Once I figured out it was the line of code that did this and how, I figured clarification would be helpful to other people.  

Also, I initially thought the tag mapping was done at the filename since that was the only thing in the javascript that matched the HTML tags.

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ X] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

