### PR TITLE
docs(tutorial/6 - Two-way Data Binding): fix exp. documentation

### DIFF
--- a/docs/content/tutorial/step_06.ngdoc
+++ b/docs/content/tutorial/step_06.ngdoc
@@ -230,9 +230,8 @@ You can now rerun `npm run protractor` to see the tests run.
 
 * Reverse the sort order by adding a `-` symbol before the sorting value:
   `<option value="-age">Oldest</option>`
-  Upon refreshing the page, you'll see that the default selection of the "age" option in "Sort by" is blank again.
-  Try fixing this in **`app/phone-list/phone-list.component.js`:**
-  
+  After making this change, you'll notice that the drop-down list has a blank option selected and does not default to age anymore.
+  Fix this by updating the `orderProp` value in `phone-list.component.js` to match the new value on the `<option>` element.
 
 
 ## Summary

--- a/docs/content/tutorial/step_06.ngdoc
+++ b/docs/content/tutorial/step_06.ngdoc
@@ -230,6 +230,9 @@ You can now rerun `npm run protractor` to see the tests run.
 
 * Reverse the sort order by adding a `-` symbol before the sorting value:
   `<option value="-age">Oldest</option>`
+  Upon refreshing the page, you'll see that the default selection of the "age" option in "Sort by" is blank again.
+  Try fixing this in **`app/phone-list/phone-list.component.js`:**
+  
 
 
 ## Summary


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Documentation update in step 6 of the PhoneCat Tutorial for AngularJS

**What is the current behavior? (You can also link to an open issue here)**

In the [Experiments section of step 6](https://docs.angularjs.org/tutorial/step_06) in AngularJS Tutorial, it is suggested to add a `-` symbol to `<option value="age">Oldest</option>`

This change is made to reverse the sort order when selecting the `age` option.

However, this change affects the default `$ctrl.orderProp` that we had set in `app/phone-list/phone-list.component.js`

After making the change, our default "Sort by" option is blank

**What is the new behavior (if this is a feature change)?**

I added additional documentation to clarify that this behavior makes sense and that the reader should try and correct the incorrect default behavior within `app/phone-list/phone-list.component.js`


**Does this PR introduce a breaking change?**

No

Let me know if this makes sense or if there's anything I can do to help improve the fix.
Thank you!

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- ~~[ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated~~
- ~~[ ] Fix/Feature: Tests have been added; existing tests pass~~

**Other information**:

