### PR TITLE
chore: make CI green again

### DIFF
--- a/lib/saucelabs/start_tunnel.sh
+++ b/lib/saucelabs/start_tunnel.sh
@@ -11,7 +11,7 @@ set -e
 # Curl and run this script as part of your .travis.yml before_script section:
 # before_script:
 #   - curl https://gist.github.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash
-SC_VERSION="4.5.2"
+SC_VERSION="4.5.4"
 CONNECT_URL="https://saucelabs.com/downloads/sc-$SC_VERSION-linux.tar.gz"
 CONNECT_DIR="/tmp/sauce-connect-$RANDOM"
 CONNECT_DOWNLOAD="sc-$SC_VERSION-linux.tar.gz"

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -11,11 +11,12 @@ export SAUCE_ACCESS_KEY
 BROWSER_STACK_ACCESS_KEY=$(echo "$BROWSER_STACK_ACCESS_KEY" | rev)
 SAUCE_ACCESS_KEY=$(echo "$SAUCE_ACCESS_KEY" | rev)
 
-# The currently latest version of Safari on Saucelabs (v12) is unstable and disconnects frequently.
-# TODO: Add `SL_Safari` back, once/if it becomes more stable again.
+# The currently latest-1 version of desktop Safari on Saucelabs (v12.0) is unstable and disconnects
+# consistently. The latest version (v12.1) works fine.
+# TODO: Add `SL_Safari-1` back, once it no longer corresponds to v12.0.
 BROWSERS="SL_Chrome,SL_Chrome-1,\
 SL_Firefox,SL_Firefox-1,\
-SL_Safari-1,\
+SL_Safari,\
 SL_iOS,SL_iOS-1,\
 SL_IE_9,SL_IE_10,SL_IE_11,\
 SL_EDGE,SL_EDGE-1"


### PR DESCRIPTION
The currently latest-1 version of desktop Safari (v12.0) on SauceLabs is completely unstable. Switched to the latest version (currently v12.1), which works fine.

This PR also upgrades SauceConnect to the latest version (although that doesn't seem to affect anything).