### PR TITLE
fix(grunt-utils): insert the core CSS styles without using innerHTML

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -111,7 +111,7 @@ module.exports = {
         .replace(/\\/g, '\\\\')
         .replace(/'/g, '\\\'')
         .replace(/\r?\n/g, '\\n');
-      js = '!window.angular.$$csp().noInlineStyle && window.angular.element(document.head).prepend(window.angular.element("<style>").text(\'' + css + '\'));';
+      js = '!window.angular.$$csp().noInlineStyle && window.angular.element(document.head).prepend(window.angular.element(\'<style>\').text(\'' + css + '\'));';
       state.js.push(js);
 
       return state;

--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -111,7 +111,7 @@ module.exports = {
         .replace(/\\/g, '\\\\')
         .replace(/'/g, '\\\'')
         .replace(/\r?\n/g, '\\n');
-      js = '!window.angular.$$csp().noInlineStyle && window.angular.element(document.head).prepend(\'<style type="text/css">' + css + '</style>\');';
+      js = '!window.angular.$$csp().noInlineStyle && window.angular.element(document.head).prepend(window.angular.element("<style>").text(\'' + css + '\'));';
       state.js.push(js);
 
       return state;

--- a/test/e2e/tests/sample.spec.js
+++ b/test/e2e/tests/sample.spec.js
@@ -9,4 +9,12 @@ describe('Sample', function() {
   it('should have the interpolated text', function() {
     expect(element(by.binding('text')).getText()).toBe('Hello, world!');
   });
+
+  it('should insert the ng-cloak styles', function() {
+    browser.executeScript(`
+    var span = document.createElement('span');
+    span.className = 'ng-cloak foo';
+    document.body.appendChild(span);`);
+    expect(element(by.className('foo')).isDisplayed()).toBe(false);
+  });
 });

--- a/test/e2e/tests/sample.spec.js
+++ b/test/e2e/tests/sample.spec.js
@@ -12,9 +12,10 @@ describe('Sample', function() {
 
   it('should insert the ng-cloak styles', function() {
     browser.executeScript(`
-    var span = document.createElement('span');
-    span.className = 'ng-cloak foo';
-    document.body.appendChild(span);`);
+      var span = document.createElement('span');
+      span.className = 'ng-cloak foo';
+      document.body.appendChild(span);
+    `);
     expect(element(by.className('foo')).isDisplayed()).toBe(false);
   });
 });


### PR DESCRIPTION
Create style elements and modify their text content instead of using
`innerHTML` to create the whole `<style>` element with its content.
That way style insertion done at bootstrap time doesn't interfere with
Trusted Types restrictions in Chrome (https://bit.ly/trusted-types).

Remove the type attribute - `text/css` is default:
https://html.spec.whatwg.org/#update-a-style-block.

# AngularJS is in LTS mode
We are no longer accepting changes that are not critical bug fixes into this project.
See https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c for more detail.

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**Does this PR fix a regression since 1.7.0, a security flaw, or a problem caused by a new browser version?**

Yes, Chrome launched [Trusted Types](https://web.dev/trusted-types) in 83, and all AngularJS applications running on pages with `require-trusted-types-for 'script'` CSP directive cause CSP violation at bootstrap time.

<!-- If the answer is no, then we will not merge this PR -->


**What is the current behavior? (You can also link to an open issue here)**

At bootstrap, AngularJS inserts the `ngCloak` styles using `element.prepend` with a payload that will trigger setting the style with `innerHTML`.

**What is the new behavior (if this is a feature change)?**

Changed the payload to create an element, and then insert the contents using as inner text instead. 

**Does this PR introduce a breaking change?**

No, the same styles are inserted, in the same place and time.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [n/a] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated

It's a grunt script change. 

- [X] Fix/Feature: Tests have been added; existing tests pass
