### PR TITLE
style(typo): Move blank to before closing bracket and fix indent

### DIFF
--- a/src/ngLocale/angular-locale_ja-jp.js
+++ b/src/ngLocale/angular-locale_ja-jp.js
@@ -1,125 +1,125 @@
 'use strict';
 angular.module("ngLocale", [], ["$provide", function($provide) {
-var PLURAL_CATEGORY = {ZERO: "zero", ONE: "one", TWO: "two", FEW: "few", MANY: "many", OTHER: "other"};
-$provide.value("$locale", {
-  "DATETIME_FORMATS": {
-    "AMPMS": [
-      "\u5348\u524d",
-      "\u5348\u5f8c"
-    ],
-    "DAY": [
-      "\u65e5\u66dc\u65e5",
-      "\u6708\u66dc\u65e5",
-      "\u706b\u66dc\u65e5",
-      "\u6c34\u66dc\u65e5",
-      "\u6728\u66dc\u65e5",
-      "\u91d1\u66dc\u65e5",
-      "\u571f\u66dc\u65e5"
-    ],
-    "ERANAMES": [
-      "\u7d00\u5143\u524d",
-      "\u897f\u66a6"
-    ],
-    "ERAS": [
-      "\u7d00\u5143\u524d",
-      "\u897f\u66a6"
-    ],
-    "FIRSTDAYOFWEEK": 6,
-    "MONTH": [
-      "1\u6708",
-      "2\u6708",
-      "3\u6708",
-      "4\u6708",
-      "5\u6708",
-      "6\u6708",
-      "7\u6708",
-      "8\u6708",
-      "9\u6708",
-      "10\u6708",
-      "11\u6708",
-      "12\u6708"
-    ],
-    "SHORTDAY": [
-      "\u65e5",
-      "\u6708",
-      "\u706b",
-      "\u6c34",
-      "\u6728",
-      "\u91d1",
-      "\u571f"
-    ],
-    "SHORTMONTH": [
-      "1\u6708",
-      "2\u6708",
-      "3\u6708",
-      "4\u6708",
-      "5\u6708",
-      "6\u6708",
-      "7\u6708",
-      "8\u6708",
-      "9\u6708",
-      "10\u6708",
-      "11\u6708",
-      "12\u6708"
-    ],
-    "STANDALONEMONTH": [
-      "1\u6708",
-      "2\u6708",
-      "3\u6708",
-      "4\u6708",
-      "5\u6708",
-      "6\u6708",
-      "7\u6708",
-      "8\u6708",
-      "9\u6708",
-      "10\u6708",
-      "11\u6708",
-      "12\u6708"
-    ],
-    "WEEKENDRANGE": [
-      5,
-      6
-    ],
-    "fullDate": "y\u5e74M\u6708d\u65e5EEEE",
-    "longDate": "y\u5e74M\u6708d\u65e5",
-    "medium": "y/MM/dd H:mm:ss",
-    "mediumDate": "y/MM/dd",
-    "mediumTime": "H:mm:ss",
-    "short": "y/MM/dd H:mm",
-    "shortDate": "y/MM/dd",
-    "shortTime": "H:mm"
-  },
-  "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "\u00a5",
-    "DECIMAL_SEP": ".",
-    "GROUP_SEP": ",",
-    "PATTERNS": [
-      {
-        "gSize": 3,
-        "lgSize": 3,
-        "maxFrac": 3,
-        "minFrac": 0,
-        "minInt": 1,
-        "negPre": "-",
-        "negSuf": "",
-        "posPre": "",
-        "posSuf": ""
-      },
-      {
-        "gSize": 3,
-        "lgSize": 3,
-        "maxFrac": 0,
-        "minFrac": 0,
-        "minInt": 1,
-        "negPre": "-\u00a4",
-        "negSuf": "",
-        "posPre": "\u00a4",
-        "posSuf": ""
-      }
-    ]
-  },
-  "id": "ja-jp",
-  "localeID": "ja_JP",
-  "pluralCat": function(n, opt_precision) {  return PLURAL_CATEGORY.OTHER;}
-});
+  var PLURAL_CATEGORY = {ZERO: "zero", ONE: "one", TWO: "two", FEW: "few", MANY: "many", OTHER: "other"};
+  $provide.value("$locale", {
+    "DATETIME_FORMATS": {
+      "AMPMS": [
+        "\u5348\u524d",
+        "\u5348\u5f8c"
+      ],
+      "DAY": [
+        "\u65e5\u66dc\u65e5",
+        "\u6708\u66dc\u65e5",
+        "\u706b\u66dc\u65e5",
+        "\u6c34\u66dc\u65e5",
+        "\u6728\u66dc\u65e5",
+        "\u91d1\u66dc\u65e5",
+        "\u571f\u66dc\u65e5"
+      ],
+      "ERANAMES": [
+        "\u7d00\u5143\u524d",
+        "\u897f\u66a6"
+      ],
+      "ERAS": [
+        "\u7d00\u5143\u524d",
+        "\u897f\u66a6"
+      ],
+      "FIRSTDAYOFWEEK": 6,
+      "MONTH": [
+        "1\u6708",
+        "2\u6708",
+        "3\u6708",
+        "4\u6708",
+        "5\u6708",
+        "6\u6708",
+        "7\u6708",
+        "8\u6708",
+        "9\u6708",
+        "10\u6708",
+        "11\u6708",
+        "12\u6708"
+      ],
+      "SHORTDAY": [
+        "\u65e5",
+        "\u6708",
+        "\u706b",
+        "\u6c34",
+        "\u6728",
+        "\u91d1",
+        "\u571f"
+      ],
+      "SHORTMONTH": [
+        "1\u6708",
+        "2\u6708",
+        "3\u6708",
+        "4\u6708",
+        "5\u6708",
+        "6\u6708",
+        "7\u6708",
+        "8\u6708",
+        "9\u6708",
+        "10\u6708",
+        "11\u6708",
+        "12\u6708"
+      ],
+      "STANDALONEMONTH": [
+        "1\u6708",
+        "2\u6708",
+        "3\u6708",
+        "4\u6708",
+        "5\u6708",
+        "6\u6708",
+        "7\u6708",
+        "8\u6708",
+        "9\u6708",
+        "10\u6708",
+        "11\u6708",
+        "12\u6708"
+      ],
+      "WEEKENDRANGE": [
+        5,
+        6
+      ],
+      "fullDate": "y\u5e74M\u6708d\u65e5EEEE",
+      "longDate": "y\u5e74M\u6708d\u65e5",
+      "medium": "y/MM/dd H:mm:ss",
+      "mediumDate": "y/MM/dd",
+      "mediumTime": "H:mm:ss",
+      "short": "y/MM/dd H:mm",
+      "shortDate": "y/MM/dd",
+      "shortTime": "H:mm"
+    },
+    "NUMBER_FORMATS": {
+      "CURRENCY_SYM": "\u00a5",
+      "DECIMAL_SEP": ".",
+      "GROUP_SEP": ",",
+      "PATTERNS": [
+        {
+          "gSize": 3,
+          "lgSize": 3,
+          "maxFrac": 3,
+          "minFrac": 0,
+          "minInt": 1,
+          "negPre": "-",
+          "negSuf": "",
+          "posPre": "",
+          "posSuf": ""
+        },
+        {
+          "gSize": 3,
+          "lgSize": 3,
+          "maxFrac": 0,
+          "minFrac": 0,
+          "minInt": 1,
+          "negPre": "-\u00a4",
+          "negSuf": "",
+          "posPre": "\u00a4",
+          "posSuf": ""
+        }
+      ]
+    },
+    "id": "ja-jp",
+    "localeID": "ja_JP",
+    "pluralCat": function(n, opt_precision) { return PLURAL_CATEGORY.OTHER; }
+  });
 }]);


### PR DESCRIPTION
# AngularJS is in LTS mode
We are no longer accepting changes that are not critical bug fixes into this project.
See https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c for more detail.

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**Does this PR fix a regression since 1.7.0, a security flaw, or a problem caused by a new browser version?**
-> No, this PR is just fix typo.

<!-- If the answer is no, then we will not merge this PR -->


**What is the current behavior? (You can also link to an open issue here)**
**What is the new behavior (if this is a feature change)?**
**Does this PR introduce a breaking change?**
-> As above, this is just fix typo. This will not affect other function.


**Please check if the PR fulfills these requirements**
- [ ◯ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ◯ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ◯ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

