### PR TITLE
docs: update end-of-life messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**AngularJS support has officially ended as of January 2022.
+[See what ending support means](https://docs.angularjs.org/misc/version-support-status)
+and [read the end of life announcement](https://goo.gle/angularjs-end-of-life).**
+
+**Visit [angular.io](https://angular.io) for the actively supported Angular.**
+
 <a name="1.8.2"></a>
 # 1.8.2 meteoric-mining (2020-10-21)
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ piece of cake. Best of all? It makes development fun!
 
 --------------------
 
-**On July 1, 2018 AngularJS entered a 3 year Long Term Support period:** [Find out more](https://docs.angularjs.org/misc/version-support-status)
+**AngularJS support has officially ended as of January 2022.
+[See what ending support means](https://docs.angularjs.org/misc/version-support-status)
+and [read the end of life announcement](https://goo.gle/angularjs-end-of-life).**
 
-**Looking for the new Angular? Go here:** https://github.com/angular/angular
+**Visit [angular.io](https://angular.io) for the actively supported Angular.**
 
 --------------------
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,19 +2,15 @@
 
 ## Supported Versions
 
+**AngularJS support has officially ended as of January 2022.**
+[See what ending support means](https://docs.angularjs.org/misc/version-support-status)
+and [read the end of life announcement](https://goo.gle/angularjs-end-of-life).
+
+Visit [angular.io](https://angular.io) for the actively supported Angular.
+
 | Version     | Supported          | Status                | Comments                             |
 | ----------- | ------------------ | --------------------- | ------------------------------------ |
-| 1.8.x       | :white_check_mark: | Long Term Support     | See [Long Term Support policy][0]    |
-| 1.3.x-1.7.x | :x:                |                       |                                      |
-| 1.2.x       | :warning:          | Security patches only | Last version to provide IE 8 support |
-| <1.2.0      | :x:                |                       |                                      |
-
-## Reporting a Vulnerability
-
-Email us at [security@angularjs.org](mailto:security@angularjs.org) to report any potential security issues in AngularJS.
-
-Please [use the latest AngularJS possible](https://docs.angularjs.org/guide/security#use-the-latest-angularjs-possible)
-and keep in mind the guidance around AngularJS'
-[expression language](https://docs.angularjs.org/guide/security#angularjs-templates-and-expressions).
-
-[0]: https://docs.angularjs.org/misc/version-support-status#long-term-support
+| 1.8.x       | :x:                | All support ended     |                                      |
+| 1.3.x-1.7.x | :x:                | All support ended     |                                      |
+| 1.2.x       | :x:                | All support ended     | Last version to provide IE 8 support |
+| <1.2.0      | :x:                | All support ended     |                                      |

--- a/docs/app/assets/css/docs.css
+++ b/docs/app/assets/css/docs.css
@@ -478,10 +478,10 @@ iframe.example {
 #navbar-sub {
   padding-top: 10px;
   padding-bottom: 5px;
-  background: rgba(245,245,245,0.88);
+  background: rgba(245,245,245,1);
   box-shadow: 0 0 2px #999;
   z-index: 1028;
-  top: 83px;
+  top: 57px;
 }
 
 .main-body-grid {
@@ -982,7 +982,7 @@ toc-container > div > toc-tree > ul > li > toc-tree > ul > li toc-tree > ul li {
 
   #navbar-sub {
     position: relative;
-    top: 17px;
+    top: 0;
     margin-top: 80px;
     padding-bottom: 0;
     margin-bottom: 0;

--- a/docs/config/templates/app/indexPage.template.html
+++ b/docs/config/templates/app/indexPage.template.html
@@ -142,17 +142,18 @@
           </div>
         </div>
       </nav>
-      <nav id="navbar-notice" class="navbar navbar-fixed-top">
-        <div class="navbar-inner">
-          <div class="container">
-            <p class="site-notice">
-              AngularJS is now in Long Term Support (LTS) mode: <a href="https://docs.angularjs.org/misc/version-support-status">Find out more</a>. Explore End Of Life (EOL) options <a href="https://blog.angular.io/finding-a-path-forward-with-angularjs-7e186fdd4429">here</a>.
-            </p>
-          </div>
-        </div>
-      </nav>
       <nav id="navbar-sub" class="sup-header navbar navbar-fixed-top" scroll-y-offset-element ng-cloak>
         <div class="container main-grid main-header-grid">
+        <p class="site-notice">
+              AngularJS support has officially ended as of January 2022.
+              <a href="https://docs.angularjs.org/misc/version-support-status">
+                See what ending support means
+              </a> and
+              <a href="https://goo.gle/angularjs-end-of-life">
+                read the end of life announcement</a>.<br>
+              Visit <a href="https://angular.io">angular.io</a> for the actively supported
+              Angular.
+            </p>
           <div class="grid-left">
             <version-picker></version-picker>
           </div>

--- a/docs/content/api/index.ngdoc
+++ b/docs/content/api/index.ngdoc
@@ -3,9 +3,12 @@
 @description
 
 # AngularJS API Docs
-
 <div class="alert alert-warning">
-**On July 1, 2018 AngularJS entered a 3 year Long Term Support period:** [Find out more](misc/version-support-status).
+AngularJS support has officially ended as of January 2022.
+[See what ending support means](https://docs.angularjs.org/misc/version-support-status)
+and [read the end of life announcement](https://goo.gle/angularjs-end-of-life).
+
+Visit [angular.io](https://angular.io) for the actively supported Angular.
 </div>
 
 ## Welcome to the AngularJS API docs page.

--- a/docs/content/misc/version-support-status.ngdoc
+++ b/docs/content/misc/version-support-status.ngdoc
@@ -4,58 +4,26 @@
 
 # Version Support Status
 
-This page describes the support status of the significant versions of AngularJS.
+**AngularJS support has officially ended as of January 2022.**
 
-<div class="alert alert-info">
-  On July 1, 2018 AngularJS entered a 3 year Long Term Support period.<br />
-  <br />
-  _**UPDATE (2020-07-27):**_<br />
-  _Due to COVID-19 affecting teams migrating from AngularJS, we are extending the LTS by six months
-  (until December 31, 2021)._
-</div>
+Visit [angular.io](https://angular.io) for the actively supported Angular.
 
-Any version branch not shown in the following table (e.g. 1.7.x) is no longer being developed.
+## What does end of support mean?
 
-<table class="dev-status table table-bordered">
-  <thead>
-    <tr><th>Version</th><th>Status</th><th>Comments</th></tr>
-  </thead>
-  <tbody>
-    <tr class="security">
-      <td><span>1.2.x</span></td>
-      <td>Security patches only</td>
-      <td>Last version to provide IE 8 support</td>
-    </tr>
-    <tr class="stable">
-      <td><span>1.8.x</span></td>
-      <td>Long Term Support</td>
-      <td>See {@link version-support-status#long-term-support Long Term Support} section below.</td>
-    </tr>
-  </tbody>
-</table>
+The code will remain accessible on [GitHub](https://github.com/angular/angular.js),
+[npm](https://www.npmjs.com/package/angular),
+[Bower](https://github.com/angular/bower-angular), and
+[Release archive](https://code.angularjs.org/1.8.2).
+This website will remain here indefinitely.
 
-### Long Term Support
+The GitHub repository will be in an archived state, meaning that no new issues or pull requests
+can be submitted.
 
-On July 1st 2018, AngularJS entered a Long Term Support period.
+See https://goo.gle/angularjs-end-of-life for the full details.
 
-We now focus exclusively on providing fixes to bugs that satisfy at least one of the following criteria:
+### Extended Long Term Support
 
-* A security flaw is detected in the 1.8.x branch of the framework
-* One of the major browsers releases a version that will cause current production applications using AngularJS 1.8.x to stop working
-* The jQuery library releases a version that will cause current production applications using AngularJS 1.8.x to stop working.
-
-AngularJS 1.2.x will get a new version if and only if a new severe security issue is discovered.
-
-
-
-### Blog Post
-
-You can read more about these plans in our [blog post announcement](https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c).
-
-### Extended Long Term Support
-
-If you need support for AngularJS beyond December 2021, you should consider:
+If you need extended support for AngularJS, you should consider:
 
 * [XLTS.dev](https://xlts.dev/angularjs)
-
-
+* [OpenLogic](https://www.openlogic.com/solutions/angularjs-support-and-services)


### PR DESCRIPTION
This change updates the messaging about AngularJS end-of-life in several places:
* Docs homepage
* Docs banner
* Security and support pages
* GitHub README

cc @aaronfrost 

@gkalpak am I missing anything here? I also want to update the changelog, but assume that happens automatically as part of the release process? 