### PR TITLE
fix(jqLite): prevent possible XSS due to regex-based HTML replacement

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -100,6 +100,7 @@
     "VALIDITY_STATE_PROPERTY": false,
     "reloadWithDebugInfo": false,
     "stringify": false,
+    "UNSAFE_restoreLegacyJqLiteXHTMLReplacement": false,
 
     "NODE_TYPE_ELEMENT": false,
     "NODE_TYPE_ATTRIBUTE": false,

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -93,6 +93,7 @@
   hasOwnProperty,
   createMap,
   stringify,
+  UNSAFE_restoreLegacyJqLiteXHTMLReplacement,
 
   NODE_TYPE_ELEMENT,
   NODE_TYPE_ATTRIBUTE,
@@ -1947,6 +1948,26 @@ function bindJQuery() {
 
   // Prevent double-proxying.
   bindJQueryFired = true;
+}
+
+/**
+ * @ngdoc function
+ * @name angular.UNSAFE_restoreLegacyJqLiteXHTMLReplacement
+ * @module ng
+ * @kind function
+ *
+ * @description
+ * Restores the pre-1.8 behavior of jqLite that turns XHTML-like strings like
+ * `<div /><span />` to `<div></div><span></span>` instead of `<div><span></span></div>`.
+ * The new behavior is a security fix so if you use this method, please try to adjust
+ * to the change & remove the call as soon as possible.
+
+ * Note that this only patches jqLite. If you use jQuery 3.5.0 or newer, please read
+ * [jQuery 3.5 upgrade guide](https://jquery.com/upgrade-guide/3.5/) for more details
+ * about the workarounds.
+ */
+function UNSAFE_restoreLegacyJqLiteXHTMLReplacement() {
+  JQLite.legacyXHTMLReplacement = true;
 }
 
 /**

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1959,10 +1959,10 @@ function bindJQuery() {
  * @description
  * Restores the pre-1.8 behavior of jqLite that turns XHTML-like strings like
  * `<div /><span />` to `<div></div><span></span>` instead of `<div><span></span></div>`.
- * The new behavior is a security fix so if you use this method, please try to adjust
- * to the change & remove the call as soon as possible.
+ * The new behavior is a security fix. Thus, if you need to call this function, please try to adjust
+ * your code for this change and remove your use of this function as soon as possible.
 
- * Note that this only patches jqLite. If you use jQuery 3.5.0 or newer, please read
+ * Note that this only patches jqLite. If you use jQuery 3.5.0 or newer, please read the
  * [jQuery 3.5 upgrade guide](https://jquery.com/upgrade-guide/3.5/) for more details
  * about the workarounds.
  */

