### PR TITLE
fix(required): correctly validate when required on non-input element …

### DIFF
--- a/src/ng/directive/validators.js
+++ b/src/ng/directive/validators.js
@@ -68,15 +68,21 @@ var requiredDirective = ['$parse', function($parse) {
     require: '?ngModel',
     link: function(scope, elm, attr, ctrl) {
       if (!ctrl) return;
-      var value = attr.required || $parse(attr.ngRequired)(scope);
+      // For boolean attributes like required, presence means true
+      var value = 'required' in attr || $parse(attr.ngRequired)(scope);
 
-      attr.required = true; // force truthy in case we are on non input element
+      if (!attr.ngRequired) {
+        // force truthy in case we are on non input element
+        // (input elements do this automatically for boolean attributes like required)
+        attr.required = true;
+      }
 
       ctrl.$validators.required = function(modelValue, viewValue) {
         return !value || !ctrl.$isEmpty(viewValue);
       };
 
       attr.$observe('required', function(newVal) {
+
         if (value !== newVal) {
           value = newVal;
           ctrl.$validate();

--- a/src/ng/directive/validators.js
+++ b/src/ng/directive/validators.js
@@ -69,7 +69,7 @@ var requiredDirective = ['$parse', function($parse) {
     link: function(scope, elm, attr, ctrl) {
       if (!ctrl) return;
       // For boolean attributes like required, presence means true
-      var value = 'required' in attr || $parse(attr.ngRequired)(scope);
+      var value = attr.hasOwnProperty('required') || $parse(attr.ngRequired)(scope);
 
       if (!attr.ngRequired) {
         // force truthy in case we are on non input element

--- a/test/ng/directive/validatorsSpec.js
+++ b/test/ng/directive/validatorsSpec.js
@@ -696,6 +696,13 @@ describe('validators', function() {
     }));
 
 
+    it('should override "required" when ng-required="false" is set', function() {
+      var inputElm = helper.compileInput('<input type="text" ng-model="notDefined" required ng-required="false" />');
+
+      expect(inputElm).toBeValid();
+    });
+
+
     it('should validate only once after compilation when inside ngRepeat', function() {
       helper.compileInput(
          '<div ng-repeat="input in [0]">' +

--- a/test/ng/directive/validatorsSpec.js
+++ b/test/ng/directive/validatorsSpec.js
@@ -731,6 +731,7 @@ describe('validators', function() {
       expect(helper.validationCounter.required).toBe(1);
     });
 
+
     it('should validate once when inside ngRepeat, and set the "required" error when ngRequired is false by default', function() {
       $rootScope.isRequired = false;
       $rootScope.refs = {};
@@ -744,5 +745,15 @@ describe('validators', function() {
       expect($rootScope.refs.input.$error.required).toBeUndefined();
     });
 
+
+    it('should validate only once when inside ngIf with required on non-input elements', inject(function($compile) {
+      $rootScope.value = '12';
+      $rootScope.refs = {};
+      helper.compileInput('<div ng-if="true"><span ng-model="value" ng-ref="refs.ctrl" ng-ref-read="ngModel" required validation-spy="required"></span></div>');
+      $rootScope.$digest();
+
+      expect(helper.validationCounter.required).toBe(1);
+      expect($rootScope.refs.ctrl.$error.required).not.toBe(true);
+    }));
   });
 });


### PR DESCRIPTION
…is surrounded by ngIf

Closes #16830

I've also ran this change against the ngMaterial unit tests, the uiBootstrap unit tests, the ionic unit tests, and manually tested with uiSelect.

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

