### PR TITLE
docs(guide/Conceptual Overview): use exchangeratesapi.io

### DIFF
--- a/docs/content/guide/concepts.ngdoc
+++ b/docs/content/guide/concepts.ngdoc
@@ -186,7 +186,7 @@ Right now, the `InvoiceController` contains all logic of our example. When the a
 is a good practice to move view-independent logic from the controller into a
 <a name="service">{@link services service}</a>, so it can be reused by other parts
 of the application as well. Later on, we could also change that service to load the exchange rates
-from the web, e.g. by calling the [Fixer.io](http://fixer.io) exchange rate API, without changing the controller.
+from the web, e.g. by calling the [exchangeratesapi.io](https://exchangeratesapi.io) exchange rate API, without changing the controller.
 
 Let's refactor our example and move the currency conversion into a service in another file:
 
@@ -300,7 +300,7 @@ to something shorter like `a`.
 
 ## Accessing the backend
 
-Let's finish our example by fetching the exchange rates from the [Fixer.io](http://fixer.io) exchange rate API.
+Let's finish our example by fetching the exchange rates from the [exchangeratesapi.io](https://exchangeratesapi.io) exchange rate API.
 The following example shows how this is done with AngularJS:
 
 <example name="guide-concepts-3" ng-app-included="true">
@@ -331,7 +331,7 @@ The following example shows how this is done with AngularJS:
         };
 
         var refresh = function() {
-          var url = 'https://api.fixer.io/latest?base=USD&symbols=' + currencies.join(",");
+          var url = 'https://api.exchangeratesapi.io/latest?base=USD&symbols=' + currencies.join(",");
           return $http.get(url).then(function(response) {
             usdToForeignRates = response.data.rates;
             usdToForeignRates['USD'] = 1;


### PR DESCRIPTION
docs(guide/Conceptual Overview): use another exchange rate API

As fixer.io introduced an API key and thus a limitation of calls (see https://github.com/fixerAPI/fixer#readme), change https://api.fixer.io to https://api.exchangeratesapi.io instead, which is "designed and tested to handle thousands of request per second" and has "built in Fixer.io compatibility so you can keep all the libraries you already like and use daily" (from https://api.exchangeratesapi.io). 


**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

docs update

**What is the current behavior? (You can also link to an open issue here)**

The finance3.js service module in the Conceptual Overview section of the Angular documentation does not work without an API key. See #16807

**What is the new behavior (if this is a feature change)?**

Another another currency converter API is used instead (namely the MIT licensed https://api.exchangeratesapi.io), which does not need an API key and which is "designed and tested to handle thousands of request per second" 
and has "built in Fixer.io compatibility so you can keep all the libraries you already like and use daily" (from https://api.exchangeratesapi.io). Idea is from #16137

**Does this PR introduce a breaking change?**

No.

**Other information**:

The Idea is from https://github.com/fixerAPI/fixer/issues/107


fixes #16807 