### PR TITLE
fix: remove return outside of a function

### DIFF
--- a/src/angular.bind.js
+++ b/src/angular.bind.js
@@ -3,7 +3,6 @@ if (window.angular.bootstrap) {
   if (window.console) {
     console.log('WARNING: Tried to load AngularJS more than once.');
   }
-  return;
 }
 
 // try to bind to jquery now so that one can write jqLite(fn)


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Bad_return_or_yield

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix: remove return outside of a function.


**What is the current behavior? (You can also link to an open issue here)**
Currently return is called outside of a function which isn't supported by JS

**What is the new behavior (if this is a feature change)?**
No need to return so it is removed.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

