### PR TITLE
fix(angular.merge): do not merge __proto__ property

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -342,8 +342,10 @@ function baseExtend(dst, objs, deep) {
         } else if (isElement(src)) {
           dst[key] = src.clone();
         } else {
-          if (!isObject(dst[key])) dst[key] = isArray(src) ? [] : {};
-          baseExtend(dst[key], [src], true);
+          if (key !== '__proto__') {
+            if (!isObject(dst[key])) dst[key] = isArray(src) ? [] : {};
+            baseExtend(dst[key], [src], true);
+          }
         }
       } else {
         dst[key] = src;

--- a/test/AngularSpec.js
+++ b/test/AngularSpec.js
@@ -814,6 +814,19 @@ describe('angular', function() {
       expect(isElement(dst.jqObject)).toBeTruthy();
       expect(dst.jqObject.nodeName).toBeUndefined(); // i.e it is a jqLite/jQuery object
     });
+
+    it('should not merge the __proto__ property', function() {
+      var src = JSON.parse('{ "__proto__": { "xxx": "polluted" } }');
+      var dst = {};
+
+      merge(dst, src);
+
+      if (typeof dst.__proto__ !== 'undefined') { // eslint-disable-line
+        // Should not overwrite the __proto__ property or pollute the Object prototype
+        expect(dst.__proto__).toBe(Object.prototype); // eslint-disable-line
+      }
+      expect(({}).xxx).toBeUndefined();
+    });
   });
 
 


### PR DESCRIPTION
By blocking `__proto__` on deep merging, this commit
prevents the `Object` prototype from being polluted.

# AngularJS is in LTS mode
We are no longer accepting changes that are not critical bug fixes into this project.
See https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c for more detail.

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**Does this PR fix a regression since 1.7.0, a security flaw, or a problem caused by a new browser version?**

<!-- If the answer is no, then we will not merge this PR -->


**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

