### PR TITLE
fix($locale): use the exact plural rule for French

### DIFF
--- a/src/ngLocale/angular-locale_fr-be.js
+++ b/src/ngLocale/angular-locale_fr-be.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-be",
   "localeID": "fr_BE",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-bf.js
+++ b/src/ngLocale/angular-locale_fr-bf.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-bf",
   "localeID": "fr_BF",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-bi.js
+++ b/src/ngLocale/angular-locale_fr-bi.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-bi",
   "localeID": "fr_BI",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-bj.js
+++ b/src/ngLocale/angular-locale_fr-bj.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-bj",
   "localeID": "fr_BJ",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-bl.js
+++ b/src/ngLocale/angular-locale_fr-bl.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-bl",
   "localeID": "fr_BL",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-ca.js
+++ b/src/ngLocale/angular-locale_fr-ca.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-ca",
   "localeID": "fr_CA",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-cd.js
+++ b/src/ngLocale/angular-locale_fr-cd.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-cd",
   "localeID": "fr_CD",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-cf.js
+++ b/src/ngLocale/angular-locale_fr-cf.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-cf",
   "localeID": "fr_CF",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-cg.js
+++ b/src/ngLocale/angular-locale_fr-cg.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-cg",
   "localeID": "fr_CG",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-ch.js
+++ b/src/ngLocale/angular-locale_fr-ch.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-ch",
   "localeID": "fr_CH",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-ci.js
+++ b/src/ngLocale/angular-locale_fr-ci.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-ci",
   "localeID": "fr_CI",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-cm.js
+++ b/src/ngLocale/angular-locale_fr-cm.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-cm",
   "localeID": "fr_CM",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-dj.js
+++ b/src/ngLocale/angular-locale_fr-dj.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-dj",
   "localeID": "fr_DJ",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-dz.js
+++ b/src/ngLocale/angular-locale_fr-dz.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-dz",
   "localeID": "fr_DZ",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-fr.js
+++ b/src/ngLocale/angular-locale_fr-fr.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-fr",
   "localeID": "fr_FR",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-ga.js
+++ b/src/ngLocale/angular-locale_fr-ga.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-ga",
   "localeID": "fr_GA",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-gf.js
+++ b/src/ngLocale/angular-locale_fr-gf.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-gf",
   "localeID": "fr_GF",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-gn.js
+++ b/src/ngLocale/angular-locale_fr-gn.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-gn",
   "localeID": "fr_GN",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-gp.js
+++ b/src/ngLocale/angular-locale_fr-gp.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-gp",
   "localeID": "fr_GP",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-gq.js
+++ b/src/ngLocale/angular-locale_fr-gq.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-gq",
   "localeID": "fr_GQ",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-ht.js
+++ b/src/ngLocale/angular-locale_fr-ht.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-ht",
   "localeID": "fr_HT",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-km.js
+++ b/src/ngLocale/angular-locale_fr-km.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-km",
   "localeID": "fr_KM",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-lu.js
+++ b/src/ngLocale/angular-locale_fr-lu.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-lu",
   "localeID": "fr_LU",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-ma.js
+++ b/src/ngLocale/angular-locale_fr-ma.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-ma",
   "localeID": "fr_MA",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-mc.js
+++ b/src/ngLocale/angular-locale_fr-mc.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-mc",
   "localeID": "fr_MC",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-mf.js
+++ b/src/ngLocale/angular-locale_fr-mf.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-mf",
   "localeID": "fr_MF",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-mg.js
+++ b/src/ngLocale/angular-locale_fr-mg.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-mg",
   "localeID": "fr_MG",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-ml.js
+++ b/src/ngLocale/angular-locale_fr-ml.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-ml",
   "localeID": "fr_ML",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-mq.js
+++ b/src/ngLocale/angular-locale_fr-mq.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-mq",
   "localeID": "fr_MQ",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-mr.js
+++ b/src/ngLocale/angular-locale_fr-mr.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-mr",
   "localeID": "fr_MR",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-mu.js
+++ b/src/ngLocale/angular-locale_fr-mu.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-mu",
   "localeID": "fr_MU",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-nc.js
+++ b/src/ngLocale/angular-locale_fr-nc.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-nc",
   "localeID": "fr_NC",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-ne.js
+++ b/src/ngLocale/angular-locale_fr-ne.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-ne",
   "localeID": "fr_NE",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-pf.js
+++ b/src/ngLocale/angular-locale_fr-pf.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-pf",
   "localeID": "fr_PF",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-pm.js
+++ b/src/ngLocale/angular-locale_fr-pm.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-pm",
   "localeID": "fr_PM",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-re.js
+++ b/src/ngLocale/angular-locale_fr-re.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-re",
   "localeID": "fr_RE",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-rw.js
+++ b/src/ngLocale/angular-locale_fr-rw.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-rw",
   "localeID": "fr_RW",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-sc.js
+++ b/src/ngLocale/angular-locale_fr-sc.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-sc",
   "localeID": "fr_SC",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-sn.js
+++ b/src/ngLocale/angular-locale_fr-sn.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-sn",
   "localeID": "fr_SN",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-sy.js
+++ b/src/ngLocale/angular-locale_fr-sy.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-sy",
   "localeID": "fr_SY",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-td.js
+++ b/src/ngLocale/angular-locale_fr-td.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-td",
   "localeID": "fr_TD",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-tg.js
+++ b/src/ngLocale/angular-locale_fr-tg.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-tg",
   "localeID": "fr_TG",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-tn.js
+++ b/src/ngLocale/angular-locale_fr-tn.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-tn",
   "localeID": "fr_TN",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-vu.js
+++ b/src/ngLocale/angular-locale_fr-vu.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-vu",
   "localeID": "fr_VU",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-wf.js
+++ b/src/ngLocale/angular-locale_fr-wf.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-wf",
   "localeID": "fr_WF",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);

--- a/src/ngLocale/angular-locale_fr-yt.js
+++ b/src/ngLocale/angular-locale_fr-yt.js
@@ -120,6 +120,6 @@ $provide.value("$locale", {
   },
   "id": "fr-yt",
   "localeID": "fr_YT",
-  "pluralCat": function(n, opt_precision) {  var i = n | 0;  if (i == 0 || i == 1) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
+  "pluralCat": function(n, opt_precision) {  if (n > -2 && n < 2) {    return PLURAL_CATEGORY.ONE;  }  return PLURAL_CATEGORY.OTHER;}
 });
 }]);


### PR DESCRIPTION
 - Get the right category for negative numbers
 - Avoid uneeded assignation and conversion

**What is the current behavior? (You can also link to an open issue here)**
-1, -0.5, -1.5 are considered plural in French

**What is the new behavior (if this is a feature change)?**
-1, -0.5, -1.5 are considered singular in French (as it should)

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass
