### PR TITLE
test(ngSanitize): disable a failing Edge test in all versions, including 18

### DIFF
--- a/test/ngSanitize/sanitizeSpec.js
+++ b/test/ngSanitize/sanitizeSpec.js
@@ -261,8 +261,8 @@ describe('HTML', function() {
       });
     });
 
-    if (!/Edge\/(16|17)/.test(window.navigator.userAgent)) {
-      // Skip test on Edge 16 due to browser bug.
+    if (!/Edge\/\d{2,}/.test(window.navigator.userAgent)) {
+      // Skip test on Edge due to a browser bug.
       it('should throw on a form with an input named "nextSibling"', function() {
         inject(function($sanitize) {
 


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Test fix.

**What is the current behavior? (You can also link to an open issue here)**

Edge 18 fails tests.

**What is the new behavior (if this is a feature change)?**

Edge 18 passes tests (or at least the one I fixed).

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- ~~Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated~~
- ~~Fix/Feature: Tests have been added; existing tests pass~~

**Other information**:

The test has been only disabled on Edge 16/17 so far which made it fail in Edge 18.