### PR TITLE
fix + docs: fix `$sceDelegateProvider.resourceUrlWhitelist()` and fix docs on recently deprecated properties/methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@
 
 ## Deprecation Notices
 
-- Deprecated ~~`aHrefSanitizationWhitelist`~~. It is now `aHrefSanitizationTrustedUri`
-- Deprecated ~~`imgSrcSanitizationWhitelist`~~. It is now `imgSrcSanitizationTrustedUri`
-- Deprecated ~~`xsrfWhitelistedOrigins`~~. It is now `xsrfTrustedOrigins`
-- Deprecated ~~`resourceUrlWhitelist`~~. It is now `trustedResourceUrlList`
-- Deprecated ~~`resourceUrlBlacklist`~~. It is now `bannedResourceUrlList`
+- Deprecated ~~`$compileProvider.aHrefSanitizationWhitelist`~~.
+  It is now [aHrefSanitizationTrustedUrlList](https://docs.angularjs.org/api/ng/provider/$compileProvider#aHrefSanitizationTrustedUrlList)`.
+- Deprecated ~~`$compileProvider.imgSrcSanitizationWhitelist`~~.
+  It is now [imgSrcSanitizationTrustedUrlList](https://docs.angularjs.org/api/ng/provider/$compileProvider#imgSrcSanitizationTrustedUrlList).
+- Deprecated ~~`$httpProvider.xsrfWhitelistedOrigins`~~.
+  It is now [xsrfTrustedOrigins](https://docs.angularjs.org/api/ng/provider/$httpProvider#xsrfTrustedOrigins).
+- Deprecated ~~`$sceDelegateProvider.resourceUrlWhitelist`~~.
+  It is now [trustedResourceUrlList](https://docs.angularjs.org/api/ng/provider/$sceDelegateProvider#trustedResourceUrlList).
+- Deprecated ~~`$sceDelegateProvider.resourceUrlBlacklist`~~.
+  It is now [bannedResourceUrlList](https://docs.angularjs.org/api/ng/provider/$sceDelegateProvider#bannedResourceUrlList).
 
 For the purposes of backward compatibility, the previous symbols are aliased to their new symbol.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@
 ## Refactorings
 
 - **SanitizeUriProvider:** remove usages of whitelist
-  ([76738102](https:github.com/angular/angular.js/commit/767381020d88bda2855ac87ca6f00748907e14ff))
+  ([76738102](https://github.com/angular/angular.js/commit/767381020d88bda2855ac87ca6f00748907e14ff))
 - **httpProvider:** remove usages of whitelist and blacklist
-  ([c953af6b](https:github.com/angular/angular.js/commit/c953af6b8cfeefe4acc0ca358550eed5da8cfe00))
+  ([c953af6b](https://github.com/angular/angular.js/commit/c953af6b8cfeefe4acc0ca358550eed5da8cfe00))
 - **sceDelegateProvider:** remove usages of whitelist and blacklist
-  ([a206e267](https:github.com/angular/angular.js/commit/a206e2675c351c3cdcde3402978126774c1c5df9))
+  ([a206e267](https://github.com/angular/angular.js/commit/a206e2675c351c3cdcde3402978126774c1c5df9))
 
 ## Deprecation Notices
 

--- a/docs/content/guide/migration.ngdoc
+++ b/docs/content/guide/migration.ngdoc
@@ -2663,7 +2663,7 @@ $scope.findTemplate = function(templateName) {
   return templateCache[templateName];
 };
 
-// Alternatively, use `$sceDelegateProvider..resourceUrlWhitelist()` (called
+// Alternatively, use `$sceDelegateProvider.resourceUrlWhitelist()` (called
 // `trustedResourceUrlList()` from 1.8.1 onwards), which means you don't
 // have to use `$sce.trustAsResourceUrl()` at all:
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -1734,15 +1734,15 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    * @deprecated
    * sinceVersion="1.8.1"
    *
-   * This function is deprecated. Use {@link $compileProvider#aHrefSanitizationTrustedUrlList
+   * This method is deprecated. Use {@link $compileProvider#aHrefSanitizationTrustedUrlList
    * aHrefSanitizationTrustedUrlList} instead.
    */
   Object.defineProperty(this, 'aHrefSanitizationWhitelist', {
     get: function() {
       return this.aHrefSanitizationTrustedUrlList;
     },
-    set: function(regexp) {
-      this.aHrefSanitizationTrustedUrlList = regexp;
+    set: function(value) {
+      this.aHrefSanitizationTrustedUrlList = value;
     }
   });
 
@@ -1785,15 +1785,15 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    * @deprecated
    * sinceVersion="1.8.1"
    *
-   * This function is deprecated. Use {@link $compileProvider#imgSrcSanitizationTrustedUrlList
+   * This method is deprecated. Use {@link $compileProvider#imgSrcSanitizationTrustedUrlList
    * imgSrcSanitizationTrustedUrlList} instead.
    */
   Object.defineProperty(this, 'imgSrcSanitizationWhitelist', {
     get: function() {
       return this.imgSrcSanitizationTrustedUrlList;
     },
-    set: function(regexp) {
-      this.imgSrcSanitizationTrustedUrlList = regexp;
+    set: function(value) {
+      this.imgSrcSanitizationTrustedUrlList = value;
     }
   });
 

--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -436,7 +436,7 @@ function $HttpProvider() {
    * @deprecated
    * sinceVersion="1.8.1"
    *
-   * This function is deprecated. Use {@link $httpProvider#xsrfTrustedOrigins xsrfTrustedOrigins}
+   * This property is deprecated. Use {@link $httpProvider#xsrfTrustedOrigins xsrfTrustedOrigins}
    * instead.
    */
   Object.defineProperty(this, 'xsrfWhitelistedOrigins', {

--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -242,7 +242,6 @@ function $SceDelegateProvider() {
    * The **default value** when no trusted resource URL list has been explicitly set is the empty
    * array (i.e. there is no `bannedResourceUrlList`.)
    */
-
   this.bannedResourceUrlList = function(value) {
     if (arguments.length) {
       bannedResourceUrlList = adjustMatchers(value);
@@ -258,7 +257,7 @@ function $SceDelegateProvider() {
    * @deprecated
    * sinceVersion="1.8.1"
    *
-   * This function is deprecated. Use {@link $sceDelegateProvider#bannedResourceUrlList
+   * This method is deprecated. Use {@link $sceDelegateProvider#bannedResourceUrlList
    * bannedResourceUrlList} instead.
    */
   Object.defineProperty(this, 'resourceUrlBlacklist', {

--- a/src/ng/sce.js
+++ b/src/ng/sce.js
@@ -215,7 +215,26 @@ function $SceDelegateProvider() {
     }
     return trustedResourceUrlList;
   };
-  this.resourceUrlWhitelist = this.trustedResourceUrlList;
+
+  /**
+   * @ngdoc method
+   * @name $sceDelegateProvider#resourceUrlWhitelist
+   * @kind function
+   *
+   * @deprecated
+   * sinceVersion="1.8.1"
+   *
+   * This method is deprecated. Use {@link $sceDelegateProvider#trustedResourceUrlList
+   * trustedResourceUrlList} instead.
+   */
+  Object.defineProperty(this, 'resourceUrlWhitelist', {
+    get: function() {
+      return this.trustedResourceUrlList;
+    },
+    set: function(value) {
+      this.trustedResourceUrlList = value;
+    }
+  });
 
   /**
    * @ngdoc method


### PR DESCRIPTION
This PR includes the following fixes (see the individual commits for more details):
- `` fix($sceDelegate): make `resourceUrlWhitelist()` is identical `trustedResourceUrlList()` ``
- `docs(*): fix docs on recently deprecated properties/methods`
