### PR TITLE
chore(*): update jQuery from 3.2.1 to 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jasmine-core": "^2.8.0",
     "jasmine-node": "^2.0.0",
     "jasmine-reporters": "^2.2.0",
-    "jquery": "3.2.1",
+    "jquery": "3.4.0",
     "jquery-2.1": "npm:jquery@2.1.4",
     "jquery-2.2": "npm:jquery@2.2.4",
     "karma": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4347,10 +4347,10 @@ jasminewd2@^2.1.0:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
   integrity sha1-LInWiJterFIqfuoywUUhVZxsvwI=
 
-jquery@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
-  integrity sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c=
+jquery@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.0.tgz#8de513fa0fa4b2c7d2e48a530e26f0596936efdf"
+  integrity sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==
 
 js-tokens@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
This updates jQuery to 3.4.0 to ensure future security fixes won't break it.