### PR TITLE
perf($compile): clean up `ngAttr`/`ngProp` watchers when element is destroyed

### DIFF
--- a/docs/config/templates/ngdoc/lib/methods.template.html
+++ b/docs/config/templates/ngdoc/lib/methods.template.html
@@ -17,7 +17,7 @@
     {% endif %}
 
     {% if method.this %}
-    <h4>Method's {% code %}this{% endcode %}</h4>
+    <h4>Method's `this`</h4>
     {$ method.this | marked $}
     {% endif %}
 

--- a/docs/config/templates/ngdoc/lib/this.template.html
+++ b/docs/config/templates/ngdoc/lib/this.template.html
@@ -1,4 +1,4 @@
 {% if doc.this %}
-<h3>Method's {% code %}this{% endcode %}</h3>
+<h3>Method's `this`</h3>
 {$ doc.this | marked $}
 {% endif %}

--- a/i18n/ucd/src/extract.js
+++ b/i18n/ucd/src/extract.js
@@ -20,7 +20,7 @@ function main() {
     } catch (e) {
       fs.mkdirSync(__dirname + '/../../../src/ngParseExt');
     }
-    fs.writeFile(__dirname + '/../../../src/ngParseExt/ucd.js', code);
+    fs.writeFileSync(__dirname + '/../../../src/ngParseExt/ucd.js', code);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -99,6 +99,11 @@
     "stringmap": "^0.2.2"
   },
   "dependencies": {},
+  "resolutions": {
+    "//1": "`natives@1.1.0` does not work with Node.js 10.x on Windows 10",
+    "//2": "(E.g. see https://github.com/gulpjs/gulp/issues/2162.)",
+    "natives": "1.1.3"
+  },
   "commitplease": {
     "style": "angular",
     "nohook": true

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3832,7 +3832,9 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               }
 
               applyPropValue();
-              scope.$watch(ngPropWatch, applyPropValue);
+              var unwatch = scope.$watch(ngPropWatch, applyPropValue);
+
+              $element.on('$destroy', unwatch);
             }
           };
         }
@@ -3893,7 +3895,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                 attr[name] = interpolateFn(scope);
 
                 ($$observers[name] || ($$observers[name] = [])).$$inter = true;
-                (attr.$$observers && attr.$$observers[name].$$scope || scope).
+                var unwatch = (attr.$$observers && attr.$$observers[name].$$scope || scope).
                   $watch(interpolateFn, function interpolateFnWatchAction(newValue, oldValue) {
                     //special case for class attribute addition + removal
                     //so that class changes can tap into the animation
@@ -3907,6 +3909,8 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
                       attr.$set(name, newValue);
                     }
                   });
+
+                element.on('$destroy', unwatch);
               }
             };
           }

