### PR TITLE
docs(security): add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+| Version     | Supported          | Status                | Comments                             |
+| ----------- | ------------------ | --------------------- | ------------------------------------ |
+| 1.8.x       | :white_check_mark: | Long Term Support     | See [Long Term Support policy][0]    |
+| 1.3.x-1.7.x | :x:                |                       |                                      |
+| 1.2.x       | :warning:          | Security patches only | Last version to provide IE 8 support |
+| <1.2.0      | :x:                |                       |                                      |
+
+## Reporting a Vulnerability
+
+Email us at [security@angularjs.org](mailto:security@angularjs.org) to report any potential security issues in AngularJS.
+
+Please [use the latest AngularJS possible](https://docs.angularjs.org/guide/security#use-the-latest-angularjs-possible)
+and keep in mind the guidance around AngularJS'
+[expression language](https://docs.angularjs.org/guide/security#angularjs-templates-and-expressions).
+
+[0]: https://docs.angularjs.org/misc/version-support-status#long-term-support


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**Does this PR fix a regression since 1.7.0, a security flaw, or a problem caused by a new browser version?** 
No, but it documents the project's Security policy in a standard GitHub-supported way.

<!-- If the answer is no, then we will not merge this PR -->


**What is the current behavior? (You can also link to an open issue here)**
There is no Security policy in the repo, only on the docs website.


**What is the new behavior (if this is a feature change)?**
There is a Security policy in the repo, in a well known GitHub-supported location.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

