### PR TITLE
docs:(attrs) extended @element ngDisabled

### DIFF
--- a/src/ng/directive/attrs.js
+++ b/src/ng/directive/attrs.js
@@ -181,7 +181,7 @@
       </file>
     </example>
  *
- * @element INPUT
+ * @element INPUT, BUTTON, SELECT
  * @param {expression} ngDisabled If the {@link guide/expression expression} is truthy,
  *     then the `disabled` attribute will be set on the element
  */


### PR DESCRIPTION
Using Intellij's IDE will cause this not to mark ng-disabled on buttons or selects as not allowed attribute

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs update


**What is the current behavior? (You can also link to an open issue here)**
Intellij will mark ng-disabled as not allowed attribute on some form elements


**What is the new behavior (if this is a feature change)?**
ng-disabled is now also allowed on buttons and selects


**Does this PR introduce a breaking change?**
nope


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
none
