### PR TITLE
chore(ci): really fix code/docs deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,7 +388,7 @@ jobs:
         # Install dependencies for Firebase functions to prevent parsing errors during deployment
         # See https://github.com/angular/angular.js/pull/16453
       - run: yarn --cwd scripts/docs.angularjs.org-firebase/functions
-      - run: yarn firebase deploy --token "$FIREBASE_TOKEN" --only hosting
+      - run: yarn firebase deploy --message  "Commit:\ $CI_COMMIT" --non-interactive --only hosting --project "docs-angularjs-org-9p2" --token "$FIREBASE_TOKEN"
 
 workflows:
   version: 2

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -56,12 +56,12 @@ setPublicVar SAUCE_READY_FILE_TIMEOUT 120
 ####################################################################################################
 # Define additional environment variables
 ####################################################################################################
-setPublicVar DIST_TAG $( jq ".distTag" "package.json" | tr -d "\"[:space:]" )
+setPublicVar DIST_TAG $( node --print "require('./package.json').distTag" )
 
 ####################################################################################################
 ####################################################################################################
 ##                  Source `$BASH_ENV` to make the variables available immediately.               ##
-##                  ***NOTE: This must remain the the last action in this script***               ##
+##                   ***NOTE: This must remain the last action in this script.***                 ##
 ####################################################################################################
 ####################################################################################################
 source $BASH_ENV;

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -61,7 +61,7 @@ setPublicVar DIST_TAG $( node --print "require('./package.json').distTag" )
 ####################################################################################################
 ####################################################################################################
 ##                  Source `$BASH_ENV` to make the variables available immediately.               ##
-##                   ***NOTE: This must remain the last action in this script.***                 ##
+##                  *** NOTE: This must remain the last command in this script. ***               ##
 ####################################################################################################
 ####################################################################################################
 source $BASH_ENV;


### PR DESCRIPTION
This PR fixes two issues related to code/docs deployment:
1. Correctly compute the `DIST_TAG` environment variable (which is needed in the `deploy-code` CI job).
2. Correctly deploy docs to Firebase (as part of the `deploy-docs` CI job).

See individual commits for details.