### PR TITLE
chore(ci): correctly compute `$DIST_TAG` in the `deploy-code` CI job

### DIFF
--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -56,7 +56,9 @@ setPublicVar SAUCE_READY_FILE_TIMEOUT 120
 ####################################################################################################
 # Define additional environment variables
 ####################################################################################################
-setPublicVar DIST_TAG $( node --print "require('./package.json').distTag" )
+
+# NOTE: Make sure the tools used to compute this are available in all executors in `config.yml`.
+setPublicVar DIST_TAG $( cat package.json | grep distTag | sed -E 's/^\s*"distTag"\s*:\s*"([^"]+)"\s*,\s*$/\1/' )
 
 ####################################################################################################
 ####################################################################################################


### PR DESCRIPTION
Previously, the `DIST_TAG` environment variable was failing to be computed correctly in the `deploy-code` CI job, because it relied on the non-existent `node` executable. It worked with the default executor (which includes `node`), but not with the `cloud-sdk` executor used in `deploy-code`, resulting in the following error:

```sh
./.circleci/env.sh: line 59: node: command not found
DIST_TAG=
```

You can see an example failure in the "Set up environment" step logs in https://app.circleci.com/pipelines/github/angular/angular.js/ 170/workflows/32fcacf9-c89b-4020-b3eb-15debe18bb67/jobs/1793

This commit fixes it by computing `$DIST_TAG` using unix tools (`cat`, `grep`, `sed`) that _are_ available on the docker images of all executors.
