### PR TITLE
docs(developers): commit message format typo

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -249,7 +249,7 @@ format that includes a **type**, a **scope** and a **subject**:
 
 The **header** is mandatory and the **scope** of the header is optional.
 
-Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
+Any line of the commit message cannot be longer than 100 characters! This allows the message to be easier
 to read on GitHub as well as in various git tools.
 
 ### Revert


### PR DESCRIPTION
Any line of the commit message cannot be longer *than* 100 characters!

# AngularJS is in LTS mode
We are no longer accepting changes that are not critical bug fixes into this project.
See https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c for more detail.

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**Does this PR fix a regression since 1.7.0, a security flaw, or a problem caused by a new browser version?**
No
<!-- If the answer is no, then we will not merge this PR -->


**What is the current behavior? (You can also link to an open issue here)**
Typographical error


**What is the new behavior (if this is a feature change)?**
None


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
Correct typographical error
