### PR TITLE
WIP fix(ngRequired): always evaluate ngRequired at least once

### DIFF
--- a/src/ng/directive/validators.js
+++ b/src/ng/directive/validators.js
@@ -69,6 +69,7 @@ var requiredDirective = ['$parse', function($parse) {
     link: function(scope, elm, attr, ctrl) {
       if (!ctrl) return;
       var oldVal = attr.required || $parse(attr.ngRequired)(scope);
+      var evaluated = false;
 
       attr.required = true; // force truthy in case we are on non input element
 
@@ -77,9 +78,10 @@ var requiredDirective = ['$parse', function($parse) {
       };
 
       attr.$observe('required', function(val) {
-        if (oldVal !== val) {
+        if (oldVal !== val || !evaluated) {
           oldVal = val;
           ctrl.$validate();
+          evaluated = true;
         }
       });
     }

--- a/test/ng/directive/validatorsSpec.js
+++ b/test/ng/directive/validatorsSpec.js
@@ -707,6 +707,15 @@ describe('validators', function() {
       expect(helper.validationCounter.required).toBe(1);
     });
 
+    it('should validate once when inside ngRepeat and ngRequired is false as ngRequired sets a default required flag of true', function() {
+      $rootScope.isRequired = false;
+      helper.compileInput(
+        '<div ng-repeat="input in [0]">' +
+        '<input type="text" ng-model="value" ng-required="isRequired" validation-spy="required" />' +
+        '</div>');
+
+      expect(helper.validationCounter.required).toBe(1);
+    });
 
     it('should validate only once after compilation when inside ngRepeat and ngRequired is true', function() {
       $rootScope.isRequired = true;


### PR DESCRIPTION
when ngRequired is initially false the required attribute will now be
updated properly.

Fixes: ##16814

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug Fix

**What is the current behavior? (You can also link to an open issue here)**

#16814 

Currently if the ngRequired starts as a false value the old value and the new value will be the same in the $observe and so ctrl.$validate() will not be called. This is a problem because by default the attr.required is set to true.

**What is the new behavior (if this is a feature change)?**

Now the ngRequired $observe will always validate on the first mutation.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**: 

