### PR TITLE
docs(misc/Version Support Status): update URL for XLTS.dev

### DIFF
--- a/docs/content/misc/version-support-status.ngdoc
+++ b/docs/content/misc/version-support-status.ngdoc
@@ -56,6 +56,6 @@ You can read more about these plans in our [blog post announcement](https://blog
 
 If you need support for AngularJS beyond December 2021, you should consider:
 
-* [XLTS.dev](https://angularjs.xlts.dev)
+* [XLTS.dev](https://xlts.dev/angularjs)
 
 


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**Does this PR fix a regression since 1.7.0, a security flaw, or a problem caused by a new browser version?**
No, it just updates the version-support-status docs.


**What is the current behavior? (You can also link to an open issue here)**
The XLTS.dev URL is out of date.
- the subdomain was switched to a path many months ago
- the angularjs.xlts.dev site will soon be used for hosting something else
  and the redirect removed (ASAP)


**What is the new behavior (if this is a feature change)?**
The XLTS.dev URL is correct.


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