--- a/src/AngularPublic.js
+++ b/src/AngularPublic.js
@@ -156,6 +156,7 @@ function publishExternalAPI(angular) {
     'callbacks': {$$counter: 0},
     'getTestability': getTestability,
     'reloadWithDebugInfo': reloadWithDebugInfo,
+    'UNSAFE_restoreLegacyJqLiteXHTMLReplacement': UNSAFE_restoreLegacyJqLiteXHTMLReplacement,
     '$$minErr': minErr,
     '$$csp': csp,
     '$$encodeUriSegment': encodeUriSegment,

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -90,9 +90,9 @@
  * - [`val()`](http://api.jquery.com/val/)
  * - [`wrap()`](http://api.jquery.com/wrap/)
  *
- * jqLite also provides a method restoring pre-1.8 insecure treatment of XHTML-like tags
- * that makes input like `<div /><span />` turned to `<div></div><span></span>` instead of
- * `<div><span></span></div>` like version 1.8 & newer do:
+ * jqLite also provides a method restoring pre-1.8 insecure treatment of XHTML-like tags.
+ * This legacy behavior turns input like `<div /><span />` to `<div></div><span></span>`
+ * instead of `<div><span></span></div>` like version 1.8 & newer do. To restore it, invoke:
  * ```js
  * angular.UNSAFE_restoreLegacyJqLiteXHTMLReplacement();
  * ```

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -96,7 +96,7 @@
  * ```js
  * angular.UNSAFE_restoreLegacyJqLiteXHTMLReplacement();
  * ```
- * Note that this only patches jqLite. If you use jQuery 3.5.0 or newer, please read
+ * Note that this only patches jqLite. If you use jQuery 3.5.0 or newer, please read the
  * [jQuery 3.5 upgrade guide](https://jquery.com/upgrade-guide/3.5/) for more details
  * about the workarounds.
  *
@@ -196,7 +196,7 @@ wrapMap.th = wrapMap.td;
 
 // Support: IE <10 only
 // IE 9 requires an option wrapper & it needs to have the whole table structure
-// set up up front; assigning `"<td></td>"` to `tr.innerHTML` doesn't work, etc.
+// set up in advance; assigning `"<td></td>"` to `tr.innerHTML` doesn't work, etc.
 var wrapMapIE9 = {
   option: [1, '<select multiple="multiple">', '</select>'],
   _default: [0, '', '']

--- a/src/jqLite.js
+++ b/src/jqLite.js
@@ -90,6 +90,16 @@
  * - [`val()`](http://api.jquery.com/val/)
  * - [`wrap()`](http://api.jquery.com/wrap/)
  *
+ * jqLite also provides a method restoring pre-1.8 insecure treatment of XHTML-like tags
+ * that makes input like `<div /><span />` turned to `<div></div><span></span>` instead of
+ * `<div><span></span></div>` like version 1.8 & newer do:
+ * ```js
+ * angular.UNSAFE_restoreLegacyJqLiteXHTMLReplacement();
+ * ```
+ * Note that this only patches jqLite. If you use jQuery 3.5.0 or newer, please read
+ * [jQuery 3.5 upgrade guide](https://jquery.com/upgrade-guide/3.5/) for more details
+ * about the workarounds.
+ *
  * ## jQuery/jqLite Extras
  * AngularJS also provides the following additional methods and events to both jQuery and jqLite:
  *
@@ -169,20 +179,36 @@ var HTML_REGEXP = /<|&#?\w+;/;
 var TAG_NAME_REGEXP = /<([\w:-]+)/;
 var XHTML_TAG_REGEXP = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:-]+)[^>]*)\/>/gi;
 
+// Table parts need to be wrapped with `<table>` or they're
+// stripped to their contents when put in a div.
+// XHTML parsers do not magically insert elements in the
+// same way that tag soup parsers do, so we cannot shorten
+// this by omitting <tbody> or other required elements.
 var wrapMap = {
-  'option': [1, '<select multiple="multiple">', '</select>'],
-
-  'thead': [1, '<table>', '</table>'],
-  'col': [2, '<table><colgroup>', '</colgroup></table>'],
-  'tr': [2, '<table><tbody>', '</tbody></table>'],
-  'td': [3, '<table><tbody><tr>', '</tr></tbody></table>'],
-  '_default': [0, '', '']
+  thead: ['table'],
+  col: ['colgroup', 'table'],
+  tr: ['tbody', 'table'],
+  td: ['tr', 'tbody', 'table']
 };
 
-wrapMap.optgroup = wrapMap.option;
 wrapMap.tbody = wrapMap.tfoot = wrapMap.colgroup = wrapMap.caption = wrapMap.thead;
 wrapMap.th = wrapMap.td;
 
+// Support: IE <10 only
+// IE 9 requires an option wrapper & it needs to have the whole table structure
+// set up up front; assigning `"<td></td>"` to `tr.innerHTML` doesn't work, etc.
+var wrapMapIE9 = {
+  option: [1, '<select multiple="multiple">', '</select>'],
+  _default: [0, '', '']
+};
+
+for (var key in wrapMap) {
+  var wrapMapValueClosing = wrapMap[key];
+  var wrapMapValue = wrapMapValueClosing.slice().reverse();
+  wrapMapIE9[key] = [wrapMapValue.length, '<' + wrapMapValue.join('><') + '>', '</' + wrapMapValueClosing.join('></') + '>'];
+}
+
+wrapMapIE9.optgroup = wrapMapIE9.option;
 
 function jqLiteIsTextNode(html) {
   return !HTML_REGEXP.test(html);
@@ -203,7 +229,7 @@ function jqLiteHasData(node) {
 }
 
 function jqLiteBuildFragment(html, context) {
-  var tmp, tag, wrap,
+  var tmp, tag, wrap, finalHtml,
       fragment = context.createDocumentFragment(),
       nodes = [], i;
 
@@ -214,13 +240,30 @@ function jqLiteBuildFragment(html, context) {
     // Convert html into DOM nodes
     tmp = fragment.appendChild(context.createElement('div'));
     tag = (TAG_NAME_REGEXP.exec(html) || ['', ''])[1].toLowerCase();
-    wrap = wrapMap[tag] || wrapMap._default;
-    tmp.innerHTML = wrap[1] + html.replace(XHTML_TAG_REGEXP, '<$1></$2>') + wrap[2];
+    finalHtml = JQLite.legacyXHTMLReplacement ?
+      html.replace(XHTML_TAG_REGEXP, '<$1></$2>') :
+      html;
 
-    // Descend through wrappers to the right content
-    i = wrap[0];
-    while (i--) {
-      tmp = tmp.lastChild;
+    if (msie < 10) {
+      wrap = wrapMapIE9[tag] || wrapMapIE9._default;
+      tmp.innerHTML = wrap[1] + finalHtml + wrap[2];
+
+      // Descend through wrappers to the right content
+      i = wrap[0];
+      while (i--) {
+        tmp = tmp.firstChild;
+      }
+    } else {
+      wrap = wrapMap[tag] || [];
+
+      // Create wrappers & descend into them
+      i = wrap.length;
+      while (--i > -1) {
+        tmp.appendChild(window.document.createElement(wrap[i]));
+        tmp = tmp.firstChild;
+      }
+
+      tmp.innerHTML = finalHtml;
     }
 
     nodes = concat(nodes, tmp.childNodes);


### PR DESCRIPTION
# AngularJS is in LTS mode
We are no longer accepting changes that are not critical bug fixes into this project.
See https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c for more detail.

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**Does this PR fix a regression since 1.7.0, a security flaw, or a problem caused by a new browser version?**

<!-- If the answer is no, then we will not merge this PR -->

Yes

**What is the current behavior? (You can also link to an open issue here)**

1. The regex-based input HTML replacement may turn sanitized code into unsanitized one. An analogous jQuery advisory: https://github.com/jquery/jquery/security/advisories/GHSA-gxr4-xjj5-5px2
1. Wrapping `<option>` elements in `<select>` ones changes parsing behavior, leading to possibly unsanitizing sanitized code. An analogous jQuery advisory: https://github.com/jquery/jquery/security/advisories/GHSA-jpcq-cgw6-v4j6

**What is the new behavior (if this is a feature change)?**

The issues are fixed. The second one is a breaking change so a new method restoring legacy insecure behavior:
```js
angular.UNSAFE_restoreLegacyJqLiteXHTMLReplacement()
```
was added.

**Does this PR introduce a breaking change?**

Yes

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

