### PR TITLE
fix(aria/ngClick): change ngAria to ignore enter or space keydowns if a modifying key is clicked

### DIFF
--- a/src/ngAria/aria.js
+++ b/src/ngAria/aria.js
@@ -387,8 +387,10 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
           if ($aria.config('bindKeydown') && !attr.ngKeydown && !attr.ngKeypress && !attr.ngKeyup) {
             elem.on('keydown', function(event) {
               var keyCode = event.which || event.keyCode;
+              // Ignore modified keypress to avoid conflict with system level shortcuts
+              var mod = event.metaKey || event.altKey || event.ctrlKey;
 
-              if (keyCode === 13 || keyCode === 32) {
+              if ((keyCode === 13 || keyCode === 32) && !mod) {
                 // If the event is triggered on a non-interactive element ...
                 if (nodeBlackList.indexOf(event.target.nodeName) === -1 && !event.target.isContentEditable) {
                   // ... prevent the default browser behavior (e.g. scrolling when pressing spacebar)

--- a/test/ngAria/ariaSpec.js
+++ b/test/ngAria/ariaSpec.js
@@ -1135,6 +1135,21 @@ describe('$aria', function() {
 
       expect(scope.onClick).not.toHaveBeenCalled();
     });
+
+    it('should not trigger ng-click if the mod key is pressed', function() {
+      compileElement('<div ng-click="onClick()">Click me</div>');
+
+      element.triggerHandler({type: 'keydown', keyCode: 13, metaKey: true});
+      element.triggerHandler({type: 'keydown', keyCode: 32, metaKey: true});
+
+      element.triggerHandler({type: 'keydown', keyCode: 13, ctrlKey: true});
+      element.triggerHandler({type: 'keydown', keyCode: 32, ctrlKey: true});
+
+      element.triggerHandler({type: 'keydown', keyCode: 13, altKey: true});
+      element.triggerHandler({type: 'keydown', keyCode: 32, altKey: true});
+
+      expect(scope.onClick).not.toHaveBeenCalled();
+    });
   });
 
   describe('actions when bindRoleForClick is set to false', function() {


### PR DESCRIPTION
ngAria registers click events for enter or space regardless of whether a modifying key is pressed at the same time. Section 5.9.2.1 of the W3C spec for aria practices suggests ignoring any modifiers to enter or space keydowns so as not to interfere with operating system shortcuts. Change ngAria to ignore alt/ctrl/meta in conjunction with enter or space.

Ref https://www.w3.org/TR/wai-aria-practices/#kbd_shortcuts_assignments_opsys_conflicts
Breaks ng-click with mod keys, ng-keydown should be used instead

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
ngAria adds a keydown listener that captures all presses of Enter and Space.


**What is the new behavior (if this is a feature change)?**
ngAria keydown listener now ignores Enter and Space if Alt, Control or Meta (command/windows) keys are pressed in conjunction.


**Does this PR introduce a breaking change?**
Breaks ng-click with mod keys, ng-keydown should be used instead


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**: 
Please advise on test failures. This is a minor change, and the unit tests appeared to pass for me locally. I'm not sure what is causing Travis to fail.
Please advise on documentation. I could find no documentation specifically about this behavior and it's unclear if it needs to be added.
