### PR TITLE
docs(version-support-status): Added link to extended long term support

### DIFF
--- a/docs/content/misc/version-support-status.ngdoc
+++ b/docs/content/misc/version-support-status.ngdoc
@@ -51,3 +51,11 @@ AngularJS 1.2.x will get a new version if and only if a new severe security issu
 ### Blog Post
 
 You can read more about these plans in our [blog post announcement](https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c).
+
+### Extended Long Term Support
+
+If you need support for AngularJS beyond December 2021, you should consider:
+
+* [XLTS.dev](https://angularjs.xlts.dev)
+
+


### PR DESCRIPTION
**What is the current behavior? (You can also link to an open issue here)**

There is currently no mention of long term support providers on the docs. This is meant to be a place where we can enumerate the providers of extended long term support. @StephenFluin 


**What is the new behavior (if this is a feature change)?**

The aforementioned list is added to the version-support-status page in the angularjs docs. 


**Does this PR introduce a breaking change?**

No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

This PR is a result of several conversations with Jules and @StephenFluin. 