### PR TITLE
docs(eol): Add EOL options text and link to template header banner

### DIFF
--- a/docs/config/templates/app/indexPage.template.html
+++ b/docs/config/templates/app/indexPage.template.html
@@ -145,12 +145,8 @@
       <nav id="navbar-notice" class="navbar navbar-fixed-top">
         <div class="navbar-inner">
           <div class="container">
-            <p class="site-notice visible-phone">
-              This site refers to AngularJS (v1.x). <a href="https://angular.io/">Go to the latest Angular</a>.
-            </p>
-            <p class="site-notice visible-desktop">
-              This site and all of its contents are referring to AngularJS (version 1.x),
-              if you are looking for the latest Angular, please visit <a href="https://angular.io/">angular.io</a>.
+            <p class="site-notice">
+              AngularJS is now in Long Term Support (LTS) mode: <a href="https://docs.angularjs.org/misc/version-support-status">Find out more</a>. Explore End Of Life (EOL) options <a href="https://blog.angular.io/finding-a-path-forward-with-angularjs-7e186fdd4429">here</a>.
             </p>
           </div>
         </div>


### PR DESCRIPTION
### Changes:
* Remove "_This site and all of its contents are referring to AngularJS (version 1.x)..._" text from page banner.
* Add "_Explore End Of Life (EOL) options here_" text to page banner.

### Previous banner text:
![image](https://user-images.githubusercontent.com/5667395/144887199-d6eaf95e-8fbd-46e1-b7b2-97360d457109.png)


### New banner text
![image](https://user-images.githubusercontent.com/5667395/144887289-3a1b1d27-124f-4824-8571-3630e8091678.png)

![image](https://user-images.githubusercontent.com/5667395/144887326-622a34c4-3993-4a9e-81dd-d1bbf5feecda.png)

