### PR TITLE
fix(angular): Make angular.isDate returns true for Date Proxy

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -597,7 +597,7 @@ function isNumber(value) {return typeof value === 'number';}
  * @returns {boolean} True if `value` is a `Date`.
  */
 function isDate(value) {
-  return toString.call(value) === '[object Date]';
+  return toString.call(value) === '[object Date]' || value instanceof Date;
 }
 
 

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -1878,6 +1878,10 @@ describe('angular', function() {
       expect(isDate(23)).toBe(false);
       expect(isDate({})).toBe(false);
     });
+
+    it('should return true for Date Proxy', function() {
+      expect(isDate(new window.Proxy(new Date(), {}))).toBe(true);
+    });
   });
 
   describe('isError', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

isDate returns false for Date proxies

**Does this PR introduce a breaking change?**

I don't think so.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [X] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [X] Fix/Feature: Tests have been added; existing tests pass

