### PR TITLE
refactor(injection): Add service name to injection error message

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -906,7 +906,9 @@ function createInjector(modulesToLoad, strictDi) {
         var key = $inject[i];
         if (typeof key !== 'string') {
           throw $injectorMinErr('itkn',
-                  'Incorrect injection token! Expected service name as string, got {0}', key);
+              'Incorrect injection token for service {0}! ' 
+              + 'Expected service name as string, got {1}.', 
+              serviceName, key);
         }
         args.push(locals && locals.hasOwnProperty(key) ? locals[key] :
                                                          getService(key, serviceName));


### PR DESCRIPTION
When injection fails due to invalid key in injection array, then the error message does not name the component about to be instantiated.

None.

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Improve error message. Assist project debugging.


**What is the current behavior? (You can also link to an open issue here)**
Error message does not provide all relevant detail information.


**What is the new behavior (if this is a feature change)?**
Error message names the affacted component.


**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

