### PR TITLE
chore(*): fix serving of URI-encoded files on code.angularjs.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ performance/temp*.html
 angular.js.tmproj
 node_modules/
 angular.xcodeproj
+.firebase/
 .idea
 *.iml
 .agignore

--- a/package.json
+++ b/package.json
@@ -101,8 +101,8 @@
   "dependencies": {},
   "resolutions": {
     "//1": "`natives@1.1.0` does not work with Node.js 10.x on Windows 10",
-    "//2": "(E.g. see https://github.com/gulpjs/gulp/issues/2162.)",
-    "natives": "1.1.3"
+    "//2": "(E.g. see https://github.com/gulpjs/gulp/issues/2162 and https://github.com/nodejs/node/issues/25132.)",
+    "natives": "1.1.6"
   },
   "commitplease": {
     "style": "angular",

--- a/scripts/code.angularjs.org-firebase/functions/index.js
+++ b/scripts/code.angularjs.org-firebase/functions/index.js
@@ -10,7 +10,11 @@ const BROWSER_CACHE_DURATION = 60 * 10;
 const CDN_CACHE_DURATION = 60 * 60 * 12;
 
 function sendStoredFile(request, response) {
-  const requestPath = request.path || '/';
+  // Request paths will be URI-encoded, so we need to decode them to match the file names in the
+  // storage bucket. Failing to do so will result in a 404 error from the bucket and `index.html`
+  // will be returned instead.
+  // Example of path requiring decoding: `.../input%5Btext%5D.html` --> `.../input[text].html`
+  const requestPath = decodeURI(request.path || '/');
   let filePathSegments = requestPath.split('/').filter((segment) => {
     // Remove empty leading or trailing path parts
     return segment !== '';

--- a/scripts/code.angularjs.org-firebase/functions/package.json
+++ b/scripts/code.angularjs.org-firebase/functions/package.json
@@ -1,6 +1,9 @@
 {
   "name": "functions-firebase-code.angularjs.org",
   "description": "Cloud Functions to serve files from gcs to code.angularjs.org",
+  "engines": {
+    "node": "8"
+  },
   "dependencies": {
     "@google-cloud/storage": "^1.1.1",
     "firebase-admin": "^5.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5440,10 +5440,10 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-natives@1.1.3, natives@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
-  integrity sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g==
+natives@1.1.6, natives@^1.1.0:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+  integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
The files served for the various versions on https://code.angularjs.org/ are retrieved by a Firebase function from a Firebase Storage bucket (where they are deployed to from Travis CI). The files are stored exactly as they are named on disk.

It turns out that some of the files have names with special characters that get URI-encoded when sent to the Firebase function. For example, `input[text].html` becomes `input%5Btext%5D.html`. As a result, the actual file cannot be retrieved from the Storage bucket (since the name does not match) and `index.html` is returned instead. Apparently, this never worked, but nobody noticed or reported it until recently.

An example of a failing URL is: https://code.angularjs.org/1.7.9/docs/api/ng/input/input%5Btext%5D

(NOTE: https://docs.angularjs.org/ works correctly, since the files are deployed to Firebase hosting directly and not to a Storage bucket.)

This commit fixes the problem by decoding the request path before trying to retrieve the corresponding file from the Storage bucket.