### PR TITLE
chore(e2e): run tests against Firefox 86 on macOS Catalina

### DIFF
--- a/protractor-circleci-conf.js
+++ b/protractor-circleci-conf.js
@@ -15,8 +15,8 @@ config.multiCapabilities = [
   }),
   capabilitiesForSauceLabs({
     browserName: 'firefox',
-    platform: 'OS X 10.14',
-    version: '76'
+    platform: 'OS X 10.15',
+    version: '86'
   })
 ];
 


### PR DESCRIPTION
# AngularJS is in LTS mode
We are no longer accepting changes that are not critical bug fixes into this project.
See https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c for more detail.

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**Does this PR fix a regression since 1.7.0, a security flaw, or a problem caused by a new browser version?**
Yes
<!-- If the answer is no, then we will not merge this PR -->


**What is the current behavior? (You can also link to an open issue here)**
- e2e is only run against Firefox 76 which is 14 months old on a 2 yo OS (macOS Mojave)


**What is the new behavior (if this is a feature change)?**
- e2e is run against Firefox 86 on macOS Catalina


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [x] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

This is expected to break due to https://github.com/angular/angular.js/issues/17117.