--- a/test/ng/compileSpec.js
+++ b/test/ng/compileSpec.js
@@ -42,7 +42,7 @@ describe('$compile', function() {
 
   var element, directive, $compile, $rootScope;
 
-  beforeEach(module(provideLog, function($provide, $compileProvider) {
+  beforeEach(module(provideLog, function($compileProvider) {
     element = null;
     directive = $compileProvider.directive;
 
@@ -134,8 +134,8 @@ describe('$compile', function() {
 
 
     return function(_$compile_, _$rootScope_) {
-      $rootScope = _$rootScope_;
       $compile = _$compile_;
+      $rootScope = _$rootScope_;
     };
   }));
 
@@ -11905,7 +11905,7 @@ describe('$compile', function() {
   describe('ngAttr* attribute binding', function() {
     it('should bind after digest but not before', inject(function() {
       $rootScope.name = 'Misko';
-      element = $compile('<span ng-attr-test="{{name}}"></span>')($rootScope);
+      compile('<span ng-attr-test="{{name}}"></span>');
       expect(element.attr('test')).toBeUndefined();
       $rootScope.$digest();
       expect(element.attr('test')).toBe('Misko');
@@ -11913,7 +11913,7 @@ describe('$compile', function() {
 
     it('should bind after digest but not before when after overridden attribute', inject(function() {
       $rootScope.name = 'Misko';
-      element = $compile('<span test="123" ng-attr-test="{{name}}"></span>')($rootScope);
+      compile('<span test="123" ng-attr-test="{{name}}"></span>');
       expect(element.attr('test')).toBe('123');
       $rootScope.$digest();
       expect(element.attr('test')).toBe('Misko');
@@ -11921,14 +11921,14 @@ describe('$compile', function() {
 
     it('should bind after digest but not before when before overridden attribute', inject(function() {
       $rootScope.name = 'Misko';
-      element = $compile('<span ng-attr-test="{{name}}" test="123"></span>')($rootScope);
+      compile('<span ng-attr-test="{{name}}" test="123"></span>');
       expect(element.attr('test')).toBe('123');
       $rootScope.$digest();
       expect(element.attr('test')).toBe('Misko');
     }));
 
     it('should set the attribute (after digest) even if there is no interpolation', inject(function() {
-      element = $compile('<span ng-attr-test="foo"></span>')($rootScope);
+      compile('<span ng-attr-test="foo"></span>');
       expect(element.attr('test')).toBeUndefined();
 
       $rootScope.$digest();
@@ -11936,12 +11936,14 @@ describe('$compile', function() {
     }));
 
     it('should remove attribute if any bindings are undefined', inject(function() {
-      element = $compile('<span ng-attr-test="{{name}}{{emphasis}}"></span>')($rootScope);
+      compile('<span ng-attr-test="{{name}}{{emphasis}}"></span>');
       $rootScope.$digest();
       expect(element.attr('test')).toBeUndefined();
+
       $rootScope.name = 'caitp';
       $rootScope.$digest();
       expect(element.attr('test')).toBeUndefined();
+
       $rootScope.emphasis = '!!!';
       $rootScope.$digest();
       expect(element.attr('test')).toBe('caitp!!!');
@@ -11987,7 +11989,7 @@ describe('$compile', function() {
       it('should provide post-digest value in synchronous directive link functions when before overridden attribute',
         function() {
           $rootScope.test = 'TEST';
-          element = $compile('<div sync-test ng-attr-test="{{test}}" test="123"></div>')($rootScope);
+          compile('<div sync-test ng-attr-test="{{test}}" test="123"></div>');
           expect(element.attr('test')).toBe('123');
           expect(log.toArray()).toEqual(['TEST', 'TEST']);
         }
@@ -11997,8 +11999,9 @@ describe('$compile', function() {
       it('should provide post-digest value in asynchronous directive link functions when after overridden attribute',
         function() {
           $rootScope.test = 'TEST';
-          element = $compile('<div async-test test="123" ng-attr-test="{{test}}"></div>')($rootScope);
+          compile('<div async-test test="123" ng-attr-test="{{test}}"></div>');
           expect(element.attr('test')).toBe('123');
+
           $rootScope.$digest();
           expect(log.toArray()).toEqual(['TEST', 'TEST']);
         }
@@ -12007,8 +12010,9 @@ describe('$compile', function() {
       it('should provide post-digest value in asynchronous directive link functions when before overridden attribute',
         function() {
           $rootScope.test = 'TEST';
-          element = $compile('<div async-test ng-attr-test="{{test}}" test="123"></div>')($rootScope);
+          compile('<div async-test ng-attr-test="{{test}}" test="123"></div>');
           expect(element.attr('test')).toBe('123');
+
           $rootScope.$digest();
           expect(log.toArray()).toEqual(['TEST', 'TEST']);
         }
@@ -12017,10 +12021,11 @@ describe('$compile', function() {
 
     it('should work with different prefixes', inject(function() {
       $rootScope.name = 'Misko';
-      element = $compile('<span ng:attr:test="{{name}}" ng-Attr-test2="{{name}}" ng_Attr_test3="{{name}}"></span>')($rootScope);
+      compile('<span ng:attr:test="{{name}}" ng-Attr-test2="{{name}}" ng_Attr_test3="{{name}}"></span>');
       expect(element.attr('test')).toBeUndefined();
       expect(element.attr('test2')).toBeUndefined();
       expect(element.attr('test3')).toBeUndefined();
+
       $rootScope.$digest();
       expect(element.attr('test')).toBe('Misko');
       expect(element.attr('test2')).toBe('Misko');
@@ -12037,8 +12042,8 @@ describe('$compile', function() {
         }));
       });
       inject(function($compile, $rootScope) {
-        $compile('<div attr-exposer ng-attr-title="12" ng-attr-super-title="34" ng-attr-my-camel_title="56">')($rootScope);
-        $rootScope.$apply();
+        compile('<div attr-exposer ng-attr-title="12" ng-attr-super-title="34" ng-attr-my-camel_title="56">');
+        $rootScope.$digest();
 
         expect(attrs.title).toBe('12');
         expect(attrs.$attr.title).toBe('title');
@@ -12062,15 +12067,15 @@ describe('$compile', function() {
 
     it('should work with the "href" attribute', inject(function() {
       $rootScope.value = 'test';
-      element = $compile('<a ng-attr-href="test/{{value}}"></a>')($rootScope);
+      compile('<a ng-attr-href="test/{{value}}"></a>');
       $rootScope.$digest();
       expect(element.attr('href')).toBe('test/test');
     }));
 
     it('should work if they are prefixed with x- or data- and different prefixes', inject(function() {
       $rootScope.name = 'Misko';
-      element = $compile('<span data-ng-attr-test2="{{name}}" x-ng-attr-test3="{{name}}" data-ng:attr-test4="{{name}}" ' +
-        'x_ng-attr-test5="{{name}}" data:ng-attr-test6="{{name}}"></span>')($rootScope);
+      compile('<span data-ng-attr-test2="{{name}}" x-ng-attr-test3="{{name}}" data-ng:attr-test4="{{name}}" ' +
+        'x_ng-attr-test5="{{name}}" data:ng-attr-test6="{{name}}"></span>');
       expect(element.attr('test2')).toBeUndefined();
       expect(element.attr('test3')).toBeUndefined();
       expect(element.attr('test4')).toBeUndefined();
@@ -12087,7 +12092,7 @@ describe('$compile', function() {
     describe('when an attribute has a dash-separated name', function() {
       it('should work with different prefixes', inject(function() {
         $rootScope.name = 'JamieMason';
-        element = $compile('<span ng:attr:dash-test="{{name}}" ng-Attr-dash-test2="{{name}}" ng_Attr_dash-test3="{{name}}"></span>')($rootScope);
+        compile('<span ng:attr:dash-test="{{name}}" ng-Attr-dash-test2="{{name}}" ng_Attr_dash-test3="{{name}}"></span>');
         expect(element.attr('dash-test')).toBeUndefined();
         expect(element.attr('dash-test2')).toBeUndefined();
         expect(element.attr('dash-test3')).toBeUndefined();
@@ -12099,7 +12104,7 @@ describe('$compile', function() {
 
       it('should work if they are prefixed with x- or data-', inject(function() {
         $rootScope.name = 'JamieMason';
-        element = $compile('<span data-ng-attr-dash-test2="{{name}}" x-ng-attr-dash-test3="{{name}}" data-ng:attr-dash-test4="{{name}}"></span>')($rootScope);
+        compile('<span data-ng-attr-dash-test2="{{name}}" x-ng-attr-dash-test3="{{name}}" data-ng:attr-dash-test4="{{name}}"></span>');
         expect(element.attr('dash-test2')).toBeUndefined();
         expect(element.attr('dash-test3')).toBeUndefined();
         expect(element.attr('dash-test4')).toBeUndefined();
@@ -12120,7 +12125,7 @@ describe('$compile', function() {
           });
         });
         inject(function($compile, $rootScope, log) {
-          $compile('<span data-dash-starter data-on-dash-start="starter"></span>')($rootScope);
+          compile('<span data-dash-starter data-on-dash-start="starter"></span>');
           $rootScope.$digest();
           expect(log).toEqual('starter');
         });
@@ -12136,13 +12141,24 @@ describe('$compile', function() {
             };
           });
         });
-        inject(function($compile, $rootScope, log) {
-          $compile('<span data-dash-ender data-on-dash-end="ender"></span>')($rootScope);
+        inject(function(log) {
+          compile('<span data-dash-ender data-on-dash-end="ender"></span>');
           $rootScope.$digest();
           expect(log).toEqual('ender');
         });
       });
     });
+
+    it('should clean up watchers when the element is destroyed', inject(function() {
+      compile('<div><p><span ng-attr-test="{{name}}"></span></p></div>');
+      var p = element.find('p');
+
+      $rootScope.$digest();
+      expect($rootScope.$countWatchers()).toBe(1);
+
+      p.remove();
+      expect($rootScope.$countWatchers()).toBe(0);
+    }));
   });
 
 

--- a/test/ng/directive/aSpec.js
+++ b/test/ng/directive/aSpec.js
@@ -71,19 +71,22 @@ describe('a', function() {
 
   it('should not link and hookup an event if href is present at compile', function() {
     var jq = jQuery || jqLite;
-    element = jq('<a href="//a.com">hello@you</a>');
+    element = jq('<a href="">hello@me</a><a href="//you.com">hello@you</a>');
     var linker = $compile(element);
 
-    spyOn(jq.prototype, 'on');
+    var calls = {'hello@me': 0, 'hello@you': 0};
+    spyOn(jq.prototype, 'on').and.callFake(function(eventName) {
+      if (eventName === 'click') {
+        ++calls[this.text()];
+      }
+    });
 
     linker($rootScope);
-
-    expect(jq.prototype.on).not.toHaveBeenCalled();
+    expect(calls).toEqual({'hello@me': 1, 'hello@you': 0});
   });
 
 
   it('should not preventDefault if anchor element is replaced with href-containing element', function() {
-    spyOn(jqLite.prototype, 'on').and.callThrough();
     element = $compile('<a link-to="https://www.google.com">')($rootScope);
     $rootScope.$digest();
 
@@ -100,7 +103,6 @@ describe('a', function() {
 
 
   it('should preventDefault if anchor element is replaced with element without href attribute', function() {
-    spyOn(jqLite.prototype, 'on').and.callThrough();
     element = $compile('<a link-not="https://www.google.com">')($rootScope);
     $rootScope.$digest();
 
@@ -146,14 +148,18 @@ describe('a', function() {
 
       it('should not link and hookup an event if xlink:href is present at compile', function() {
         var jq = jQuery || jqLite;
-        element = jq('<svg><a xlink:href="bobby">hello@you</a></svg>');
+        element = jq('<svg><a xlink:href="">hello@me</a><a xlink:href="you">hello@you</a></svg>');
         var linker = $compile(element);
 
-        spyOn(jq.prototype, 'on');
+        var calls = {'hello@me': 0, 'hello@you': 0};
+        spyOn(jq.prototype, 'on').and.callFake(function(eventName) {
+          if (eventName === 'click') {
+            ++calls[this.text()];
+          }
+        });
 
         linker($rootScope);
-
-        expect(jq.prototype.on).not.toHaveBeenCalled();
+        expect(calls).toEqual({'hello@me': 1, 'hello@you': 0});
       });
     });
   }

--- a/test/ng/ngPropSpec.js
+++ b/test/ng/ngPropSpec.js
@@ -202,6 +202,17 @@ describe('ngProp*', function() {
     });
   });
 
+  it('should clean up watchers when the element is destroyed', inject(function($compile, $rootScope) {
+    var element = $compile('<div><p><span ng-prop-test="name"></span></p></div>')($rootScope);
+    var p = element.find('p');
+
+    $rootScope.$digest();
+    expect($rootScope.$countWatchers()).toBe(1);
+
+    p.remove();
+    expect($rootScope.$countWatchers()).toBe(0);
+  }));
+
 
   ['img', 'audio', 'video'].forEach(function(tag) {
     // Support: IE 9 only

--- a/yarn.lock
+++ b/yarn.lock
@@ -5750,10 +5750,10 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-natives@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.0.tgz#e9ff841418a6b2ec7a495e939984f78f163e6e31"
-  integrity sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=
+natives@1.1.3, natives@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
+  integrity sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
(Minor) perf improvement/memory leak fix.


**What is the current behavior? (You can also link to an open issue here)**
Previously, the watchers registered by `ngAttr`/`ngProp` "pseudo-directives" were not unregistered after the element was destroyed (i.e. premanently removed from the DOM).

In most cases, this was fine, since DOM manipulation happens via structural directives (such as `ngIf`, `ngSwitch`, `ngRepeat`, etc.), which take care of cleaning up after themselves (e.g. by providing a new scope to each element and ensuring it is destroyed - along with its watchers - when the element is removed).

Yet, when imperatively manipulating the DOM via `jqLite`/`jQuery` (which is discouraged but possible - e.g. a component manipulating its template), these watchers would be left behind, consuming computational resources and memory.


**What is the new behavior (if this is a feature change)?**
This PR fixes this by unregistering the watchers as soon as the element is destroyed.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] ~~Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated~~
- [x] Fix/Feature: Tests have been added; existing tests pass
