### PR TITLE
chore: update Copyrights to Google LLC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2010-2020 Google, Inc. http://angularjs.org
+Copyright (c) 2010-2020 Google LLC. http://angularjs.org
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/app/src/examples.js
+++ b/docs/app/src/examples.js
@@ -55,7 +55,7 @@ angular.module('examples', [])
   return function(url, newWindow, fields) {
     /**
      * If the form posts to target="_blank", pop-up blockers can cause it not to work.
-     * If a user choses to bypass pop-up blocker one time and click the link, they will arrive at
+     * If a user chooses to bypass pop-up blocker one time and click the link, they will arrive at
      * a new default plnkr, not a plnkr with the desired template.  Given this undesired behavior,
      * some may still want to open the plnk in a new window by opting-in via ctrl+click.  The
      * newWindow param allows for this possibility.
@@ -74,7 +74,7 @@ angular.module('examples', [])
 }])
 
 .factory('createCopyrightNotice', function() {
-    var COPYRIGHT = 'Copyright ' + (new Date()).getFullYear() + ' Google Inc. All Rights Reserved.\n'
+    var COPYRIGHT = 'Copyright ' + (new Date()).getFullYear() + ' Google LLC. All Rights Reserved.\n'
      + 'Use of this source code is governed by an MIT-style license that\n'
      + 'can be found in the LICENSE file at http://angular.io/license';
     var COPYRIGHT_JS_CSS = '\n\n/*\n' + COPYRIGHT + '\n*/';

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "//1": "`natives@1.1.0` does not work with Node.js 10.x on Windows 10",
     "//2": "(E.g. see https://github.com/gulpjs/gulp/issues/2162 and https://github.com/nodejs/node/issues/25132.)",
     "natives": "1.1.6",
-    "//3": "`graceful-fs` needs to be pinned to support gulp 3,  on Node v12+",
+    "//3": "`graceful-fs` needs to be pinned to support gulp 3, on Node v12+",
     "graceful-fs": "^4.2.3"
   },
   "commitplease": {

--- a/src/angular.prefix
+++ b/src/angular.prefix
@@ -1,6 +1,6 @@
 /**
  * @license AngularJS v"NG_VERSION_FULL"
- * (c) 2010-2020 Google, Inc. http://angularjs.org
+ * (c) 2010-2020 Google LLC. http://angularjs.org
  * License: MIT
  */
 (function(window) {

--- a/src/loader.prefix
+++ b/src/loader.prefix
@@ -1,6 +1,6 @@
 /**
  * @license AngularJS v"NG_VERSION_FULL"
- * (c) 2010-2020 Google, Inc. http://angularjs.org
+ * (c) 2010-2020 Google LLC. http://angularjs.org
  * License: MIT
  */
 'use strict';

--- a/src/module.prefix
+++ b/src/module.prefix
@@ -1,6 +1,6 @@
 /**
  * @license AngularJS v"NG_VERSION_FULL"
- * (c) 2010-2020 Google, Inc. http://angularjs.org
+ * (c) 2010-2020 Google LLC. http://angularjs.org
  * License: MIT
  */
 (function(window, angular) {

--- a/vendor/ng-closure-runner/LICENSE
+++ b/vendor/ng-closure-runner/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2013 Google, Inc. http://angularjs.org
+Copyright (c) 2013-2020 Google LLC. http://angularjs.org
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
# AngularJS is in LTS mode
We are no longer accepting changes that are not critical bug fixes into this project.
See https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c for more detail.

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**Does this PR fix a regression since 1.7.0, a security flaw, or a problem caused by a new browser version?**
No


**What is the current behavior?**
The Copyrights currently use the old name, Google, Inc. You can see [here](https://en.wikipedia.org/wiki/Google) that the new name is Google LLC and that Google, Inc. is the former name.


**What is the new behavior?**
Use Google LLC as the name. This is consistent with the [angular/angular LICENSE](https://github.com/angular/angular/blob/master/LICENSE#L3).


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

