### PR TITLE
fix(ngRepeat): fix trackBy function being invoked with incorrect scope

### DIFF
--- a/src/ng/directive/ngRepeat.js
+++ b/src/ng/directive/ngRepeat.js
@@ -592,6 +592,12 @@ var ngRepeatDirective = ['$parse', '$animate', '$compile', function($parse, $ani
             }
           }
 
+          // Clear the value property from the hashFnLocals object to prevent a reference to the last value
+          // being leaked into the ngRepeatCompile function scope
+          if (hashFnLocals) {
+            hashFnLocals[valueIdentifier] = undefined;
+          }
+
           // remove leftover items
           for (var blockKey in lastBlockMap) {
             block = lastBlockMap[blockKey];

--- a/test/ng/directive/ngRepeatSpec.js
+++ b/test/ng/directive/ngRepeatSpec.js
@@ -400,6 +400,43 @@ describe('ngRepeat', function() {
       expect(element.find('input')[1].checked).toBe(true);
       expect(element.find('input')[2].checked).toBe(true);
     }));
+
+    it('should invoke track by with correct locals', function() {
+      scope.trackBy = jasmine.createSpy().and.callFake(function(k, v) {
+        return [k, v].join('');
+      });
+
+      element = $compile(
+        '<ul>' +
+          '<li ng-repeat="(k, v) in [1, 2] track by trackBy(k, v)"></li>' +
+        '</ul>')(scope);
+      scope.$digest();
+
+      expect(scope.trackBy).toHaveBeenCalledTimes(2);
+      expect(scope.trackBy.calls.argsFor(0)).toEqual([0, 1]);
+      expect(scope.trackBy.calls.argsFor(1)).toEqual([1, 2]);
+    });
+
+    // https://github.com/angular/angular.js/issues/16776
+    it('should invoke nested track by with correct locals', function() {
+      scope.trackBy = jasmine.createSpy().and.callFake(function(k1, v1, k2, v2) {
+        return [k1, v1, k2, v2].join('');
+      });
+
+      element = $compile(
+        '<ul>' +
+          '<li ng-repeat="(k1, v1) in [1, 2]">' +
+            '<div ng-repeat="(k2, v2) in [3, 4] track by trackBy(k1, v1, k2, v2)"></div>' +
+          '</li>' +
+        '</ul>')(scope);
+      scope.$digest();
+
+      expect(scope.trackBy).toHaveBeenCalledTimes(4);
+      expect(scope.trackBy.calls.argsFor(0)).toEqual([0, 1, 0, 3]);
+      expect(scope.trackBy.calls.argsFor(1)).toEqual([0, 1, 1, 4]);
+      expect(scope.trackBy.calls.argsFor(2)).toEqual([1, 2, 0, 3]);
+      expect(scope.trackBy.calls.argsFor(3)).toEqual([1, 2, 1, 4]);
+    });
   });
 
   describe('alias as', function() {


### PR DESCRIPTION
This also fixes a leak of that scope across all further instances of the
repeated element.

Fixes #16776


**What is the current behavior? (You can also link to an open issue here)**
The track-by function would get created on the *first* linking of an `ng-repeat` and then get cached forever, so each time that `ng-repeat` was re-linked (when it is repeated, or destroyed+recreated via `ng-if` etc.) the previous scope would be used. This also "leaks" the scope for the lifetime of that compiled node.


**What is the new behavior (if this is a feature change)?**
The track-by no longer directly references the scope
